### PR TITLE
test(mcp-conformance): close SDK tool-call + gated-write gaps (rf2-ke5n56)

### DIFF
--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -59,6 +59,32 @@ handshake, walks one canonical workflow per server using `listTools()`
 and `callTool()`, and tears the transport down cleanly. Any spec drift
 on the server side surfaces as an SDK parse-error.
 
+### callTool() coverage ratchet (rf2-ke5n56)
+
+`listTools()` + `assertDescriptorShape` + `assertClassificationRatchet`
+pin every advertised tool's *descriptor metadata*. But descriptor
+metadata is not the wire envelope: a tool that is only LISTED (never
+driven through `callTool()`) can regress its result envelope,
+`outputSchema` / `structuredContent` shape, or argument handling and
+still ship green. A senior review found several advertised Story + Pair
+tools were exactly this — descriptor-only in conformance.
+
+`assertCallCoverageRatchet` (in [`test/_runner.cjs`](test/_runner.cjs))
+closes it. Each end-to-end harness records every tool it drives through
+`callTool()` and asserts at the end that EVERY advertised tool was
+either SDK-called or listed in a reviewed exclusion table with a
+non-empty rationale naming where its coverage lives (a live-only gate, a
+hermetic harness, a unit/fixture pin). A new advertised tool the
+workflow forgets to probe trips RED; a stale, blank, or contradictory
+exclusion row also trips RED, so the table cannot rot into a rubber
+stamp. The ratchet's own teeth are unit-tested in
+[`test/call-coverage-ratchet.test.cjs`](test/call-coverage-ratchet.test.cjs).
+Today both servers' exclusion tables are EMPTY — every advertised tool
+is SDK-called (Story reads + write-loop; Pair degraded `:nrepl-port-not-
+found` envelopes for the read/session/streaming-shaped surface +
+`:rf.error/writes-disabled` pre-connection refusals for the two gated
+writes).
+
 ### Coverage boundary — keyword-intern bounds (rf2-fphr3)
 
 The charter's threat model asks whether the corpus has teeth on the
@@ -175,14 +201,60 @@ wire gate.
 - `test/end-to-end-flag-gates.cjs` — cross-MCP operator-opt-in CLI
   flag-vocabulary conformance (rf2-ee38b.20). Boots story-mcp without /
   with / with-a-legacy `--allow-writes` spelling and asserts the
-  default-OFF write gate (`structuredContent.gated`) + the
+  default-OFF write gate (`structuredContent.gated` + `.tool`) + the
   hard-rename-rejection rule (an unrecognised flag must NOT open the
   gate) over the MCP wire — the NAMING.md §"Operator-opt-in CLI flag
-  vocabulary" contract. Needs `clojure` (the JVM story-mcp server). The
+  vocabulary" contract. rf2-ke5n56 extended the default-OFF coverage from
+  `register-variant`-only to ALL the gated write tools: `register-variant`
+  + `unregister-variant` (gate-first refusal, `:tool` slot pinned) +
+  `record-as-variant` write-back (both gate states — see the VERIFIED
+  gate-ordering note below), plus the intentionally UNGATED
+  snippet-only `record-as-variant` path. Needs `clojure` (the JVM
+  story-mcp server). The
   pair-mcp eval-cljs gate flipped to default-ON in rf2-a0z0h; its
   disabled-envelope wire counterpart now rides the live
   `live-re-frame2-pair-subscribe.cjs` path (the one boot config where
   the gate is observable — non-degraded, WITH `--no-eval`).
+
+### VERIFIED: `record-as-variant` write-back gate ORDERING asymmetry (rf2-ke5n56, flagged)
+
+While wiring the rf2-ke5n56 default-OFF gated-refusal coverage for
+`record-as-variant` write-back, the harness author verified a server-side
+gate-ordering asymmetry worth flagging to the story-mcp owner:
+
+- `register-variant` / `unregister-variant`
+  (`tools/story-mcp/.../tools/write.cljc`) check `assert-writes-allowed`
+  as their FIRST expression — BEFORE any variant resolution — so a
+  gate-OFF boot refuses with `structuredContent.gated === true`
+  regardless of whether the target variant exists.
+- `record-as-variant`
+  (`tools/story-mcp/.../tools/recorder.cljc` `tool-record-as-variant`)
+  wraps the whole body in `(targs/with-variant arguments (fn [vk body] …))`,
+  which resolves `:variant-id` against the live registered-variant set
+  FIRST; the `(when write-back? (write/assert-writes-allowed …))` gate is
+  NESTED inside that callback.
+
+The canonical-vocabulary boot registers NO variants, and a gate-OFF boot
+cannot register one through the MCP surface, so a gate-OFF
+`record-as-variant` write-back:true call short-circuits to `Variant not
+found` BEFORE the gate is consulted — the `gated:true` envelope is
+**unreachable default-off**. The literal default-OFF `gated:true` probe the
+acceptance criterion describes is therefore impossible via the MCP surface
+without either (a) reordering the gate ahead of variant resolution
+(consistent with the two siblings), or (b) a registered fixture under a
+closed gate (no single boot provides both).
+
+`end-to-end-flag-gates.cjs` `assertRecordAsVariantWriteBackGate` pins what
+IS reachable on both gate states — gate-OFF write-back:true ⇒ `Variant not
+found` (regression-locking the current ordering), gate-ON write-back:true
+⇒ success + `:written-back? true` (the positive control) — and its
+gate-OFF assertion is written so that if the server is later reordered
+gate-first, it flips RED with a message telling the maintainer to update
+it to expect `gated:true` + `tool:"record-as-variant"`. The
+intentionally-ungated snippet-only path (`record-as-variant` without
+`:write-back`) is pinned by `assertSnippetOnlyRecordIsUngated`. Whether to
+reorder the gate is a server-owner decision (filed as a follow-up); the
+conformance harness does NOT modify server source.
 
 ## How to run
 
@@ -220,9 +292,14 @@ npm test
    catalogue (sourced from re-frame2-pair-mcp's `tool-names.json`
    fixture — the single source of truth)
 3. Spot-check every descriptor carries an `inputSchema`
-4. Walk degraded-mode `dispatch` / `watch-epochs` / `snapshot` /
-   `subscribe` — each call routes through the SDK's
-   `CallToolResultSchema` parse step
+4. Walk degraded-mode `callTool()` for EVERY advertised tool (rf2-ke5n56)
+   — the read / session / streaming-shaped surface returns the shared
+   `:nrepl-port-not-found` envelope; the two gated writes
+   (`restore-epoch` / `replace-app-db`) return the
+   `:rf.error/writes-disabled` PRE-connection refusal (default-OFF write
+   gate). Each call routes through the SDK's `CallToolResultSchema` parse
+   step. The `callTool` coverage ratchet then asserts no advertised tool
+   was left descriptor-only.
 5. Clean `Client.close()`
 
 Runs without an nREPL on `$SHADOW_CLJS_NREPL_PORT`, so it's
@@ -336,14 +413,22 @@ so CI runs one JVM boot here instead of two near-identical ones.
 3. `assertDescriptorShape` — every descriptor: `inputSchema`
    (type=object + `max-tokens`) + `outputSchema` + an `annotations`
    classification hint
-4. `register-variant` → `get-variant` (body `:doc` round-trips through
-   EDN text) → `preview-variant` (`:lifecycle` surfaces) →
-   `run-variant` (vacuous pass) → `read-failures` (total=0) →
-   `snapshot-identity` (stable content-hash twice) →
-   `record-as-variant` (recorder bridge wired, rf2-luhdu) →
+4. Closed-world reads (`get-story-instructions` / `list-substrates` /
+   `list-modes` / `list-tags` / `list-stories` / `list-assertions` /
+   `list-decorators`) → success envelopes; `get-story` /
+   `get-docs-markdown` default-off refusal probes (rf2-ke5n56) →
+   `Story not found`
+5. `register-variant` → `get-variant` (body `:doc` round-trips through
+   EDN text) → `variant->edn` (the rf2-vyacl outputSchema-defect twin) +
+   `run-a11y` (JVM-standalone empty read) → `preview-variant`
+   (`:lifecycle` surfaces) → `run-variant` (vacuous pass) →
+   `read-failures` (total=0) → `snapshot-identity` (stable content-hash
+   twice) → `record-as-variant` (recorder bridge wired, rf2-luhdu) →
    `unregister-variant` + not-found verify
