### PR TITLE
refactor(http): cull compat + test scaffolding (rf2-w59es5)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -245,7 +245,7 @@
   "Compose `build-reply-event` with a late-bind `:router/dispatch!` lookup
   and fire the dispatch. The single truth point for 'how does http
   dispatch its reply' — shared by `http-transport/dispatch-reply!` and
-  the canned-stub handlers in `http-machine-wrapper`. Per rf2-2utlm.
+  the canned-stub handlers in `http-test-support`. Per rf2-2utlm.
 
   `args` is the same map `build-reply-event` consumes; `frame` (optional)
   is threaded as `{:frame <id>}` onto the dispatch options when present.

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -117,7 +117,7 @@
   surfaces as `:rf.error/http-bad-request` (rf2-93bck).
 
   Public (rf2-azrcs) so the canned-stub override target
-  (`http-machine-wrapper`/`http-test-support`'s route-map stub) validates
+  (`http-test-support`'s route-map stub) validates
   the FINAL post-`:before` url with the same canonical error the real
   `:rf.http/managed` handler emits — a `:before` that blanks the url must
   raise `:rf.error/http-bad-request`, not receive a synthetic stubbed reply.

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -1,6 +1,5 @@
 (ns re-frame.http-machine-wrapper
-  "Machine-shape wrapper for `:rf.http/managed` (rf2-ijm7) + canned-stub
-  handler bodies.
+  "Machine-shape wrapper for `:rf.http/managed` (rf2-ijm7).
 
   Extracted from `re-frame.http-managed` per rf2-3i9b. Per Spec 014
   §Machine-shape wrapper: `:rf.http/managed` ALSO registers as a child-
@@ -35,215 +34,21 @@
   AND `{:spawn {:machine-id :rf.http/managed ...}}` resolves to the
   machine.
 
-  ## Canned-stub handler bodies
+  ## Where the canned-stub handlers live (rf2-w59es5)
 
-  `canned-success-handler` / `canned-failure-handler` live here because
-  the machine-shape wrapper's reply walk is symmetric with the stubs'
-  reply walk — both feed `middleware/run-after-then-dispatch!` (the
-  shared run-`:after`-then-late-bind reply tail, also used by the real-
-  transport path in `http-transport/dispatch-reply!`). The
-  fx registrations that bind the `:rf.http/managed-canned-*` ids to
-  these handlers live in `re-frame.http-test-support` (per rf2-cdmle —
-  test-only require gate). The `with-managed-request-stubs*` helper —
-  which composes against these handlers directly — also lives in
-  `re-frame.http-test-support` (per rf2-lwmgw — single discoverable
-  home for HTTP test surfaces)."
-  (:require [re-frame.frame           :as frame]
-            [re-frame.http-encoding   :as encoding]
-            [re-frame.http-middleware :as middleware]
-            [re-frame.http-privacy    :as privacy]
-            [re-frame.late-bind       :as late-bind]))
-
-;; rf2-2utlm / rf2-k67u3 — the canned stubs delegate to
-;; `middleware/run-after-then-dispatch!`, the shared run-`:after`-then-
-;; late-bind reply tail `http-transport/dispatch-reply!` also uses, so
-;; the `:after`-chain + build-reply-event + late-bind lookup pattern
-;; lives in one place.
-
-;; ---- canned stub handlers (used by the `:rf.http/managed-canned-*` fxs
-;; registered in `re-frame.http-test-support` AND the per-call stub
-;; fx-override that with-managed-request-stubs installs). The handlers
-;; stay here so the test-support ns can reach them without circular
-;; requires.
-;;
-;; rf2-622e3 — origin-event resolution lives in
-;; `encoding/resolve-origin-event` (single source of truth shared with
-;; `http-managed/managed-handler`).
-
-(defn run-request-chain
-  "Per rf2-yhfgf — the request-side middleware chain (Spec 014 §Middleware)
-  fires for every issued request, not just real-transport ones. The canned
-  stub fxs replace the TRANSPORT, not the entire managed pipeline, so they
-  walk the chain before synthesising the reply. The chain's `:before` fns
-  may carry load-bearing side effects (auth-token attachment, idempotency-
-  key stamping, observability) that the canned path would otherwise mask.
-
-  A throw inside any `:before` raises `:rf.error/http-interceptor-failed`
-  with the same classification the real handler emits (per `run-interceptor-
-  chain!`), and the canned reply is NOT dispatched.
-
-  Returns the post-`:before` middleware-ctx so the caller can thread it
-  through `run-after-chain!` — the same ctx the `:after` chain sees on
-  the real-transport path (carried forward by `managed-handler` as the
-  normalised ctx's `:middleware-ctx`). The route-map stub
-  (`http-test-support/stub-handler`, rf2-azrcs) ALSO reads the
-  post-`:before` `:request` back off this ctx to key its match against
-  the url the managed pipeline would actually issue, and runs
-  `handlers/validate-url!` on it — the final-url validation belongs to the
-  `:rf.http/managed` OVERRIDE-TARGET role (the stub), not to this shared
-  chain walk, which the lower-level canned handlers also call with a bare
-  `:value` and no `:request`.
-
-  rf2-xmp74u — seeds the SAME effective top-level `:sensitive?` into `ctx0`
-  that `http-handlers/managed-handler` seeds on the real-transport path
-  (via `privacy/request-sensitive?`, OR-reducing per-call `:sensitive?` and
-  `[:request :sensitive?]`). Without it, a request that opted in via the
-  TOP-LEVEL `:sensitive? true` form ran the canned/stub `:before` chain with
-  no top-level flag, so a throwing `:before` emitted
-  `:rf.error/http-interceptor-failed` WITHOUT redacting non-denylisted query
-  values — a stub-path leak + test false-green relative to production. The
-  chain's own `:sensitive-of` reducer still recomputes the EFFECTIVE
-  sensitivity from the threaded ctx (so a `:before` that MARKS the request
-  sensitive is honoured); seeding the floor here matches production's
-  pre-chain reading."
-  [frame-ctx args-map]
-  (let [;; EP-0002 carried invariant — the canned stub runs inside a
-        ;; cascade, so the fx context carries the envelope frame as
-        ;; `:frame`; a nil stamp is an invariant failure
-        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame-id     (frame/require-frame-stamp!
-                       (:frame frame-ctx) :rf.http/managed-canned
-                       {:where 'rf.http/run-request-chain})
-        origin-event (encoding/resolve-origin-event frame-ctx args-map)
-        sensitive?   (privacy/request-sensitive? args-map origin-event)
-        ctx0         {:request    (:request args-map)
-                      :args       args-map
-                      :frame      frame-id
-                      :event      origin-event
-                      :sensitive? sensitive?}]
-    (middleware/run-interceptor-chain! frame-id ctx0)))
-
-(defn- dispatch-canned-reply!
-  "rf2-r5m22 — the canned-stub reply tail, mirroring
-  `http-transport/dispatch-reply!`: thread the synthesised reply-payload
-  through the per-frame `:after` interceptor chain (REVERSE registration
-  order) BEFORE handing off to the late-bind reply router.
-
-  Before this, the canned path ran ONLY the `:before` half of the
-  interceptor chain (`run-request-chain`) and called the reply router
-  directly — so an `:after` carrying response-time telemetry, header-
-  driven auth refresh, or any of the response-side use-cases the
-  middleware contract sells (Spec 014 §Middleware) silently never fired
-  on the stub path. That broke `run-request-chain`'s own promise that
-  load-bearing interceptor side effects 'fire on the canned path the
-  same way they fire on the real-transport path' — stub-path response
-  handling diverged from production.
-
-  `middleware-ctx` is the post-`:before` ctx `run-request-chain`
-  produced for THIS request — the exact same shape the real-transport
-  `:after` chain sees, so a `:before` that recorded a wall-clock mark /
-  stamped a correlation-id can read its own work back in the `:after`.
-  An `:after` throw propagates as `:rf.error/http-interceptor-failed`
-  (per `run-after-chain!`), matching the real path; the reply is then
-  not dispatched.
-
-  rf2-k67u3 — the run-`:after`-then-dispatch tail is shared with the
-  real-transport reply path (`http-transport/dispatch-reply!`) via
-  `middleware/run-after-then-dispatch!`. The canned path always supplies
-  a `:middleware-ctx` (produced by `run-request-chain`), so the `:after`
-  chain always runs here."
-  [{:keys [origin-event explicit-on reply-payload kind frame middleware-ctx]}]
-  (middleware/run-after-then-dispatch!
-    {:frame          frame
-     :middleware-ctx middleware-ctx
-     :origin-event   origin-event
-     :explicit-on    explicit-on
-     :reply-payload  reply-payload
-     :kind           kind}))
-
-;; rf2-azrcs — the canned-success / canned-failure bodies split into a
-;; pre-computed-ctx emit (`emit-canned-success!` / `emit-canned-failure!`)
-;; plus a thin run-the-chain-then-emit wrapper. The route-map stub
-;; (`http-test-support/stub-handler`) runs the `:before` chain ONCE itself
-;; (so it can key its route match against the post-`:before` url), then
-;; calls the emit fns with that same ctx — WITHOUT re-running `:before`
-;; (which would double-fire load-bearing interceptor side effects).
-(defn emit-canned-success!
-  "Synthesise a success reply from a PRE-COMPUTED post-`:before`
-  `middleware-ctx` (rf2-azrcs). Threads the reply through the `:after`
-  chain via `dispatch-canned-reply!`. Does NOT run the `:before` chain —
-  the caller already did."
-  [frame-ctx args-map middleware-ctx]
-  (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
-        ;; envelope stamp; a nil stamp is an invariant failure, never a
-        ;; synthesised `:rf/default`.
-        frame-id (frame/require-frame-stamp!
-                   (:frame frame-ctx) :rf.http/managed-canned-success
-                   {:where 'rf.http/emit-canned-success!})
-        value    (get args-map :value {:stubbed true})]
-    (dispatch-canned-reply!
-      {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
-       :explicit-on    {:supplied? (contains? args-map :on-success)
-                        :value     (:on-success args-map)}
-       :reply-payload  {:kind :success :value value}
-       :kind           :success
-       :frame          frame-id
-       :middleware-ctx middleware-ctx})
-    nil))
-
-(defn emit-canned-failure!
-  "Synthesise a failure reply from a PRE-COMPUTED post-`:before`
-  `middleware-ctx` (rf2-azrcs). Symmetric with `emit-canned-success!`."
-  [frame-ctx args-map middleware-ctx]
-  (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
-        ;; envelope stamp; a nil stamp is an invariant failure, never a
-        ;; synthesised `:rf/default`.
-        frame-id (frame/require-frame-stamp!
-                   (:frame frame-ctx) :rf.http/managed-canned-failure
-                   {:where 'rf.http/emit-canned-failure!})
-        kind     (or (:kind args-map) :rf.http/transport)
-        tags     (or (:tags args-map) {})
-        failure  (assoc tags :kind kind)]
-    (dispatch-canned-reply!
-      {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
-       :explicit-on    {:supplied? (contains? args-map :on-failure)
-                        :value     (:on-failure args-map)}
-       :reply-payload  {:kind :failure :failure failure}
-       :kind           :failure
-       :frame          frame-id
-       :middleware-ctx middleware-ctx})
-    nil))
-
-(defn canned-success-handler
-  "Stub fx — synthesises a success reply per Spec 014 §Testing.
-
-  Per rf2-yhfgf — walks the per-frame request-side (`:before`) interceptor
-  chain before synthesising the reply, so `:before` interceptors with
-  load-bearing side effects (auth headers, observability) fire on the
-  canned path the same way they fire on the real-transport path.
-  Per rf2-azrcs — the chain walk (`run-request-chain`) also validates the
-  final post-`:before` url with the canonical `:rf.error/http-bad-request`.
-
-  Per rf2-r5m22 — also threads the reply through the response-side
-  (`:after`) chain (via `dispatch-canned-reply!`), mirroring
-  `http-transport/dispatch-reply!` so the stub path is a faithful test
-  seam for BOTH halves of the middleware chain."
-  [frame-ctx args-map]
-  (emit-canned-success! frame-ctx args-map (run-request-chain frame-ctx args-map)))
-
-(defn canned-failure-handler
-  "Stub fx — synthesises a failure reply per Spec 014 §Testing.
-
-  Per rf2-yhfgf — walks the per-frame request-side (`:before`) interceptor
-  chain before synthesising the reply (symmetric with `canned-success-
-  handler`). Real-transport failures still go through the chain too; the
-  canned path honours the same pre-transport contract.
-
-  Per rf2-r5m22 — also threads the reply through the response-side
-  (`:after`) chain (via `dispatch-canned-reply!`), mirroring
-  `http-transport/dispatch-reply!`."
-  [frame-ctx args-map]
-  (emit-canned-failure! frame-ctx args-map (run-request-chain frame-ctx args-map)))
+  The canned-stub handler bodies (`canned-success-handler` /
+  `canned-failure-handler` and their `emit-canned-*!` / `run-request-
+  chain` / `dispatch-canned-reply!` helpers) are TEST scaffolding — they
+  live in `re-frame.http-test-support` alongside the canned-stub fx
+  registrations and the `with-managed-request-stubs*` helper that
+  composes against them. They used to share this production-loaded
+  namespace (so the stub macros could reach them without a circular
+  require); that constraint no longer holds now that the stub macros and
+  the stub fx registrations have consolidated into `http-test-support`
+  (rf2-lwmgw), so the stub bodies moved there. This namespace is
+  production-loaded (by `re-frame.http-managed`) and now carries ONLY the
+  machine-shape wrapper."
+  (:require [re-frame.late-bind :as late-bind]))
 
 ;; ---- machine-shape wrapper spec (rf2-ijm7) --------------------------------
 

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -99,12 +99,13 @@
    - `re-frame.http-handlers`      — `:rf.http/managed` /
                                       `:rf.http/managed-abort` fx
                                       handler bodies (rf2-0eyp2).
-   - `re-frame.http-machine-wrapper`— machine-shape wrapper (rf2-ijm7)
-                                      and canned-stub handler bodies.
+   - `re-frame.http-machine-wrapper`— machine-shape wrapper (rf2-ijm7).
    - `re-frame.http-test-support`   — test-only surface: stub macros
-                                      + canned-stub fx registrations
-                                      + late-bind hook publication for
-                                      the stub family (rf2-lwmgw).
+                                      + canned-stub handler bodies
+                                      (rf2-w59es5) + canned-stub fx
+                                      registrations + late-bind hook
+                                      publication for the stub family
+                                      (rf2-lwmgw).
    - `re-frame.util-json`           — pure-Clojure JSON reader extracted
                                       per rf2-p7da; shared by the decode
                                       pipeline. (Currently shipped in

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -435,7 +435,7 @@
      the `(if middleware-ctx …)` guard skips the `:after` chain and
      passes the payload through unchanged — the chain's contract is to
      see the `:before`'s ctx, not a synthesised one.
-   - `http-machine-wrapper/dispatch-canned-reply!` — the canned-stub
+   - `http-test-support/dispatch-canned-reply!` — the canned-stub test
      path, which always produces a `:middleware-ctx` via
      `run-request-chain` and therefore always runs the `:after` chain.
 

--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -78,15 +78,212 @@
   hook publications under `:http/install-managed-request-stubs!`,
   `:http/uninstall-managed-request-stubs!`, `:http/with-managed-request-stubs*`)."
   (:require [re-frame.events               :as events]
+            [re-frame.frame                :as frame]
             [re-frame.fx                   :as fx]
             [re-frame.http-encoding        :as encoding]
             [re-frame.http-handlers        :as handlers]
-            [re-frame.http-machine-wrapper :as machine-wrapper]
+            [re-frame.http-middleware      :as middleware]
+            [re-frame.http-privacy         :as privacy]
             [re-frame.late-bind            :as late-bind]
             [re-frame.registrar            :as registrar]
             [re-frame.router               :as router]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; ---- canned-stub handler bodies (rf2-w59es5) ------------------------------
+;;
+;; These synthesise a managed-HTTP reply WITHOUT a real transport, for the
+;; canned-stub fxs (`:rf.http/managed-canned-*`) and the route-map stub
+;; (`stub-handler`) below. They are TEST scaffolding — they used to live in
+;; the production-loaded `re-frame.http-machine-wrapper` so the (then-split)
+;; stub macros could reach them without a circular require. Now that the
+;; macros and the canned-stub fx registrations both live HERE (rf2-lwmgw),
+;; the constraint is gone and the bodies moved here too, leaving
+;; `http-machine-wrapper` to carry only the production machine spec.
+;;
+;; rf2-2utlm / rf2-k67u3 — the canned path delegates to
+;; `middleware/run-after-then-dispatch!`, the shared run-`:after`-then-late-
+;; bind reply tail `http-transport/dispatch-reply!` also uses, so the
+;; `:after`-chain + build-reply-event + late-bind lookup pattern lives in one
+;; place.
+;;
+;; rf2-622e3 — origin-event resolution lives in
+;; `encoding/resolve-origin-event` (single source of truth shared with
+;; `http-managed/managed-handler`).
+
+(defn run-request-chain
+  "Per rf2-yhfgf — the request-side middleware chain (Spec 014 §Middleware)
+  fires for every issued request, not just real-transport ones. The canned
+  stub fxs replace the TRANSPORT, not the entire managed pipeline, so they
+  walk the chain before synthesising the reply. The chain's `:before` fns
+  may carry load-bearing side effects (auth-token attachment, idempotency-
+  key stamping, observability) that the canned path would otherwise mask.
+
+  A throw inside any `:before` raises `:rf.error/http-interceptor-failed`
+  with the same classification the real handler emits (per `run-interceptor-
+  chain!`), and the canned reply is NOT dispatched.
+
+  Returns the post-`:before` middleware-ctx so the caller can thread it
+  through `run-after-chain!` — the same ctx the `:after` chain sees on
+  the real-transport path (carried forward by `managed-handler` as the
+  normalised ctx's `:middleware-ctx`). The route-map stub (`stub-handler`,
+  rf2-azrcs) ALSO reads the post-`:before` `:request` back off this ctx to
+  key its match against the url the managed pipeline would actually issue,
+  and runs `handlers/validate-url!` on it — the final-url validation belongs
+  to the `:rf.http/managed` OVERRIDE-TARGET role (the stub), not to this
+  shared chain walk, which the lower-level canned handlers also call with a
+  bare `:value` and no `:request`.
+
+  rf2-xmp74u — seeds the SAME effective top-level `:sensitive?` into `ctx0`
+  that `http-handlers/managed-handler` seeds on the real-transport path
+  (via `privacy/request-sensitive?`, OR-reducing per-call `:sensitive?` and
+  `[:request :sensitive?]`). Without it, a request that opted in via the
+  TOP-LEVEL `:sensitive? true` form ran the canned/stub `:before` chain with
+  no top-level flag, so a throwing `:before` emitted
+  `:rf.error/http-interceptor-failed` WITHOUT redacting non-denylisted query
+  values — a stub-path leak + test false-green relative to production. The
+  chain's own `:sensitive-of` reducer still recomputes the EFFECTIVE
+  sensitivity from the threaded ctx (so a `:before` that MARKS the request
+  sensitive is honoured); seeding the floor here matches production's
+  pre-chain reading."
+  [frame-ctx args-map]
+  (let [;; EP-0002 carried invariant — the canned stub runs inside a
+        ;; cascade, so the fx context carries the envelope frame as
+        ;; `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id     (frame/require-frame-stamp!
+                       (:frame frame-ctx) :rf.http/managed-canned
+                       {:where 'rf.http/run-request-chain})
+        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        sensitive?   (privacy/request-sensitive? args-map origin-event)
+        ctx0         {:request    (:request args-map)
+                      :args       args-map
+                      :frame      frame-id
+                      :event      origin-event
+                      :sensitive? sensitive?}]
+    (middleware/run-interceptor-chain! frame-id ctx0)))
+
+(defn- dispatch-canned-reply!
+  "rf2-r5m22 — the canned-stub reply tail, mirroring
+  `http-transport/dispatch-reply!`: thread the synthesised reply-payload
+  through the per-frame `:after` interceptor chain (REVERSE registration
+  order) BEFORE handing off to the late-bind reply router.
+
+  Before this, the canned path ran ONLY the `:before` half of the
+  interceptor chain (`run-request-chain`) and called the reply router
+  directly — so an `:after` carrying response-time telemetry, header-
+  driven auth refresh, or any of the response-side use-cases the
+  middleware contract sells (Spec 014 §Middleware) silently never fired
+  on the stub path. That broke `run-request-chain`'s own promise that
+  load-bearing interceptor side effects 'fire on the canned path the
+  same way they fire on the real-transport path' — stub-path response
+  handling diverged from production.
+
+  `middleware-ctx` is the post-`:before` ctx `run-request-chain`
+  produced for THIS request — the exact same shape the real-transport
+  `:after` chain sees, so a `:before` that recorded a wall-clock mark /
+  stamped a correlation-id can read its own work back in the `:after`.
+  An `:after` throw propagates as `:rf.error/http-interceptor-failed`
+  (per `run-after-chain!`), matching the real path; the reply is then
+  not dispatched.
+
+  rf2-k67u3 — the run-`:after`-then-dispatch tail is shared with the
+  real-transport reply path (`http-transport/dispatch-reply!`) via
+  `middleware/run-after-then-dispatch!`. The canned path always supplies
+  a `:middleware-ctx` (produced by `run-request-chain`), so the `:after`
+  chain always runs here."
+  [{:keys [origin-event explicit-on reply-payload kind frame middleware-ctx]}]
+  (middleware/run-after-then-dispatch!
+    {:frame          frame
+     :middleware-ctx middleware-ctx
+     :origin-event   origin-event
+     :explicit-on    explicit-on
+     :reply-payload  reply-payload
+     :kind           kind}))
+
+;; rf2-azrcs — the canned-success / canned-failure bodies split into a
+;; pre-computed-ctx emit (`emit-canned-success!` / `emit-canned-failure!`)
+;; plus a thin run-the-chain-then-emit wrapper. The route-map stub
+;; (`stub-handler`) runs the `:before` chain ONCE itself (so it can key its
+;; route match against the post-`:before` url), then calls the emit fns with
+;; that same ctx — WITHOUT re-running `:before` (which would double-fire
+;; load-bearing interceptor side effects).
+(defn emit-canned-success!
+  "Synthesise a success reply from a PRE-COMPUTED post-`:before`
+  `middleware-ctx` (rf2-azrcs). Threads the reply through the `:after`
+  chain via `dispatch-canned-reply!`. Does NOT run the `:before` chain —
+  the caller already did."
+  [frame-ctx args-map middleware-ctx]
+  (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
+        ;; envelope stamp; a nil stamp is an invariant failure, never a
+        ;; synthesised `:rf/default`.
+        frame-id (frame/require-frame-stamp!
+                   (:frame frame-ctx) :rf.http/managed-canned-success
+                   {:where 'rf.http/emit-canned-success!})
+        value    (get args-map :value {:stubbed true})]
+    (dispatch-canned-reply!
+      {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
+       :explicit-on    {:supplied? (contains? args-map :on-success)
+                        :value     (:on-success args-map)}
+       :reply-payload  {:kind :success :value value}
+       :kind           :success
+       :frame          frame-id
+       :middleware-ctx middleware-ctx})
+    nil))
+
+(defn emit-canned-failure!
+  "Synthesise a failure reply from a PRE-COMPUTED post-`:before`
+  `middleware-ctx` (rf2-azrcs). Symmetric with `emit-canned-success!`."
+  [frame-ctx args-map middleware-ctx]
+  (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
+        ;; envelope stamp; a nil stamp is an invariant failure, never a
+        ;; synthesised `:rf/default`.
+        frame-id (frame/require-frame-stamp!
+                   (:frame frame-ctx) :rf.http/managed-canned-failure
+                   {:where 'rf.http/emit-canned-failure!})
+        kind     (or (:kind args-map) :rf.http/transport)
+        tags     (or (:tags args-map) {})
+        failure  (assoc tags :kind kind)]
+    (dispatch-canned-reply!
+      {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
+       :explicit-on    {:supplied? (contains? args-map :on-failure)
+                        :value     (:on-failure args-map)}
+       :reply-payload  {:kind :failure :failure failure}
+       :kind           :failure
+       :frame          frame-id
+       :middleware-ctx middleware-ctx})
+    nil))
+
+(defn canned-success-handler
+  "Stub fx — synthesises a success reply per Spec 014 §Testing.
+
+  Per rf2-yhfgf — walks the per-frame request-side (`:before`) interceptor
+  chain before synthesising the reply, so `:before` interceptors with
+  load-bearing side effects (auth headers, observability) fire on the
+  canned path the same way they fire on the real-transport path.
+  Per rf2-azrcs — the chain walk (`run-request-chain`) also validates the
+  final post-`:before` url with the canonical `:rf.error/http-bad-request`.
+
+  Per rf2-r5m22 — also threads the reply through the response-side
+  (`:after`) chain (via `dispatch-canned-reply!`), mirroring
+  `http-transport/dispatch-reply!` so the stub path is a faithful test
+  seam for BOTH halves of the middleware chain."
+  [frame-ctx args-map]
+  (emit-canned-success! frame-ctx args-map (run-request-chain frame-ctx args-map)))
+
+(defn canned-failure-handler
+  "Stub fx — synthesises a failure reply per Spec 014 §Testing.
+
+  Per rf2-yhfgf — walks the per-frame request-side (`:before`) interceptor
+  chain before synthesising the reply (symmetric with `canned-success-
+  handler`). Real-transport failures still go through the chain too; the
+  canned path honours the same pre-transport contract.
+
+  Per rf2-r5m22 — also threads the reply through the response-side
+  (`:after`) chain (via `dispatch-canned-reply!`), mirroring
+  `http-transport/dispatch-reply!`."
+  [frame-ctx args-map]
+  (emit-canned-failure! frame-ctx args-map (run-request-chain frame-ctx args-map)))
 
 ;; ---- optional `:after-ms` delay (rf2-j1mo4) ------------------------------
 ;;
@@ -177,12 +374,12 @@
 ;; Per the namespace docstring: the gate is \"explicit test-support
 ;; import\". These (fx/reg-fx ...) calls fire iff some namespace in the
 ;; require closure pulled `re-frame.http-test-support` in. Production app
-;; code must not. The handler bodies live in `re-frame.http-machine-wrapper`
-;; (rf2-3i9b) so the `with-managed-request-stubs*` helper — which composes
-;; against `canned-success-handler` / `canned-failure-handler` directly —
-;; still reaches them without circular requires. The `with-after-ms`
-;; decorator (rf2-j1mo4) adds the optional `:after-ms` delay around those
-;; same bodies without changing their contract.
+;; code must not. The handler bodies (`canned-success-handler` /
+;; `canned-failure-handler`) live HERE alongside their registrations
+;; (rf2-w59es5 — the stub scaffolding consolidated into this test-support
+;; namespace). The `with-after-ms` decorator (rf2-j1mo4) adds the optional
+;; `:after-ms` delay around those same bodies without changing their
+;; contract.
 
 (fx/reg-fx :rf.http/managed-canned-success
            {:doc "Spec 014 — synthesised success reply (test stub).
@@ -190,7 +387,7 @@
                   require per rf2-cdmle. Optional `:after-ms` (rf2-j1mo4)
                   defers the reply via `:dispatch-later`."}
            (with-after-ms :rf.http/managed-canned-success
-                          machine-wrapper/canned-success-handler))
+                          canned-success-handler))
 
 (fx/reg-fx :rf.http/managed-canned-failure
            {:doc "Spec 014 — synthesised failure reply (test stub).
@@ -198,7 +395,7 @@
                   require per rf2-cdmle. Optional `:after-ms` (rf2-j1mo4)
                   defers the reply via `:dispatch-later`."}
            (with-after-ms :rf.http/managed-canned-failure
-                          machine-wrapper/canned-failure-handler))
+                          canned-failure-handler))
 
 ;; ---- with-managed-request-stubs ------------------------------------------
 ;;
@@ -212,12 +409,12 @@
 
   rf2-azrcs — the stub now keys its route match against the request the
   managed pipeline would ACTUALLY issue, not the pre-middleware draft. It
-  runs the per-frame `:before` chain ONCE (`run-request-chain`, which also
-  validates the final url with the canonical `:rf.error/http-bad-request`),
-  reads the post-`:before` `:method`/`:url` back off that ctx to key the
-  route map, then emits the canned reply through the `:after` chain with
-  that SAME ctx — without re-running `:before` (no double-firing of
-  load-bearing interceptor side effects).
+  runs the per-frame `:before` chain ONCE (`run-request-chain` above, which
+  also validates the final url with the canonical
+  `:rf.error/http-bad-request`), reads the post-`:before` `:method`/`:url`
+  back off that ctx to key the route map, then emits the canned reply
+  through the `:after` chain with that SAME ctx — without re-running
+  `:before` (no double-firing of load-bearing interceptor side effects).
 
   Consequences of the prior pre-`:before` matching this fixes:
    - a base-URL / url-rewriting `:before` made the stub match the ORIGINAL
@@ -235,7 +432,7 @@
   ;; guard the real handler runs after its `:before` chain. A `:before`
   ;; that blanks the url now throws here instead of receiving a synthetic
   ;; stubbed reply.
-  (let [middleware-ctx (machine-wrapper/run-request-chain frame-ctx args-map)
+  (let [middleware-ctx (run-request-chain frame-ctx args-map)
         _              (handlers/validate-url! (:request middleware-ctx))
         ;; Match against the POST-`:before` request — the url the managed
         ;; pipeline would actually send.
@@ -246,25 +443,25 @@
         reply          (:reply entry)]
     (cond
       (and entry (contains? reply :ok))
-      (machine-wrapper/emit-canned-success! frame-ctx (assoc args-map :value (:ok reply))
-                                            middleware-ctx)
+      (emit-canned-success! frame-ctx (assoc args-map :value (:ok reply))
+                            middleware-ctx)
 
       (and entry (contains? reply :failure))
-      (machine-wrapper/emit-canned-failure! frame-ctx
-                                            (-> args-map
-                                                (assoc :kind (or (:kind (:failure reply))
-                                                                 :rf.http/transport))
-                                                (assoc :tags (dissoc (:failure reply) :kind)))
-                                            middleware-ctx)
+      (emit-canned-failure! frame-ctx
+                            (-> args-map
+                                (assoc :kind (or (:kind (:failure reply))
+                                                 :rf.http/transport))
+                                (assoc :tags (dissoc (:failure reply) :kind)))
+                            middleware-ctx)
 
       :else
-      (machine-wrapper/emit-canned-failure! frame-ctx
-                                            (assoc args-map
-                                                   :kind :rf.http/transport
-                                                   :tags {:message "no stub matched"
-                                                          :method  method
-                                                          :url     url})
-                                            middleware-ctx))))
+      (emit-canned-failure! frame-ctx
+                            (assoc args-map
+                                   :kind :rf.http/transport
+                                   :tags {:message "no stub matched"
+                                          :method  method
+                                          :url     url})
+                            middleware-ctx))))
 
 (def ^:private stub-fx-id :rf.http/managed-test-stub)
 

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -69,7 +69,7 @@
                    :success explicit-on-success
                    :failure explicit-on-failure)]
     ;; rf2-uheqq — `:after` chain + late-bind dispatch. Shared with the
-    ;; canned-stub reply path (`http-machine-wrapper/dispatch-canned-
+    ;; canned-stub reply path (`http-test-support/dispatch-canned-
     ;; reply!`) via `middleware/run-after-then-dispatch!` (rf2-k67u3): the
     ;; `:after` chain is skipped when no middleware-ctx is present
     ;; (synthetic / test-path callers).

--- a/implementation/http/src/re_frame/http_transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http_transport_jvm.cljc
@@ -327,13 +327,17 @@
      `:elapsed-ms` is a measured wall-clock delta `>= :limit-ms` by the
      scheduling margin — a consumer can compute overshoot
      (`- :elapsed-ms :limit-ms`) portably (it was the synthetic constant
-     `== :limit-ms` on CLJS before rf2-6ecc6). `elapsed-ms` is nil only
-     when no start mark was threaded (the legacy 2-arity test/synthetic
-     callers), preserving back-compat."
-     ([^Throwable t] (classify-jvm-error t nil nil))
-     ([^Throwable t timeout-ms] (classify-jvm-error t timeout-ms nil))
-     ([^Throwable t timeout-ms elapsed-ms]
-      (let [cause (or (.getCause t) t)
+     `== :limit-ms` on CLJS before rf2-6ecc6).
+
+     rf2-w59es5 — single 3-arity. The production caller (`run-attempt!`)
+     always threads the configured `timeout-ms` and the measured
+     `elapsed-ms`; the prior 1-/2-arity fallbacks existed only for
+     synthetic/test callers and have been removed (pre-alpha, no
+     back-compat). Pass `nil` explicitly for either when no value is in
+     scope — on a timeout the corresponding tag rides `nil` (the JDK
+     exposes no elapsed value on a synthetic throwable)."
+     [^Throwable t timeout-ms elapsed-ms]
+     (let [cause (or (.getCause t) t)
             msg   (.getMessage cause)
             cls   (.getName (class cause))]
         (cond
@@ -344,7 +348,7 @@
           {:kind :rf.http/aborted :reason :user :message msg}
 
           :else
-          {:kind :rf.http/transport :message msg :cause cls})))))
+          {:kind :rf.http/transport :message msg :cause cls}))))
 
 ;; ---- per-row CLJS-only-key tracing on JVM ---------------------------------
 

--- a/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
@@ -195,13 +195,14 @@
       (is (= 1234 (:elapsed-ms failure)) "measured elapsed wall-clock is carried")
       (is (= 30000 (:limit-ms failure)) "the configured limit is preserved"))))
 
-(deftest classify-jvm-error-elapsed-ms-nil-for-legacy-arities
-  (testing "rf2-a3wxe — the 2-arity (and 1-arity) preserve back-compat:
-            :elapsed-ms is nil when no start mark was threaded"
+(deftest classify-jvm-error-elapsed-ms-nil-when-unmeasured
+  (testing "rf2-w59es5 — the single 3-arity carries a nil :elapsed-ms when no
+            start mark was measured (the synthetic-caller case); :limit-ms
+            still rides whatever was threaded"
     (let [classify transport-jvm/classify-jvm-error
           timeout  (java.net.http.HttpTimeoutException. "request timed out")]
-      (is (nil? (:elapsed-ms (classify timeout 30000))))
-      (is (nil? (:elapsed-ms (classify timeout)))))))
+      (is (nil? (:elapsed-ms (classify timeout 30000 nil))))
+      (is (nil? (:elapsed-ms (classify timeout nil nil)))))))
 
 (deftest jvm-real-timeout-populates-elapsed-ms
   (testing "rf2-a3wxe — a live JVM request that exceeds its per-attempt

--- a/implementation/http/test/re_frame/http_test_support_test.clj
+++ b/implementation/http/test/re_frame/http_test_support_test.clj
@@ -9,11 +9,12 @@
    - load-time registration of the two canned-stub fxs:
       - `:rf.http/managed-canned-success`
       - `:rf.http/managed-canned-failure`
-     Each wraps `re-frame.http-machine-wrapper/canned-success-handler`
-     / `canned-failure-handler` in the rf2-j1mo4 `:after-ms` delay
-     decorator: absent / 0 `:after-ms` delegates straight through
-     (immediate reply); a positive `:after-ms` defers via the framework
-     `:dispatch-later`.
+     Each wraps this namespace's own `canned-success-handler` /
+     `canned-failure-handler` (rf2-w59es5 — the canned-stub bodies live
+     here in test-support, not the production machine-wrapper) in the
+     rf2-j1mo4 `:after-ms` delay decorator: absent / 0 `:after-ms`
+     delegates straight through (immediate reply); a positive `:after-ms`
+     defers via the framework `:dispatch-later`.
    - the stub macros / fns:
       - `with-managed-request-stubs`
       - `with-managed-request-stubs*`
@@ -26,7 +27,7 @@
      `re-frame.core-http`'s defwrapper surface).
 
   This smoke pins the load-time side effects: fx registrations land,
-  the fx ids delegate (on the immediate path) to the machine-wrapper
+  the fx ids delegate (on the immediate path) to this namespace's
   canned-* bodies, and the stub-family late-bind hooks are non-nil after
   the require. The deeper end-to-end
   behaviour (canned reply → late-bind dispatch → reply lands in
@@ -52,20 +53,20 @@
     (is (some? (registrar/lookup :fx :rf.http/managed-canned-failure))
         ":rf.http/managed-canned-failure registered")))
 
-(deftest canned-stub-fxs-delegate-to-machine-wrapper-handlers
-  (testing "rf2-j1mo4 — the registered handlers wrap the machine-wrapper
-            canned-* vars in the `with-after-ms` delay decorator. On the
-            immediate path (no `:after-ms`) the wrapper delegates straight
-            through to the machine-wrapper body, so Spec 014 §Testing's
-            args-map contract carries through unchanged; a positive
-            `:after-ms` defers via the framework `:dispatch-later`.
+(deftest canned-stub-fxs-delegate-to-canned-handlers
+  (testing "rf2-j1mo4 — the registered handlers wrap the canned-* handler
+            vars in the `with-after-ms` delay decorator. On the immediate
+            path (no `:after-ms`) the wrapper delegates straight through to
+            the canned handler body, so Spec 014 §Testing's args-map contract
+            carries through unchanged; a positive `:after-ms` defers via the
+            framework `:dispatch-later`.
 
-            The handlers are deliberately NOT `identical?` to the
-            machine-wrapper vars anymore — the delay is a parameter of the
-            same effect, threaded by wrapping the reg-fx body. We pin the
-            delegation by driving the immediate path through a stub
-            late-bind router and asserting the wrapper body fired the
-            machine-wrapper reply walk (a dispatch through `:router/dispatch!`)."
+            The handlers are deliberately NOT `identical?` to the canned-*
+            vars anymore — the delay is a parameter of the same effect,
+            threaded by wrapping the reg-fx body. We pin the delegation by
+            driving the immediate path through a stub late-bind router and
+            asserting the canned body fired the reply walk (a dispatch
+            through `:router/dispatch!`)."
     (let [dispatched (atom [])
           ;; Save the live router hook and RESTORE it in finally — never
           ;; null it. Nulling `:router/dispatch!` is global state that
@@ -76,14 +77,14 @@
                          (fn [ev opts] (swap! dispatched conj [ev opts])))
       (try
         ;; Immediate path — no :after-ms. The wrapper must delegate to the
-        ;; machine-wrapper body, which calls dispatch-reply-via-late-bind!.
+        ;; canned handler body, which calls dispatch-reply-via-late-bind!.
         ((registrar/handler :fx :rf.http/managed-canned-success)
          {:frame :rf/default :event [:t/load]}
          {:value {:ok true}})
         (is (= 1 (count @dispatched))
-            "immediate canned-success delegated to the machine-wrapper body (one reply dispatch)")
+            "immediate canned-success delegated to the canned handler body (one reply dispatch)")
         (is (= :success (-> @dispatched first first (nth 1) :rf/reply :kind))
-            "the synthesised reply is the machine-wrapper's success envelope")
+            "the synthesised reply is the canned handler's success envelope")
         (finally
           (late-bind/set-fn! :router/dispatch! original))))))
 

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -344,7 +344,7 @@
   legitimately stays nil on JVM (the JDK exposes no elapsed value)."
     (let [classify re-frame.http-transport-jvm/classify-jvm-error
           t   (java.net.http.HttpTimeoutException. "request timed out")
-          out (classify t 5000)]
+          out (classify t 5000 nil)]
       (is (= :rf.http/timeout (:kind out)))
       (is (= 5000 (:limit-ms out)) ":limit-ms is threaded from the configured timeout-ms")
       (is (nil? (:elapsed-ms out)) ":elapsed-ms stays nil on JVM"))))
