### PR TITLE
refactor(support-tools): prune retired regression scaffolding (rf2-880s2r)

### DIFF
--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -538,16 +538,11 @@ test('PR + nightly Story/Xray jobs cache the shadow-cljs compile output (rf2-og3
   assert.match(nightly, /story-xray-shadow-/);
 });
 
-// rf2-t5slp — the framework-testbeds gate was retired after all four
-// rf2-tglku migration waves moved every framework + top-level testbed
-// Playwright spec.cjs to CLJS/JVM unit tests. The classifier no longer
-// emits a `framework_testbeds` output; testbed source diffs only light
-// `cljs_browser` (for the transitive CLJS compile coverage).
-
-test('framework_testbeds output is no longer emitted (rf2-t5slp)', () => {
-  const result = classify('testbeds/ssr_basic/core.cljs');
-  assert.equal(result.framework_testbeds, undefined);
-});
+// Testbed Playwright specs were migrated to CLJS/JVM unit tests
+// (rf2-tglku waves), so a testbed source diff only needs the transitive
+// CLJS compile coverage: top-level testbeds light `cljs_browser`, Xray
+// testbeds light `story_xray_browser`, and only adapter testbeds (which
+// keep a live Playwright smoke) light `adapter_testbed_smokes`.
 
 test('top-level testbed .cljs change fires cljs_browser only (rf2-t5slp)', () => {
   const result = classify('testbeds/ssr_basic/core.cljs');
@@ -634,17 +629,11 @@ test('examples/scripts static-only scanners stay on the always-on JS harness pat
   }
 });
 
-test('framework-testbeds workflow job is removed (rf2-t5slp)', () => {
-  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
-  assert.doesNotMatch(workflow, /^\s*framework-testbeds:/m);
-  assert.doesNotMatch(workflow, /framework_testbeds/);
-});
-
 test('adapter-testbed-smokes workflow remains scoped to EXAMPLES_FILTER=adapters/ (rf2-t5slp)', () => {
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
-  // Find the adapter-testbed-smokes job block and verify it still
-  // passes the narrow adapters/ filter — the only Playwright surface
-  // under the examples orchestrator after framework-testbeds retired.
+  // Verify the adapter-testbed-smokes job still passes the narrow
+  // adapters/ filter — adapter testbeds are the only Playwright surface
+  // under the examples orchestrator.
   assert.match(
     workflow,
     /adapter-testbed-smokes:[\s\S]*EXAMPLES_FILTER:\s*"adapters\/"/,

--- a/implementation/scripts/_examples-filter.test.cjs
+++ b/implementation/scripts/_examples-filter.test.cjs
@@ -313,18 +313,12 @@ it('SPEC_ROOTS resolve under the repo root', () => {
 });
 
 // ---- root TESTING.md examples-gate drift guard (rf2-n4nc2o) --------------
-// The root testing guide previously documented a retired/nonexistent
-// `test:examples:realworld` command and "whole-example browser smoke"
-// wording for the examples gate, while the actual scripts are
-// adapter-smoke-only. Two teeth pin the human-facing gate map to reality:
-//
-//   1. Every example-gate script the guide names (the `test:examples*`
-//      family) must actually exist in implementation/package.json — so a
-//      reintroduced `test:examples:realworld` row fails loud rather than
-//      sending contributors to a nonexistent command.
-//   2. The retired "whole-example browser smoke" wording must not reappear
-//      for this gate — `test:examples` is the three adapter testbed smokes
-//      only (the `examples/` tree is test-free).
+// Pin the human-facing gate map to reality: every example-gate script the
+// root testing guide names (the `test:examples*` family) must actually
+// exist in implementation/package.json, so a guide row pointing at a
+// nonexistent command fails loud rather than sending contributors to a
+// dead script. (`test:examples` is the three adapter testbed smokes only —
+// the `examples/` tree is itself test-free.)
 
 const ROOT_TESTING_MD = path.join(REPO_ROOT, 'TESTING.md');
 const PKG_JSON = path.join(REPO_ROOT, 'implementation', 'package.json');
@@ -350,19 +344,6 @@ it('every `test:examples*` command named in root TESTING.md exists in implementa
     missing,
     [],
     `root TESTING.md names example-gate scripts absent from implementation/package.json: ${missing.join(', ')}`,
-  );
-});
-
-it('root TESTING.md does not resurrect the retired examples-gate wording (rf2-n4nc2o)', () => {
-  const doc = fs.readFileSync(ROOT_TESTING_MD, 'utf8');
-  assert.ok(
-    !/test:examples:realworld/.test(doc),
-    'root TESTING.md references the retired `test:examples:realworld` script',
-  );
-  assert.ok(
-    !/whole-example browser smoke/i.test(doc),
-    'root TESTING.md uses retired "whole-example browser smoke" wording for the examples gate; ' +
-      'test:examples is the three adapter testbed smokes only',
   );
 });
 

--- a/implementation/scripts/test-mcp-conformance.cjs
+++ b/implementation/scripts/test-mcp-conformance.cjs
@@ -12,11 +12,13 @@
  *   5. MCP conformance tools/story-mcp           (SDK Client driver, rf2-cum40)
  *   6. MCP conformance wire-vocab  (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)
  *
- * Gates #4 + #5 ride on `tools/mcp-conformance/npm test` (which itself
- * dispatches via `scripts/test-all.cjs` — exec-safety + re-frame2-pair +
- * live-overflow SKIP + live-subscribe SKIP + story + flag-gates). The
- * re-frame2-pair conformance harness drives the compiled
- * `out/server.js` Node bundle, so this script also runs
+ * Gates #4 + #5 ride on `tools/mcp-conformance/npm test`, which dispatches
+ * via `tools/mcp-conformance/scripts/test-all.cjs`. That orchestrator's
+ * `TESTS` array IS the authoritative conformance inventory (exec-safety +
+ * runner/hermetic unit gates + re-frame2-pair end-to-end + the SKIP-gated
+ * live-* probes + story end-to-end + flag-gates) — this wrapper does not
+ * re-enumerate it. The re-frame2-pair conformance harness drives the
+ * compiled `out/server.js` Node bundle, so this script also runs
  * `shadow-cljs compile server` from `tools/re-frame2-pair-mcp/`
  * before invoking the conformance suite — matching what
  * `mcp-conformance-re-frame2-pair` does in CI.
