### PR TITLE
feat(core): EP-0018 C+D — reg-event macro source-coords + app-value lowering (rf2-xhfxcs.3,xhfxcs.4)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1682,7 +1682,10 @@
   appears in `frame-ids` — not the malformed flat slot the registrar-only path
   produced (rf2-chc8vs). The `:event/kind` is read from the descriptor metadata
   (defaulting to `:db`), so a module event entry tagged `{:event/kind :fx}`
-  lowers through `reg-event-fx`.
+  lowers through the one public `reg-event` runtime fn (EP-0018 D,
+  rf2-xhfxcs.4 — `reg-event` IS `reg-event-fx` semantics, so behaviour-
+  preserving); a `:ctx` entry through `reg-event-ctx`; an untagged entry
+  through `reg-event-db`.
 
   For the step-8-DEFERRED kinds (`install-deferred-kinds`) THROWS
   `:rf.error/unsupported-descriptor-kind` (the ex-data IS the diagnostic —
@@ -1720,7 +1723,23 @@
       :else
       (case kind
         :event (do (case (:event/kind meta)
-                     :fx  (events/reg-event-fx  id meta handler)
+                     ;; EP-0018 D (rf2-xhfxcs.4): the fx-shape event descriptor
+                     ;; lowers through the ONE public `reg-event` runtime fn
+                     ;; rather than `reg-event-fx` directly. `reg-event` IS
+                     ;; `reg-event-fx` semantics (coeffects in, a closed
+                     ;; effects map out — registers `:event/kind :fx` with the
+                     ;; `:rf/fx-handler` wrapper), so this is byte-for-byte
+                     ;; behaviour-preserving; it just routes the install seam
+                     ;; through the surface the EP collapses onto. The legacy
+                     ;; `:db` (the untagged module-descriptor default) and
+                     ;; `:ctx` shapes keep their own reg fns through the
+                     ;; additive window (their db-handler / ctx-handler
+                     ;; semantics differ from `reg-event`'s fx shape, so routing
+                     ;; them through `reg-event` would NOT be behaviour-
+                     ;; preserving); dropping `:event/kind` so EVERY module
+                     ;; event lowers through the one `reg-event` shape is the
+                     ;; later removal slice (Z = rf2-xhfxcs.14).
+                     :fx  (events/reg-event     id meta handler)
                      :ctx (events/reg-event-ctx id meta handler)
                      (events/reg-event-db id meta handler))
                    true)

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -36,6 +36,7 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.app-value :as av]
+            [re-frame.events :as events]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
@@ -706,18 +707,77 @@
       (is (contains? (registrar/lookup :event :xms/ev) :interceptors)
           ":event seated the kind-appropriate interceptor chain (real reg-* logic ran)"))))
 
