### PR TITLE
docs(derivation-conformance): align stale six-source wording (rf2-r0ycw8)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -3,9 +3,11 @@
   EP-0014 Reference Implementation Plan item 9 + §Validation / Conformance;
   spec/Derivations.md §Conformance).
 
-  EP-0014's whole point is ONE derivation/process vocabulary across SIX
-  plural source forms — `reg-sub`, `reg-runtime-sub`, `reg-flow`,
-  `reg-resource`, `reg-route`, `reg-machine` — so a tool reads ONE graph
+  EP-0014's whole point is ONE derivation/process vocabulary across the FIVE
+  graph families — subscriptions (`reg-sub`, which folds `reg-runtime-sub`
+  under the same subs contributor), flows (`reg-flow`), resources
+  (`reg-resource`), route facts (`reg-route`), and machines (`reg-machine`)
+  — so a tool reads ONE graph
   (`{:mode :nodes :edges}`) and a maintainer answers ONE question
   consistently: where does this fact come from, when is it evaluated, where
   does it live, and who owns it? Each family already exposes its OWN algebra


### PR DESCRIPTION
## Summary

Aligns the stale SIX-source-form claim in the EP-0014 cross-family derivation/process-algebra conformance suite docstring (rf2-r0ycw8, P4 vestigial).

The namespace docstring (`derivation_algebra_conformance_cljs_test.cljc:6-8`) claimed ONE vocabulary across **SIX** plural source forms — `reg-sub`, `reg-runtime-sub`, `reg-flow`, `reg-resource`, `reg-route`, `reg-machine`. The actual fixture wires **FIVE** graph families:

- `register-one-of-each!` (`:256-301`) registers exactly: subs / flow / resource / route / machine — no `reg-runtime-sub`.
- `all-contributors` (`:215-231`) has five keys: `:subs :flows :resources :routes :machines`.
- The lowering assertion (`:320-322`) asserts `#{:subs :flows :resources :routes :machines}` and reads "all five families".
- `deps.edn` already says "ALL FIVE families" and "the five tooling siblings" (`:9, :60, :75`).

The six-source prose was left over from an earlier enumeration; runtime subs are folded under the subs contributor, not a separate fixture here.

## Change

Rewrote the docstring's opening claim to describe the **five graph families**, documenting inline that `reg-runtime-sub` folds under the `reg-sub` subs contributor. No standalone SIX claim remains; no duplicate coverage introduced (`reg-runtime-sub` stays covered only by the subs algebra-view suite). The top docstring, deps.edn rationale, contributor map, and lowering assertion now agree.

Premise verified before editing (counted the actual sources). Docstring-only change — no code paths or `:require`s touched. Repo-wide `git grep` confirmed no other `SIX source` claim exists in any tracked spec/implementation/tools file (nothing to flag in hot-zone spec).

## Quality gates

- `clojure -M:test` (derivation-conformance JVM): **15 tests, 324 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node CLJS gate): **7081 tests, 29146 assertions, 0 failures, 0 errors**

Acceptance (per rf2-r0ycw8):
- No standalone SIX source-form claim remains (✓ — `reg-runtime-sub` not registered/asserted, claim removed).
- Top docstring, deps.edn rationale, contributor map, and lowering assertions agree (✓).
- No duplicate coverage introduced (✓ — runtime-sub stays subs-suite-only).