@@ -358,13 +358,13 @@
 (deftest classify-jvm-error-uses-instance-checks-only
   (testing "rf2-q3ts4 — HttpTimeoutException → :rf.http/timeout (instance match)"
     (let [t (java.net.http.HttpTimeoutException. "request timed out after 30s")
-          out (classify-jvm-error t)]
+          out (classify-jvm-error t nil nil)]
       (is (= :rf.http/timeout (:kind out)))
       (is (string? (:message out)))))
 
   (testing "rf2-q3ts4 — CancellationException → :rf.http/aborted (instance match)"
     (let [t (java.util.concurrent.CancellationException. "cancelled")
-          out (classify-jvm-error t)]
+          out (classify-jvm-error t nil nil)]
       (is (= :rf.http/aborted (:kind out)))
       (is (= :user (:reason out)))))
 
@@ -377,8 +377,8 @@
           (java.io.IOException. "upstream service reported: gateway timed out at edge")
           abort-substring-trap
           (java.lang.RuntimeException. "user clicked abort on 3rd-party retry-wrapper")
-          out-1 (classify-jvm-error timed-out-substring-trap)
-          out-2 (classify-jvm-error abort-substring-trap)]
+          out-1 (classify-jvm-error timed-out-substring-trap nil nil)
+          out-2 (classify-jvm-error abort-substring-trap nil nil)]
       (is (= :rf.http/transport (:kind out-1))
           "an IOException whose message says \"timed out\" is NOT a JDK timeout — stays at :rf.http/transport")
       (is (= :rf.http/transport (:kind out-2))
@@ -389,7 +389,7 @@
   (testing "rf2-q3ts4 — wrapped causes still resolve through (.getCause t)"
     (let [inner (java.net.http.HttpTimeoutException. "inner timeout")
           outer (java.util.concurrent.CompletionException. inner)
-          out (classify-jvm-error outer)]
+          out (classify-jvm-error outer nil nil)]
       (is (= :rf.http/timeout (:kind out))
           "the JDK HttpClient wraps in CompletionException; classify- still resolves the underlying HttpTimeoutException via (.getCause t)"))))
 

