### PR TITLE
docs(testing): correct stale Xray feature-matrix + MCP counts (rf2-dvwvyk)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -21,7 +21,7 @@ Running everything everywhere makes PRs slow and the dev loop painful. Skipping 
 | **MCP conformance — live** (`test:re-frame2-pair-live-overflow-hermetic`, `test:re-frame2-pair-live-subscribe`) | expensive | Real re-frame2-pair-mcp behaviour against a real shadow-cljs nREPL; over-budget eval cap; subscribe/unsubscribe lifecycle. |
 | **Example smoke** (`test:examples`) + **compile gate** (`test:examples-compile`) | medium | `test:examples` = the three adapter-level testbed smokes (Reagent / UIx / Helix — mount + dispatch + assert). The `examples/` tree itself is test-free (one smoke per adapter; no per-example specs). `test:examples-compile` compiles every declared standalone `:examples/*` build. |
 | **Story feature gates** (`test:story-feature-load`, `test:story-play-scripts`) | expensive | Story testbed exercises the feature/load matrix; play-scripts double every story's `:play-script` as a regression test. `test:story-play-scripts` is single-testbed + high-signal (it renders the live shell + assertion-strip) and stays on the PR critical path; `test:story-feature-load` is nightly-full only (see the Story/Xray PR-smoke vs nightly-full split below). |
