### PR TITLE
refactor(examples/shared): prune smoke-runner skip support + docs drift (rf2-vhjy3x)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,13 +7,13 @@
 
 ## Layout — grouped by substrate
 
-Examples are organised under per-substrate top-level directories. Reagent is the canonical substrate; UIx and Helix each ship a curated set rather than a 1:1 mirror — the **Decision-7 smoke-test subset is counter + login**, plus one design-led example per non-canonical substrate (dashboard for UIx, process-monitor for Helix) that is a documented build but not part of the smoke subset.
+Examples are organised under per-substrate top-level directories. Reagent is the canonical substrate; UIx and Helix each ship a curated set rather than a 1:1 mirror — the **Decision-7 curated pair is counter + login** (carrying compile coverage), plus one design-led example per non-canonical substrate (dashboard for UIx, process-monitor for Helix) that is a documented build. None of these are browser-smoke surfaces: browser smoke coverage is exactly the three adapter-level smokes (see below).
 
 ```
 examples/
   scripts/                              <-- orchestrator + Playwright helpers
     serve-and-run-examples-tests.cjs    <-- compiles, stages, serves, runs (entry point of `npm run test:examples`)
-    run-examples-tests.cjs              <-- Playwright runner (walks SPEC_ROOTS, picks up *.spec.cjs / spec.cjs)
+    run-examples-tests.cjs              <-- Playwright runner (runs the EXAMPLES manifest's specs; reconciles it against the spec.cjs on disk under SPEC_ROOTS)
     spec-helpers.cjs                    <-- shared assertion helpers used by every spec
   reagent/                              <-- canonical substrate (full set)
     counter/
@@ -45,14 +45,14 @@ examples/
     login/
   reagent-slim/                         <-- day8/reagent-slim substrate (its own adapter)
     counter_slim_and_fast/              <-- same dataflow, mounted on day8/reagent-slim
-  uix/                                  <-- UIx adapter examples (smoke subset counter + login; dashboard documented-not-smoke)
+  uix/                                  <-- UIx adapter examples (curated pair counter + login; dashboard design-led; all compile-only)
     counter_uix/                        <-- folder name carries the namespace suffix so it
     login_uix/                              doesn't collide with reagent/{counter,login}/ on the classpath
-    dashboard_uix/                      <-- design-led example; documented build, not part of the smoke subset
-  helix/                                <-- Helix adapter examples (smoke subset counter + login; process-monitor documented-not-smoke)
+    dashboard_uix/                      <-- design-led example; documented build (compile-only)
+  helix/                                <-- Helix adapter examples (curated pair counter + login; process-monitor design-led; all compile-only)
     counter_helix/                      <-- folder name carries the namespace suffix so it
     login_helix/                            doesn't collide with reagent/ or uix/ siblings on the classpath
-    process_monitor_helix/              <-- design-led example; documented build, not part of the smoke subset
+    process_monitor_helix/              <-- design-led example; documented build (compile-only)
 ```
 
 > **The `examples/` tree is test-free.** No `*.spec.cjs` may live under `examples/`. Browser smoke coverage is exactly 3 adapter-level smokes (Reagent / UIx / Helix) at [`implementation/adapters/<name>/testbed/spec.cjs`](../implementation/adapters/). Real-regression coverage lives in substrate contract tests (`npm run test:cljs`), the Xray feature-matrix gate (`npm run test:xray-feature-gate`), bundle-isolation (`npm run test:bundle-isolation`), the perf-bundle gate (`npm run test:perf-bundle`), and mcp-conformance. Framework testbeds at [`tools/xray/testbeds/`](../tools/xray/testbeds/) and the top-level [`testbeds/`](../testbeds/) stay in-tree as Xray observation targets and carry no paired Playwright `spec.cjs` files — their assertions live as CLJS/JVM unit tests under `implementation/{core,epoch,flows,http,machines,ssr}/test/`.
@@ -119,17 +119,17 @@ The UIx adapter ships a curated set rather than a 1:1 mirror of the Reagent set.
 |---|---|---|---|---|
 | 1 | [`uix/counter_uix/`](uix/counter_uix/) | Pedagogical sketch | `examples/counter-uix` | The Reagent [`counter/`](reagent/counter/) dataflow rendered through the UIx adapter — same events, subs, and `app-db` shape; the view layer is `defui` components consuming subs via the `use-subscribe` hook. |
 | 2 | [`uix/login_uix/`](uix/login_uix/) | Pedagogical sketch | `examples/login-uix` | The Reagent [`login/`](reagent/login/) example through UIx — schemas, machine, and managed-HTTP stub are unchanged (substrate-agnostic); only the view layer differs. |
