### PR TITLE
refactor(resources): remove scope compat shims (rf2-bwwk6l)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -752,10 +752,11 @@
                                       :tags        tags})))
         ;; route the concrete scope through the SHARED validation path
         ;; (rf2-hosnba, rf2-lzv9xc): rejects reserved-namespace typos +
-        ;; host / non-EDN scope values, normalizes [:rf.scope/global] → bare,
-        ;; canonicalizes — the SAME single path event/sub resolution, route
-        ;; planning, and clear-scope use. No resource-id (a tag invalidation
-        ;; spans resources); nil when scope-agnostic cross-scope.
+        ;; host / non-EDN scope values, rejects the wrapped [:rf.scope/global]
+        ;; singleton (rf2-bwwk6l — supply bare), canonicalizes — the SAME
+        ;; single path event/sub resolution, route planning, and clear-scope
+        ;; use. No resource-id (a tag invalidation spans resources); nil when
+        ;; scope-agnostic cross-scope.
         cscope     (when (some? scope)
                      (state/canonicalize-scope scope 'rf.resource/invalidate-tags nil))
         ;; rf2-ru73k6 F1 — the SAME shared tag-input normalizer the mutation

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -278,10 +278,10 @@
   Routes the resolved concrete scope through the SAME shared validation
   path resources use (`state/canonicalize-scope`, rf2-lzv9xc): a host /
   opaque scope value is rejected, a misspelled reserved `:rf.scope/*`
-  keyword is rejected fail-closed (rf2-pd7akw), and the historical
-  `[:rf.scope/global]` singleton-vector spelling normalizes to bare
-  `:rf.scope/global` (rf2-vv87xz) — so a mutation can never invalidate /
-  patch a silent WRONG (or second, distinct global) cache scope. Returns
+  keyword is rejected fail-closed (rf2-pd7akw), and the reserved global
+  scope wrapped as the singleton `[:rf.scope/global]` is rejected fail-closed
+  in favour of the canonical bare `:rf.scope/global` (rf2-bwwk6l) — so a
+  mutation can never invalidate / patch a silent WRONG cache scope. Returns
   the canonical scope. Per EP-0003 §Mutations (hybrid scope: fail-open
   execution default, fail-closed invalidation)."
   [mutation-id spec payload-scope]

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -397,8 +397,9 @@
   "Route a CONCRETE resolved scope through the single shared concrete-scope
   validation path (`state/canonicalize-scope`, rf2-lzv9xc): reject a
   reserved-namespace typo fail-closed (rf2-pd7akw), reject a host / opaque
-  value, normalize the historical `[:rf.scope/global]` singleton-vector
-  spelling to bare `:rf.scope/global` (rf2-vv87xz), then canonicalize. Per
+  value, reject the global scope wrapped as the singleton `[:rf.scope/global]`
+  in favour of the canonical bare `:rf.scope/global` (rf2-bwwk6l), then
+  canonicalize. Per
   Spec 016 §Resource identity / §Scope resolution. Used by both event and
   sub scope resolution, so a misspelled reserved `:rf.scope/*` in a payload /
   route-resolver / fn-of-nothing / pure-data policy is caught at the concrete
@@ -554,12 +555,11 @@
   `:rf.scope/from-caller` policy or a multi-arg `(route, ctx)` resolver is
   not sub-resolvable. Returns the canonical scope.
 
-  4-arity (no `db`) is kept for callers that never use a `{:from-db …}`
-  scope — references then resolve against an empty db (fail-closed)."
-  ([resource-id spec payload-scope where]
-   (resolve-scope-for-sub resource-id spec payload-scope where nil))
-  ([resource-id spec payload-scope where db]
-   (let [policy (:scope spec)]
+  Every caller supplies the frame `db` explicitly (rf2-bwwk6l): a caller
+  that resolves no `{:from-db …}` scope passes `{}`, where references resolve
+  fail-closed."
+  [resource-id spec payload-scope where db]
+  (let [policy (:scope spec)]
     (cond
       ;; 1. payload scope — a {:from-db …} reference resolves against the
       ;; frame db at use time + fails closed on nil (sub-side).
@@ -605,4 +605,4 @@
                     "resolution.")
                {:resource-id resource-id :policy from-caller-scope-policy}))
       ;; a pure data-value policy is sub-resolvable
-      :else (canonical-scope! resource-id policy where)))))
+      :else (canonical-scope! resource-id policy where))))

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -308,9 +308,10 @@
 
     - a `{:from-db <id>}` named-resolver REFERENCE (EP-0016 D3 slice 3),
       resolved against the route-entry `app-db` at use time — db-derived
