### PR TITLE
refactor(schemas): remove stale compat (rf2-kdims9)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -82,11 +82,11 @@
 ;; Posture (rf2-l5r974 ruling, option (a) end-state — reverses the earlier
 ;; rf2-1gm0o "public-by-design fixture primitive" framing). Exposing the atoms
 ;; as Vars was an encapsulation leak that is worse than aesthetic:
-;;   1. `schemas-by-frame` is the authoritative store, so the rep could not
-;;      evolve without breaking ad-hoc consumers — already realised: rf2-naihn1
-;;      added per-frame `frame-reg-locks` companion state that
-;;      `clear-schemas-by-frame!` clears but raw `(reset! schemas-by-frame {})`
-;;      sites silently skip, leaving stale locks.
+;;   1. `schemas-by-frame` is the authoritative store, so the rep cannot
+;;      evolve without breaking ad-hoc consumers — a future companion
+;;      side-table (or a change to the map shape itself) would have to be
+;;      cleared through `clear-schemas-by-frame!`, but raw
+;;      `(reset! schemas-by-frame {})` sites would silently skip it.
 ;;   2. The public `printer-fn` atom bypassed the never-nil invariant
 ;;      `run-printer` relies on with NO read guard — `(reset! printer-fn nil)`
 ;;      NPEs the digest path; the setters exist precisely to coerce
@@ -94,8 +94,7 @@
 ;;
 ;; The supported encapsulated replacements (all below):
 ;;   - REGISTRY:  `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` /
-;;                `clear-schemas-by-frame!` (the last also drops the
-;;                `frame-reg-locks` companion).
+;;                `clear-schemas-by-frame!`.
 ;;   - BUNDLE:    `snapshot-schema-fns` / `restore-schema-fns!` (rf2-l4ljvr) +
 ;;                `set-schema-fns!` / `set-schema-{validator,explainer,printer}!`
 ;;                / `reset-schema-validator!`.

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -562,13 +562,6 @@
 ;; and the per-slot extractors still serve the machine `:data-schema` bridge
 ;; (EP-0005) — both consult the schema directly, never this registry.
 