-| **Xray feature gates** (`test:xray-feature-gate`, `test:xray-feature-gate:smoke`) | expensive (full) / medium (smoke) | Xray feature matrix (4-layer chrome, tab navigation, exception/issue surfacing). The `--smoke` tier runs the 3 highest-signal scenarios over 2 staged surfaces on the PR critical path; the full 14-scenario / 13-surface sweep runs nightly. |
+| **Xray feature gates** (`test:xray-feature-gate`, `test:xray-feature-gate:smoke`) | expensive (full) / medium (smoke) | Xray feature matrix (4-layer chrome, tab navigation, exception/issue surfacing). The `--smoke` tier runs the 4 highest-signal scenarios over 3 staged surfaces on the PR critical path; the full 15-scenario / 10-surface sweep runs nightly. |
 | **Template emitted-app smoke** (`jvm-tools-template`) | expensive | The emitted app from `tools/template/` boots + passes its own gates — proves the template stays viable. Also carries a second fixture that materialises the `skills/re-frame2-setup/*` MANUAL day-one scaffold from the skill's own snippets and compiles it against the in-repo source (semantic-drift net for the skill's hand-written boot ceremony, which diverges from the generator template — rf2-ae98go). Both are gated behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`. |
 | **Skills structural** (`skills-structural`) | fast | Skill manifests + shared content stay structurally valid against the schema. |
 | **docs/cljs playground** (`tools-playground`, Playwright + headless Chromium) | medium | The roll-your-own live-CLJS-cell engine behind the docs reading guide + interactive chapters: rebuilds both committed bundles, smokes plain-eval + live re-frame2 (v2) render cells against them, then gates freshness — strict `git diff --exit-code` on the byte-deterministic esbuild artefacts (`docs/cljs/playground.{js,css}`) plus a smoke + structural-validity gate on the Closure `:advanced` SCI bundle (`docs/cljs/playground-rf2.js`), whose minified symbols are not byte-stable cross-platform so a byte-diff would be flaky. |
@@ -40,7 +40,7 @@ where adapter / framework gates already carry the signal (rf2-eceuv).
 | `tools/xray/testbeds/` | Xray-rich demos and the deterministic `feature_matrix` substrate driven by `test:xray-feature-gate`. The `panel_gallery` substrate is a local-only visual gallery — its rf2-kgn0c workspace-switch regression class is covered by CLJS unit tests in `tools/story/test/re_frame/story_ui_cljs_test.cljs` (variant-id-keyed React identity) plus the `workspace-switch-no-stale-subscribe-derefs-rf2-kgn0c` Playwright scenario in `tools/story/test/story_browser_scenarios.cjs` (driven per-PR by `test:story-feature-load`). | Yes — `feature_matrix` carries the per-PR Xray scenarios; other substrates here are local dev surfaces. |
 | `tools/story/testbeds/` | Story testbeds (counter-with-stories, login-form). | Yes — Story-owned scenarios. |
 | Framework tests (`clojure -M:test` per artefact) | The spec is the artefact; these protect contracts. | N/A (unit, not smoke). |
-| Xray feature-matrix gate (`test:xray-feature-gate`) | 13 scenarios across the matrix. | N/A (feature-gate, not smoke). |
+| Xray feature-matrix gate (`test:xray-feature-gate`) | 15 scenarios across the matrix. | N/A (feature-gate, not smoke). |
 
 Real bugs land in framework contracts + adapter wire-up + Xray lens
 behaviour, not in "this example mounted + clicked." Coverage value
@@ -96,17 +96,18 @@ made it the single slowest CI gate at ~700s (≈6× the next slowest job),
 and the **identical** sweep already runs nightly in
 `expensive-tests.yml` — so PR time ran the full matrix twice over. The
 dominant cost is shadow-cljs testbed compilation (each bundle is 400+
-files, ~24s; the full Xray gate stages 13 surfaces).
+files, ~24s; the full Xray gate stages 10 surfaces).
 
 The gate is now split into two tiers:
 
 - **PR tier (`story-xray-browser` in `test.yml`)** — a fast smoke on the
   critical path. It runs only:
-  - `npm run test:xray-feature-gate:smoke` — the 3 highest-signal Xray
+  - `npm run test:xray-feature-gate:smoke` — the 4 highest-signal Xray
     scenarios (6-tab shell handoff, deterministic-exception →
-    Issues/Trace surfacing, Cmd-K palette) over just 2 staged surfaces
-    (`counter` + `deliberate-throw`), compiling 2 testbed bundles
-    instead of 13. Scenarios opt into the smoke via `smoke: true` in
+    Issues/Trace surfacing, Cmd-K palette, panel-gallery theme-token
+    CSS-variable resolution) over just 3 staged surfaces
+    (`counter` + `deliberate-throw` + `panel-gallery`), compiling 3
+    testbed bundles instead of 10. Scenarios opt into the smoke via `smoke: true` in
     `tools/xray/testbeds/feature_matrix/scenarios.cjs`; the gate fails
     loud if the smoke set is ever empty.
   - `npm run test:story-play-scripts` — single-testbed
@@ -118,7 +119,7 @@ The gate is now split into two tiers:
   keyed `.shadow-cljs/` + `.cpcache` compile cache (next bullet).
 
 - **Nightly tier (`expensive-tests.yml`)** — the full sweep:
-  `test:xray-feature-gate` (all 14 scenarios / 13 surfaces),
+  `test:xray-feature-gate` (all 15 scenarios / 10 surfaces),
   `test:story-feature-load`, `test:story-play-scripts`, and
   `test:story-static`. Off the PR critical path; the nightly-full set is
   a strict superset of the PR-smoke set, so nothing the smoke covers is
@@ -245,8 +246,8 @@ agent pre-checkin "narrow to the changed surface" workflow.
 | `npm run test:examples-compile` | Compile-coverage gate (rf2-0vav5.1 + rf2-cn6kc.1): `shadow-cljs compile` over EVERY declared standalone `:examples/*` build (list derived from `shadow-cljs.edn`, so new example builds are swept automatically). Fails on any compile error AND on any warning (`compile` exits 0 on warnings; a typo'd `:init-fn` surfaces as an `:undeclared-var`). Closes the gap where standalone examples (`login-uix`, `dashboard-uix`, `login-helix`, `process-monitor-helix`, …) were declared but compiled by no gate. Runs in the `cljs-browser` CI job; teeth pinned by `check-examples-compile.test.cjs` in `test:script-policy`. |
 | `npm run test:story-feature-load` | Story full-browser feature-load and resilience gate (`tools/story/test/story_feature_load.cjs`). **Nightly-full tier** — runs in `expensive-tests.yml`, not on the PR critical path (per the Story/Xray split above). |
 | `npm run test:story-play-scripts` | Story `:play-script` CI-as-test gate (rf2-3qcxk). Discovers every registered variant whose body carries a non-empty `:play-script` slot, navigates the live shell to each, waits for the auto-run's terminal status, and reports per-variant pass/fail. Variants whose id contains `failing` or `expected-fail` invert the assertion (expected `:fail`); everything else asserts `:pass`. **PR-smoke tier** — single-testbed, renders the assertion-strip, runs in the `story-xray-browser` PR job (and nightly). |
-| `npm run test:xray-feature-gate` | Xray browser feature/load gate from `tools/xray/spec/017-Test-Coverage-Matrix.md` — the full 14-scenario / 13-surface sweep. **Nightly-full tier** (`expensive-tests.yml`). |
-| `npm run test:xray-feature-gate:smoke` | PR-smoke tier of the Xray gate (`--smoke`). Runs only the scenarios tagged `smoke: true` over just the surfaces those scenarios load (3 scenarios / 2 surfaces today). On the `story-xray-browser` PR critical path. |
+| `npm run test:xray-feature-gate` | Xray browser feature/load gate from `tools/xray/spec/017-Test-Coverage-Matrix.md` — the full 15-scenario / 10-surface sweep. **Nightly-full tier** (`expensive-tests.yml`). |
+| `npm run test:xray-feature-gate:smoke` | PR-smoke tier of the Xray gate (`--smoke`). Runs only the scenarios tagged `smoke: true` over just the surfaces those scenarios load (4 scenarios / 3 surfaces today). On the `story-xray-browser` PR critical path. |
 | `npm run test:story-static` | Static-build contract and deployable-output sanity for the Story export. |
 | `npm run story:build` | Build the Story static artefact. |
 | `npm run test:script-policy` / `npm run test:script-helpers` | Self-tests for the JS harness helpers (path policy, changed-surface classifier port, browser-test report, gate report, local browser harness). |
@@ -440,7 +441,7 @@ PR time; one row per output here so the table stays scannable).
 | `adapter_testbed_smokes` | `adapter-testbed-smokes` (Playwright; the 3 adapter smokes only — rf2-9grp6 split out the framework + top-level testbeds into a separate gate, which rf2-t5slp then retired after all four rf2-tglku migration waves moved every framework + top-level testbed assertion to CLJS/JVM unit tests) |
 | `tools_jvm` | Per-tool JVM probes ×4 (`jvm-tools-xray`, `jvm-tools-story`, `jvm-tools-story-mcp`, `jvm-tools-mcp-base`) |
 | `template_expensive` | `jvm-tools-template` (emitted-app smoke) |
-| `mcp_conformance` | MCP conformance ×4 (`mcp-conformance-{story,re-frame2-pair,wire-vocab,...}`) |
+| `mcp_conformance` | MCP conformance ×3 (`mcp-conformance-{story,re-frame2-pair,wire-vocab}`) |
 | `mcp_live` | `mcp-conformance-re-frame2-pair` (live + hermetic) |
 | `story_xray_browser` | `story-xray-browser` (PR-smoke, Playwright — Xray feature-matrix `--smoke` + Story play-scripts only; the full Xray matrix, Story feature-load, and Story static run nightly in `expensive-tests.yml` — see the Story/Xray split above) |
 | `skills_structural` | `skills-structural` |

--- a/scripts/check_testing_md_counts.py
+++ b/scripts/check_testing_md_counts.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Ratchet TESTING.md's hand-maintained Xray + MCP counts against source.
+
+TESTING.md carries several prose/table counts that are *hand-maintained*
+against two source-of-truth files:
+
+  * the Xray feature-matrix substrate
+    ``tools/xray/testbeds/feature_matrix/scenarios.cjs`` — the full
+    scenario count, the ``smoke: true`` scenario count, the full-sweep
+    staged-surface count, and the count of *distinct* surfaces the smoke
+    scenarios stage; and
+  * the PR workflow ``.github/workflows/test.yml`` — the number of
+    ``mcp-conformance-*`` jobs.
+
+These counts drifted silently once already (rf2-dvwvyk): PR 4163
+(rf2-fxnszc) removed four staged surfaces from ``scenarios.cjs`` but did
+not update TESTING.md in the same PR, because a change under
+``tools/xray/testbeds/`` fires the ``story_xray_browser`` surface, not the
+S1 blast-trigger (only TESTING.md / report-changed-surfaces.sh / the two
+workflow files mark_all) — so nothing forced the prose counts to be
+re-checked. TESTING.md's tables are explicitly "hand-maintained" and these
+prose counts had no automated guard at all.
+
+This script closes that gap. It derives the live counts from the two
+source files, extracts every count TESTING.md *claims*, and asserts they
+agree.
+
+Ground truth derivation (deterministic, line-oriented — no JS/YAML parser):
+
+  * scenario count       = object-literal ``name: '...'`` fields in
+                           scenarios.cjs (a leading-comment ``name:`` is
+                           excluded because the regex requires a quoted
+                           string value at field indentation).
+  * smoke scenario count = ``smoke: true`` fields.
+  * full surface count   = ``servedPath: '...'`` fields in STAGED_SURFACES.
+  * smoke surface count  = distinct surfaces the ``smoke: true`` scenarios
+                           stage, computed exactly as the gate runner's
+                           ``surfaceForScenario`` does: take each smoke
+                           scenario's ``url``, drop the ``#``/``?`` tail and
+                           surrounding slashes, and match against the set of
+                           ``servedPath`` values.
+  * MCP-conformance jobs = top-level ``  mcp-conformance-<name>:`` job keys
+                           in test.yml (two-space indent = a job key).
+
+Claimed counts in TESTING.md are matched by a small registry of regexes
+(``CLAIM_PATTERNS`` below). Each pattern names which ground-truth value it
+must equal; every match is checked, so a count repeated on several lines is
+all verified. A pattern that *never* matches is itself a failure — that
+catches the case where a TESTING.md rewrite drops or rewords a sentence the
+guard was pinning, so the guard can be re-aimed rather than silently
+passing.
+
+Exit code:
+    0  all claimed counts agree with source
+    1  at least one mismatch, or a claim pattern matched nothing
+    2  invocation / setup error (a source file is missing/unreadable)
+
+The script is stdlib-only (no third-party deps) and cross-platform: it
+reads files via pathlib and never shells out, so it runs identically on the
+Windows dev box and the Linux CI runners.
+
+Usage:
+    python scripts/check_testing_md_counts.py [--verbose]
+    python scripts/check_testing_md_counts.py --self-test [--verbose]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+TESTING_MD = REPO_ROOT / "TESTING.md"
+SCENARIOS_CJS = REPO_ROOT / "tools" / "xray" / "testbeds" / "feature_matrix" / "scenarios.cjs"
+TEST_YML = REPO_ROOT / ".github" / "workflows" / "test.yml"
+
+# Source-derivation regexes (line-oriented; see module docstring).
+RE_SCENARIO_NAME = re.compile(r"^\s+name:\s*'")
+RE_SMOKE_TRUE = re.compile(r"^\s+smoke:\s*true\b")
+RE_SERVED_PATH = re.compile(r"^\s+servedPath:\s*'([^']*)'")
+RE_MCP_JOB = re.compile(r"^  (mcp-conformance-[A-Za-z0-9-]+):")
+
+# For the smoke-surface derivation: a scenario object opens with a
+# ``name: '...'`` line and (somewhere before the next ``name:``) may carry a
+# ``smoke: true`` and a ``url: '...'``. We walk scenario blocks rather than
+# trying to parse JS objects.
+RE_URL = re.compile(r"^\s+url:\s*'([^']*)'")
+
+
+def fail_setup(msg: str) -> "None":
+    sys.stderr.write(f"check_testing_md_counts: setup error: {msg}\n")
+    raise SystemExit(2)
+
+
+def _surface_for_url(url: str, served_paths: set) -> "str | None":
+    """Mirror the gate runner's surfaceForScenario(): strip hash + query +
+    surrounding slashes, then match against servedPath values."""
+    path_only = url.split("#")[0].split("?")[0]
+    url_path = path_only.strip("/")
+    return url_path if url_path in served_paths else None
+
+
+def derive_ground_truth(scenarios_text: str, test_yml_text: str) -> dict:
+    """Return the five live counts derived from the two source files."""
+    scenario_count = 0
+    smoke_count = 0
+    served_paths = []
+
+    for line in scenarios_text.splitlines():
+        if RE_SCENARIO_NAME.match(line):
+            scenario_count += 1
+        if RE_SMOKE_TRUE.match(line):
+            smoke_count += 1
+        m = RE_SERVED_PATH.match(line)
+        if m:
+            served_paths.append(m.group(1))
+
+    served_set = set(served_paths)
+
+    # Smoke-surface count: walk scenario blocks, and for each block that
+    # carries `smoke: true`, resolve its `url` to a staged surface.
+    smoke_surfaces = set()
+    cur_url = None
+    cur_is_smoke = False
+    have_block = False
+
+    def _flush():
+        nonlocal cur_url, cur_is_smoke
+        if cur_is_smoke and cur_url is not None:
+            surface = _surface_for_url(cur_url, served_set)
+            if surface is not None:
+                smoke_surfaces.add(surface)
+        cur_url = None
+        cur_is_smoke = False
+
+    for line in scenarios_text.splitlines():
+        if RE_SCENARIO_NAME.match(line):
+            if have_block:
+                _flush()
+            have_block = True
+            continue
+        if not have_block:
+            continue
+        if RE_SMOKE_TRUE.match(line):
+            cur_is_smoke = True
+        m = RE_URL.match(line)
+        if m and cur_url is None:
+            cur_url = m.group(1)
+    if have_block:
+        _flush()
+
+    mcp_jobs = sum(1 for line in test_yml_text.splitlines() if RE_MCP_JOB.match(line))
+
+    return {
+        "scenarios": scenario_count,
+        "smoke_scenarios": smoke_count,
+        "full_surfaces": len(served_set),
+        "smoke_surfaces": len(smoke_surfaces),
+        "mcp_jobs": mcp_jobs,
+    }
+
+
+# Each entry: (human label, regex with one capturing group for the digit,
+# ground-truth key it must equal). A pattern that matches zero lines is a
+# failure, so a TESTING.md reword that drops a pinned sentence re-surfaces
+# here rather than silently passing.
+CLAIM_PATTERNS = [
+    ("smoke-scenario prose (--smoke tier)", re.compile(r"runs the (\d+) highest-signal scenarios over"), "smoke_scenarios"),
+    ("smoke-surface prose (--smoke tier)", re.compile(r"highest-signal scenarios over (\d+) staged surfaces"), "smoke_surfaces"),
+    ("full-sweep scenario/surface (overview table)", re.compile(r"full (\d+)-scenario / (\d+)-surface sweep"), ("scenarios", "full_surfaces")),
+    ("feature-matrix scenario count (smoke table)", re.compile(r"\| (\d+) scenarios across the matrix"), "scenarios"),
+    ("full Xray gate staged surfaces (split prose)", re.compile(r"the full Xray gate stages (\d+) surfaces"), "full_surfaces"),
+    ("smoke prose (N highest-signal Xray scenarios)", re.compile(r"the (\d+) highest-signal Xray"), "smoke_scenarios"),
+    ("smoke prose (over just N staged surfaces)", re.compile(r"over just (\d+) staged surfaces"), "smoke_surfaces"),
+    ("nightly full sweep (all N scenarios / M surfaces)", re.compile(r"all (\d+) scenarios / (\d+) surfaces"), ("scenarios", "full_surfaces")),
+    ("smoke gate row (N scenarios / M surfaces today)", re.compile(r"\((\d+) scenarios / (\d+) surfaces today\)"), ("smoke_scenarios", "smoke_surfaces")),
+    ("MCP conformance fan-out (xN)", re.compile(r"MCP conformance ×(\d+)"), "mcp_jobs"),
+]
+
+
+def check_claims(testing_text: str, truth: dict, verbose: bool) -> "list[str]":
+    """Return a list of violation strings (empty == all good)."""
+    violations = []
+    lines = testing_text.splitlines()
+
+    for label, pattern, keys in CLAIM_PATTERNS:
+        key_tuple = keys if isinstance(keys, tuple) else (keys,)
+        match_count = 0
+        for lineno, line in enumerate(lines, start=1):
+            m = pattern.search(line)
+            if not m:
+                continue
+            match_count += 1
+            claimed = m.groups()
+            if len(claimed) != len(key_tuple):
+                violations.append(
+                    f"TESTING.md:{lineno}: claim pattern for '{label}' captured "
+                    f"{len(claimed)} group(s) but expects {len(key_tuple)} — pattern bug"
+                )
+                continue
+            for claimed_str, key in zip(claimed, key_tuple):
+                claimed_n = int(claimed_str)
+                expected = truth[key]
+                if claimed_n != expected:
+                    violations.append(
+                        f"TESTING.md:{lineno}: '{label}' claims {claimed_n} for "
+                        f"'{key}' but source has {expected}"
+                    )
+                elif verbose:
+                    sys.stderr.write(
+                        f"  ok  TESTING.md:{lineno}  {label}: {key}={claimed_n}\n"
+                    )
+        if match_count == 0:
+            violations.append(
+                f"TESTING.md: claim pattern '{label}' matched no line — the "
+                f"sentence it pins may have been reworded; re-aim CLAIM_PATTERNS "
+                f"in scripts/check_testing_md_counts.py"
+            )
+    return violations
+
+
+def run_real(verbose: bool) -> int:
+    for p in (TESTING_MD, SCENARIOS_CJS, TEST_YML):
+        if not p.is_file():
+            fail_setup(f"missing source file: {p}")
+
+    testing_text = TESTING_MD.read_text(encoding="utf-8")
+    scenarios_text = SCENARIOS_CJS.read_text(encoding="utf-8")
+    test_yml_text = TEST_YML.read_text(encoding="utf-8")
+
+    truth = derive_ground_truth(scenarios_text, test_yml_text)
+    if verbose:
+        sys.stderr.write(f"ground truth: {truth}\n")
+
+    violations = check_claims(testing_text, truth, verbose)
+    if violations:
+        sys.stderr.write("check_testing_md_counts: FAIL\n")
+        for v in violations:
+            sys.stderr.write(f"  {v}\n")
+        return 1
+    sys.stderr.write(
+        "check_testing_md_counts: OK — TESTING.md counts match "
+        "scenarios.cjs + test.yml "
+        f"(scenarios={truth['scenarios']}, smoke={truth['smoke_scenarios']}, "
+        f"full-surfaces={truth['full_surfaces']}, smoke-surfaces={truth['smoke_surfaces']}, "
+        f"mcp-jobs={truth['mcp_jobs']})\n"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Self-test: exercise derivation + claim-checking on synthetic fixtures so
+# the guard's own parsing logic is covered without depending on the live
+# (and intentionally mutable) repo counts.
+# --------------------------------------------------------------------------
+
+_SELFTEST_SCENARIOS = """\
+const STAGED_SURFACES = [
+  {
+    servedPath: 'counter',
+  },
+  {
+    servedPath: 'testbeds/deliberate-throw',
+  },
+  {
+    servedPath: 'testbeds/panel-gallery',
+  },
+  {
+    servedPath: 'testbeds/extra',
+  },
+];
+// name: this is a comment, not a scenario field
+const SCENARIOS = [
+  {
+    name: 'alpha',
+    url: '/counter/',
+    smoke: true,
+  },
+  {
+    name: 'beta',
+    url: '/testbeds/deliberate-throw/',
+    smoke: true,
+  },
+  {
+    name: 'gamma palette',
+    url: '/counter/',
+    smoke: true,
+  },
+  {
+    name: 'delta gallery',
+    url: '/testbeds/panel-gallery/#/stories',
+    smoke: true,
+  },
+  {
+    name: 'epsilon (nightly only)',
+    url: '/testbeds/extra/',
+  },
+];
+"""
+
+# Expected from the fixture above:
+#   scenarios=5, smoke=4, full-surfaces=4, smoke-surfaces=3 (counter,
+#   deliberate-throw, panel-gallery — gamma reuses counter), mcp-jobs=2.
+_SELFTEST_TEST_YML = """\
+jobs:
+  some-other-job:
+    steps: []
+  mcp-conformance-re-frame2-pair:
+    steps: []
+  mcp-conformance-story:
+    steps: []
+  # mcp-conformance-commented-out (a comment, not a job key)
+"""
+
+_SELFTEST_TRUTH = {
+    "scenarios": 5,
+    "smoke_scenarios": 4,
+    "full_surfaces": 4,
+    "smoke_surfaces": 3,
+    "mcp_jobs": 2,
+}
+
+_SELFTEST_TESTING_GOOD = """\
+The `--smoke` tier runs the 4 highest-signal scenarios over 3 staged surfaces; the full 5-scenario / 4-surface sweep runs nightly.
+| 5 scenarios across the matrix |
+the full Xray gate stages 4 surfaces).
+the 4 highest-signal Xray scenarios over just 3 staged surfaces (`a` + `b` + `c`).
+`test:xray-feature-gate` (all 5 scenarios / 4 surfaces),
+(4 scenarios / 3 surfaces today)
+MCP conformance ×2 (`mcp-conformance-{story,re-frame2-pair}`)
+"""
+
+_SELFTEST_TESTING_BAD = _SELFTEST_TESTING_GOOD.replace(
+    "MCP conformance ×2", "MCP conformance ×4"
+).replace("| 5 scenarios across the matrix |", "| 13 scenarios across the matrix |")
+
+
+def run_self_test(verbose: bool) -> int:
+    failures = []
+
+    truth = derive_ground_truth(_SELFTEST_SCENARIOS, _SELFTEST_TEST_YML)
+    if truth != _SELFTEST_TRUTH:
+        failures.append(f"derivation mismatch: got {truth}, want {_SELFTEST_TRUTH}")
+
+    good_violations = check_claims(_SELFTEST_TESTING_GOOD, _SELFTEST_TRUTH, verbose)
+    if good_violations:
+        failures.append(
+            "GOOD fixture should pass but reported violations:\n    "
+            + "\n    ".join(good_violations)
+        )
+
+    bad_violations = check_claims(_SELFTEST_TESTING_BAD, _SELFTEST_TRUTH, verbose)
+    # The BAD fixture flips the MCP count (xN) and the matrix-scenario count;
+    # both pinned claims must fire.
+    if not any("MCP conformance" in v for v in bad_violations):
+        failures.append("BAD fixture: MCP-count mismatch was not caught")
+    if not any("feature-matrix scenario count" in v for v in bad_violations):
+        failures.append("BAD fixture: matrix scenario-count mismatch was not caught")
+
+    if failures:
+        sys.stderr.write("check_testing_md_counts --self-test: FAIL\n")
+        for f in failures:
+            sys.stderr.write(f"  {f}\n")
+        return 1
+    sys.stderr.write("check_testing_md_counts --self-test: OK\n")
+    return 0
+
+
+def main(argv: "list[str]") -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="run on synthetic fixtures")
+    parser.add_argument("--verbose", action="store_true", help="print per-claim detail")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return run_self_test(args.verbose)
+    return run_real(args.verbose)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

TESTING.md's hand-maintained Xray feature-matrix + MCP counts went stale after PR #4163 (rf2-fxnszc) removed four staged surfaces from `tools/xray/testbeds/feature_matrix/scenarios.cjs` without updating the doc in the same PR. A change under `tools/xray/testbeds/` fires the `story_xray_browser` surface, not the S1 blast-trigger, so nothing forced the prose counts to be re-checked.

Factual-accuracy fix only — the document's framing and structure are unchanged. Each count was re-verified live against source (not trusted from the bead):

| Count | Was | Now | Source of truth |
|---|---|---|---|
| Xray scenarios (full) | 14 | **15** | `name:` fields in `scenarios.cjs` |
| Smoke scenarios | 3 | **4** | `smoke: true` fields |
| Full-sweep staged surfaces | 13 | **10** | `servedPath:` entries in `STAGED_SURFACES` |
| Smoke staged surfaces | 2 | **3** | smoke scenarios' URLs resolved to surfaces |
| MCP-conformance jobs | ×4 (+ misleading `...`) | **×3** | `mcp-conformance-*` job keys in `test.yml` |

Note on smoke surfaces: the bead provisionally said "2 staged smoke surfaces (counter + deliberate-throw) is still correct." Counting from source shows it is now **3** — the rf2-azfct panel-gallery theme-token smoke scenario (added after the bead's reference) introduced `testbeds/panel-gallery` as a third smoke-staged surface. The gate runner's `surfaceForScenario` confirms it compiles every surface its smoke scenarios load. Per the bead's "count from source, don't trust the numbers blindly" instruction, ground truth wins.

Lines corrected (located by content; line numbers had not shifted): the overview-table Xray row, the smoke-tier table row, the Story/Xray split prose (3 places), the nightly-full bullet, the command-reference `test:xray-feature-gate` + `:smoke` rows, and the `mcp_conformance` output→jobs row. The unrelated `×4` rows (`adapter_diagnostic`, `tools_jvm`) are correct and were left alone.

## Guard (optional, per bead "CONSIDER")

Adds `scripts/check_testing_md_counts.py` — a stdlib-only, cross-platform drift guard that derives the live counts from `scenarios.cjs` + `test.yml` and asserts every count TESTING.md cites agrees (a pinned claim that matches no line is itself a failure, so a future reword re-surfaces here rather than silently passing). Carries a `--self-test` mode following the repo's existing `scripts/check_*.py` convention.

**Workflow wiring deferred (flagged):** `.github/workflows/*` is hot-zone. `docs.yml` already path-filters `TESTING.md`, so the natural home is a step alongside the existing `check_doc_slugs.py` gate there (`python scripts/check_testing_md_counts.py --self-test` then `... --verbose`). I left wiring out of this PR to avoid touching a hot-zone workflow; the script is fully runnable standalone in the meantime.

## Quality gates

- `python scripts/check_testing_md_counts.py --self-test` — **PASS** (synthetic-fixture coverage of derivation + claim-matching)
- `python scripts/check_testing_md_counts.py` — **PASS** (live: scenarios=15, smoke=4, full-surfaces=10, smoke-surfaces=3, mcp-jobs=3 all match TESTING.md)
- Negative check: temporarily flipping a derived count makes the guard report violations (regression-catching confirmed)
- `python -m mkdocs build --strict` — **PASS** (exit 0). Note: root `TESTING.md` is **not** in the mkdocs nav (the site serves the independent `docs/api/10-testing.md`, which has none of these counts), so mkdocs is not the relevant gate here — run for completeness only.