### PR TITLE
refactor(xray): remove unused feature-matrix staged surfaces (rf2-fxnszc)

### DIFF
--- a/tools/xray/testbeds/feature_matrix/README.md
+++ b/tools/xray/testbeds/feature_matrix/README.md
@@ -4,15 +4,22 @@ This directory owns the Xray browser feature/load gate scenarios for
 [`tools/xray/spec/017-Test-Coverage-Matrix.md`](../../spec/017-Test-Coverage-Matrix.md).
 
 The gate deliberately reuses the shared deterministic framework testbeds
-under `testbeds/` rather than duplicating app logic in Xray:
+under `testbeds/` (plus the Xray-owned routing/machine decks under
+`tools/xray/testbeds/`) rather than duplicating app logic in Xray. The
+live substrates are:
 
-- `deliberate_throw` for handler/fx/flow/machine exceptions.
-- `schema_violation` for event, cofx, app-db, and fx-args schema failures.
+- `deliberate_throw` for handler/fx/machine exceptions (Epoch + Trace).
 - `http_toggle` for managed HTTP success and failure categories.
-- `multi_frame`, `deep_machine`, `long_flow_w_failure`, and
-  `drain_depth_trigger` for frame, machine, flow, and load semantics.
-- `non_trivial_app_db`, `large_dispatcher`, and SSR
-  hydration testbeds for panel-specific payload shapes.
+- `multi_frame` for per-frame isolation (Trace + Epoch cascades).
+- `deep_machine` and the `machine_epochs` deck for machine semantics
+  (Machine Inspector chart render + per-track step matrix).
+- the `routes_epochs` deck for routing (Routing panel: current route,
+  navigation-this-epoch, nested route table, blocked nav).
+- `large_dispatcher` and the SSR hydration-mismatch testbed for
+  panel-specific payload shapes (large-value elision, Epoch under
+  cascade scope).
+- the `panel_gallery` deck for the theme-token CSS-variable resolution
+  probe.
 
 Run from `implementation/`:
 
@@ -26,29 +33,43 @@ state, the last trace rows, load stats when applicable, and a screenshot path.
 
 ## Current slice
 
-This gate covers the deterministic browser substrates plus the 20-event/load
-re-check. It now exercises the follow-up surfaces directly:
+After the 4-layer chrome refactor (`rf2-xy4yb`) the live L3/L4 tabs are
+Epoch / App-DB / Views / Trace / Machines / Routing / Resources /
+Derivation-Graph / Module-View. The dedicated Event-Detail, Time-Travel,
+Schema, Flows, and Performance panels were retired, so this gate exercises
+only the surviving tabs (chiefly Epoch / Trace / Routing / Machines) plus
+the 20-event/load re-check:
 
-- Open in Editor / Source Coordinates: trace and issues source chips are
-  clicked in the browser. Failures include the panel, source coordinate,
-  expected editor URI, observed bridge traces, network outcome, and screenshot.
+- Open in Editor / Source Coordinates: trace source chips are clicked in
+  the browser. Failures include the panel, source coordinate, expected
+  editor URI, observed bridge traces, network outcome, and screenshot.
 - Pop-out: the gate asserts that the inline shell leaves the host app
-  (laid out to the left of Xray) clickable and that `popout!` renders a same-origin second-window
-  Xray shell sharing the opener's runtime. (Per `rf2-sbfb7`, the dock /
-  docked-overlay and `mount-inline-panel!` debug surfaces were removed;
-  full-shell embedding lands under 008-Embedding-Contract.)
-- Schema recovery: the schema testbed loads the Malli adapter so browser runs
-  assert rollback, skipped handlers, skipped fx, and the Xray schema panel's
-  current row/empty-state projection.
-- Multi-frame fan-out: the multi-frame testbed uses a testbed-only bridge fx to
-  dispatch into explicit frames. The gate asserts direct A/B isolation, fan-out
-  into `:counter/b` and `:log`, per-frame epoch history, trace selection,
-  event-detail projection/orphan-state behavior, and the time-travel panel's
-  current `:counter/b` target-frame projection.
-- Large payload load: the large dispatcher scenario drives 20 meaningful host
-  dispatches, asserting large-elision markers and app-db/trace panel stability
-  under repeated size events.
+  (laid out to the left of Xray) clickable and that `popout!` renders a
+  same-origin second-window Xray shell sharing the opener's runtime. (Per
+  `rf2-sbfb7`, the dock / docked-overlay and `mount-inline-panel!` debug
+  surfaces were removed; full-shell embedding lands under
+  008-Embedding-Contract.)
+- Deterministic exceptions: the deliberate-throw testbed surfaces thrown
+  handlers inline in the Epoch panel's numbered cascade and via Trace
+  source-coord chips. (Schema-failure recovery — rollback, skipped
+  handlers/fx, the four `:where` surfaces — moved to CLJS unit at
+  `tools/xray/test/.../panels/epoch/projection_cljs_test.cljc`.)
+- Multi-frame fan-out: the multi-frame testbed uses a testbed-only bridge
+  fx to dispatch into explicit frames. The gate asserts direct A/B
+  isolation, fan-out into `:counter/b` and `:log`, and per-frame epoch
+  history via the Trace and Epoch tabs (the per-frame cascade).
+- Routing: the routes-epochs deck drives the real `reg-route` +
+  `:rf.route/navigate` surface, asserting the Routing panel's current
+  route, navigation-this-epoch outcome, nested route table, and blocked
+  navigation.
+- Machines: the deep-machine substrate asserts the Machine Inspector
+  chart SVG renders; the machine-epochs deck steps a multi-machine,
+  frame-isolated matrix and confirms the inspector mounts on a focused
+  machine event.
+- Large payload load: the large dispatcher scenario drives 20 meaningful
+  host dispatches, asserting large-elision markers and app-db/trace panel
+  stability under repeated size events.
 - Trace row budget: the load gate saturates Xray's 1000-event trace ring,