-5. `assertJsonRpcErrorCodes` — MethodNotFound + (InvalidParams|InternalError)
-6. Clean `Client.close()`
+6. `assertJsonRpcErrorCodes` — MethodNotFound + (InvalidParams|InternalError)
+7. `callTool` coverage ratchet (rf2-ke5n56) — every advertised tool
+   SDK-called or reviewed-excluded
+8. Clean `Client.close()`
 
 Watchdog: 90s (cold JVM boot is ~10–30s on a CI runner).
 
@@ -372,9 +457,13 @@ The `mcp-conformance-re-frame2-pair` job runs three steps in sequence:
    opt-out wire envelope (`:rf.error/eval-cljs-disabled`) post-rf2-a0z0h.
 
 The `mcp-conformance-story` job runs two steps: **`test:story`** (the
-write-loop + read-path conformance) and **`test:flag-gates`** (the
-cross-MCP CLI flag-vocabulary conformance — story-mcp `--allow-writes`
-default-OFF + opt-in + hard-rename rejection). Both need `clojure`.
+write-loop + read-path conformance + the rf2-ke5n56 callTool coverage
+ratchet) and **`test:flag-gates`** (the cross-MCP CLI flag-vocabulary
+conformance — story-mcp `--allow-writes` default-OFF for all three gated
+write tools + the ungated snippet-only path + opt-in + hard-rename
+rejection). Both need `clojure`. The `callTool` coverage ratchet's own
+unit tests (`test:call-coverage-ratchet`) run with the cheap Node unit
+tests via `npm test`.
 
 ## Why a separate artefact?
 

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -15,6 +15,7 @@
     "test:exec-safety": "node --test test/exec-safety.test.cjs",
     "test:runner-watchdog": "node --test test/runner-watchdog.test.cjs",
     "test:runner-cleanup": "node --test test/runner-cleanup.test.cjs",
+    "test:call-coverage-ratchet": "node --test test/call-coverage-ratchet.test.cjs",
     "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
     "test:port-file-escape": "node --test test/port-file-escape.test.cjs",
     "test": "node scripts/test-all.cjs"

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -64,6 +64,10 @@ const TESTS = [
     argv: ['--test', 'test/port-file-escape.test.cjs'],
   },
   {
+    name: 'callTool coverage ratchet unit tests (rf2-ke5n56)',
+    argv: ['--test', 'test/call-coverage-ratchet.test.cjs'],
+  },
+  {
     name: 're-frame2-pair-mcp end-to-end',
     argv: ['test/end-to-end-re-frame2-pair.cjs'],
   },

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -652,6 +652,110 @@ function assertClassificationRatchet(tools, expected) {
   }
 }
 
