### PR TITLE
examples: EP-0018 J — migrate to reg-event (rf2-xhfxcs.10)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -6,7 +6,7 @@
    the React state model is hooks all the way down. Demonstrates:
 
      - `rf/init!` with the Helix adapter
-     - `reg-event-db` / `reg-event-fx` / `reg-sub` (substrate-agnostic)
+     - `reg-event` / `reg-sub` (substrate-agnostic)
      - `use-subscribe` hook (Helix idiomatic)
      - `(:dispatch (rf/frame-handle))` for click handlers (components
        call dispatch / use-subscribe directly, no auto-injection)
@@ -44,14 +44,14 @@
 ;; example is the SUBSTRATE BOUNDARY below — same dataflow, three view layers
 ;; — not a file-extraction boundary.
 
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:counter/value 5}))
+(rf/reg-event :counter/initialise
+  (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :counter/value dec)))
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event] {:db (update db :counter/value dec)}))
 
 (rf/reg-sub :counter/value
   (fn [db _query] (:counter/value db)))

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -86,7 +86,7 @@
 ;; mount/unmount (e.g. a hot-reload teardown) therefore leaves at most one
 ;; live tick chain, and a teardown leaves none.
 
-(rf/reg-event-fx :monitor/initialise
+(rf/reg-event :monitor/initialise
   (fn [{:keys [db]} _event]
     (let [next-gen (inc (:monitor/tick-gen db 0))]
       {:db {:monitor/processes initial-processes
@@ -97,7 +97,7 @@
             :monitor/tick-gen   next-gen}
        :fx [[:dispatch-later {:ms 1800 :event [:monitor/tick next-gen]}]]})))
 
-(rf/reg-event-fx :monitor/tick
+(rf/reg-event :monitor/tick
   (fn [{:keys [db]} [_ gen]]
     (if (not= gen (:monitor/tick-gen db))
       ;; Stale tick from a retired generation (a later initialise bumped
@@ -132,21 +132,21 @@
 ;; `:monitor/tick` carries a now-stale generation and no-ops. Dispatched from
 ;; the `monitor` component's `use-effect` cleanup on unmount, so the loop
 ;; never outlives the rendered root.
-(rf/reg-event-db :monitor/stop
-  (fn [db _event]
-    (update db :monitor/tick-gen (fnil inc 0))))
+(rf/reg-event :monitor/stop
+  (fn [{:keys [db]} _event]
+    {:db (update db :monitor/tick-gen (fnil inc 0))}))
 
-(rf/reg-event-db :monitor/toggle-level
-  (fn [db [_ level]]
-    (update db :monitor/level-filter
+(rf/reg-event :monitor/toggle-level
+  (fn [{:keys [db]} [_ level]]
+    {:db (update db :monitor/level-filter
             (fn [levels] (if (contains? levels level)
                            (disj levels level)
-                           (conj levels level))))))
+                           (conj levels level))))}))
 
-(rf/reg-event-db :monitor/select-process
-  (fn [db [_ id]]
-    (assoc db :monitor/selected
-              (if (= id (:monitor/selected db)) nil id))))
+(rf/reg-event :monitor/select-process
+  (fn [{:keys [db]} [_ id]]
+    {:db (assoc db :monitor/selected
+              (if (= id (:monitor/selected db)) nil id))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -25,14 +25,14 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:counter/value 5}))
+(rf/reg-event :counter/initialise
+  (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :counter/value dec)))
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event] {:db (update db :counter/value dec)}))
 
 (rf/reg-sub :counter/value
   (fn [db _query] (:counter/value db)))

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -90,13 +90,13 @@
 ;; :hydrating transition to write the loaded values into the
 ;; top-level app-db slices.
 
-(rf/reg-event-db :boot/stage-payload
+(rf/reg-event :boot/stage-payload
   {:doc "Write a child-loaded payload into the boot machine's
          staging slot. Dispatched by the :boot/loader child's
          :dispatch-done action just before it fires the join-completion
          event back to the parent."}
-  (fn handler-boot-stage-payload [db [_ staging-key payload]]
-    (assoc-in db [:boot/staging staging-key] payload)))
+  (fn handler-boot-stage-payload [{:keys [db]} [_ staging-key payload]]
+    {:db (assoc-in db [:boot/staging staging-key] payload)}))
 
 ;; ============================================================================
 ;; CHILD LOADER MACHINE — :boot/loader
@@ -356,14 +356,14 @@
 ;; HYDRATION PROMOTION
 ;; ============================================================================
 ;;
-;; A plain reg-event-fx does the cross-slice writes the boot
+;; A plain reg-event does the cross-slice writes the boot
 ;; machine's :hydrating action dispatches. Keeping the cross-slice
 ;; reads / writes in an explicit handler (not inside the machine's
 ;; action body) makes the boot trace one-step inspectable: the
 ;; machine's `:enter-hydrating` action is one trace; the
 ;; :boot/apply-hydration handler is another.
 
-(rf/reg-event-fx :boot/apply-hydration
+(rf/reg-event :boot/apply-hydration
   {:doc "Promote every staged child payload at [:boot/staging ...]
          into the canonical top-level app-db slices the running app
          reads. Fires :boot/hydrated back at :app/boot to transition
@@ -404,7 +404,7 @@
 ;; PUBLIC ENTRY EVENT
 ;; ============================================================================
 
-(rf/reg-event-fx :boot/initialise
+(rf/reg-event :boot/initialise
   {:doc "Top-level app boot. Fires the :app/boot machine's
          `:rf.machine/start` creation marker to kick the boot sequence
          off — the machine is born directly into `:configuring` and runs

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -80,7 +80,7 @@
       (str/includes? u "/user.json")   demo-user
       :else                            {})))
 
-(rf/reg-event-fx :boot.demo/schedule-reply
+(rf/reg-event :boot.demo/schedule-reply
   {:doc "Private — entered via dispatch from :boot.demo/http-stub. Uses
          `:dispatch-later` so framework time controls (Tool-Pair
          time-travel, the documented `:dispatch-later` nil-override
@@ -91,7 +91,7 @@
            {:ms    60
             :event [:boot.demo/deliver-reply args-map payload]}]]}))
 
-(rf/reg-event-fx :boot.demo/deliver-reply
+(rf/reg-event :boot.demo/deliver-reply
   {:doc "Private — fired by the :dispatch-later scheduled in
          :boot.demo/schedule-reply. Delegates to the framework-shipped
          `:rf.http/managed-canned-success` with the per-URL canned

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -1,7 +1,7 @@
 (ns counter.core
   "A minimal counter against the re-frame2 API.
 
-   Demonstrates: `reg-event-db`, `reg-sub`, `reg-view` with frame-bound
+   Demonstrates: `reg-event`, `reg-sub`, `reg-view` with frame-bound
    `dispatch`/`subscribe` injection."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core    :as rf]
@@ -11,14 +11,14 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:counter/value 5}))
+(rf/reg-event :counter/initialise
+  (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :counter/value dec)))
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event] {:db (update db :counter/value dec)}))
 
 (rf/reg-sub :counter/value
   (fn [db _query] (:counter/value db)))

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -115,37 +115,37 @@
    {:sku "RF2-TEE"   :name "Six-domino t-shirt" :price 3200 :qty 2}
    {:sku "RF2-STKR"  :name "Sticker pack"       :price 500  :qty 3}])
 
-(rf/reg-event-db :cart/initialise
+(rf/reg-event :cart/initialise
   {:doc "Seed the cart. The :cart/subtotal and :cart/total flows fire right
          after THIS event's handler (before the db install) and materialise
          their outputs — a newly-registered flow's first walk always
          recomputes."}
-  (fn handler-cart-initialise [db _]
-    (assoc db :cart {:items seed-items})))
+  (fn handler-cart-initialise [{:keys [db]} _]
+    {:db (assoc db :cart {:items seed-items})}))
 
-(rf/reg-event-db :cart/inc-qty
+(rf/reg-event :cart/inc-qty
   {:doc    "Bump a line item's quantity. Touching [:cart :items] re-fires
             :cart/subtotal (its input changed), which in turn re-fires
             :cart/total — the cascade settles in one walk."
    :schema [:cat [:= :cart/inc-qty] :string]}
-  (fn handler-cart-inc-qty [db [_ sku]]
-    (update-in db [:cart :items]
+  (fn handler-cart-inc-qty [{:keys [db]} [_ sku]]
+    {:db (update-in db [:cart :items]
                (fn [items]
                  (mapv (fn [item]
                          (cond-> item
                            (= sku (:sku item)) (update :qty inc)))
-                       items)))))
+                       items)))}))
 
-(rf/reg-event-db :cart/dec-qty
+(rf/reg-event :cart/dec-qty
   {:doc    "Drop a line item's quantity (min 1)."
    :schema [:cat [:= :cart/dec-qty] :string]}
-  (fn handler-cart-dec-qty [db [_ sku]]
-    (update-in db [:cart :items]
+  (fn handler-cart-dec-qty [{:keys [db]} [_ sku]]
+    {:db (update-in db [:cart :items]
                (fn [items]
                  (mapv (fn [item]
                          (cond-> item
                            (= sku (:sku item)) (update :qty #(max 1 (dec %)))))
-                       items)))))
+                       items)))}))
 
 ;; Runtime-toggleable derivation (Spec 013 §Dynamic toggle via fx). The
 ;; discount flow is registered / cleared mid-event via the two reserved
@@ -161,7 +161,7 @@
 ;; discounted figure. The re-walk is driven by the dispatched event
 ;; draining — NOT by `:cart/touch` writing anything (it writes nothing).
 ;; This is the spec's own `:wizard/settle` pattern (§Sequencing).
-(rf/reg-event-fx :cart/apply-discount
+(rf/reg-event :cart/apply-discount
   {:doc "Engage the 10%-off feature gate by registering a flow that writes
          the discount rate, then nudge a re-walk so :cart/total recomputes."}
   (fn handler-cart-apply-discount [_ _]
@@ -176,7 +176,7 @@
             :path   [:cart :discount-rate]}]
           [:dispatch [:cart/touch]]]}))
 