-      viewer scope (session / tenant / account), the primary slice-3 form;
+      viewer scope (session / tenant / account);
     - a `(fn [route ctx] …)` resolver, evaluated against the route + entry
-      ctx (the legacy/anonymous form).
+      ctx (the route-resource resolver form — Spec 016 §Scope resolution
+      precedence tier 2).
 
   A PRESENT `:scope` that resolves to `nil` (a reference whose declared
   inputs are absent, or a fn returning nil) is a fail-closed PLANNING error
@@ -336,7 +337,7 @@
                       "§Scope resolution.")
                  {:resource-id resource :recovery :fix-scope :from-db (:from-db scope-fn)}))
         s))
-    ;; a (fn [route ctx] …) resolver — the legacy anonymous form
+    ;; a (fn [route ctx] …) resolver — the route-resource resolver form
     (fn? scope-fn)
     (let [s (scope-fn route ctx)]
       (if (nil? s)

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -425,9 +425,10 @@
   `(inputs nil)` (the `ctx` arg is reserved, literal nil in this slice), then
   routes a non-nil result through the SHARED concrete-scope canonicalization
   path (`state/canonicalize-scope` — rejects a misspelled `:rf.scope/*`
-  keyword fail-closed, rejects a host/opaque value, normalizes the
-  `[:rf.scope/global]` singleton spelling). A nil result passes through as nil
-  (the fail-closed unresolved condition the use site interprets).
+  keyword fail-closed, rejects a host/opaque value, rejects the global scope
+  wrapped as the singleton `[:rf.scope/global]` in favour of the canonical
+  bare keyword). A nil result passes through as nil (the fail-closed
+  unresolved condition the use site interprets).
 
   This is the resolver EVALUATOR. Passive reads advertised as pure — the
   `resolve-resource-scope` helper and subscription key resolution — call this

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -394,10 +394,12 @@
 ;;   2. a BARE unknown `:rf.scope/*` keyword (a reserved-namespace typo such
 ;;      as `:rf.scope/glabal`) is rejected fail-closed (rf2-pd7akw) — it can
 ;;      NEVER become a silent wrong cache scope;
-;;   3. the singleton-vector `[:rf.scope/global]` global-scope spelling is
-;;      normalized to the canonical bare `:rf.scope/global` (rf2-vv87xz) so a
-;;      payload copied from historical prose cannot create a SECOND, distinct
-;;      global cache key.
+;;   3. a reserved bare-keyword scope wrapped in a vector (the canonical
+;;      `:rf.scope/global` supplied as the singleton `[:rf.scope/global]`) is
+;;      rejected fail-closed (rf2-bwwk6l) — the global scope IS the bare
+;;      keyword, and a wrapped spelling that silently collapsed to it was a
+;;      back-compat alias for historical prose, not a second spelling the
+;;      contract blesses.
 
 (def reserved-scope-ns
   "The framework-reserved scope namespace (`:rf.scope/*`, per Conventions
@@ -430,22 +432,36 @@
        (= reserved-scope-ns (namespace scope))
        (not (contains? reserved-concrete-scopes scope))))
 
