### PR TITLE
fix(xray): surface failing/blocking guard + machine-cascade inline rendering (rf2-35mwxv,982212)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -152,6 +152,23 @@ below; the three render states are:
    bespoke summary that diverged from the Epoch panel's richer microstep
    view — sharing the one renderer fixes that permanently.
 
+   **Cascade-row VERB rendering (rf2-982212).** Each `:guard` / `:action`
+   cascade row paints a VERB beside its KIND+PHASE badge. A NAMED
+   action/guard — a keyword into the machine's `:actions` / `:guards` map —
+   renders its keyword verbatim (`:may-close?` / `:my-ns/count-open`). An
+   INLINE action/guard — an anonymous `(fn …)` declared directly in an
+   `:on` / `:always` / `:entry` / `:exit` / `:after` slot — carries a bare
+   FUNCTION OBJECT (not a keyword) as its `:action-id` / `:guard-id` (the
+   runtime carries the fn; impl: `re-frame.machines.transition` resolve-guard
+   / resolve-action). Such rows render the synthetic placeholder `⟨inline⟩`
+   for the verb — NOT the raw fn-object toString (`#object[Function …]` / a
+   minified blob), which is what leaked before rf2-982212
+   (`format/verb-label` replaced the `ns-keyword` `str` fallthrough at the
+   cascade-row label site). The row's KIND+PHASE badge, per-row outcome chip,
+   and (in dev builds) the interleaved SOURCE BODY + click-to-source via the
+   derived spec-path still carry WHAT the inline declaration is; the
+   `⟨inline⟩` verb reads as "an anonymous declaration" rather than garbage.
+
 The header carries:
 - A **prev/next nav** (`◀ Prev` / `Next ▶`) that walks the spine's
   epoch history to the prior/next epoch whose cascade ALSO touched
@@ -673,13 +690,22 @@ transition does, with these differences:
   active state's exits affordance-blue and gave ZERO rejection signal.)
 - **No snapshot drill-in.** The no-op trace carries no `:before` / `:after`
   snapshot pair (`:data` did not change), so the drill-in suppresses cleanly.
-- **No guards / actions LIST in the lens.** The lens's GUARDS-RUN / ACTIONS-RUN
-  forensic LIST is still driven off the cascade projection (the no-op trace is
-  its sole signal there), so no rows attach to the lens list. (The CHART,
-  however, DOES surface the failing guard — it consumes the
-  `:rf.machine/guard-evaluated` fail/threw trace directly; see the rf2-fzrzlw
-  section. A follow-on bead may surface the failing guard in the lens LIST too;
-  the record shape stays stable.)
+- **The blocking guard IS surfaced in the lens cascade LIST (rf2-35mwxv).**
+  The lens's GUARDS-RUN / ACTIONS-RUN forensic list is the SHARED machine
+  cascade — the Machine Inspector lens (via `:rf.xray/machine-focused-epoch-
+  cascade`) and the Epoch panel's EVENT HANDLER mini-pipeline both render the
+  one `machine-cascade-rows` projection over the focused epoch's RAW
+  `:trace-events` (rf2-g2axio). A guard-blocked no-op emits BOTH the
+  `:rf.machine/guard-evaluated` fail/threw trace (during the candidate walk)
+  AND the `:rf.machine.event/unhandled-no-op` trace; BOTH ops are members of
+  `machine-cascade-trace-ops`, so the cascade carries a `[GUARD]` row NAMING
+  the blocking guard with its `fail` / `threw` outcome chip, AHEAD of the
+  `[NO OP]` row (canonical rank: guard → no-op). The operator's most common
+  guard-block question — "my event did nothing, which guard blocked it?" — is
+  answerable from the LIST, not only the chart. (The CHART independently
+  surfaces the same failing guard by painting the rejected edge PINK — it
+  consumes the `:rf.machine/guard-evaluated` fail/threw trace directly; see
+  the rf2-fzrzlw section.)
 
 A machine that BOTH transitioned (or was born) AND no-op'd in the same cascade
 surfaces only its transition / birth record — a no-op is single-signalled

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -61,6 +61,37 @@
     (keyword? id)           (str ":" (name id))
     :else                   (str id)))
 