-(rf/reg-event-fx :cart/remove-discount
+(rf/reg-event :cart/remove-discount
   {:doc "Disengage the feature gate. `:rf.fx/clear-flow` removes the flow
          AND dissoc-in's its [:cart :discount-rate] output back to nil, so
          :cart/total recomputes to the full price on the next walk."}
@@ -191,17 +191,17 @@
 ;; now visible in the registry — materialising the one-drain-lagged
 ;; output. The toggle is the `:rf.fx/reg-flow` / `:rf.fx/clear-flow`
 ;; registration itself; this event is the drain that surfaces its effect.
-(rf/reg-event-db :cart/touch
+(rf/reg-event :cart/touch
   {:doc "No-op drain. Exists only to trigger the re-walk that materialises
          the one-event-lagged discount flow output (Spec 013 §Sequencing)."}
-  (fn handler-cart-touch [db _] db))
+  (fn handler-cart-touch [{:keys [db]} _] {:db db}))
 
 ;; Reading a flow's output inside an event handler — Spec 013 §Sub
 ;; integration (a). The handler reads [:cart :total] as plain `app-db`
 ;; data; no subscribe, no special flow accessor. This is the central
 ;; reason the total is a flow and not a sub: a sub's value lives in the
 ;; view-facing sub-cache and is awkward to read from a handler.
-(rf/reg-event-fx :checkout/place-order
+(rf/reg-event :checkout/place-order
   {:doc "Place the order. Reads the materialised :cart/total straight off
          app-db — the flow output IS ordinary application state."}
   (fn handler-checkout-place-order [{:keys [db]} _]

--- a/examples/reagent/login/stories.cljs
+++ b/examples/reagent/login/stories.cljs
@@ -118,7 +118,7 @@
 ;; cascade lands cleanly at `:authed`.
 ;; ---------------------------------------------------------------------------
 
-(rf/reg-event-fx :login.story/submit
+(rf/reg-event :login.story/submit
   {:doc "Story-shell driver for the auth-submit cascade. Dispatches the
          real `:auth.login/submit` sub-event so the machine's
          `:issue-request` action fires the real `:rf.http/managed` fx;

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -78,7 +78,7 @@
 ;; `:work/initialise` resets the parent flow machine to :idle;
 ;; `:ui/initialise` seeds the Show/Hide toggle to true.
 
-(rf/reg-event-fx :app/initialise
+(rf/reg-event :app/initialise
   {:doc "App boot. Fans out to per-feature initialisers."}
   (fn handler-app-initialise [_ _]
     {:fx [[:dispatch [:work/initialise]]

--- a/examples/reagent/long_running_work/views.cljs
+++ b/examples/reagent/long_running_work/views.cljs
@@ -177,13 +177,13 @@
 ;; running, the component unmounts → with-let's finally → dispatch
 ;; :cancel → parent exits :working → cascade tears every child down.
 
-(rf/reg-event-db :ui/initialise
-  (fn [db _]
-    (assoc db :ui {:show-bench? true})))
+(rf/reg-event :ui/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db :ui {:show-bench? true})}))
 
-(rf/reg-event-db :ui/toggle-bench
-  (fn [db _]
-    (update-in db [:ui :show-bench?] not)))
+(rf/reg-event :ui/toggle-bench
+  (fn [{:keys [db]} _]
+    {:db (update-in db [:ui :show-bench?] not)}))
 
 (rf/reg-sub :ui/show-bench?
   (fn [db _] (get-in db [:ui :show-bench?] true)))

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -426,7 +426,7 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-fx :work/initialise
+(rf/reg-event :work/initialise
   {:doc "Boot the parent machine to its :idle state."}
   (fn handler-work-initialise [_ _]
     {:fx [[:dispatch [:work/flow [:reset]]]]}))

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -82,11 +82,11 @@
 ;; Per spec/Conventions §Feature-modularity prefix convention every
 ;; app-db slot and sub-id carries the feature prefix; events already do.
 
-(rf/reg-event-db :counter/initialise
-  (fn [_db _ev]
-    {:counter/count  0
+(rf/reg-event :counter/initialise
+  (fn [{:keys [db]} _ev]
+    {:db {:counter/count  0
      :counter/status :idle
-     :counter/error  nil}))
+     :counter/error  nil}}))
 
 ;; -- +1 (real round-trip via Fetch) ------------------------------------------
 ;;
@@ -96,7 +96,7 @@
 ;; [:counter/+1 (assoc msg :rf/reply ...)] to the originating handler,
 ;; which branches on (:rf/reply msg) to apply the increment.
 
-(rf/reg-event-fx :counter/+1
+(rf/reg-event :counter/+1
   (fn [{:keys [db]} [_ msg]]
     (cond
       ;; Reply branch — increment by the delta the server returned.
@@ -121,7 +121,7 @@
 
 ;; -- Fail (real 404 from http-server) ----------------------------------------
 
-(rf/reg-event-fx :counter/fail
+(rf/reg-event :counter/fail
   (fn [{:keys [db]} [_ msg]]
     (cond
       (some-> msg :rf/reply :kind (= :failure))
@@ -151,7 +151,7 @@
 ;; same reply shape would land if the live fx ran the retry policy
 ;; against a real endpoint that 503'd once and then 200'd.
 
-(rf/reg-event-fx :counter/retry-recover
+(rf/reg-event :counter/retry-recover
   (fn [{:keys [db]} [_ msg]]
     (cond
       (some-> msg :rf/reply :kind (= :success))
@@ -241,7 +241,7 @@
                                   {:frame frame}))}))
     nil))
 
-(rf/reg-event-fx :counter/start-long
+(rf/reg-event :counter/start-long
   (fn [{:keys [db]} [_ msg]]
     (cond
       ;; Reply branch — the abort-fn dispatches :rf.http/aborted on
@@ -262,7 +262,7 @@
       {:db (assoc db :counter/status :loading :counter/error nil)
        :fx [[:counter/seed-long-request {:request-id long-request-id}]]})))
 
-(rf/reg-event-fx :counter/cancel
+(rf/reg-event :counter/cancel
   (fn [{:keys [db]} _]
     {:db db
      ;; Abort by request-id via the LIVE :rf.http/managed-abort fx. It

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -349,13 +349,13 @@
 ;; the machine directly) keeps the imperative bits (clear the form,
 ;; bump app-db) out of the view.
 
-(rf/reg-event-fx :nine-states.app/initialise
+(rf/reg-event :nine-states.app/initialise
   {:doc "Seed the form slice + reset the machine to its initial state."}
   (fn handler-app-initialise [{:keys [db]} _]
     {:db (assoc db :new-todo new-todo-defaults)
      :fx [[:dispatch [:ui/nine-states [:reset]]]]}))
 
-(rf/reg-event-fx :nine-states.demo/load
+(rf/reg-event :nine-states.demo/load
   {:doc "Drive a synthetic fetch through the demo HTTP stub. The reply
          folds back via :nine-states.demo/loaded → the machine's
          :fetch-succeeded event; the :data region's :always-cascade
@@ -370,7 +370,7 @@
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
-(rf/reg-event-fx :nine-states.demo/load-with-failure
+(rf/reg-event :nine-states.demo/load-with-failure
   {:doc "Drive a synthetic failing fetch — the :data region lands in
          :error."}
   (fn handler-demo-load-with-failure [_ _]
@@ -381,13 +381,13 @@
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
-(rf/reg-event-fx :nine-states.demo/loaded
+(rf/reg-event :nine-states.demo/loaded
   {:doc "Successful fetch. Forwards the items to the machine via
          :fetch-succeeded; the :always-cascade picks the bucket."}
   (fn handler-demo-loaded [_ [_ {:keys [value]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-succeeded {:items value}]]]]}))
 
-(rf/reg-event-fx :nine-states.demo/load-failed
+(rf/reg-event :nine-states.demo/load-failed
   {:doc "Failed fetch. Forwards the failure category to the machine."}
   (fn handler-demo-load-failed [_ [_ {:keys [failure]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-failed {:failure failure}]]]]}))
@@ -404,7 +404,7 @@
     (and title (> (count title) 80))
     (assoc :title ["Title must be at most 80 characters."])))
 
-(rf/reg-event-fx :new-todo/edit-field
+(rf/reg-event :new-todo/edit-field
   {:doc  "User edited a form field. Updates :draft and marks the field
           touched; broadcasts :edit into the machine so the :form region
           returns from :correct or :incorrect to :neutral."
@@ -415,7 +415,7 @@
              (update-in [:new-todo :touched]    conj field))
      :fx [[:dispatch [:ui/nine-states [:edit]]]]}))
 
-(rf/reg-event-fx :new-todo/submit
+(rf/reg-event :new-todo/submit
   {:doc "Validate the draft. If invalid → :submit-invalid (the :form
          region lands in :incorrect). If valid → append to the
          machine's :data items via :fetch-succeeded, clear the draft,

--- a/examples/reagent/nine_states/stories.cljs
+++ b/examples/reagent/nine_states/stories.cljs
@@ -122,7 +122,7 @@
   (vec (for [i (range n)]
          {:id (random-uuid) :title (str "Todo #" (inc i)) :done? false})))
 
-(rf/reg-event-fx :nine-states.story/load
+(rf/reg-event :nine-states.story/load
   {:doc "Story-shell variant of `:nine-states.demo/load`. Drives the
          same real fetch cascade — `:fetch-started` → `:rf.http/managed`
          → reply → `:fetch-succeeded` — but carries the synthetic todos
@@ -139,7 +139,7 @@
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
-(rf/reg-event-fx :nine-states.story/load-failing
+(rf/reg-event :nine-states.story/load-failing
   {:doc "Story-shell variant of `:nine-states.demo/load-with-failure`.
          Drives the same real fetch cascade — `:fetch-started` →
          `:rf.http/managed` → reply → `:fetch-failed` — into the

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -57,23 +57,23 @@
 ;; EVENTS  (CP-1)
 ;; ============================================================================
 
-(rf/reg-event-db :notebook/initialise
-  (fn [_db _event]
-    {:notebook/documents   initial-documents
-     :notebook/selected-id :welcome}))
+(rf/reg-event :notebook/initialise
+  (fn [{:keys [db]} _event]
+    {:db {:notebook/documents   initial-documents
+     :notebook/selected-id :welcome}}))
 
-(rf/reg-event-db :notebook/select
-  (fn [db [_ id]]
-    (assoc db :notebook/selected-id id)))
+(rf/reg-event :notebook/select
+  (fn [{:keys [db]} [_ id]]
+    {:db (assoc db :notebook/selected-id id)}))
 
-(rf/reg-event-db :notebook/edit-body
-  (fn [db [_ text]]
-    (let [id (:notebook/selected-id db)]
+(rf/reg-event :notebook/edit-body
+  (fn [{:keys [db]} [_ text]]
+    {:db (let [id (:notebook/selected-id db)]
       (update db :notebook/documents
               (fn [docs]
                 (mapv (fn [d]
                         (if (= (:id d) id) (assoc d :body text) d))
-                      docs))))))
+                      docs))))}))
 
 ;; EP-0010 (Causal World Inputs): the new document's id is written into durable
 ;; app-db (`:notebook/documents`), so it must be a function of prior frame-state
@@ -96,13 +96,13 @@
                      (apply max 0))]
     (keyword (str "doc-" (inc used-ns)))))
 
-(rf/reg-event-db :notebook/new
-  (fn [db _event]
-    (let [id  (allocate-next-doc-id (:notebook/documents db))
+(rf/reg-event :notebook/new
+  (fn [{:keys [db]} _event]
+    {:db (let [id  (allocate-next-doc-id (:notebook/documents db))
           doc {:id id :title "Untitled" :body "# Untitled\n\nStart writing…"}]
       (-> db
           (update :notebook/documents (fnil conj []) doc)
-          (assoc :notebook/selected-id id)))))
+          (assoc :notebook/selected-id id)))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS  (CP-2)

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -207,7 +207,7 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-fx :editor/initialise
+(rf/reg-event :editor/initialise
   {:doc "Reset the editor slice + machine, and register the
          `:editor/can-submit?` flow against the dispatching frame (Spec
          013 §Dynamic toggle via fx). The flow's first walk fires on the
@@ -218,7 +218,7 @@
      :fx [[:dispatch [:ui/article-editor [:reset]]]
           [:rf.fx/reg-flow can-submit-flow]]}))
 
-(rf/reg-event-fx :editor/load-article
+(rf/reg-event :editor/load-article
   {:doc "Load an existing article into the editor in :edit mode.
          data-fetch retry policy applies (Spec 014). Broadcasts
          `:use-edit` so the :mode region tracks the edit-load and
@@ -239,29 +239,29 @@
                           :on-success [:editor/loaded]
                           :on-failure [:editor/load-failed]})]]})))
 
-(rf/reg-event-fx :editor/loaded
+(rf/reg-event :editor/loaded
   (fn [{:keys [db]} [_ {:keys [value]}]]
     (let [article (:article value)
           draft   (draft-from-article article)]
       {:db (assoc db :editor (editor-slice (:slug article) draft))
        :fx [[:dispatch [:ui/article-editor [:fetch-succeeded]]]]})))
 
-(rf/reg-event-fx :editor/load-failed
+(rf/reg-event :editor/load-failed
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     {:db (assoc-in db [:editor :submit-error] (rh/failure->message failure))
      :fx [[:dispatch [:ui/article-editor [:fetch-failed]]]]}))
 
-(rf/reg-event-db :editor/edit-field
-  (fn [db [_ field value]]
-    (-> db
+(rf/reg-event :editor/edit-field
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:editor :draft field] value)
-        (update-in [:editor :touched] (fnil conj #{}) field))))
+        (update-in [:editor :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-db :editor/blur-field
-  (fn [db [_ field]]
-    (update-in db [:editor :touched] (fnil conj #{}) field)))
+(rf/reg-event :editor/blur-field
+  (fn [{:keys [db]} [_ field]]
+    {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
 
-(rf/reg-event-fx :editor/submit
+(rf/reg-event :editor/submit
   {:doc "Save the article (POST for create, PUT for edit). NO retry — the
          user's intent is one submission per click; surface errors so the
          user can decide whether to retry (Spec 014).
@@ -321,7 +321,7 @@
                             :on-success [:editor/submit-success]
                             :on-failure [:editor/submit-error]})]]}))))
 
-(rf/reg-event-fx :editor/submit-success
+(rf/reg-event :editor/submit-success
   (fn [{:keys [db]} [_ {:keys [value]}]]
     (let [article (:article value)
           draft   (draft-from-article article)]
@@ -330,12 +330,12 @@
             [:dispatch [:ui/article-editor [:submit-succeeded]]]
             [:dispatch [:rf.route/navigate :realworld.article/show {:slug (:slug article)}]]]})))
 
-(rf/reg-event-fx :editor/submit-error
+(rf/reg-event :editor/submit-error
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     {:db (assoc-in db [:editor :submit-error] (rh/failure->message failure))
      :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))
 
-(rf/reg-event-fx :editor/delete
+(rf/reg-event :editor/delete
   {:doc "Delete the article. No retry — destructive action, one click.
          Broadcasts `:submit-started` so the lifecycle region advances
          to :submitting (which carries the :editor/busy tag)."}
@@ -351,13 +351,13 @@
                           :on-success [:editor/delete-success]
                           :on-failure [:editor/delete-error]})]]})))
 
-(rf/reg-event-fx :editor/delete-success
+(rf/reg-event :editor/delete-success
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:ui/article-editor [:reset]]]
           [:dispatch [:rf.route/navigate :realworld/home]]]}))
 
-(rf/reg-event-fx :editor/delete-error
+(rf/reg-event :editor/delete-error
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     {:db (assoc-in db [:editor :submit-error] (rh/failure->message failure))
      :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -209,7 +209,7 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-fx :articles/initialise
+(rf/reg-event :articles/initialise
   {:doc "Seed the global-articles slice to the standard idle shape and
          reset the home machine to its initial configuration."}
   (fn [{:keys [db]} _]
@@ -220,7 +220,7 @@
 ;; GLOBAL FEED
 ;; ============================================================================
 
-(rf/reg-event-fx :articles/load
+(rf/reg-event :articles/load
   {:doc "Fetch the global articles list, optionally filtered by the route's
          `?tag=` query parameter. Uses :rf.http/managed (Spec 014) with
          a Malli-decoded response and the standard data-fetch retry policy.
@@ -261,7 +261,7 @@
                           :on-success [:articles/loaded]
                           :on-failure [:articles/load-failed]})]]})))
 
-(rf/reg-event-fx :articles/loaded
+(rf/reg-event :articles/loaded
   {:doc "Successful fetch. Replace the list and clear any prior error.
          Receives `{:kind :success :value <ArticlesResponse>}` from
          Spec 014's reply-addressing. Folds the new count into the home
@@ -283,7 +283,7 @@
        :fx [[:dispatch [:realworld/articles-home
                         [:fetch-succeeded {:items items}]]]]})))
 
-(rf/reg-event-fx :articles/load-failed
+(rf/reg-event :articles/load-failed
   {:doc "Failed fetch. Keep prior data when present and surface a
          human-readable error message (projected from the Spec 014
          failure map). Folds the failure into the home machine via
@@ -296,13 +296,13 @@
        :fx [[:dispatch [:realworld/articles-home
                         [:fetch-failed {:failure message}]]]]})))
 
-(rf/reg-event-fx :articles/cancel
+(rf/reg-event :articles/cancel
   {:doc "Abort an in-flight :articles/load. Useful when the user navigates
          away from the home page mid-fetch (Spec 014 §Aborts)."}
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :articles/load]]}))
 
-(rf/reg-event-fx :articles/reset
+(rf/reg-event :articles/reset
   (fn [{:keys [db]} _]
     {:db (assoc db :articles (request-slice []))
      :fx [[:dispatch [:realworld/articles-home [:reset]]]]}))

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -97,19 +97,19 @@
 ;; SUPPORT EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :auth/store-session
-  (fn [db [_ user]]
-    (-> db
+(rf/reg-event :auth/store-session
+  (fn [{:keys [db]} [_ user]]
+    {:db (-> db
         (assoc-in [:auth :user] user)
-        (assoc-in [:auth :token] (:token user)))))
+        (assoc-in [:auth :token] (:token user)))}))
 
-(rf/reg-event-db :auth/clear-session
-  (fn [db _]
-    (-> db
+(rf/reg-event :auth/clear-session
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (assoc-in [:auth :user] nil)
-        (assoc-in [:auth :token] nil))))
+        (assoc-in [:auth :token] nil))}))
 
-(rf/reg-event-fx :auth/post-login-redirect
+(rf/reg-event :auth/post-login-redirect
   {:doc "Bounce the freshly-authenticated user back to the route the auth
          guard intercepted (`[:auth :return-to]`, set in routing.cljs), or
          home when there is none. Dispatched by the auth machine's
@@ -248,7 +248,7 @@
 ;; INITIALISATION + SESSION RESTORE
 ;; ============================================================================
 
-(rf/reg-event-fx :auth/initialise
+(rf/reg-event :auth/initialise
   {:rf.cofx/requires [:auth.session/token]}
   (fn handler-auth-initialise [{:keys [db auth.session/token]} _]
     ;; ITEM 8 (rf2-ygh4m): we dispatch `:auth/flow [:auth/restore token]`
@@ -273,25 +273,25 @@
 (def login-form-defaults    {:email "" :password ""})
 (def register-form-defaults {:username "" :email "" :password ""})
 
-(rf/reg-event-db :auth.login-form/initialise
-  (fn [db _]
-    (assoc-in db [:auth :login-form]
+(rf/reg-event :auth.login-form/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :login-form]
               {:draft             login-form-defaults
                :submitted         nil
                :status            :idle
                :errors            {}
                :touched           #{}
                :submit-attempted? false
-               :submit-error      nil})))
+               :submit-error      nil})}))
 
-(rf/reg-event-db :auth.login-form/edit-field
+(rf/reg-event :auth.login-form/edit-field
   {:schema [:cat [:= :auth.login-form/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:auth :login-form :draft field] value)
-        (update-in [:auth :login-form :touched] (fnil conj #{}) field))))
+        (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-fx :auth.login-form/submit
+(rf/reg-event :auth.login-form/submit
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:auth :login-form :draft])]
       {:db (-> db
@@ -299,24 +299,24 @@
                (assoc-in [:auth :login-form :status] :submitting))
        :fx [[:dispatch [:auth/flow [:auth/login draft]]]]})))
 
-(rf/reg-event-db :auth.register-form/initialise
-  (fn [db _]
-    (assoc-in db [:auth :register-form]
+(rf/reg-event :auth.register-form/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :register-form]
               {:draft             register-form-defaults
                :submitted         nil
                :status            :idle
                :errors            {}
                :touched           #{}
                :submit-attempted? false
-               :submit-error      nil})))
+               :submit-error      nil})}))
 
-(rf/reg-event-db :auth.register-form/edit-field
-  (fn [db [_ field value]]
-    (-> db
+(rf/reg-event :auth.register-form/edit-field
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:auth :register-form :draft field] value)
-        (update-in [:auth :register-form :touched] (fnil conj #{}) field))))
+        (update-in [:auth :register-form :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-fx :auth.register-form/submit
+(rf/reg-event :auth.register-form/submit
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:auth :register-form :draft])]
       {:db (-> db

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -36,25 +36,25 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-db :article/initialise
-  (fn [db _]
-    (assoc db :article {:status :idle :data nil :error nil
-                        :loaded-at nil :attempt 0})))
+(rf/reg-event :article/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db :article {:status :idle :data nil :error nil
+                        :loaded-at nil :attempt 0})}))
 
-(rf/reg-event-db :comments/initialise
-  (fn [db _]
-    (assoc db :comments {:status :idle :data [] :error nil
-                         :loaded-at nil :attempt 0})))
+(rf/reg-event :comments/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db :comments {:status :idle :data [] :error nil
+                         :loaded-at nil :attempt 0})}))
 
-(rf/reg-event-db :comment-form/initialise
-  (fn [db _]
-    (assoc db :comment-form (comment-form-defaults))))
+(rf/reg-event :comment-form/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db :comment-form (comment-form-defaults))}))
 
 ;; ============================================================================
 ;; ARTICLE
 ;; ============================================================================
 
-(rf/reg-event-fx :article/load
+(rf/reg-event :article/load
   {:doc "Load the article matching `[:rf.runtime/routing :current :params :slug]`
          (EP-0001: the route slice is durable runtime-db state).
 
@@ -100,7 +100,7 @@
 ;; COMMENTS
 ;; ============================================================================
 
-(rf/reg-event-fx :comments/load
+(rf/reg-event :comments/load
   {:doc "Load comments for the current article. Uses explicit success /
          failure handlers (cf. :article/load above which uses default
          reply addressing) — both shapes are valid Spec 014; pick whichever
@@ -122,7 +122,7 @@
                           :on-success [:comments/loaded]
                           :on-failure [:comments/load-failed]})]]})))
 
-(rf/reg-event-fx :comments/loaded
+(rf/reg-event :comments/loaded
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     {:db (-> db
@@ -131,23 +131,23 @@
              (assoc-in [:comments :error] nil)
              (assoc-in [:comments :loaded-at] time-ms))}))
 
-(rf/reg-event-db :comments/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
+(rf/reg-event :comments/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
         (assoc-in [:comments :status] :error)
-        (assoc-in [:comments :error] (rh/failure->message failure)))))
+        (assoc-in [:comments :error] (rh/failure->message failure)))}))
 
 ;; ============================================================================
 ;; COMMENT FORM
 ;; ============================================================================
 
-(rf/reg-event-db :comment-form/edit-field
-  (fn [db [_ field value]]
-    (-> db
+(rf/reg-event :comment-form/edit-field
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:comment-form :draft field] value)
-        (update-in [:comment-form :touched] (fnil conj #{}) field))))
+        (update-in [:comment-form :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-fx :comment-form/submit
+(rf/reg-event :comment-form/submit
   {:doc "Optimistically post a new comment. NO retry — the user clicked
          once. The temp-id correlates the optimistic UI card with the
          eventual save / rollback (Spec 014 - explicit on-success/on-failure
@@ -194,9 +194,9 @@
                             :on-success [:comment-form/submit-success temp-id]
                             :on-failure [:comment-form/submit-error temp-id]})]]}))))
 
-(rf/reg-event-db :comment-form/submit-success
-  (fn [db [_ temp-id {:keys [value]}]]
-    (let [saved (:comment value)]
+(rf/reg-event :comment-form/submit-success
+  (fn [{:keys [db]} [_ temp-id {:keys [value]}]]
+    {:db (let [saved (:comment value)]
       (-> db
           (assoc-in [:comment-form] (comment-form-defaults))
           ;; Replace the optimistic temp card IN PLACE with the saved
@@ -208,19 +208,19 @@
                      (fn [comments]
                        (mapv (fn [comment]
                                (if (= temp-id (:id comment)) saved comment))
-                             (or comments []))))))))
+                             (or comments []))))))}))
 
