### PR TITLE
fix(ssr-ring): public examples + test-path warning (rf2-09iktm)

### DIFF
--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -49,14 +49,17 @@
          day8/re-frame2-ssr {:local/root "../ssr"}}
 
  :aliases
- {:test {;; rf2-i3qc0 — `../ssr/test` is on the path so the shared
-         ;; `re-frame.ssr.test-fixture` ns (one source of truth for the
-         ;; ssr-artefact `:each` reset) is loadable here too. The
-         ;; `--dir test` flag below limits cognitect-test-runner's
-         ;; discovery to THIS artefact's `test/` dir; the ssr-test
-         ;; namespaces under `../ssr/test` are only loaded transitively
-         ;; (the fixture ns is the only `:require` target).
-         :extra-paths ["test" "../ssr/test"]
+ {:test {;; rf2-09iktm — the per-test reset is now artefact-local
+         ;; (`re-frame.ssr.ring.test-support/reset-runtime`), built on
+         ;; the published `re-frame.test-support/make-reset-runtime-
+         ;; fixture` (core/src) plus the four SSR per-request side-channel
+         ;; atom resets (reached through the existing `day8/re-frame2-ssr`
+         ;; production dep). The former `../ssr/test` source dir — which
+         ;; only hosted the shared `re-frame.ssr.test-fixture` ns — is
+         ;; removed: the Clojure CLI deprecates `:paths` external to the
+         ;; project, and nothing here reaches the sibling test tree any
+         ;; more.
+         :extra-paths ["test"]
          ;; Mirrors implementation/ssr/deps.edn :test alias — schemas /
          ;; flows / routing / machines load at ns-load time and the
          ;; reset-runtime fixture reloads them after registrar/clear-all!.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -363,8 +363,14 @@
 
     (rf/init! (requiring-resolve 'ssr-ring-app/ssr-adapter))
     (def handler
-      (ssr-ring/ssr-handler {:on-create [:rf/server-init]
-                             :root-view [:app/root]
+      (ssr-ring/ssr-handler {:on-create  [:rf/server-init]
+                             :root-view  [:app/root]
+                             ;; REQUIRED, fail-closed (rf2-gtgf9). A vector
+                             ;; is an allowlist of top-level app-db keys to
+                             ;; ship; `:rf.ssr.payload/whole-app-db` opts into
+                             ;; the whole db. Omit it and construction throws
+                             ;; `:rf.error/ssr-missing-payload-policy`.
+                             :payload    [:articles :session-user]
                              :html-shell ssr-ring-app/shell}))
     (jetty/run-jetty handler {:port 3000 :join? false})"
   [raw-opts]
@@ -422,12 +428,18 @@
 
   Example:
 
+    ;; `ssr-middleware` is CURRIED: `(ssr-middleware opts)` returns a
+    ;; Ring middleware `(handler) → wrapped-handler`. Apply it to the
+    ;; fallback handler, then compose normally. `:payload` is REQUIRED
+    ;; (fail-closed, rf2-gtgf9) — the same allowlist-or-whole-db policy
+    ;; `ssr-handler` enforces.
     (def app
       (-> default-handler
-          (ssr-ring/ssr-middleware
-            {:on-create [:rf/server-init]
-             :root-view [:app/root]
-             :match? (fn [req] (= :get (:request-method req)))})
+          ((ssr-ring/ssr-middleware
+             {:on-create [:rf/server-init]
+              :root-view [:app/root]
+              :payload   [:articles :session-user]
+              :match?    (fn [req] (= :get (:request-method req)))}))
           wrap-static-assets))"
   [{:keys [match?] :as opts}]
   (let [match? (or match? (fn default-match? [req]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -80,14 +80,13 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]
-            [re-frame.ssr.test-fixture :as tf])
+            [re-frame.ssr.ring.test-support :as ts])
   (:import [java.io InputStream IOException]
            [java.net.http HttpResponse$BodyHandlers]
            [java.util.concurrent CountDownLatch TimeUnit]
            [java.util.concurrent.atomic AtomicInteger AtomicLong]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each ts/reset-runtime)
 
 ;; ===========================================================================
 ;; Knobs

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
@@ -1,0 +1,133 @@
+(ns re-frame.ssr.ring.facade-examples-test
+  "Per rf2-09iktm — pin that the PUBLIC docstring EXAMPLES on the
+  `re-frame.ssr.ring` facade stay aligned with the runtime contract.
+
+  `facade-metadata-test` proves the facade vars carry a non-empty `:doc`
+  + `:arglists`; it does NOT look INSIDE the docstring at the example
+  code. After the fail-closed `:payload` change (rf2-gtgf9) and the
+  curried-middleware shape, the worked examples drifted: the
+  `ssr-handler` example omitted `:payload` (a copy-paste would throw
+  `:rf.error/ssr-missing-payload-policy` at construction) and the
+  `ssr-middleware` example used the wrong, uncurried `(-> handler
+  (ssr-middleware opts) ...)` shape (the public surface is
+  `(ssr-middleware opts) -> (handler -> wrapped)`). REPL `doc`, editor
+  hover, and the JVM api-manifest surface these examples, so they are
+  user-facing.
+
+  This test is the drift tripwire. It reads the live docstring, extracts
+  the worked example forms, and asserts the structural invariants a
+  copyable example must hold:
+
+    1. The `ssr-handler` example opts map carries a `:payload` policy,
+       AND that opts map actually passes `validate-construction-opts!`
+       (so the example is constructible, not merely textually present).
+    2. The `ssr-middleware` example is the CURRIED shape — the
+       `(ssr-middleware opts)` call is itself applied to the fallback
+       handler — AND its opts map carries `:payload`.
+
+  Reads from the FACADE var docstring (not the source file text) so the
+  test follows wherever the canonical doc lives."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]))
+
+(defn- example-block
+  "Return the text following the `Example:` marker in `docstring`, i.e.
+  the worked-example region of a facade fn doc."
+  [docstring]
+  (let [idx (str/index-of docstring "Example:")]
+    (when idx
+      (subs docstring (+ idx (count "Example:"))))))
+
+(defn- read-forms
+  "Read all top-level Clojure forms from `s`, ignoring trailing garbage.
+  Used to recover the example forms embedded in a docstring."
+  [s]
+  (let [rdr (java.io.PushbackReader. (java.io.StringReader. s))
+        eof (Object.)]
+    (loop [acc []]
+      (let [form (try (read rdr false eof) (catch Exception _ eof))]
+        (if (= form eof)
+          acc
+          (recur (conj acc form)))))))
+
+(defn- find-call
+  "Depth-first search `forms` for the first list whose head symbol's NAME
+  is `head-name` (namespace-insensitive, so `ssr-ring/ssr-handler` and a
+  bare `ssr-handler` both match)."
+  [head-name forms]
+  (letfn [(walk [form]
+            (cond
+              (and (seq? form)
+                   (symbol? (first form))
+                   (= head-name (name (first form))))
+              form
+
+              (coll? form)
+              (some walk (seq form))
+
+              :else nil))]
+    (some walk forms)))
+
+(deftest ssr-handler-docstring-example-includes-payload-and-constructs
+  (testing "rf2-09iktm: the ssr-handler facade example carries a :payload
+            policy and the example opts map passes
+            validate-construction-opts! (so a copy-paste is constructible,
+            not a fail-closed boot throw)"
+    (let [doc   (-> #'ssr-ring/ssr-handler meta :doc)
+          forms (read-forms (example-block doc))
+          call  (find-call "ssr-handler" forms)
+          opts  (second call)]
+      (is (some? call) "the docstring Example: shows an `ssr-handler` call")
+      (is (map? opts) "the ssr-handler example passes a literal opts map")
+      (is (contains? opts :payload)
+          (str "the ssr-handler example opts map MUST include a :payload "
+               "policy (rf2-gtgf9 fail-closed) — saw keys: "
+               (pr-str (keys opts))))
+      ;; Stronger than textual presence: the example opts map must pass
+      ;; the live construction validator (with placeholder event/view
+      ;; registered) — proving the example is actually constructible.
+      (rf/reg-event-fx :init/facade-example {:platforms #{:server}} (fn [_ _] {}))
+      (rf/reg-view* :pages/facade-example (fn [] [:div "facade example"]))
+      (is (= (assoc opts :on-create [:init/facade-example]
+                         :root-view [:pages/facade-example])
+             (lifecycle/validate-construction-opts!
+               (assoc opts :on-create [:init/facade-example]
+                           :root-view [:pages/facade-example])))
+          "the ssr-handler example opts map passes validate-construction-opts!"))))
+
+(deftest ssr-middleware-docstring-example-is-curried-and-includes-payload
+  (testing "rf2-09iktm: the ssr-middleware facade example uses the correct
+            CURRIED composition shape — `((ssr-middleware opts) handler)` —
+            and its opts map carries :payload"
+    (let [doc   (-> #'ssr-ring/ssr-middleware meta :doc)
+          block (example-block doc)
+          forms (read-forms block)
+          call  (find-call "ssr-middleware" forms)
+          opts  (second call)]
+      (is (some? call) "the docstring Example: shows an `ssr-middleware` call")
+      (is (map? opts) "the ssr-middleware example passes a literal opts map")
+      (is (contains? opts :payload)
+          (str "the ssr-middleware example opts map MUST include a :payload "
+               "policy (rf2-gtgf9 fail-closed) — saw keys: "
+               (pr-str (keys opts))))
+      ;; Curried-shape invariant: the `(ssr-middleware opts)` form must be
+      ;; APPLIED — i.e. it appears in head (callee) position of an outer
+      ;; list, `((ssr-middleware opts) <handler>)`. The pre-fix, broken
+      ;; example used `(-> handler (ssr-middleware opts) ...)`, where the
+      ;; `(ssr-middleware opts)` form is an ARGUMENT, never a callee.
+      (letfn [(applied? [form]
+                (cond
+                  (seq? form)
+                  (or (and (seq? (first form))
+                           (= call (first form)))
+                      (some applied? (seq form)))
+                  (coll? form) (some applied? (seq form))
+                  :else nil))]
+        (is (some applied? forms)
+            "the ssr-middleware example applies `(ssr-middleware opts)` to a
+             fallback handler — the curried shape `((ssr-middleware opts) h)`
+             — rather than threading it as a plain `(-> h (ssr-middleware ...))`
+             arg")))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -47,9 +47,9 @@
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.headers :as headers]
             [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.ring.test-support :as ts]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each ts/reset-runtime)
 
 ;; ===========================================================================
 ;; ssr-response->ring-response — redirect target resolution (:location only)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -83,13 +83,12 @@
             [re-frame.interop :as interop]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.streaming :as streaming]
-            [re-frame.ssr.ring.test-support :as ts]
-            [re-frame.ssr.test-fixture :as tf])
+            [re-frame.ssr.ring.test-support :as ts])
   (:import [java.io InputStream IOException OutputStream
                     PipedInputStream PipedOutputStream]
            [java.net.http HttpResponse$BodyHandlers]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each ts/reset-runtime)
 
 ;; ===========================================================================
 ;; Shared test scaffolding — handlers, view registrations, helpers

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -50,11 +50,11 @@
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.ssr.ring.test-support :as ts]
             [re-frame.trace :as trace])
   (:import [java.io InputStream OutputStream PipedInputStream PipedOutputStream]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each ts/reset-runtime)
 
 (defn- with-trace-capture
   [coll-atom body-fn]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
@@ -12,24 +12,123 @@
   reads its own knobs at the call site rather than hiding them in a copy
   edit.
 
-  This is the established local pattern: the artefact already shares
-  `re-frame.ssr.test-fixture` for the per-test reset (deps.edn
-  `:extra-paths`), and `with-jetty` etc. are pure test plumbing with no
+  This is the established local pattern: the artefact also single-sources
+  the per-test reset here (`reset-runtime`, rf2-09iktm — see the section
+  below), and `with-jetty` etc. are pure test plumbing with no
   production-path coupling — so consolidating them here removes review
   surface without introducing a new abstraction style.
 
   Independence note: requiring this ns does NOT co-load any test
-  namespace (it depends only on `ring.adapter.jetty` + JDK classes), so
-  every test ns stays independently runnable under the artefact `:test`
-  alias.
+  namespace (it depends only on production `re-frame.*` source +
+  `ring.adapter.jetty` + JDK classes), so every test ns stays
+  independently runnable under the artefact `:test` alias.
 
   Contract smoke coverage for these helpers lives in
-  `test_support_contract_test.clj` (rf2-l1qgjw)."
-  (:require [ring.adapter.jetty :as jetty])
+  `test_support_contract_test.clj` (rf2-l1qgjw).
+
+  ## Per-test reset fixture (rf2-09iktm)
+
+  `reset-runtime` is the artefact-local `:each` reset for the ssr-ring
+  JVM suite. It WAS `re-frame.ssr.test-fixture/reset-runtime`, loaded by
+  putting the sibling `../ssr/test` source dir on the test classpath —
+  which the Clojure CLI now warns is a deprecated use of a path external
+  to the project. The reset is now sourced entirely from artefacts this
+  one already depends on: the published, substrate-agnostic
+  `re-frame.test-support/make-reset-runtime-fixture` (core/src) does the
+  registrar / frames / flows / schemas / machines / routing reset and
+  installs the SSR adapter; the four SSR per-request side-channel atoms
+  (Spec 011 §Per-request frame teardown) live in `re-frame.ssr.*`
+  production namespaces (ssr/src), reachable through the existing
+  `day8/re-frame2-ssr` dep with no test-path reach. The single source of
+  truth for the COMMON reset shape stays the published core fixture; only
+  the four SSR-specific atom resets are local, fired through the fixture's
+  `:init-fn` seam (runs after adapter install, under the ambient
+  `:rf/default` scope, before each test body)."
+  (:require [ring.adapter.jetty :as jetty]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.error-listener :as error-listener]
+            [re-frame.ssr.head :as head]
+            [re-frame.ssr.request :as request]
+            [re-frame.ssr.response :as response]
+            [re-frame.test-support :as test-support])
   (:import [java.net URI]
            [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
            [java.time Duration]
            [org.eclipse.jetty.server Server]))
+
+;; ===========================================================================
+;; Per-test reset fixture (rf2-09iktm — supersedes the external
+;; `../ssr/test` path to `re-frame.ssr.test-fixture`)
+;; ===========================================================================
+
+(defn- reset-ssr-runtime!
+  "The SSR-specific reset the published core fixture does NOT cover, run
+  through the fixture's `:init-fn` seam (after adapter install + the
+  fixture's registrar/listener clears, under the ambient `:rf/default`
+  scope, before each test body). Two parts:
+
+  1. Clear the four per-request SSR side-channel atoms (Spec 011
+     §Per-request frame teardown). All four are keyed by frame-id; a stale
+     entry from a prior test would otherwise bleed process-wide. Mirrors
+     what the runtime's per-request frame teardown hook
+     (`re-frame.ssr/on-frame-destroyed!`) clears at end-of-request:
+       - `request/request-slots`               — the active HTTP request
+       - `response/response-slots`             — the HTTP response accumulator
+       - `error-listener/pending-error-traces` — per-frame error-trace buffer
+       - `head/head-snapshots`                 — per-frame head-model snapshot
+
+     These atoms ship in `re-frame.ssr.*` production source, reached
+     directly (the same atoms the private façade aliases hold) — no
+     external test path needed.
+
+  2. Reinstate the ns-load-time LISTENER + late-bind registrations the
+     SSR / routing / head / machines namespaces install at load. The
+     published fixture clears the trace-tooling + event-emit listener
+     registries each test (`trace-tooling/clear-listeners!` /
+     `event-emit/clear-event-listeners!`), which drops the always-on SSR
+     `::error-projection` error-emit listener and its dev-trace twin
+     (`re-frame.ssr` ns-load, rf2-fb598) — without them a render-/drain-
+     time throw recovers to a silent HTTP 200 instead of the fail-closed
+     5xx the SSR contract mandates. A `:reload` re-runs each ns body so
+     those listeners — and the routing late-bind hooks `reg-route`
+     resolves through (`:routing/reg-route`, Spec 012) — resurrect. This
+     is exactly what the former `re-frame.ssr.test-fixture/reset-runtime`
+     did; the only change is WHERE the registrar reset comes from (the
+     published core fixture, not a sibling-test-tree clear-all!)."
+  []
+  (reset! request/request-slots {})
+  (reset! response/response-slots {})
+  (reset! error-listener/pending-error-traces {})
+  (reset! head/head-snapshots {})
+  (require 're-frame.routing  :reload)
+  (require 're-frame.ssr      :reload)
+  (require 're-frame.ssr.head :reload)
+  (require 're-frame.machines :reload))
+
+(def ^:private reset-runtime-fixture
+  "The published, substrate-agnostic per-test reset
+  (`re-frame.test-support/make-reset-runtime-fixture`) configured for the
+  ssr-ring JVM suite: it installs the SSR substrate adapter (which also
+  ensures the ordinary `:rf/default` app frame and binds it as the body's
+  ambient scope) and resets the registrar / frames / flows / schemas /
+  machines / routing around each test. `:init-fn` layers the SSR-specific
+  side-channel resets on top, fired after adapter install and before the
+  test body under the same ambient `:rf/default` scope. Built once at
+  ns-load so the registrar baseline is pinned to THIS suite's ns-load
+  registrations (run-order independence, rf2-7hwnu)."
+  (test-support/make-reset-runtime-fixture
+    {:adapter ssr/adapter
+     :init-fn reset-ssr-runtime!}))
+
+(defn reset-runtime
+  "The canonical `:each` fixture for the ssr-ring JVM suite. Drop-in for
+  the former `re-frame.ssr.test-fixture/reset-runtime` (rf2-09iktm): same
+  `(use-fixtures :each reset-runtime)` and same callable
+  `(reset-runtime (fn [] …))` shapes. Wipes the registrar, every
+  per-frame SSR side-channel atom, and installs the SSR adapter + ensures
+  the ambient `:rf/default` frame."
+  [test-fn]
+  (reset-runtime-fixture test-fn))
 
 ;; ===========================================================================
 ;; Ephemeral Jetty host

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -84,17 +84,17 @@
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]
-            [re-frame.ssr.test-fixture :as tf])
+            [re-frame.ssr.ring.test-support :as ts])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
-;; rf2-i3qc0 — canonical reset-runtime fixture; same shape every
-;; ssr-ring JVM test uses. Each test starts from a wiped registrar +
-;; reloaded SSR / routing ns-bodies so `:rf.route/handle-url-change`,
-;; `:rf.route/navigate`, the `:rf.server/request` cofx, and the always-on
-;; error-emit-projection-listener all resurrect between tests.
-(use-fixtures :each tf/reset-runtime)
+;; rf2-i3qc0 / rf2-09iktm — canonical reset-runtime fixture; same shape
+;; every ssr-ring JVM test uses. Each test starts from a reset registrar
+;; (snapshot/restore baseline) with the SSR adapter installed, so
+;; `:rf.route/handle-url-change`, `:rf.route/navigate`, the
+;; `:rf.server/request` cofx, and the always-on error-emit-projection-
+;; listener are all live between tests.
+(use-fixtures :each ts/reset-runtime)
 
 ;; ===========================================================================
 ;; Jetty + java.net.http harness

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -84,13 +84,12 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.ring.test-support :as ts]))
 
-;; rf2-i3qc0 — canonical reset-runtime fixture; same shape as
-;; `ring_test.clj`. Each test starts from a wiped registrar + reloaded
-;; SSR ns-bodies so the per-test registrations don't bleed.
-(use-fixtures :each tf/reset-runtime)
+;; rf2-i3qc0 / rf2-09iktm — canonical reset-runtime fixture; same shape as
+;; `ring_test.clj`. Each test starts from a reset registrar with the SSR
+;; adapter installed so the per-test registrations don't bleed.
+(use-fixtures :each ts/reset-runtime)
 
 ;; The NUL byte as a one-char string. Defined once here so the wire-
 ;; scan helper below reads as obvious set membership.

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
@@ -61,10 +61,9 @@
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.ring.test-support :as ts]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each ts/reset-runtime)
 
 ;; ===========================================================================
 ;; Jetty + java.net.http harness

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -17,12 +17,12 @@
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.test-fixture :as tf])
+            [re-frame.ssr.ring.test-support :as ts])
   (:import [java.io InputStream]))
 
 (defn- reset+reg-test-handlers
   [test-fn]
-  (tf/reset-runtime
+  (ts/reset-runtime
     (fn []
       (rf/reg-event-db :rf.test/seed-articles
         (fn [_ [_ arts]] {:articles arts}))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -6,8 +6,9 @@
   Ring response, then on the frame-lifecycle side-effects (destroyed?,
   trace events).
 
-  Each test resets the runtime exactly the way the ssr artefact's
-  test fixture does (registrar/clear-all! → reload ns)."
+  Each test resets the runtime via the artefact-local
+  `re-frame.ssr.ring.test-support/reset-runtime` (registrar snapshot/
+  restore + SSR adapter install + SSR side-channel atom clears)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
@@ -15,12 +16,14 @@
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.ring.test-support :as ts]))
 
-;; rf2-i3qc0 — the canonical reset-runtime fixture lives in
-;; `re-frame.ssr.test-fixture` (loadable here via the ssr artefact's
-;; test path; see this artefact's deps.edn :test alias `:extra-paths`).
-(use-fixtures :each tf/reset-runtime)
+;; rf2-i3qc0 / rf2-09iktm — the canonical reset-runtime fixture is
+;; artefact-local in `re-frame.ssr.ring.test-support`. It wraps the
+;; published `re-frame.test-support/make-reset-runtime-fixture` and layers
+;; the four SSR per-request side-channel atom resets, so no external
+;; `../ssr/test` path is required.
+(use-fixtures :each ts/reset-runtime)
 
 ;; ===========================================================================
 ;; Cookie serialisation (RFC 6265)


### PR DESCRIPTION
Senior-review slice for `implementation/ssr-ring` (rf2-09iktm).

## What changed

### 1. Stale/broken facade docstring examples (`re-frame.ssr.ring`)
- **`ssr-handler` example** now includes an explicit `:payload` policy. The runtime is fail-closed (Spec 011 / rf2-gtgf9): a copy-paste of the old example threw `:rf.error/ssr-missing-payload-policy` at construction.
- **`ssr-middleware` example** now shows the correct **curried** composition shape `((ssr-middleware opts) handler)` and includes `:payload`. The old `(-> handler (ssr-middleware opts) ...)` placed `(ssr-middleware opts)` in argument position, which is wrong for the curried `(ssr-middleware opts) -> (handler -> wrapped)` public surface.
- These docstrings are user-facing via the `import-fn` metadata-preservation work (REPL `doc`, editor hover, JVM api-manifest).

### 2. Drift-proof regression test (`facade_examples_test.clj`, new)
Reads the **live** facade docstrings, extracts the worked example forms, and asserts:
- the `ssr-handler` example opts map carries `:payload` **and** passes `validate-construction-opts!` (constructible, not merely textually present);
- the `ssr-middleware` example carries `:payload` **and** is the applied curried shape.

Negative-control verified: reverting either example to its broken form fails the test.

### 3. Deprecated external test path
- Removed `../ssr/test` from the `:test` alias `:extra-paths` (the Clojure CLI deprecates `:paths` external to the project).
- The former `re-frame.ssr.test-fixture/reset-runtime` (which only that path provided) is replaced by an **artefact-local** `re-frame.ssr.ring.test-support/reset-runtime`, built on the published, substrate-agnostic `re-frame.test-support/make-reset-runtime-fixture` (core/src) for the registrar/frames/flows/schemas/machines/routing reset + SSR adapter install, plus (via the fixture `:init-fn` seam) the four SSR per-request side-channel atom resets and the SSR/routing/head/machines ns-load listener + late-bind reinstatement that the published fixture's clears would otherwise drop.
- All nine consumer test namespaces repointed from `tf/reset-runtime` to the local `ts/reset-runtime`.

## Quality gates
- `implementation/ssr-ring` `clojure -M:test`: **156 tests, 698 assertions, 0 failures, 0 errors**; the `WARNING: Use of :paths external to the project ... ../ssr/test` deprecation warning is **gone** (confirmed at both `-Spath` classpath-build and test-run phases).
- `implementation` `npm run test:cljs`: **7073 tests, 29103 assertions, 0 failures, 0 errors**.