### PR TITLE
fix(examples/scripts): serve-example uses clean-stage boundary (rf2-rg2tze)

### DIFF
--- a/examples/scripts/serve-example.cjs
+++ b/examples/scripts/serve-example.cjs
@@ -19,9 +19,13 @@
  *      so there is no hardcoded build->folder table to drift. The example's
  *      hand-written `index.html` is the one colocated with the source file
  *      that declares the build's init-fn namespace.
- *   2. Stages `index.html` + the `examples/_shared/` tree into the output dir
- *      (the SAME staging the adapter-smoke orchestrator uses — reused from
- *      examples-staging.cjs, not re-implemented).
+ *   2. Applies the clean-stage boundary to the selected output dir (remove +
+ *      recreate it empty, path-guarded under out/examples), then stages
+ *      `index.html` + the `examples/_shared/` tree into it — the SAME
+ *      clean-then-stage contract the adapter-smoke / Story orchestrators use,
+ *      reused from examples-staging.cjs, not re-implemented. Serving from a
+ *      freshly cleaned dir means no stale prior bundle/asset is ever served as
+ *      a fresh run (rf2-rg2tze).
  *   3. Resolves a free port (reusing the examples port resolver) and serves
  *      the output dir over http-server on 127.0.0.1.
  *   4. Spawns `shadow-cljs watch <build>` so edits recompile live. A
@@ -57,7 +61,7 @@
 const fs = require('fs');
 const path = require('path');
 const { resolveExamplesPort } = require('./examples-port.cjs');