-(deftest install-event-kind-tag-routes-through-reg-event-fx
-  (testing "a module event entry tagged {:event/kind :fx} lowers through
-            reg-event-fx (the install-descriptor! :event/kind read), so the
-            wired-kind seam honours the event sub-kind (rf2-xmslkr)"
+(deftest install-event-kind-tag-routes-through-reg-event
+  (testing "EP-0018 D (rf2-xhfxcs.4): a module event entry tagged {:event/kind
+            :fx} lowers through the ONE public `reg-event` runtime fn (the
+            install-descriptor! :event/kind read now routes the fx shape onto
+            `reg-event` rather than `reg-event-fx` directly). `reg-event` IS
+            reg-event-fx semantics, so this is behaviour-preserving — the entry
+            is still seated as a resolvable :event/kind :fx handler with the
+            interceptor chain (rf2-xmslkr × EP-0018 D)"
     (rf/install! (rf/app {:id :xms/evfx :modules
                           [(rf/module {:id :m
                                        :events {:xms/evfx {:event/kind :fx
                                                            :handler (fn [_cofx _ev] {})}}})]}))
     (is (some? (registrar/handler :event :xms/evfx))
         "the :event/kind :fx entry is seated as a resolvable event handler")
+    (is (= :fx (:event/kind (registrar/lookup :event :xms/evfx)))
+        "it registered under :event/kind :fx — byte-for-byte reg-event-fx semantics")
     (is (contains? (registrar/lookup :event :xms/evfx) :interceptors)
-        "it ran through reg-event-fx (interceptor chain seated), not the flat path")))
+        "it ran through reg-event (interceptor chain seated), not the flat path")))
+
+(deftest install-fx-descriptor-lowers-through-the-reg-event-runtime-fn
+  (testing "EP-0018 D (rf2-xhfxcs.4) ADVERSARIAL: an fx-shape event descriptor's
+            install lowering reaches the ONE public `reg-event` runtime fn — a
+            spy over `events/reg-event` records the call (delegating to the real
+            fn so the handler is genuinely seated), proving the install seam
+            routes through `reg-event`, not the flat fallback."
+    (let [calls          (atom 0)
+          real-reg-event events/reg-event]
+      (with-redefs [events/reg-event (fn [id & args]
+                                       (swap! calls inc)
+                                       (apply real-reg-event id args))]
+        (rf/install! (rf/app {:id :xhfxcs/d :modules
+                              [(rf/module {:id :m
+                                           :events {:xhfxcs/ev {:event/kind :fx
+                                                                :handler (fn [{:keys [db]} _] {:db db})}}})]})))
+      (is (= 1 @calls)
+          "the install seam lowered the fx descriptor through events/reg-event")
+      ;; The spy delegated to the real `reg-event`, so the handler is genuinely
+      ;; seated + dispatch-ready (behaviour-preserving end-to-end).
+      (is (some? (registrar/handler :event :xhfxcs/ev))
+          "the descriptor is a real, resolvable event registration after lowering"))))
+
+(deftest install-fx-descriptor-seats-reg-event-fx-semantics-not-db
+  (testing "EP-0018 D (rf2-xhfxcs.4) ADVERSARIAL (behavioural discriminator): an
+            fx-shape module event descriptor lowered through `reg-event` seats
+            byte-for-byte `reg-event-fx` semantics — `:event/kind :fx` and the
+            `:rf/fx-handler` framework wrapper — NOT the `:rf/db-handler` /
+            `:event/kind :db` shape `reg-event-db` would seat. This is the
+            runtime-independent counterpart of the spy test: a regression that
+            routes the fx descriptor back through `reg-event-db` would flip BOTH
+            the sub-kind tag and the wrapper id and fail here, and the handler is
+            proven dispatch-ready with the cofx-in / effects-out contract."
+    (rf/reg-frame :xhfxcs.d/app {:doc "fx-lowering app"})
+    (rf/install! (rf/app {:id :xhfxcs.d/app :modules
+                          [(rf/module {:id :m
+                                       :events {:xhfxcs.d/set
+                                                {:event/kind :fx
+                                                 :handler (fn [{:keys [db]} [_ v]]
+                                                            {:db (assoc db :n v)})}}})]}))
+    (let [meta (registrar/lookup :event :xhfxcs.d/set)]
+      (is (= :fx (:event/kind meta))
+          "seated under :event/kind :fx (reg-event = reg-event-fx semantics), not :db")
+      ;; The framework wrapper interceptor is the per-kind tell: reg-event/-fx
+      ;; seat :rf/fx-handler; reg-event-db seats :rf/db-handler.
+      (is (some #(= :rf/fx-handler (:id %)) (:interceptors meta))
+          "the :rf/fx-handler wrapper is seated — the install path used the fx shape, not :rf/db-handler"))
+    ;; End-to-end: the seated handler dispatches with fx-shape semantics
+    ;; (coeffects-in, effects-out — `{:db …}`), confirming the lowering produced
+    ;; a working reg-event registration, not just a tagged slot.
+    (rf/dispatch-sync [:xhfxcs.d/set 7] {:frame :xhfxcs.d/app})
+    (is (= {:n 7} (rf/app-db-value :xhfxcs.d/app))
+        "the fx-lowered handler committed its `{:db …}` effect on dispatch")))
 
 (deftest install-into-an-unknown-realm-id-throws-before-any-mutation
   (testing "FLIPPED (rf2-c6armm.1 #1 / .2 #2): installing into an EXPLICIT,

--- a/implementation/core/test/re_frame/handler_source_cljs_test.cljs
+++ b/implementation/core/test/re_frame/handler_source_cljs_test.cljs
@@ -19,6 +19,20 @@
 
 (use-fixtures :each (test-support/make-reset-runtime-fixture))
 
+(deftest reg-event-captures-form-source-cljs
+  (testing "EP-0018 C (rf2-xhfxcs.3): CLJS `reg-event` stamps :rf.handler/source
+  under DEBUG=true — the consolidated macro layer routes the ONE public
+  reg-event through the same defreg-event-macro form-source capture as the
+  legacy forms"
+    (rf/reg-event :rf2-xhfxcs.cljs/event
+                  (fn [{:keys [db]} _ev] {:db db}))
+    (let [m   (rf/handler-meta :event :rf2-xhfxcs.cljs/event)
+          src (:rf.handler/source m)]
+      (is (string? src) ":rf.handler/source should be a string under DEBUG=true")
+      (is (str/includes? src "reg-event"))
+      (is (str/includes? src ":rf2-xhfxcs.cljs/event"))
+      (is (str/includes? src "(fn [{:keys [db]} _ev] {:db db})")))))
+
 (deftest reg-event-db-captures-form-source-cljs
   (testing "rf2-xgfuy: CLJS reg-event-db stamps :rf.handler/source under DEBUG=true"
     (rf/reg-event-db :rf2-xgfuy.cljs/event-db

--- a/implementation/core/test/re_frame/handler_source_test.clj
+++ b/implementation/core/test/re_frame/handler_source_test.clj
@@ -42,6 +42,23 @@
 
 ;; ---- per-kind captures ----------------------------------------------------
 
+(deftest reg-event-captures-form-source
+  (testing "EP-0018 C (rf2-xhfxcs.3): the ONE public `reg-event` macro stamps
+  :rf.handler/source on JVM — the same whole-form capture the legacy
+  reg-event-{db,fx,ctx} macros do (the macro layer consolidated onto
+  defreg-event-macro, so `reg-event` rides the identical form-source path)"
+    (rf/reg-event :rf2-xhfxcs/event-sample
+                  (fn [{:keys [db]} _ev] {:db db}))
+    (assert-source :event :rf2-xhfxcs/event-sample "reg-event")
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xhfxcs/event-sample))]
+      ;; Whole-form capture: the handler-fn body (the fx-shape return) must
+      ;; appear, not just the surface.
+      (is (str/includes? src "(fn [{:keys [db]} _ev] {:db db})")
+          ":rf.handler/source should include the reg-event handler-fn body")
+      (is (str/includes? src ":db")
+          ":rf.handler/source should include the effect-map keyword"))))
+
 (deftest reg-event-db-captures-form-source
   (testing "rf2-xgfuy: reg-event-db stamps :rf.handler/source on JVM"
     (rf/reg-event-db :rf2-xgfuy/event-db-sample

--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -50,6 +50,21 @@
 ;; MUST NOT happen is the slot being present and equal to the
 ;; `\"NO_SOURCE_PATH\"` sentinel — that's the bug rf2-mdjp tracks.
 
+(deftest reg-event-file-is-not-no-source-path
+  (testing "EP-0018 C (rf2-xhfxcs.3): the ONE public `reg-event` macro emits a
+  real :file under CLJS, not NO_SOURCE_PATH — same coord-capture path as the
+  legacy reg-event-* macros (consolidated macro layer)"
+    (rf/reg-event :rf2-mdjp/reg-event-sample
+                  (fn [{:keys [db]} _] {:db db}))
+    (let [m (rf/handler-meta :event :rf2-mdjp/reg-event-sample)
+          f (:file m)]
+      (is (some? m))
+      (is (not= "NO_SOURCE_PATH" f)
+          ":file must NOT be the cljs.analyzer NO_SOURCE_PATH sentinel")
+      (when (some? f)
+        (is (file-is-real? f)
+            ":file when present must be a real source path")))))
+
 (deftest reg-event-db-file-is-not-no-source-path
   (testing "rf2-mdjp: reg-event-db emits a real :file under CLJS, not NO_SOURCE_PATH"
     (rf/reg-event-db :rf2-mdjp/reg-event-db-sample

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -83,6 +83,16 @@
 
 ;; ---- one assertion per reg-* kind ----------------------------------------
 
+(deftest source-coords-on-reg-event
+  (testing "EP-0018 C (rf2-xhfxcs.3): the ONE public `reg-event` macro stamps
+  :ns / :line / :file — the same compile-time source-coord capture the legacy
+  reg-event-{db,fx,ctx} macros do (consolidated macro layer: `reg-event` rides
+  the identical defreg-event-macro coord-capture skeleton)"
+    (rf/reg-event :rf2-k84s/reg-event-sample
+                  (fn [{:keys [db]} _] {:db db}))
+    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-sample)
+                   :event :rf2-k84s/reg-event-sample)))
+
 (deftest source-coords-on-reg-event-db
   (testing "reg-event-db stamps :ns / :line / :file"
     (rf/reg-event-db :rf2-k84s/reg-event-db-sample


### PR DESCRIPTION
EP-0018 slices **C (rf2-xhfxcs.3)** + **D (rf2-xhfxcs.4)**, landed together (same core surface). ADDITIVE/refinement only — the B-add merge already landed `reg-event` as both runtime fn + JVM macro; the old `reg-event-db`/`-fx`/`-ctx` forms + `:event/kind` STILL work. Removal is slice Z (rf2-xhfxcs.14) and is NOT touched here.

## Slice C — macro layer: `reg-event` source-coords (consolidation + adversarial coverage)

The `reg-event` macro (added in B via `core-reg-macros/defreg-event-macro`) already rides the **identical** compile-time capture skeleton the legacy `reg-event-{db,fx,ctx}` macros use — `:ns`/`:line`/`:file` source-coords (`with-coords-form`) plus the whole-form `:rf.handler/source` string (`with-form-source-form`), both DEBUG-gated for production elision. C pins that consolidation with the adversarial coverage the B-add tests did **not** carry:

- `source_coords_test.clj` (JVM) + `source_coords_cljs_test.cljs` (CLJS): `reg-event` stamps real `:ns`/`:line`/`:file` (not `NO_SOURCE_PATH`).
- `handler_source_test.clj` (JVM) + `handler_source_cljs_test.cljs` (CLJS): `reg-event` stamps `:rf.handler/source` whole-form — asserting the macro name, id literal, and the fx-shape handler-fn body round-trip into the registry meta.

No macro source change was needed (B's `defreg-event-macro` wiring is correct and already consolidated); the elision probe confirms the `reg-event` capture DCEs in production exactly like the legacy forms.

## Slice D — app-values: EP-0013 event descriptors lower through `reg-event`

`core/install-descriptor!`'s `:event` lowering now routes the **fx-shape** descriptor through the one public `events/reg-event` runtime fn instead of `events/reg-event-fx` directly. `reg-event` IS `reg-event-fx` semantics (registers `:event/kind :fx` with the `:rf/fx-handler` wrapper), so this is **byte-for-byte behaviour-preserving** — it just routes the install seam through the surface EP-0018 collapses onto.

The `:ctx` branch and the untagged default (`:db`) keep their own reg fns through the additive window — their db-/ctx-handler shapes differ from `reg-event`'s fx shape, so routing them through `reg-event` would NOT be behaviour-preserving. Dropping `:event/kind` so EVERY module event lowers through the one shape (and rewriting constructed-app examples to fx shape) is the later removal slice (Z).

Adversarial tests (`app_value_install_cljs_test.cljc`, runs JVM + CLJS):
- a `with-redefs` spy over `events/reg-event` proves an fx descriptor's install lowering reaches `reg-event` (delegating to the real fn so the handler is genuinely seated);
- a runtime-independent behavioural discriminator: the fx descriptor seats `:event/kind :fx` + the `:rf/fx-handler` wrapper (NOT `:rf/db-handler`/`:event/kind :db`) and dispatches with the cofx-in/effects-out `{:db …}` contract end-to-end.

The existing `install-event-kind-tag-routes-through-reg-event-fx` test was renamed/retargeted to `…-routes-through-reg-event`; the untagged `install-lowers-the-four-wired-kinds…` test is unchanged (untagged still lowers through `reg-event-db`).

## Manifest delta

**None.** Only a private install seam + tests changed; no public facade export added/removed. `api-manifest --check`: in sync (506 public vars). Old-form rows untouched.

## Quality gates

All run from the worker worktree (bounded core nses + isolated surfaces; the full core-JVM spine is CI-Linux-covered per the Windows-deadlock note).

- **api-manifest `--check`**: `OK: spec/api-manifest.edn in sync (506 public vars).`
- **bounded core JVM nses** (events/core/app_value + the new/changed tests):
  - `handler-source-test` + `source-coords-test`: 32 tests, 162 assertions, 0 failures, 0 errors
  - `app-value-install-cljs-test` + `app-value-cljs-test`: 48 tests, 290 assertions, 0 failures, 0 errors (and `app-value-install-cljs-test` solo after the test fix: 35 tests, 244 assertions, 0/0)
  - `reg-event-cljs-test` + `smoke-test`: 45 tests, 169 assertions, 0 failures, 0 errors
- **`npm run test:cljs`**: 7163 tests, 29536 assertions, 0 failures, 0 errors
- **`npm run test:elision`**: PASS — production 42/42 absent, control 42/42 present
- **`mkdocs build --strict`**: built successfully (only pre-existing INFO relative-link notes, unrelated to this PR)
- **slug + link checks** (`check_doc_slugs.py`, `check_readme_links.py`): clean (exit 0)

Beads: rf2-xhfxcs.3, rf2-xhfxcs.4. Do NOT merge.