--- a/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
@@ -42,13 +42,13 @@
   The decoration seam IS the production `:rf.http/managed` per-frame
   interceptor chain (`re-frame.http-middleware`). To exercise it without a
   live fetch we override `:rf.http/managed` with a stub that runs the REAL
-  request-side chain (`http-machine-wrapper/run-request-chain`) — so the
+  request-side chain (`http-test-support/run-request-chain`) — so the
   registered interceptors genuinely fire on the request the resource /
   mutation runtime lowered — captures the post-`:before` decorated request,
   and exposes the runtime-owned reply addressing so the test can replay the
   internal reply (the genuine 3-element transport-append shape) and watch
   the entry / instance settle. This is the same `run-request-chain` the
-  production canned-stub path and the real Fetch/HttpClient transport walk."
+  canned-stub path and the real Fetch/HttpClient transport walk."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
@@ -63,7 +63,10 @@
    ;; transport feature probe (`:http/abort-on-actor-destroy`) the resource
    ;; lowering consults AND registers the per-frame interceptor chain.
    [re-frame.http-managed :as http-managed]
-   [re-frame.http-machine-wrapper :as http-wrapper]
+   ;; the request-side chain walker `run-request-chain` is HTTP test
+   ;; scaffolding (rf2-w59es5) — it lives in http-test-support alongside the
+   ;; canned-stub fxs, not the production machine-wrapper.
+   [re-frame.http-test-support :as http-test-support]
    [re-frame.schemas]
    [re-frame.test-support :as core-test-support]
    [re-frame.trace.tooling :as trace-tooling]
