### PR TITLE
refactor(skills/retro): remove local tracker scaffolding + metadata drift (rf2-edd3wd)

### DIFF
--- a/skills/re-frame2-pair-retro/.claude-plugin/plugin.json
+++ b/skills/re-frame2-pair-retro/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "skills": [
     "./SKILL.md"
   ],
-  "status": "alpha"
+  "status": "pre-alpha"
 }

--- a/skills/re-frame2-pair-retro/.gitignore
+++ b/skills/re-frame2-pair-retro/.gitignore
@@ -1,8 +1,3 @@
 .DS_Store
 Thumbs.db
 node_modules/
-
-# Beads / Dolt files (added by bd init)
-.dolt/
-*.db
-.beads-credential-key

--- a/skills/re-frame2-pair-retro/spec/authoring-prompt.md
+++ b/skills/re-frame2-pair-retro/spec/authoring-prompt.md
@@ -21,7 +21,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 >
 > ```
 > skills/re-frame2-pair-retro/
-> ├── SKILL.md (~170 lines; conversation guide + 6-step workflow)
+> ├── SKILL.md (conversation guide + 6-step workflow)
 > ├── README.md (human-facing intro)
 > ├── LICENSE (MIT)
 > ├── package.json (npm metadata)
@@ -31,9 +31,9 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > ├── evals/                          # repo-maintenance artifact; excluded from the npm `files` array
 > │ └── evals.json (trigger-accuracy fixtures — which prompts should / should not activate)
 > ├── references/
-> │ ├── analysis-lenses.md (~140 lines; nine root-cause lenses)
-> │ ├── known-frictions.md (~120 lines; recurring pain patterns)
-> │ ├── issue-template.md (~90 lines; GitHub-issue-body template + redaction)
+> │ ├── analysis-lenses.md (nine root-cause lenses)
+> │ ├── known-frictions.md (recurring pain patterns)
+> │ ├── issue-template.md (GitHub-issue-body template + redaction)
 > │ └── working-style.md (diagnostic-posture rules; the SHIPPED operational home of design.md §8)
 > └── spec/
 > ├── design.md
@@ -41,7 +41,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > └── authoring-prompt.md
 > ```
 >
