### PR TITLE
fix(mcp): repair stale story-mcp overflow conformance + triplet leftovers (rf2-yxgcsz)

### DIFF
--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -90,7 +90,7 @@ All six parsers are pure `.cljc`. They use:
 Per-parser fixture tests live in `tools/mcp-base/test/`. Cross-consumer convention checks live in `tools/mcp-conformance/`:
 
 - Every cross-MCP tool that accepts a finite-option arg uses `safe-keyword`. The conformance harness diffs argument schemas across consumers and asserts the same allowlist appears everywhere.
-- Default-handling parity: a sample arg that's unset on each consumer must produce identical observable behaviour across the triplet. The harness drives each tool with `{}` (no args) and asserts the response envelope matches the convention's documented defaults.
+- Default-handling parity: a sample arg that's unset on each consumer must produce identical observable behaviour across both servers. The harness drives each tool with `{}` (no args) and asserts the response envelope matches the convention's documented defaults.
 
 ## See also
 

--- a/tools/mcp-base/spec/overflow.md
+++ b/tools/mcp-base/spec/overflow.md
@@ -85,20 +85,27 @@ The cap is a **soft** constraint at the algorithm level — the consumer can ove
 
 ## Conformance posture
 
-The cross-MCP conformance gate at `tools/mcp-conformance/wire-vocab/` pins the canonical Malli schema for the `:rf.mcp/overflow` marker:
+The cross-MCP conformance gate at `tools/mcp-conformance/wire-vocab/` pins the canonical Malli schema for the `:rf.mcp/overflow` marker (`wire_vocab/schemas.clj` `Overflow` / `ReFrame2PairOverflowBody`):
 
 ```clojure
-[:map
+[:map {:closed true}
  [:rf.mcp/overflow
-  [:map
-   [:limit       [:= :reached]]
+  [:map {:closed false}
+   [:limit       [:enum :reached]]
    [:token-count :int]
    [:cap-tokens  :int]
-   [:tool        :string]
-   [:hint        :string]]]]
+   [:tool        [:or :string :keyword]]
+   [:hint        [:or :string :keyword]]]]]
 ```
 
