### PR TITLE
refactor(skills/core): clean stale Beads wording + eval drift (rf2-orpd31)

### DIFF
--- a/skills/re-frame2-improver/README.md
+++ b/skills/re-frame2-improver/README.md
@@ -18,11 +18,11 @@ If 1 holds but 2 doesn't — vocabulary with no file, snippet, or named path —
 
 - `SKILL.md` — the skill itself
 - `references/` — the anti-pattern catalogue. Each leaf carries detection rule, symptom example, canonical re-frame2 idiom, suggested rewrite, and a cross-link to the matching idiom under `skills/re-frame2/patterns/` or `spec/`.
-- `evals/evals.json` — eval fixtures: 16 trigger fixtures (8 should-trigger + 8 should-not-trigger, per skill-creator's description-optimisation contract) plus 9 behavioural fixtures that grade the critique itself — right anti-pattern named, evidence cited, canonical idiom cross-linked, no false positives, Edit gate respected. See [`evals/README.md`](evals/README.md) for the coverage table and grading guidance.
+- `evals/evals.json` — eval fixtures: 26 total — 16 trigger fixtures (8 should-trigger + 8 should-not-trigger, per skill-creator's description-optimisation contract) plus 10 behavioural fixtures that grade the critique itself — right anti-pattern named, evidence cited, canonical idiom cross-linked, no false positives, Edit gate respected. See [`evals/README.md`](evals/README.md) for the coverage table and grading guidance.
 - `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata
 - `package.json` — npm packaging metadata (skill is also distributable as an Agent Skill)
 - `spec/` — skill-internal meta-docs (`design.md`, `inputs.md`, `authoring-prompt.md`) that let a future pass re-author the skill from committed inputs. Not loaded during normal operation.
-- `../shared/retro-protocol.md` — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in bead protocol). Consumed jointly by this skill and `re-frame2-pair-retro`.
+- `../shared/retro-protocol.md` — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in issue-filing protocol). Consumed jointly by this skill and `re-frame2-pair-retro`.
 
 ## Relationship to other skills
 

--- a/skills/re-frame2-improver/SKILL.md
+++ b/skills/re-frame2-improver/SKILL.md
@@ -73,7 +73,7 @@ If 1 holds but 2 doesn't — vocabulary about "my project" with no file, snippet
  - Higher-leverage redesigns always stay as suggestions — present the option, let the user decide.
 6. **Surface findings** in the output shape below.
 
-The diagnosis-first discipline, evidence-citation rules, layer-routing heuristics, untrusted-evidence boundary, universal-redaction rules, and opt-in bead / Edit protocol are shared with `re-frame2-pair-retro` — load the shared leaf at [`../shared/retro-protocol.md`](../shared/retro-protocol.md). The workflow above is the consuming view; the protocol leaf is the normative source for the Edit-gate split.
+The diagnosis-first discipline, evidence-citation rules, layer-routing heuristics, untrusted-evidence boundary, universal-redaction rules, and opt-in issue-filing / Edit protocol are shared with `re-frame2-pair-retro` — load the shared leaf at [`../shared/retro-protocol.md`](../shared/retro-protocol.md). The workflow above is the consuming view; the protocol leaf is the normative source for the Edit-gate split.
 
 ## Output format
 
@@ -96,10 +96,10 @@ If the in-scope code is too thin for findings, say so plainly and ask for a wide
 - Don't reduce every finding to "read the spec". The cross-link is supporting evidence; the finding must stand on its own with the symptom + suggested rewrite.
 - Don't apply `Edit` for higher-leverage redesigns or for any finding the user hasn't agreed to. Only canonical-idiom-shaped rewrites bypass the approval gate; evidence-shaped rewrites require explicit approval first, even when mechanical — full statement at §Workflow step 5 and the normative source [`../shared/retro-protocol.md` §Step 6](../shared/retro-protocol.md#the-seven-step-protocol).
 - Don't interrupt authoring with anti-pattern detections. The skill is pull-only; if the user is in the middle of writing code via `re-frame2`, wait for the pull.
-- Don't propose framework-shape changes here. If the friction is really a gap in re-frame2's Tool-Pair surface or spec, route the user toward filing a bead via the appropriate retro skill rather than rewriting their code. **Filing is delegated, not performed here** — this skill's `allowed-tools` deliberately omit a `gh` / issue-filing surface; it critiques code and hands framework-shape friction to the retro skill that owns filing.
+- Don't propose framework-shape changes here. If the friction is really a gap in re-frame2's Tool-Pair surface or spec, route the user toward filing a GitHub issue via the appropriate retro skill rather than rewriting their code. **Filing is delegated, not performed here** — this skill's `allowed-tools` deliberately omit a `gh` / issue-filing surface; it critiques code and hands framework-shape friction to the retro skill that owns filing.
 
 ## Reference files
 
 - [`references/`](references/) — anti-pattern catalogue (6 leaves resident at launch). Each leaf carries: detection rule, symptom example, canonical re-frame2 idiom, suggested rewrite, cross-link to `skills/re-frame2/patterns/` or `spec/`.
-- [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in bead protocol). Consumed by both this skill and `re-frame2-pair-retro`.
+- [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in issue-filing protocol). Consumed by both this skill and `re-frame2-pair-retro`.
 - [`spec/`](spec/) — skill-internal meta-docs (design rationale, canonical inputs, re-authoring prompt). Not loaded during normal operation; exists to re-author the skill from committed inputs.

--- a/skills/re-frame2-improver/spec/authoring-prompt.md
+++ b/skills/re-frame2-improver/spec/authoring-prompt.md
@@ -27,7 +27,7 @@ A self-contained prompt that re-authors the `re-frame2-improver` skill from this
 > ├── package.json
 > ├── .claude-plugin/plugin.json
 > ├── evals/
-> │   ├── evals.json (8 should-trigger + 8 should-not-trigger + 9 behavioural critique fixtures)
+> │   ├── evals.json (8 should-trigger + 8 should-not-trigger + 10 behavioural critique fixtures)
 > │   └── README.md (coverage table + grading guidance + release threshold)
 > ├── references/
 > │   ├── README.md (catalogue index + locked five-section leaf format + growth procedure)

--- a/skills/re-frame2-improver/spec/design.md
+++ b/skills/re-frame2-improver/spec/design.md
@@ -99,7 +99,7 @@ skills/re-frame2-improver/
 ├── package.json (npm metadata)
 ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 ├── evals/
-│   ├── evals.json (8 should-trigger + 8 should-not-trigger + 9 behavioural critique fixtures)
+│   ├── evals.json (8 should-trigger + 8 should-not-trigger + 10 behavioural critique fixtures)
 │   └── README.md (coverage table + grading guidance + release threshold)
 ├── references/
 │   ├── README.md (catalogue index + locked leaf format + growth procedure)

--- a/skills/re-frame2/decision-trees/pick-a-pattern.md
+++ b/skills/re-frame2/decision-trees/pick-a-pattern.md
@@ -116,7 +116,7 @@ Every pattern that has a worked example is verified end-to-end by a Playwright s
 - The event names in your task scale to the example's `:feature/<verb>` naming.
 - The schema attachment points (`reg-app-schema` invocations) cover the same boundaries.
 
-If the example contradicts the leaf, **the example wins** — re-frame2's cardinal rule is that implementation is ground truth (per SKILL.md §Cardinal rules). File a bead against the spec; don't silently work around.
+If the example contradicts the leaf, **the example wins** — re-frame2's cardinal rule is that implementation is ground truth (per SKILL.md §Cardinal rules). Report the divergence upstream as a `day8/re-frame2` GitHub issue against the spec; don't silently work around.
 
 ## Step 4 — load the leaves
 

--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -119,7 +119,7 @@ Cardinal rule (per SKILL.md §1): when the spec and `implementation/**` disagree
 - A machine? — match a reference machine that uses state + tags + (where relevant) parallel regions or managed-HTTP. (In the re-frame2 repo itself, see `examples/reagent/login/` for state machine + tags + managed-HTTP, `examples/reagent/state_machine_walkthrough/` for the chapter as runnable code, `examples/reagent/nine_states/` for parallel regions.)
 - A slice? — match a reference slice. (In the re-frame2 repo itself, see `examples/reagent/counter/` for the smallest possible slice, `examples/reagent/todomvc/` for a list-of-items slice with editing and filters, and the 7GUIs cluster.)
 
-If a reference declaration contradicts the leaf you'd pick from this tree, **the reference wins** — and if that reference is the spec itself disagreeing with `implementation/**`, file a bead against the spec; don't silently work around (per the standing directive on file-bead-for-spec-gaps).
+If a reference declaration contradicts the leaf you'd pick from this tree, **the reference wins** — and if that reference is the spec itself disagreeing with `implementation/**`, report the divergence upstream as a `day8/re-frame2` GitHub issue against the spec; don't silently work around (per the standing directive on reporting spec gaps).
 
 ## Cross-references
 


### PR DESCRIPTION
Cleans the stale Beads-wording and eval-count drift named in **rf2-orpd31** (P2 vestigial). Pre-alpha CLARITY pass; no behaviour change, docs/wording only.

## What changed

**Finding 1 — stale Beads-routing wording → GitHub issue / issue-filing.** Shared policy (`skills/shared/issue-filing.md`, `skills/shared/retro-protocol.md`) is that published skills file GitHub issues against the target repo and never invoke `bd`. Several published leaves still used "bead" wording:

- `skills/re-frame2-improver/SKILL.md` — `:76`/`:104` "opt-in **bead** protocol" → "opt-in **issue-filing** protocol" (matches the shared leaf's own §Step 6 title, "opt-in issue-filing and edit protocol"); `:99` "filing a **bead** via the appropriate retro skill" → "filing a **GitHub issue** via …".
- `skills/re-frame2-improver/README.md` `:25` — same "bead" → "issue-filing".
- `skills/re-frame2/decision-trees/pick-a-pattern.md` `:119` and `slice-or-machine.md` `:122` — "File a **bead** against the spec" → "Report the divergence upstream as a `day8/re-frame2` GitHub issue against the spec". The authoring skill has no `gh`/`bd` surface and runs in a consumer's own repo; the upstream GitHub tracker is the correct spec-gap egress (matches the implementor/migration policy in `shared/issue-filing.md`).

**Finding 3 — eval-count drift.** Improver evals are now **26 total = 16 trigger (8+8) + 10 behavioural** (verified against `evals.json`), but the count prose still said 9 behavioural:

- `skills/re-frame2-improver/README.md` `:21` — "9 behavioural" → "26 total … 10 behavioural".
- `skills/re-frame2-improver/spec/design.md` `:102` and `spec/authoring-prompt.md` `:30` — "9 behavioural critique fixtures" → "10". (`evals/README.md` already stated 26 / 10 correctly.)

## Premise verification — one finding rejected as already-fixed

**Finding 2 (rf2-hhutya bead-id leak in `ssr-authoring.md:135` / `production-observability.md:139`) was ALREADY resolved** by the overlapping **rf2-tnikip** (commit `d96a6026d`, already on `main`), which removed both ids and added `scripts/check_skill_re_frame2_drift.py` to guard re-introduction. No `rf2-*` id remains in any `skills/re-frame2` user-facing leaf. No edit was needed here — premise stale, verified.

**Deliberately not changed (out of the user-facing slice / addressed to maintainers who do have `bd`):** the two `evals/README.md` "file a follow-up bead against the leaf" lines (eval-harness maintenance docs) and the `spec/` workflow bead refs. These sit in harness/spec scope (the sibling drift gate explicitly scopes `evals/` and `spec/` out), are addressed to the monorepo maintainer, and were not in the bead's enumerated evidence.

## Scope / flagged shared files

Owned slice only: `skills/re-frame2` + `skills/re-frame2-improver` (+ `skills/shared` was inspected, no edit). **Not touched (flagged):** `skills/re-frame2-pair/references/errors.md:23` and `ops.md:301` carry "file a `bd` bead" wording — the pair skill is owned by a concurrent `skills/pair-xray` worker, so left for that surface. The shared `scripts/check_skill_*.py` gates were run but not modified. The bead's "consider an improver eval-doc drift gate" suggestion was not actioned — `scripts/check_skill_eval_docs.py` already validates the `evals/README.md` total-count against `evals.json`; a new gate would risk colliding with the concurrent skills worker and is non-binding for acceptance.

## Quality gates

All run from the worktree, all green:

- `python scripts/check_skill_re_frame2_drift.py` (self-test + live) — exit 0
- `python scripts/check_skill_eval_docs.py` (self-test + live) — exit 0
- `python scripts/check_readme_links.py --ci` — exit 0
- `python scripts/check_skill_eval_packaging.py` — exit 0
- `python scripts/check_skill_package_refs.py` — exit 0
- `python scripts/check_skill_redirect_anchors.py` — exit 0
- `python scripts/check_skill_mcp_drift.py` — exit 0
- `python -m mkdocs build --strict` — exit 0 (skills are served on the site)