-(defn ^:no-doc clear-frame-reg-locks!
-  "Retained as a no-op for the test fixture's `clear-schemas-by-frame!`
-  call site. The per-frame registration linearization lock it once cleared
-  was removed with the schema→elision population (EP-0015 §8, rf2-d2r3um)."
-  []
-  nil)
-
 ;; ---- app-db schema registration -------------------------------------------
 
 (defn reg-app-schema
@@ -883,12 +876,12 @@
 (defn clear-schemas-by-frame!
   "Reset the per-frame schema registry to `{}`. Used by test fixtures
   and by `make-reset-runtime-fixture`'s `:clear-app-schemas? true`
-  path (rf2-cq1ak). Calls the now-no-op `clear-frame-reg-locks!`
-  (the per-frame registration lock was removed with the schema→elision
-  population — EP-0015 §8, rf2-d2r3um)."
+  path (rf2-cq1ak). The per-frame registry is the schemas artefact's
+  only mutable registration state — there is no companion side-table to
+  clear (the registration linearization lock was removed with the
+  schema→elision population, EP-0015 §8, rf2-d2r3um)."
   []
-  (reset! schemas-by-frame {})
-  (clear-frame-reg-locks!))
+  (reset! schemas-by-frame {}))
 
 (defn on-frame-destroyed!
   "Per Spec 002 §Destroy: drop every schema registered against the

--- a/implementation/schemas/test/re_frame/schemas/test_fixture.clj
+++ b/implementation/schemas/test/re_frame/schemas/test_fixture.clj
@@ -22,9 +22,8 @@
   - `(reset! frame/frames {})`
   - `(flows/reset-flows!)`
   - `(schemas/clear-schemas-by-frame!)` — resets the per-frame
-    registry AND drops the rf2-naihn1 `frame-reg-locks` companion
-    (the raw `schemas-by-frame` atom is no longer re-exported per the
-    rf2-l5r974 encapsulated-only posture)
+    registry (the raw `schemas-by-frame` atom is no longer re-exported
+    per the rf2-l5r974 encapsulated-only posture)
   - `(schemas/reset-schema-validator!)` — restores Malli defaults
     per rf2-froe so a test that mutates the pluggable validator
     surface doesn't poison sibling tests.

--- a/implementation/schemas/test/re_frame/schemas_atom_privacy_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_atom_privacy_test.clj
@@ -8,10 +8,10 @@
   encapsulation leak worse than aesthetic (rf2-l5r974):
 
     1. `schemas-by-frame` is the authoritative store, so its rep cannot
-       evolve without breaking ad-hoc consumers — already realised:
-       rf2-naihn1 added per-frame `frame-reg-locks` companion state that
-       `clear-schemas-by-frame!` clears but raw `(reset! schemas-by-frame
-       {})` sites silently skip, leaving stale locks.
+       evolve without breaking ad-hoc consumers — a future companion
+       side-table (or a map-shape change) would have to be cleared through
+       `clear-schemas-by-frame!`, but raw `(reset! schemas-by-frame {})`
+       sites would silently skip it.
     2. The public `printer-fn` atom bypassed the never-nil invariant
        `run-printer` relies on with NO read guard — `(reset! printer-fn
        nil)` NPEs the digest path; the setters exist to coerce nil →
@@ -67,7 +67,7 @@
             `re-frame.schemas` — the migration target the swept test sites
             now use"
     (let [publics (ns-publics 're-frame.schemas)]
-      (doseq [sym '[;; registry pair + clear (also drops frame-reg-locks)
+      (doseq [sym '[;; registry pair + clear
                     snapshot-schemas-by-frame
                     restore-schemas-by-frame!
                     clear-schemas-by-frame!


### PR DESCRIPTION
Removes the vestigial schemas-compat shim called out by **rf2-kdims9** (Finding 1). Findings 2 and 3 were verified against the source + spec and **rejected** — their removal premises are stale/wrong; details below.

## What was removed (Finding 1 — `clear-frame-reg-locks!`)

Genuinely dead, verified:

- `clear-frame-reg-locks!` in `re-frame.schemas.storage` was a no-op shim returning `nil` (was `^:no-doc`).
- Its **only** call site was `clear-schemas-by-frame!`.
- The per-frame registration linearization lock it once cleared was removed with the schema→elision population (EP-0015 §8, rf2-d2r3um), so the var did nothing.

Changes:

- `implementation/schemas/src/re_frame/schemas/storage.cljc` — delete the `clear-frame-reg-locks!` var and its call in `clear-schemas-by-frame!`; reword the `clear-schemas-by-frame!` docstring (no companion side-table to clear).
- `implementation/schemas/src/re_frame/schemas.cljc` — scrub two `frame-reg-locks` companion-state mentions from the encapsulation-posture comment (kept the rationale, rephrased to a hypothetical future companion side-table / map-shape change).
- `implementation/schemas/test/re_frame/schemas/test_fixture.clj` — drop the "AND drops the rf2-naihn1 `frame-reg-locks` companion" claim from the `clear-schemas-by-frame!` bullet.
- `implementation/schemas/test/re_frame/schemas_atom_privacy_test.clj` — scrub two `frame-reg-locks` mentions from docstrings/comments (the test logic never depended on it).

Post-change: zero `clear-frame-reg-locks!` / `frame-reg-locks` references remain anywhere under `implementation/schemas`.

## Findings rejected (premise wrong)

**Finding 2 (walker docs claim schema flags populate runtime elision declarations) — REJECTED, already satisfied.** The acceptance criterion "Walker docs no longer claim schema props populate the app-db elision registry" is **already met**. `walker.cljc` (the EP-0015 §8 block, lines 16–44) and `schemas.cljc` (lines 251–258) already state the extractors no longer feed `[:rf.runtime/elision …]`; `decl-from-props` (walker.cljc) explicitly documents `:source :schema` as "NOT the (removed, EP-0015 §8) app-db egress registry." The only remaining `elision` mentions in the walker are accurate references to the **core-elision coordinate system** (path-coordinate alignment), not a population claim. No edit required.

**Finding 3 (missing-Malli warning + no-adapter soft-pass tests are an artificial state) — REJECTED, live supported path.** The soft-pass is a **normative Spec 010 contract**, not an artificial state:
- Spec 010 §577–636 ("Recommended soft-pass") + claim 4 of the four normative claims (010-Schemas.md:519, :766) define soft-pass as the cross-port dependency-absent posture, kept on the CLJS reference for substitute-validator apps (clojure.spec bridge, custom validator) that never bind the Malli hook.
- The `:rf.warning/schema-validator-unavailable` warning is a catalogued Spec 009 diagnostic (009-Instrumentation.md:1790) for exactly that state.

The bead's acceptance allows this branch: "Missing-Malli behavior is removed/fail-closed **or explicitly justified by a live supported path**." It is justified by a live spec-mandated path. Removing it / making it fail-closed would contradict the normative spec contract, so neither the warning, the clear hook, nor the no-adapter soft-pass tests were touched.

## Out-of-surface follow-up note
`spec/010-Schemas.md:620` still cites `frame-reg-locks` companion state as a live example justifying the encapsulated-only posture. That is a hot-zone spec file outside this bead's `implementation/schemas` surface, so it was left untouched — worth a small spec-doc follow-up.

## Quality gates
- `clojure -M:test` (schemas JVM): **296 tests, 18767 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs`: **7089 tests, 29168 assertions, 0 failures, 0 errors** ✅
- `npm run test:elision`: **PASS** — production 42/42 absent (642501 chars); control 42/42 present (721793 chars) ✅

Closes rf2-kdims9.