-  asserts the Trace panel keeps the DOM to the 200-row rendering budget with an
-  overflow indicator, then drives 20 more host dispatches without growing the
-  rendered row count.
+  asserts the Trace panel keeps the DOM to the 200-row rendering budget
+  with an overflow indicator, then drives 20 more host dispatches without
+  growing the rendered row count.

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -7,7 +7,6 @@ const {
 } = require('../../../../examples/scripts/spec-helpers.cjs');
 const {
   clearTraceBus,
-  readEpochHistoryAsEdn,
   readTraceEventsAsEdn,
 } = require('../../../../testbeds/spec-helpers.cjs');
 
@@ -87,12 +86,15 @@ const STAGED_SURFACES = [
     html: ['testbeds', 'deliberate_throw', 'index.html'],
     servedPath: 'testbeds/deliberate-throw',
   },
-  {
-    build: 'testbeds/schema-violation',
-    bundleDir: ['out', 'testbeds', 'schema-violation'],
-    html: ['testbeds', 'schema_violation', 'index.html'],
-    servedPath: 'testbeds/schema-violation',
-  },
+  // ---- retired with the migrated scenario (rf2-w1mnq / rf2-fxnszc) -----
+  //
+  // The `testbeds/schema-violation` surface had been a no-op SKIP since
+  // #1745 and its schema-recovery assertions moved to CLJS unit
+  // (`tools/xray/test/.../panels/epoch/projection_cljs_test.cljc`, landed
+  // #1753). No live SCENARIOS entry navigated to `/testbeds/schema-
+  // violation/`, so staging it only paid a dead compile + serve. The
+  // testbed source remains under `testbeds/schema_violation/` as a manual-
+  // inspection target.
   {
     build: 'testbeds/http-toggle',
     bundleDir: ['out', 'testbeds', 'http-toggle'],
@@ -117,18 +119,18 @@ const STAGED_SURFACES = [
     html: ['testbeds', 'deep_machine', 'index.html'],
     servedPath: 'testbeds/deep-machine',
   },
-  {
-    build: 'testbeds/long-flow-w-failure',
-    bundleDir: ['out', 'testbeds', 'long-flow-w-failure'],
-    html: ['testbeds', 'long_flow_w_failure', 'index.html'],
-    servedPath: 'testbeds/long-flow-w-failure',
-  },
-  {
-    build: 'testbeds/drain-depth-trigger',
-    bundleDir: ['out', 'testbeds', 'drain-depth-trigger'],
-    html: ['testbeds', 'drain_depth_trigger', 'index.html'],
-    servedPath: 'testbeds/drain-depth-trigger',
-  },
+  // ---- retired with the dropped panels (rf2-xy4yb / rf2-fxnszc) -------
+  //
+  // `testbeds/long-flow-w-failure` (Flows panel) and `testbeds/drain-depth-
+  // trigger` (Performance panel) staged surfaces drove scenarios that were
+  // retired when the 4-layer chrome refactor (rf2-xy4yb) dropped both
+  // panels — there is no UI handoff left to assert. No live SCENARIOS
+  // entry navigates to either served path, so both were dead staged
+  // surfaces paying a compile + serve for nothing. The flow-failure trace
+  // evidence stays covered by the `deterministic exceptions` scenario; the
+  // `:halted-depth` epoch record stays observable via the substrate's
+  // host-side epoch-history probe. The testbed sources remain under
+  // `testbeds/{long_flow_w_failure,drain_depth_trigger}/`.
   // ---- retired with the converted scenario (rf2-rviu8) ----------------
   //
   // The `testbeds/non-trivial-app-db` build was driven by the
@@ -150,12 +152,14 @@ const STAGED_SURFACES = [
     html: ['testbeds', 'ssr_hydration_mismatch', 'index.html'],
     servedPath: 'testbeds/ssr-hydration-mismatch',
   },
-  {
-    build: 'testbeds/ssr-multi-frame',
-    bundleDir: ['out', 'examples', 'testbed-ssr-multi-frame'],
-    html: ['testbeds', 'ssr_multi_frame', 'index.html'],
-    servedPath: 'testbeds/ssr-multi-frame',
-  },
+  // ---- retired: never wired to a live scenario (rf2-fxnszc) -----------
+  //
+  // The `testbeds/ssr-multi-frame` surface was staged but no SCENARIOS
+  // entry ever navigated to `/testbeds/ssr-multi-frame/` — a dead staged
+  // surface that compiled + served a bundle nothing hit. The SSR
+  // multi-frame isolation invariant is covered as pure JVM coverage at
+  // `implementation/ssr/test/re_frame/ssr_multi_frame_isolation_test.clj`.
+  // The testbed source remains under `testbeds/ssr_multi_frame/`.
   // rf2-azfct — panel-gallery testbed staged for the theme-token CSS-
   // variable resolution probe. The gallery embeds bare Xray widgets
   // without mounting the Xray shell, so its boot path must call
@@ -1607,35 +1611,6 @@ async function runDeepMachine(page, state) {
   }
   state.deepMachine = state.deepMachine || {};
   state.deepMachine.chartProjection = chartProjection;
-}
-
-async function runLongFlow(page) {
-  await openXray(page);
-  await clearTrace(page);
-  await page.locator('[data-testid="fail-at"]').fill('3');
-  await page.locator('[data-testid="total-ticks"]').fill('6');
-  await clickTestId(page, 'start');
-  await expectTextEquals(page.locator('[data-testid="status"]'), 'done', 10000);
-  await waitForTraceMatch(page, /rf\.flow\/failed|flow-eval-exception|long-flow-w-failure \/ :flow-b/, 'flow failure trace');
-  await clickSidebar(page, 'flows', 'rf-xray-flows');
-  await expectVisible(page.locator('[data-testid="rf-xray-flows"]'), 5000);
-}
-
-async function runDrainDepth(page) {
-  await openXray(page);
-  await clearTrace(page);
-  await page.locator('[data-testid="drain-depth"]').fill('5');
-  await clickTestId(page, 'start');
-  await expectTextEquals(page.locator('[data-testid="depth-reached"]'), '0', 5000);
-  const history = await waitForValue(
-    () => readEpochHistoryAsEdn(page),
-    (probe) => probe.ok && probe.records.some((record) => record.includes(':halted-depth')),
-    { timeoutMs: 10000, description: ':halted-depth epoch record' },
-  );
-  await waitForTraceMatch(page, /drain-depth-exceeded|halted-depth|:rf\.error\/drain-depth-exceeded/, 'drain-depth trace');
-  await clickSidebar(page, 'performance', 'rf-xray-performance');
-  await expectVisible(page.locator('[data-testid="rf-xray-performance"]'), 5000);
-  return { haltedEpochs: history.records.filter((record) => record.includes(':halted-depth')).length };
 }
 
 async function runAppDbPrivacyLarge(page) {
@@ -3628,20 +3603,15 @@ const SCENARIOS = [
   },
   // ---- retired by rf2-xy4yb (4-layer chrome refactor) -------------------
   //
-  // 'long flow failure substrate' — the dedicated Flows panel was
-  // dropped (spec/018 §5: Flows fold into the Views tab as derived
-  // state). The Views tab itself is a stub pending its full impl;
-  // re-instate this scenario once the Views tab projects per-flow
-  // rows. Surviving evidence (flow-failure trace events) is covered
-  // by `deterministic exceptions and issue/trace surfacing`.
-  //
-  // 'drain-depth load failure substrate' — the Performance panel was
-  // dropped per Mike's call; Chrome DevTools' Performance tab is the
-  // v2 replacement. The `:halted-depth` epoch record is still
-  // observable via the substrate's host-side `readEpochHistoryAsEdn`
-  // probe, but there is no Xray UI handoff to assert against.
-  // Scenario retired; runDrainDepth / runLongFlow stay in place for
-  // any future revival.
+  // 'long flow failure substrate' (Flows panel) and 'drain-depth load
+  // failure substrate' (Performance panel) were retired when the 4-layer
+  // chrome refactor dropped both panels — Flows folds into the Views tab
+  // as derived state (spec/018 §5) and Performance is replaced by Chrome
+  // DevTools' Performance tab (Mike's call). With no UI handoff to assert,
+  // their runners + staged surfaces were removed (rf2-fxnszc). Surviving
+  // flow-failure trace evidence is covered by `deterministic exceptions
+  // and inline/trace surfacing`; the `:halted-depth` epoch record stays
+  // observable via the substrate's host-side epoch-history probe.
   //
   // ---- converted to multi-frame e2e CLJS (rf2-rviu8) --------------------
   //


### PR DESCRIPTION
Closes rf2-fxnszc.

## What

The Xray feature-matrix gate (`tools/xray/testbeds/feature_matrix/`) staged four browser surfaces that no active `SCENARIOS` entry navigated to, and kept two dead runner functions targeting panels removed by the 4-layer chrome refactor (rf2-xy4yb). In the nightly-full sweep these dead surfaces were still `shadow-cljs compile`d, copied into the static root, and existence-checked (`stageSurfaces` throws if a bundle/HTML source is missing) — pure dead compile + serve cost.

### Removed `STAGED_SURFACES` entries (verified dead)
| Surface | Why dead |
|---|---|
| `testbeds/schema-violation` | No-op SKIP scenario since #1745; recovery coverage migrated to CLJS unit `panels/epoch/projection_cljs_test.cljc` (#1753). No scenario navigates to `/testbeds/schema-violation/`. |
| `testbeds/long-flow-w-failure` | Flows panel dropped (rf2-xy4yb) — no UI handoff to assert. No scenario navigates there. |
| `testbeds/drain-depth-trigger` | Performance panel dropped (Mike's call → Chrome DevTools) — no UI handoff. No scenario navigates there. |
| `testbeds/ssr-multi-frame` | Never wired to any scenario; SSR multi-frame isolation covered by `implementation/ssr/test/.../ssr_multi_frame_isolation_test.clj`. |

Testbed sources under `testbeds/*` are left intact (out of this slice; manual-inspection / other-owner surfaces).

### Deleted dead runners
- `runLongFlow` — clicked the removed `flows` sidebar (`rf-xray-flows`).
- `runDrainDepth` — clicked the removed `performance` sidebar (`rf-xray-performance`).
- Plus the now-orphaned `readEpochHistoryAsEdn` import and the "stay in place for future revival" scaffolding comment.

### README
Rewrote the substrate list + "Current slice" section to describe only the live Epoch / Trace / Routing / Machines coverage, dropping the stale `schema_violation` / `long_flow_w_failure` / `drain_depth_trigger` substrate claims and the retired event-detail / time-travel panel assertions.

## Acceptance (per bead)
- [x] No `STAGED_SURFACES` entry is unused by active `SCENARIOS` — now 10 surfaces, all consumed; 0 unused; 0 unmapped scenario URLs.
- [x] `rg` finds no `runLongFlow` / `runDrainDepth` / future-revival scaffolding in `tools/xray/testbeds/feature_matrix`.
- [x] README current-slice text no longer advertises retired event-detail / time-travel / long-flow / drain-depth coverage.
- [x] Equivalent runner-mapping check passes (full-sweep + smoke-tier surface resolution both validated).

## Verification of premise
Cross-referenced every active `SCENARIOS` `url:` against `STAGED_SURFACES` `servedPath`: the four named surfaces are exactly the ones with no consumer. The gate runner (`implementation/scripts/serve-and-run-xray-feature-gate.cjs`) does not depend on the removed surfaces — they were only compiled/staged, never navigated. No `STAGED_SURFACES` entry or removed runner symbol is referenced by `tools/xray/spec/*`. Premise confirmed; nothing rejected.

## Spec note
`tools/xray/spec/*` unchanged because no spec references the removed `STAGED_SURFACES` entries, `runLongFlow`/`runDrainDepth`, or the feature_matrix README by symbol; spec 017's "Required shared testbed" affordances describe abstract coverage requirements (still satisfied — testbed sources kept; schema/flow/drain coverage relocated to CLJS) and the 4-layer coverage-matrix rows reference retired panels independently of this change (pre-existing, out of this vestigial slice).

## Quality gates
- Runner mapping check (the bead's named equivalent to the browser gate): validated via `node` against the edited `scenarios.cjs` — module parses; **10** staged surfaces, all consumed by an active scenario; **0** unused staged surfaces; **0** unmapped scenario URLs. Smoke-tier resolution also clean (4 smoke scenarios → 3 surviving surfaces: counter / deliberate-throw / panel-gallery).
- Full `npm run test:xray-feature-gate` browser sweep NOT run: change is JS-data + dead-fn removal + docs only (no CLJS touched); removing never-navigated surfaces can only reduce compile/stage work, not break a passing scenario. The deterministic mapping check above is the high-signal equivalent.
- `clojure -M:test` (xray CLJS unit) not separately run: zero CLJS source changed; the unit suite does not consume `scenarios.cjs`.