### PR TITLE
fix(testbed-support): root-path join + coverage (rf2-fzgcii)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -25,6 +25,7 @@
     "dev": "node scripts/dev-testbed.cjs",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",
+    "test:testbed-support": "shadow-cljs compile node-test-testbed-support && node out/node-test-testbed-support.js",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
     "test:browser-schemas-boundary-prod": "shadow-cljs release browser-test-schemas-boundary-prod && node scripts/serve-and-run-schemas-boundary-prod-tests.cjs",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -542,6 +542,37 @@
    :compiler-options {:warnings      {:redef false}
                       :infer-externs false}}
 
+  ;; rf2-fzgcii — FOCUSED node-test build for the tools/testbed-support slice.
+  ;;
+  ;; tools/testbed-support is a tiny but cross-platform-load-bearing helper
+  ;; library (the open-in-editor project-root resolver + the live-app ↔
+  ;; Story-shell hash host). It has no `deps.edn` (it is consumed purely as
+  ;; an extra source path), so its only executable home was the full
+  ;; consolidated `npm run test:cljs` build — which compiles + runs the whole
+  ;; ~3500-test node suite and, in a fresh worker worktree, may not even start
+  ;; without a local shadow-cljs binary. That made this small slice expensive
+  ;; to verify in worktrees and in targeted CI (the bead's finding #3).
+  ;;
+  ;; This build runs ONLY the testbed-support node-runnable suites, matched by
+  ;; the `^re-frame\.testbed\..+-cljs-test$` ns-regexp (the slice's test
+  ;; namespaces all live under the `re-frame.testbed.` prefix — nothing else
+  ;; in the repo does). Wired as `npm run test:testbed-support`
+  ;; (implementation/package.json) so workers have a named, cheap focused
+  ;; gate. The DOM-tagged handoff suite (`story-host-dom-cljs-test`) ALSO
+  ;; matches the broader `:browser-test` `-dom-cljs-test$` regex for its real
+  ;; React-root handoff assertions; under this node build its body gates on
+  ;; `(browser?)` and no-ops cleanly. The same namespaces additionally ride
+  ;; the always-on `:node-test` gate (`cljs-test$` matches), so the slice is
+  ;; covered on every PR whether or not this focused build is invoked — this
+  ;; is the *named* convenience surface, not an additional required gate.
+  :node-test-testbed-support
+  {:target    :node-test
+   :output-to "out/node-test-testbed-support.js"
+   :ns-regexp "^re-frame\\.testbed\\..+-cljs-test$"
+   :main      re-frame.test-quiet.shadow-node/main
+   :compiler-options {:warnings      {:redef false}
+                      :infer-externs false}}
+
   ;; rf2-2hrj8 — `:browser-test` is narrowed to DOM-dependent tests only.
   ;; The ns-regexp `-dom-cljs-test$` matches files whose namespace ends in
   ;; `-dom-cljs-test` (i.e. files named `*_dom_cljs_test.cljs`). The

--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -115,15 +115,46 @@ suites (see below). Bundle-isolation holds: nothing under
 
 ## How to test
 
-Both `config_cljs_test.cljs` (the resolver) and `story_host_cljs_test.cljs`
-(the host harness's listener lifecycle / hot-reload behaviour) run as part
-of the always-on CLJS gate: `npm run test:cljs` from `implementation/`
-compiles the `:node-test` build, whose `:ns-regexp "cljs-test$"` discovers
-both namespaces through this slice's wired `../tools/testbed-support/test`
-source path. There is no standalone test alias for this directory (no
-`deps.edn`); the suites live under a dedicated `test/` root — the same
-src/test split every other tool/artefact uses — and the wired test source
-path picks them up.
+Three suites under `test/`:
+
+- `config_cljs_test.cljs` — the resolver: param parsing, cross-platform
+  path joining (Windows / POSIX, including the lone-`/` filesystem-root
+  edge — rf2-fzgcii), and the build-time-vs-`?project-root=` tier
+  precedence.
+- `story_host_cljs_test.cljs` — the host harness's `hashchange`-listener
+  lifecycle / hot-reload idempotence and the project-root config contract,
+  with the mount switch stubbed to count-only no-ops (listener-identity
+  focus, runs under `:node-test`).
+- `story_host_dom_cljs_test.cljs` — a **browser-level** handoff test
+  (rf2-fzgcii) that drives the host through `#/` → `#/stories` → `#/`
+  (plus a hot-reload re-run) on a real `#app` node with **real React
+  roots**, asserting the live ↔ shell root handoff leaks no root and emits
+  no `createRoot`-reuse warning. ns ends in `-dom-cljs-test`, so the
+  `:browser-test` build runs the real-DOM assertions; under `:node-test`
+  its body gates on `(browser?)` and no-ops.
+
+### The always-on gate
+
+`npm run test:cljs` from `implementation/` compiles the `:node-test` build,
+whose `:ns-regexp "cljs-test$"` discovers all three namespaces through this
+slice's wired `../tools/testbed-support/test` source path; `npm run
+test:browser` runs the DOM suite's real-React assertions. The slice rides
+both on every PR.
+
+### The focused gate (rf2-fzgcii)
+
+There is no `deps.edn` here (the library is consumed purely as a source
+path), but workers no longer need the full ~3500-test consolidated build to
+verify this slice. `npm run test:testbed-support` from `implementation/`
+compiles a dedicated `:node-test-testbed-support` build whose
+`:ns-regexp "^re-frame\.testbed\..+-cljs-test$"` matches ONLY the
+`re-frame.testbed.*` test namespaces, then runs it on Node — a cheap,
+named, slice-scoped gate. (It still needs the shared shadow-cljs binary
+`npm install` provides; it does not depend on the rest of the node suite
+compiling.) The DOM suite's real-React-root assertions still require the
+`:browser-test` runner — the focused node build exercises only the
+node-runnable bodies. The suites live under a dedicated `test/` root — the
+same src/test split every other tool/artefact uses.
 
 ## See also
 

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -152,7 +152,18 @@
   trailing slash stripped (so `/repo/` + `sub` never yields `/repo//sub`);
   `subdir` is trimmed and any leading slash(es) removed (so callers may
   pass it with or without a leading slash). A blank / nil / slash-only
-  `subdir` collapses to the normalised root verbatim."
+  `subdir` collapses to the normalised root verbatim.
+
+  The one root that survives normalisation WITH a trailing slash is the
+  lone POSIX filesystem root `\"/\"`: `strip-trailing-slash` preserves it
+  (a lone separator is meaningful — destroying it would make the root a
+  blank relative path), so it is the only case where `normalized-root`
+  ends in `/`. We therefore add the boundary separator only when the
+  root does not already supply one, so `\"/\"` + `\"tools/xray/testbeds\"`
+  yields `/tools/xray/testbeds` (exactly one separator) rather than the
+  `//tools/xray/testbeds` the unconditional `(str root \"/\" subdir)`
+  produced — honouring the single-separator contract for every root,
+  POSIX filesystem-root included (rf2-fzgcii)."
   [root subdir]
   (let [normalized-root   (-> root str/trim to-forward-slashes strip-trailing-slash)
         normalized-subdir (-> (or subdir "")
@@ -160,7 +171,12 @@
                               to-forward-slashes
                               (str/replace #"^/+" ""))]
     (if (seq normalized-subdir)
-      (str normalized-root "/" normalized-subdir)
+      ;; Add the boundary "/" only when the root does not already end in
+      ;; one — the lone-"/" filesystem root is the sole normalised root
+      ;; that keeps a trailing slash, so this is what stops `//tools/...`.
+      (if (str/ends-with? normalized-root "/")
+        (str normalized-root normalized-subdir)
+        (str normalized-root "/" normalized-subdir))
       normalized-root)))
 
 (defn resolve-project-root

--- a/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/config_cljs_test.cljs
@@ -70,6 +70,24 @@
             [clojure.string :as str]
             [re-frame.testbed.config :as config]))
 
+;; ---- shared test helper: composed-editor-path --------------------------
+;;
+;; The whole point of the resolved root is that the open-in-editor resolver
+;; prepends it to a CLASSPATH-RELATIVE source coord (the form-meta `:file`
+;; slot, e.g. `standard_epochs/core.cljs`). The downstream prepend is
+;; `(str root "/" file)`; this helper reproduces that single join so the
+;; slice's unit suite can pin the end-to-end composed path (no `//`, the
+;; tool source-root segment present) without reaching into the Xray
+;; editor-uri resolver. Defined here at the top so every composition test
+;; below — the rf2-w4yw9q override form, the rf2-d01s6s Windows form, and
+;; the rf2-fzgcii lone-`"/"`-root edge — can use it.
+
+(defn- composed-editor-path
+  "Mirror the open-in-editor prepend: resolved-root + \"/\" + the
+  classpath-relative source-coord `:file`."
+  [root file]
+  (str root "/" file))
+
 ;; ---- private helper: non-blank -----------------------------------------
 
 (deftest non-blank-only-passes-real-strings
@@ -211,6 +229,80 @@
             `non-blank` gate on the root"
     (with-redefs [config/repo-root "   "]
       (is (nil? (config/resolve-project-root "tools/xray/testbeds"))))))
+
+;; ---- resolve-project-root: the lone POSIX filesystem root "/" (rf2-fzgcii)
+;;
+;; `strip-trailing-slash` DELIBERATELY preserves a lone `"/"` (the count > 1
+;; guard) so a Unix filesystem root is not destroyed into a blank relative
+;; path. That is the one normalised root that still ends in a separator — so
+;; the join must NOT then prepend a SECOND `/`. The pre-fix
+;; `(str normalized-root "/" subdir)` unconditionally did, yielding
+;; `//tools/xray/testbeds` for `root = "/"`, breaking the docstring's
+;; single-separator promise. These tests pin the edge through the FULL
+;; `resolve-project-root` surface for BOTH root tiers (build-time define and
+;; `?project-root=` override), and confirm the blank/slash-only-subdir
+;; collapse still returns the lone root verbatim.
+
+(deftest resolve-project-root-lone-root-slash-build-time-tier
+  (testing "rf2-fzgcii: a build-time `repo-root` of the lone POSIX
+            filesystem root `\"/\"` joins a nonblank subdir with EXACTLY
+            ONE separator — `/tools/xray/testbeds`, not the pre-fix
+            `//tools/xray/testbeds`"
+    (with-redefs [config/repo-root "/"]
+      (let [resolved (config/resolve-project-root "tools/xray/testbeds")]
+        (is (= "/tools/xray/testbeds" resolved)
+            "lone-root + subdir → single leading separator")
+        (is (not (str/includes? resolved "//"))
+            "no // boundary duplication"))
+      (is (= "/tools/story/testbeds"
+             (config/resolve-project-root "tools/story/testbeds"))
+          "the other tool subdir joins the same single-separator way")
+      (is (= "/tools/xray/testbeds"
+             (config/resolve-project-root "/tools/xray/testbeds"))
+          "a leading slash on the subdir is still normalised away (no ///)"))))
+
+(deftest resolve-project-root-lone-root-slash-override-tier
+  (testing "rf2-fzgcii: the SAME lone-root edge through the
+            `?project-root=` override tier — both tiers share one join, so
+            an override of `\"/\"` must also yield a single-separator path"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root") "/"))
+                  config/repo-root ""]
+      (let [resolved (config/resolve-project-root "tools/xray/testbeds")]
+        (is (= "/tools/xray/testbeds" resolved)
+            "override lone-root + subdir → single leading separator")
+        (is (not (str/includes? resolved "//"))
+            "no // boundary duplication via the override tier")))))
+
+(deftest resolve-project-root-lone-root-slash-blank-subdir-yields-root
+  (testing "rf2-fzgcii: with the lone `\"/\"` root a blank / nil / slash-only
+            subdir still collapses to the lone root verbatim (the
+            graceful-no-subdir contract is unaffected by the join fix)"
+    (with-redefs [config/repo-root "/"]
+      (is (= "/" (config/resolve-project-root ""))
+          "blank subdir → lone root preserved")
+      (is (= "/" (config/resolve-project-root nil))
+          "nil subdir → lone root preserved")
+      (is (= "/" (config/resolve-project-root "   "))
+          "whitespace subdir → lone root preserved")
+      (is (= "/" (config/resolve-project-root "/"))
+          "slash-only subdir normalises to empty → lone root preserved"))))
+
+(deftest resolve-project-root-lone-root-composes-to-intended-on-disk-file
+  (testing "rf2-fzgcii: the lone-root case composes with a representative
+            classpath-relative source coord to a clean on-disk path —
+            `/tools/xray/testbeds/standard_epochs/core.cljs`, the tool
+            source-root segment present and no `//` anywhere (the exact
+            downstream prepend the open-in-editor resolver performs)"
+    (with-redefs [config/repo-root "/"]
+      (let [root     (config/resolve-project-root "tools/xray/testbeds")
+            composed (composed-editor-path root "standard_epochs/core.cljs")]
+        (is (= "/tools/xray/testbeds/standard_epochs/core.cljs" composed)
+            "the composed editor path reaches the real on-disk source file")
+        (is (str/includes? composed "/tools/xray/testbeds/")
+            "the tool source-root segment is present (not missing)")
+        (is (not (str/includes? composed "//"))
+            "no // boundary duplication in the composed path")))))
 
 ;; ---- query-param-from-search: the pure override parser (tier 1) --------
 ;;