@@ -34,11 +36,14 @@
  *   - Rich output formatting / unified report
  *   - Incremental `--changed-only` mode
  *
- * Hermetic live-overflow (which boots shadow-cljs + Playwright Chromium
- * against `skills/re-frame2-pair/tests/fixture/`) is intentionally NOT
- * chained here — that gate lives in CI's `mcp-conformance-re-frame2-pair`
- * job and burns ~2 min of wall-clock on a cold-cache run. Operators who
- * want it run `cd tools/mcp-conformance && npm run test:re-frame2-pair-live-overflow-hermetic`
+ * The hermetic live conformance gate (which boots shadow-cljs + Playwright
+ * Chromium against `skills/re-frame2-pair/tests/fixture/` and runs the
+ * SKIP-gated live probes against it — its `INNER_TESTS` array in
+ * `tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`
+ * is the authoritative list) is intentionally NOT chained here. That gate
+ * lives in CI's `mcp-conformance-re-frame2-pair` job and burns ~2 min of
+ * wall-clock on a cold-cache run. Operators who want it run
+ * `cd tools/mcp-conformance && npm run test:re-frame2-pair-live-overflow-hermetic`
  * directly.
  */
 'use strict';


### PR DESCRIPTION
Prunes retired regression scaffolding in `implementation/scripts` (rf2-880s2r, P3 vestigial, pre-alpha ELEGANCE). Each item was verified genuinely dead before deletion.

## What was pruned

**`_changed-surfaces.test.cjs` — retired-name resurrection guards**
- Dropped `framework_testbeds output is no longer emitted` — a pure absence-of-retired-field assertion (`classify(...).framework_testbeds === undefined`), redundant with the *positive* `top-level testbed .cljs change fires cljs_browser only` test on the identical input that immediately follows it.
- Dropped `framework-testbeds workflow job is removed` — a pure resurrection guard asserting the workflow lacks `framework-testbeds:` / `framework_testbeds`. The job/output has no path back pre-alpha; the guard only kept the dead names alive in the corpus.
- Trimmed the retirement-narrative comments down to the current positive behavior (testbed diffs light `cljs_browser` / `story_xray_browser`; only adapter testbeds light `adapter_testbed_smokes`).
- Kept the positive `adapter-testbed-smokes workflow remains scoped to EXAMPLES_FILTER=adapters/` check.

**`_examples-filter.test.cjs` — retired-wording resurrection guard**
- Dropped `root TESTING.md does not resurrect the retired examples-gate wording` — pins absence of `test:examples:realworld` / `whole-example browser smoke`.
- Kept the positive existence check: every `test:examples*` command the root guide names must exist in `implementation/package.json`.
- Trimmed the comment block to the surviving positive tooth.

**`test-mcp-conformance.cjs` — wrapper inventory drift (comment-only)**
- Gate `[4+5/6]` no longer re-enumerates `test-all.cjs`'s contents (the stale list omitted the watchdog / cleanup / setup-timeout / port-escape / live-redaction tests that have since landed). It now points at `test-all.cjs`'s `TESTS` array as the authoritative inventory.
- The hermetic note points at `run-live-re-frame2-pair-overflow-hermetic.cjs`'s `INNER_TESTS` array as the authoritative list (now overflow + subscribe + egress-protection, not "overflow" alone).
- The wrapper's own **six-gate CI model is live and accurate** — `.github/workflows/test.yml` runs exactly six split MCP-conformance jobs (jvm-story-mcp, node-story-mcp, node-pair-mcp, mcp-conformance-{re-frame2-pair,story,wire-vocab}). The "six gates" framing was NOT touched; the bead's finding 2 was about the delegated gate-4/5 *inventory* drift, which is what was fixed.

## Verification (premises checked, none rejected)
- `framework_testbeds` / `framework-testbeds` are genuinely retired — grep across `implementation/scripts` returns only the guards being removed; no live emission.
- `test-all.cjs` grew from the comment's stale list to 11 tests — confirmed against the canonical orchestrator's `TESTS` array.
- The hermetic orchestrator's Playwright/Chromium-against-fixture claim is *accurate* and was preserved; only the stale single-test "overflow" framing was generalized to `INNER_TESTS`.

## Quality gates
- `npm run test:script-policy` (from `implementation/`) — **PASS** (all 14 sub-suites; `changed-surfaces` 74 passed, `examples-filter` all passed, `script-spawn-policy` 110 passed). This is the bead's explicit acceptance gate.
- `node --check scripts/test-mcp-conformance.cjs` — **PASS** (comment-only change; syntax OK).
- `npm run test:cljs` — **N/A** (changes are `.cjs` Node CI files, not CLJS source; nothing compiles there).
- `npm run test:bundle-isolation` — **N/A** (edited files are CI policy-test `.cjs` + a Node CI wrapper; none are required by or compile into any production bundle).