-(rf/reg-event-db :comment-form/submit-error
-  (fn [db [_ temp-id {:keys [failure]}]]
-    (-> db
+(rf/reg-event :comment-form/submit-error
+  (fn [{:keys [db]} [_ temp-id {:keys [failure]}]]
+    {:db (-> db
         (update-in [:comments :data]
                    (fn [comments]
                      (vec (remove #(= temp-id (:id %)) comments))))
         (assoc-in [:comment-form :status] :idle)
         (assoc-in [:comment-form :submit-error]
-                  (rh/failure->message failure)))))
+                  (rh/failure->message failure)))}))
 
-(rf/reg-event-fx :comment/delete
+(rf/reg-event :comment/delete
   {:doc "Optimistically remove a comment, then DELETE. On failure, the
          rollback handler re-inserts the comment at its original index."}
   (fn [{:keys [db] rt :rf.db/runtime} [_ id]]
@@ -239,12 +239,12 @@
                           :on-success [:comment/delete-success id]
                           :on-failure [:comment/delete-rollback prior]})]]})))
 
-(rf/reg-event-db :comment/delete-success
-  (fn [db _] db))
+(rf/reg-event :comment/delete-success
+  (fn [{:keys [db]} _] {:db db}))
 
-(rf/reg-event-db :comment/delete-rollback
-  (fn [db [_ {:keys [index comment]} _failure-payload]]
-    (if (and (some? index) comment)
+(rf/reg-event :comment/delete-rollback
+  (fn [{:keys [db]} [_ {:keys [index comment]} _failure-payload]]
+    {:db (if (and (some? index) comment)
       (update-in db [:comments :data]
                  (fn [xs]
                    ;; Clamp to the CURRENT length: the captured index is from
@@ -257,7 +257,7 @@
                      (vec (concat (subvec xs 0 i)
                                   [comment]
                                   (subvec xs i))))))
-      db)))
+      db)}))
 
 ;; ============================================================================
 ;; ARTICLE-DETAIL SOCIAL CONTROLS  (rf2-2xi8sr)
@@ -271,7 +271,7 @@
 ;; distinct from profile.cljs's `:profile/follow` which targets the profile-page
 ;; banner slice.
 
-(rf/reg-event-fx :article/toggle-follow-author
+(rf/reg-event :article/toggle-follow-author
   {:doc "Optimistically toggle following the article's author, then POST/DELETE
          /profiles/:username/follow. On failure the prior flag is restored.
          Auth-gated (same rationale as :article/toggle-favorite): a logged-out
@@ -294,17 +294,17 @@
                               :on-success [:article/author-follow-synced]
                               :on-failure [:article/author-follow-rollback following?]})]]})))))
 
-(rf/reg-event-db :article/author-follow-synced
-  (fn [db [_ {:keys [value]}]]
-    (if-let [profile (:profile value)]
+(rf/reg-event :article/author-follow-synced
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (if-let [profile (:profile value)]
       (assoc-in db [:article :data :author] profile)
-      db)))
+      db)}))
 
-(rf/reg-event-db :article/author-follow-rollback
-  (fn [db [_ previous-following _failure-payload]]
-    (assoc-in db [:article :data :author :following] previous-following)))
+(rf/reg-event :article/author-follow-rollback
+  (fn [{:keys [db]} [_ previous-following _failure-payload]]
+    {:db (assoc-in db [:article :data :author :following] previous-following)}))
 
-(rf/reg-event-fx :article/delete
+(rf/reg-event :article/delete
   {:doc "Delete the current article from the DETAIL page (author only). No
          retry — destructive, one click. On success navigate home; the editor's
          own Delete path (article_editor.cljs) remains reachable too."}
@@ -319,13 +319,13 @@
                             :on-success [:article/delete-success]
                             :on-failure [:article/delete-failed]})]]}))))
 
