### PR TITLE
docs(template): clean stale migration + package-shape docs (rf2-2hd3hs)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,9 +1,11 @@
 # tools/
 
 This directory houses **CLJS dev / inspection tools** that consume re-frame2's
-instrumentation API. Each tool ships as its own Maven artefact, on its own
-release cadence, and is intentionally kept out of the runtime path that
-production consumers depend on.
+instrumentation API. Each tool ships independently, on its own release
+cadence, and is intentionally kept out of the runtime path that
+production consumers depend on. Most ship as their own Maven artefact;
+the publication model and its deliberate exceptions (git-coord, npm,
+source-path-only) are detailed under [Per-tool layout](#per-tool-layout).
 
 `tools/` is a sibling of `implementation/`, not part of it. The split is
 deliberate — see the bundle-isolation contract below.
@@ -58,7 +60,19 @@ tools/
 
 Each `deps.edn` carries a `:local/root` dep on `../../implementation/core`
 (plus whichever per-feature artefacts the tool legitimately consumes).
-Each tool publishes to Clojars under `day8/re-frame2-<tool>`.
+
+Most tools publish to Clojars under `day8/re-frame2-<tool>` (the
+Node-side MCP servers publish to npm instead — `@day8/re-frame2-pair-mcp`).
+Two tools are deliberate exceptions to the Clojars publish model:
+
+- **`tools/template/`** distributes by **git-coord, not Clojars**
+  (rf2-dolpf §2.5) — the published artefact is a tagged commit on the
+  template repo, invoked via `clojure -Tnew create`. See the `template`
+  entry under "Shipped" below.
+- **`tools/testbed-support/`** is **not a published jar at all** — it
+  has no `deps.edn`/Clojars coord and is consumed only as an extra
+  source path wired into the testbed builds. See its entry under
+  "Shipped" below.
 
 A top-level `tools/deps.edn` and `tools/shadow-cljs.edn` (rf2-nuuk3) act
 as build coordinators across the tool tier, matching the pattern in

--- a/tools/template/spec/003-DepsNew-Rebuild-Plan.md
+++ b/tools/template/spec/003-DepsNew-Rebuild-Plan.md
@@ -14,10 +14,16 @@
 
 ## §0 Lineage
 
-The current template is a [clj-new](https://github.com/seancorfield/clj-new)
+> **Historical.** This section records the *pre-migration* starting
+> state. The migration described by this plan is **complete** (Stages
+> 2-3 landed 2026-05-20; see §2.5 / §3) — the template is now a
+> deps-new + git-coord tool, no longer clj-new + Clojars. Read the
+> steady-state shape in the docs listed under §Scope, not here.
+
+The template *was* a [clj-new](https://github.com/seancorfield/clj-new)
 template at `tools/template/`, published as `day8/clj-template.re-frame2`
 on Clojars (publish pipeline wired via clein). Per Mike's lock
-(template walkthrough Q2, 2026-05-12), the rebuild moves to:
+(template walkthrough Q2, 2026-05-12), the rebuild moved to:
 
 - **[deps-new](https://github.com/seancorfield/deps-new)** as the
   template framework — programmatic `:data-fn` / `:template-fn` /
@@ -248,8 +254,8 @@ check on the emitted tree is the spike's effective signal.
   dev/{user,scratch}, resources/public/{index.html, css/app.css}).
 - ✓ Updated `template-fn` to handle all three substrates + the
   `:include-story?` branch (see §2.4 below).
-- ✓ The clj-new tree at `src/clj/new/re_frame2/` stays in parallel as
-  a backstop until §2.5 (rf2-40vmd) lands.
+- ✓ The clj-new tree at `src/clj/new/re_frame2/` was kept in parallel
+  as a backstop until §2.5 (rf2-40vmd) landed and removed it.
 
 ### §2.3 — Port the test suite (rf2-c2770 — DONE 2026-05-20)
 

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -31,10 +31,15 @@
    This forces the `:include-story?` branch to be implemented as
    **separate template-source files** rather than conditional blocks
    inside one file: `_reagent/deps.edn` (default) vs
-   `_reagent/deps_with_story.edn` (with-story), and similarly for
-   `package.json`. `template-fn` picks the right source per the
-   flag. The output filename is the same (`deps.edn` / `package.json`)
-   regardless of which source ran.
+   `_reagent/deps_with_story.edn` (with-story). `template-fn` picks the
+   right source per the flag; the output filename is the same
+   (`deps.edn`) regardless of which source ran.
+
+   `package.json` is the exception. Its sole per-flag delta — the
+   `description` parenthetical naming the Story playground — is small
+   enough to carry as the `{{story-tag}}` subst var, so a single
+   `_shared/package.json` source serves both paths (rf2-sqqxj). No
+   second `package_with_story.json` source exists.
 
    The steady-state shape (see tools/template/spec/003-DepsNew-Rebuild-Plan.md
    §1) is the same matrix; additional flags (`:css`, `:include-ssr?`)

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -730,23 +730,22 @@
         (finally
           (delete-recursively tmp))))))
 