@@ -367,13 +459,8 @@
 ;; override exists to provide. (The downstream prepend is `(str root "/"
 ;; file)`; we reproduce that single join here so the slice's unit suite
 ;; pins the end-to-end contract without reaching into the Xray editor-uri
-;; resolver.)
-
-(defn- composed-editor-path
-  "Mirror the open-in-editor prepend: resolved-root + \"/\" + the
-  classpath-relative source-coord `:file`."
-  [root file]
-  (str root "/" file))
+;; resolver. (`composed-editor-path` itself is defined near the top of this
+;; file so the lone-root and Windows composition tests can use it too.)
 
 (deftest documented-override-composes-to-intended-on-disk-file
   (testing "rf2-w4yw9q: pasting a CHECKOUT root into `?project-root=` (the

--- a/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
@@ -1,0 +1,263 @@
+(ns re-frame.testbed.story-host-dom-cljs-test
+  "Browser-level handoff test for `re-frame.testbed.story-host` (rf2-fzgcii).
+
+  ## Why this exists (the gap the node suite cannot close)
+
+  The sibling node suite (`story_host_cljs_test.cljs`) pins the
+  `hashchange`-listener lifecycle — exactly one active listener across
+  hot-reload re-`run`s — but it does so with `mount-app!` / `mount-stories!`
+  redefined to count-only NO-OPS and a fake `js/window`. That is the right
+  shape for proving listener identity, but by stubbing the mount switch it
+  CANNOT catch a regression in the real React-DOM-root choreography the host
+  performs on the live `#app` node:
+
+    - `mount-app!`     → `story/unmount-shell!` then `ensure-app-root!`
+                         (`rdc/create-root`) then `rdc/render` the live view.
+    - `mount-stories!` → `tear-down-app-root!` (`rdc/unmount` the live root)
+                         then `story/mount-shell!` (a fresh `rdc/create-root`
+                         on the SAME node).
+
+  The load-bearing invariant is that whichever surface currently owns the
+  `#app` node MUST release its React root before the other surface calls
+  `rdc/create-root` on that same node — otherwise React 19 emits the
+  \"You are calling ReactDOMClient.createRoot() on a container that has
+  already been passed to createRoot() before\" warning, and roots leak.
+  rf2-fq1yg was exactly that class of bug (passing the DOM node, not the
+  root handle, to `unmount` — a silent no-op that left the shell root alive).
+  Only a test that drives the REAL handoff on a REAL node can lock it out.
+
+  ## What this test does
+
+  It mounts on a real `#app` div and drives the REAL `on-hash-change!`
+  listener through the full `#/` -> `#/stories` -> `#/` cycle, plus a
+  hot-reload-style re-`run`, asserting:
+
+    1. exactly one `hashchange` listener is ever active (across the re-run);
+    2. the surfaces hand off the `#app` node cleanly — the live view's text
+       and the (stand-in) shell's text alternate correctly, proving each
+       side's root was torn down before the other created one;
+    3. React emits NO createRoot-reuse / handoff warning across the whole
+       cycle (captured off `console.error` / `console.warn`).
+
+  ## Why the shell side is a REAL minimal root, not the full Story shell
+
+  We redefine `story/mount-shell!` / `story/unmount-shell!` to perform the
+  GENUINE React-root lifecycle (`rdc/create-root` + `rdc/render` +
+  `rdc/unmount`) on the passed node, rendering a tiny marker view rather
+  than the full Story shell tree (sidebar + embedded Xray inspector +
+  recorder + command palette …). That keeps the slice test free of the
+  heavyweight Story+Xray render surface and its registry/app-state
+  preconditions, while still exercising the EXACT root-handoff contract the
+  bead names — the host's `tear-down-app-root!` must release the live root
+  before this real `create-root` runs on the same node, or React warns.
+  This is a non-stubbed handoff (real roots, real unmount), not the
+  count-only no-op the node suite uses.
+
+  ns ends in `-dom-cljs-test` so shadow's `:browser-test` discovers it; the
+  `:node-test` runner also loads it, where the body gates on `(browser?)`
+  and no-ops cleanly (no DOM)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.story :as story]
+            [re-frame.testbed.story-host :as host]))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the real `#app` node ------------------------------------------------
+;;
+;; `story_host` reads the node via `(js/document.getElementById "app")`, so
+;; the test must install a real element with that id on the live document.
+
+(defn- ensure-app-node! []
+  (when (browser?)
+    (or (js/document.getElementById "app")
+        (let [el (.createElement js/document "div")]
+          (set! (.-id el) "app")
+          (.appendChild js/document.body el)
+          el))))
+
+(defn- remove-app-node! []
+  (when-let [el (and (browser?) (js/document.getElementById "app"))]
+    (.remove el)))
+
+;; ---- a real-but-minimal Story-shell stand-in -----------------------------
+;;
+;; A holder for the shell's own React root so our `mount-shell!` /
+;; `unmount-shell!` stand-ins perform the genuine create-root / unmount
+;; lifecycle on the `#app` node — the real handoff the host must coordinate.
+(defonce ^:private shell-root* (atom nil))
+
+(defn- shell-mount! [node]
+  ;; Mirror the real `story/mount-shell!` contract: tear down any prior
+  ;; shell root, then create + render a fresh root on the node.
+  (when-let [prev @shell-root*]
+    (try (rdc/unmount prev) (catch :default _ nil)))
+  (let [root (rdc/create-root node)]
+    (rdc/render root [:div {:id "shell-marker"} "STORIES"])
+    (reset! shell-root* root)
+    {:root root :node node}))
+
+;; Mirror the real `story/unmount-shell!` arities ([] / [handle]) so the
+;; `(story/unmount-shell!)` arity-0 call site inside `mount-app!` resolves
+;; against the redefinition (a variadic-only stand-in does not expose the
+;; arity-0 invoke slot the compiled call site dispatches through).
+(defn- shell-unmount!
+  ([] (shell-unmount! nil))
+  ([_handle]
+   (when-let [root @shell-root*]
+     (try (rdc/unmount root) (catch :default _ nil))
+     (reset! shell-root* nil)
+     nil)))
+
+;; ---- console capture (createRoot-reuse warnings land on error/warn) ------
+
+(defn- with-captured-console [thunk]
+  (let [calls         (atom [])
+        orig-error    (.-error js/console)
+        orig-warn     (.-warn js/console)
+        record        (fn [& args] (swap! calls conj (apply str args)))]
+    (try
+      (set! (.-error js/console) record)
+      (set! (.-warn js/console) record)
+      (thunk)
+      @calls
+      (finally
+        (set! (.-error js/console) orig-error)
+        (set! (.-warn js/console) orig-warn)))))
+
+(defn- handoff-warning? [msg]
+  (let [m (str/lower-case msg)]
+    (or (str/includes? m "createroot")
+        (str/includes? m "already been passed")
+        (str/includes? m "already mounted"))))
+
+;; ---- reset the host's defonce handles between tests ----------------------
+
+(defn- reset-host-handles! []
+  (reset! @#'host/hash-listener* nil)
+  (reset! @#'host/root-view* nil)
+  (reset! @#'host/app-root nil))
+
+(use-fixtures :each
+  {:before (fn []
+             (reset-host-handles!)
+             (reset! shell-root* nil))
+   :after  (fn []
+             ;; Tear down anything still mounted so a leaked root never
+             ;; bleeds into another namespace's tests. Unmount the held
+             ;; roots directly (do NOT re-enter `mount-app!`, which would
+             ;; call the REAL `story/unmount-shell!` outside the test's
+             ;; `with-redefs` and create a root on a possibly-removed node).
+             (when-let [r @@#'host/app-root]
+               (try (rdc/unmount r) (catch :default _ nil)))
+             (when-let [r @shell-root*]
+               (try (rdc/unmount r) (catch :default _ nil)))
+             (reset-host-handles!)
+             (reset! shell-root* nil)
+             (remove-app-node!))})
+
+;; ---- a trivial live-app root view ----------------------------------------
+
+(defn- live-view [] [:div {:id "live-marker"} "LIVE"])
+
+(defn- set-hash! [h]
+  (set! (.. js/window -location -hash) h))
+
+(defn- marker-text [id]
+  (when-let [el (js/document.getElementById id)]
+    (.-textContent el)))
+
+;; ---------------------------------------------------------------------------
+;; The handoff test
+;; ---------------------------------------------------------------------------
+
+(deftest live-stories-live-handoff-no-listener-or-root-leak
+  (testing "rf2-fzgcii: driving the REAL host through #/ -> #/stories -> #/
+            (plus a hot-reload re-run) hands the #app node off between the
+            live view and the (real-root) Story shell with NO duplicate
+            hashchange listener, NO leaked React root, and NO createRoot
+            handoff warning"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [app-node (ensure-app-node!)
+            warnings
+            (with-captured-console
+              (fn []
+                (with-redefs [story/mount-shell!   shell-mount!
+                              story/unmount-shell! shell-unmount!]
+                  ;; Start on the live app (#/). mount-with-hash-routing!
+                  ;; installs the listener and renders the current hash's
+                  ;; surface.
+                  (set-hash! "#/")
+                  (react-dom/flushSync
+                   (fn [] (host/mount-with-hash-routing! live-view)))
+                  ;; -> #/stories : tear down the live root, mount the shell
+                  ;; root on the SAME node.
+                  (set-hash! "#/stories")
+                  (react-dom/flushSync (fn [] (#'host/on-hash-change!)))
+                  ;; -> #/ : tear down the shell, re-create the live root on
+                  ;; the same node.
+                  (set-hash! "#/")
+                  (react-dom/flushSync (fn [] (#'host/on-hash-change!)))
+                  ;; Hot-reload re-run: a fresh `run` re-installs the
+                  ;; listener (must REMOVE the prior one, not stack) and
+                  ;; re-renders the current surface on the same node.
+                  (react-dom/flushSync
+                   (fn [] (host/mount-with-hash-routing! live-view)))
+                  ;; One more #/stories -> #/ cycle AFTER the re-run, to
+                  ;; prove the post-reload listener still drives a clean
+                  ;; handoff.
+                  (set-hash! "#/stories")
+                  (react-dom/flushSync (fn [] (#'host/on-hash-change!)))
+                  (set-hash! "#/")
+                  (react-dom/flushSync (fn [] (#'host/on-hash-change!))))))]
+        ;; -- exactly one active listener (no stacking across the re-run) --
+        ;; The host stores the single installed handle; a stacked duplicate
+        ;; would mean a different handle was added without removing the old.
+        (is (some? @@#'host/hash-listener*)
+            "the single installed hashchange handle is recorded")
+        ;; -- the node ends on the LIVE surface, cleanly handed back --------
+        (is (= "LIVE" (marker-text "live-marker"))
+            "after the final #/ the live view owns #app")
+        (is (nil? (marker-text "shell-marker"))
+            "the Story-shell marker is gone — its root was torn down on handoff")
+        (is (nil? @shell-root*)
+            "the shell root handle was released (no leaked shell root)")
+        (is (= app-node (js/document.getElementById "app"))
+            "the same #app node was reused throughout (one node, one owner)")
+        ;; -- NO React createRoot-reuse / handoff warning -------------------
+        (let [bad (filterv handoff-warning? warnings)]
+          (is (empty? bad)
+              (str "no createRoot-reuse / handoff warning across the full "
+                   "#/ <-> #/stories cycle and re-run; saw: " (pr-str bad))))))))
+
+(deftest hot-reload-rerun-does-not-stack-listener-on-real-node
+  (testing "rf2-fzgcii: a hot-reload re-run where on-hash-change! is rebound
+            to a fresh fn (the CLJS recompile churn) still leaves the stored
+            listener handle advanced to the NEW fn — the remove-then-add
+            discipline holds on a real node, not just the fake-window node
+            suite"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (do
+        (ensure-app-node!)
+        (with-redefs [story/mount-shell!   shell-mount!
+                      story/unmount-shell! shell-unmount!]
+          (set-hash! "#/")
+          (react-dom/flushSync
+           (fn [] (host/mount-with-hash-routing! live-view)))
+          (let [handle-1 @@#'host/hash-listener*]
+            (is (some? handle-1) "first run records a listener handle")
+            ;; Simulate a recompile: on-hash-change! becomes a fresh fn.
+            (with-redefs [host/on-hash-change! (fn [] nil)]
+              (react-dom/flushSync
+               (fn [] (host/mount-with-hash-routing! live-view))))
+            (let [handle-2 @@#'host/hash-listener*]
+              (is (some? handle-2) "re-run records a (new) listener handle")
+              (is (not (identical? handle-1 handle-2))
+                  "the stored handle advanced to the recompiled listener fn — the
+                   prior one was removed, not stacked"))))))))


### PR DESCRIPTION
Implements **rf2-fzgcii** — fixes the `tools/testbed-support` root-path join bug and hardens coverage per the senior-review findings.

## The bug (finding 1)

`join-root+subdir` violated its documented single-separator contract when the checkout root was the lone POSIX filesystem root `"/"`. `strip-trailing-slash` deliberately preserves a lone `"/"` (a meaningful separator), but the join then unconditionally returned `(str normalized-root "/" normalized-subdir)`, so `"/"` + `"tools/xray/testbeds"` yielded `//tools/xray/testbeds`.

**Fix:** add the boundary separator only when the normalised root does not already end in one. `"/"` is the sole normalised root that keeps a trailing slash, so this is the only case the guard changes — every other root joins exactly as before. Result: `"/"` + `"tools/xray/testbeds"` → `/tools/xray/testbeds`.

## Coverage hardening (findings 1 & 2)

- **config tests:** pin the lone-`"/"` root edge through the full `resolve-project-root` surface for **both** the build-time `repo-root` tier and the `?project-root=` override tier, plus the blank/slash-only-subdir collapse and the composed editor path. Hoisted `composed-editor-path` to the top of the file so the lone-root, Windows, and override composition tests all share it. Existing Windows / POSIX path behaviour is untouched and still passes.
- **new browser-level handoff suite** (`story_host_dom_cljs_test.cljs`): closes finding 2 (the node suite stubs `mount-app!`/`mount-stories!` to no-ops and so cannot catch real React-root handoff regressions). Drives the **real** host through `#/` → `#/stories` → `#/` plus a hot-reload re-run on a real `#app` node with **real React roots** (genuine `create-root`/`render`/`unmount`), asserting: exactly one `hashchange` listener across the re-run, a clean live ↔ shell node handoff, no leaked root, and **no `createRoot`-reuse / handoff warning** (captured off `console.error`/`console.warn`). The shell side is a real minimal React root, not the heavyweight full Story shell tree, keeping the slice test self-contained while exercising the exact root-handoff contract the bead names (the rf2-fq1yg class of bug). ns ends in `-dom-cljs-test` so `:browser-test` runs the real-DOM assertions; under `:node-test` the body gates on `(browser?)` and no-ops.

## Focused gate (finding 3)

`tools/testbed-support` has no `deps.edn`, so its only executable home was the full consolidated `npm run test:cljs` (which a fresh worktree could not even start without a local shadow-cljs binary). Added a dedicated `:node-test-testbed-support` shadow build (`:ns-regexp "^re-frame\.testbed\..+-cljs-test$"`, matching only the slice's `re-frame.testbed.*` test namespaces), wired as `npm run test:testbed-support`, modelled on the existing `:node-test-security` focused build. README updated to document it. The slice still rides the always-on `test:cljs` + `test:browser` gates on every PR; this is the named convenience surface, not an additional required gate.

## Quality gates

All run from `implementation/` in this worktree (after `npm install`):

- `npm run test:testbed-support` (new focused gate) — **46 tests, 109 assertions, 0 failures, 0 errors**.
- `npm run test:browser` (DOM handoff suite + full browser suite) — **213 tests, 663 assertions, 0 failures, 0 errors** (assertion count rose vs. baseline, confirming the new DOM browser-side assertions run and pass).
- `npm run test:cljs` (full node gate, regression check) — **7079 tests, 29118 assertions, 0 failures, 0 errors**.
- `:browser-test` compiles clean (0 warnings).

xray/machines-viz spec note: this slice does not touch `tools/xray/` or `tools/machines-viz/`, so no `tools/xray/spec/*` update applies.