-| 3 | [`uix/dashboard_uix/`](uix/dashboard_uix/) | Design-led (documented-not-smoke) | `examples/dashboard-uix` | Design-led example proving UIx can drive a substantive multi-pane layout. Documented build (carries compile coverage) but not part of the Decision-7 smoke subset. Shares the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css) with the Reagent `notebook/` and Helix `process_monitor_helix/` siblings. |
+| 3 | [`uix/dashboard_uix/`](uix/dashboard_uix/) | Design-led (compile-only) | `examples/dashboard-uix` | Design-led example proving UIx can drive a substantive multi-pane layout. Documented build (carries compile coverage) but not part of the Decision-7 curated pair. Shares the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css) with the Reagent `notebook/` and Helix `process_monitor_helix/` siblings. |
 
 ## Helix
 
-The Helix adapter ships the same shape as UIx — the **smoke-test subset is counter + login** per Decision 7, plus the process-monitor design-led example (a documented build, not part of the smoke subset). The eight UIx decisions transferred unchanged because Helix and UIx share the React + hooks substrate model; only the component-shape primitive (`defnc` rather than `defui`) and the target version (Helix 0.2.x rather than UIx 2.x) differ. Adapter-level smoke coverage lives at [`implementation/adapters/helix/testbed/spec.cjs`](../implementation/adapters/helix/testbed/spec.cjs).
+The Helix adapter ships the same shape as UIx — the **curated pair is counter + login** per Decision 7, plus the process-monitor design-led example (a documented build). All three carry compile coverage only. The eight UIx decisions transferred unchanged because Helix and UIx share the React + hooks substrate model; only the component-shape primitive (`defnc` rather than `defui`) and the target version (Helix 0.2.x rather than UIx 2.x) differ. The runtime browser-smoke that proves the Helix adapter wires up end-to-end is the single adapter-testbed smoke at [`implementation/adapters/helix/testbed/spec.cjs`](../implementation/adapters/helix/testbed/spec.cjs), not the example pages.
 
 | # | Example | Maturity | Build id | What it demonstrates |
 |---|---|---|---|---|
 | 1 | [`helix/counter_helix/`](helix/counter_helix/) | Pedagogical sketch | `examples/counter-helix` | The Reagent [`counter/`](reagent/counter/) dataflow rendered through the Helix adapter — same events, subs, and `app-db` shape; the view layer is `defnc` components consuming subs via the `use-subscribe` hook. |
 | 2 | [`helix/login_helix/`](helix/login_helix/) | Pedagogical sketch | `examples/login-helix` | The Reagent [`login/`](reagent/login/) example through Helix — schemas, machine, and managed-HTTP stub are unchanged (substrate-agnostic); only the view layer differs. |
-| 3 | [`helix/process_monitor_helix/`](helix/process_monitor_helix/) | Design-led (documented-not-smoke) | `examples/process-monitor-helix` | Design-led example proving Helix can drive a substantive multi-pane layout. Documented build (carries compile coverage) but not part of the Decision-7 smoke subset. Shares the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css) with the Reagent `notebook/` and UIx `dashboard_uix/` siblings. |
+| 3 | [`helix/process_monitor_helix/`](helix/process_monitor_helix/) | Design-led (compile-only) | `examples/process-monitor-helix` | Design-led example proving Helix can drive a substantive multi-pane layout. Documented build (carries compile coverage) but not part of the Decision-7 curated pair. Shares the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css) with the Reagent `notebook/` and UIx `dashboard_uix/` siblings. |
 
 The bundle-isolation grep at `implementation/scripts/check-bundle-isolation.cjs` runs against the Reagent `examples/counter` bundle — separate per-example shadow-cljs builds per substrate let CI verify a Reagent-substrate example carries no UIx or Helix code, a UIx-substrate example carries no Reagent or Helix code, and a Helix-substrate example carries no Reagent or UIx code.
 

--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -39,18 +39,14 @@
  *     name:  string,                         // human-readable
  *     url:   string,                         // path under the static server root
  *     run:   async (page) => void,           // Playwright assertions
- *     skip:  string | falsy                  // optional — when truthy
- *                                            //   (any non-empty string),
- *                                            //   the spec is reported as
- *                                            //   SKIP with this string as
- *                                            //   the reason. Any falsy
- *                                            //   value (false / null /
- *                                            //   undefined / "") = run
- *                                            //   normally.
  *   }
  *
- * Exit code: 0 if every spec's `run` resolves (skipped specs count as
- * non-failing); 1 if any spec throws or a pageerror fires during a spec.
+ * There is no opt-out: every selected spec runs. Opting an example out of
+ * the smoke surface means removing it from the EXAMPLES manifest
+ * (examples-filter.cjs) / deleting its spec, not flagging the spec.
+ *
+ * Exit code: 0 if every selected spec's `run` resolves; 1 if any spec
+ * throws or a pageerror fires during a spec.
  */
 
 const path = require('path');
