### PR TITLE
refactor(ssr): prune redirect + streaming-doc drift (rf2-3rsrr4)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -80,10 +80,15 @@
        hook clears the per-frame request slot in the same step
        (rf2-fcj33).
 
+  Streaming counterpart: `stream-handler` (re-exported below from
+  `re-frame.ssr.ring.streaming`) is the chunked-HTTP sibling of
+  `ssr-handler` — it flushes a shell on first byte and streams
+  `:rf/suspense-boundary` subtrees as their data resolves (Spec 011
+  §Streaming SSR; rf2-ojakd / rf2-olb64). `ssr-handler` itself is
+  single-shot: it mirrors `render-to-string`.
+
   Out of scope (deferred / other beads):
 
-    - Streaming SSR (rf2-olb64) — `render-to-string` is single-shot;
-      this adapter mirrors that.
     - Async Ring handler (3-arity) — synchronous-only in v1;
       extension is additive."
   (:require [re-frame.ssr :as ssr]

--- a/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
+++ b/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
@@ -156,18 +156,18 @@
   `re-frame.ssr.response`; this is the structural shape check.
 
   [Spec-Schemas §`:rf.fx.server/redirect-args`]'s `RedirectFxArgs`, Spec
-  011 §Standard fx (line 435), and `re-frame.ssr.response/redirect-fx`
-  all agree: the target is supplied under any ONE of `:location` /
-  `:url` / `:to`, and redirect-fx reads all three (`(or :location :url
-  :to)`). The schema accepts any one of the three target keys (a
-  `:string`), each optional, plus the optional `:int` `:status`. The fx
-  handler resolves precedence (`:location` wins, then `:url`, then
-  `:to`).
+  011 §Standard fx, and `re-frame.ssr.response/redirect-fx` all agree:
+  the canonical (and only) target key is `:location` (rf2-vngir / EP-0007
+  one-name-per-fact — this fx writes an HTTP `Location` response header,
+  so it uses header vocabulary). The retired synonyms `:url` / `:to` are
+  NOT accepted: `redirect-fx` throws `:rf.error/redirect-retired-target-
+  key` naming `:location` (no back-compat alias). The schema accepts the
+  optional `:string` `:location` plus the optional `:int` `:status`.
 
   PERMISSIVE on the no-target case (rf2-ee38b.11 contract, the live half
-  of decision rf2-cwfy2). All three target keys are optional AND a
-  redirect with ZERO target keys PASSES this shape gate — it is not a
-  structural error. A target-less redirect is the established
+  of decision rf2-cwfy2). `:location` is optional AND a redirect with NO
+  `:location` PASSES this shape gate — it is not a structural error. A
+  target-less redirect is the established
   `:rf.ssr/ssr-redirect-no-target` graceful-degradation path: the
   redirect-fx accepts it (location is caller-trusted/optional at the fx
   boundary) and the adapter emits the warning trace + a 3xx with no
@@ -179,9 +179,7 @@
   fall through to the runtime's warning path."
   [:map
    [:status   {:optional true} :int]      ;; default 302
-   [:location {:optional true} :string]
-   [:url      {:optional true} :string]
-   [:to       {:optional true} :string]])
+   [:location {:optional true} :string]]) ;; canonical (and only) target key (rf2-vngir)
 
 (def safe-redirect-args
   "Args of `:rf.server/safe-redirect` — `:rf.fx.server/safe-redirect-args`.


### PR DESCRIPTION
Prunes genuine SSR/Ring vestigial drift per **rf2-3rsrr4**, and **rejects** one bead finding whose premise is wrong (verified pre-alpha; ELEGANCE stance).

## What changed

### Finding 1 — streaming-doc drift (ACCEPTED + fixed)
`implementation/ssr-ring/src/re_frame/ssr/ring.clj` — the `ssr-handler` docstring listed "Streaming SSR (rf2-olb64)" under **"Out of scope (deferred / other beads)"** while the namespace eagerly `:require`s `re-frame.ssr.ring.streaming` and re-exports `stream-handler` + `default-streaming-prefix` / `default-streaming-suffix` (a fully-implemented 514-line streaming surface). Spec 011 §Streaming SSR records the status as **"shipped — rf2-ojakd / rf2-olb64 (a)"**. Rewrote the stale paragraph to name `stream-handler` as the shipped chunked-HTTP counterpart; kept the genuinely-deferred async 3-arity item.

### Adjacent drift rf2-vngir missed (fixed)
`implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc` — the `redirect-args` schema still listed the retired `:url` / `:to` target keys plus a docstring claiming `redirect-fx` "reads all three `(or :location :url :to)`". rf2-vngir (merged 2026-06-10) canonicalised the target to `:location` and made `:url`/`:to` throw — but its close-note shows it touched spec/011, Spec-Schemas, response.cljc, pipeline.clj, **not** this schema. Pruned to `:location`-only + corrected the docstring. **Behaviour-neutral**: the malli `:map` is open, so the explicit `:url`/`:to` entries gated nothing; the loud gate (`reject-retired-redirect-keys!` in `redirect-fx`) is unchanged.

## REJECTED finding (premise wrong — reported, not actioned)
The bead's second finding asks to **delete** the retired-key special case + the `:rf.error/redirect-retired-target-key` path + the tests "pinning retired spellings". That premise is incorrect — the path is **not vestigial**:
- Deliberate, Mike-ruled feature: **rf2-vngir DECISION 2026-06-10** ("retired spellings must produce a clear diagnostic naming `:location`... must NOT degrade into the no-target warning").
- Spec-mandated: spec/011 §Standard fx, spec/Spec-Schemas `RedirectFxArgs`, spec/009 error catalogue (rf2-lacjen), spec/Conventions.
- **CI-guarded**: `scripts/check_retired_spellings.py` fails the build if `:url`/`:to` reappear as SSR redirect target keys.
- Merged **3 days before** this bead was filed.
- The flagged tests (`ssr_end_to_end_test` 477/497/1211/1233; `pipeline_materialiser_test` 74/86/95) pin the **fail-loud rejection** and the materialiser's **refusal to honour** retired keys — i.e. they ARE the canonical `:location` coverage the acceptance asks to *preserve*. Deleting them would revert rf2-vngir.

Acceptance impact: criteria 1 (ring docs), 3 (canonical `:location` coverage retained), 4 (slice tests pass) all met. Criterion 2 (delete the retired-key path) is declined as a premise error and reported here for Mike's call.

## Quality gates
- `implementation/ssr` JVM `clojure -M:test` — **337 tests, 1349 assertions, 0 failures / 0 errors**
- `implementation/ssr-ring` JVM `clojure -M:test` — **156 tests, 698 assertions, 0 failures / 0 errors**
- `npm run test:cljs` — **7081 tests, 29146 assertions, 0 failures / 0 errors**
- `scripts/check_retired_spellings.py` — exit 0 (retired-spelling CI gate clean)
- `clj-kondo` (both changed files) — 0 errors, 0 warnings
- mkdocs not run: no mkdocs-served markdown changed (edits are Clojure docstrings only)