-(rf/reg-event-fx :article/delete-success
+(rf/reg-event :article/delete-success
   (fn [_ _]
     {:fx [[:dispatch [:rf.route/navigate :realworld/home]]]}))
 
-(rf/reg-event-db :article/delete-failed
-  (fn [db [_ {:keys [failure]}]]
-    (assoc-in db [:article :error] (rh/failure->message failure))))
+(rf/reg-event :article/delete-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (assoc-in db [:article :error] (rh/failure->message failure))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -76,7 +76,7 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-fx :app/initialise
+(rf/reg-event :app/initialise
   {:doc "App boot. Fans out to per-feature initialisers. `:auth/initialise` is
          NOT in this fan-out — it consumes the RECORDABLE+PROVIDED
          `:auth.session/token` coeffect, whose value the host boundary
@@ -259,7 +259,7 @@
                      "| --- | --- |\n"
                      "| markdown | CommonMark |\n"
                      "| links | scheme-allowlisted |\n\n"
-                     "```clojure\n(rf/reg-event-db :hello (fn [db _] db))\n```\n\n"
+                     "```clojure\n(rf/reg-event :hello (fn [{:keys [db]} _] {:db db}))\n```\n\n"
                      "> A blockquote, for good measure.")
           :tagList ["intro" "demo"]
           :createdAt "2026-01-01T00:00:00Z"

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -48,11 +48,11 @@
 ;; FEED
 ;; ============================================================================
 
-(rf/reg-event-db :feed/initialise
-  (fn [db _]
-    (assoc db :feed (request-slice))))
+(rf/reg-event :feed/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db :feed (request-slice))}))
 
-(rf/reg-event-fx :feed/load
+(rf/reg-event :feed/load
   {:doc "Fetch the authenticated user's feed. Tagged with
          `:request-id :feed/load` so :feed/cancel can abort an in-flight
          load when the user navigates away (Spec 014 §Aborts).
@@ -84,13 +84,13 @@
                           :on-success [:feed/loaded]
                           :on-failure [:feed/load-failed]})]]})))
 
-(rf/reg-event-fx :feed/cancel
+(rf/reg-event :feed/cancel
   {:doc "Abort an in-flight :feed/load. Useful when the user navigates
          away mid-load (Spec 014 §Aborts)."}
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :feed/load]]}))
 
-(rf/reg-event-fx :feed/loaded
+(rf/reg-event :feed/loaded
   {:doc "Successful user-feed fetch. Folds the new count into the home
          machine via `:fetch-succeeded`; the `:data` region's
          `:resolving` `:always`-cascade picks `:empty` or `:some`."
@@ -106,7 +106,7 @@
        :fx [[:dispatch [:realworld/articles-home
                         [:fetch-succeeded {:items items}]]]]})))
 
-(rf/reg-event-fx :feed/load-failed
+(rf/reg-event :feed/load-failed
   {:doc "Failed user-feed fetch. Folds the failure into the home machine
          via `:fetch-failed`; the `:data` region advances to `:error`."}
   (fn [{:keys [db]} [_ {:keys [failure]}]]
@@ -143,7 +143,7 @@
 ;; by `:comment-form/submit-success`'s in-place swap. So: shared where it
 ;; helps, distinct where the data shapes genuinely differ — not an oversight.
 
-(rf/reg-event-fx :article/toggle-favorite
+(rf/reg-event :article/toggle-favorite
   {:doc "Optimistically flip the favorited flag and bump the count, then
          POST or DELETE the favorite. On failure the prior state is
          restored (rollback).
@@ -176,22 +176,22 @@
                               :on-failure [:article/favorite-rollback slug prior]})]]})
         {}))))
 
-(rf/reg-event-db :article/favorite-synced
-  (fn [db [_ slug {:keys [value]}]]
-    (if-let [article (:article value)]
+(rf/reg-event :article/favorite-synced
+  (fn [{:keys [db]} [_ slug {:keys [value]}]]
+    {:db (if-let [article (:article value)]
       (patch-article-everywhere db slug
                                 (fn [_]
                                   (select-keys article
                                                [:slug :title :description :body :tagList
                                                 :createdAt :updatedAt :favorited
                                                 :favoritesCount :author])))
-      db)))
+      db)}))
 
-(rf/reg-event-db :article/favorite-rollback
-  (fn [db [_ slug {:keys [favorited favoritesCount]} _failure-payload]]
-    (patch-article-everywhere db slug
+(rf/reg-event :article/favorite-rollback
+  (fn [{:keys [db]} [_ slug {:keys [favorited favoritesCount]} _failure-payload]]
+    {:db (patch-article-everywhere db slug
                               #(assoc % :favorited favorited
-                                        :favoritesCount favoritesCount))))
+                                        :favoritesCount favoritesCount))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -190,7 +190,7 @@
 ;; stamps `:loaded-at` declares `:rf.cofx/requires [:rf/time-ms]` and reads the
 ;; `time-ms` value FLAT from its coeffects map (EP-0017 §4):
 ;;
-;;     (rf/reg-event-fx :feed/loaded
+;;     (rf/reg-event :feed/loaded
 ;;       {:rf.cofx/requires [:rf/time-ms]}
 ;;       (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
 ;;         {:db (assoc-in db [:feed :loaded-at] time-ms)}))

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -146,7 +146,7 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-fx :profile/initialise
+(rf/reg-event :profile/initialise
   (fn [{:keys [db]} _]
     {:db (-> db
              (assoc :profile (request-slice))
@@ -158,7 +158,7 @@
 ;; LOADS
 ;; ============================================================================
 
-(rf/reg-event-fx :profile/load
+(rf/reg-event :profile/load
   {:doc "Load the public profile (username, bio, image, following).
          Public endpoint; data-fetch retry.
 
@@ -183,7 +183,7 @@
                           :on-success [:profile/loaded]
                           :on-failure [:profile/load-failed]})]]})))
 
-(rf/reg-event-fx :profile/loaded
+(rf/reg-event :profile/loaded
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     {:db (-> db
@@ -193,7 +193,7 @@
              (assoc-in [:profile :loaded-at] time-ms))
      :fx [[:dispatch [:ui/profile [:fetch-succeeded]]]]}))
 
-(rf/reg-event-fx :profile/load-failed
+(rf/reg-event :profile/load-failed
   (fn [{:keys [db]} [_ {:keys [failure]}]]
     (let [message (rh/failure->message failure)]
       {:db (-> db
@@ -201,7 +201,7 @@
                (assoc-in [:profile :error] message))
        :fx [[:dispatch [:ui/profile [:fetch-failed {:failure message}]]]]})))
 
-(rf/reg-event-fx :profile.articles/load
+(rf/reg-event :profile.articles/load
   {:doc "Load the profile's authored articles. Public; data-fetch retry.
          Also broadcasts `:show-articles` so the `:ui/profile` :tab
          region tracks the active tab. `?page=` paginates the list via
@@ -225,7 +225,7 @@
                           :on-success [:profile.articles/loaded]
                           :on-failure [:profile.articles/load-failed]})]]})))
 
-(rf/reg-event-fx :profile.articles/loaded
+(rf/reg-event :profile.articles/loaded
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     {:db (-> db
@@ -235,13 +235,13 @@
                        (or (:articlesCount value) (count (:articles value))))
              (assoc-in [:profile.articles :loaded-at] time-ms))}))
 
-(rf/reg-event-db :profile.articles/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
+(rf/reg-event :profile.articles/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
         (assoc-in [:profile.articles :status] :error)
-        (assoc-in [:profile.articles :error] (rh/failure->message failure)))))
+        (assoc-in [:profile.articles :error] (rh/failure->message failure)))}))
 
-(rf/reg-event-fx :profile.favorites/load
+(rf/reg-event :profile.favorites/load
   {:doc "Load the profile's favorited articles. Public; data-fetch retry.
          Also broadcasts `:show-favorites` so the `:ui/profile` :tab
          region tracks the active tab. `?page=` paginates the list via
@@ -265,7 +265,7 @@
                           :on-success [:profile.favorites/loaded]
                           :on-failure [:profile.favorites/load-failed]})]]})))
 
-(rf/reg-event-fx :profile.favorites/loaded
+(rf/reg-event :profile.favorites/loaded
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     {:db (-> db
@@ -275,17 +275,17 @@
                        (or (:articlesCount value) (count (:articles value))))
              (assoc-in [:profile.favorites :loaded-at] time-ms))}))
 
-(rf/reg-event-db :profile.favorites/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
+(rf/reg-event :profile.favorites/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
         (assoc-in [:profile.favorites :status] :error)
-        (assoc-in [:profile.favorites :error] (rh/failure->message failure)))))
+        (assoc-in [:profile.favorites :error] (rh/failure->message failure)))}))
 
 ;; ============================================================================
 ;; FOLLOW / UNFOLLOW
 ;; ============================================================================
 
-(rf/reg-event-fx :profile/follow
+(rf/reg-event :profile/follow
   {:doc "Optimistically mark the profile as followed; reconcile on reply.
 
          Auth-gated (same rationale as favorites.cljs/:article/toggle-favorite):
@@ -305,11 +305,11 @@
                             :on-success [:profile/followed]
                             :on-failure [:profile/follow-rollback false]})]]}))))
 
-(rf/reg-event-db :profile/followed
-  (fn [db [_ {:keys [value]}]]
-    (assoc-in db [:profile :data] (:profile value))))
+(rf/reg-event :profile/followed
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc-in db [:profile :data] (:profile value))}))
 
-(rf/reg-event-fx :profile/unfollow
+(rf/reg-event :profile/unfollow
   {:doc "Optimistically clear the followed flag; reconcile on reply.
          Auth-gated like `:profile/follow` above."
    :rf.http/decode-schemas [schema/ProfileResponse]}
@@ -325,13 +325,13 @@
                             :on-success [:profile/unfollowed]
                             :on-failure [:profile/follow-rollback true]})]]}))))
 
-(rf/reg-event-db :profile/unfollowed
-  (fn [db [_ {:keys [value]}]]
-    (assoc-in db [:profile :data] (:profile value))))
+(rf/reg-event :profile/unfollowed
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc-in db [:profile :data] (:profile value))}))
 
-(rf/reg-event-db :profile/follow-rollback
-  (fn [db [_ previous-value _failure-payload]]
-    (assoc-in db [:profile :data :following] previous-value)))
+(rf/reg-event :profile/follow-rollback
+  (fn [{:keys [db]} [_ previous-value _failure-payload]]
+    {:db (assoc-in db [:profile :data :following] previous-value)}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -425,7 +425,7 @@
   (fn sub-profile-page-count [total _]
     (rh/page-count total)))
 
-(rf/reg-event-fx :profile/show-page
+(rf/reg-event :profile/show-page
   {:doc "Navigate to a 1-indexed pagination page for the active profile tab.
          Stays on the current profile route (authored vs favorited) and
          username; changing `?page=` re-fires the route `:on-match`, re-running

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -218,13 +218,13 @@
 ;; sibling namespaces (auth.cljs) need no change. Each one fans out to
 ;; one or more machine broadcasts.
 
-(rf/reg-event-fx :settings/initialise
+(rf/reg-event :settings/initialise
   {:doc "Reset the settings-form machine to its initial state.
          Dispatched from :app/initialise."}
   (fn handler-settings-initialise [_ _]
     {:fx [[:dispatch [:settings/form [:reset]]]]}))
 
-(rf/reg-event-fx :settings/load
+(rf/reg-event :settings/load
   {:doc "Seed the form draft from the currently-authenticated user.
          Dispatched by the :realworld.user/settings :on-match (see routing.cljs)
          and by tests after :auth/store-session."
@@ -235,7 +235,7 @@
                         [:load {:user user
                                 :now  time-ms}]]]]})))
 
-(rf/reg-event-fx :settings/edit-field
+(rf/reg-event :settings/edit-field
   {:doc  "User edited a form field. Broadcasts :edit into the machine —
           the :form region returns from :correct / :incorrect to
           :neutral and updates the draft + :touched."
@@ -244,7 +244,7 @@
     {:fx [[:dispatch [:settings/form
                       [:edit {:field field :value value}]]]]}))
 
-(rf/reg-event-fx :settings/submit
+(rf/reg-event :settings/submit
   {:doc "Save the user-settings draft. NO retry — single user-initiated
          submission per click (Spec 014). Broadcasts :submit-valid into
          the machine (which transitions to :submitting and clears
@@ -267,7 +267,7 @@
                           :on-success [:settings/submit-success]
                           :on-failure [:settings/submit-error]})]]})))
 
-(rf/reg-event-fx :settings/submit-success
+(rf/reg-event :settings/submit-success
   {:doc "Server accepted. Folds the new user into the machine's :data
          via the :store-user action (region lands in :correct), pushes
          the same user through :auth/store-session, and navigates to
@@ -279,7 +279,7 @@
             [:dispatch [:auth/store-session user]]
             [:dispatch [:rf.route/navigate :realworld.profile/show {:username (:username user)}]]]})))
 