-(def ^:private global-scope
-  "The canonical CONCRETE global cache scope — the bare keyword the
-  implementation stores as the first element of a scoped key for an explicit
-  global resource (rf2-vv87xz). The historical singleton-vector spelling
-  `[:rf.scope/global]` normalizes to this."
-  :rf.scope/global)
-
-(defn- normalize-global-scope
-  "Normalize the historical singleton-vector global spelling
-  `[:rf.scope/global]` to the canonical concrete `:rf.scope/global` bare
-  keyword (rf2-vv87xz), so a payload that copied the singleton-vector form
-  from older prose collapses to the SAME global cache key the implementation
-  resolves an explicit-global policy to — it can never silently create a
-  second, distinct global key. Every other value passes through unchanged."
-  [scope]
-  (if (= scope [global-scope]) global-scope scope))
+(defn reject-wrapped-reserved-scope!
+  "Throw `:rf.error/resource-invalid-scope` when `scope` is a VECTOR whose
+  head is a reserved bare-keyword concrete scope (`:rf.scope/global`) —
+  i.e. the singleton `[:rf.scope/global]` spelling (rf2-bwwk6l). The global
+  scope IS the bare keyword `:rf.scope/global`; wrapping it in a vector was a
+  back-compat alias the implementation silently collapsed, kept only for
+  payloads copied from historical prose. Pre-alpha there is no alias: the
+  wrapped form fails closed and the diagnostic names the canonical bare
+  spelling. A genuine scope TUPLE like `[:rf.scope/session {…}]` carries a
+  payload after the namespaced tag and is untouched — only a reserved
+  bare-keyword head with NO concrete payload (the historical alias shape) is
+  rejected. `where` / `resource-id` name the offending boundary. Returns
+  `scope` unchanged when it conforms."
+  [scope where resource-id]
+  (when (and (vector? scope)
+             (contains? reserved-concrete-scopes (first scope)))
+    (throw (ex-info ":rf.error/resource-invalid-scope"
+                    {:rf.error/id :rf.error/resource-invalid-scope
+                     :where       where
+                     :recovery    :fix-scope
+                     :reason      (str "resource " resource-id " was reached with a "
+                                       "scope " (pr-str scope) " — a reserved "
+                                       ":rf.scope/* concrete scope wrapped in a "
+                                       "vector. The global scope IS the bare keyword "
+                                       ":rf.scope/global; supply it bare, not as the "
+                                       "singleton [:rf.scope/global]. Per Spec 016 "
+                                       "§Scope resolution.")
+                     :resource-id resource-id
+                     :scope       scope})))
+  scope)
 
 (defn reject-reserved-scope-typo!
   "Throw `:rf.error/resource-invalid-scope` when `scope` is a reserved-
@@ -483,20 +499,22 @@
 
     1. reject a reserved-namespace typo fail-closed
        (`reject-reserved-scope-typo!`, rf2-pd7akw);
-    2. reject a host / opaque value (`reject-non-edn!`);
-    3. normalize the historical `[:rf.scope/global]` singleton-vector
-       spelling to the canonical bare `:rf.scope/global` (rf2-vv87xz);
+    2. reject a reserved bare-keyword scope wrapped in a vector — the
+       singleton `[:rf.scope/global]` alias (`reject-wrapped-reserved-scope!`,
+       rf2-bwwk6l);
+    3. reject a host / opaque value (`reject-non-edn!`);
     4. canonicalize the EDN (`canonicalize`).
 
   Every scope-bearing operation routes its concrete scope through this fn so
-  the typo / host / global-spelling guarantees hold uniformly across event
+  the typo / wrapped-global / host guarantees hold uniformly across event
   resolution, sub resolution, route planning, and mutation invalidation
   defaults. `where` / `resource-id` name the boundary for the structured
   errors. Returns the canonical scope."
   [scope where resource-id]
   (reject-reserved-scope-typo! scope where resource-id)
+  (reject-wrapped-reserved-scope! scope where resource-id)
   (reject-non-edn! scope where :scope resource-id)
-  (canonicalize (normalize-global-scope scope)))
+  (canonicalize scope))
 
 ;; ---- scoped resource key (Spec 016 §Resource identity) --------------------
 

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -98,21 +98,20 @@
   when the resolver's declared app-db inputs change mid-session
   (rf2-616xa6). A reference that resolves nil raises
   `:rf.error/resource-sub-unresolved-scope` (the \"scope unresolved\"
-  diagnostic) — never a silent global / wrong-entry read. The 1-arity is
-  kept for the direct-dispatch test path (no `{:from-db …}` scope), where
-  references resolve against an empty db (fail-closed)."
-  ([payload] (resolve-scoped-key payload nil))
-  ([{:keys [resource] :as payload} db]
-   (let [spec    (registry/require-resource-spec! resource 'rf.resource/subscribe)
-         scope   (registry/resolve-scope-for-sub
-                   resource spec (:scope payload) 'rf.resource/subscribe db)
-         ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) so
-         ;; the sub re-keys to the SAME identity the ensure produced (an absent
-         ;; slot defaults to `{}` at the boundary; explicit nil reaches the
-         ;; schema unchanged).
-         cparams (registry/validate+canonicalize-params
-                   resource spec (state/params-present? payload) 'rf.resource/subscribe)]
-     (state/scoped-resource-key scope resource cparams))))
+  diagnostic) — never a silent global / wrong-entry read. Every caller
+  supplies the frame `db` explicitly (rf2-bwwk6l): a caller that resolves no
+  `{:from-db …}` scope passes `{}`."
+  [{:keys [resource] :as payload} db]
+  (let [spec    (registry/require-resource-spec! resource 'rf.resource/subscribe)
+        scope   (registry/resolve-scope-for-sub
+                  resource spec (:scope payload) 'rf.resource/subscribe db)
+        ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) so
+        ;; the sub re-keys to the SAME identity the ensure produced (an absent
+        ;; slot defaults to `{}` at the boundary; explicit nil reaches the
+        ;; schema unchanged).
+        cparams (registry/validate+canonicalize-params
+                  resource spec (state/params-present? payload) 'rf.resource/subscribe)]
+    (state/scoped-resource-key scope resource cparams)))
 
 ;; ---- dev-mode scope-mismatch warning (Spec 016 §Subscription-side scope
 ;; ---- resolution — likely-mismatch dev warning) ----------------------------

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -310,21 +310,19 @@
             [:rf.resource/invalidate-tags
              {:scope {:cb (fn [])} :tags #{[:article "w"]}}])))))
 
-(deftest invalidate-tags-normalizes-singleton-global-scope
-  ;; rf2-hosnba / rf2-vv87xz — the historical [:rf.scope/global] singleton
-  ;; spelling normalizes to the canonical bare :rf.scope/global so it matches
-  ;; the SAME entries an explicit-global resource stored under.
-  (rf/reg-resource :ivg/article (article-spec)) ;; :rf.scope/global policy
-  (let [k (state/scoped-resource-key :rf.scope/global :ivg/article {:slug "w"})]
-    (ensure! :ivg/article :rf.scope/global "w" [:lease :g 1])
-    (succeed! k {:title "G"})
-    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :g 1]}])
-    (testing "the singleton-vector global spelling matches the bare-global key"
-      (rf/dispatch-sync [:rf.resource/invalidate-tags
-                         {:scope [:rf.scope/global] :tags #{[:article "w"]}}])
-      (is (some? (:invalidated-at (entry k)))
-          "entry under bare :rf.scope/global was matched via the normalized
-           singleton-vector scope"))))
+(deftest invalidate-tags-rejects-singleton-global-scope
+  ;; rf2-hosnba / rf2-bwwk6l — the historical [:rf.scope/global] singleton
+  ;; spelling is NO LONGER an accepted global alias; an invalidate-tags scope
+  ;; carrying it fails closed (the global scope IS the bare keyword). The
+  ;; back-compat normalize that silently collapsed it is removed pre-alpha.
+  (testing "the wrapped singleton-vector global spelling is rejected
+            fail-closed at the shared scope-validation boundary"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (events/invalidate-tags-handler
+            (invalidate-cofx {})
+            [:rf.resource/invalidate-tags
+             {:scope [:rf.scope/global] :tags #{[:article "w"]}}])))))
 
 (deftest clear-scope-rejects-reserved-scope-typo
   (testing "rf2-hosnba / rf2-lzv9xc — clear-scope routes its scope through

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -425,7 +425,7 @@
             read / :idle) — Spec 016 §Subscription-side scope resolution"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-sub-unresolved-scope"
-          (subs/resolve-scoped-key {:resource :ss/from-caller :params {:slug "x"}})))))
+          (subs/resolve-scoped-key {:resource :ss/from-caller :params {:slug "x"}} {})))))
 
 ;; ===========================================================================
 ;; 3. Pure lifecycle status transition fn (NOT a spawned machine)
@@ -868,7 +868,7 @@
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
             (registry/resolve-scope-for-sub
-              :tp/article spec :rf.scope/sesssion 'test))))
+              :tp/article spec :rf.scope/sesssion 'test {}))))
     (testing "rf2-pd7akw — :rf.scope/from-caller reaching a CONCRETE boundary
               as a payload value (not a policy) is a typo-class rejection"
       (is (thrown-with-msg?
@@ -888,37 +888,31 @@
                'test))))))
 
 ;; ===========================================================================
-;; 14. Singleton-vector [:rf.scope/global] cannot create a 2nd global key
-;;     (rf2-vv87xz, impl/guard half)
+;; 14. Singleton-vector [:rf.scope/global] is rejected fail-closed — the
+;;     global scope IS the bare keyword (rf2-bwwk6l; was rf2-vv87xz's
+;;     back-compat normalize alias, removed pre-alpha)
 ;; ===========================================================================
 
-(deftest singleton-vector-global-normalizes-to-bare-global
-  (testing "rf2-vv87xz — a [:rf.scope/global] payload normalizes to the bare
-            :rf.scope/global so it collapses to the SAME global cache key the
-            implementation resolves an explicit-global policy to (it cannot
-            silently create a second, distinct global key)"
-    (let [k-bare      (state/canonicalize-scope :rf.scope/global 'test :r/x)
-          k-singleton (state/canonicalize-scope [:rf.scope/global] 'test :r/x)]
-      (is (= :rf.scope/global k-bare))
-      (is (= :rf.scope/global k-singleton)
-          "singleton-vector spelling collapses to the bare canonical scope")
-      (is (= k-bare k-singleton) "both spellings produce ONE global cache key")))
-  (testing "rf2-vv87xz — end-to-end: an ensure under :rf.scope/global and a
-            sub under [:rf.scope/global] read the SAME entry (no second key)"
+(deftest singleton-vector-global-rejected-fail-closed
+  (testing "rf2-bwwk6l — the bare :rf.scope/global is the canonical concrete
+            global scope and canonicalizes unchanged"
+    (is (= :rf.scope/global (state/canonicalize-scope :rf.scope/global 'test :r/x))))
+  (testing "rf2-bwwk6l — the singleton-vector [:rf.scope/global] spelling is
+            NO LONGER accepted as a global alias; it fails closed at the shared
+            canonicalize boundary, naming the canonical bare spelling"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (state/canonicalize-scope [:rf.scope/global] 'test :r/x))))
+  (testing "rf2-bwwk6l — a sub payload carrying the wrapped [:rf.scope/global]
+            spelling fails closed too (never a silent read of the bare global
+            entry)"
     (rf/reg-resource :gv/article (article-spec))
-    (let [bare-key (state/scoped-resource-key :rf.scope/global :gv/article {:slug "w"})]
-      (rf/dispatch-sync [:rf.resource/ensure {:resource :gv/article :scope :rf.scope/global
-                                              :params {:slug "w"} :owner [:lease 1]}])
-      (let [wid (:current-work (entry bare-key))]
-        (rf/dispatch-sync [:rf.resource.internal/succeeded
-                           {:resource-key bare-key :work/id wid :generation 1
-                            :data {:title "W"}}]))
-      ;; a sub payload using the historical singleton-vector spelling resolves
-      ;; to the SAME bare key — it reads the loaded entry, not a fresh skeleton.
-      (is (= bare-key
-             (subs/resolve-scoped-key {:resource :gv/article
-                                       :scope [:rf.scope/global]
-                                       :params {:slug "w"}}))))))
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (subs/resolve-scoped-key {:resource :gv/article
+                                    :scope [:rf.scope/global]
+                                    :params {:slug "w"}}
+                                   {})))))
 
 ;; ===========================================================================
 ;; 15. clear-resource disposes live runtime state (rf2-m9h5iq)
@@ -989,10 +983,14 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
           (mreg/resolve-scope :m/x {} {:fn (fn [])}))))
-  (testing "rf2-lzv9xc — the default global scope still resolves, and the
-            [:rf.scope/global] spelling normalizes to bare (no 2nd key)"
-    (is (= :rf.scope/global (mreg/resolve-scope :m/x {} nil)))
-    (is (= :rf.scope/global (mreg/resolve-scope :m/x {} [:rf.scope/global])))))
+  (testing "rf2-lzv9xc — the default global scope still resolves to the bare
+            :rf.scope/global"
+    (is (= :rf.scope/global (mreg/resolve-scope :m/x {} nil))))
+  (testing "rf2-bwwk6l — the wrapped [:rf.scope/global] singleton is rejected
+            fail-closed (no back-compat alias); supply the bare keyword"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (mreg/resolve-scope :m/x {} [:rf.scope/global])))))
 
 ;; ===========================================================================
 ;; 17. resource-state fails closed without an explicit frame (rf2-c8lgy3)

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -132,7 +132,7 @@
   (testing "a fn resolver scope is accepted"
     (is (= :test/fn
            (resources/reg-resource :test/fn
-                                   (assoc (valid-spec) :scope (fn [] [:rf.scope/global])))))))
+                                   (assoc (valid-spec) :scope (fn [] :rf.scope/global)))))))
 
 (deftest resource-kind-in-closed-set
   (testing ":resource is a valid registrar kind"


### PR DESCRIPTION
Removes the vestigial scope compatibility shims and stale wording flagged in **rf2-bwwk6l** (P2 vestigial). Pre-alpha posture — no back-compat shims.

## What changed

**1. Singleton-vector global alias removed (fail-closed)**
The runtime previously normalized the historical `[:rf.scope/global]` singleton-vector spelling to the canonical bare `:rf.scope/global` (`normalize-global-scope` in `state.cljc`). The global scope **is** the bare keyword; the wrapped form was a back-compat alias for payloads copied from older prose. Replaced the silent normalize with a structured fail-closed rejection (`reject-wrapped-reserved-scope!`) wired into the shared `state/canonicalize-scope` path, so it rejects uniformly across event resolution, sub resolution, route planning, mutation invalidation defaults, and scope-resolver evaluation. The diagnostic names the canonical bare spelling.

**2. No-db scope arities removed**
Dropped `subs/resolve-scoped-key` 1-arity and `registry/resolve-scope-for-sub` 4-arity. Since `{:from-db …}` made use-time db explicit, production always threads the frame db; the only callers of the no-db arities were direct tests. Tests updated to pass an explicit `{}` (references still resolve fail-closed). Unresolved `{:from-db …}` fail-closed behavior unchanged.

**3. Route scope wording de-staled (form kept, not removed)**
The `(fn [route ctx] …)` route-resource scope resolver was labelled `legacy/anonymous` but is **spec-mandated** (Spec 016 §Scope resolution precedence tier 2, 016-Resources.md:87/98) and actively tested as valid. Per the bead's option (b), removed the stale `legacy` labels and described only the current supported forms; the form itself is kept.

## Premise verification

All three findings verified against source + Spec 016 before action. Findings 1 and 2 were genuine dead/back-compat shims and were removed. Finding 3's premise (remove the anonymous route resolver) is **rejected** — the form is spec-mandated and live — so the bead's alternative (de-stale the wording) was taken instead. Spec prose was left untouched: 016-Resources.md uses `[:rf.scope/global]` as loose notation for "the global scope" (and line 1306 already frames rf2-vv87xz as a spelling ambiguity resolved at the API boundary), not as a mandate to accept the singleton-vector as an input alias.

## Quality gates

- `clojure -M:test` (resources artefact): **403 tests, 1586 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs` (node-runtime CLJS suite): **7089 tests, 29167 assertions, 0 failures, 0 errors** ✅
