### PR TITLE
docs(impl): clean stale root security/resource residue (rf2-2cqkgz)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -147,7 +147,8 @@ implementation/
     src/re_frame/resources.cljc    reg-resource / clear-resource / resource-meta /
                                    resource-state / resources, :rf.resource/* events
                                    + passive subs, :resource registrar kind, work-ledger.
-    test/re_frame/                 CLJS resources skeleton tests.
+    test/re_frame/                 CLJS surface/wiring smoke + runtime behaviour tests
+                                   (ensure/refetch, work ledger, invalidation/GC, hydration).
 
   ssr-ring/                  day8/re-frame2-ssr-ring — Ring host adapter for the SSR pipeline
                              (rf2-ny6v7).

--- a/implementation/SECURITY.md
+++ b/implementation/SECURITY.md
@@ -234,5 +234,5 @@ Every concrete CLJS-reference security call recorded as a bead, with one-line ra
 - [`../spec/010-Schemas.md`](../spec/010-Schemas.md) — schema-driven privacy declaration; boundary-validation seam.
 - [`../spec/011-SSR.md`](../spec/011-SSR.md) — response-shape fx (the CRLF-check sites); `:rf.server/safe-redirect`.
 - [`../spec/014-HTTPRequests.md`](../spec/014-HTTPRequests.md) — managed-HTTP input-validation and DoS defaults.
-- [`../spec/API.md`](../spec/API.md) — public-surface signatures (the names a user types: schema `:sensitive?` / `:large?` metadata, handler `:sensitive?` meta, `elide-wire-value`).
+- [`../spec/API.md`](../spec/API.md) — public-surface signatures (the names a user types: schema `:sensitive?` / `:large?` metadata, `elide-wire-value`). Path-based sensitivity (schema-slot `:sensitive?`) is the surviving declaration; the legacy handler-meta `:sensitive?` annotation was removed (rf2-hjs2d).
 - [`../spec/Tool-Pair.md`](../spec/Tool-Pair.md) — MCP-server direct-read wire-egress contract.

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -48,8 +48,9 @@
          day8/re-frame2-ssr-ring {:local/root "ssr-ring"}
          day8/re-frame2-epoch    {:local/root "epoch"}
          ;; rf2-p10npe — the optional Resources artefact (Spec 016,
-         ;; EP-0003 slice 2). Skeleton slice; runtime logic lands in
-         ;; later slices.
+         ;; EP-0003). Managed resource queries: reg-resource, the
+         ;; :rf.resource/* events + passive subs, work ledger,
+         ;; invalidation/GC, and hydration — runtime landed and tested.
          day8/re-frame2-resources {:local/root "resources"}}
 
  :aliases

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -2,12 +2,14 @@
 ;; rf2-k682, rf2-tfw3, rf2-5kpd, rf2-uo7v, rf2-3yij, rf2-lt4e, rf2-2qit,
 ;; rf2-ny6v7).
 ;;
-;; Pulls in every published artefact's source path (core/, reagent/,
-;; uix/, helix/, schemas/, machines/, routing/, flows/, http/, ssr/,
-;; epoch/) plus their test trees and the examples. The shadow build
-;; runs as a *consumer* of every artefact; the deps.edn at this level
-;; wires the classpath via :local/root for any clojure-tools-driven
-;; steps.
+;; Pulls in every published artefact's source path (the core, the
+;; per-substrate adapters, and the per-feature artefacts) plus their
+;; test trees, the cross-artefact conformance tiers, and the examples.
+;; The :source-paths vector below is the authoritative enumeration; the
+;; canonical artefact inventory lives in implementation/README.md. The
+;; shadow build runs as a *consumer* of every artefact; the deps.edn at
+;; this level wires the classpath via :local/root for any
+;; clojure-tools-driven steps.
 ;;
 ;; Per rf2-3yij the UIx adapter ships in implementation/adapters/uix;
 ;; its sources are added to :source-paths and com.pitch/uix.{core,dom}
@@ -18,7 +20,7 @@
 ;; :source-paths and lilactown/helix is added to :dependencies so the
 ;; per-example Helix builds resolve.
 ;;
-;; Per rf2-zha9 the three adapters live under
+;; Per rf2-zha9 the per-substrate adapters live under
 ;; implementation/adapters/<name>/ (renamed from substrates/ per
 ;; rf2-0imy); per-feature artefacts (schemas, machines, ...) stay flat
 ;; under implementation/<name>/.
@@ -104,10 +106,12 @@
                 "epoch/src"
                 "epoch/test"
                 ;; rf2-p10npe — the optional Resources artefact (Spec 016,
-                ;; EP-0003 slice 2). Source + test paths added so the
+                ;; EP-0003). Source + test paths added so the
                 ;; consolidated :node-test build picks up the resources
-                ;; ns's + any `*-cljs-test` suites under resources/test/.
-                ;; Skeleton slice; runtime logic lands in later slices.
+                ;; ns's + the `*-cljs-test` suites under resources/test/.
+                ;; The Resources runtime has landed (reg-resource, the
+                ;; :rf.resource/* events + passive subs, work ledger,
+                ;; invalidation/GC, hydration); the suites exercise it.
                 ;; Bundle-isolation holds: nothing under tools/ is
                 ;; required, and core never :requires re-frame.resources.
                 "resources/src"
@@ -1292,9 +1296,9 @@
   ;; event-driven ensure under an app lease, manual refresh as a cause, and
   ;; a machine-owned resource — all read through passive [:rf.resource/*]
   ;; subs. `resources/src` is already on :source-paths above (rf2-p10npe),
-  ;; so `resources.core` resolves without per-build deps. Skeleton slice:
-  ;; compiles + registers; the causal ensure/refetch bodies light up when
-  ;; the runtime slices land.
+  ;; so `resources.core` resolves without per-build deps. The Resources
+  ;; runtime has landed (EP-0003): the causal ensure/refetch bodies are
+  ;; real and operational.
   :examples/resources
   {:target     :browser
    :output-dir "out/examples/resources"


### PR DESCRIPTION
Cleans stale documentation/commentary at the `implementation/` root per rf2-2cqkgz (P3 vestigial). Each premise was verified against the live tree before editing.

## What changed

- **`implementation/shadow-cljs.edn` header** — dropped the "three adapters" count and the stale enumerated source-family list (which omitted reagent-slim, test-react, ssr-ring, resources, and the cross-artefact conformance tiers). Made the header generic and pointed at the `:source-paths` vector + `implementation/README.md` as the canonical inventory, so it does not re-rot as artefacts are added.
- **`implementation/shadow-cljs.edn` + `implementation/deps.edn` Resources comments** — replaced "Skeleton slice; runtime logic lands in later slices" with the current runtime/test role. Verified the runtime has landed: `resources/src/re_frame/resources.cljc` is 499 LoC and `resources/test/` carries ~27 suites (runtime, lifecycle, work ledger, invalidation/GC, mutation, hydration, SSR, classification).
- **`implementation/shadow-cljs.edn` `:examples/resources` comment** — dropped "the causal ensure/refetch bodies light up when the runtime slices land"; the example's own docstring now states the runtime has LANDED and the ensure/refetch bodies are real and operational.
- **`implementation/README.md`** — the resources test-tree line said "CLJS resources skeleton tests"; updated to reflect surface/wiring smoke + runtime behaviour tests.
- **`implementation/SECURITY.md`** — the cross-references section (line 237) still listed handler-meta `:sensitive?` as a *current* public-surface signature a user types. Removed it from the current-API wording (kept schema/path-based `:sensitive?` + `elide-wire-value`); the handler-meta annotation was removed per rf2-hjs2d, and `spec/API.md` already documents it as removed.

## Verified-not-stale (no edit)

- `SECURITY.md:87` already describes handler-meta `:sensitive?` as **removed** (accurate prose) — left as-is.
- `SECURITY.md:167` is a historical decisions-log entry recording the removal decision (rf2-hjs2d) — correct audit trail, left as-is.
- The `resources_skeleton_cljs_test.cljs` smoke suite (ns `re-frame.resources-skeleton-cljs-test`) is a current, explicitly-named surface/wiring stub; "skeleton" there is accurate (surface smoke vs. runtime behaviour), so the README wording keeps both senses.
- Remaining "skeleton" hits under `implementation/adapters/**/README.md` are out of this slice (other workers' surfaces) and are non-stale usages ("skeleton bead", "the skeleton, briefly").

## Acceptance (rf2-2cqkgz)

- ✅ No root implementation file describes Resources as `Skeleton slice` / `runtime logic lands later` / `skeleton tests` (the one remaining "skeleton" is the explicitly-named current smoke suite).
- ✅ SECURITY.md no longer describes handler-meta `:sensitive?` as current public/API surface.
- ✅ shadow-cljs.edn root header no longer says `three adapters` and points at the authoritative source-path families.

## Quality gates

Docs/EDN-comment-only change — no code touched, so `npm run test:cljs` is not in scope (gate rule: tests required only if code changes). EDN diffs are strictly inside `;;` comment lines (no structural change).

- `python scripts/check_readme_links.py --ci` — exit 0
- `python scripts/check_readme_inventories.py` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `clojure -M -e "(edn/read-string (slurp \"implementation/deps.edn\"))"` — parses OK
- `implementation/SECURITY.md` / `implementation/README.md` are not in the mkdocs nav, so `mkdocs build --strict` is not gated on them; README link + inventory ratchets cover them and pass.