-(rf/reg-event-fx :settings/submit-error
+(rf/reg-event :settings/submit-error
   {:doc "Server rejected. Folds a human-readable error message into the
          machine's :data via the :set-submit-error action; the region
          lands in :incorrect (the same surface the validation-error

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -146,7 +146,7 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-fx :tags/initialise
+(rf/reg-event :tags/initialise
   {:doc "Reset the popular-tags machine to its initial state. Dispatched
          from `:app/initialise` (see core.cljs)."}
   (fn handler-tags-initialise [_ _]
@@ -157,7 +157,7 @@
 ;; Pattern-RemoteData, translated into machine broadcasts.
 ;; ============================================================================
 
-(rf/reg-event-fx :tags/load
+(rf/reg-event :tags/load
   {:doc "Fetch the popular-tags list. Broadcasts `:fetch-started` into
          the `:realworld/tags` machine; the region picks `:loading` or
          `:fetching` based on whether prior tags are present (the
@@ -175,7 +175,7 @@
                         :on-success [:tags/loaded]
                         :on-failure [:tags/load-failed]})]]}))
 
-(rf/reg-event-fx :tags/loaded
+(rf/reg-event :tags/loaded
   {:doc "Successful tags fetch. Folds the list + a load timestamp into
          the machine's `:data` via the `:set-tags` action; the region
          lands in `:loaded`."
@@ -185,7 +185,7 @@
                       [:fetch-succeeded {:tags (vec (:tags value))
                                          :now  time-ms}]]]]}))
 
-(rf/reg-event-fx :tags/load-failed
+(rf/reg-event :tags/load-failed
   {:doc "Failed tags fetch. Folds a human-readable error message into
          the machine's `:data` via the `:set-error` action; the region
          lands in `:error`. Any prior tags remain in `:data` so the
@@ -249,7 +249,7 @@
      :feed (:feed query)
      :page (:page query)}))
 
-(rf/reg-event-fx :home/load
+(rf/reg-event :home/load
   {:doc "Route :on-match handler for `:realworld/home`. Reads the route's
          query params and:
            - broadcasts the `:feed` region into `:user-feed` / `:tag-feed`
@@ -285,15 +285,15 @@
 ;; `?feed=following`. `:home/show-page` re-targets whichever home route is
 ;; active (tag route keeps its `:tag` param) so paging stays within the tag.
 
-(rf/reg-event-fx :home/show-global-feed
+(rf/reg-event :home/show-global-feed
   (fn [_ _]
     {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {}}]]]}))
 
-(rf/reg-event-fx :home/show-your-feed
+(rf/reg-event :home/show-your-feed
   (fn [_ _]
     {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {:feed following-feed-token}}]]]}))
 
-(rf/reg-event-fx :home/show-page
+(rf/reg-event :home/show-page
   {:doc "Navigate to a 1-indexed pagination page for the active home feed,
          carrying the current feed / tag forward so paging stays within it. A
          tag-filtered list re-targets the `/tag/:tag` PATH route with the tag
@@ -308,11 +308,11 @@
         (let [query (cond-> {:page page} feed (assoc :feed feed))]
           {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query query}]]]})))))
 
-(rf/reg-event-fx :tags/apply-filter
+(rf/reg-event :tags/apply-filter
   (fn [_ [_ tag]]
     {:fx [[:dispatch [:rf.route/navigate :realworld/home-tag {:tag tag}]]]}))
 
-(rf/reg-event-fx :tags/clear-filter
+(rf/reg-event :tags/clear-filter
   (fn [_ _]
     ;; Clearing the tag leaves the `/tag/:tag` route entirely, back to the
     ;; global feed at `/` (page 1).

--- a/examples/reagent/realworld_resources/article_editor.cljs
+++ b/examples/reagent/realworld_resources/article_editor.cljs
@@ -201,7 +201,7 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-fx :editor/initialise
+(rf/reg-event :editor/initialise
   {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Reset the
          editor slice to a blank draft, clear any prior save instance, and
          register the `:editor/can-submit?` flow against the dispatching frame
@@ -211,7 +211,7 @@
      :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
           [:rf.fx/reg-flow can-submit-flow]]}))
 
-(rf/reg-event-fx :editor/load-article
+(rf/reg-event :editor/load-article
   {:doc "Edit-mode entry (`:realworld.editor/edit` `:on-match`). Seed the draft
          from the existing article via a one-shot resource ensure under a
          releaseable lease, register the flow, and clear any prior save
@@ -230,15 +230,15 @@
                          :owner    [:lease :editor/article slug]
                          :cause    [:route-entry :realworld.editor/edit]}]]]})))
 
-(rf/reg-event-db :editor/seed-from-article
+(rf/reg-event :editor/seed-from-article
   {:doc "Seed the editor draft + baseline from a loaded article. Dispatched by
          the editor page's Form-3 load reaction when the article read first
          settles with data (off the render path)."}
-  (fn [db [_ article]]
-    (let [draft (draft-from-article article)]
-      (assoc db :editor (editor-slice (:slug article) draft)))))
+  (fn [{:keys [db]} [_ article]]
+    {:db (let [draft (draft-from-article article)]
+      (assoc db :editor (editor-slice (:slug article) draft)))}))
 
-(rf/reg-event-fx :editor/release-article
+(rf/reg-event :editor/release-article
   {:doc "Release the edit-mode article lease (dispatched on unmount). Drops the
          editor's owner on the article read so it can go inactive / GC. The
          release path is mandatory for an app-minted lease (Spec 016 §Active
@@ -249,19 +249,19 @@
                         {:owner [:lease :editor/article slug]
                          :cause [:route-leave :realworld.editor/edit]}]]]})))
 
-(rf/reg-event-db :editor/edit-field
+(rf/reg-event :editor/edit-field
   {:schema [:cat [:= :editor/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:editor :draft field] value)
         (update-in [:editor :touched] (fnil conj #{}) field)
-        (update-in [:editor :errors] dissoc field))))
+        (update-in [:editor :errors] dissoc field))}))
 
-(rf/reg-event-db :editor/blur-field
-  (fn [db [_ field]]
-    (update-in db [:editor :touched] (fnil conj #{}) field)))
+(rf/reg-event :editor/blur-field
+  (fn [{:keys [db]} [_ field]]
+    {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
 
-(rf/reg-event-fx :editor/submit
+(rf/reg-event :editor/submit
   {:doc "Save the article. Reads the `:editor/can-submit?` FLOW output straight
          off app-db (Spec 013 §Sub integration (a)) — a materialised derived
          value consumed as plain data, no subscribe ceremony. Valid-and-dirty
@@ -299,7 +299,7 @@
                            :reply-to [:editor/replied]
                            :cause    [:submit :editor/save]}]]]}))))
 
-(rf/reg-event-fx :editor/replied
+(rf/reg-event :editor/replied
   {:doc "The save / delete mutation completion continuation (the `:reply-to`
          target, EP-0016 D1). Receives the canonical reply map appended as the
          final arg, observed AFTER the mutation's `:invalidates` staled the
@@ -325,7 +325,7 @@
        :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
             [:dispatch [:rf.route/navigate :realworld/home]]]})))
 
-(rf/reg-event-fx :editor/delete
+(rf/reg-event :editor/delete
   {:doc "Delete the article (edit mode only). Fires the delete mutation under
          the same instance the save uses, with the same `:reply-to
          [:editor/replied]` continuation (which branches save vs delete on the

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -112,11 +112,11 @@
 ;; SESSION SUPPORT EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :auth/store-session
-  (fn [db [_ user]]
-    (-> db
+(rf/reg-event :auth/store-session
+  (fn [{:keys [db]} [_ user]]
+    {:db (-> db
         (assoc-in [:auth :user] user)
-        (assoc-in [:auth :token] (:token user)))))
+        (assoc-in [:auth :token] (:token user)))}))
 
 ;; ----------------------------------------------------------------------------
 ;; PRINCIPAL-SWITCH RE-ENSURE  (the qiv160-review footgun, rf2-mdmjix)
@@ -158,7 +158,7 @@
    across switches; released on logout."
   [:lease :auth/session-feed])
 
-(rf/reg-event-fx :auth/ensure-session-feed
+(rf/reg-event :auth/ensure-session-feed
   {:doc "Re-ensure the session feed under the CURRENT principal so a principal
          switch with no route change (cold-boot session restore) actually
          loads it — the `{:from-db :realworld/session}` re-key alone is passive
@@ -178,7 +178,7 @@
                          :owner    session-feed-owner
                          :cause    [:principal-switch :realworld/feed]}]]]})))
 
-(rf/reg-event-fx :auth/clear-session
+(rf/reg-event :auth/clear-session
   {:doc "Clear the auth slice AND drop the session-scoped resource cache. The
          personalised feed is cached under the session scope (Spec 016
          §Scope); logout MUST clear it (`:rf.resource/clear-scope`) so the next
@@ -207,7 +207,7 @@
              old-scope (conj [:dispatch [:rf.resource/clear-scope
                                          {:scope old-scope :cause :logout}]]))})))
 