-const { stageExample, listStandaloneExamples } = require('./examples-staging.cjs');
+const { stageExample, listStandaloneExamples, cleanStageDirs } = require('./examples-staging.cjs');
 const {
   createHarnessCleanup,
   spawnHarnessProcess,
@@ -68,6 +72,12 @@ const {
 // where shadow-cljs runs and node_modules lives.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+// The shared staging root every example build emits under
+// (`:output-dir "out/examples/<name>"`). It is the clean-stage boundary's
+// owned root: cleanStageDirs path-guards each selected outDir to live strictly
+// under it, so a clean can never touch the shared root or a sibling output the
+// same root holds. Mirrors OUT_ROOT in serve-and-run-examples-tests.cjs.
+const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
 const READY_TIMEOUT_MS = 30000;
 
 function parseArgs(argv) {
@@ -140,11 +150,29 @@ async function main() {
   const shadowRunner = resolveShadowRunner();
   const httpServerBin = resolveHttpServerBin();
 
+  // Clean-stage boundary (rf2-bf4vdy / rf2-rg2tze): remove + recreate the
+  // SELECTED build's output dir BEFORE any compile or staging, so every served
+  // file is produced from the CURRENT source this run — exactly the contract
+  // the CI/Story orchestrators already honour (serve-and-run-examples-tests.cjs
+  // cleanSelectedOutDirs, the Story load/play runners). Without this the dev
+  // runner overlaid index.html + _shared onto whatever a PRIOR run left behind,
+  // so a stale main.js (or a retired asset the manifest no longer produces)
+  // stayed serveable — and in watch mode the browser could render that old
+  // bundle while the runner had already printed a live URL, masking an initial
+  // compile that had not yet landed (or had failed). Cleaning first makes a
+  // missing bundle VISIBLY absent until the current watch's first compile lands
+  // — no stale prior main.js is ever advertised or served as a fresh run. We
+  // clean ONLY this dir (never the shared OUT_ROOT) so sibling outputs another
+  // run/harness relies on survive; the helper path-guards the target to live
+  // strictly under OUT_ROOT.
+  cleanStageDirs([entry.outDir], OUT_ROOT);
+
   // For `--no-watch` we compile once up front (CI-shaped: the output dir is
-  // fully built before staging + serving). For the default watch mode the
-  // watch process below produces main.js, so we stage immediately and the
-  // first compile lands in place — http-server serves the freshly built file
-  // the moment the watch finishes its initial compile.
+  // fully built into the freshly cleaned dir before staging + serving). For the
+  // default watch mode the watch process below produces main.js into the clean
+  // dir, so we stage immediately and the first compile lands in place — until
+  // it does, the cleaned dir has no main.js, so http-server cannot serve a
+  // stale bundle.
   if (!watch) {
     const { spawnSync } = require('child_process');
     const result = spawnSync(process.execPath, [shadowRunner, 'compile', entry.build], {
@@ -156,9 +184,9 @@ async function main() {
     }
   }
 
-  // Stage index.html + the _shared design-system tree into the output dir.
-  // The output dir is created by the staging helper if the watch hasn't
-  // emitted into it yet, so the page's assets are present from the start.
+  // Stage index.html + the _shared design-system tree into the (now clean)
+  // output dir. The output dir already exists (cleanStageDirs recreated it),
+  // so the page's assets are present from the start.
   stageExample(entry);
 
   if (watch) {

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -33,6 +33,7 @@ const {
   readShadowEdn,
   isStrictlyUnder,
   cleanStageDirs,
+  stageExample,
 } = require('../../examples/scripts/examples-staging.cjs');
 
 let failed = 0;
@@ -208,6 +209,78 @@ it('cleanStageDirs (re)creates a not-yet-existing selected dir (first run)', () 
   } finally {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }
+});
+
+// ---- serve-example dev-runner clean-stage boundary (rf2-rg2tze) ----------
+//
+// `npm run dev:example` / serve-example.cjs used to overlay index.html +
+// _shared onto whatever a PRIOR run left in the selected output dir — so a
+// stale main.js (or a retired asset) stayed serveable, and in watch mode the
+// browser could render that old bundle while the runner had already printed a
+// live URL. The fix pins serve-example to the SAME clean-then-stage boundary
+// the CI/Story orchestrators use: cleanStageDirs([entry.outDir], OUT_ROOT)
+// BEFORE stageExample(entry). These tests pin both the behaviour (a stale
+// main.js is removed, siblings survive, assets land) and the call-site (the
+// clean precedes the stage), so a refactor that drops the clean fails here.
+
+it('dev-runner clean-then-stage removes a stale main.js and re-stages the example (rf2-rg2tze)', () => {
+  // Seed a temp OUT_ROOT with a selected dir holding a STALE main.js + retired
+  // asset from a "prior run", plus a sibling output another build relies on.
+  // Run the EXACT sequence serve-example.cjs now performs — clean the selected
+  // dir, then stageExample — and prove the stale bundle is gone, the example's
+  // index.html landed fresh, and the sibling survived.
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-serve-'));
+  try {
+    const outRoot = path.join(tmpRoot, 'out', 'examples');
+    const sel = path.join(outRoot, 'counter-uix');
+    const sibling = path.join(outRoot, 'login-uix');
+    fs.mkdirSync(sel, { recursive: true });
+    fs.mkdirSync(sibling, { recursive: true });
+    // A stale bundle + retired asset the current source no longer produces.
+    fs.writeFileSync(path.join(sel, 'main.js'), 'STALE_BUNDLE');
+    fs.writeFileSync(path.join(sel, 'retired-asset.js'), 'RETIRED');
+    fs.writeFileSync(path.join(sibling, 'main.js'), 'SIBLING_BUNDLE');
+
+    // A real (temp) hand-written index.html for the example source.
+    const srcDir = path.join(tmpRoot, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const htmlSrc = path.join(srcDir, 'index.html');
+    fs.writeFileSync(htmlSrc, '<!doctype html><title>counter-uix</title>');
+    const entry = { build: 'examples/counter-uix', outDir: sel, htmlSrc, srcDir };
+
+    // The serve-example contract: clean the SELECTED dir first, then stage.
+    cleanStageDirs([entry.outDir], outRoot);
+    stageExample(entry);
+
+    assert.ok(!fs.existsSync(path.join(sel, 'main.js')), 'the stale main.js must be removed by the clean');
+    assert.ok(!fs.existsSync(path.join(sel, 'retired-asset.js')), 'the retired asset must be removed');
+    assert.ok(fs.existsSync(path.join(sel, 'index.html')), 'the example index.html must be staged fresh');
+    assert.strictEqual(
+      fs.readFileSync(path.join(sel, 'index.html'), 'utf8'),
+      '<!doctype html><title>counter-uix</title>',
+      'the staged index.html must be the current source',
+    );
+    // The sibling output another build/run relies on must be untouched.
+    assert.ok(fs.existsSync(path.join(sibling, 'main.js')), 'a sibling output dir must survive a narrow clean');
+    assert.strictEqual(fs.readFileSync(path.join(sibling, 'main.js'), 'utf8'), 'SIBLING_BUNDLE');
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+it('serve-example.cjs calls cleanStageDirs on the selected outDir BEFORE stageExample (rf2-rg2tze)', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'examples', 'scripts', 'serve-example.cjs'),
+    'utf8',
+  );
+  assert.ok(
+    /cleanStageDirs\s*\(\s*\[\s*entry\.outDir\s*\]\s*,\s*OUT_ROOT\s*\)/.test(src),
+    'serve-example must clean the selected entry.outDir under OUT_ROOT (clean-stage boundary)',
+  );
+  const cleanAt = src.indexOf('cleanStageDirs([entry.outDir], OUT_ROOT)');
+  const stageAt = src.indexOf('stageExample(entry)');
+  assert.ok(cleanAt !== -1 && stageAt !== -1, 'both the clean call and the stage call must be present');
+  assert.ok(cleanAt < stageAt, 'the clean must precede the stage so no stale file survives into the served dir');
 });
 
 // A no-op io for the guard-refusal tests: they must throw BEFORE any fs call,


### PR DESCRIPTION
## Summary

`examples/scripts/serve-example.cjs` (the `npm run dev:example` front door) reused the shared standalone-example staging helper but **never applied the clean-stage boundary** before serving the selected output dir. It overlaid `index.html` + `_shared` onto whatever a prior run had left in `implementation/out/examples/<build>`, then started `shadow-cljs watch` + `http-server`.

Premise verified against the bead's file:line evidence:
- The CI/Story orchestrators (`serve-and-run-examples-tests.cjs`, `serve-and-run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs`) all call `cleanStageDirs(dirs, OUT_ROOT)` before compile/stage.
- `serve-example.cjs` called `stageExample(entry)` directly — no clean. So a stale `main.js` or retired asset stayed serveable, and in watch mode the browser could render that old bundle while the runner had already printed a live URL — masking an initial compile that had not yet landed (or had failed).

## Fix

- Import `cleanStageDirs` and define `OUT_ROOT = IMPL_ROOT/out/examples` (mirrors the CI runner's owned root).
- Call `cleanStageDirs([entry.outDir], OUT_ROOT)` **before** any compile or staging. This recreates the selected dir empty, so:
  - `--no-watch` compiles into a fresh dir before staging/serving.
  - watch mode has **no `main.js` until the current watch's first compile lands** — a missing bundle is visibly absent rather than a stale one being served as fresh (acceptance "clean first" option).
- Clean only the selected dir (never the shared `OUT_ROOT`); the helper path-guards the target strictly under `OUT_ROOT`, so siblings another run/harness relies on survive.
- Updated the script's header contract comment to describe the clean-then-stage boundary.

## Regression

Two tests added to `implementation/scripts/_examples-staging.test.cjs` (run under `test:script-policy`):
- **Behavioural**: seeds a selected dir with a stale `main.js` + retired asset plus a sibling output, runs the exact clean-then-stage sequence serve-example now performs, and proves the stale files are removed, the example `index.html` lands fresh, and the sibling survives.
- **Call-site**: pins that `serve-example.cjs` calls `cleanStageDirs` on `entry.outDir` under `OUT_ROOT` **before** `stageExample`, so a refactor dropping the clean fails the gate.

## Scope

`examples/scripts/` only (serve-example + its staging boundary + the script-policy regression). No `examples/<adapter>/` dirs touched. The sibling staging bead rf2-bz2b4b is held to sequence after this.

## Quality gates

- `npm run test:script-policy` — green (EXIT=0); includes `_examples-staging.test.cjs` (12 PASS, incl. the 2 new rf2-rg2tze tests) and `_examples-filter.test.cjs`.

Closes rf2-rg2tze.