@@ -208,8 +204,7 @@ function withTimeout(promise, ms, label) {
 
   // Silent-on-success: buffer per-spec narration into `lines` and
   // only flush it for specs that FAIL. Green specs emit nothing; the
-  // final summary is a single counts line. SKIP specs still flush so
-  // the reason is visible.
+  // final summary is a single counts line.
   for (const spec of specs) {
     const label = spec.name || path.basename(spec.file);
     const lines = [];
@@ -219,19 +214,6 @@ function withTimeout(promise, ms, label) {
     };
 
     log(`\n=== ${label} ===`);
-
-    if (spec.skip) {
-      // Spec opted out at the spec-module level (truthy `skip`
-      // value). Print a SKIP line with the reason and don't navigate
-      // or run assertions. The orchestrator still compiled the
-      // example's bundle (per its EXAMPLES entry) — so under-
-      // construction examples remain compile-checked, just not
-      // smoke-tested at the user-visible behaviour level.
-      log(`SKIP  ${label}: ${spec.skip}`);
-      flush();
-      results.push({ label, passed: true, skipped: true, reason: spec.skip });
-      continue;
-    }
 
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -276,21 +258,15 @@ function withTimeout(promise, ms, label) {
 
   // Silent-on-success: green runs emit the canonical single-line
   // summary; red runs also list the failing labels for quick triage.
-  const passedCount = results.filter((r) => r.passed && !r.skipped).length;
-  const skippedCount = results.filter((r) => r.skipped).length;
   const failedCount = results.filter((r) => !r.passed).length;
   if (anyFailed) {
     console.log('\n=== summary ===');
     for (const r of results) {
-      if (r.skipped) {
-        console.log(`SKIP  ${r.label}  (${r.reason})`);
-      } else {
-        console.log(`${r.passed ? 'PASS' : 'FAIL'}  ${r.label}`);
-      }
+      console.log(`${r.passed ? 'PASS' : 'FAIL'}  ${r.label}`);
     }
   }
   console.log(
-    `Ran ${results.length} example specs. ${failedCount} failures, ${skippedCount} skipped.`,
+    `Ran ${results.length} example specs. ${failedCount} failures.`,
   );
 
   process.exit(anyFailed ? 1 : 0);


### PR DESCRIPTION
Prunes vestigial skip-support from the examples Playwright smoke-runner and reconciles `examples/README.md` drift against the actual contract. Pre-alpha masterpiece stance (ELEGANCE) — no opt-out, manifest-first selection. Bead rf2-vhjy3x is authoritative.

## What changed

**`examples/scripts/run-examples-tests.cjs` — removed `skip` support**
- Removed `skip` from the spec-format docstring (no adapter spec uses it; all three export only `{name, url, run}`).
- Removed the per-spec `if (spec.skip)` branch + the SKIP narration line.
- Removed `skipped`/`skippedCount` from the summary accounting; summary is now `Ran N example specs. M failures.`
- Dropped the unused `passedCount` local that only fed the removed skip-aware summary.
- New contract: there is no opt-out. Opting an example out of the smoke surface means removing it from the EXAMPLES manifest (`examples-filter.cjs`) / deleting its spec — documented in the runner docstring.

**`examples/README.md` — docs drift**
- No longer calls counter+login the "Decision-7 smoke-test subset". Browser smoke coverage is exactly the three adapter-level smokes (`implementation/adapters/<name>/testbed/spec.cjs`); counter+login are the curated parity pair carrying compile coverage only. Fixed in the layout intro, the layout tree comments, the UIx/Helix section prose, and the per-example table rows.
- Updated the runner's catalogue line from "walks SPEC_ROOTS, picks up `*.spec.cjs` / `spec.cjs`" to the manifest-first/reconcile contract it actually implements (runs the EXAMPLES manifest's specs; reconciles against the spec.cjs on disk under SPEC_ROOTS).

## Premise verification

All three bead premises CONFIRMED against the tree — none rejected:
- skip support present in `run-examples-tests.cjs` (docstring :37-50, impl :223-234, summary :280/:286/:293); adapter specs export `{name,url,run}` only.
- README called counter/login the Decision-7 smoke subset (:10, :48, :52, :116, :122, :126, :132) while line 58 + End-to-end section say smoke = 3 adapter smokes.
- README described generic SPEC_ROOTS walking (:16) but the contract is manifest-first with reconciliation.

## Boundary

- Did NOT touch `serve-example.cjs` / `_examples-staging.test.cjs` — the rf2-rg2tze clean-stage boundary is preserved untouched. Rebased onto fresh origin/main (which includes rg2tze) first.
- Did NOT edit `examples/<adapter>/` dirs (owned by sibling workers) or `.beads/issues.jsonl`. Surgical in `examples/scripts/` so the held sibling rf2-bz2b4b can sequence after.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:script-policy` | PASS — all suites (changed-surfaces 74, script-spawn 113, examples-filter, examples-staging, check-examples-assets, reagent-slim, etc.), exit 0 |
| `npm run test:examples` | PASS — `Ran 3 example specs. 0 failures.`, exit 0 |
| `npm run test:examples-compile` | PASS — all 42 example builds compiled, 0 warnings, exit 0 |