-(rf/reg-event-fx :auth/post-login-redirect
+(rf/reg-event :auth/post-login-redirect
   {:doc "Bounce the user who INTERACTIVELY logged in / registered to the route
          the auth guard intercepted (`[:auth :return-to]`), or home. Dispatched
          ONLY by the `:store-session` action (the interactive `:submitting →
@@ -341,7 +341,7 @@
 ;; INITIALISATION + SESSION RESTORE
 ;; ============================================================================
 
-(rf/reg-event-fx :auth/initialise
+(rf/reg-event :auth/initialise
   {:rf.cofx/requires [:realworld-resources.session/token]}
   (fn [{:keys [db realworld-resources.session/token]} _]
     ;; Dispatch `:auth/restore` UNCONDITIONALLY (even with a nil token) so the
@@ -357,30 +357,30 @@
 (def login-form-defaults    {:email "" :password ""})
 (def register-form-defaults  {:username "" :email "" :password ""})
 
-(rf/reg-event-db :auth.login-form/initialise
-  (fn [db _] (assoc-in db [:auth :login-form] {:draft login-form-defaults :touched #{}})))
+(rf/reg-event :auth.login-form/initialise
+  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :login-form] {:draft login-form-defaults :touched #{}})}))
 
-(rf/reg-event-db :auth.login-form/edit-field
+(rf/reg-event :auth.login-form/edit-field
   {:schema [:cat [:= :auth.login-form/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:auth :login-form :draft field] value)
-        (update-in [:auth :login-form :touched] (fnil conj #{}) field))))
+        (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-fx :auth.login-form/submit
+(rf/reg-event :auth.login-form/submit
   (fn [{:keys [db]} _]
     {:fx [[:dispatch [:auth/flow [:auth/login (get-in db [:auth :login-form :draft])]]]]}))
 
-(rf/reg-event-db :auth.register-form/initialise
-  (fn [db _] (assoc-in db [:auth :register-form] {:draft register-form-defaults :touched #{}})))
+(rf/reg-event :auth.register-form/initialise
+  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :register-form] {:draft register-form-defaults :touched #{}})}))
 
-(rf/reg-event-db :auth.register-form/edit-field
-  (fn [db [_ field value]]
-    (-> db
+(rf/reg-event :auth.register-form/edit-field
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:auth :register-form :draft field] value)
-        (update-in [:auth :register-form :touched] (fnil conj #{}) field))))
+        (update-in [:auth :register-form :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-fx :auth.register-form/submit
+(rf/reg-event :auth.register-form/submit
   (fn [{:keys [db]} _]
     {:fx [[:dispatch [:auth/flow [:auth/register (get-in db [:auth :register-form :draft])]]]]}))
 

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -64,7 +64,7 @@
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-fx :app/initialise
+(rf/reg-event :app/initialise
   {:doc "App boot. Seeds the form drafts. Session restore (`:auth/initialise`)
          is NOT in this fan-out — it consumes the RECORDABLE+PROVIDED
          `:realworld-resources.session/token` coeffect, whose value the host

--- a/examples/reagent/realworld_resources/settings.cljs
+++ b/examples/reagent/realworld_resources/settings.cljs
@@ -61,21 +61,21 @@
 ;; DRAFT (app-db) + EVENTS
 ;; ============================================================================
 
-(rf/reg-event-fx :settings/load
+(rf/reg-event :settings/load
   {:doc "Seed the settings draft from the authenticated user. Dispatched from
          the settings view on mount (the page is auth-guarded, so a user is
          always present here)."}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:settings-form :draft] (draft-from-user (get-in db [:auth :user])))}))
 
-(rf/reg-event-db :settings/edit-field
+(rf/reg-event :settings/edit-field
   {:schema [:cat [:= :settings/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
         (assoc-in [:settings-form :draft field] value)
-        (update-in [:settings-form :touched] (fnil conj #{}) field))))
+        (update-in [:settings-form :touched] (fnil conj #{}) field))}))
 
-(rf/reg-event-fx :settings/submit
+(rf/reg-event :settings/submit
   {:doc "Fire the update-settings mutation with the current draft. The form
          watches the `:settings/save` instance for pending / error; the success
          continuation is the call-site `:reply-to [:settings/replied]` target
@@ -89,7 +89,7 @@
                          :reply-to [:settings/replied]
                          :cause    [:submit :settings/save]}]]]})))
 
-(rf/reg-event-fx :settings/replied
+(rf/reg-event :settings/replied
   {:doc "The update-settings mutation completion continuation (the `:reply-to`
          target). Receives the canonical reply map appended as the final arg
          (EP-0016 D1) — observed AFTER the mutation's `:invalidates` cleared the

--- a/examples/reagent/realworld_resources/views.cljs
+++ b/examples/reagent/realworld_resources/views.cljs
@@ -57,16 +57,16 @@
 
 (def following-feed-token "following")
 
-(rf/reg-event-fx :home/show-global-feed
+(rf/reg-event :home/show-global-feed
   (fn [_ _] {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {}}]]]}))
 
-(rf/reg-event-fx :home/show-your-feed
+(rf/reg-event :home/show-your-feed
   (fn [_ _] {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {:feed following-feed-token}}]]]}))
 
-(rf/reg-event-fx :home/apply-tag
+(rf/reg-event :home/apply-tag
   (fn [_ [_ tag]] {:fx [[:dispatch [:rf.route/navigate :realworld/home-tag {:tag tag}]]]}))
 
-(rf/reg-event-fx :home/clear-tag
+(rf/reg-event :home/clear-tag
   (fn [_ _] {:fx [[:dispatch [:rf.route/navigate :realworld/home]]]}))
 
 ;; Page navigation preserves the active feed + tag (read off the live route)
@@ -74,7 +74,7 @@
 ;; cache keys. A tag-filtered page re-targets the `/tag/:tag` PATH route with
 ;; the tag param preserved; otherwise the home route carries `?feed=`. Page 1
 ;; drops the `?page=` param entirely (the canonical first-page URL).
-(rf/reg-event-fx :home/go-to-page
+(rf/reg-event :home/go-to-page
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [current (get-in rt [:rf.runtime/routing :current])
           tag     (get-in current [:params :tag])
@@ -100,7 +100,7 @@
 ;; backend would 401). One instance id per (verb, slug/username) so concurrent
 ;; toggles on different articles don't clobber each other.
 
-(rf/reg-event-fx :ui/favorite
+(rf/reg-event :ui/favorite
   (fn [{:keys [db]} [_ slug favorited?]]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
@@ -110,7 +110,7 @@
                          :instance [:favorite slug]
                          :cause    [:click :ui/favorite slug]}]]]})))
 
-(rf/reg-event-fx :ui/follow
+(rf/reg-event :ui/follow
   (fn [{:keys [db]} [_ username following?]]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
@@ -131,7 +131,7 @@
 ;; the mutation reply-side seam the variant previously had to emulate with
 ;; Form-3 settle reactions on the article page.
 
-(rf/reg-event-fx :ui/follow-author
+(rf/reg-event :ui/follow-author
   {:doc "Follow / unfollow the article author from the detail page. Fires the
          follow / unfollow mutation; the detail page's embedded `:author` lives
          in the `[:article slug]` entry (not the `[:profile username]` resource
@@ -151,7 +151,7 @@
                          :reply-to [:ui/follow-author-replied slug]
                          :cause    [:click :ui/follow-author username]}]]]})))
 
-(rf/reg-event-fx :ui/follow-author-replied
+(rf/reg-event :ui/follow-author-replied
   {:doc "Follow / unfollow completion continuation (the `:reply-to` target,
          EP-0016 D1). On `:ok`, stale the current article so its embedded
          `:author.following` refetches — the follow mutation invalidates
@@ -168,7 +168,7 @@
                          :cause [:follow-author-detail-sync slug]}]]]}
       {})))
 
-(rf/reg-event-fx :ui/delete-article
+(rf/reg-event :ui/delete-article
   {:doc "Delete the current article from the detail page (author only). Fires
          the `:realworld/delete-article` mutation with a `:reply-to
          [:ui/article-deleted]` continuation that navigates home on success."}
@@ -182,7 +182,7 @@
                          :reply-to [:ui/article-deleted]
                          :cause    [:click :ui/delete-article slug]}]]]})))
 
-(rf/reg-event-fx :ui/article-deleted
+(rf/reg-event :ui/article-deleted
   {:doc "Delete-article completion continuation (the `:reply-to` target). On
          `:ok`, clear the delete instance and navigate home — the mutation's
          `:invalidates` already staled the lists + feed (and the now-gone
@@ -198,10 +198,10 @@
 ;; COMMENT FORM — a tiny app-db draft + a post mutation
 ;; ============================================================================
 
-(rf/reg-event-db :comment-form/edit
-  (fn [db [_ body]] (assoc-in db [:comment-form :body] body)))
+(rf/reg-event :comment-form/edit
+  (fn [{:keys [db]} [_ body]] {:db (assoc-in db [:comment-form :body] body)}))
 
-(rf/reg-event-fx :comment-form/submit
+(rf/reg-event :comment-form/submit
   (fn [{:keys [db]} [_ slug]]
     (let [body (str/trim (or (get-in db [:comment-form :body]) ""))]
       (if (str/blank? body)
@@ -213,7 +213,7 @@
                            :instance [:post-comment slug]
                            :cause    [:submit :comment-form slug]}]]]}))))
 
-(rf/reg-event-fx :comment/delete
+(rf/reg-event :comment/delete
   (fn [_ [_ slug id]]
     {:fx [[:dispatch [:rf.mutation/execute
                       {:mutation :realworld/delete-comment
@@ -564,7 +564,7 @@
 
 ;; Page navigation on a profile tab preserves the current route + username and
 ;; swaps only `?page=`. Page 1 drops the param (the canonical first-page URL).
-(rf/reg-event-fx :profile/go-to-page
+(rf/reg-event :profile/go-to-page
   (fn [{rt :rf.db/runtime} [_ page]]
     (let [{:keys [current]} (get rt :rf.runtime/routing)
           {:keys [route-id params]} current

--- a/examples/reagent/resources/core.cljs
+++ b/examples/reagent/resources/core.cljs
@@ -220,7 +220,7 @@
 ;; lease MUST have a matching `:rf.resource/release-owner` path, or the
 ;; lease pins the entry alive (Xray lints an orphaned lease).
 
-(rf/reg-event-fx :resources.app/preview-opened
+(rf/reg-event :resources.app/preview-opened
   {:doc "Open a lightweight article preview from the list — ensure the
          detail under a releaseable lease, and record the open slug in
          app-db so the view can render the preview panel."}
@@ -232,7 +232,7 @@
                        :owner    [:lease :resources.app/preview slug]
                        :cause    [:event :resources.app/preview-opened]}]]]}))
 
-(rf/reg-event-fx :resources.app/preview-closed
+(rf/reg-event :resources.app/preview-closed
   {:doc "Close the preview — release the lease so the entry can GC, and
          clear the open slug from app-db."}
   (fn [{:keys [db]} [_ slug]]
@@ -244,7 +244,7 @@
 ;; work happened): clicking "Refresh" wants fresh data but does NOT intend
 ;; to keep the resource alive — that's the route's job. So it dispatches
 ;; `:rf.resource/refetch` with `:cause` and omits `:owner`.
-(rf/reg-event-fx :resources.app/refresh-articles
+(rf/reg-event :resources.app/refresh-articles
   {:doc "Manual refresh of the articles list."}
   (fn [_ _]
     {:fx [[:dispatch [:rf.resource/refetch
@@ -295,14 +295,14 @@
 ;; affordance. Stopping emits the reserved `[:rf.machine/destroy …]` fx,
 ;; which runs the actor's `:exit` cascade and releases its `[:machine …]`
 ;; resource owner so the entry can GC, then clears the slice.
-(rf/reg-event-fx :resources.app/start-reader
+(rf/reg-event :resources.app/start-reader
   {:doc "Start the reader workflow that owns the given article for its lifetime."}
   (fn [{:keys [db]} [_ slug]]
     (let [instance-id (str "reader-" slug)]
       {:db (assoc db :resources.app/reader {:slug slug :instance-id instance-id})
        :fx [[:dispatch [:resources.app/reader [:rf.machine/start slug instance-id]]]]})))
 
-(rf/reg-event-fx :resources.app/stop-reader
+(rf/reg-event :resources.app/stop-reader
   {:doc "Destroy the reader actor — releases its machine-owned resource."}
   (fn [{:keys [db]} _]
     {:db (dissoc db :resources.app/reader)

--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -102,7 +102,7 @@
 ;; render and is released on request teardown — it never survives as a live
 ;; client lease (it reconciles to an orphan on hydration).
 
-(rf/reg-event-fx :rf/server-init
+(rf/reg-event :rf/server-init
   {:doc       "Per-request server init — preload the page resource."
    :platforms #{:server}}
   (fn [{:keys [db]} _]

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -53,11 +53,11 @@
 ;; route-id. The route-registry and reg-sub registries are independent,
 ;; but keeping the sub-id + app-db-key separate from the route-id makes
 ;; the example easier to scan.
-(rf/reg-event-db :routing.app/initialise
-  (fn [_ _]
-    {:routing.app/articles-list
+(rf/reg-event :routing.app/initialise
+  (fn [{:keys [db]} _]
+    {:db {:routing.app/articles-list
      [{:id "intro" :title "Intro to re-frame2" :body "..."}
-      {:id "ssr"   :title "Server rendering"  :body "..."}]}))
+      {:id "ssr"   :title "Server rendering"  :body "..."}]}}))
 
 (rf/reg-sub :routing.app/articles-list
   (fn [db _] (:routing.app/articles-list db)))

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -186,28 +186,28 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :cells/initialise
+(rf/reg-event :cells/initialise
   {:doc "Seed an empty spreadsheet."}
-  (fn handler-cells-initialise [db _]
-    (assoc db :cells {:cells {} :selected-id "A1" :editing-id nil})))
+  (fn handler-cells-initialise [{:keys [db]} _]
+    {:db (assoc db :cells {:cells {} :selected-id "A1" :editing-id nil})}))
 
-(rf/reg-event-db :cells/select
+(rf/reg-event :cells/select
   {:doc "User clicked a cell. Marks it selected (without opening the editor)."}
-  (fn handler-cells-select [db [_ id]]
-    (assoc-in db [:cells :selected-id] id)))
+  (fn handler-cells-select [{:keys [db]} [_ id]]
+    {:db (assoc-in db [:cells :selected-id] id)}))
 
-(rf/reg-event-db :cells/start-editing
+(rf/reg-event :cells/start-editing
   {:doc "Open the inline editor for cell `id` (also selects it)."}
-  (fn handler-cells-start-editing [db [_ id]]
-    (-> db
+  (fn handler-cells-start-editing [{:keys [db]} [_ id]]
+    {:db (-> db
         (assoc-in [:cells :selected-id] id)
-        (assoc-in [:cells :editing-id]  id))))
+        (assoc-in [:cells :editing-id]  id))}))
 
-(rf/reg-event-db :cells/commit
+(rf/reg-event :cells/commit
   {:doc "Commit the user's edit. Parses formulas and stores deps."
    :schema [:cat [:= :cells/commit] :string :string]}
-  (fn handler-cells-commit [db [_ id raw]]
-    (let [formula? (and (string? raw) (str/starts-with? raw "="))
+  (fn handler-cells-commit [{:keys [db]} [_ id raw]]
+    {:db (let [formula? (and (string? raw) (str/starts-with? raw "="))
           ast      (when formula? (parse-formula raw))
           deps     (when formula? (collect-deps ast))
           entry    (cond
@@ -221,7 +221,7 @@
           (update-in [:cells :cells]
                      (fn [m] (if entry
                                (assoc m id entry)
-                               (dissoc m id))))))))
+                               (dissoc m id))))))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -93,13 +93,13 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :drawer/initialise
+(rf/reg-event :drawer/initialise
   {:doc "Seed an empty canvas. `:next-id` is the deterministic id allocator
          (EP-0010) — circles take monotonic int ids starting at 1."}
-  (fn handler-drawer-initialise [db _]
-    (assoc db :drawer {:circles [] :next-id 1 :dialog nil :undo [] :redo []})))
+  (fn handler-drawer-initialise [{:keys [db]} _]
+    {:db (assoc db :drawer {:circles [] :next-id 1 :dialog nil :undo [] :redo []})}))
 
-(rf/reg-event-db :drawer/add-circle
+(rf/reg-event :drawer/add-circle
   {:doc "Click on canvas. Adds a circle of default radius. The id is minted
          deterministically from the db-held `:next-id` counter (EP-0010 causal
          world inputs — a durable id must be a function of prior frame-state,
@@ -107,37 +107,37 @@
          counter is NOT in the undoable `:circles` snapshot, so it advances
          monotonically across undo/redo and never re-mints a live id."
    :interceptors [undoable]}
-  (fn handler-drawer-add-circle [db [_ x y]]
-    (let [id (get-in db [:drawer :next-id])]
+  (fn handler-drawer-add-circle [{:keys [db]} [_ x y]]
+    {:db (let [id (get-in db [:drawer :next-id])]
       (-> db
           (update-in [:drawer :circles] conj {:id id :x x :y y :radius 30})
-          (assoc-in  [:drawer :next-id] (inc id))))))
+          (assoc-in  [:drawer :next-id] (inc id))))}))
 
-(rf/reg-event-db :drawer/open-dialog
+(rf/reg-event :drawer/open-dialog
   {:doc "Right-clicked a circle. Opens the adjust-diameter dialog. Not undoable."}
-  (fn handler-drawer-open-dialog [db [_ circle-id]]
-    (let [{:keys [radius]} (->> (get-in db [:drawer :circles])
+  (fn handler-drawer-open-dialog [{:keys [db]} [_ circle-id]]
+    {:db (let [{:keys [radius]} (->> (get-in db [:drawer :circles])
                                 (filter #(= circle-id (:id %)))
                                 first)]
       (assoc-in db [:drawer :dialog] {:circle-id      circle-id
                                       :initial-radius radius
-                                      :draft-radius   radius}))))
+                                      :draft-radius   radius}))}))
 
-(rf/reg-event-db :drawer/dialog-drag
+(rf/reg-event :drawer/dialog-drag
   {:doc "Slider movement during the dialog. Updates the draft radius only;
          the circle itself is not mutated until the dialog commits.
          Continuous; does NOT push undo."}
-  (fn handler-drawer-dialog-drag [db [_ new-radius]]
-    (assoc-in db [:drawer :dialog :draft-radius] new-radius)))
+  (fn handler-drawer-dialog-drag [{:keys [db]} [_ new-radius]]
+    {:db (assoc-in db [:drawer :dialog :draft-radius] new-radius)}))
 
-(rf/reg-event-db :drawer/close-dialog
+(rf/reg-event :drawer/close-dialog
   {:doc "Dialog closed (committing the new radius). The :circles vector
          was untouched while the slider moved, so the undoable
          interceptor's prior-snapshot is exactly the pre-dialog state —
          the whole edit collapses into a single undo step."
    :interceptors [undoable]}
-  (fn handler-drawer-close-dialog [db _]
-    (let [{:keys [circle-id draft-radius]} (get-in db [:drawer :dialog])]
+  (fn handler-drawer-close-dialog [{:keys [db]} _]
+    {:db (let [{:keys [circle-id draft-radius]} (get-in db [:drawer :dialog])]
       (-> db
           (update-in [:drawer :circles]
                      (fn [cs]
@@ -145,29 +145,29 @@
                                 (assoc % :radius draft-radius)
                                 %)
                              cs)))
-          (assoc-in [:drawer :dialog] nil)))))
+          (assoc-in [:drawer :dialog] nil)))}))
 
-(rf/reg-event-db :drawer/undo
+(rf/reg-event :drawer/undo
   {:doc "Pop one snapshot from :undo, push current :circles to :redo."}
-  (fn handler-drawer-undo [db _]
-    (let [{:keys [undo redo circles]} (:drawer db)]
+  (fn handler-drawer-undo [{:keys [db]} _]
+    {:db (let [{:keys [undo redo circles]} (:drawer db)]
       (if (empty? undo)
         db
         (-> db
             (assoc-in [:drawer :circles] (peek undo))
             (update-in [:drawer :undo] pop)
-            (update-in [:drawer :redo] (fnil conj []) circles))))))
+            (update-in [:drawer :redo] (fnil conj []) circles))))}))
 
-(rf/reg-event-db :drawer/redo
+(rf/reg-event :drawer/redo
   {:doc "Pop one snapshot from :redo, push current :circles to :undo."}
-  (fn handler-drawer-redo [db _]
-    (let [{:keys [undo redo circles]} (:drawer db)]
+  (fn handler-drawer-redo [{:keys [db]} _]
+    {:db (let [{:keys [undo redo circles]} (:drawer db)]
       (if (empty? redo)
         db
         (-> db
             (assoc-in [:drawer :circles] (peek redo))
             (update-in [:drawer :redo] pop)
-            (update-in [:drawer :undo] (fnil conj []) circles))))))
+            (update-in [:drawer :undo] (fnil conj []) circles))))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -53,68 +53,68 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :crud/initialise
+(rf/reg-event :crud/initialise
   {:doc "Seed the list with the 7GUIs reference data."}
-  (fn handler-crud-initialise [db _]
-    (assoc db :crud {:people      [{:id (random-uuid) :name "Hans"  :surname "Emil"}
+  (fn handler-crud-initialise [{:keys [db]} _]
+    {:db (assoc db :crud {:people      [{:id (random-uuid) :name "Hans"  :surname "Emil"}
                                    {:id (random-uuid) :name "Max"   :surname "Mustermann"}
                                    {:id (random-uuid) :name "Roman" :surname "Tisch"}]
                      :filter-text ""
                      :selected-id nil
-                     :draft       {:name "" :surname ""}})))
+                     :draft       {:name "" :surname ""}})}))
 
-(rf/reg-event-db :crud/set-filter
+(rf/reg-event :crud/set-filter
   {:doc "User typed in the filter input."}
-  (fn handler-crud-set-filter [db [_ s]]
-    (assoc-in db [:crud :filter-text] s)))
+  (fn handler-crud-set-filter [{:keys [db]} [_ s]]
+    {:db (assoc-in db [:crud :filter-text] s)}))
 
-(rf/reg-event-db :crud/select
+(rf/reg-event :crud/select
   {:doc "User clicked a list entry. Populates the draft from the selected person."
    :schema [:cat [:= :crud/select] :uuid]}
-  (fn handler-crud-select [db [_ id]]
-    (let [people (get-in db [:crud :people])
+  (fn handler-crud-select [{:keys [db]} [_ id]]
+    {:db (let [people (get-in db [:crud :people])
           person (first (filter #(= id (:id %)) people))]
       (-> db
           (assoc-in [:crud :selected-id] id)
-          (assoc-in [:crud :draft]       (select-keys person [:name :surname]))))))
+          (assoc-in [:crud :draft]       (select-keys person [:name :surname]))))}))
 
-(rf/reg-event-db :crud/edit-name
-  (fn handler-crud-edit-name [db [_ s]]
-    (assoc-in db [:crud :draft :name] s)))
+(rf/reg-event :crud/edit-name
+  (fn handler-crud-edit-name [{:keys [db]} [_ s]]
+    {:db (assoc-in db [:crud :draft :name] s)}))
 
-(rf/reg-event-db :crud/edit-surname
-  (fn handler-crud-edit-surname [db [_ s]]
-    (assoc-in db [:crud :draft :surname] s)))
+(rf/reg-event :crud/edit-surname
+  (fn handler-crud-edit-surname [{:keys [db]} [_ s]]
+    {:db (assoc-in db [:crud :draft :surname] s)}))
 
-(rf/reg-event-db :crud/create
+(rf/reg-event :crud/create
   {:doc "Add a new person from the draft. Selects the new entry."}
-  (fn handler-crud-create [db _]
-    (let [new-id (random-uuid)
+  (fn handler-crud-create [{:keys [db]} _]
+    {:db (let [new-id (random-uuid)
           {:keys [name surname]} (get-in db [:crud :draft])]
       (-> db
           (update-in [:crud :people] conj {:id new-id :name name :surname surname})
-          (assoc-in  [:crud :selected-id] new-id)))))
+          (assoc-in  [:crud :selected-id] new-id)))}))
 
-(rf/reg-event-db :crud/update
+(rf/reg-event :crud/update
   {:doc "Apply the draft to the selected person."}
-  (fn handler-crud-update [db _]
-    (let [{:keys [selected-id draft]} (:crud db)]
+  (fn handler-crud-update [{:keys [db]} _]
+    {:db (let [{:keys [selected-id draft]} (:crud db)]
       (if selected-id
         (update-in db [:crud :people]
                    (fn [people]
                      (mapv #(if (= selected-id (:id %)) (merge % draft) %) people)))
-        db))))
+        db))}))
 
-(rf/reg-event-db :crud/delete
+(rf/reg-event :crud/delete
   {:doc "Remove the selected person."}
-  (fn handler-crud-delete [db _]
-    (let [{:keys [selected-id]} (:crud db)]
+  (fn handler-crud-delete [{:keys [db]} _]
+    {:db (let [{:keys [selected-id]} (:crud db)]
       (if selected-id
         (-> db
             (update-in [:crud :people] (fn [ps] (vec (remove #(= selected-id (:id %)) ps))))
             (assoc-in  [:crud :selected-id] nil)
             (assoc-in  [:crud :draft]       {:name "" :surname ""}))
-        db))))
+        db))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -48,35 +48,35 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :flight/initialise
+(rf/reg-event :flight/initialise
   {:doc "Seed the flight slice."}
-  (fn handler-flight-initialise [db _]
+  (fn handler-flight-initialise [{:keys [db]} _]
     ;; Seed both date fields to a fixed valid ISO date. The original 7GUIs
     ;; spec seeds "today"; we use a constant so the example is
     ;; deterministic (and not silently wrong on any given day).
-    (assoc db :flight {:trip-type   :one-way
+    {:db (assoc db :flight {:trip-type   :one-way
                        :start-text  "2026-05-06"
-                       :return-text "2026-05-06"})))
+                       :return-text "2026-05-06"})}))
 
-(rf/reg-event-db :flight/set-trip-type
+(rf/reg-event :flight/set-trip-type
   {:doc "User changed the trip-type combo."
    :schema [:cat [:= :flight/set-trip-type] [:enum :one-way :return]]}
-  (fn handler-flight-set-trip-type [db [_ trip-type]]
-    (assoc-in db [:flight :trip-type] trip-type)))
+  (fn handler-flight-set-trip-type [{:keys [db]} [_ trip-type]]
+    {:db (assoc-in db [:flight :trip-type] trip-type)}))
 
-(rf/reg-event-db :flight/set-start
+(rf/reg-event :flight/set-start
   {:doc "User edited the start-date input."
    :schema [:cat [:= :flight/set-start] :string]}
-  (fn handler-flight-set-start [db [_ raw]]
-    (assoc-in db [:flight :start-text] raw)))
+  (fn handler-flight-set-start [{:keys [db]} [_ raw]]
+    {:db (assoc-in db [:flight :start-text] raw)}))
 
-(rf/reg-event-db :flight/set-return
+(rf/reg-event :flight/set-return
   {:doc "User edited the return-date input."
    :schema [:cat [:= :flight/set-return] :string]}
-  (fn handler-flight-set-return [db [_ raw]]
-    (assoc-in db [:flight :return-text] raw)))
+  (fn handler-flight-set-return [{:keys [db]} [_ raw]]
+    {:db (assoc-in db [:flight :return-text] raw)}))
 
-(rf/reg-event-fx :flight/book
+(rf/reg-event :flight/book
   {:doc "User clicked Book. Emits a confirmation effect."}
   (fn handler-flight-book [{:keys [db]} _]
     (let [{:keys [trip-type start-text return-text]} (:flight db)]

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -51,10 +51,10 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :temp/initialise
+(rf/reg-event :temp/initialise
   {:doc "Seed the temperature slice."}
-  (fn handler-temp-initialise [db _]
-    (assoc db :temp {:celsius 0.0 :input-source :celsius :typing "0"})))
+  (fn handler-temp-initialise [{:keys [db]} _]
+    {:db (assoc db :temp {:celsius 0.0 :input-source :celsius :typing "0"})}))
 
 (defn parse-num [s]
   (let [trimmed (str/trim s)]
@@ -62,22 +62,22 @@
       (let [n (js/parseFloat trimmed)]
         (when-not (js/isNaN n) n)))))
 
-(rf/reg-event-db :temp/edit-celsius
+(rf/reg-event :temp/edit-celsius
   {:doc "User edited the Celsius input."}
-  (fn handler-temp-edit-celsius [db [_ raw]]
-    (assoc db :temp {:celsius      (parse-num raw)
+  (fn handler-temp-edit-celsius [{:keys [db]} [_ raw]]
+    {:db (assoc db :temp {:celsius      (parse-num raw)
                      :input-source :celsius
-                     :typing       raw})))
+                     :typing       raw})}))
 
-(rf/reg-event-db :temp/edit-fahrenheit
+(rf/reg-event :temp/edit-fahrenheit
   {:doc "User edited the Fahrenheit input. We store Celsius canonically;
          conversion happens here so the rest of the app reads from one path."}
-  (fn handler-temp-edit-fahrenheit [db [_ raw]]
-    (let [f (parse-num raw)
+  (fn handler-temp-edit-fahrenheit [{:keys [db]} [_ raw]]
+    {:db (let [f (parse-num raw)
           c (when f (* (- f 32) (/ 5.0 9.0)))]
       (assoc db :temp {:celsius      c
                        :input-source :fahrenheit
-                       :typing       raw}))))
+                       :typing       raw}))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -69,7 +69,7 @@
 ;; tick — resuming the chain without a Reset. This is what makes "the slider
 ;; changes the duration on the fly" hold after completion.
 
-(rf/reg-event-fx :timer/initialise
+(rf/reg-event :timer/initialise
   {:doc "Seed the timer slice and start the periodic tick."}
   (fn handler-timer-initialise [{:keys [db]} _]
     {:db (assoc db :timer {:elapsed-ms   0
@@ -78,7 +78,7 @@
                            :tick-gen     0})
      :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick 0]}]]}))
 
-(rf/reg-event-fx :timer/tick
+(rf/reg-event :timer/tick
   {:doc "Advance elapsed by one tick. Schedules the next tick if still ticking.
          Stale ticks (gen != current :tick-gen) are dropped — see header note."}
   (fn handler-timer-tick [{:keys [db]} [_ gen]]
@@ -93,7 +93,7 @@
             (and tick-active? (not done?))
             (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick gen]}]])))))))
 
-(rf/reg-event-fx :timer/set-duration
+(rf/reg-event :timer/set-duration
   {:doc "User dragged the slider. Update the duration, and — if the tick
          chain had already stopped because elapsed reached the *old*
          duration — re-arm it under a bumped generation so a longer
@@ -117,7 +117,7 @@
       (cond-> {:db db'}
         rearm? (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick next-gen]}]])))))
 
-(rf/reg-event-fx :timer/reset
+(rf/reg-event :timer/reset
   {:doc "User clicked Reset. Zero elapsed, retire any in-flight tick by
          bumping :tick-gen, and arm a fresh tick under the new generation."}
   (fn handler-timer-reset [{:keys [db]} _]

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -108,7 +108,7 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-fx :rf/server-init
+(rf/reg-event :rf/server-init
   {:doc       "Per-request server-side initialisation. Reads the request
                via the :rf.server/request cofx (Spec 011 §Request storage
                substrate), dispatches setup events. Server only."
@@ -131,9 +131,9 @@
             :decode     :json
             :on-success [:articles/loaded]}]]}))
 
-(rf/reg-event-db :articles/loaded
-  (fn handler-articles-loaded [db [_ {:keys [value]}]]
-    (assoc db :articles value)))
+(rf/reg-event :articles/loaded
+  (fn handler-articles-loaded [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc db :articles value)}))
 
 ;; HYDRATION IS FRAMEWORK-OWNED. `:rf/hydrate` is a reserved `:rf/*` event
 ;; (Conventions §Reserved namespaces) registered by `re-frame.ssr` — the app
@@ -164,8 +164,8 @@
 ;; correspondent, so it lives outside the SSR payload's authoritative
 ;; slice and starts at its default value on the client.
 
-(rf/reg-event-db :articles/toggle-bodies
-  (fn [db _] (update db :articles/show-bodies? (fnil not true))))
+(rf/reg-event :articles/toggle-bodies
+  (fn [{:keys [db]} _] {:db (update db :articles/show-bodies? (fnil not true))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS / VIEWS
@@ -345,9 +345,9 @@
 ;; `:rf/server-init` is the documented per-request server-init pattern event
 ;; the app supplies a body for). This client-only-load bootstrap is a fresh
 ;; user invention, so it gets the app's own `:ssr/` namespace.
-(rf/reg-event-db :ssr/client-bootstrap
+(rf/reg-event :ssr/client-bootstrap
   {:doc "Client-side init that runs even if the server didn't render this page."}
-  (fn [db _] db))
+  (fn [{:keys [db]} _] {:db db}))
 
 ;; The React root is held in an atom and materialised lazily inside `run`
 ;; (not at ns-load) per examples/TESTING.md §Example mount-isolation

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -39,7 +39,7 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-fx :rf/server-init
+(rf/reg-event :rf/server-init
   {:doc       "Per-request server-side init. In a real app the cards' data
                loads would dispatch :rf.http/managed fetches against three
                microservices; here we synchronously seed three card values

--- a/examples/reagent/todomvc/events.cljs
+++ b/examples/reagent/todomvc/events.cljs
@@ -42,12 +42,12 @@
            (js/JSON.stringify)
            (.setItem ls db/ls-key)))))
 
-(rf/reg-event-fx :todo/initialise
+(rf/reg-event :todo/initialise
   {:rf.cofx/requires [:todo.storage/todos]}
   (fn [{:todo.storage/keys [todos]} _]
     {:db (assoc db/default-db :todos todos)}))
 
-(rf/reg-event-fx :todo/add
+(rf/reg-event :todo/add
   (fn [{:keys [db]} [_ title]]
     (let [title' (str/trim (or title ""))]
       (if (str/blank? title')
@@ -57,22 +57,22 @@
                                 {:id id :title title' :completed false})]
           (persist-db next-db))))))
 
-(rf/reg-event-fx :todo/toggle-completed
+(rf/reg-event :todo/toggle-completed
   (fn [{:keys [db]} [_ id]]
     (persist-db (update-in db [:todos id :completed] not))))
 
-(rf/reg-event-fx :todo/save
+(rf/reg-event :todo/save
   (fn [{:keys [db]} [_ id title]]
     (let [title' (str/trim (or title ""))]
       (if (str/blank? title')
         (persist-db (update db :todos dissoc id))
         (persist-db (assoc-in db [:todos id :title] title'))))))
 
-(rf/reg-event-fx :todo/delete
+(rf/reg-event :todo/delete
   (fn [{:keys [db]} [_ id]]
     (persist-db (update db :todos dissoc id))))
 
-(rf/reg-event-fx :todo/clear-completed
+(rf/reg-event :todo/clear-completed
   (fn [{:keys [db]} _]
     (persist-db
       (update db :todos
@@ -81,7 +81,7 @@
                       (remove (comp :completed val))
                       todos))))))
 
-(rf/reg-event-fx :todo/toggle-all
+(rf/reg-event :todo/toggle-all
   (fn [{:keys [db]} _]
     (let [todos          (:todos db)
           mark-complete? (not (and (seq todos)

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -416,7 +416,7 @@
   (fn [snap _] (get-in snap [:data :error])))
 
 ;; --- init event -------------------------------------------------------
-(rf/reg-event-fx :ws.connection/initialise
+(rf/reg-event :ws.connection/initialise
   {:doc "Seed the connection machine into its `:disconnected` initial
          state — the lazy initial materialises on the first dispatch."}
   (fn handler-ws-connection-initialise [_ _]

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -48,7 +48,7 @@
 ;; APP-BOOT EVENT
 ;; ============================================================================
 
-(rf/reg-event-fx :ws.app/initialise
+(rf/reg-event :ws.app/initialise
   {:doc "App boot. Seeds the messages slice + materialises the
          connection machine's initial `:disconnected` snapshot.
 

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -365,7 +365,7 @@
 ;; The connection machine dispatches [:ws/handle-message body] for
 ;; every received message (correlated or server-pushed); this
 ;; handler folds it into app-db for the views.
-(rf/reg-event-db :ws/handle-message
+(rf/reg-event :ws/handle-message
   {:doc "Translate an inbound `:ws/received` body into an app-db write.
          Records the message in the [:messages :received] log + stashes
          the latest correlated reply at [:messages :last-reply] when
@@ -373,24 +373,24 @@
          so the inbox view can give every <li> a stable React :key —
          server pushes carry no `:request-id`, so position can't be used
          as identity once the newest-first list grows."}
-  (fn handler-ws-handle-message [db [_ body]]
-    (let [rx-seq (get-in db [:messages :rx-count] 0)]
+  (fn handler-ws-handle-message [{:keys [db]} [_ body]]
+    {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
       (-> db
           (update-in [:messages :received]
                      (fn [received]
                        (vec (cons (assoc body :rx-seq rx-seq) (or received [])))))
           (assoc-in [:messages :rx-count] (inc rx-seq))
           (cond-> (:request-id body)
-            (assoc-in [:messages :last-reply] body))))))
+            (assoc-in [:messages :last-reply] body))))}))
 
 ;; --- app-level events -------------------------------------------------
-(rf/reg-event-fx :ws.app/send
+(rf/reg-event :ws.app/send
   {:doc "Submit the form's draft as an outbound message."}
   (fn handler-app-send [{:keys [db]} [_ body]]
     {:db (assoc-in db [:messages :draft] "")
      :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
 
-(rf/reg-event-fx :ws.app/request
+(rf/reg-event :ws.app/request
   {:doc "Issue a request-reply via the connection machine's
          correlation slot. The reply lands at [:messages :last-reply]
          once the mock server echoes back."}
@@ -403,24 +403,24 @@
                                       :reply      [:ws.app/request-reply]
                                       :timeout-ms 5000}]]]]})))
 
-(rf/reg-event-db :ws.app/request-reply
+(rf/reg-event :ws.app/request-reply
   {:doc "Reply event fired by the connection machine's :register-request
          flow once the correlated reply lands."}
-  (fn handler-app-request-reply [db [_ body]]
-    (assoc-in db [:messages :last-reply] body)))
+  (fn handler-app-request-reply [{:keys [db]} [_ body]]
+    {:db (assoc-in db [:messages :last-reply] body)}))
 
-(rf/reg-event-fx :ws.app/subscribe-demo
+(rf/reg-event :ws.app/subscribe-demo
   {:doc "Demo subscription — the mock server acks with a synthetic
          server push so the app demonstrates the subscribe-then-push
          shape."}
   (fn handler-app-subscribe-demo [_ _]
     {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
 
-(rf/reg-event-db :ws.app/edit-draft
-  (fn handler-app-edit-draft [db [_ text]]
-    (assoc-in db [:messages :draft] text)))
+(rf/reg-event :ws.app/edit-draft
+  (fn handler-app-edit-draft [{:keys [db]} [_ text]]
+    {:db (assoc-in db [:messages :draft] text)}))
 
-(rf/reg-event-fx :ws.messages/initialise
+(rf/reg-event :ws.messages/initialise
   (fn handler-messages-initialise [{:keys [db]} _]
     {:db (assoc db :messages {:draft "" :received [] :last-reply nil :rx-count 0})}))
 

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -6,7 +6,7 @@
    down. Demonstrates:
 
      - `rf/init!` with the UIx adapter
-     - `reg-event-db` / `reg-event-fx` / `reg-sub` (substrate-agnostic)
+     - `reg-event` / `reg-sub` (substrate-agnostic)
      - `use-subscribe` hook (UIx idiomatic)
      - `(:dispatch (rf/frame-handle))` for click handlers (components
        call dispatch / use-subscribe directly, no auto-injection)
@@ -23,14 +23,14 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:counter/value 5}))
+(rf/reg-event :counter/initialise
+  (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :counter/value dec)))
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event] {:db (update db :counter/value dec)}))
 
 (rf/reg-sub :counter/value
   (fn [db _query] (:counter/value db)))

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -70,20 +70,20 @@
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :dashboard/initialise
-  (fn [_db _event]
-    {:dashboard/metrics      initial-metrics
+(rf/reg-event :dashboard/initialise
+  (fn [{:keys [db]} _event]
+    {:db {:dashboard/metrics      initial-metrics
      :dashboard/active-tags  #{:money :perf :usage}
-     :dashboard/range         :w14}))
+     :dashboard/range         :w14}}))
 
-(rf/reg-event-db :dashboard/toggle-tag
-  (fn [db [_ tag]]
-    (update db :dashboard/active-tags
-            (fn [s] (if (contains? s tag) (disj s tag) (conj s tag))))))
+(rf/reg-event :dashboard/toggle-tag
+  (fn [{:keys [db]} [_ tag]]
+    {:db (update db :dashboard/active-tags
+            (fn [s] (if (contains? s tag) (disj s tag) (conj s tag))))}))
 
-(rf/reg-event-db :dashboard/set-range
-  (fn [db [_ range-id]]
-    (assoc db :dashboard/range range-id)))
+(rf/reg-event :dashboard/set-range
+  (fn [{:keys [db]} [_ range-id]]
+    {:db (assoc db :dashboard/range range-id)}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS


### PR DESCRIPTION
## Summary

EP-0018 Slice **J** (rf2-xhfxcs.10) — propagate the one-event-registration collapse into `/examples`. Every `reg-event-db` / `reg-event-fx` registrar site collapses to the single public `reg-event` form:

- `reg-event-fx` → **rename** (body byte-for-byte unchanged — `reg-event` *is* `reg-event-fx`).
- `reg-event-db` → **rewrite**: `db` param becomes a `{:keys [db]}` cofx destructure; body wrapped `{:db BODY}`.

Applied via the merged Slice-E codemod (`migration/from-re-frame-v1/codemod`) run corpus-wide over `examples/`, then the **12** nil-capable `-db` sites the codemod conservatively flagged (D7) were hand-handled. Each of the 12 returns the app-db unchanged on its no-op / rollback branch (`(fn [db _] db)`, `(if cond (modify db) db)`, `cond->` tail, function call returning db) — never a deliberate `nil` write — so `{:db BODY}` is the faithful, semantics-preserving rewrite for every one.

**Zero** `reg-event-ctx` in examples (as the bead predicted; zero `:complex` flags too). Old forms still work (additive window), so behaviour is identical and the build stays green.

A handful of docstring / comment / demo-markdown references to the retired forms were also refreshed for idiomatic consistency (e.g. counter ns-docstrings, the boot hydration comment, the EP-0017 cofx teaching snippet in `realworld/http.cljs`).

Examples remain **test-free** (rf2-8cevm) — no `*.spec.cjs` added. Coverage rests on the adapter smokes, substrate contract tests, and the build.

**Tally:** 244 registrar sites migrated across 47 files — 89 `-db` rewrites, 143 `-fx` renames, 12 hand-handled flags. (Diff is a balanced 487+/487-: every changed line is a 1:1 form replacement.)

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:examples-compile` (all example builds) | ✅ 42/42 builds compiled, 0 warnings |
| `npm run test:cljs` (substrate contract tests) | ✅ 7159 tests / 29523 assertions, 0 failures, 0 errors |
| `npm run test:elision` (production elision probe) | ✅ PASS — 42/42 absent in prod, 42/42 present in control |
| `mkdocs build --strict` | ✅ exit 0 (no example feeds a literal snippet include; docs unaffected) |
| Post-codemod scan (`codemod ../../../examples`) | ✅ `{:total 0}` — zero registrar sites remain |

`story:build` not run — it targets the `tools/story` testbed (`counter_with_stories`), not any `examples/` file, so it is not relevant to this surface.

Closes rf2-xhfxcs.10.