@@ -95,7 +98,7 @@
   (http-managed/clear-all-http-interceptors!)
   (rf/reg-fx :rf.http/managed
              (fn [frame-ctx args]
-               (let [ctx (http-wrapper/run-request-chain frame-ctx args)]
+               (let [ctx (http-test-support/run-request-chain frame-ctx args)]
                  (reset! last-decorated
                          {:request    (:request ctx)
                           :on-success (:on-success args)


### PR DESCRIPTION
Implements **rf2-w59es5** ([vestigial][implementation/http] Cull HTTP compat and test-stub layers). Verified each of the three findings before acting; one is rejected with premise reasoning.

## Finding 2 — canned-stub bodies in production-loaded `http-machine-wrapper` (VALID, fixed)

The canned-stub handler bodies (`run-request-chain`, `dispatch-canned-reply!`, `emit-canned-success!`/`-failure!`, `canned-success-handler`/`-failure-handler`) lived in `http-machine-wrapper.cljc`, which production `http-managed` loads for machine registration. They are test scaffolding. Moved them into `http-test-support.cljc` alongside the canned-stub fx registrations and the `with-managed-request-stubs*` helper that composes against them. `http-machine-wrapper` now carries **only** the production machine-shape wrapper spec (`http-managed-machine-spec` / `register-managed-machine!`).

Updated the two code consumers: `http-test-support`'s own `stub-handler` (now calls the local fns) and `resources_request_decoration_cljs_test.cljc` (repointed its require + `run-request-chain` call to `http-test-support`). Refreshed the stale pointer comments in `http-encoding`, `http-handlers`, `http-middleware`, `http-transport`, `http-managed`, and the `http-test-support` smoke test narration.

Acceptance met: production-loaded HTTP source no longer contains canned-stub handler bodies or `managed-canned-*` implementation outside test-support.

## Finding 3 — `classify-jvm-error` legacy arities (VALID, fixed)

`classify-jvm-error` had 1- and 2-arity fallbacks that forwarded to the 3-arity with nils, existing only for synthetic/test callers (production `run-attempt!` always calls 3-arity with measured elapsed time). Collapsed to a single 3-arity; updated `http_transport_security_test.clj` and `http_jvm_binary_decode_test.clj` to call 3-arity with explicit `nil` where no value is in scope.

Acceptance met: no `classify-jvm-error` calls with fewer than 3 args remain.

## Finding 1 — `reply->public-payload` / `:rf.http/compat-reply` (REJECTED, premise wrong)

The bead frames `{:kind :success :value v}` / `{:kind :failure :failure f}` as an "older" payload kept as back-compat sugar. It is **not** vestigial. Per `spec/014-HTTPRequests.md` (§Reply payload shape, §Lowering onto the uniform reply envelope), that `{:kind ...}` payload is the **current, normative public reply contract** — the spec explicitly states "The `{:kind …}` payload above is the public shape, and it is unchanged." Every app `:on-success`/`:on-failure` handler and the co-located `(:rf/reply msg)` merge depend on it, and the **resources/mutations families consume it as their `http-result`** (`re-frame.resources.reply` re-lifts the public payload into the canonical reply map). Removing `reply->public-payload` would break the app-facing contract and cascade across the resources consumer.

The bead's own acceptance carves the exception: "*unless re-justified as current spec*" — it **is** the current spec. Left untouched. (Note: there is also no registered `:rf.http/compat-reply` event — the name is a conceptual label for the inline projection in `http-transport`; the reshape is the current public projection, not compat for an older shape.)

## Quality gates

- **http JVM** (`clojure -M:test`): 423 tests / 1942 assertions, **0 failures, 0 errors**
- **resources JVM** (`clojure -M:test`, managed-HTTP consumer): 403 tests / 1587 assertions, **0 failures, 0 errors**
- **CLJS node** (`npm run test:cljs`): 7073 tests / 29103 assertions, **0 failures, 0 errors**

Rebased on `rak684` (`:http/abort-in-flight!`); nothing it added was removed.