-;; --- package.json byte-identical regression (rf2-sqqxj) ------------------
+;; --- package.json one-source byte-exact contract (rf2-sqqxj) -------------
 ;;
-;; The default and with-Story package.json sources were collapsed from
-;; two near-identical files into one `_shared/package.json` whose
-;; `description` parenthetical rides the `{{story-tag}}` subst var
-;; (`""` default / `", with Story playground"` under :include-story?).
-;; This test is the generate-both-and-diff proof: both emitted variants
-;; must be BYTE-IDENTICAL to the pre-refactor two-file output. The
-;; expected strings below are verbatim copies of the (now-deleted)
-;; pre-refactor `package_with_story.json` / `package.json` content, with
-;; the template's three subst vars resolved for the `acme/my-app`
-;; Reagent emission. If a future edit to the shared package.json or the
+;; The template emits package.json from a SINGLE `_shared/package.json`
+;; source whose `description` parenthetical rides the `{{story-tag}}`
+;; subst var (`""` default / `", with Story playground"` under
+;; :include-story?). This test is the generate-both-and-diff proof: both
+;; the default and the with-Story emission must be BYTE-EXACT against the
+;; expected literals below. The expected strings are the full resolved
+;; output for the `acme/my-app` Reagent emission (the template's three
+;; subst vars resolved), differing only in the `description`
+;; parenthetical. If a future edit to the shared package.json or the
 ;; story-tag derivation drifts the output, this fires.
 
 (def ^:private expected-package-json-default
-  "Verbatim pre-refactor `_shared/package.json` emission for
-  `acme/my-app` on the Reagent default path (subst vars resolved)."
+  "Expected `_shared/package.json` emission for `acme/my-app` on the
+  Reagent default path (`:include-story? false`, subst vars resolved)."
   (str "{\n"
        "  \"name\": \"acme/my-app\",\n"
        "  \"version\": \"0.1.0\",\n"
@@ -767,9 +766,9 @@
        "}\n"))
 
 (def ^:private expected-package-json-with-story
-  "Verbatim pre-refactor `_shared/package_with_story.json` emission for
-  `acme/my-app` on the Reagent :include-story? true path — identical to
-  the default save for the `description` parenthetical."
+  "Expected `_shared/package.json` emission for `acme/my-app` on the
+  Reagent `:include-story? true` path — identical to the default save
+  for the `{{story-tag}}`-driven `description` parenthetical."
   (str "{\n"
        "  \"name\": \"acme/my-app\",\n"
        "  \"version\": \"0.1.0\",\n"
@@ -799,9 +798,9 @@
   (string/replace s "\r" ""))
 
 (deftest package-json-story-tag-byte-identical-test
-  (testing "the {{story-tag}}-driven single package.json emits the same
-            content as the pre-refactor two-file split, on both the
-            default and :include-story? true paths (rf2-sqqxj DRY proof —
+  (testing "the {{story-tag}}-driven single package.json emits the
+            expected byte-exact content on both the default and
+            :include-story? true paths (rf2-sqqxj one-source proof —
             EOL-normalised so it is portable Windows↔CI)"
     (let [tmp (tmp-dir "rf2-template-pkg-story-tag-")]
       (try
@@ -809,8 +808,8 @@
               default-txt  (slurp (io/file default-root "package.json"))]
           (is (= (normalise-eol expected-package-json-default)
                  (normalise-eol default-txt))
-              "default-path package.json content matches the
-               pre-refactor _shared/package.json emission"))
+              "default-path package.json content matches the expected
+               single-source _shared/package.json emission"))
         (finally
           (delete-recursively tmp)))
       ;; Fresh tmp for the with-Story path so the two emissions don't
@@ -821,8 +820,8 @@
                 story-txt  (slurp (io/file story-root "package.json"))]
             (is (= (normalise-eol expected-package-json-with-story)
                    (normalise-eol story-txt))
-                "with-Story package.json content matches the
-                 pre-refactor _shared/package_with_story.json emission"))
+                "with-Story package.json content matches the expected
+                 single-source _shared/package.json emission (story-tag on)"))
           (finally
             (delete-recursively tmp2)))))))
 


### PR DESCRIPTION
Cleans stale migration / package-shape docs+comments+tests in `tools/template` (and the `tools/` root publication model). Pre-alpha masterpiece stance: CLARITY. Each premise in rf2-2hd3hs was verified against current source; one cited premise was wrong and is reported as rejected.

Rebased onto fresh `origin/main` first; reconciled with rf2-7s8ou3 (merged earlier — refreshed scaffold-contract docs + added a spec-prose drift guard). Scope here is the **different** migration/package-shape findings; rf2-7s8ou3's `002-Generated-Shape.md` edits and its drift guard are untouched and stay green.

## What changed

- **`tools/README.md` — publication model (Finding 1).** Rewrote the generic "Each tool publishes to Clojars under `day8/re-frame2-<tool>`" claim to state the model *with its deliberate exceptions*: most tools → Clojars; Node MCP servers → npm; **`tools/template/` → git-coord, not Clojars** (rf2-dolpf §2.5); **`tools/testbed-support/` → not a published jar, source-path-only**. Also softened the opening "Each tool ships as its own Maven artefact" sentence to point at the detailed model rather than assert a universal the detail section contradicts.
- **`hooks.clj` substitution-engine note (Finding 2).** Dropped the stale "…and similarly for `package.json`" two-file claim. `package.json` is **single-source** via `{{story-tag}}`; only `deps.edn` uses the separate-source (`deps.edn` / `deps_with_story.edn`) split. Added an explicit "no `package_with_story.json` source exists" note.
- **`template_test.clj` package.json contract (Finding 3).** Kept the byte-exact output coverage; reframed the block comment, the two `expected-package-json-*` var docstrings, the deftest docstring, and both assertion messages around the **current one-source `{{story-tag}}` contract** instead of the deleted pre-refactor two-file `package_with_story.json` split. No test logic / assertion changed — comment/message text only.
- **`spec/003-DepsNew-Rebuild-Plan.md` (Finding 4).** Archived §0 Lineage to past-tense with a **Historical** callout (the migration is complete — §2.5 / §3 marked DONE — so "The current template *is* a clj-new template, published on Clojars" was a present-tense contradiction). Fixed the §2.2 "✓ The clj-new tree … stays in parallel as a backstop" present-tense line to past-tense (it was removed by §2.5). Left all other ✓-DONE stage records and legitimate historical clj-new references intact.

## Rejected premise

- **Finding 3's citation `spec/002-Generated-Shape.md:241-244` is wrong.** Those lines are the `{{react-version}}` substitution-table row + the `{{namespace}}` derivation note. That doc already describes the current single-source `{{story-tag}}` contract correctly (lines ~255-258) and was just refreshed by rf2-7s8ou3 — there is no two-file / `package_with_story` stale claim there. Left unchanged. (The real stale `package_with_story` references were the three in `template_test.clj`, which are fixed.)

Acceptance (rf2-2hd3hs):
- No current-tense clj-new/Clojars/two-file claims remain in live template docs/comments/tests — verified via `git grep` (only remaining `package_with_story` mention is a deliberate negative: "no … source exists").
- `tools/README.md` publication model now handles the template + testbed-support exceptions.
- package.json tests assert the current one-source `{{story-tag}}` contract without framing correctness around `package_with_story`.

## Quality gates

- `tools/template` `clojure -M:test` — **green**: 39 tests, 435 assertions, 0 failures, 0 errors (includes the rf2-7s8ou3 spec-prose drift guard + the package.json one-source byte-exact tests).
- `mkdocs build --strict` — **green** (exit 0). `tools/template/spec/` is not under `docs_dir: docs`, so these edits don't affect the served docs regardless; pre-existing INFO relative-link notes are unrelated.