+(def inline-verb-label
+  "The synthetic verb a cascade row paints for an ANONYMOUS (inline-fn)
+  action / guard (rf2-982212). An inline `(fn …)` declared directly in an
+  `:on` / `:always` / `:entry` / `:exit` / `:after` slot has a FUNCTION
+  OBJECT — not a keyword — as its `:action-id` / `:guard-id` (the runtime
+  carries the bare fn; impl: `re-frame.machines.transition` resolve-guard /
+  resolve-action), so `ns-keyword`'s `str` fallthrough rendered the raw
+  fn-object toString (`#object[Function …]` / a minified blob). Inline fns
+  are first-class in every slot (Spec 005), so the case is common; this
+  legible placeholder stands in for the un-nameable fn. The row's
+  KIND+PHASE badge, per-row outcome chip, and (in dev builds) the
+  interleaved SOURCE BODY + click-to-source still carry WHAT it is — the
+  verb only needs to read as 'an inline declaration', not garbage."
+  "⟨inline⟩")
+
+(defn verb-label
+  "Render a cascade row's VERB id (an `:action-id` / `:guard-id`) as a
+  legible label (rf2-982212). A keyword (a NAMED action/guard registered in
+  the machine's `:actions` / `:guards` map) renders cleanly via `ns-keyword`
+  (`:my-guard` / `:my-ns/foo`). A non-keyword id — an ANONYMOUS inline `(fn
+  …)` carried bare by the runtime — renders the synthetic
+  `inline-verb-label` placeholder rather than the raw fn-object toString
+  (`#object[Function …]` / minified blob). nil renders an empty string so a
+  slot that legitimately carries no verb (the pill + chip carry it) stays
+  blank rather than printing `\"\"`-ish garbage. Pure-data."
+  [id]
+  (cond
+    (nil? id)     ""
+    (keyword? id) (ns-keyword id)
+    :else         inline-verb-label))
+
 (defn truncate
   "Truncate a string to `n` chars with an ellipsis. Pure fn used by
   the view layer for long arg displays in the FX table."
@@ -248,12 +279,17 @@
     ;; GUARD), so it is dropped. The state the guard gates rides the
     ;; `for <state>` clause (the item-6 pattern; `cascade-guard-for-state`)
     ;; rendered alongside the verb in the view — `[GUARD] for :open :may-close?`.
-    :guard       (ns-keyword guard-id)
+    ;; rf2-982212 — a NAMED guard renders its keyword; an INLINE `(fn …)`
+    ;; guard (a bare fn id) renders the `⟨inline⟩` placeholder via
+    ;; `verb-label` rather than the raw fn-object toString.
+    :guard       (verb-label guard-id)
     ;; rf2-nhovk — the ACTION kind-pill + phase chip already convey kind +
-    ;; phase, so the verb is JUST the action-id (empty for an anonymous
-    ;; action — the pill + chip + source body carry it). The redundant
-    ;; "{phase} action " prefix is dropped.
-    :action      (ns-keyword action-id)
+    ;; phase, so the verb is JUST the action-id (the pill + chip + source body
+    ;; carry the rest). rf2-982212 — a NAMED action renders its keyword; an
+    ;; INLINE `(fn …)` action renders the `⟨inline⟩` placeholder via
+    ;; `verb-label` (was: the raw fn-object toString); a nil action-id renders
+    ;; empty. The redundant "{phase} action " prefix is dropped.
+    :action      (verb-label action-id)
     ;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb is JUST the state
     ;; change `<before> → <after>`, made the focal point. The redundant
     ;; leading "transition" word (the KIND pill already says TRANSITION)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -177,13 +177,28 @@
     ;; #5 — re-open, arm the hold (internal), then attempt the BLOCKED close.
     (drive! :door/main [:door/push])                    ; → :open
     (drive! :door/main [:door/hold])                    ; arm :held-open?
-    (let [rows (cascade (drive! :door/main [:door/close]))]
-      (is (= :fail (:outcome (first (rows-of-kind rows :guard))))
+    (let [rows      (cascade (drive! :door/main [:door/close]))
+          guard-row (first (rows-of-kind rows :guard))]
+      (is (= :fail (:outcome guard-row))
           "(a) :may-close? fails when held-open?")
       (is (= 1 (count (rows-of-kind rows :no-op)))
           "(b) the blocked guard is a no-op — one [NO OP] row")
       (is (empty? (rows-of-kind rows :transition))
-          "(c) blocked → NO transition row (suppressed beside the no-op)"))
+          "(c) blocked → NO transition row (suppressed beside the no-op)")
+      ;; rf2-35mwxv — the blocking guard is SURFACED in the cascade LIST (the
+      ;; shared lens + Epoch mini-pipeline), not only on the chart: the LIST
+      ;; carries a [GUARD] row NAMING the blocking guard with its fail outcome
+      ;; chip, so the operator can answer "which guard blocked my event?" from
+      ;; the list. Driven against the REAL substrate's emitted traces.
+      (is (= :may-close? (:guard-id guard-row))
+          "rf2-35mwxv — the LIST guard row NAMES the blocking guard")
+      (is (= ":may-close?" (fmt/cascade-row-label guard-row))
+          "rf2-35mwxv — the guard row renders a legible verb naming the guard")
+      (is (= "fail" (fmt/cascade-outcome-label guard-row))
+          "rf2-35mwxv — the guard row's fail outcome chip renders")
+      ;; The guard row leads the no-op (canonical rank guard(0) → no-op(2)).
+      (is (= [:guard :no-op] (mapv :kind rows))
+          "rf2-35mwxv — the blocking guard leads the [NO OP] in the LIST"))
     (is (= :open (:state (snapshot :door/main)))
         "(c) the door STAYS :open — the blocked close did not advance")))
 