+// ---------------------------------------------------------------------
+// SDK callTool() coverage ratchet (rf2-ke5n56).
+//
+// The name ratchet (`tool-names.json`) pins WHICH tools the catalogue
+// advertises; `assertDescriptorShape` / `assertClassificationRatchet`
+// pin the descriptor METADATA of every advertised tool. NEITHER pins
+// that a tool was ever actually INVOKED through `Client.callTool()` —
+// so a regression in a tool's callTool envelope, outputSchema /
+// structuredContent shape, or argument handling ships GREEN for any
+// advertised tool the conformance workflow only LISTS but never CALLS.
+// This was the false-green class the senior review flagged: several
+// advertised Story + Pair tools were descriptor-only in conformance.
+//
+// This ratchet closes it. The harness records every tool name it
+// drove through `callTool()` (in a `Set`), then calls this gate with:
+//
+//   - `advertised`  — the live `tools/list` names (sourced from the
+//                     server's own `tool-names.json` fixture, the same
+//                     single-source the name ratchet compares against).
+//   - `called`      — the Set of names the workflow SDK-invoked.
+//   - `exclusions`  — a REVIEWED table: `{ "<tool>": "<rationale>" }`.
+//                     Each row names a tool that is intentionally NOT
+//                     SDK-call-covered HERE and states WHERE its
+//                     alternative coverage lives (a live-only gate, a
+//                     hermetic harness, a lower-layer unit/fixture pin).
+//                     A bare-string rationale is mandatory and must be
+//                     non-empty — an empty exclusion is a silent hole.
+//
+// The gate fails when a tool is NEITHER called NOR excluded-with-
+// rationale, AND when the exclusion table carries a stale row (a name
+// that is excluded but was also called, or that the catalogue no longer
+// advertises) — so the table cannot rot into a rubber stamp. A NEW
+// advertised tool that the author forgets to probe trips RED with a
+// message naming it and pointing at the two ways to green it (add a
+// probe, or add a reviewed exclusion row).
+//
+// Throws on the first violation with a descriptive, server-agnostic
+// message. Returns nothing.
+// ---------------------------------------------------------------------
+function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
+  const advertisedSet = new Set(advertised);
+  const calledSet = called instanceof Set ? called : new Set(called);
+  const excludedNames = Object.keys(exclusions);
+
+  // 0. The exclusion table must not carry stale rows. A row whose tool
+  // is not advertised is a dangling rationale (the tool was renamed /
+  // removed); a row whose tool WAS called is a contradiction (it claims
+  // "not covered here" but the workflow drove it) — both mean the table
+  // drifted from reality and must be corrected, not silently tolerated.
+  const staleNotAdvertised = excludedNames.filter((n) => !advertisedSet.has(n));
+  const staleAlsoCalled = excludedNames.filter((n) => calledSet.has(n));
+  if (staleNotAdvertised.length > 0 || staleAlsoCalled.length > 0) {
+    throw new Error(
+      'callTool coverage ratchet (rf2-ke5n56): the exclusion table has ' +
+        'stale rows.\n  excluded but no longer advertised (remove the row): ' +
+        JSON.stringify(staleNotAdvertised) +
+        '\n  excluded yet ALSO SDK-called (the row contradicts the ' +
+        'workflow — drop it, the tool IS covered): ' +
+        JSON.stringify(staleAlsoCalled),
+    );
+  }
+
+  // 1. Every excluded row MUST carry a non-empty string rationale. An
+  // empty / non-string rationale is a silent hole dressed as a decision.
+  const blankRationale = excludedNames.filter(
+    (n) => typeof exclusions[n] !== 'string' || exclusions[n].trim().length === 0,
+  );
+  if (blankRationale.length > 0) {
+    throw new Error(
+      'callTool coverage ratchet (rf2-ke5n56): these exclusion rows MUST ' +
+        'carry a non-empty rationale naming WHERE the tool is otherwise ' +
+        'covered (a live-only gate, a hermetic harness, a unit/fixture ' +
+        'pin); a blank exclusion is an unreviewed hole: ' +
+        JSON.stringify(blankRationale),
+    );
+  }
+
+  // 2. The load-bearing check: every advertised tool is either driven
+  // through callTool() or carries a reviewed exclusion. An advertised
+  // tool that is neither trips RED — the descriptor-only false-green
+  // this ratchet exists to catch.
+  const excludedSet = new Set(excludedNames);
+  const uncovered = advertised.filter(
+    (n) => !calledSet.has(n) && !excludedSet.has(n),
+  );
+  if (uncovered.length > 0) {
+    throw new Error(
+      'callTool coverage ratchet (rf2-ke5n56): these advertised tools are ' +
+        'NEITHER invoked through Client.callTool() NOR listed in the ' +
+        'reviewed exclusion table.\n  uncovered: ' +
+        JSON.stringify(uncovered.sort()) +
+        '\n\n  An advertised tool that is only LISTED (descriptor metadata ' +
+        'checked) but never CALLED can regress its callTool envelope / ' +
+        'outputSchema / structuredContent shape and still ship green — the ' +
+        'exact false-green class this ratchet closes. To green this:\n' +
+        '    (a) add a cheap SDK-call probe (prefer a non-mutating read or ' +
+        'a default-off refusal probe), OR\n' +
+        '    (b) add a row to the exclusion table with a rationale naming ' +
+        'where the tool IS covered (a live-only / hermetic / unit-layer ' +
+        'gate).',
+    );
+  }
+}
+
 module.exports = {
   runWithWatchdog,
   connectServer,
@@ -661,4 +765,5 @@ module.exports = {
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
   assertClassificationRatchet,
+  assertCallCoverageRatchet,
 };

--- a/tools/mcp-conformance/test/call-coverage-ratchet.test.cjs
+++ b/tools/mcp-conformance/test/call-coverage-ratchet.test.cjs
@@ -1,0 +1,115 @@
+// Unit test for the SDK callTool() coverage ratchet (rf2-ke5n56).
+//
+// `assertCallCoverageRatchet` is itself a conformance gate — it is the
+// teeth that turn a descriptor-only advertised tool (LISTED but never
+// SDK-CALLED) RED. A gate with no test is a gate that can silently lose
+// its teeth, so this pins its contract directly, in-process, with no
+// child / no MCP server (it is a pure data assertion). Uses Node's
+// built-in `node:test` — same zero-dependency posture as the sibling
+// runner tests.
+//
+// The end-to-end harnesses (`end-to-end-story.cjs` /
+// `end-to-end-re-frame2-pair.cjs`) exercise the GREEN path live (every
+// advertised tool is SDK-called, exclusion tables empty). This test pins
+// the RED paths the green runs never hit:
+//
+//   - an advertised tool neither called nor excluded ⇒ throws.
+//   - a blank / non-string exclusion rationale ⇒ throws.
+//   - a stale exclusion row (not advertised) ⇒ throws.
+//   - a contradictory exclusion row (excluded yet also called) ⇒ throws.
+//   - the fully-covered / reviewed-excluded case ⇒ does NOT throw.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { assertCallCoverageRatchet } = require('./_runner.cjs');
+
+test('GREEN: every advertised tool SDK-called ⇒ no throw', () => {
+  assert.doesNotThrow(() =>
+    assertCallCoverageRatchet({
+      advertised: ['a', 'b', 'c'],
+      called: new Set(['a', 'b', 'c']),
+      exclusions: {},
+    }),
+  );
+});
+
+test('GREEN: a mix of called + reviewed-excluded ⇒ no throw', () => {
+  assert.doesNotThrow(() =>
+    assertCallCoverageRatchet({
+      advertised: ['a', 'b', 'live-only'],
+      called: new Set(['a', 'b']),
+      exclusions: { 'live-only': 'covered by live-x.cjs under a real nREPL' },
+    }),
+  );
+});
+
+test('GREEN: `called` accepts a plain array too', () => {
+  assert.doesNotThrow(() =>
+    assertCallCoverageRatchet({
+      advertised: ['a', 'b'],
+      called: ['a', 'b'],
+      exclusions: {},
+    }),
+  );
+});
+
+test('RED: an advertised tool neither called nor excluded ⇒ throws + names it', () => {
+  assert.throws(
+    () =>
+      assertCallCoverageRatchet({
+        advertised: ['a', 'b', 'forgotten'],
+        called: new Set(['a', 'b']),
+        exclusions: {},
+      }),
+    /NEITHER invoked through Client\.callTool\(\)[\s\S]*"forgotten"/,
+  );
+});
+
+test('RED: a blank exclusion rationale ⇒ throws', () => {
+  assert.throws(
+    () =>
+      assertCallCoverageRatchet({
+        advertised: ['a', 'b'],
+        called: new Set(['a']),
+        exclusions: { b: '   ' },
+      }),
+    /MUST[\s\S]*carry a non-empty rationale[\s\S]*"b"/,
+  );
+});
+
+test('RED: a non-string exclusion rationale ⇒ throws', () => {
+  assert.throws(
+    () =>
+      assertCallCoverageRatchet({
+        advertised: ['a', 'b'],
+        called: new Set(['a']),
+        exclusions: { b: true },
+      }),
+    /non-empty rationale/,
+  );
+});
+
+test('RED: a stale exclusion row (not advertised) ⇒ throws', () => {
+  assert.throws(
+    () =>
+      assertCallCoverageRatchet({
+        advertised: ['a', 'b'],
+        called: new Set(['a', 'b']),
+        exclusions: { 'ghost-tool': 'rationale for a tool that no longer exists' },
+      }),
+    /stale rows[\s\S]*no longer advertised[\s\S]*"ghost-tool"/,
+  );
+});
+
+test('RED: a contradictory exclusion row (excluded yet also called) ⇒ throws', () => {
+  assert.throws(
+    () =>
+      assertCallCoverageRatchet({
+        advertised: ['a', 'b'],
+        called: new Set(['a', 'b']),
+        exclusions: { b: 'claims not-covered-here but the workflow drove it' },
+      }),
+    /excluded yet ALSO SDK-called[\s\S]*"b"/,
+  );
+});

--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -28,10 +28,21 @@
 //
 // ### story-mcp `--allow-writes` (default OFF, hard-rename rejection)
 //
-//   1. Boot WITHOUT the flag ⇒ `register-variant` returns
-//      `isError: true` + `structuredContent.gated === true`
-//      (the default-OFF posture). This is the security-critical claim:
-//      a fresh / CI boot cannot mutate the registry.
+//   1. Boot WITHOUT the flag ⇒ ALL THREE gated write tools
+//      (`register-variant`, `unregister-variant`, and
+//      `record-as-variant` WITH `:write-back true`) return
+//      `isError: true` + `structuredContent.gated === true` +
+//      `structuredContent.tool` naming the tripping tool (the default-OFF
+//      posture per spec/003-Write-Surface-Gating.md §"What's gated"). This
+//      is the security-critical claim: a fresh / CI boot cannot mutate the
+//      registry by ANY gated path. (Pre-rf2-ke5n56 only `register-variant`
+//      was probed default-off, so a dropped gate-check on either of the
+//      other two shipped green.)
+//   1b. Boot WITHOUT the flag (well, WITH it to seed a fixture, then) ⇒
+//      `record-as-variant` WITHOUT `:write-back` SUCCEEDS — the
+//      intentionally UNGATED snippet-only recording path. Together with
+//      probe 1's write-back:true refusal this pins the gating boundary
+//      exactly on `:write-back`.
 //   2. Boot WITH `--allow-writes` ⇒ `register-variant` succeeds
 //      (`isError: false`, registered) — the positive control proving the
 //      flag spelling NAMING.md pins is the one the parser actually wires.
@@ -73,6 +84,18 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { connectServer, closeQuietly } = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
+const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
+
+// `record-as-variant` ships its structuredContent wrapped in the
+// `{:rf.mcp/dedup-table …}` envelope (recorder.cljc `:dedup-eligible?
+// true`); a real MCP client decodes it via `de-dupe.core/expand` before
+// reading semantic slots. `structured` mirrors that — idempotent on
+// payloads without the marker (register/unregister envelopes pass
+// through unchanged), so it is safe to route every structuredContent
+// read through it. Same adapter the sibling end-to-end-story.cjs uses.
+function structured(resp) {
+  return decodeDedupEnvelope((resp && resp.structuredContent) || {});
+}
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
@@ -94,15 +117,17 @@ const FIXTURE_BODY_EDN = '{:doc "flag-gate conformance probe." :tags #{:dev}}';
 
 // Cold JVM boot is ~10-30s; each gate below boots a fresh JVM (the gate
 // is a boot-time atom — we can't flip it on a running server through the
-// MCP surface, which is exactly the point). Three sequential boots fit
-// comfortably under the watchdog with margin.
+// MCP surface, which is exactly the point). rf2-ke5n56 grew the boot
+// count from 3 to 7 (default-off, snippet-only-ungated, record-as-variant
+// write-back gate OFF + ON, opt-in, two legacy spellings), so the cap is
+// lifted from 180s to 300s to keep comfortable margin on a cold CI worker.
 //
 // `$FLAG_GATE_WATCHDOG_MS` overrides the cap for the hermetic
 // connect-hang regression harness ONLY (rf2-wqi4n4 finding 1's
 // `runner-watchdog.test.cjs` drives this module with a stubbed
 // never-resolving connect under a 200ms cap to prove the watchdog tears
-// the hung JVM down). Production CI never sets it, so the 180s cap stands.
-const WATCHDOG_MS = Number(process.env.FLAG_GATE_WATCHDOG_MS) || 180000;
+// the hung JVM down). Production CI never sets it, so the 300s cap stands.
+const WATCHDOG_MS = Number(process.env.FLAG_GATE_WATCHDOG_MS) || 300000;
 
 // ---------------------------------------------------------------------------
 // Boot one story-mcp server with the given extra CLI args, run `body`
@@ -168,42 +193,326 @@ function callRegisterVariant(client) {
   });
 }
 