-> *Every reference is ≤250 lines (target ~120). SKILL.md is ~170 lines (well under Anthropic's 500-line ceiling).*
+> *Keep each reference focused and self-contained, and keep SKILL.md compact — well under Anthropic's 500-line ceiling.*
 >
 > ***Preserve the shipped load paths.** `SKILL.md` MUST cross-link `references/working-style.md` (the diagnostic-posture rules) and `references/issue-template.md` — both are packaged `references/` leaves that load during normal operation. Do NOT relegate the diagnostic-posture rules back into `spec/`: `spec/` is excluded from the npm package / plugin bundle and is not loaded during normal operation, so a `SKILL.md → spec/design.md §8` link breaks in every packaged / plugin / vendored install. `.claude-plugin/plugin.json` and `agents/openai.yaml` are shipped slice files — keep them in the package `files` array. `evals/evals.json` (the trigger fixtures) is a re-authoring slice too — keep it on disk so the description-optimisation loop can score the activation boundary — but, like `spec/`, it is a **repo-maintenance artifact deliberately excluded from the npm `files` array** (it runs from a full clone, not from a packaged consumer's install); do NOT add `evals/` to `files`. This matches the sibling `re-frame2` / `re-frame2-setup` / `re-frame2-pair` skills.*
 >

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -115,7 +115,7 @@ GitHub-issue drafts redact secrets, tokens, internal URLs, and unnecessary local
 
 ```
 skills/re-frame2-pair-retro/
-├── SKILL.md (~170 lines; the conversation guide + workflow)
+├── SKILL.md (the conversation guide + workflow)
 ├── README.md (human-facing intro)
 ├── LICENSE (MIT)
 ├── package.json (npm metadata)
@@ -125,9 +125,9 @@ skills/re-frame2-pair-retro/
 ├── evals/                          # repo-maintenance artifact; excluded from the npm `files` array
 │ └── evals.json (trigger-accuracy fixtures — which prompts should / should not activate)
 ├── references/
-│ ├── analysis-lenses.md (~140 lines; nine root-cause lenses + improvement shapes)
-│ ├── known-frictions.md (~120 lines; recurring re-frame2-pair pain patterns)
-│ ├── issue-template.md (~90 lines; GitHub-issue-body template, redaction rules)
+│ ├── analysis-lenses.md (nine root-cause lenses + improvement shapes)
+│ ├── known-frictions.md (recurring re-frame2-pair pain patterns)
+│ ├── issue-template.md (GitHub-issue-body template, redaction rules)
 │ └── working-style.md (diagnostic-posture rules; shipped operational home of §8)
 └── spec/
  ├── design.md (this file)
@@ -135,7 +135,7 @@ skills/re-frame2-pair-retro/
  └── authoring-prompt.md (one-shot reauthor prompt)
 ```
 
-SKILL.md (~170) + 3 references (~350) + spec (~300) ≈ ~820 LoC. Typical session reads SKILL.md (~170) + at most one or two references (`analysis-lenses.md` when classification is hard, `known-frictions.md` when the session smells recurring) = ~310-450 LoC.
+Keep SKILL.md compact (well under Anthropic's 500-line ceiling) and each reference focused. A typical session reads SKILL.md plus at most one or two references (`analysis-lenses.md` when classification is hard, `known-frictions.md` when the session smells recurring) — never the whole tree.
 
 ## 6. Discovery surface (frontmatter `description`)
 


### PR DESCRIPTION
Implements **rf2-edd3wd** (P3 vestigial). Removes local Beads/Dolt tracker scaffolding and metadata drift from the `skills/re-frame2-pair-retro` skill. Pre-alpha posture: no back-compat; CLARITY lens. All three bead premises verified before editing.

## Changes

1. **`.gitignore`** — dropped the Beads/Dolt init leftovers (`.dolt/`, `*.db`, `.beads-credential-key` + the `# Beads / Dolt files (added by bd init)` comment). Verified no such files exist under the skill — pure scaffolding residue. Kept the legitimate general ignores (`.DS_Store`, `Thumbs.db`, `node_modules/`).
2. **`.claude-plugin/plugin.json`** — `status: "alpha"` → `"pre-alpha"`. It was the lone outlier; the README already says pre-alpha and every sibling manifest (re-frame2, re-frame2-setup, re-frame2-pair, re-frame2-improver, re-frame2-xray, re-frame2-implementor, re-frame-migration) uses `pre-alpha`. No graduation decision exists. Left `version` (`0.1.0-alpha.1`) untouched — that prerelease tag is uniform across all siblings (not drift).
3. **`spec/design.md` + `spec/authoring-prompt.md`** — replaced stale `~N lines` / `~N LoC` locks with qualitative guidance. The counts had drifted (SKILL.md claimed ~170, actually 142; known-frictions ~120, actually 179; issue-template ~90, actually 134; total ~820 LoC, actually ~972). None are generated or verified by a gate, so they were pure manual drift. Preserved the meaningful constraint (Anthropic's real 500-line ceiling) and the read-budget intent; preserved the legitimate design-decision "locks" (L1–L12 pillars) — those are design intent, not line-count drift.

## Acceptance (all met)

- No `.dolt/`, `.beads-credential-key`, or Beads/Dolt comments remain under `skills/re-frame2-pair-retro` ✓
- Retro plugin manifest status matches repo-wide pre-alpha posture and sibling manifests ✓
- No stale `~N lines` / `~N LoC` assertions remain (none are gate-generated) ✓

## Quality gates

- `scripts/check_readme_links.py --ci` — PASS (exit 0)
- `scripts/check_skill_pair_authoring_drift.py --ci` — PASS (exit 0)
- `scripts/check_skill_package_refs.py --ci` — PASS (exit 0)
- `scripts/check_skill_eval_packaging.py --ci` — PASS (exit 0)
- `scripts/check_skill_mcp_drift.py --ci` — PASS (exit 0)
- `scripts/check_skill_redirect_anchors.py --ci` — PASS (exit 0)
- `mkdocs build --strict` — not run locally (mkdocs not installed); edited files (`spec/*.md`, `.gitignore`, `plugin.json` under `skills/`) are NOT mkdocs-served sources and no served doc references the changed content, so docs output is unaffected. CI runs the full mkdocs gate.

Scope: confined to `skills/re-frame2-pair-retro/` only. No shared skills index, shared scripts, or `.beads/issues.jsonl` touched.