@@ -898,3 +913,56 @@
       (is (= :rejected (check-branch 0 :rejected)) "(c) level 0 → :rejected (fallback)"))
     (is (= :idle (:state (snapshot :gate/main)))
         "(c) the gate is back at the :idle fork node after the three branches")))
+
+;; ============================================================================
+;; INLINE action/guard verb rendering (rf2-982212) — REAL substrate
+;; ============================================================================
+;;
+;; The deck machines all reference NAMED guards/actions (keyword → `:guards`
+;; / `:actions` map). An INLINE `(fn …)` declared DIRECTLY in an `:on` /
+;; `:entry` / `:exit` slot is first-class per Spec 005, and the runtime
+;; carries the bare fn as the trace's `:guard-id` / `:action-id`
+;; (transition.cljc resolve-guard / resolve-action). Before rf2-982212 the
+;; cascade VERB rendered that fn via `ns-keyword`'s `str` fallthrough — the
+;; raw fn-object toString (`#object[Function …]` / a minified blob). This
+;; drives a machine whose guard AND actions are inline fns through the REAL
+;; substrate and asserts the cascade rows render the legible `⟨inline⟩`
+;; placeholder, not a fn-object blob.
+
+(deftest inline-guard-and-action-render-legible-verb
+  (testing "rf2-982212 — an INLINE-declared guard AND inline-declared
+            entry/exit actions, driven through the REAL substrate, render a
+            legible `⟨inline⟩` cascade verb — NOT the raw fn-object toString."
+    (setup!)
+    ;; A tiny machine whose guard + entry + exit are ALL inline (fn …)s
+    ;; declared directly in their slots (no `:guards` / `:actions` keyword
+    ;; refs). The guard PASSES so a transition fires and its exit/entry inline
+    ;; actions run, producing inline guard + action cascade rows.
+    (rf/reg-machine :inline/probe
+      {:initial :a
+       :states
+       {:a {:exit  (fn inline-exit [{data :data}] {:data (assoc data :left-a? true)})
+            :on    {:inline/go {:target :b
+                                :guard  (fn inline-guard [_] true)}}}
+        :b {:entry (fn inline-entry [{data :data}] {:data (assoc data :in-b? true)})}}})
+    (rf/dispatch-sync [:inline/probe [:rf.machine/start]])
+    (let [rows      (cascade (drive! :inline/probe [:inline/go]))
+          guard-row (first (rows-of-kind rows :guard))
+          action-rows (rows-of-kind rows :action)]
+      (is (= :b (:state (snapshot :inline/probe))) "the inline guard passed → transitioned to :b")
+      ;; The inline GUARD row carries a fn id and renders the legible verb.
+      (is (some? guard-row) "an inline guard produced a :guard cascade row")
+      (is (fn? (:guard-id guard-row)) "the runtime carries the bare inline fn as :guard-id")
+      (is (= "⟨inline⟩" (fmt/cascade-row-label guard-row))
+          "rf2-982212 — inline guard verb is `⟨inline⟩`, not the fn-object str")
+      ;; The inline ACTION rows (exit :left-a? + entry :in-b?) render legibly.
+      (is (seq action-rows) "the inline exit/entry actions produced :action rows")
+      (doseq [a action-rows]
+        (is (fn? (:action-id a)) "the runtime carries the bare inline fn as :action-id")
+        (let [verb (fmt/cascade-row-label a)]
+          (is (= "⟨inline⟩" verb)
+              "rf2-982212 — inline action verb is `⟨inline⟩`, not the fn-object str")
+          ;; Adversarial: NO host-runtime fn-object garbage leaks into the verb.
+          (is (not (string/includes? verb "object")) "no `#object` blob")
+          (is (not (string/includes? verb "$"))      "no munged fn `$` separator")
+          (is (not (string/includes? verb "@"))      "no fn-object `@hash` suffix"))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -921,6 +921,74 @@
       (is (some? (:machine r)))
       (is (= [:no-op] (mapv :kind (-> r :machine :cascade)))))))
 
+;; ---- rf2-35mwxv — a GUARD-BLOCKED no-op surfaces the blocking guard ------
+;;
+;; When a guard FAILS and blocks a transition (a clause for the event-id
+;; exists but its `:guard` returned false / threw, and no unguarded
+;; fallback matched), the runtime emits BOTH:
+;;
+;;   1. `:rf.machine/guard-evaluated {:outcome :fail|:threw …}` — during the
+;;      candidate walk in `pick-transition` → `evaluate-guard`
+;;      (transition.cljc), and
+;;   2. `:rf.machine.event/unhandled-no-op {…}` — the `:else` no-op branch,
+;;      since no candidate passed (transition.cljc ~3760).
+;;
+;; BOTH ops are members of `machine-cascade-trace-ops`, so the cascade
+;; projection (consumed by the Epoch panel HANDLER mini-pipeline AND the
+;; Machine Inspector lens via `:rf.xray/machine-focused-epoch-cascade`,
+;; rf2-g2axio) surfaces the failing guard as a `[GUARD ✗]` row NAMING the
+;; blocking guard + its fail/threw outcome — NOT just a bare `[NO OP]`. This
+;; resolved the follow-on the spec's §guard-blocked flagged; the test pins
+;; it so the shared-cascade wiring cannot silently regress back to a
+;; guard-blind no-op.
+
+(deftest guard-blocked-no-op-surfaces-blocking-guard-test
+  (testing "rf2-35mwxv — a guard-blocked no-op cascade carries a :guard
+            fail row NAMING the blocking guard alongside the :no-op row;
+            the guard's fail outcome renders (not just a bare [NO OP])."
+    ;; The two traces the runtime emits for a guard-blocked no-op, in the
+    ;; order they occur (guard eval during pick, then the no-op resolution).
+    (let [evs  [(machine-guard-ev :may-close? :fail)
+                (machine-unhandled-no-op-ev :door/main [:door/close] :open)]
+          rows (proj/machine-cascade-rows evs)
+          by-kind (group-by :kind rows)
+          guard-row (first (:guard by-kind))
+          no-op-row (first (:no-op by-kind))]
+      ;; BOTH rows are present — the failing guard is NOT swallowed.
+      (is (= [:guard :no-op] (mapv :kind rows))
+          "guard(0) → no-op(2) canonical order; the blocking guard leads the no-op")
+      ;; The guard row NAMES the blocking guard + carries the fail outcome.
+      (is (some? guard-row) "a :guard row attaches to the guard-blocked no-op")
+      (is (= :may-close? (:guard-id guard-row)) "the row names the blocking guard")
+      (is (= :fail (:outcome guard-row)) "the row carries the :fail outcome")
+      (is (= ":may-close?" (fmt/cascade-row-label guard-row))
+          "the LIST row identifies the blocking guard (not a bare [NO OP])")
+      (is (= "fail" (fmt/cascade-outcome-label guard-row))
+          "the fail outcome renders on the guard row's chip")
+      ;; The no-op row is still present (the consequence: stayed put).
+      (is (= "staying in :open" (fmt/cascade-row-label no-op-row)))))
+
+  (testing "rf2-35mwxv — a guard that THREW while blocking surfaces a :threw
+            outcome row naming the guard."
+    (let [evs  [(machine-guard-ev :may-close? :threw)
+                (machine-unhandled-no-op-ev :door/main [:door/close] :open)]
+          rows (proj/machine-cascade-rows evs)
+          guard-row (first (filter #(= :guard (:kind %)) rows))]
+      (is (= :threw (:outcome guard-row)))
+      (is (= "threw" (fmt/cascade-outcome-label guard-row))
+          "a throwing blocking guard surfaces its :threw outcome in the LIST")))
+
+  (testing "rf2-35mwxv — the SHARED projection feeds the Machine Inspector
+            lens cascade identically (rf2-g2axio): the handler-row's machine
+            cascade carries the guard fail row + the no-op row."
+    (let [r (proj/handler-row
+              [(machine-guard-ev :may-close? :fail)
+               (machine-unhandled-no-op-ev :door/main [:door/close] :open)]
+              :door/main)]
+      (is (= :reg-machine (:flavour r)))
+      (is (= [:guard :no-op] (mapv :kind (-> r :machine :cascade)))
+          "the shared machine cascade (lens + Epoch panel) carries BOTH rows"))))
+
 ;; ---- rf2-it4vt — the machine's [START] badge -----------------------------
 
 (deftest machine-started-projects-to-start-row-test
@@ -3066,6 +3134,68 @@
     (is (= ":foo"       (fmt/ns-keyword :foo)))
     (is (= ":my/foo"    (fmt/ns-keyword :my/foo)))
     (is (= "non-kw"     (fmt/ns-keyword "non-kw")))))
+
+;; ---- rf2-982212 — inline action/guard verb label ------------------------
+;;
+;; An INLINE `(fn …)` declared directly in an `:on` / `:always` / `:entry` /
+;; `:exit` / `:after` slot has a FUNCTION OBJECT — not a keyword — as its
+;; `:action-id` / `:guard-id` (the runtime carries the bare fn). The prior
+;; `(ns-keyword <fn>)` fell through to `(str <fn>)`, rendering the raw
+;; fn-object toString (`#object[Function …]` / a minified blob) as the
+;; cascade-row VERB. `verb-label` renders the `⟨inline⟩` placeholder for a
+;; non-keyword id; named (keyword) ids render unchanged.
+
+(deftest verb-label-test
+  (testing "rf2-982212 — `verb-label` renders a NAMED id (keyword) cleanly,
+            an INLINE (non-keyword fn) id as the `⟨inline⟩` placeholder, and
+            nil as the empty string."
+    (is (= ":may-close?" (fmt/verb-label :may-close?))
+        "named keyword guard/action → its keyword, unchanged")
+    (is (= ":my/foo" (fmt/verb-label :my/foo))
+        "qualified keyword → its full keyword, unchanged")
+    (is (= "⟨inline⟩" (fmt/verb-label (fn [_] true)))
+        "inline fn → the legible synthetic placeholder, NOT the fn-object str")
+    (is (= "" (fmt/verb-label nil))
+        "nil id → empty string (pill + chip carry it)")
+    ;; The defect: the placeholder must NOT be the fn-object toString — no
+    ;; `#object` / `$` / `@` host-runtime garbage leaks into the verb.
+    (let [inline-fn (fn [_] true)]
+      (is (not= (str inline-fn) (fmt/verb-label inline-fn))
+          "verb-label must NOT be the raw fn-object toString (the rf2-982212 defect)")
+      (is (not (str/includes? (fmt/verb-label inline-fn) "object"))
+          "no `#object[...]` blob leaks into the verb"))))
+
+(deftest cascade-row-label-inline-verb-test
+  (testing "rf2-982212 — an INLINE-declared guard AND an INLINE-declared
+            action cascade row render a LEGIBLE verb (`⟨inline⟩`), not a
+            fn-object / minified blob; NAMED rows are unchanged."
+    (let [inline-guard  (fn [_ctx] true)
+          inline-action (fn [_ctx] {})]
+      ;; INLINE guard — was the raw fn-object str; now the legible placeholder.
+      (is (= "⟨inline⟩"
+             (fmt/cascade-row-label {:kind :guard :guard-id inline-guard}))
+          "inline guard verb is legible, not a fn-object blob")
+      ;; INLINE action — same defect on the action arm (format.cljc :256).
+      (is (= "⟨inline⟩"
+             (fmt/cascade-row-label {:kind :action :action-id inline-action
+                                     :phase :entry}))
+          "inline action verb is legible, not a fn-object blob")
+      ;; Regression guard: the rendered verb must carry NO host-runtime
+      ;; fn-object garbage (the symptom Mike observed live, 2026-06-14).
+      (doseq [row [{:kind :guard :guard-id inline-guard}
+                   {:kind :action :action-id inline-action :phase :exit}]]
+        (let [verb (fmt/cascade-row-label row)]
+          (is (not (str/includes? verb "object")) "no `#object` blob")
+          (is (not (str/includes? verb "@"))       "no host fn-object `@hash` suffix")
+          (is (not (str/includes? verb "$"))       "no munged fn-object `$` separator")))
+      ;; NAMED rows are untouched — the keyword still renders verbatim.
+      (is (= ":may-close?"
+             (fmt/cascade-row-label {:kind :guard :guard-id :may-close?}))
+          "named guard verb unchanged")
+      (is (= ":open-socket"
+             (fmt/cascade-row-label {:kind :action :action-id :open-socket
+                                     :phase :entry}))
+          "named action verb unchanged"))))
 
 (deftest machine-event-orientation-test
   (testing "rf2-akvfe — the EVENT HANDLER orientation triple is projected off


### PR DESCRIPTION
## Summary

Two `tools/xray` machine-cascade beads, one PR (same surface: the Epoch panel + Machine Inspector cascade, both sharing `panels/epoch` projection + format).

### rf2-982212 (BUG — FIXED)
The machine cascade rendered an **inline** (anonymous `(fn …)`) action/guard verb as the raw fn-object toString (`#object[Function …]` / a minified blob). `cascade-row-label` called `ns-keyword` on the verb id, whose `str` fallthrough stringified the bare fn the runtime carries for an inline slot (named keyword refs rendered fine).

**Fix:** add `format/verb-label` (keyword → its keyword via `ns-keyword`; non-keyword fn → the legible `⟨inline⟩` placeholder; nil → `""`), used at the `:guard` and `:action` `cascade-row-label` sites. Named rows are byte-for-byte unchanged. The KIND+PHASE badge, outcome chip, and dev-build source body + click-to-source still carry *what* the inline declaration is.

### rf2-35mwxv (TASK — REJECTED: premise stale; behaviour already present)
The bead claims a guard-blocked no-op shows only a bare `[NO OP]` row and the blocking guard never reaches the lens cascade LIST (citing the spec's own "follow-on bead may surface it" deferral).

**Verified against live code — premise is false for current code.** A guard-blocked no-op emits **both** `:rf.machine/guard-evaluated {:outcome :fail|:threw}` (during the candidate walk in `transition/evaluate-guard`) **and** `:rf.machine.event/unhandled-no-op`. Both ops are members of `machine-cascade-trace-ops`, so `machine-cascade-rows` already projects a `[GUARD]` row naming the blocking guard (rank 0, ahead of the `[NO OP]` row at rank 2). The Machine Inspector lens consumes that **same** projection over the raw trace via `:rf.xray/machine-focused-epoch-cascade` — the shared-cascade refactor (**rf2-g2axio**) retired the bespoke no-op-only forensic list the spec text still described. The pre-existing real-substrate harness test `door-guard-allowed-then-blocked` already pins the guard fail row + no-op coexistence.

No code change was needed for rf2-35mwxv. Done instead: corrected the spec's stale deferral language to match shipped behaviour, and strengthened the existing real-substrate test to assert the guard row names the blocking guard with a legible label + fail/threw outcome chip.

## Tests (≥1 adversarial/regression per fix)
- `projection_cljs_test.cljc`: `verb-label-test` + `cascade-row-label-inline-verb-test` (inline fn → `⟨inline⟩`; adversarial — no `#object`/`$`/`@` leak; named unchanged); `guard-blocked-no-op-surfaces-blocking-guard-test` (guard fail/threw row coexists with no-op; shared `handler-row` cascade carries both).
- `machine_epochs_harness_cljs_test.cljs` (drives the REAL substrate): strengthened `door-guard-allowed-then-blocked` for rf2-35mwxv; new `inline-guard-and-action-render-legible-verb` for rf2-982212.

## Spec
`tools/xray/spec/003-Machine-Inspector.md` updated in this PR (xray-specs-current rule): corrected the stale lens-LIST deferral bullet (rf2-35mwxv) + added the inline cascade-row verb rendering note (rf2-982212).

## Quality gates
- `clojure -M:test` (xray JVM): **1195 tests, 5326 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs` (xray CLJS panel suite — runs both new harness + projection tests under node against the real substrate): **7122 tests, 29420 assertions, 0 failures, 0 errors** ✅
- `npm run test:xray-feature-gate` (full nightly sweep, incl. machine-epochs deck guard-blocked step): **15 scenarios, 0 failures, 13 matrix rows** ✅ (smoke tier also green: 4/4)
- `mkdocs build --strict`: **not required** — `tools/xray/spec/003-Machine-Inspector.md` is not referenced in `mkdocs.yml` (the xray internal spec tree is not part of the mkdocs site).