+// The story-mcp write-gated tools whose gate is reachable in a CLEAN
+// gate-OFF boot, per tools/story-mcp/spec/003-Write-Surface-Gating.md
+// §"What's gated". `register-variant` and `unregister-variant` check the
+// `--allow-writes` gate as their FIRST line (write.cljc:
+// `(or (assert-writes-allowed …) …)`), BEFORE resolving any variant — so
+// with the gate closed they refuse with a tool-execution error (NOT a
+// JSON-RPC protocol error — the agent's conversation survives) carrying
+// `structuredContent.gated === true` AND `structuredContent.tool` naming
+// the tripping tool (the `:tool` slot is per-tool, not hardcoded —
+// rf2-c52j0).
+//
+// Pre-rf2-ke5n56 the flag-gate harness funnelled ALL default-off probes
+// through `register-variant` only; `unregister-variant` appeared solely
+// as positive-control cleanup, so a dropped gate-check on it shipped
+// green. These two rows close that gap. The THIRD gated tool,
+// `record-as-variant` (gated only when `:write-back true`), has a
+// different gate-ORDERING and is handled separately by
+// `assertRecordAsVariantWriteBackGate` — see the long note there.
+const GATED_WRITE_PROBES = [
+  {
+    name: 'register-variant',
+    arguments: { 'variant-id': FIXTURE_VARIANT, body: FIXTURE_BODY_EDN },
+  },
+  {
+    name: 'unregister-variant',
+    arguments: { 'variant-id': FIXTURE_VARIANT },
+  },
+];
+
 // ---------------------------------------------------------------------------
 // The three story-mcp `--allow-writes` conformance probes.
 // ---------------------------------------------------------------------------
 
 async function assertWriteGateClosedByDefault() {
+  // One fresh gate-OFF boot exercises ALL THREE gated write tools
+  // (rf2-ke5n56). Pre-rf2-ke5n56 only `register-variant` was probed
+  // default-off; `unregister-variant` and `record-as-variant`
+  // (write-back) had no default-off wire coverage despite the spec
+  // gating all three — a dropped gate-check on either shipped green.
   await withStoryServer([], async (client) => {
-    const resp = await callRegisterVariant(client);
-    // Default-OFF: the write tool MUST refuse with a tool-execution
-    // error (NOT a JSON-RPC protocol error — the agent's conversation
-    // survives) carrying the documented `:gated true` structuredContent.
-    if (!resp.isError) {
-      throw new Error(
-        'story-mcp register-variant MUST isError when booted WITHOUT ' +
-          '--allow-writes (default-OFF posture per NAMING.md ' +
-          '§"Operator-opt-in CLI flag vocabulary"); got: ' +
-          JSON.stringify(resp),
+    for (const probe of GATED_WRITE_PROBES) {
+      const resp = await client.callTool(probe);
+      // Default-OFF: the write tool MUST refuse with a tool-execution
+      // error (NOT a JSON-RPC protocol error — the agent's conversation
+      // survives) carrying the documented `:gated true` structuredContent.
+      if (!resp.isError) {
+        throw new Error(
+          'story-mcp ' + probe.name + ' MUST isError when booted WITHOUT ' +
+            '--allow-writes (default-OFF posture per NAMING.md ' +
+            '§"Operator-opt-in CLI flag vocabulary" + ' +
+            'spec/003-Write-Surface-Gating.md); got: ' + JSON.stringify(resp),
+        );
+      }
+      const struct = resp.structuredContent || {};
+      if (struct.gated !== true) {
+        throw new Error(
+          'story-mcp ' + probe.name + ' write-gate-closed envelope MUST carry ' +
+            'structuredContent.gated === true; got: ' + JSON.stringify(resp),
+        );
+      }
+      // The `:tool` slot names the tripping tool (rf2-c52j0 — it was once
+      // hardcoded and lied about its origin). Assert it matches the tool we
+      // called so a copy-paste regression that returned a sibling tool's
+      // refusal (still carrying `:gated true`) is caught.
+      if (struct.tool !== probe.name) {
+        throw new Error(
+          'story-mcp ' + probe.name + ' gated envelope MUST name the tripping ' +
+            'tool in structuredContent.tool (per spec/003 §"How the gate ' +
+            'fails"); expected "' + probe.name + '", got: ' +
+            JSON.stringify(struct.tool) + ' — full: ' + JSON.stringify(resp),
+        );
+      }
+      const text = resp.content?.[0]?.text || '';
+      if (!/write surface disabled/i.test(text)) {
+        throw new Error(
+          'story-mcp ' + probe.name + ' write-gate-closed text MUST mention ' +
+            '"Write surface disabled"; got: ' + text.slice(0, 200),
+        );
+      }
+      console.log(
+        'OK   story-mcp --allow-writes default-OFF -> ' + probe.name +
+          ' isError + structuredContent.gated=true + tool="' + probe.name + '"',
       );
     }
-    const struct = resp.structuredContent || {};
-    if (struct.gated !== true) {
+  });
+}
+
+// The intentional UNGATED path (rf2-ke5n56 + spec/003-Write-Surface-Gating.md
+// §"What's gated"): `record-as-variant` WITHOUT `:write-back` is a
+// snippet-only recording — it returns the `(reg-variant …)` text snippet
+// and does NOT mutate the registry, so it is deliberately NOT gated
+// (recorder.cljc gates only `(when write-back? …)`). A regression that
+// wrongly extended the write gate to the snippet-only path would break the
+// read-only recording loop for every default (gate-OFF) deploy.
+//
+// This probe + `assertRecordAsVariantWriteBackGate` together pin the
+// gating boundary EXACTLY on `:write-back`:
+//
+//   - write-back:FALSE ⇒ ALWAYS succeeds, snippet only, NO mutation
+//     (this probe).
+//   - write-back:TRUE  ⇒ requires the gate open; gate-closed refuses
+//     once a target is registered (the other probe).
+//
+// We need a registered target to record against, which a gate-OFF boot
+// cannot create through the MCP surface, so this boots WITH --allow-writes
+// to seed the fixture; the load-bearing claim is that the write-back:FALSE
+// call succeeds and reports `:written-back? false` (no registry mutation)
+// — proving the snippet-only path is gated by NOTHING, exactly the spec
+// contract.
+async function assertSnippetOnlyRecordIsUngated() {
+  await withStoryServer(['--allow-writes'], async (client) => {
+    // Seed a fixture to record against (needs a registered variant).
+    const seed = await client.callTool({
+      name: 'register-variant',
+      arguments: { 'variant-id': FIXTURE_VARIANT, body: FIXTURE_BODY_EDN },
+    });
+    if (seed.isError) {
       throw new Error(
-        'story-mcp write-gate-closed envelope MUST carry ' +
-          'structuredContent.gated === true; got: ' + JSON.stringify(resp),
+        'snippet-only-ungated setup: register-variant failed: ' +
+          JSON.stringify(seed),
       );
     }
-    const text = resp.content?.[0]?.text || '';
-    if (!/write surface disabled/i.test(text)) {
+    // Snippet-only record: NO `:write-back` — the ungated path. MUST
+    // succeed and return a `:play-snippet`, and MUST NOT report a
+    // write-back (`:written-back? false`).
+    const rec = await client.callTool({
+      name: 'record-as-variant',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    if (rec.isError) {
       throw new Error(
-        'story-mcp write-gate-closed text MUST mention "Write surface ' +
-          'disabled"; got: ' + text.slice(0, 200),
+        'record-as-variant snippet-only (no :write-back) MUST succeed — it ' +
+          'is the INTENTIONALLY UNGATED recording path (spec/003 §"What\'s ' +
+          'gated"); got isError: ' + JSON.stringify(rec),
+      );
+    }
+    const struct = structured(rec);
+    if (struct.gated === true) {
+      throw new Error(
+        'record-as-variant snippet-only MUST NOT be gated (write-back absent); ' +
+          'got a gated envelope: ' + JSON.stringify(rec),
+      );
+    }
+    if (typeof struct['play-snippet'] !== 'string') {
+      throw new Error(
+        'record-as-variant snippet-only MUST emit a :play-snippet string; ' +
+          'got: ' + JSON.stringify(rec),
+      );
+    }
+    if (struct['written-back?'] !== false) {
+      throw new Error(
+        'record-as-variant snippet-only MUST report :written-back? false ' +
+          '(no registry mutation on the ungated path); got: ' + JSON.stringify(rec),
       );
     }
     console.log(
-      'OK   story-mcp --allow-writes default-OFF -> register-variant ' +
-        'isError + structuredContent.gated=true',
+      'OK   story-mcp record-as-variant snippet-only (no --write-back) -> ' +
+        'ungated success + :play-snippet, :written-back? false',
     );
+    // Symmetric teardown.
+    try {
+      await client.callTool({
+        name: 'unregister-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+    } catch (_e) {
+      // best-effort; fresh-JVM-per-boot makes a stray registration harmless.
+    }
+  });
+}
+
+// `record-as-variant` write-back gate — VERIFIED ORDERING ASYMMETRY
+// (rf2-ke5n56, flagged for the server owner; see PR / follow-up bead).
+//
+// The bead's acceptance criterion asks for a DEFAULT-OFF gated refusal
+// (`gated:true` + `tool:"record-as-variant"`) for `record-as-variant`
+// with `:write-back true`, mirroring register/unregister. While wiring
+// it I verified the source and found it is NOT reachable in a clean
+// gate-OFF boot, because `record-as-variant`'s gate ORDERING differs from
+// its two siblings:
+//
+//   - register-variant / unregister-variant (write.cljc) check
+//     `assert-writes-allowed` as their FIRST expression — BEFORE any
+//     variant resolution — so a gate-OFF boot refuses with `gated:true`
+//     regardless of whether any variant exists.
+//   - record-as-variant (recorder.cljc `tool-record-as-variant`) wraps
+//     the whole body in `(targs/with-variant arguments (fn [vk body] …))`,
+//     which resolves `:variant-id` against the LIVE registered-variant
+//     set FIRST; the `(when write-back? (write/assert-writes-allowed …))`
+//     gate is NESTED inside that callback. The canonical-vocabulary boot
+//     registers NO variants, and a gate-OFF boot cannot register one
+//     through the MCP surface, so a gate-OFF `record-as-variant`
+//     write-back:true call short-circuits to `Variant not found` BEFORE
+//     the gate is ever consulted — the `gated:true` envelope is
+//     unreachable default-off.
+//
+// So the literal default-off `gated:true` probe is IMPOSSIBLE via the MCP
+// surface without either (a) a server change reordering the gate ahead of
+// variant resolution (consistent with the two siblings — FLAGGED), or
+// (b) a registered fixture under a closed gate (no single boot provides
+// both). Rather than fake it, this function pins what IS reachable and
+// adversarial, on both gate states:
+//
+//   1. gate OFF, write-back:true, unregistered target ⇒ `Variant not
+//      found` (NOT `gated:true`). This documents + REGRESSION-LOCKS the
+//      verified ordering: if the server is later fixed to gate-first
+//      (the flagged change), this assertion flips to expect `gated:true`
+//      and `tool:"record-as-variant"` — the test is the executable record
+//      of the current contract and the seam for the fix.
+//   2. gate ON, write-back:true ⇒ the positive control: the write-back
+//      path SUCCEEDS, reports `:written-back? true`, and mints the new
+//      variant id. This is the load-bearing write-back coverage the bead
+//      asked for (a regression that broke the write-back registration, or
+//      that gated it even with the flag ON, ships RED here) — just on the
+//      reachable gate state.
+async function assertRecordAsVariantWriteBackGate() {
+  const NEW_VID = 'story.mcp-conformance/flag-gate.recorded';
+
+  // 1. gate OFF — write-back:true against an unregistered target. The
+  // verified ordering means this surfaces `Variant not found`, NOT a
+  // gated envelope. We assert that precisely so the asymmetry is locked.
+  await withStoryServer([], async (client) => {
+    const resp = await client.callTool({
+      name: 'record-as-variant',
+      arguments: {
+        'variant-id': FIXTURE_VARIANT,
+        'write-back': true,
+        'new-variant-id': NEW_VID,
+      },
+    });
+    if (!resp.isError) {
+      throw new Error(
+        'record-as-variant (write-back, gate OFF, unregistered target) MUST ' +
+          'isError; got: ' + JSON.stringify(resp),
+      );
+    }
+    const struct = structured(resp);
+    const text = resp.content?.[0]?.text || '';
+    // The VERIFIED current contract: variant resolution precedes the gate,
+    // so an unregistered target short-circuits to not-found and the gate
+    // is never reached. If a future server change reorders the gate ahead
+    // of variant resolution (the flagged consistency fix), update this to
+    // expect `struct.gated === true` + `struct.tool === 'record-as-variant'`.
+    if (struct.gated === true) {
+      throw new Error(
+        'record-as-variant write-back gate ORDERING changed: this gate-OFF ' +
+          'probe now sees `gated:true` (the server was reordered to ' +
+          'gate-first — the rf2-ke5n56 flagged consistency fix). Update this ' +
+          "assertion to pin `tool:\"record-as-variant\"` like its register/" +
+          'unregister siblings. got: ' + JSON.stringify(resp),
+      );
+    }
+    if (!/not found/i.test(text)) {
+      throw new Error(
+        'record-as-variant (write-back, gate OFF, unregistered target) MUST ' +
+          'surface `Variant not found` under the verified variant-resolution-' +
+          'before-gate ordering (rf2-ke5n56); got: ' + text.slice(0, 200),
+      );
+    }
+    console.log(
+      'OK   story-mcp record-as-variant (write-back, gate OFF, unregistered) ' +
+        '-> Variant not found (verified gate-ordering asymmetry, rf2-ke5n56)',
+    );
+  });
+
+  // 2. gate ON — positive control: write-back:true SUCCEEDS, writes back.
+  await withStoryServer(['--allow-writes'], async (client) => {
+    const seed = await client.callTool({
+      name: 'register-variant',
+      arguments: { 'variant-id': FIXTURE_VARIANT, body: FIXTURE_BODY_EDN },
+    });
+    if (seed.isError) {
+      throw new Error(
+        'record-as-variant write-back setup: register-variant failed: ' +
+          JSON.stringify(seed),
+      );
+    }
+    const rec = await client.callTool({
+      name: 'record-as-variant',
+      arguments: {
+        'variant-id': FIXTURE_VARIANT,
+        'write-back': true,
+        'new-variant-id': NEW_VID,
+      },
+    });
+    if (rec.isError) {
+      throw new Error(
+        'record-as-variant (write-back, gate ON) MUST succeed — the gate is ' +
+          'open and the target is registered; got: ' + JSON.stringify(rec),
+      );
+    }
+    const struct = structured(rec);
+    if (struct.gated === true) {
+      throw new Error(
+        'record-as-variant (write-back, gate ON) MUST NOT be gated; got a ' +
+          'gated envelope: ' + JSON.stringify(rec),
+      );
+    }
+    if (struct['written-back?'] !== true) {
+      throw new Error(
+        'record-as-variant (write-back, gate ON) MUST report ' +
+          ':written-back? true (the registry mutation happened); got: ' +
+          JSON.stringify(rec),
+      );
+    }
+    console.log(
+      'OK   story-mcp record-as-variant (write-back, gate ON) -> success + ' +
+        ':written-back? true (positive control)',
+    );
+    // Teardown both the source and the written-back variant.
+    for (const vid of [FIXTURE_VARIANT, NEW_VID]) {
+      try {
+        await client.callTool({
+          name: 'unregister-variant',
+          arguments: { 'variant-id': vid },
+        });
+      } catch (_e) {
+        // best-effort; fresh-JVM-per-boot makes a stray registration harmless.
+      }
+    }
   });
 }
 
@@ -285,6 +594,8 @@ async function main() {
   }
 
   await assertWriteGateClosedByDefault();
+  await assertSnippetOnlyRecordIsUngated();
+  await assertRecordAsVariantWriteBackGate();
   await assertWriteGateOpensWithFlag();
   await assertLegacyFlagSpellingRejected();
 

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -34,6 +34,7 @@ const {
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
   assertClassificationRatchet,
+  assertCallCoverageRatchet,
 } = require('./_runner.cjs');
 
 const RE_FRAME2_PAIR_MCP_DIR = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp');
@@ -69,6 +70,51 @@ const EXPECTED_TOOLS = JSON.parse(
 const env = { ...process.env };
 delete env.SHADOW_CLJS_NREPL_PORT;
 
+// SDK callTool() coverage tracking (rf2-ke5n56). Every tool driven through
+// `Client.callTool()` records its name here; the coverage ratchet at the
+// end of the body fails if any ADVERTISED tool is neither recorded nor in
+// the reviewed exclusion table. `track(rawClient)` returns a Proxy that
+// records the tool name on each `callTool({name,…})` and transparently
+// delegates every other client member (listTools, getServerVersion,
+// request, …) — so existing call sites read unchanged. Same shape as the
+// sibling end-to-end-story.cjs.
+const CALLED = new Set();
+function track(rawClient) {
+  return new Proxy(rawClient, {
+    get(target, prop, receiver) {
+      if (prop === 'callTool') {
+        return (req, ...rest) => {
+          if (req && typeof req.name === 'string') CALLED.add(req.name);
+          return target.callTool(req, ...rest);
+        };
+      }
+      const v = Reflect.get(target, prop, receiver);
+      return typeof v === 'function' ? v.bind(target) : v;
+    },
+  });
+}
+
+// Advertised pair-mcp tools intentionally NOT SDK-call-covered by THIS
+// degraded harness, each with a rationale naming WHERE its coverage lives
+// (rf2-ke5n56). The pair-mcp conformance surface is split: this
+// end-to-end runs DEGRADED (no nREPL), where every tool returns the same
+// `:nrepl-port-not-found` envelope (except the two gated writes, refused
+// pre-connection) — so a degraded probe proves the descriptor reaches the
+// SDK, the dispatch-table entry is wired, the arg shape is accepted, and
+// the SDK's CallToolResultSchema parses the envelope. The genuinely
+// LIVE-only behaviours (streaming progress frames, overflow markers,
+// redaction, the eval/write gates' SUCCESS/refusal under a real runtime)
+// are pinned by the gated live harnesses. This table is currently EMPTY:
+// rf2-ke5n56 added a cheap degraded probe for every previously
+// descriptor-only tool, so all 28 advertised tools are now SDK-called
+// here. The table is wired through `assertCallCoverageRatchet` so a
+// FUTURE tool that is genuinely unreachable degraded has a reviewed home
+// (e.g. `{ 'some-live-only-tool': 'live-only; covered by
+// live-re-frame2-pair-<x>.cjs under a real nREPL' }`) instead of silently
+// dropping out of coverage. A blank/stale/contradictory row trips the
+// ratchet.
+const PAIR_CALL_EXCLUSIONS = {};
+
 runWithWatchdog(
   {
     watchdogMs: 60000,
@@ -80,7 +126,12 @@ runWithWatchdog(
       env,
     },
   },
-  async (client) => {
+  async (rawClient) => {
+    // Wrap the SDK client in the coverage tracker (rf2-ke5n56): every
+    // `client.callTool({name,…})` below records `name` for the callTool
+    // coverage ratchet at the end of this body. All other client members
+    // delegate transparently.
+    const client = track(rawClient);
     // The SDK's `client.connect()` (invoked by the runner) already
     // validated the initialize envelope against `InitializeResultSchema`
     // — a missing / malformed `serverInfo` would have thrown there.
@@ -187,6 +238,52 @@ runWithWatchdog(
       { name: 'read-dom', arguments: { selector: 'body', limit: 1 } },
       { name: 'read-ui', arguments: { selector: 'body' } },
       { name: 'orient', arguments: {} },
+      // rf2-ke5n56 — close the descriptor-only gap. Every advertised
+      // pair-mcp tool below was LISTED (descriptor + classification
+      // metadata checked) but never SDK-CALLED, so a regression in its
+      // callTool envelope / outputSchema / structuredContent shape /
+      // argument handling shipped green. In degraded mode (no nREPL) each
+      // routes through `ensure-connection!` first and returns the SAME
+      // `:nrepl-port-not-found` envelope — which still proves, per tool:
+      // (a) the descriptor reaches the SDK, (b) the dispatch-table entry
+      // is wired (an unwired name surfaces a different error), (c) the arg
+      // shape is accepted into the envelope, (d) the SDK's
+      // CallToolResultSchema parses the result. The two gated WRITE tools
+      // (restore-epoch / replace-app-db) are NOT here — they are refused
+      // PRE-connection with `:writes-disabled`, not `:nrepl-port-not-found`
+      // (writes/refuse-pre-connection fires before ensure-connection!), so
+      // they get their own assertion block below. The closed-world inline
+      // tools (get-re-frame2-pair-instructions / get-stream-controls) DO
+      // appear here: dispatch still routes them through ensure-connection!,
+      // which rejects degraded before the inline body runs.
+      { name: 'discover-app', arguments: {} },
+      // eval-cljs is default-ON post-rf2-a0z0h (no pre-connection gate
+      // unless --no-eval), so degraded it routes through ensure-connection!
+      // and returns the shared :nrepl-port-not-found envelope. Its LIVE
+      // success / overflow behaviour is covered by
+      // live-re-frame2-pair-overflow.cjs and its --no-eval refusal by
+      // live-re-frame2-pair-subscribe.cjs; this degraded probe pins the
+      // callTool envelope + dispatch wiring.
+      { name: 'eval-cljs', arguments: { form: '(+ 1 2)' } },
+      { name: 'dispatch-dry-run', arguments: { event: '[:rf-conformance/probe]' } },
+      { name: 'get-operating-frame', arguments: {} },
+      { name: 'get-path', arguments: { path: '[:does :not :matter]' } },
+      { name: 'get-re-frame2-pair-instructions', arguments: {} },
+      { name: 'get-stream-controls', arguments: {} },
+      { name: 'handler-meta', arguments: { kind: 'event', id: ':rf-conformance/probe' } },
+      { name: 'list-handlers', arguments: { kind: 'event' } },
+      { name: 'read-recording', arguments: { 'recording-id': 'rf2-conformance-no-such' } },
+      { name: 'read-sub', arguments: { sub: '[:rf-conformance/probe]' } },
+      { name: 'record', arguments: { signals: '[[:rf-conformance/probe]]' } },
+      { name: 'reset-operating-frame', arguments: {} },
+      { name: 'set-operating-frame', arguments: { frame: ':rf/default' } },
+      { name: 'tail-build', arguments: {} },
+      { name: 'trace-window', arguments: { 'max-ms': 50 } },
+      { name: 'unsubscribe', arguments: { 'sub-id': 'rf2-conformance-no-such' } },
+      {
+        name: 'watch-until',
+        arguments: { signals: '[[:rf-conformance/probe]]', pred: '(constantly true)' },
+      },
     ];
 
     // Call one tool and assert the shared degraded envelope. Returns the
@@ -212,6 +309,60 @@ runWithWatchdog(
     const degradedResp = {};
     for (const tool of DEGRADED_TOOLS) {
       degradedResp[tool.name] = await assertDegraded(tool);
+    }
+
+    // 3c. Gated WRITE tools — pre-connection refusal (rf2-ke5n56). The two
+    // state-mutating tools `restore-epoch` and `replace-app-db` are gated
+    // behind `--allow-writes` (default OFF, rf2-ee38b.18). This server
+    // booted WITHOUT the flag, so `writes/refuse-pre-connection` short-
+    // circuits BOTH to the `:rf.error/writes-disabled` envelope BEFORE
+    // `ensure-connection!` runs (rf2-wz66k7) — so unlike every other tool
+    // they do NOT return `:nrepl-port-not-found` in degraded mode; they
+    // return the write-gate refusal. These were advertised but never
+    // SDK-called by this harness. Probing them here pins the default-safe
+    // write posture at the real MCP boundary (the env that ships) — a
+    // regression that flipped the default ON, renamed the gate flag, or
+    // dropped the pre-connection guard surfaces RED. The args are
+    // well-formed but inert: the guard fires before the arg is read or any
+    // nREPL touched. (The LIVE, non-degraded refusal — gate-OFF with a
+    // runtime attached — is additionally pinned by
+    // live-re-frame2-pair-subscribe.cjs, which also asserts the `:tool`
+    // slot; here we pin the degraded/pre-connection path the live test
+    // cannot reach.)
+    for (const probe of [
+      { name: 'restore-epoch', arguments: { 'epoch-id': '0' } },
+      { name: 'replace-app-db', arguments: { db: '{}' } },
+    ]) {
+      const resp = await client.callTool(probe);
+      degradedResp[probe.name] = resp;
+      if (!resp.isError) {
+        throw new Error(
+          probe.name + ' MUST isError when booted WITHOUT --allow-writes ' +
+            '(default-OFF write gate, rf2-ee38b.18); the state-mutating ' +
+            'surface is reachable unauthorised. got: ' + JSON.stringify(resp),
+        );
+      }
+      const text = resp.content?.[0]?.text || '';
+      if (!text.includes(':rf.error/writes-disabled')) {
+        throw new Error(
+          probe.name + ' default-OFF write-gate envelope MUST carry ' +
+            ':rf.error/writes-disabled (writes/disabled-result, NAMING.md ' +
+            'cross-server flag-vocabulary contract); got: ' + text.slice(0, 200),
+        );
+      }
+      // The pre-connection refusal must NOT leak a misleading
+      // :nrepl-port-not-found (rf2-wz66k7 — the guard runs before discovery).
+      if (text.includes('nrepl-port-not-found')) {
+        throw new Error(
+          probe.name + ' write-gate refusal MUST NOT mention ' +
+            ':nrepl-port-not-found — the gate is refused PRE-connection, not ' +
+            'after a failed discovery (rf2-wz66k7); got: ' + text.slice(0, 200),
+        );
+      }
+      console.log(
+        'OK   tools/call ' + probe.name + ' (no --allow-writes, degraded) -> ' +
+          'isError + :rf.error/writes-disabled (pre-connection refusal)',
+      );
     }
 
     // 3d. structuredContent dual-slot conformance (rf2-hj3pi). Every
@@ -273,6 +424,22 @@ runWithWatchdog(
     await assertJsonRpcErrorCodes(client);
     console.log(
       'OK   JSON-RPC error codes -> MethodNotFound + (InvalidParams|InternalError)',
+    );
+
+    // 4b. callTool() coverage ratchet (rf2-ke5n56). Every advertised
+    // pair-mcp tool MUST have been driven through `Client.callTool()`
+    // above (recorded in `CALLED` by the `track` proxy) or carry a
+    // reviewed exclusion in `PAIR_CALL_EXCLUSIONS`. A NEW advertised tool
+    // the workflow forgets to probe trips RED here — closing the
+    // descriptor-only false-green the senior review flagged.
+    assertCallCoverageRatchet({
+      advertised: names,
+      called: CALLED,
+      exclusions: PAIR_CALL_EXCLUSIONS,
+    });
+    console.log(
+      'OK   callTool coverage ratchet -> every advertised tool SDK-called ' +
+        '(' + CALLED.size + '/' + names.length + ') or reviewed-excluded',
     );
 
     // 5. The runner tears down the transport via client.close() on

--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -58,6 +58,7 @@ const {
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
   assertClassificationRatchet,
+  assertCallCoverageRatchet,
 } = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
 const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
@@ -115,6 +116,41 @@ function structured(resp) {
   return decodeDedupEnvelope(resp.structuredContent || {});
 }
 
+// SDK callTool() coverage tracking (rf2-ke5n56). Every tool the workflow
+// drives through `Client.callTool()` records its name here; the coverage
+// ratchet at the end of the body fails if any ADVERTISED tool is neither
+// recorded here nor in the reviewed exclusion table. `track(rawClient)`
+// returns a Proxy that records the tool name on each `callTool({name,…})`
+// and otherwise transparently delegates EVERY other member (listTools,
+// getServerVersion, request, close, …) to the real SDK client — so the
+// existing call sites read unchanged. A `callTool` that bypasses the
+// proxy can't quietly erode coverage: the tool would simply go unrecorded
+// and the ratchet would catch it as uncovered.
+const CALLED = new Set();
+function track(rawClient) {
+  return new Proxy(rawClient, {
+    get(target, prop, receiver) {
+      if (prop === 'callTool') {
+        return (req, ...rest) => {
+          if (req && typeof req.name === 'string') CALLED.add(req.name);
+          return target.callTool(req, ...rest);
+        };
+      }
+      const v = Reflect.get(target, prop, receiver);
+      return typeof v === 'function' ? v.bind(target) : v;
+    },
+  });
+}
+
+// Tools intentionally NOT SDK-call-covered by THIS harness, each with the
+// rationale + where its alternative coverage lives (rf2-ke5n56). Today the
+// Story workflow below drives a probe for every advertised tool, so this
+// table is empty — but it is wired through `assertCallCoverageRatchet` so
+// a FUTURE runtime-heavy/live-only Story tool has a reviewed home instead
+// of silently dropping out of coverage. A blank rationale, a stale row, or
+// an excluded-yet-called row trips the ratchet.
+const STORY_CALL_EXCLUSIONS = {};
+
 // JVM boot is slow on a cold CI worker (~10-30s); the whole register →
 // run → read → unregister loop adds a few more seconds. 90s is
 // comfortably above that without leaving a hung process if something
@@ -130,7 +166,12 @@ runWithWatchdog(
       env: { ...process.env },
     },
   },
-  async (client) => {
+  async (rawClient) => {
+    // Wrap the SDK client in the coverage tracker (rf2-ke5n56): every
+    // `client.callTool({name,…})` below records `name` for the callTool
+    // coverage ratchet at the end of this body. All other client members
+    // delegate transparently.
+    const client = track(rawClient);
     // The SDK's `client.connect()` (invoked by the runner) already
     // validated the initialize envelope against `InitializeResultSchema`
     // — a missing / malformed `serverInfo` would have thrown there.
@@ -257,6 +298,75 @@ runWithWatchdog(
         'list-modes/list-tags) -> success envelopes',
     );
 
+    // 2f. Remaining closed-world LIST reads (rf2-ke5n56). The read loop
+    // above covered four of story-mcp's reads; `list-stories`,
+    // `list-assertions`, and `list-decorators` were advertised but never
+    // SDK-CALLED — descriptor-only in conformance, so a callTool-envelope
+    // / outputSchema / structuredContent regression on any of them shipped
+    // green. These three need no runtime and no fixture (they enumerate
+    // the canonical-vocabulary registry the server installs at boot), so
+    // each is a zero-arg success probe routed through the SDK's
+    // CallToolResultSchema + the declared outputSchema parse — the same
+    // success-path shape pin the four reads above carry.
+    for (const readTool of ['list-stories', 'list-assertions', 'list-decorators']) {
+      const r = await client.callTool({ name: readTool, arguments: {} });
+      if (r.isError) {
+        throw new Error(
+          'closed-world read ' + readTool + ' MUST succeed (isError=false) ' +
+            'with no runtime/fixture; got: ' + JSON.stringify(r),
+        );
+      }
+      if (r.structuredContent === undefined || r.structuredContent === null ||
+          typeof r.structuredContent !== 'object' ||
+          Array.isArray(r.structuredContent)) {
+        throw new Error(
+          readTool + ' success envelope MUST carry a JSON-object ' +
+            ':structuredContent slot; got: ' + JSON.stringify(r),
+        );
+      }
+    }
+    console.log(
+      'OK   closed-world reads (list-stories/list-assertions/list-decorators)' +
+        ' -> success envelopes',
+    );
+
+    // 2g. Refusal-path coverage for the two story-id read tools
+    // (rf2-ke5n56). `get-story` and `get-docs-markdown` were advertised
+    // but never SDK-called. Both REQUIRE a `:story-id` and resolve it via
+    // `safe-keyword` against the registered-stories set — an unregistered
+    // id short-circuits to a documented `Story not found` tool-execution
+    // error (isError:true, NOT a JSON-RPC protocol error). A default-off
+    // refusal probe is the cheap, fixture-free way to drive the callTool
+    // path: it pins the not-found envelope shape AND proves the tool is
+    // wired into dispatch (an unwired name would surface a different
+    // error). A success-path hit would need a registered STORY, but the
+    // conformance fixture is a VARIANT (the canonical vocabulary installs
+    // no stable story id to hit), so the refusal probe is the coverage.
+    const ABSENT_STORY = ':story.mcp-conformance/no-such-story';
+    for (const storyTool of ['get-story', 'get-docs-markdown']) {
+      const r = await client.callTool({
+        name: storyTool,
+        arguments: { 'story-id': ABSENT_STORY },
+      });
+      if (!r.isError) {
+        throw new Error(
+          storyTool + ' on an unregistered story-id MUST isError (documented ' +
+            '`Story not found` refusal); got: ' + JSON.stringify(r),
+        );
+      }
+      const text = r.content?.[0]?.text || '';
+      if (!/not found/i.test(text)) {
+        throw new Error(
+          storyTool + ' not-found envelope MUST mention "not found"; got: ' +
+            text.slice(0, 200),
+        );
+      }
+    }
+    console.log(
+      'OK   story-id refusal probes (get-story/get-docs-markdown on absent ' +
+        'id) -> isError + "not found" (tool wired, envelope shape pinned)',
+    );
+
     // 3. register-variant — body as an EDN string so JSON's lack of
     // keyword support doesn't dilute the assertion (Cheshire would
     // coerce {"doc": "..."} into a string-keyed map, which Story's
@@ -307,6 +417,69 @@ runWithWatchdog(
       throw new Error('get-variant text payload missing :doc; got: ' + getText.slice(0, 200));
     }
     console.log('OK   get-variant -> body :doc round-trips through EDN text');
+
+    // 4b. variant->edn (rf2-ke5n56). Advertised but never SDK-called —
+    // and it is the EXACT latent-defect twin of get-story-instructions:
+    // it declares an :outputSchema, so the SDK's high-level callTool
+    // REJECTS a result with no structuredContent (-32600); rf2-vyacl
+    // notes variant->edn was the only OTHER tool still text-only before
+    // the fix. Driving it against the live fixture pins that the fix
+    // stays fixed across the wire. The text slot is the byte-stable
+    // pr-str EDN; assert the fixture :doc round-trips through it AND that
+    // a JSON-object structuredContent rides alongside (the slot the SDK
+    // outputSchema parse demands).
+    const ednResp = await client.callTool({
+      name: 'variant->edn',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    if (ednResp.isError) {
+      throw new Error('variant->edn on fixture failed: ' + JSON.stringify(ednResp));
+    }
+    const ednText = ednResp.content?.[0]?.text || '';
+    if (!/MCP-conformance harness probe variant\./.test(ednText)) {
+      throw new Error(
+        'variant->edn text payload missing :doc; got: ' + ednText.slice(0, 200),
+      );
+    }
+    if (ednResp.structuredContent === undefined || ednResp.structuredContent === null ||
+        typeof ednResp.structuredContent !== 'object' ||
+        Array.isArray(ednResp.structuredContent)) {
+      throw new Error(
+        'variant->edn MUST carry a JSON-object :structuredContent slot ' +
+          '(the SDK outputSchema parse demands it — rf2-vyacl latent-defect ' +
+          'class); got: ' + JSON.stringify(ednResp),
+      );
+    }
+    console.log('OK   variant->edn -> :doc round-trips through EDN text + structuredContent present');
+
+    // 4c. run-a11y (rf2-ke5n56). Advertised but never SDK-called. The
+    // axe-core run is CLJS-in-browser only; from this JVM-standalone boot
+    // the tool READS the (empty) violations atom and returns a success
+    // envelope with `:violations []` + a JVM-standalone `:note` — so it
+    // is a cheap, fixture-backed, runtime-free success probe (NOT a live
+    // browser dependency). Pins the callTool envelope + structuredContent
+    // shape for the testing-category read against the registered fixture.
+    const a11yResp = await client.callTool({
+      name: 'run-a11y',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    if (a11yResp.isError) {
+      throw new Error('run-a11y on fixture failed: ' + JSON.stringify(a11yResp));
+    }
+    const a11yStruct = structured(a11yResp);
+    if (!Array.isArray(a11yStruct.violations)) {
+      throw new Error(
+        'run-a11y :violations MUST be an array (empty on a JVM-standalone ' +
+          'boot); got: ' + JSON.stringify(a11yResp),
+      );
+    }
+    if (a11yStruct.violations.length !== 0) {
+      throw new Error(
+        'run-a11y :violations expected empty on a JVM-standalone boot (no ' +
+          'in-browser axe-core run); got: ' + JSON.stringify(a11yResp),
+      );
+    }
+    console.log('OK   run-a11y -> :violations=[] (JVM-standalone read, envelope pinned)');
 
     // 5. preview-variant — exercise the full lifecycle via the preview
     // tool. With no :play events the run is vacuously passing; the
@@ -518,7 +691,23 @@ runWithWatchdog(
       'OK   JSON-RPC error codes -> MethodNotFound + (InvalidParams|InternalError)',
     );
 
-    // 12. Clean disconnect — runner handles client.close() on success.
+    // 12. callTool() coverage ratchet (rf2-ke5n56). Every advertised
+    // story-mcp tool MUST have been driven through `Client.callTool()`
+    // above (recorded in `CALLED` by the `track` proxy) or carry a
+    // reviewed exclusion in `STORY_CALL_EXCLUSIONS`. A NEW advertised
+    // tool that the workflow forgets to probe trips RED here — closing
+    // the descriptor-only false-green the senior review flagged.
+    assertCallCoverageRatchet({
+      advertised: names,
+      called: CALLED,
+      exclusions: STORY_CALL_EXCLUSIONS,
+    });
+    console.log(
+      'OK   callTool coverage ratchet -> every advertised tool SDK-called ' +
+        '(' + CALLED.size + '/' + names.length + ') or reviewed-excluded',
+    );
+
+    // 13. Clean disconnect — runner handles client.close() on success.
     console.log('\nSTORY-MCP MCP-CLIENT CONFORMANCE GREEN');
   },
 );


### PR DESCRIPTION
@-