### PR TITLE
spec(routing): use :rf.route/nav-token in with-nav-token prose (rf2-9j1rh9)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3021,7 +3021,7 @@ Args of the framework-supplied `:rf.route/with-nav-token` fx wrapper, per [012 �
    [:route-id {:optional true} :any]])                                    ;; OPTIONAL captured route id (rf2-azcmd3): when present, a cross-route stale completion attributes its work-id to the route-loader attempt, not the route live at arrival
 ```
 
-Registered under spec id `:rf.fx/with-nav-token-args`. The wrapped fx receives the carried token in cofx; on receipt, the `:nav-token` cofx (a subsystem-registered coeffect a handler declares via `:rf.cofx/requires [:nav-token]` per [001 §`:rf.cofx/requires`](001-Registration.md#rfcofxrequires--the-declaration-key)) checks the carried token against the current route slice's (`[:rf.runtime/routing :current]`) `:nav-token`. Mismatch → suppress + emit `:rf.route.nav-token/stale-suppressed` trace.
+Registered under spec id `:rf.fx/with-nav-token-args`. The wrapped fx receives the carried token in cofx; on receipt, the `:rf.route/nav-token` cofx (a subsystem-registered coeffect a handler declares via `:rf.cofx/requires [:rf.route/nav-token]` per [001 §`:rf.cofx/requires`](001-Registration.md#rfcofxrequires--the-declaration-key)) checks the carried token against the current route slice's (`[:rf.runtime/routing :current]`) `:nav-token`. Mismatch → suppress + emit `:rf.route.nav-token/stale-suppressed` trace.
 
 ### `:rf/hydration-payload`
 


### PR DESCRIPTION
Fixes rf2-9j1rh9 (P3, spec-coherence).

## What

The `:rf.fx/with-nav-token-args` schema prose in `spec/Spec-Schemas.md` named the
nav-token cofx as `:nav-token` and instructed declaring it via
`:rf.cofx/requires [:nav-token]`. The shipped cofx id is **`:rf.route/nav-token`**.

This was the single tracked stale occurrence:
- `spec/API.md` and `spec/012-Routing.md` already use `:rf.route/nav-token`.
- `implementation/routing/src/re_frame/routing/nav_token.cljc` registers and supplies
  `:rf.route/nav-token`, delivered flat under coeffect key `:rf.route/nav-token`,
  declared via `:rf.cofx/requires [:rf.route/nav-token]`.

A reader or generator consuming Spec-Schemas would otherwise declare the wrong cofx id
and miss the routing token the reference implementation actually provides.

## Why this is a prose-coherence fix (not a semantics change)

Spec and implementation agree on behaviour; only this one prose line named the wrong
cofx id. No implementation change needed. The carried-token slice key
`[:rf.runtime/routing :current :nav-token]` is unchanged — that is the route-slice
field name, distinct from the cofx id.

## Scope

One line changed in `spec/Spec-Schemas.md` (the only hot-zone file touched; sole spec
worker this wave). `git grep "requires [:nav-token]"` across tracked `spec/` +
`implementation/` is now clean. `spec/Conventions.md` was already clean.

## Quality gates

- `python -m mkdocs build --strict` — built successfully (12.77s; only pre-existing
  INFO relative-link notes, unrelated to this change).
- Staged docs check (CI parity: `rm -rf docs/spec && cp -r spec docs/spec`):
  - `python scripts/check_doc_slugs.py` — OK
  - `python scripts/check_readme_links.py --ci` — OK
- `npm run test:cljs` — not run (no routing code/conformance touched; prose-only).

## Acceptance criteria (from bead)

- [x] `spec/Spec-Schemas.md` uses `:rf.route/nav-token` for with-nav-token cofx prose.
- [x] Grep for the stale literal `:rf.cofx/requires [:nav-token]` is clean.
- [x] No implementation change.