-Every server's cap-trigger fixture asserts the response matches this schema. The conformance harness at `tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs` drives a real `:max-tokens 100` over-budget call on each server and asserts the marker shape parity.
+Both servers emit this marker via the shared `cap/apply-cap` → `overflow-payload`, so the body is byte-identical; the gate carries a per-server cap-trigger fixture (`:re-frame2-pair-mcp` and `:story-mcp`) and asserts each validates against this one schema.
+
+Live cap-trigger coverage today:
+
+- **re-frame2-pair-mcp** — over the real MCP wire via `tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs` (a `:max-tokens 100` over-budget `tools/call` against a live nREPL-backed server; hermetic on CI, SKIPs without `$SHADOW_CLJS_NREPL_PORT`).
+- **story-mcp** — at the wire-pipeline boundary via `tools/story-mcp/test/re_frame/story_mcp/tools_test.clj` (`wire-pipeline/invoke-tool` with `:max-tokens 1` asserts the `{:rf.mcp/overflow …}` marker; `:max-tokens 0` asserts the bypass). story-mcp is JVM-side with no nREPL/browser runtime, so its over-budget trip is exercised in-process rather than through a parallel `.cjs` SDK script.
+
+The marker SHAPE builder (`overflow-payload`) is additionally driven live JVM-side in `wire_vocab_test.clj` (`overflow-marker-shape-emitted-live-by-canonical-builder`) — the one builder both servers share.
 
 ## See also
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -12,7 +12,7 @@ This doc is one of eleven per-namespace contracts indexed from [`README.md`](REA
 - The `:rf.mcp/*` marker keyword catalogue.
 - The `:rf.size/*` marker keyword catalogue (shared with the framework's `rf/elide-wire-value` walker).
 - The unqualified envelope counter slots (`:dropped-sensitive`, `:elided-large`).
-- The JSON-RPC 2.0 §5.1 error codes used by every server in the triplet.
+- The JSON-RPC 2.0 §5.1 error codes used by every server in the pair.
 
 `vocab` does NOT own:
 
@@ -61,7 +61,7 @@ Both slots ride the response envelope alongside the tool's unqualified slots. **
 
 ## JSON-RPC error codes (per JSON-RPC 2.0 §5.1)
 
-The same numeric codes apply across the triplet. Owned constants:
+The same numeric codes apply across both servers. Owned constants:
 
 - `code-parse-error` (-32700)
 - `code-invalid-request` (-32600)

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -37,7 +37,7 @@
   ## JSON-RPC error codes
 
   Per JSON-RPC 2.0 §5.1 and MCP's reuse of them — the same numeric
-  codes apply across the triplet. Story-mcp emits them via Cheshire;
+  codes apply across both servers. Story-mcp emits them via Cheshire;
   re-frame2-pair-mcp would emit them via the npm MCP SDK if it surfaced
   JSON-RPC-level errors directly (today it uses the SDK's
   `isError: true` tool-result shape, but the codes still pin the
@@ -49,7 +49,8 @@
 
 (def overflow-key
   "Top-level marker on a response that exceeded the per-call token cap.
-  Shape (per re-frame2-pair-mcp's `apply-cap`):
+  Shape (per the shared `mcp-base.cap/apply-cap` → `overflow/overflow-payload`
+  builder, emitted by BOTH re-frame2-pair-mcp and story-mcp):
     `{:rf.mcp/overflow {:limit :reached :token-count N :cap-tokens M
                         :tool \"<name>\" :hint \"...\"}}`.
   Per rf2-rvyzy."

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.diff-encode-test
   "Tests for the path-keyed structural diff used at the MCP wire
-  boundary (rf2-1wdzp, shared across the triplet via rf2-vw4sq)."
+  boundary (rf2-1wdzp, shared across both servers via rf2-vw4sq)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [re-frame.mcp-base.diff-encode :as de]))

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -21,7 +21,7 @@ per rf2-hvl1g — AI agent access to Xray state already flows via
 `re-frame2-pair-mcp` against the framework-published Xray runtime API,
 so a dedicated xray-mcp is unnecessary.)
 
-This doc locks the verb vocabulary the triplet picks from. New tools
+This doc locks the verb vocabulary the pair picks from. New tools
 land against an existing verb; novel verbs require a Lock entry in
 the relevant server's `DESIGN-RATIONALE.md` and a return-trip here
 to extend the table. The conformance harness in
@@ -181,8 +181,8 @@ The convention for per-server tool-catalogue docs:
 - **PR-review rule.** A PR that adds or removes a tool MUST update the
   canonical count site in the catalogue heading. Any other doc that still
   reads "the N tools" after the catalogue update is a stale citation — fix
-  it or convert it to a count-free link. The cross-MCP audit walks the
-  triplet once per release looking for the pattern; until that audit is
+  it or convert it to a count-free link. The cross-MCP audit walks both
+  servers once per release looking for the pattern; until that audit is
   automated, the discipline lives here.
 - **`Server alignment today` (above) carries no integer counts in its
   headings.** Per-server subsections link to the catalogue for the live
@@ -224,7 +224,7 @@ Underneath the `:reason` keyword layer above sits the **JSON-RPC 2.0
 numeric error-code** layer — the codes the SDK / framework return
 when a request is malformed at the protocol level rather than failing
 in tool-result space. Per JSON-RPC §5.1 and MCP's reuse, the same
-numeric codes apply across the triplet; the canonical home for every
+numeric codes apply across both servers; the canonical home for every
 code constant is
 [`tools/mcp-base/src/re_frame/mcp_base/vocab.cljc`](../mcp-base/src/re_frame/mcp_base/vocab.cljc)
 (see the `code-*` defs).
@@ -233,7 +233,7 @@ The conformance contract pins:
 
 - **`-32601 MethodNotFound`** — the canonical code for an unknown
   JSON-RPC method. Pinned by `mcp-base/vocab.cljc/code-method-not-found`.
-  Every server in the triplet MUST yield this code for an unrecognised
+  Every server in the pair MUST yield this code for an unrecognised
   method name; the conformance harness asserts the exact value (see
   `tools/mcp-conformance/test/_runner.cjs/assertJsonRpcErrorCodes`).
 - **`-32602 InvalidParams` / `-32603 InternalError`** — both are
@@ -260,7 +260,7 @@ dispatching a tool.
 ## Operator-opt-in CLI flag vocabulary
 
 Boot-time CLI flags that gate authority surfaces share a canonical
-name across all servers in the triplet. Same operator semantic ⇒
+name across both servers. Same operator semantic ⇒
 same flag spelling. Sourced from rf2-2x3ql: story-mcp originally
 shipped `--allow-sensitive-reads` (rf2-uaymx / rf2-g9fje); pair-mcp
 shipped `--allow-raw-state` for the same concept. Both servers now

--- a/tools/mcp-conformance/TOKEN-BUDGETS.md
+++ b/tools/mcp-conformance/TOKEN-BUDGETS.md
@@ -82,9 +82,10 @@ responses share one cumulative budget rather than per-key.
 - Positive integer ⇒ that cap applies for this call.
 
 The slot surfaces in `tools/list` on every tool descriptor so clients
-discover it automatically. Story-mcp's spec'd shape uses the same
-`:max-tokens` keyword and the same defaults — when its
-implementation passes lands the wire shape is identical.
+discover it automatically. Story-mcp uses the same `:max-tokens`
+keyword and the same defaults — the wire shape is identical, both
+servers resolving the cap through the shared
+`re-frame.mcp-base.cap/max-tokens`.
 
 ### Overflow marker (cross-server reserved key)
 
@@ -167,14 +168,36 @@ top: byte-identical second reads collapse to a sub-100-byte marker.
 Full per-mechanism documentation:
 [`tools/re-frame2-pair-mcp/spec/Principles.md` §"Tight token budget per response"](../re-frame2-pair-mcp/spec/Principles.md#tight-token-budget-per-response).
 
-### story-mcp — normative, enforcement pending
+### story-mcp — enforced at the wire boundary
 
-The cap is **normative in spec** — every catalogue entry in
-[`002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md) must
-respect it — but the runtime wire-boundary check is not yet wired in
-`tools/story-mcp/src/`. The exposed surfaces (`run-variant` output,
-`list-*` enumerations on populous libraries) currently stay inside
-the cap by construction via:
+The cap is **enforced at the wire boundary** in
+`tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc`
+(`invoke-tool` → `re-frame.mcp-base.cap/apply-cap`, rf2-90eft) — the
+SAME shared `mcp-base` algorithm re-frame2-pair-mcp runs, reified over
+story-mcp's `{:content [...] :structuredContent ...}` CLJ-map result
+shape. Per-tool functions emit the shapes they always did; the cap is a
+property of egress. When a response exceeds the per-call cap the payload
+is replaced with the canonical `{:rf.mcp/overflow {...}}` marker carrying
+the tool-specific next-step hint — a structured retry signal, never a
+silent truncation. The `:max-tokens` per-call override and `0`-disables
+sentinel ride the same way they do on re-frame2-pair-mcp.
+
+Two transforms compose at story-mcp's wire boundary, in pipeline order
+(mirroring re-frame2-pair-mcp's invariant — dedup is always the last
+transform before the cap check):
+
+1. **Structural dedup** (`:rf.mcp/dedup-table`, rf2-90eft) — opt-in via
+   `:dedup-eligible?` on `preview-variant` / `run-variant` /
+   `record-as-variant`, the surfaces where repeated subtrees (the same
+   `:app-db` slice reappearing in `:rendered-hiccup` and `:snapshot`)
+   dominate the wire cost.
+2. **Wire-boundary token-cap** (`:rf.mcp/overflow`, rf2-90eft via the
+   shared `mcp-base.cap/apply-cap`) — sizes the post-dedup payload and
+   swaps the overflow marker when over.
+
+Cap-first design still pushes each tool to bound its egress by
+construction, so the cap is the safety net rather than the primary
+mechanism for the common case:
 
 - **Pagination / cursor** on `list-variants`, `list-modes`,
   `list-assertions`, `list-stories`, `list-substrates`, `list-tags`.
@@ -188,10 +211,6 @@ keeps the typical workflow well inside the cap.
 
 Full posture text:
 [`tools/story-mcp/spec/Principles.md` §"Tight token budget per response"](../story-mcp/spec/Principles.md#tight-token-budget-per-response).
-
-When the wire-boundary check lands, it follows re-frame2-pair-mcp's shape
-(`max-tokens` arg, `:rf.mcp/overflow` marker) — the keyword namespace
-is reserved cross-server.
 
 ## Chained budgets — when agents attach multiple servers
 
@@ -229,15 +248,23 @@ The agent-host workflow Mike's skills assume:
 The contract above is shared. These differences exist today and are
 deliberate or pending alignment.
 
-### Overflow-marker slot vocabulary
+### Overflow-marker slot vocabulary — converged
+
+Both servers now emit the **identical** overflow marker body, built by
+the shared `mcp-base.cap/apply-cap` → `overflow/overflow-payload`:
 
 | Server | Slot shape |
 |---|---|
-| `re-frame2-pair-mcp` (implemented) | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` |
-| `story-mcp` (spec'd, generic) | `:isError true` with `:reason :budget-exceeded` + hint string (legacy path; converges to `:rf.mcp/overflow` when wire-boundary check lands) |
+| `re-frame2-pair-mcp` | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` |
+| `story-mcp` | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` (same builder; the marker rides story-mcp's `:structuredContent` slot, the `:hint` text is story-mcp's per-tool table) |
 
-The **reserved keyword** (`:rf.mcp/overflow`) and the **retry-signal
-contract** are identical today; only the slot vocabulary differs.
+The **reserved keyword** (`:rf.mcp/overflow`), the **marker body
+shape**, and the **retry-signal contract** are all identical — the
+former `:reason :budget-exceeded` legacy path is gone (it never
+shipped; the wire-boundary check converged story-mcp onto the shared
+shape per rf2-90eft). Only the per-tool `:hint` prose is
+server-authored, which the cross-MCP contract leaves to the consumer
+by design.
 
 ### Streaming-overflow surface
 
@@ -246,21 +273,23 @@ re-frame2-pair-mcp ships an **upstream-queue budget**
 subscription, with `:overflow-reason` reported per drain. story-mcp
 doesn't ship streaming.
 
-### Enforcement surface
+### Enforcement surface — both runtime-enforced
 
 | Server | Enforcement | Note |
 |---|---|---|
-| `re-frame2-pair-mcp` | Runtime — `apply-cap` at `invoke` boundary | Live in `tools.cljs`. |
-| `story-mcp` | Spec-only — pagination + summary modes are normative but no wire-boundary check yet | Cap-violating tools would currently ship. Pending wiring. |
+| `re-frame2-pair-mcp` | Runtime — `apply-cap` at the `invoke` boundary | Live in `tools.cljs` via the shared `mcp-base.cap/apply-cap`. |
+| `story-mcp` | Runtime — `apply-cap` at the `invoke-tool` wire boundary | Live in `wire_pipeline.cljc` via the same shared `mcp-base.cap/apply-cap` (rf2-90eft). |
 
-The shared **default cap (5,000)**, the **shared override slot name
-(`max-tokens`)**, and the **shared overflow keyword
-(`:rf.mcp/overflow`)** are pinned cross-server even where enforcement
-hasn't landed.
+Both servers run the **same** `mcp-base.cap/apply-cap` algorithm,
+reified over their respective result shapes (`#js {...}` for
+re-frame2-pair-mcp, CLJ maps for story-mcp). The shared **default cap
+(5,000)**, the **shared override slot name (`max-tokens`)**, and the
+**shared overflow keyword (`:rf.mcp/overflow`)** are pinned cross-server
+AND enforced at both wire boundaries.
 
 ## Recommended client-side override convention
 
-Agent hosts and skills that drive the triplet follow one
+Agent hosts and skills that drive both servers follow one
 override-pattern convention:
 
 1. **First call: defaults.** No `max-tokens` arg. The server's default

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -55,14 +55,16 @@ This test is the conformance gate. It asserts:
    (`re-frame2-pair-mcp/src/`) asserts the canonical literal appears,
    and asserts that no near-miss spelling (snake_case, pluralised,
    namespace-with-underscores) appears.
-4. **story-mcp uncontracted-marker tripwire.** story-mcp emits one
-   cross-MCP marker today — `:rf.mcp/dedup-table` (rf2-90eft, mirror
-   of pair-mcp's rf2-obpa9 wire-boundary structural dedup) — and
-   otherwise uses its own `:rf.story/*` / `:rf.assert/*` /
-   `:rf.error/*` vocabularies. A test asserts that NO UNCONTRACTED
-   cross-MCP marker leaks into story-mcp source, so the day it adopts
-   another marker the test fails loud and forces the reviewer to
-   register a fixture and a source file (rather than diverge silently).
+4. **story-mcp uncontracted-marker tripwire.** story-mcp emits two
+   cross-MCP markers today — `:rf.mcp/dedup-table` (rf2-90eft, mirror
+   of pair-mcp's rf2-obpa9 wire-boundary structural dedup) and
+   `:rf.mcp/overflow` (rf2-yxgcsz, its wire-boundary token-cap, sharing
+   pair-mcp's `mcp-base.cap/apply-cap` builder) — and otherwise uses its
+   own `:rf.story/*` / `:rf.assert/*` / `:rf.error/*` vocabularies. A
+   test asserts that NO UNCONTRACTED cross-MCP marker leaks into
+   story-mcp source, so the day it adopts another marker the test fails
+   loud and forces the reviewer to register a fixture and a source file
+   (rather than diverge silently).
 
 ## Files
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -30,21 +30,25 @@
 ;; ---------------------------------------------------------------------------
 
 (def ReFrame2PairOverflowBody
-  "re-frame2-pair-mcp's `:rf.mcp/overflow` body shape (per
+  "The canonical `:rf.mcp/overflow` body shape (per
   `mcp-base/overflow.cljc/overflow-payload`). Every emit carries
   `:cap-tokens` + `:token-count` + `:tool` + `:hint` plus the `:limit
   :reached` sentinel. Required-not-optional — an emit missing any of
   these is a contract break, not a degenerate but tolerated marker.
 
-  Single-emitter today; the per-server name IS the canonical name.
-  Pinned cross-server as a re-frame2-pair-mcp-only shape; if a future
-  MCP server ships an `:rf.mcp/overflow` emit, the wrapper's body
-  slot below becomes `[:or ReFrame2PairOverflowBody PairXOverflowBody]`
-  rather than a one-arm canonical alias. (Same posture as
-  `ReFrame2PairProgressNotificationParams`.) Cap renames (`cap-tokens`
-  vs `cap_tokens`), field renames (`hint` vs `next-step`), or empty
-  bodies all trip the schema. Per rf2-kn8cj (refactor-audit r2 of
-  rf2-azk9c §F-VOCAB-2)."
+  Multi-emitter as of rf2-yxgcsz: BOTH re-frame2-pair-mcp and story-mcp
+  emit this marker via the shared `mcp-base.cap/apply-cap` →
+  `overflow-payload` builder, so the body is byte-identical across both
+  — there is exactly one shape, not a per-server variant. (Historically
+  documented as a re-frame2-pair-mcp-only shape while story-mcp's cap
+  enforcement was still spec-pending; story-mcp's wire-boundary cap
+  landed — `tools/story-mcp/.../tools/wire_pipeline.cljc` calls
+  `base-cap/apply-cap` — making the marker a genuine cross-server
+  emission. The name keeps the `ReFrame2Pair` prefix as the historical
+  shape-author; the SHAPE is the cross-MCP contract.) Cap renames
+  (`cap-tokens` vs `cap_tokens`), field renames (`hint` vs `next-step`),
+  or empty bodies all trip the schema. Per rf2-kn8cj (refactor-audit r2
+  of rf2-azk9c §F-VOCAB-2)."
   [:map
    {:closed false}
    [:limit       [:enum :reached]]
@@ -450,7 +454,16 @@
   `:servers` mentions the marker key literally."
   [{:key      :rf.mcp/overflow
     :schema   Overflow
-    :servers  #{:re-frame2-pair-mcp}                                    ;; not :story-mcp
+    ;; Multi-server marker as of rf2-yxgcsz — story-mcp's wire-boundary
+    ;; cap landed (`tools/story-mcp/.../tools/wire_pipeline.cljc` calls
+    ;; `base-cap/apply-cap`), so BOTH servers emit `:rf.mcp/overflow`
+    ;; via the shared `mcp-base.cap/apply-cap` → `overflow/overflow-payload`
+    ;; builder. The body is byte-identical across both — same posture as
+    ;; `:rf.mcp/dedup-table` (rf2-90eft). Both servers source the marker
+    ;; key from `re-frame.mcp-base.vocab/overflow-key` so the literal
+    ;; stays byte-identical; an agent that learned the overflow retry
+    ;; signal on either server recognises it on the other.
+    :servers  #{:re-frame2-pair-mcp :story-mcp}
     :fixtures {:re-frame2-pair-mcp {:rf.mcp/overflow
                            {:limit       :reached
                             :token-count 12400
@@ -462,7 +475,22 @@
                                          :token-count 12400
                                          :cap-tokens  5000
                                          :tool        "snapshot"
-                                         :hint        :narrow-scope}}}}
+                                         :hint        :narrow-scope}}
+               ;; story-mcp emission (rf2-yxgcsz) — the `run-variant`
+               ;; payload (`:app-db` + `:rendered-hiccup` + `:snapshot`)
+               ;; can blow the cap; `wire_pipeline/invoke-tool` replaces it
+               ;; via `base-cap/apply-cap`, whose `build-overflow-result`
+               ;; surfaces the `overflow/overflow-payload` marker as the
+               ;; `:structuredContent` slot. The body is the SAME shape the
+               ;; shared builder emits — the fixture pins that a regression
+               ;; in story-mcp's cap-pipeline wiring trips this gate. The
+               ;; per-tool `:hint` is story-mcp's own (`run-variant` table).
+               :story-mcp {:rf.mcp/overflow
+                           {:limit       :reached
+                            :token-count 9300
+                            :cap-tokens  5000
+                            :tool        "run-variant"
+                            :hint        "Tighten scope: pass `:cell-overrides` to shrink the run, or omit `:active-modes`. The :app-db / :rendered-hiccup slots dominate; raise `max-tokens` (0 disables) if the full payload is genuinely needed."}}}}
 
    {:key      :rf.mcp/summary
     :schema   Summary

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -41,14 +41,17 @@
                               `:handle` slot per `ElisionMarkerBody`
                               (NOT a standalone top-level marker)
 
-  story-mcp does NOT currently emit any of these markers — it operates
-  on small, structured story/variant metadata and stays under the
-  wire-cap by construction. The story-mcp `tools/*.cljc` files namespace
-  their own vocabulary under `:rf.story/*`, `:rf.assert/*`, `:rf.error/*`
-  per its own spec. The vocabulary becomes relevant on story-mcp the
-  day a tool starts returning bulk runtime state; until then the
-  conformance gate guards the *contract*: when story-mcp adopts a
-  marker it MUST use the canonical shape, not invent a near-miss.
+  story-mcp emits two of these markers today — `:rf.mcp/dedup-table`
+  (rf2-90eft, the wire-boundary structural-dedup transform) and
+  `:rf.mcp/overflow` (rf2-yxgcsz, its wire-boundary token-cap), both via
+  the shared `mcp-base` builders so the shapes stay byte-identical with
+  re-frame2-pair-mcp. Its remaining vocabulary is namespaced under
+  `:rf.story/*`, `:rf.assert/*`, `:rf.error/*` per its own spec. For
+  every marker story-mcp does NOT yet emit, the conformance gate guards
+  the *contract*: when story-mcp adopts one it MUST use the canonical
+  shape, not invent a near-miss — the `story-mcp-still-emits-zero-
+  uncontracted-cross-mcp-markers` tripwire below fires the day a NEW
+  uncontracted marker leaks in.
 
   ## What this test guards
 
@@ -629,11 +632,14 @@
   ;; `mcp-base/vocab.cljc`) trips the gate even if old docstrings still
   ;; mention the prior name.
   ;;
-  ;; story-mcp emits zero markers today — its servers entry is empty in
-  ;; `canonical-markers/:servers`, so this loop never iterates over it.
-  ;; The doc-source fallback path (spec-text-only coverage for an MCP
-  ;; server whose impl hasn't landed) is retained for any future server
-  ;; adopted into the cross-MCP family before its `src/` ships.
+  ;; story-mcp is contracted for `:rf.mcp/dedup-table` (rf2-90eft) and
+  ;; `:rf.mcp/overflow` (rf2-yxgcsz); both source their literal from
+  ;; `mcp-base/vocab.cljc` (the shared emit-source for both servers per
+  ;; `source-pins/emit-source-files`), so this loop checks the literal
+  ;; is present there for story-mcp too. The doc-source fallback path
+  ;; (spec-text-only coverage for an MCP server whose impl hasn't landed)
+  ;; is retained for any future server adopted into the cross-MCP family
+  ;; before its `src/` ships.
   (doseq [{:keys [key servers]} canonical-markers
           server                servers]
     (testing (str "marker " key " literal in " server " emit-sources")
@@ -825,10 +831,11 @@
   ;; conformance is not free.
   ;;
   ;; Markers story-mcp is ALREADY contracted to emit are skipped — the
-  ;; contract IS the green-state.  As of rf2-90eft that set is
-  ;; `#{:rf.mcp/dedup-table}` (story-mcp adopted pair-mcp's structural-
-  ;; dedup wire-boundary transform); the gate continues to fire on
-  ;; every OTHER marker.
+  ;; contract IS the green-state. As of rf2-yxgcsz that set is
+  ;; `#{:rf.mcp/dedup-table :rf.mcp/overflow}` (story-mcp adopted pair-
+  ;; mcp's structural-dedup wire-boundary transform under rf2-90eft and
+  ;; its token-cap under rf2-yxgcsz, both via the shared mcp-base
+  ;; builders); the gate continues to fire on every OTHER marker.
   ;;
   ;; Comment- and docstring-only mentions are stripped before the
   ;; check (via `strip-comments-and-strings`). story-mcp re-uses


### PR DESCRIPTION
Fixes **rf2-yxgcsz** ([vestigial][tools/mcp]). story-mcp's wire-boundary token-cap landed (`wire_pipeline.cljc` → `mcp-base.cap/apply-cap`, rf2-90eft) and now emits the cross-MCP `:rf.mcp/overflow` marker via the shared builder — but the conformance surface and several docs still described story-mcp's cap as spec-only/pending and referred to a three-server "triplet" after `xray-mcp` was dropped (rf2-hvl1g). Rebased onto fresh origin/main (story-mcp rf2-vqfqtg/rf2-e6knrq + mcp-conformance rf2-ke5n56 already present).

## Premises verified

All four bead findings confirmed against current source before editing:

1. **TOKEN-BUDGETS.md stale** — `wire_pipeline.cljc:2-26,217-221,291-294` enforces the mcp-base cap + emits `:rf.mcp/overflow`, while the doc claimed "enforcement pending / spec-only" and a `:reason :budget-exceeded` legacy path. TRUE.
2. **wire-vocab false-green** — `:rf.mcp/overflow` `:servers` was `#{:re-frame2-pair-mcp}` (comment "not :story-mcp"); the uncontracted-marker tripwire passed only because story-mcp sources the literal from `mcp-base/vocab.cljc` (not inlined), so the gate did not observe story-mcp's real emission. TRUE.
3. **overflow.md overstated coverage** — line 101 claimed the live `.cjs` harness drives an over-budget call on "each server", but only `live-re-frame2-pair-overflow.cjs` exists. TRUE.
4. **triplet/xray leftovers** — present-tense "triplet" (false-three) across NAMING.md, TOKEN-BUDGETS.md, args.md, vocab.md, vocab.cljc, diff_encode_test.clj. TRUE.

## Fixes

- **wire-vocab**: added `:story-mcp` to `:rf.mcp/overflow` `:servers` + a story-mcp fixture (mirrors `:rf.mcp/dedup-table`); `ReFrame2PairOverflowBody` documented as the multi-emitter shared shape. Refreshed the test ns + README docstrings that said story-mcp emits zero/one markers (now two: dedup-table + overflow).
- **TOKEN-BUDGETS.md**: rewrote the story-mcp section (enforced at the wire boundary, not pending); converged the overflow-marker divergence + enforcement tables (identical body, both runtime-enforced via the shared `apply-cap`); removed the never-shipped `:reason :budget-exceeded` path; corrected the `:max-tokens` "when implementation lands" wording.
- **mcp-base/spec/overflow.md**: corrected the reproduced Malli schema (`:tool`/`:hint` are `[:or :string :keyword]`, wrappers closed) and the live cap-trigger coverage — pair-mcp over the `.cjs` MCP wire, story-mcp at its wire-pipeline boundary (`tools_test.clj` `:max-tokens 1`/`0`); no parallel story `.cjs` script exists.
- **triplet → pair/both servers** across the in-scope files. Historical "was an MCP triplet / xray-mcp was envisaged" framings left intact (already correct history).

## Rejected / flagged

- **handler-arity.md** (bead finding #4 cites `spec/handler-arity.md:46-55`, actual path `tools/mcp-base/spec/handler-arity.md`): NO EDIT. Both `xray-mcp` mentions are already past-tense ("was dropped per rf2-hvl1g"); the "future third server" language is legitimate deferred-unification rationale, not obsolete scaffolding. Already satisfies the acceptance "reduced to historical context only".
- **No story-mcp src touched.** story-mcp already emits overflow correctly (merged); only the conformance/docs surface was stale. No server-side change needed.

## Quality gates

- `wire-vocab` JVM conformance (`clojure -M:test`): **72 tests / 762 assertions, 0 failures** — genuinely iterates story-mcp for overflow now (greps the `:rf.mcp/overflow` literal in `mcp-base/vocab.cljc`).
- `mcp-base` JVM (`clojure -M:test`): **234 / 761, 0 failures**.
- `story-mcp` JVM (`clojure -M:test`): **267 / 1331, 0 failures** (confirms the cited `tools_test.clj` overflow coverage).
- `npm run test:story` (SDK-wire conformance): **GREEN, 20/20 tools**.
- `npm install` run first in `tools/mcp-conformance` (no vendored node_modules in fresh worktree).
- Note: the `re-frame2-pair-mcp` end-to-end `.cjs` (`test:re-frame2-pair`) fails in a fresh worktree with `MODULE_NOT_FOUND: tools/re-frame2-pair-mcp/out/server.js` — it requires a prebuilt CLJS server artifact (CI build step). Environmental; this change touches no pair-mcp source or build config.
