### PR TITLE
docs(skills/re-frame2-xray): align tour with 9-tab surface (rf2-kv41xg)

### DIFF
--- a/docs/skills/re-frame2-xray.md
+++ b/docs/skills/re-frame2-xray.md
@@ -1,21 +1,22 @@
 # re-frame2-xray
 
-> A read-only tour of **Xray**, the re-frame2 in-app devtools panel. Answers two questions and only two: *how do I launch Xray?* and *which tab — across its Dynamic and Static modes — shows X?*
+> A read-only tour of **Xray**, the re-frame2 in-app devtools panel. Answers three questions and only three: *how do I launch Xray?*, *which tab — across its Dynamic and Static modes — shows X?*, and *what's the chrome around the tabs for?*
 
 ## What it does
 
 The `re-frame2-xray` skill is a tour guide for [Xray](../xray/index.md), the human-facing devtools panel that ships with re-frame2. Xray is preloaded into dev builds via shadow-cljs `:preloads` and renders true-inline on the right side of the host app; production builds elide it entirely through the `interop/debug-enabled?` gate.
 
-The skill answers two questions:
+The skill answers three questions:
 
-1. **How do I launch Xray?** — the inline panel, the pop-out (`(xray/popout!)`), the programmatic `(xray/init! opts)` path, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
+1. **How do I launch Xray?** — the inline panel, the overlay fallback (`(xray/open-overlay!)`, for hosts that can't give Xray a layout column), the pop-out (`(xray/popout!)`), the programmatic `(xray/init! opts)` path, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
 2. **Which tab shows X?** — a one-line purpose for each tab, across both modes.
+3. **What's the chrome around the tabs for?** — the first-screen navigation primitives: time-travel inspect / `Reset`-rewind, the filter pills, the command palette, and the Settings popup.
 
 ## Two modes
 
 Xray runs in one of two modes, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`:
 
-- **Dynamic** — the event-coupled spine (4-layer chrome). Every tab is a lens on the *one focused event*. 8 tabs: **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph** (mnemonics `e a v t m r s g`) — the core six plus the cross-feature **Resources** (declarative server-state) and **Graph** (Xray's UI over the EP-0014 derivation/process graph) lenses. There is **no Issues tab** — issues surface inline (in the Epoch cascade, the L2 event-row pink-wash, and the always-on issues-ribbon signal).
+- **Dynamic** — the event-coupled spine (4-layer chrome). Every tab is a lens on the *one focused event*. 9 tabs: **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Modules** (mnemonics `e a v t m r s g u`) — the core six plus the cross-feature **Resources** (declarative server-state), **Graph** (Xray's UI over the EP-0014 derivation/process graph), and **Modules** (the EP-0013 module / realm / app-value lens) lenses. There is **no Issues tab** — issues surface inline (in the Epoch cascade, the L2 event-row pink-wash, and the always-on issues-ribbon signal).
 - **Static** — event-INDEPENDENT registry browse (3-layer chrome, no spine). Every tab is a catalogue of what's *registered* in the picked frame's **realm** (the registrar is realm-owned, not frame-owned — in the common single-realm app this is just the picked frame's registrations). 5 tabs: **Machines · Routes · Schemas · Flows · Interceptors**.
 
 When the user wants to inspect a single dispatch, that's Dynamic; when they want to browse the whole registry, that's Static.
@@ -33,7 +34,7 @@ Four hotkey families have keydown listeners installed:
 
 ## When to reach for it
 
-Load this skill when the user wants to *read* the Xray panel — "open Xray", "where is X in Xray", "which Xray tab shows…", "Xray Static mode", "browse registered machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray popout", "Xray machine inspector".
+Load this skill when the user wants to *read* the Xray panel — "open Xray", "where is X in Xray", "which Xray tab shows…", "Xray Static mode", "browse registered machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray popout", "Xray machine inspector", "Xray Modules tab", "what realms/frames are installed in Xray".
 
 Do **not** use this skill for:
 

--- a/skills/re-frame2-xray/.claude-plugin/plugin.json
+++ b/skills/re-frame2-xray/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (8 Dynamic event-spine tabs incl. Resources + the EP-0014 derivation/process Graph + 5 Static registry-browse tabs); defers driving / implementing Xray to sibling skills.",
+  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (9 Dynamic event-spine tabs incl. Resources + the EP-0014 derivation/process Graph + the EP-0013 module/realm/app-value Modules tab + 5 Static registry-browse tabs); defers driving / implementing Xray to sibling skills.",
   "skills": [
     "./SKILL.md"
   ],

--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -5,7 +5,7 @@
 `re-frame2-xray` is a Claude Code **tour skill** for [Xray](https://github.com/day8/re-frame2/tree/main/tools/xray) — the re-frame2 in-app devtools panel. It answers three questions, and only three:
 
 1. **How do I launch Xray?** — the inline panel, the overlay fallback (`open-overlay!`, for hosts that can't give Xray a layout column), the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
-2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 8 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph) and the 5 Static registry-browse tabs. The **Graph** tab is Xray's UI over the EP-0014 derivation/process graph; the underlying graph accessor stays internal (no `re-frame.core` facade export).
+2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 9 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Modules) and the 5 Static registry-browse tabs. The **Graph** tab is Xray's UI over the EP-0014 derivation/process graph; the **Modules** tab is its EP-0013 module / realm / app-value lens (an L4-only tab — focusable, no standalone mount facade). The underlying graph accessor stays internal (no `re-frame.core` facade export).
 3. **What's the chrome around the tabs for?** — the first-screen navigation primitives: time-travel inspect / `Reset`-rewind, the filter-pill cluster, the command palette, and the Settings popup.
 
 Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction-marker semantics) are out of scope for this iteration — see `SKILL.md` §Out of scope for what to do when one of those comes up.
@@ -20,7 +20,7 @@ Xray is the **human-facing** panel; for an AI agent surface against the running 
 
 - `SKILL.md` — the compact tour/router (launch quick-reference, mode/tab chooser, chrome one-liners, and the leaf-loading guide)
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, the `open-overlay!` no-layout-host fallback, pop-out lifecycle, wired hotkeys)
-- `references/panels.md` — the full tab tour in depth (8 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance, the retired-panel content-home mapping)
+- `references/panels.md` — the full tab tour in depth (9 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance, the retired-panel content-home mapping)
 - `references/chrome.md` — the first-screen chrome inventory in depth (LIVE/RETRO, time-travel rewind, filter pills, command-palette sources, the Settings-popup tabs, the Snapshot app-db redaction contract)
 - `references/shared-components.md` — the components every L4 panel reuses (`edn-inspector/render-node`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
 - `evals/evals.json` — eval fixtures (trigger accuracy + answer-quality assertions for the high-drift launch / chrome / tab-routing prompts)

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -16,7 +16,9 @@ description: >
  [data-rf-xray-host] / full-screen canvas", "Xray machine inspector",
  "Xray epoch cascade", "where do Xray issues show up", "Xray Graph
  tab", "Xray derivation/process graph", "where does this value come
- from in Xray", "Xray Resources tab", and similar.
+ from in Xray", "Xray Resources tab", "Xray Modules tab", "Xray
+ module-view", "what realms/frames/app-values are installed in Xray",
+ and similar.
  **Do not use** for: driving Xray
  programmatically from a live REPL (that's `re-frame2-pair`), authoring
  the host app (`re-frame2`), bootstrapping a new project
@@ -68,10 +70,10 @@ This skill answers three questions, and only three:
  programmatic entry points, the wired hotkeys, the Dynamic ↔ Static
  mode toggle.
 2. **Which tab shows X?** — a one-line purpose for each tab Xray ships,
- across both modes: the 8 Dynamic event-spine tabs (the 6 in
- spec/018 §5 + spec/021 §9.1, plus the cross-feature **Resources**
- and **Graph** tabs) and the 5 Static registry-browse tabs (per
- spec/007-UX-IA.md §Static mode).
+ across both modes: the 9 Dynamic event-spine tabs (the 6 in
+ spec/018 §5 + spec/021 §9.1, plus the cross-feature **Resources**,
+ **Graph**, and **Modules** tabs) and the 5 Static registry-browse tabs
+ (per spec/007-UX-IA.md §Static mode).
 3. **What's the chrome around the tabs for?** — the first-screen
  navigation primitives the user meets immediately: the time-travel
  inspect / `Reset`-rewind, the filter-pill cluster, the command
@@ -121,8 +123,8 @@ the `Cmd/Ctrl+Shift+M` chord:
 - **Dynamic** — the event-coupled spine. A 4-layer chrome (L1 ribbon ·
  L2 event list · L3 tab bar · L4 detail). Every tab is a *lens on the
  one focused event* — pick an event in the L2 list and every tab
- rebinds. This is "what happened in **this** epoch?". 8 tabs (the
- core 6 plus the cross-feature Resources + Graph lenses).
+ rebinds. This is "what happened in **this** epoch?". 9 tabs (the
+ core 6 plus the cross-feature Resources + Graph + Modules lenses).
 - **Static** — event-INDEPENDENT browse of what's *registered*. A
  3-layer chrome (no L2 spine — Static has no event focus). Every tab is
  a registry catalogue: every machine, every route, every schema, every
@@ -237,15 +239,16 @@ Static (about the whole registry) — then route to the tab. For per-tab
 layout, iconography, stripe tokens, and "open it when…" depth see
 [`references/panels.md`](references/panels.md).
 
-### Dynamic mode — 8 lenses on the focused event
+### Dynamic mode — 9 lenses on the focused event
 
-The L3 tab bar holds **8 lenses on the focused event**, left-to-right
-(mnemonics `e a v t m r s g`): **Epoch · app-db · Views · Trace ·
-Machine · Routes · Resources · Graph**. The first six are the core spine
-lenses (spec/018 §5 + spec/021 §9.1); **Resources** and **Graph** are the
-two cross-feature lenses that landed last (the registry-driven L4 tab
-seam lets a panel register its own tab — see `panels/resources.cljs` and
-`panels/derivation_graph.cljs`). Cross-epoch signal lives on the L2
+The L3 tab bar holds **9 lenses on the focused event**, left-to-right
+(mnemonics `e a v t m r s g u`): **Epoch · app-db · Views · Trace ·
+Machine · Routes · Resources · Graph · Modules**. The first six are the
+core spine lenses (spec/018 §5 + spec/021 §9.1); **Resources**, **Graph**,
+and **Modules** are the three cross-feature lenses that landed last (the
+registry-driven L4 tab seam lets a panel register its own tab — see
+`panels/resources.cljs`, `panels/derivation_graph.cljs`, and
+`panels/module_view.cljs`). Cross-epoch signal lives on the L2
 timeline above (badges + stripes); every tab answers "what happened in
 **this** epoch?" through its own lens. To browse a machine's full
 topology cold (spine-INDEPENDENT — picker + zoom / pan / fit, regardless
@@ -265,6 +268,7 @@ inline (see *Where issues surface now* below).
 | **Routes** | `r` · `🌐` · yellow | Flat focused-event lens: current matched route + params/query/fragment + a **Simulate-URL** input that ranks every registered route, with per-event glyphs `◉ TO` / `◇ FROM` / `● HERE`. Silent when no routes registered. (Display label **Routes**, plural-noun convention; internal tab id `:routing`.) | "What route am I on?" / "Did the route change this epoch?" / "What params resolved?" |
 | **Resources** | `s` · cross-feature | The declarative server-state lens (Spec 016 §Xray and AI tooling): the static resource registry, per-frame **live instances** (state · generation · owners · freshness), the **work ledger** of live fetch attempts, the route/resource graph, lifecycle/invalidation/cache-growth, and a scope audit + lints. It is also the EP-0016 mutation-completion lens — **mutation `:reply-to` continuations** (the `:rf.mutation/replied` trace), **descriptor-level invalidation evidence** (the `:invalidation` facet on the mutation settlement op — per-descriptor resolved scope / tags / `:refetch-populated?`, plus the fail-closed `:unresolved` and `:populate-exempt` sets), and the **named scope resolver resolution timeline** (`:rf.resource/scope-resolved` — resolver id, declared inputs, resolved scope). **Read-only** — observing pins nothing; values are summarized (params/scopes/data redaction-aware), never raw. Reads the runtime-db resource slices decoupled — Xray does **not** `:require` the optional resources artefact, so the panel renders cleanly even when the host has no resources. | "Where's my server state, what owns it, and is it stale?" / "What fetches are in flight?" / "Did my mutation's `:reply-to` fire, and did it invalidate the right scopes?" / "Why didn't this read refetch?" |
 | **Graph** | `g` · cross-feature (violet — the algebra lens) | Xray's UI over the **EP-0014 derivation/process graph** — the one node-and-edge view where every declared fact and process across **all five contributor families** (subscriptions, flows, resources, route facts, machine processes + selectors) is a node over the frame fold. Every node is classified by its two closed superkinds (`:derivation` / `:process`) read off `:kind` alone; the refined kinds tint the family accent. Each node carries its storage / evaluation / lifecycle (owner) classifications, plus an **authority chip** for remote-backed nodes (an *authority* axis, not a storage class — see below). A per-panel **static ↔ live** toggle (its own toggle, distinct from the L1 mode pill) flips between the registration-derived graph (parametric subs marked, no edge — the don't-execute rule) and the frame-realized graph (concrete query vectors, active resource keys, live machine instances, the materialized route slice with its nav-token owner). **On-box raw, off-box redacted.** | "Where does this value come from / when is it evaluated / where does it live / who owns it?" — across families, in one place |
+| **Modules** *(`:order 9`)* | `u` · cross-feature | Xray's UI over the **EP-0013 module / realm / app-value** address space: the projected `(realm, frame)` topology — every installed **realm** (`rf/realm-ids`), the **frames** it owns (`rf/frame-ids` · `rf/frame-realm`), and the **per-module provenance** read off each realm's installed app value (`rf/installed-app`). It answers "what's installed, and how is the process partitioned into realms / frames / modules?" — the structural counterpart to the Graph tab's per-fact view. **Read-only** — enumerating realms / frames and reading installed app values pins nothing and dispatches nothing (a static read of the install-time value, not a routing path). Like the Graph tab it does not compose off an `:rf.xray/*` app-db slot — the address space is a process-global fact (realms + frames live in the framework's registries). | "What realms exist, which frames belong to each, and what modules / app values are installed?" |
 
 #### What the Graph tab contributes (all five families)
 
@@ -303,6 +307,18 @@ views.)
 > API from their app code — there isn't one. Source of truth:
 > [`spec/Derivations.md` §Graph inspection — internal but structured](../../spec/Derivations.md#graph-inspection--internal-but-structured)
 > + [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../docs/EP/EP-0014-derivation-and-process-algebra.md).
+
+> **Modules + Graph are L4-only registry tabs.** Both `:module-view`
+> (Modules) and `:derivation-graph` (Graph) register through the
+> `reg-l4-tab!` seam but expose **no standalone `mount-*!` facade** — they
+> are shell-internal tabs, focusable via the command palette / `focus!`
+> but not independently mountable the way the other seven Dynamic panels
+> are. Route users to **open the Modules tab** (it ships); do not tell them
+> to call a `mount-module-view!` — there isn't one. The Modules tab reads
+> the **public** EP-0013 realm / frame seams (`rf/realm-ids`,
+> `rf/frame-ids`, `rf/frame-realm`) and the realm→installed-app read seam
+> (`rf/installed-app`); these are framework-public reads, but the tab is
+> still a shell-internal surface, not a public mount API.
 
 #### Where issues surface now (no Issues tab)
 

--- a/skills/re-frame2-xray/evals/README.md
+++ b/skills/re-frame2-xray/evals/README.md
@@ -40,8 +40,8 @@ when the eval shape changes in a way that breaks readers.
 
 ## Coverage
 
-27 evals — **19 positives** (skill should fire) and **8 negatives** (skill
-should stay quiet). **11 positives** carry the Layer-2 answer-quality
+29 evals — **21 positives** (skill should fire) and **8 negatives** (skill
+should stay quiet). **13 positives** carry the Layer-2 answer-quality
 `expectations[]`; they target the prompts whose answer drifts fastest as
 the Xray UI moves:
 
@@ -58,6 +58,8 @@ the Xray UI moves:
 | 23 | `chrome-palette` | yes | Palette source kinds + representative command verbs; `Cmd/Ctrl+K` is wired (not struck). |
 | 24 | `launch-overlay` | yes | `open-overlay!` is the supported FALLBACK for no-layout-host; floats above `document.body`; not the primary path. |
 | 26 | `config-init-vs-settings` | yes | Settings popup wins over the `init!` boot default; merge order `defaults < configure! < Settings`; density is NOT a popup control. |
+| 28 | `panel-route-modules` | yes | The realms / frames / modules / app-values question → the Dynamic **Modules** tab (`:module-view`, EP-0013 lens); Modules is SHIPPED, not absent, not Static, not the same as Graph; no `mount-module-view!` (L4-only). |
+| 29 | `tab-inventory-count` | yes | The full ordered **9-tab** Dynamic list incl. Modules (count is 9, not 8); correct `:order`; no removed tab (Issues / Event / Chrome A11y / Machines-Canvas). |
 | 4, 5, 6, 7, 9, 10, 22, 25 | `launch-hotkey` … `config-init-boot` | no | Trigger-only positives (lower drift; covered by the body's quick-reference). |
 | 13–20 | `neg-*` | no | Negatives — adjacent surfaces (drive→pair, implement→spec, author→re-frame2, setup, migration, implementor, vocab-only). |
 
@@ -66,7 +68,10 @@ launch-default, launch-overlay, launch-popout-button, launch-programmatic,
 config-init-vs-settings, chrome-rewind, chrome-palette,
 panel-route-machine-canvas, panel-route-schema, panel-route-hydration —
 plus launch-popout (the paired programmatic counterpart to the button
-prompt).
+prompt), and the tab-inventory pair **panel-route-modules** +
+**tab-inventory-count** that pin the 9-tab Dynamic surface (incl. Modules)
+so a future drop / misroute of Modules, or a revert to 8 tabs, fails the
+answer-quality layer.
 
 ## How to run
 
@@ -113,3 +118,50 @@ as the discipline of updating them alongside the product.
 > the `skills/re-frame2/` harness specifically; this README has no
 > automated count/coverage gate, so the table above is maintained by hand —
 > keep it in step with `evals.json` when you add or rename an entry.
+
+## Keeping the tab inventory in sync (the source of truth)
+
+The tour skill's Dynamic tab inventory (the `e a v t m r s g u` set across
+`SKILL.md`, `README.md`, `references/panels.md`,
+`references/shared-components.md`, `package.json`, and
+`.claude-plugin/plugin.json`) is **hand-maintained against the live Xray
+registry** — there is no in-tree script that diffs it for this skill. When
+an Xray tab is added, removed, or reordered, re-verify the skill against
+the **single source of truth** in this order:
+
+1. **`tools/xray/src/day8/re_frame2_xray/focus.cljc` — `valid-panels`.**
+   This `#{…}` set MIRRORS the live `panel-registry/tab-ids-for-mode
+   :dynamic` registry (a cross-check test, `registry_cljs_test.cljs`,
+   fails the Xray build if they drift) and is the JVM-runnable, single
+   authoritative count. Today it is
+   `#{:epoch :app-db :views :trace :machines :routing :resources
+   :derivation-graph :module-view}` — **9 tabs.** The internal ids map to
+   display labels: `:views`→Views, `:routing`→Routes,
+   `:derivation-graph`→Graph, `:module-view`→Modules.
+2. **The per-panel `reg-l4-tab!` calls** under
+   `tools/xray/src/day8/re_frame2_xray/panels/*.cljs` — confirm each tab's
+   `:label`, `:mnem`, and `:order` (e.g. `module_view.cljs` →
+   `{:id :module-view :label "Modules" :mnem "u" :order 9}`). An L4-only
+   tab (Graph, Modules) registers via `reg-l4-tab!` but is **not** in
+   `panel-enum` (it has no standalone `mount-*!` facade).
+3. **`tools/xray/spec/API.md`** (the §Public surfaces table + §Panel
+   reg-views) — the normative published surface, which also enumerates
+   which tabs are standalone-mountable vs L4-only registry tabs.
+
+A quick CLI cross-check (count the skill's claimed tabs vs the source):
+
+```bash
+# The authoritative set (one id per shipped Dynamic L4 tab):
+grep -A2 'def valid-panels' tools/xray/src/day8/re_frame2_xray/focus.cljc
+
+# Where the skill states the count — keep every hit at the same number:
+grep -rnE '[0-9]+ Dynamic|[0-9]+ lenses|[0-9]+ tabs|e a v t m r s g' \
+  skills/re-frame2-xray/
+```
+
+If the source moves and the skill doesn't, the Layer-2 `tab-inventory-count`
++ `panel-route-modules` evals are designed to catch it on the next
+answer-quality run — but they only fire when run, so this manual cross-check
+is the front-line discipline. Update the skill body, the matching reference
+leaf, and the corresponding `expectations[]` in the same PR (per §Keeping
+evals + skill in sync above).

--- a/skills/re-frame2-xray/evals/evals.json
+++ b/skills/re-frame2-xray/evals/evals.json
@@ -2,7 +2,7 @@
  "skill_name": "re-frame2-xray",
  "schema_version": "2",
  "convention": "anthropics/skills/skill-creator evals.json — per references/schemas.md. Two-layer fixture: every entry carries `should_trigger` so skill-creator's description-optimisation loop can score train/held-out trigger accuracy; the high-drift positives ALSO carry `expected_output` + `expectations[]` (answer-quality assertions) so a description-optimisation pass that keeps the skill firing cannot mask an answer that has drifted behind the shipped Xray UI. Negatives keep `rationale` (no answer-quality layer — there is no right answer to assert).",
- "notes": "Positives (should_trigger: true) target the launch + tab-routing + first-screen-chrome surface of SKILL.md across both modes (Dynamic event-spine + Static registry browse). The launch positives exercise the FULL public mount-verb set — the default true-inline panel (launch-default), the open-overlay! no-layout-host fallback (launch-overlay), the popout! pop-out window via both the visible chrome `⛶` top-bar button (launch-popout-button — a no-code question whose answer must name the shipped button, not a programmatic-only or future-right-click path) and the programmatic API (launch-popout), and the programmatic init! (launch-programmatic) — plus the init!/configure!-vs-Settings boot-config contract (config-init-boot, config-init-vs-settings). The high-drift entries carry expectations[] that PIN current elegant-v2 guidance (visible pop-out button canonical / open-overlay! fallback-only / init! installs-but-does-not-open / Settings override order / passive inspect vs explicit Reset / Static Machines for full topology / redacted-by-default Snapshot / no standalone Issues|Hydration|Schemas Dynamic tab) AND reject stale guidance (wired r/R/* rewind keys, density radio in Settings, raw app-db snapshot by default, a re-frame-10x compatibility path). Negatives target adjacent surfaces (re-frame2-pair drives Xray; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering. NB: density is NOT a Settings-popup control (the radio was removed 2026-05-27); config-init-vs-settings exercises the boot-default-vs-runtime-override contract through epoch-history, a slot the popup actually surfaces.",
+ "notes": "Positives (should_trigger: true) target the launch + tab-routing + first-screen-chrome surface of SKILL.md across both modes (Dynamic event-spine + Static registry browse). The launch positives exercise the FULL public mount-verb set — the default true-inline panel (launch-default), the open-overlay! no-layout-host fallback (launch-overlay), the popout! pop-out window via both the visible chrome `⛶` top-bar button (launch-popout-button — a no-code question whose answer must name the shipped button, not a programmatic-only or future-right-click path) and the programmatic API (launch-popout), and the programmatic init! (launch-programmatic) — plus the init!/configure!-vs-Settings boot-config contract (config-init-boot, config-init-vs-settings). The tab-inventory positives PIN the current 9-tab Dynamic surface: panel-route-modules routes the EP-0013 module/realm/app-value question to the Modules tab (:module-view, mnem u, :order 9, L4-only — no standalone mount facade), and tab-inventory-count asserts the full ordered 9-tab list (Epoch·app-db·Views·Trace·Machine·Routes·Resources·Graph·Modules, mnemonics e a v t m r s g u) matching focus.cljc's valid-panels set — so a future drift that drops Modules or reverts to 8 tabs fails answer-quality. The high-drift entries carry expectations[] that PIN current elegant-v2 guidance (visible pop-out button canonical / open-overlay! fallback-only / init! installs-but-does-not-open / Settings override order / passive inspect vs explicit Reset / Static Machines for full topology / redacted-by-default Snapshot / 9 Dynamic tabs incl. Modules / no standalone Issues|Hydration|Schemas Dynamic tab) AND reject stale guidance (wired r/R/* rewind keys, density radio in Settings, raw app-db snapshot by default, a re-frame-10x compatibility path, an 8-tab inventory). Negatives target adjacent surfaces (re-frame2-pair drives Xray; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering. NB: density is NOT a Settings-popup control (the radio was removed 2026-05-27); config-init-vs-settings exercises the boot-default-vs-runtime-override contract through epoch-history, a slot the popup actually surfaces.",
  "evals": [
  {
  "id": 1,
@@ -142,6 +142,30 @@
  "The output says the Settings popup value wins over the init!/configure! boot default for epoch-history depth.",
  "The output states (or clearly implies) the layered merge order: defaults < configure! < Settings.",
  "The output does NOT claim density is a Settings-popup control (the density radio was removed 2026-05-27 — density is a boot/configure! concern only)."
+ ]
+ },
+ {
+ "id": 28,
+ "name": "panel-route-modules",
+ "should_trigger": true,
+ "prompt": "Which Xray tab shows me what realms and frames are installed and which modules / app values each realm composed in?",
+ "expected_output": "The agent routes to the Dynamic Modules tab (internal id :module-view, mnemonic u, :order 9) — the EP-0013 module / realm / app-value lens that projects the (realm, frame) topology (rf/realm-ids · rf/frame-ids · rf/frame-realm) plus the per-module provenance read off each realm's installed app value (rf/installed-app). It names Modules as one of the 9 Dynamic tabs, NOT a Static tab, and NOT an omitted/absent tab. It may note Modules is an L4-only registry tab (focusable, no standalone mount facade).",
+ "expectations": [
+ "The output routes the 'what realms / frames / modules / app values are installed' question to the Dynamic Modules tab (the :module-view / EP-0013 module-realm-app-value lens).",
+ "The output treats Modules as a SHIPPED Dynamic tab — it does NOT say Xray has no such tab, and does NOT misroute it to Static mode or to the Graph tab as the same thing.",
+ "The output does NOT invent a public mount-module-view! / standalone mount call (Modules is an L4-only registry tab — focusable, no standalone mount facade)."
+ ]
+ },
+ {
+ "id": 29,
+ "name": "tab-inventory-count",
+ "should_trigger": true,
+ "prompt": "List every tab Xray's Dynamic mode ships, in order.",
+ "expected_output": "The agent enumerates the 9 Dynamic L4 tabs in :order — Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Modules (mnemonics e a v t m r s g u) — matching focus.cljc's valid-panels set (#{:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view}). It does NOT report 8 tabs / omit Modules, and does NOT list a removed tab (Issues / Event / Chrome A11y / a standalone Machines-Canvas).",
+ "expectations": [
+ "The output lists exactly the 9 Dynamic tabs (Epoch, app-db, Views, Trace, Machine, Routes, Resources, Graph, Modules) — Modules is present, and the count is 9, not 8.",
+ "The output orders them correctly (Epoch first via :order -1; Resources :order 7, Graph :order 8, Modules :order 9 last).",
+ "The output does NOT include a removed tab (Issues, Event, Chrome A11y, or a standalone Dynamic Machines-Canvas) in the Dynamic inventory."
  ]
  },
  {"id": 13, "name": "neg-drive-xray", "should_trigger": false, "prompt": "Use Xray to dispatch [:cart/apply-coupon \"SPRING25\"] and tell me what happens.", "rationale": "Driving Xray from a REPL is re-frame2-pair's surface, not the read-only tour."},

--- a/skills/re-frame2-xray/package.json
+++ b/skills/re-frame2-xray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@day8/re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host / full-screen-canvas hosts, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 8 Dynamic event-spine tabs (incl. Resources and the EP-0014 derivation/process Graph) and 5 Static registry-browse tabs — surfaces the data you're looking for.",
+  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host / full-screen-canvas hosts, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 9 Dynamic event-spine tabs (incl. Resources, the EP-0014 derivation/process Graph, and the EP-0013 module/realm/app-value Modules tab) and 5 Static registry-browse tabs — surfaces the data you're looking for.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -15,16 +15,23 @@ palette tokens, density. Tab order is set declaratively via `reg-l4-tab!`
 `:order` and rendered by `shell.cljs` (Dynamic) / `static/shell.cljs`
 (Static). The live Dynamic `:order` values are Epoch `-1` · app-db `1` ·
 Views `2` · Trace `3` · Machine `4` · Routes `6` · Resources `7` ·
-Graph `8` — eight Dynamic tabs in all (the core six plus the two
-cross-feature lenses, **Resources** and **Graph**, each registered by its
-own panel through the `reg-l4-tab!` seam).
+Graph `8` · Modules `9` — nine Dynamic tabs in all (the core six plus the
+three cross-feature lenses, **Resources**, **Graph**, and **Modules**,
+each registered by its own panel through the `reg-l4-tab!` seam). (`:order
+5` is unallocated — it was the retired Issues tab's slot.) The canonical
+inventory lives in `focus.cljc`'s `valid-panels` def (`#{:epoch :app-db
+:views :trace :machines :routing :resources :derivation-graph
+:module-view}`), which mirrors the live `panel-registry/tab-ids-for-mode
+:dynamic` set — a cross-check test fails the build if the two drift, so
+that def is the authoritative count when this leaf and the source ever
+disagree.
 
 ## Two modes
 
 The two-mode model (Dynamic event-spine 4-layer chrome · Static registry
 3-layer chrome, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`) is
 covered in [`SKILL.md` §Two modes](../SKILL.md#two-modes). This leaf is
-the per-panel tour: the 8 Dynamic tabs in §Panel-by-panel below, the 5
+the per-panel tour: the 9 Dynamic tabs in §Panel-by-panel below, the 5
 Static tabs in §Static mode — registry browse. One binding constraint to
 restate: **no cross-epoch L4 panels** — every Dynamic L4 tab is a lens on
 the one focused epoch; aggregate signal lives on L2 badges only (§021
@@ -75,15 +82,17 @@ tab-bar ribbon, which rewinds the observed frame's live
 
 ## Panel-by-panel (Dynamic mode)
 
-Eight Dynamic tabs, left-to-right by `:order` (mnemonics
-`e a v t m r s g`): **Epoch · app-db · Views · Trace · Machine · Routes ·
-Resources · Graph.** The first six are the core spine lenses (§018 §5 +
-§021 §9.1); **Resources** (`:order 7`) and **Graph** (`:order 8`) are the
-two cross-feature lenses that landed last, each self-registered through
-the `reg-l4-tab!` seam (`panels/resources.cljs`,
-`panels/derivation_graph.cljs`). (Internal tab ids stay `:epoch :app-db
-:views :trace :machines :routing :resources :derivation-graph` — the
-display labels rebased over a rename history but the ids are stable.) The
+Nine Dynamic tabs, left-to-right by `:order` (mnemonics
+`e a v t m r s g u`): **Epoch · app-db · Views · Trace · Machine · Routes ·
+Resources · Graph · Modules.** The first six are the core spine lenses
+(§018 §5 + §021 §9.1); **Resources** (`:order 7`), **Graph** (`:order 8`),
+and **Modules** (`:order 9`) are the three cross-feature lenses that
+landed last, each self-registered through the `reg-l4-tab!` seam
+(`panels/resources.cljs`, `panels/derivation_graph.cljs`,
+`panels/module_view.cljs`). (Internal tab ids stay `:epoch :app-db
+:views :trace :machines :routing :resources :derivation-graph
+:module-view` — the display labels rebased over a rename history but the
+ids are stable.) The
 pre-rebuild **Event** panel was retired (2026-05-27 —
 `panels/event_detail.cljs` is deleted) and the **Issues** tab was retired
 (2026-05-31 — `panels/issues_ribbon.cljs` is deleted); see §What's
@@ -600,6 +609,61 @@ implementation at
 [`panels/derivation_graph.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs)
 + [`panels/derivation_graph_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc).
 
+### Modules — cross-feature · mnem `u` · `:order 9`
+
+Question: **What's installed, and how is the process partitioned into
+realms / frames / modules?** (Display label **Modules**; internal tab id
+`:module-view`.) Xray's UI over the **EP-0013 module / realm / app-value**
+address space — the structural counterpart to the Graph tab (Graph is the
+per-fact derivation/process view; Modules is the per-(realm, frame)
+topology + per-module provenance view). Registered at `:order 9`, after
+the Graph tab (`:order 8`), keeping the cross-feature runtime-structure
+tabs adjacent.
+
+The panel projects the `(realm, frame)` address space plus the
+per-module provenance read off each realm's installed app value:
+
+- **The realm / frame topology** — every installed **realm**
+ (`rf/realm-ids`), the **frames** each realm owns
+ (`rf/frame-ids` + `rf/frame-realm` mapping each frame to its owning
+ realm). In a single-realm app this is one realm holding every frame; a
+ multi-realm process shows the partition.
+- **Per-module provenance** — read off each realm's **installed app
+ value** (`rf/installed-app`, EP-0013 disposition 6) — the modules /
+ app-value composed into the realm at install time.
+
+The projection runs through the pure
+`module_view_helpers/project-module-view` over those public seams.
+
+> **`:module-view` is an L4-only registry tab — no standalone mount
+> facade.** Like the Graph tab, Modules registers through `reg-l4-tab!`
+> but exposes **no** `mount-*!` facade (it is **not** in `panel-enum`,
+> which carries only the standalone-mountable surface) — it is a
+> shell-internal tab, focusable via `focus!` / the command palette but not
+> independently mountable the way the other seven Dynamic panels are.
+> Route users to **open the Modules tab**; do not tell them to call a
+> `mount-module-view!` — there isn't one.
+
+**Does not compose off an `:rf.xray/*` app-db slot.** The address space is
+a process-global fact (realms + frames live in the framework's registries,
+not Xray's app-db); the sub reads them directly at recompute time, and a
+tab activation re-renders the panel which re-derefs (a browse-on-open
+shape matching the other Static-style surfaces).
+
+**Read-only** — enumerating realms / frames and reading installed app
+values pins nothing and dispatches nothing (`rf/installed-app` is a STATIC
+read of the install-time value, not a routing path).
+
+**Open when:** "what realms exist?", "which frames belong to which
+realm?", "what modules / app values are installed?", "how is this process
+partitioned?"
+
+Spec: [`007-UX-IA.md` §EP-0013 realm-awareness](../../../tools/xray/spec/007-UX-IA.md)
++ [`026-Module-View-Panel.md`](../../../tools/xray/spec/026-Module-View-Panel.md);
+implementation at
+[`panels/module_view.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs)
++ [`panels/module_view_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc).
+
 ### Issues — no longer a Dynamic tab
 
 There is **no dedicated Issues tab**. Mike ruled it out (#2540,
@@ -686,9 +750,11 @@ Per §021 §15 (Dynamic mode) + §007 §Static mode:
 - **No Event tab.** Retired (2026-05-27 —
  `panels/event_detail.cljs` deleted). The **Epoch** panel (numbered
  cascade, `:order -1`) is the canonical "what happened" surface.
-- **No extra Dynamic L4 lens.** The 6-tab Dynamic set is the contract;
- sub-layer surfaces inline in Views + the app-db hover popover (no peer
- Subs panel).
+- **No peer Subscriptions L4 tab.** The reactive cascade surfaces inline
+ in Views + the app-db hover popover, not as its own Dynamic tab. (The
+ Dynamic set is open through the `reg-l4-tab!` seam — Resources, Graph,
+ and Modules each registered their own cross-feature tab — but there is
+ no separate Subs lens.)
 - **No Chrome A11y tab.** Removed; a11y dogfooding is Story's domain.
 - **No standalone Dynamic "Machines Canvas" tab.** Removed;
  the spine-INDEPENDENT browse-all machine canvas lives under Static
@@ -702,8 +768,8 @@ Per §021 §15 (Dynamic mode) + §007 §Static mode:
  §1.6); switch focus via the L1 frame picker.
 - **No legacy panels.** Subscriptions, Effects, Flows, Performance,
  Schemas, Hydration are NOT separate Dynamic tabs. Their content is
- surfaced through the Dynamic 6 above — and the registry catalogues live
- in Static mode:
+ surfaced through the Dynamic tabs above — and the registry catalogues
+ live in Static mode:
  - Subscriptions → Views (cascade tree) + app-db (hover popover)
  - Effects → Epoch EFFECT HANDLERS step (flat ledger) + Trace (raw `:rf.fx/*` ops)
  - Flows → Epoch FLOW step (one per flow) · Static → Flows (registry)

--- a/skills/re-frame2-xray/references/shared-components.md
+++ b/skills/re-frame2-xray/references/shared-components.md
@@ -86,13 +86,15 @@ signal, colour is never alone):
 | Routes | `r` | `🌐` | `:yellow` |
 | Resources | `s` | — | (family-tinted rows; no single stripe) |
 | Graph | `g` | — | `:magenta` (violet — the algebra lens) |
+| Modules | `u` | — | (family-tinted rows; no single stripe) |
 
-Eight Dynamic tabs (Epoch is `:order -1`, the leftmost / default-landing
-slot; **Resources** `:order 7` and **Graph** `:order 8` are the two
-cross-feature lenses, each self-registered through `reg-l4-tab!`). There
-is **no Issues tab** and **no Event tab** (replaced by Epoch) — issues
-surface inline in the Epoch cascade, the L2 pink-wash, and the
-issues-ribbon signal.
+Nine Dynamic tabs (Epoch is `:order -1`, the leftmost / default-landing
+slot; **Resources** `:order 7`, **Graph** `:order 8`, and **Modules**
+`:order 9` are the three cross-feature lenses, each self-registered
+through `reg-l4-tab!`; the **Modules** and **Graph** tabs are L4-only —
+focusable, no standalone mount facade). There is **no Issues tab** and
+**no Event tab** (replaced by Epoch) — issues surface inline in the Epoch
+cascade, the L2 pink-wash, and the issues-ribbon signal.
 
 L2 row badges (live impl `l2_timeline.cljc`): `⚠` issue · `◆` machine
 transition · `🌐` HTTP activity · `⚡` fx-emit child dispatch · `⏲` timer


### PR DESCRIPTION
Aligns the `re-frame2-xray` tour skill with the current shipped **9-tab** Dynamic Xray surface, adding the EP-0013 **Modules** (`:module-view`) tab the tour previously omitted (it taught an 8-tab set).

## Premise verification

Verified the tab inventory against the live source of truth before editing:

- `tools/xray/src/day8/re_frame2_xray/focus.cljc` `valid-panels` = `#{:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view}` — **9 tabs** (mirrors `panel-registry/tab-ids-for-mode :dynamic`; a cross-check test fails the build if they drift).
- `panels/module_view.cljs` `reg-l4-tab!` → `{:id :module-view :label "Modules" :mnem "u" :order 9 :modes #{:dynamic}}`, L4-only (not in `panel-enum`, no standalone `mount-*!` facade), EP-0013 module/realm/app-value lens.
- Full ordered set: Epoch(-1) · app-db(1) · Views(2) · Trace(3) · Machine(4) · Routes(6) · Resources(7) · Graph(8) · Modules(9); `:order 5` is the retired Issues tab's vacated slot.

Bead premise confirmed correct — nothing rejected.

## Changes

- **SKILL.md / README.md / package.json / .claude-plugin/plugin.json** — 8→9 Dynamic tabs; added the Modules tab + a note that Modules and Graph are L4-only registry tabs (no standalone mount facade); added Modules trigger phrases.
- **references/panels.md** — added the full Modules panel section; fixed the `:order` summary, the panel-by-panel intro, and the stale "6-tab Dynamic set is the contract" / "Dynamic 6" lines; cited `focus.cljc` `valid-panels` as the authoritative count.
- **references/shared-components.md** — added the Modules iconography row; 8→9.
- **docs/skills/re-frame2-xray.md** — scope prose now consistently answers the same **three** questions (launch / tab routing / chrome) and the launch summary includes the `open-overlay!` fallback; 8→9 Dynamic tabs.
- **evals/** — added two Layer-2 evals (`panel-route-modules`, `tab-inventory-count`) that pin the 9-tab surface incl. Modules and reject an 8-tab inventory; updated `notes` + coverage table (29 evals, 21 pos / 8 neg, 13 Layer-2); documented the manual tab-inventory verification step against `focus.cljc` / `reg-l4-tab!` / `spec/API.md`.

Skill content stays generic to any consumer app; repo paths/spec citations are examples/source-of-truth only. No rf2 bead ids in user-facing skill docs (preserved). Xray is anchored onto its Redux-DevTools / React-DevTools-Profiler JS mental model where the skill already does that; Modules is framed as the structural counterpart to the Graph tab.

## Quality gates

- `python scripts/check_skill_eval_packaging.py` — pass (exit 0)
- `python scripts/check_skill_package_refs.py` — pass (exit 0)
- `python scripts/check_readme_links.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0; only pre-existing unrelated INFO link notes)
- `evals.json` JSON valid; counts reconcile (29 / 21 pos / 8 neg / 13 Layer-2); no duplicate ids
- Residue grep: no stale "8 Dynamic" / "two questions" claims as fact; no rf2 bead-id leaks in user-facing skill docs