### PR TITLE
docs(guide): EP-0018 L — migrate event chapters to reg-event (rf2-xhfxcs.12)

### DIFF
--- a/docs/guide/25-from-re-frame-v1.md
+++ b/docs/guide/25-from-re-frame-v1.md
@@ -4,9 +4,9 @@ You have a re-frame v1 app and a migration to plan. The real question on your mi
 
 ## The good news first, because it's load-bearing
 
-The bones are identical. The six dominoes are still the six dominoes. Events — the data describing what happened — are still data. Handlers, the pure functions that take your current state and an event and return new state, are still `(db, event) → db`. Subscriptions, the read side that derives values from state, are still derivations off a single `app-db` (your app's whole state, held in one map). The opinionated stance hasn't moved either: one source of truth, data over APIs over syntax, immutable values and stable contracts. v2 is v1's architecture with new capabilities grown on top.
+The bones are identical. The six dominoes are still the six dominoes. Events — the data describing what happened — are still data. Handlers are still pure functions of state, registered against an event id. Subscriptions, the read side that derives values from state, are still derivations off a single `app-db` (your app's whole state, held in one map). The opinionated stance hasn't moved either: one source of truth, data over APIs over syntax, immutable values and stable contracts. v2 is v1's architecture with new capabilities grown on top.
 
-That's why your v1 code reads as v2 code on the first pass. A `reg-event-db` is a `reg-event-db`. A `reg-sub` is a `reg-sub`. A hiccup view — the data structure describing your UI — is a hiccup view. The migration is not a rewrite. It's a sweep: a bounded set of mechanical renames, a smaller set of judgment calls, and a few new shapes you choose to adopt. The framework counts "40-plus M- and O-rules," and that number sounds alarming, but the vast majority are find-and-replace, and a tool does them for you.
+That's why your v1 code reads as v2 code on the first pass. A `reg-sub` is a `reg-sub`. A hiccup view — the data structure describing your UI — is a hiccup view. Event registration is the one part of the loop whose *spelling* changed — v2 has a single `reg-event` form where v1 had `reg-event-db` / `reg-event-fx` — but it's a deterministic, codemod-handled rewrite, covered in its own section below. The migration is not a rewrite. It's a sweep: a bounded set of mechanical renames, a smaller set of judgment calls, and a few new shapes you choose to adopt. The framework counts "40-plus M- and O-rules," and that number sounds alarming, but the vast majority are find-and-replace, and a tool does them for you.
 
 ## Don't do this by hand
 
@@ -39,6 +39,17 @@ The skill handles every part of this. The list is here so you know what's coming
 ## What changed, and why — the categories
 
 These are the broad shapes of breakage. The skill identifies and resolves them; this is the taxonomy, so you can read a diff with comprehension instead of alarm.
+
+**One event registration form.** This is the highest-volume rewrite, because `reg-event-db` is the most common registration in nearly every v1 app — and v2 doesn't have it. v2 collapses v1's three public registrars (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`) to a single **`reg-event`**, semantically v1's `reg-event-fx`: every handler takes the coeffects map and returns the closed effects map (`{:db … :fx […]}`). The win is that there's no longer a db-only form that breaks the moment a handler needs an effect or a coeffect — adding the world becomes adding a key to a map you already return, not converting to a different registration. The mapping is deterministic, which is why it's codemod-able:
+
+```clojure
+;; v1                                  ;; v2
+(rf/reg-event-fx ID handler)       =>  (rf/reg-event ID handler)         ;; rename only
+(rf/reg-event-db ID (fn [db EV] BODY))
+                                   =>  (rf/reg-event ID (fn [{:keys [db]} EV] {:db BODY}))
+```
+
+`BODY` always evaluates to the new db (that *is* the `reg-event-db` contract), so wrapping it `{:db BODY}` is mechanical regardless of how complex it is. A first-class, tested codemod ships in [`migration/from-re-frame-v1/codemod/`](../../migration/from-re-frame-v1/codemod/README.md) (rule M-73) and the migration skill runs it for you. It renames `-fx` forms, rewrites simple `-db` forms, and **flags** two cases for human review rather than guessing: a `-db` handler whose body can return `nil` (under v2 a bare `nil` is a clean no-op and `{:db nil}` coerces to `{:db {}}`, so you choose the reading you want), and any `reg-event-ctx` (withdrawn from the public surface — full-context work moves to an interceptor via `->interceptor`). For the common pure-state handler, a nice habit on the way through is to lift the body into a plain `(defn step [db] …)` and register `(fn [{:keys [db]} _] {:db (step db)})` — the state transition stays bare and testable, the handler stays one line.
 
 **Registrar imports.** Some v1 code requires `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, or `re-frame.alpha` directly. That reached past the front door, and v2 closes it. The single-import contract is `(:require [re-frame.core :as rf])`. Direct access to `re-frame.db/app-db` was always off-contract and is now firmly so. The accessor is `(rf/app-db-value app-frame)`, which names your app frame and returns a plain map. The reason for the tightening is the same reason chapter 18's frames work at all: when there can be N isolated app-db instances, "the global app-db atom" stops being a coherent thing to reach for, so the contract has to be a function call that names which frame you mean.
 
@@ -105,7 +116,7 @@ There's no automated rewrite for the cache-key habit. It's a judgement call abou
 (rf/reg-cofx :viewport
   {:doc "Ambient viewport width."}
   (fn [] (.-innerWidth js/window)))           ;; just the value; no ctx, no assoc-in
-(rf/reg-event-fx :layout/measure
+(rf/reg-event :layout/measure
   {:rf.cofx/requires [:viewport]}             ;; declaration metadata, not an interceptor
   (fn [{:keys [db viewport]} _] ...))
 ```

--- a/docs/guide/concepts/app-db.md
+++ b/docs/guide/concepts/app-db.md
@@ -17,12 +17,12 @@ Everything your app knows sits in one map — the logged-in user, the cart, whic
 Nested maps, vectors, sets, keywords. Ordinary data, no imposed schema. You can [add one](../how-to/validate-with-schemas.md) when you want the app to scream the instant the shape goes wrong. And exactly one thing ever changes it: an [event handler](events-and-the-cascade.md) — the function that runs in response to something happening — returning a new version of the map.
 
 ```clojure
-(rf/reg-event-db :cart/add
-  (fn [db [_event item]]
-    (update-in db [:cart :items] conj item)))
+(rf/reg-event :cart/add
+  (fn [{:keys [db]} [_event item]]
+    {:db (update-in db [:cart :items] conj item)}))
 ```
 
-Read that carefully, because it is the immutability story in four lines. The handler does not *change* app-db. `db` is a value, not a mutable cell, so it computes a new map from the old one rather than editing in place. The runtime then atomically swaps which value app-db points at. The old value still exists, untouched. The new one shares almost all of its structure with the old one — Clojure's persistent data structures don't copy, which means the new map just points at the unchanged parts of the old one. Nobody ever observes anything halfway.
+Read that carefully, because it is the immutability story in four lines. The handler does not *change* app-db. `db` — handed in via the coeffects map — is a value, not a mutable cell, so it computes a new map from the old one and returns it as the `:db` effect rather than editing in place. The runtime then atomically swaps which value app-db points at. The old value still exists, untouched. The new one shares almost all of its structure with the old one — Clojure's persistent data structures don't copy, which means the new map just points at the unchanged parts of the old one. Nobody ever observes anything halfway.
 
 Here is the sentence to hold onto. Everything else on this page restates it:
 
@@ -79,22 +79,22 @@ There is exactly one category of state in a running re-frame2 app that is *not* 
 
 So it doesn't live in app-db at all. A frame holds **two partitions**:
 
-- **app-db** — yours. Application data and *nothing else*. Every `reg-event-db` handler receives and returns it; an ordinary `:db` effect replaces it.
+- **app-db** — yours. Application data and *nothing else*. Every event handler receives it (as the `:db` coeffect) and replaces it (by returning a `:db` effect).
 - **runtime-db** — the framework's. [Machine](machines.md) snapshots, the [route](routing.md) slice, the [resource](server-state.md) cache, in-flight work records, all under reserved `:rf.runtime/*` keys. The relevant runtime writes it; you read it through that feature's subscriptions, like `[:rf/machine :checkout/flow]` or `[:rf.route/id]`.
 
 Why a separate partition instead of a reserved key in one map? Because a single map invites a footgun.
 
 !!! warning "Why the partition is structural, not a convention"
 
-    In a single map, a handler returning a fresh `{:user ...}` would silently wipe a machine snapshot living beside it. With two partitions, an ordinary `:db` return replaces *only* app-db, and a `reg-event-db` handler never even holds runtime-db — so it cannot clobber it by accident. The boundary is structural, not a rule you have to remember.
+    In a single map, a handler returning a fresh `{:user ...}` would silently wipe a machine snapshot living beside it. With two partitions, a `:db` effect replaces *only* app-db, and an ordinary event handler never even holds runtime-db — so it cannot clobber it by accident. The boundary is structural, not a rule you have to remember.
 
 The doctrine for the framework's partition is **read, don't write**. You read a managed slice through subscriptions, and you influence it by dispatching — handing off — the events its process understands. You never write it directly, because the process that put it there is what keeps it correct:
 
 ```clojure
 ;; WRONG — forging the route by hand. This writes app-db; the real route
 ;; slice lives in runtime-db, and no navigation actually happens.
-(rf/reg-event-db :go-to-cart
-  (fn [db _] (assoc db :route :route/cart)))
+(rf/reg-event :go-to-cart
+  (fn [{:keys [db]} _] {:db (assoc db :route :route/cart)}))
 
 ;; RIGHT — speak the process's language; the routing runtime writes its own slice.
 (rf/dispatch [:rf.route/navigate :route/cart])

--- a/docs/guide/concepts/effects-and-coeffects.md
+++ b/docs/guide/concepts/effects-and-coeffects.md
@@ -10,9 +10,9 @@ The input half follows one rule: a handler reads only what was recorded, never t
 
 ## The way out: effects are descriptions
 
-A pure function can't *perform* a side-effect, but it can *return a description of one* and let the runtime do the dirty work. Computing a description is pure; doing the thing is not. You've already relied on this: when a `reg-event-db` handler returns a new `db` (the next value of `app-db`, your app's single state map), your handler didn't mutate anything — the runtime did. Effects generalise that one trade to every side-effect.
+A pure function can't *perform* a side-effect, but it can *return a description of one* and let the runtime do the dirty work. Computing a description is pure; doing the thing is not. You've already relied on this: when a handler returns `{:db new-db}` (the next value of `app-db`, your app's single state map), your handler didn't mutate anything — the runtime read that `:db` effect and swapped it in. Effects generalise that one trade to every side-effect.
 
-A `reg-event-fx` handler returns a map with two top-level keys — the entire grammar for application handlers:
+A `reg-event` handler returns a map with two top-level keys — the entire grammar for application handlers:
 
 | Key | Meaning |
 |---|---|
@@ -20,7 +20,7 @@ A `reg-event-fx` handler returns a map with two top-level keys — the entire gr
 | `:fx` | A vector of `[fx-id args]` pairs. *Every* other effect — a dispatch, an HTTP request, a navigation, a storage write, one you wrote yourself — rides in here. |
 
 ```clojure
-(rf/reg-event-fx :counter/save
+(rf/reg-event :counter/save
   (fn [{:keys [db]} _event]
     {:db (assoc db :counter/saved? true)
      :fx [[:rf.http/managed
@@ -39,7 +39,7 @@ That's a state change, an HTTP POST, a storage write, and a follow-up dispatch �
 
 > **Coming from Redux?** `:fx` is what thunks/sagas/middleware do, minus the machinery: no middleware ordering, no generator runtime — the handler returns data and one interpreter loop executes it.
 
-`reg-event-db` is sugar for `reg-event-fx` with the return value auto-wrapped as `{:db ...}` — same machinery underneath. And if you came from re-frame v1: the top-level `:dispatch` / `:dispatch-later` / `:dispatch-n` effect keys are gone. Everything rides in `:fx` as ordinary rows now, so you learn one grammar instead of two.
+There's exactly one event form — `reg-event` — and a db update is just the `:db` effect in the map every handler returns. There's no separate db-only registration: the "I only touch state" case is `{:db …}` and nothing else, the same map shape as a handler that also fires three effects. And if you came from re-frame v1: the top-level `:dispatch` / `:dispatch-later` / `:dispatch-n` effect keys are gone. Everything rides in `:fx` as ordinary rows now, so you learn one grammar instead of two.
 
 ### Your own effects: `reg-fx`
 
@@ -63,9 +63,9 @@ Effects handle impurity going *out*; the second category sneaks in on the way *i
 
 ```clojure
 ;; ❌ Don't do this
-(rf/reg-event-db :todo/add
-  (fn [db [_ title]]
-    (assoc-in db [:todos] {:title title :created-at (js/Date.)})))
+(rf/reg-event :todo/add
+  (fn [{:keys [db]} [_ title]]
+    {:db (assoc-in db [:todos] {:title title :created-at (js/Date.)})}))
 ```
 
 Now the handler isn't pure: same inputs, a different output every call. No test can pin it down without monkey-patching the global clock, and — worse — replay breaks, for a reason the next section makes precise. These inputs-from-the-world are **coeffects**. Hold onto the symmetry: an effect is data the handler *outputs* for the runtime to perform; a coeffect is data the runtime *delivers* for the handler to read.
@@ -77,7 +77,7 @@ Now the handler isn't pure: same inputs, a different output every call. No test 
 | **You opt in per handler with** | `:rf.cofx/requires` | (returned in the effect map) |
 | **The impure work happens in** | the cofx supplier | the fx handler |
 
-That `{:keys [db]}` you destructure in every `reg-event-fx` handler *is* the coeffects map. `:db` and `:event` are staged automatically; every other world fact is opt-in, through one declaration key.
+That `{:keys [db]}` you destructure in every handler *is* the coeffects map. `:db` and `:event` are staged automatically; every other world fact is opt-in, through one declaration key.
 
 ### Two grades: ambient and recordable
 
@@ -104,7 +104,7 @@ The framework ships exactly one built-in entry: **`:rf/time-ms`**. It's wall-clo
 Nothing reaches a handler implicitly — **not even the time**. A handler declares the facts it consumes as registration metadata, and the runtime hands it exactly those, flat in the coeffects map beside `:db`:
 
 ```clojure
-(rf/reg-event-fx :todo/add
+(rf/reg-event :todo/add
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [id title]}]]
     {:db (assoc-in db [:todos id]
@@ -115,7 +115,7 @@ Delivery is **declared-only**: a fact on the token that this handler didn't decl
 
 Two consequences worth pinning:
 
-- **`reg-event-db` can't declare requires.** Its handler receives only the db, so `:rf.cofx/requires` on it is a registration-time error. Needing the world is what graduates a handler to the fx form.
+- **Every handler can declare requires — there's no second-class form.** Because there is exactly one `reg-event`, and it always receives the coeffects map, *any* event can carry `:rf.cofx/requires`. Adding a world fact is adding a line of metadata to a handler you already wrote; its signature and return shape never change. (This is the EP-0018 collapse: re-frame once had a db-only registration that structurally couldn't declare coeffects — that hole is gone.)
 - **`inject-cofx` is gone.** re-frame v1's coeffect-injection interceptor is removed, with no alias — calling it is a hard error that names `:rf.cofx/requires` as the replacement. Coeffect delivery is no longer a chain member you order relative to other interceptors; it's the construction of the chain's input. So v1's wart — an early interceptor blind to a later injection — can't even be expressed.
 
 > **Coming from re-frame v1?** `[(rf/inject-cofx :local-store "k")]` in the interceptor vector becomes `:rf.cofx/requires [[:local-store "k"]]` in the metadata map, and your cofx handler drops the ctx wrapper — see the [migration guide](../25-from-re-frame-v1.md).
@@ -131,7 +131,7 @@ Two consequences worth pinning:
   (fn [storage-key]
     (some-> (.-localStorage js/globalThis) (.getItem storage-key))))
 
-(rf/reg-event-fx :prefs/apply-theme
+(rf/reg-event :prefs/apply-theme
   {:rf.cofx/requires [[:ui/local-theme "ui-theme"]]}
   (fn [{:keys [db ui/local-theme]} _]
     {:db (assoc db :ui/theme (or local-theme "system"))}))
@@ -168,13 +168,13 @@ Recorded coeffects are the last rung, not the default. The `:todo/add` handler a
 ```clojure
 ;; ❌ BROKEN REPLAY — the clock is an ambient read the ledger never recorded.
 ;;    Replay this event tomorrow and :created-at is tomorrow's date. The log lies.
-(rf/reg-event-db :todo/add
-  (fn [db [_ title]]
-    (assoc-in db [:todos] {:title title :created-at (js/Date.)})))
+(rf/reg-event :todo/add
+  (fn [{:keys [db]} [_ title]]
+    {:db (assoc-in db [:todos] {:title title :created-at (js/Date.)})}))
 
 ;; ✅ HONEST REPLAY — the clock is the recorded :rf/time-ms fact the runtime supplies.
 ;;    Replay re-presents the same value; the same log reproduces the same state.
-(rf/reg-event-fx :todo/add
+(rf/reg-event :todo/add
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ title]]
     {:db (assoc-in db [:todos] {:title title :created-at time-ms})}))
@@ -193,7 +193,7 @@ A live todo-adder. The durable facts — *when* each todo was created, *what* it
 ;; A PURE handler: the clock arrives as the declared :rf/time-ms recordable
 ;; coeffect; the fresh id rides the event from the dispatch site (minting
 ;; ladder, rung 2). Both facts are durable — both are recorded.
-(rf/reg-event-fx :demo.todo/add
+(rf/reg-event :demo.todo/add
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [id]}]]
     {:db (assoc-in db [:demo.todo/items id]
@@ -201,8 +201,8 @@ A live todo-adder. The durable facts — *when* each todo was created, *what* it
                     :title (str "Todo #" (inc (count (:demo.todo/items db))))
                     :created-at time-ms})}))
 
-(rf/reg-event-db :demo.todo/initialise
-  (fn [_db _event] {:demo.todo/items {}}))
+(rf/reg-event :demo.todo/initialise
+  (fn [_cofx _event] {:db {:demo.todo/items {}}}))
 
 (rf/reg-sub :demo.todo/items
   (fn [db _query] (vals (:demo.todo/items db))))

--- a/docs/guide/concepts/errors.md
+++ b/docs/guide/concepts/errors.md
@@ -102,17 +102,17 @@ Delete either `{:frame frame}` and that callback's dispatch raises `:rf.error/no
 *The user arrived on a deep link that bypassed your init event, so `:cart` was never seeded. The first click walks `update-in` straight into a `nil` and throws.*
 
 ```clojure
-(rf/reg-event-db :cart/add-item
-  (fn [db [_ item]]
-    (update-in db [:cart :items] conj item)))    ;; throws when :cart doesn't exist
+(rf/reg-event :cart/add-item
+  (fn [{:keys [db]} [_ item]]
+    {:db (update-in db [:cart :items] conj item)}))    ;; throws when :cart doesn't exist
 ```
 
 The runtime catches it and emits `:rf.error/handler-exception` with `:recovery :no-recovery`: cascade halted, nothing committed, app-db untouched. The fix is a defensive default at the point of access:
 
 ```clojure
-(rf/reg-event-db :cart/add-item
-  (fn [db [_ item]]
-    (update-in db [:cart :items] (fnil conj []) item)))
+(rf/reg-event :cart/add-item
+  (fn [{:keys [db]} [_ item]]
+    {:db (update-in db [:cart :items] (fnil conj []) item)}))
 ```
 
 !!! note "Do, observe"
@@ -141,7 +141,7 @@ Errors are data, so asserting them is as boring as asserting anything else. Coll
       (try
         (rf/reg-fx :checkout/analytics
           (fn [_frame-ctx args] (swap! fired conj args)))
-        (rf/reg-event-fx :checkout/submit
+        (rf/reg-event :checkout/submit
           (fn [_ _]
             {:fx [[:checkout/never-registered {:order-id 7}]   ;; the typo under test
                   [:checkout/analytics        {:order-id 7}]]}))

--- a/docs/guide/concepts/events-and-the-cascade.md
+++ b/docs/guide/concepts/events-and-the-cascade.md
@@ -40,19 +40,19 @@ This is the first load-bearing idea, and it's the one that trips people up comin
 **2 — The handler runs.** The runtime dequeues `[:counter/inc]` and looks up its registered handler:
 
 ```clojure
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 ```
 
-It runs as a pure function: current `db` and the event in, next `db` out. No I/O, no DOM, no clock. You can test it in one line, because given `{:counter/value 5}` it returns `{:counter/value 6}` and nothing else ([Test an event handler](../how-to/test-an-event-handler.md) is exactly this).
+It runs as a pure function: the coeffects (the facts it's handed — `:db` among them) and the event in, an **effect map** out. No I/O, no DOM, no clock. You can test it in one line, because given a coeffects map with `:db {:counter/value 5}` it returns `{:db {:counter/value 6}}` and nothing else ([Test an event handler](../how-to/test-an-event-handler.md) is exactly this).
 
-**3 — Effects come out, as data.** The handler returned `{:counter/value 6}`. Because this was a `reg-event-db` registration, the runtime wraps that bare return into an **effect map** — a description of what should happen, expressed as data:
+**3 — Effects come out, as data.** The handler returned an **effect map** — a description of what should happen, expressed as data:
 
 ```clojure
 {:db {:counter/value 6}}
 ```
 
-Pause here, because it reframes what a handler is. Even our trivially pure handler caused a side effect: somebody has to swap app-db. The trick is that the handler *described* the change and the runtime *performed* it. `reg-event-db` is just sugar for the general form, `reg-event-fx`. Its handlers return the effect map themselves: `:db` to replace app-db, plus an `:fx` vector of `[effect-id args]` rows for everything else. Same machine, two spellings.
+Pause here, because it reframes what a handler is. Even our trivially pure handler caused a side effect: somebody has to swap app-db. The trick is that the handler *described* the change and the runtime *performed* it. Read the map as *"the next state, and anything else to do."* The "anything else" rides in an `:fx` vector of `[effect-id args]` rows — an HTTP request, a navigation, a follow-up dispatch. The counter's map has only `:db`, so there's nothing else to do; but it's the same map a handler that fires three effects returns, just with the other keys empty. One shape, no second spelling: a db update is the effect `{:db …}`, stated as plainly as every other effect.
 
 **4 — The runtime executes the effects.** It sees `:db` and swaps app-db to `{:counter/value 6}` in one atomic step, which means no observer ever sees a half-written state. If there were `:fx` rows, it would run them next, in source order, after the `:db` commit. For this click there are none.
 
@@ -81,14 +81,14 @@ Real apps reach outside themselves: servers, storage, timers. The counter never 
 
 ```clojure
 ;; Don't do this.
-(rf/reg-event-db :article/load
-  (fn [db [_ {:keys [slug]}]]
+(rf/reg-event :article/load
+  (fn [{:keys [db]} [_ {:keys [slug]}]]
     (.then (js/fetch (str "/api/articles/" slug))
            (fn [response]
              ;; ...and now what? The `db` this closure captured is
              ;; already stale, and returning from here goes nowhere.
              ))
-    (assoc db :article/loading? true)))
+    {:db (assoc db :article/loading? true)}))
 ```
 
 This fails three ways, and the failures are the reasons for the architecture, not style points:
@@ -107,7 +107,7 @@ Here is the same load, written so the handler stays pure. An effect, here, is a 
 
 ```clojure
 ;; cf. examples/reagent/realworld/articles.cljs
-(rf/reg-event-fx :article/load
+(rf/reg-event :article/load
   (fn [{:keys [db]} [_ {:keys [slug]}]]
     {:db (assoc db :article/loading? true)
      :fx [[:rf.http/managed
@@ -119,17 +119,17 @@ Here is the same load, written so the handler stays pure. An effect, here, is a 
 
 ;; The reply payload rides as the last event argument;
 ;; :value is the decoded response body — here {:article {...}}.
-(rf/reg-event-db :article/loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc :article/loading? false)
-        (assoc :article/current (:article value)))))
+(rf/reg-event :article/loaded
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc :article/loading? false)
+             (assoc :article/current (:article value)))}))
 
-(rf/reg-event-db :article/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc :article/loading? false)
-        (assoc :article/load-error failure))))
+(rf/reg-event :article/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
+             (assoc :article/loading? false)
+             (assoc :article/load-error failure))}))
 ```
 
 The handler still returns nothing but a Clojure map: strings, keywords, vectors. No promise, no callback, no `js/fetch`. The map describes everything that should happen: "set app-db to this, fire a managed HTTP request, on success dispatch `[:article/loaded ...]`, on failure dispatch `[:article/load-failed ...]`." The runtime reads the `:fx` row, looks up the `:rf.http/managed` effect handler, and performs the request. When the reply arrives, it enters the system the only way anything enters the system: as a fresh event on the queue, with its own trip through the six steps and its own row in Xray.
@@ -138,10 +138,10 @@ Read what that bought you. The entire fetch flow is three pure handlers you read
 
 Two notes before moving on:
 
-- **The first argument is the coeffects map** — a coeffect being an input fact the handler needs from the world, gathered with everything else into one value. `:db` and `:event` arrive for free. A handler that needs more (the current time, a storage read) declares those facts at registration with `:rf.cofx/requires` and receives them as plain values in that map. That declaration — and why needing the world is what graduates a handler from `reg-event-db` to `reg-event-fx` — is [the coeffects page's](effects-and-coeffects.md) subject.
+- **The first argument is the coeffects map** — a coeffect being an input fact the handler needs from the world, gathered with everything else into one value. `:db` and `:event` arrive for free. A handler that needs more (the current time, a storage read) declares those facts at registration with `:rf.cofx/requires` and receives them as plain values in that map — no change to the handler's shape, just a line of metadata. That declaration is [the coeffects page's](effects-and-coeffects.md) subject.
 - **Follow-up events from inside a handler are effects too.** Never call `dispatch` from a handler body. Return `:fx [[:dispatch [:next-thing]]]` and the runtime queues it. Same rule, same reason: describe, don't do.
 
-> **Coming from Redux?** `reg-event-fx` is where thunks, sagas, and middleware used to live — except the handler stays a pure function, and the "middleware" is the runtime's effect interpreter.
+> **Coming from Redux?** The `:fx` vector is where thunks, sagas, and middleware used to live — except the handler stays a pure function returning data, and the "middleware" is the runtime's effect interpreter.
 
 For real server data you will usually reach one level higher than raw HTTP — [resources](server-state.md) manage the request, caching, and staleness for you — but the mechanism underneath is exactly this fx.
 
@@ -188,6 +188,6 @@ The trade is the framework's signature move, made for the third time on this pag
 
 - explain what an event is (a recorded fact, not an instruction) and what `dispatch` does (queue it and return),
 - trace a click through all six steps of the cascade and point at each one in Xray's event rows,
-- say why handlers return effect descriptions instead of performing effects, and rewrite an inline fetch into a pure `reg-event-fx` handler with named success and failure events,
+- say why handlers return effect descriptions instead of performing effects, and rewrite an inline fetch into a pure `reg-event` handler with named success and failure events,
 - state the ledger promise — *two fresh apps, fed the same sequence of events, finish in identical states* — and name its precondition (recorded inputs, not ambient reads),
 - predict when the screen repaints: once per drain, after the cascade settles.

--- a/docs/guide/concepts/flows.md
+++ b/docs/guide/concepts/flows.md
@@ -66,12 +66,12 @@ The RealWorld editor's submit gate is the canonical case. "Can the user submit?"
                   (not= draft baseline)))
    :path   [:editor :can-submit?]})
 
-(rf/reg-event-fx :editor/initialise
+(rf/reg-event :editor/initialise
   (fn [{:keys [db]} _event]
     {:db (assoc db :editor (editor-slice))         ;; the blank {:draft … :baseline …} slice
      :fx [[:rf.fx/reg-flow can-submit-flow]]}))    ;; registered on page entry, bound to this frame
 
-(rf/reg-event-fx :editor/submit
+(rf/reg-event :editor/submit
   (fn [{:keys [db]} _event]
     (let [draft (get-in db [:editor :draft])]
       (if (get-in db [:editor :can-submit?])       ;; the flow's output, read as plain data
@@ -106,7 +106,7 @@ Flows are registered against the runtime, not compiled into event chains. So you
 
 ```clojure
 ;; Condensed from examples/reagent/flows/core.cljs — a 10%-off feature gate
-(rf/reg-event-fx :cart/apply-discount
+(rf/reg-event :cart/apply-discount
   (fn [_cofx _event]
     {:fx [[:rf.fx/reg-flow {:id     :cart/discount-rate
                             :inputs [[:cart :subtotal]]
@@ -114,13 +114,13 @@ Flows are registered against the runtime, not compiled into event chains. So you
                             :path   [:cart :discount-rate]}]
           [:dispatch [:cart/touch]]]}))             ;; see the lag note below
 
-(rf/reg-event-fx :cart/remove-discount
+(rf/reg-event :cart/remove-discount
   (fn [_cofx _event]
     {:fx [[:rf.fx/clear-flow :cart/discount-rate]
           [:dispatch [:cart/touch]]]}))
 
-(rf/reg-event-db :cart/touch
-  (fn [db _event] db))                              ;; no-op; exists only to trigger a drain
+(rf/reg-event :cart/touch
+  (fn [{:keys [db]} _event] {:db db}))              ;; no-op; exists only to trigger a drain
 ```
 
 `:rf.fx/clear-flow` removes the registration **and vacates the value at `:path`**, so no stale derived state is left behind for downstream readers to trust by mistake. (If you need the last value, copy it somewhere else before clearing.)

--- a/docs/guide/concepts/frames.md
+++ b/docs/guide/concepts/frames.md
@@ -12,7 +12,7 @@ A frame is one running instance of your app. It owns the runtime state of that i
 - its **event queue** — the dispatches (requests to run an event) waiting to run against this instance,
 - its **subscription cache** — the memoised graph of derived values computed over this instance's state.
 
-A frame deliberately does *not* own the handlers — the functions you register to handle events and subscriptions. Every `reg-event-db`, `reg-event-fx`, `reg-sub`, and `reg-view` in your program goes into a single shared registry. So two frames running the `[:counter/inc]` event run the *same handler function* against *different app-dbs*. That's the whole trick.
+A frame deliberately does *not* own the handlers — the functions you register to handle events and subscriptions. Every `reg-event`, `reg-sub`, and `reg-view` in your program goes into a single shared registry. So two frames running the `[:counter/inc]` event run the *same handler function* against *different app-dbs*. That's the whole trick.
 
 A frame isolates state, not behaviour. You write the app once, and the frame decides which copy of the state it runs against.
 
@@ -28,9 +28,9 @@ Almost every app is a one-frame app, and stays one. You register a frame at boot
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]))
 
-(rf/reg-event-db :app/initialise
-  (fn [_db _event]
-    {:screen :home}))
+(rf/reg-event :app/initialise
+  (fn [_cofx _event]
+    {:db {:screen :home}}))
 
 (rf/reg-sub :screen (fn [db _] (:screen db)))
 
@@ -71,8 +71,8 @@ Here's the split pane, end to end:
 
 ```clojure
 ;; Adapted from testbeds/multi_frame/core.cljs
-(rf/reg-event-db ::init (fn [_db _ev] {:n 0}))
-(rf/reg-event-db ::inc  (fn [db _ev] (update db :n inc)))
+(rf/reg-event ::init (fn [_cofx _ev] {:db {:n 0}}))
+(rf/reg-event ::inc  (fn [{:keys [db]} _ev] {:db (update db :n inc)}))
 (rf/reg-sub :n (fn [db _] (:n db)))
 
 ;; Registered once. The injected `dispatch` / `subscribe` resolve against
@@ -178,7 +178,7 @@ Reach for `frame-handle` for the common dispatch/subscribe case. Reach for `fram
 And there's one important case where you need none of this: scheduling from inside an event handler. A handler that wants a later dispatch returns effect data — a description of work for the runtime to perform — and the effects carry the frame for you:
 
 ```clojure
-(rf/reg-event-fx :toast/show
+(rf/reg-event :toast/show
   (fn [{:keys [db]} [_ message]]
     {:db (assoc db :toast message)
      :fx [[:dispatch-later {:ms 3000 :event [:toast/clear]}]]}))

--- a/docs/guide/concepts/http.md
+++ b/docs/guide/concepts/http.md
@@ -38,7 +38,7 @@ That's seven sins and a frame leak in three lines. The fix isn't more careful fe
    :max-attempts 3
    :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
 
-(rf/reg-event-fx :article/load
+(rf/reg-event :article/load
   (fn [{:keys [db]} [_ slug]]
     {:db (-> db
              (assoc-in [:article :status] :loading)
@@ -63,7 +63,7 @@ Almost everything here is optional, which means the common case stays short. The
 There is no `await`. The handler — the function that runs in response to an event — never pauses to wait for the server and then resumes. The handler above returned a map and finished. When the response lands, the runtime dispatches a **new event**, with the reply appended as the last argument:
 
 ```clojure
-(rf/reg-event-fx :article/loaded
+(rf/reg-event :article/loaded
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
     {:db (-> db
@@ -71,11 +71,11 @@ There is no `await`. The handler — the function that runs in response to an ev
              (assoc-in [:article :data]      (:article value))
              (assoc-in [:article :loaded-at] time-ms))}))
 
-(rf/reg-event-db :article/load-error
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:article :status] :error)
-        (assoc-in [:article :error]  failure))))
+(rf/reg-event :article/load-error
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
+             (assoc-in [:article :status] :error)
+             (assoc-in [:article :error]  failure))}))
 ```
 
 The success payload is `{:kind :success :value <decoded>}`. The failure payload is `{:kind :failure :failure <failure-map>}`. Three small handlers — issue, succeed, fail. Each does one thing, and the failure path has its own name instead of being an afterthought tacked onto the success path. Two details here are load-bearing, and they trip people up the first time:
@@ -95,7 +95,7 @@ Sometimes the request and reply really do belong together. Omit `:on-success` / 
 
 ```clojure
 ;; From examples/reagent/managed_http_counter (core.cljs), condensed.
-(rf/reg-event-fx :counter/+1
+(rf/reg-event :counter/+1
   (fn [{:keys [db]} [_ msg]]
     (if-let [reply (:rf/reply msg)]
       (case (:kind reply)

--- a/docs/guide/concepts/index.md
+++ b/docs/guide/concepts/index.md
@@ -36,17 +36,17 @@ flowchart LR
 
 One pass through the pipeline is one **epoch**. Dominoes and epoch are the same picture under two names — you'll hear both, so it's worth knowing they point at the same thing.
 
-In code, the simplest handler just returns a new state. `reg-event-db` is the spelling for that:
+In code, every handler is registered with `reg-event`, and it returns a map: the next state under `:db`, plus anything else to do. The simplest handler only touches state, so the map has only `:db`:
 
 ```clojure
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 ```
 
-When the event also needs the world to do something, the handler graduates to `reg-event-fx` and returns the full effects map — still pure, still just data:
+When the event also needs the world to *do* something, you add an `:fx` vector to the same map — same registration, same signature, still pure, still just data:
 
 ```clojure
-(rf/reg-event-fx :feed/refresh
+(rf/reg-event :feed/refresh
   (fn [{:keys [db]} _event]
     {:db (assoc db :feed/loading? true)
      :fx [[:rf.http/managed
@@ -56,7 +56,7 @@ When the event also needs the world to do something, the handler graduates to `r
             :on-failure [:feed/load-failed]}]]}))
 ```
 
-These are one machine in two spellings: `reg-event-db` is sugar for `reg-event-fx` whose bare return gets wrapped as `{:db ...}`. The server's reply comes back as a new event — `[:feed/loaded ...]` — which walks the same six dominoes itself. And the world coming *in* is symmetric. A handler that needs a fact from the world — the current time, a stored token — declares it and receives it as an input (that incoming fact is a **coeffect**), rather than reaching out for it mid-function. Both directions live in [Effects and coeffects](effects-and-coeffects.md).
+One form, one map: a db update is the effect `{:db …}`, and everything else rides in `:fx` beside it. The server's reply comes back as a new event — `[:feed/loaded ...]` — which walks the same six dominoes itself. And the world coming *in* is symmetric. A handler that needs a fact from the world — the current time, a stored token — declares it with `:rf.cofx/requires` and receives it as an input (that incoming fact is a **coeffect**), rather than reaching out for it mid-function. Both directions live in [Effects and coeffects](effects-and-coeffects.md).
 
 > **Coming from Redux?** Dominoes 3–4 replace the entire middleware question — thunks, sagas, observables — with a plain map the reducer-equivalent returns.
 

--- a/docs/guide/concepts/interceptors.md
+++ b/docs/guide/concepts/interceptors.md
@@ -88,11 +88,11 @@ Both slots are optional. An interceptor is just a map carrying `:id`, `:before`,
 Attach it where the event is registered: the metadata map's `:interceptors` key. The historical positional vector has been removed, so interceptor chains always live alongside the rest of the registration metadata:
 
 ```clojure
-(rf/reg-event-db :cart.item/add
+(rf/reg-event :cart.item/add
   {:doc          "Add an item to the cart."
    :interceptors [logger]}
-  (fn [db [_ item]]
-    (update db :cart/items conj item)))
+  (fn [{:keys [db]} [_ item]]
+    {:db (update db :cart/items conj item)}))
 ```
 
 Dispatch `[:cart.item/add ...]` and the console shows the trip in and the timed trip out. Now open Xray and focus the event's epoch: the pipeline lists your chain by `:id` with a jump-to-source link, and the after-interceptors stage shows the way out. (In a real app the [trace wire](observability.md) already records every event with timings — this logger is the teaching shape.)
@@ -171,47 +171,47 @@ The most satisfying interceptor is undo. Hand-rolled, it smears "remember the ol
 Read it through the two-key lens. `:before` reads the *inputs* (`:coeffects`, where `:db` is the pre-handler value) and stashes the prior circles on the context. `:after` reads the *outputs* (`:effects`, where `:db` is the post-handler value — absent if nothing changed), compares, and only then pushes an undo step and clears redo. Which events are undoable is decided entirely by inclusion: both consuming events tag the chain, and the continuous one opts out by omission.
 
 ```clojure
-(rf/reg-event-db :drawer/add-circle
+(rf/reg-event :drawer/add-circle
   {:doc "Click on canvas — add a circle of default radius."
    :interceptors [undoable]}
-  (fn [db [_ x y]]
+  (fn [{:keys [db]} [_ x y]]
     (let [id (get-in db [:drawer :next-id])]
-      (-> db
-          (update-in [:drawer :circles] conj {:id id :x x :y y :radius 30})
-          (assoc-in  [:drawer :next-id] (inc id))))))
+      {:db (-> db
+               (update-in [:drawer :circles] conj {:id id :x x :y y :radius 30})
+               (assoc-in  [:drawer :next-id] (inc id)))})))
 
-(rf/reg-event-db :drawer/dialog-drag
+(rf/reg-event :drawer/dialog-drag
   {:doc "Slider movement — updates the draft radius only. Continuous; NOT undoable."}
-  (fn [db [_ new-radius]]
-    (assoc-in db [:drawer :dialog :draft-radius] new-radius)))
+  (fn [{:keys [db]} [_ new-radius]]
+    {:db (assoc-in db [:drawer :dialog :draft-radius] new-radius)}))
 
-(rf/reg-event-db :drawer/close-dialog
+(rf/reg-event :drawer/close-dialog
   {:doc "Commit the dialog's draft radius onto its circle. One undo step."
    :interceptors [undoable]}
-  (fn [db _]
+  (fn [{:keys [db]} _]
     (let [{:keys [circle-id draft-radius]} (get-in db [:drawer :dialog])]
-      (-> db
-          (update-in [:drawer :circles]
-                     (fn [cs] (mapv #(if (= circle-id (:id %))
-                                       (assoc % :radius draft-radius)
-                                       %)
-                                    cs)))
-          (assoc-in [:drawer :dialog] nil)))))
+      {:db (-> db
+               (update-in [:drawer :circles]
+                          (fn [cs] (mapv #(if (= circle-id (:id %))
+                                            (assoc % :radius draft-radius)
+                                            %)
+                                         cs)))
+               (assoc-in [:drawer :dialog] nil))})))
 ```
 
 The drag handler mutates only the dialog's draft, so a hundred slider moves never touch `:circles`. When `:drawer/close-dialog` commits, the snapshot `undoable` took is exactly the pre-dialog state, and the whole edit collapses into one undo step, for free. Closing the loop, undo itself is an ordinary event — no interceptor needed, just state moving between stacks (redo mirrors it with the stacks swapped):
 
 ```clojure
-(rf/reg-event-db :drawer/undo
+(rf/reg-event :drawer/undo
   {:doc "Pop one snapshot from :undo, push current :circles to :redo."}
-  (fn [db _]
+  (fn [{:keys [db]} _]
     (let [{:keys [undo circles]} (:drawer db)]
-      (if (empty? undo)
-        db
-        (-> db
-            (assoc-in [:drawer :circles] (peek undo))
-            (update-in [:drawer :undo] pop)
-            (update-in [:drawer :redo] (fnil conj []) circles))))))
+      {:db (if (empty? undo)
+             db
+             (-> db
+                 (assoc-in [:drawer :circles] (peek undo))
+                 (update-in [:drawer :undo] pop)
+                 (update-in [:drawer :redo] (fnil conj []) circles)))})))
 ```
 
 One interceptor, plus which chains include it: that's the entire undo feature.

--- a/docs/guide/concepts/machines.md
+++ b/docs/guide/concepts/machines.md
@@ -11,7 +11,7 @@ The anchor here is [**XState v5**](https://stately.ai/docs). re-frame2's machine
 You already write state machines. You just call them other things. The keyword you stuffed into app-db — `:idle`, `:submitting`, `:authed` — plus the rules in your head about which states can legally follow which: that's a machine, written informally. Here's a login flow written the way most people write it first:
 
 ```clojure
-(rf/reg-event-fx :auth/submit
+(rf/reg-event :auth/submit
   (fn [{:keys [db]} [_ creds]]
     (cond
       (= :submitting (:auth/state db))
@@ -28,11 +28,11 @@ You already write state machines. You just call them other things. The keyword y
               :on-success [:auth/login-success]
               :on-failure [:auth/login-error]}]]})))
 
-(rf/reg-event-db :auth/login-error
-  (fn [db [_ {:keys [failure]}]]
-    (if (>= (:auth/attempts db) 3)
-      (assoc db :auth/state :locked-out)
-      (-> db (assoc :auth/state :error-shown) (assoc :auth/error failure)))))
+(rf/reg-event :auth/login-error
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (if (>= (:auth/attempts db) 3)
+           (assoc db :auth/state :locked-out)
+           (-> db (assoc :auth/state :error-shown) (assoc :auth/error failure)))}))
 
 ;; ... plus :auth/login-success, :auth/dismiss, :auth/reset ...
 ```
@@ -114,12 +114,12 @@ Registering the table is one line, and this is where people sometimes brace for 
 ```clojure
 (rf/reg-machine :auth.login/flow login-flow)
 ;; exactly equivalent to (machines/make-machine-handler is in re-frame.machines):
-;; (rf/reg-event-fx :auth.login/flow (machines/make-machine-handler login-flow))
+;; (rf/reg-event :auth.login/flow (machines/make-machine-handler login-flow))
 ```
 
 > **One-time setup.** Machines ship in their own artefact, `day8/re-frame2-machines`, so apps without machines build a bundle clean of them. Add the dep and require `re-frame.machines` once at app boot — that registers the hooks through which `rf/reg-machine`, `rf/machine-transition`, and `rf/sub-machine` resolve.
 
-A machine **is** an event handler. It's a `reg-event-fx` whose body interprets the transition table: look up the snapshot, compute the transition, write it back, return the action's effects (the effects being the data describing what should happen in the world — the HTTP call, the storage write). Every event reaches it through the same `dispatch` — the call that sends an event into the system — and the same [cascade](events-and-the-cascade.md) as everything else. There's no actor object and no second messaging system, which is the point: one mechanism, used everywhere. (`reg-machine` is a macro that also stamps dev-only source coordinates so tools can jump from a diagram arrow to your code; production builds elide them.)
+A machine **is** an event handler. It's a `reg-event` whose body interprets the transition table: look up the snapshot, compute the transition, write it back, return the action's effects (the effects being the data describing what should happen in the world — the HTTP call, the storage write). Every event reaches it through the same `dispatch` — the call that sends an event into the system — and the same [cascade](events-and-the-cascade.md) as everything else. There's no actor object and no second messaging system, which is the point: one mechanism, used everywhere. (`reg-machine` is a macro that also stamps dev-only source coordinates so tools can jump from a diagram arrow to your code; production builds elide them.)
 
 Dispatching routes through the machine's id, wrapping an inner event vector:
 
@@ -150,7 +150,7 @@ XState v5 is the behaviour re-frame2 matches; the *expression* is re-frame-nativ
 |---|---|---|
 | `context` (extended state) | `:data` | Same idea; "context" is already overloaded in re-frame2 (interceptor context, React context). |
 | `createActor(machine).start()`, then `actor.send({type: ...})` | the machine **is an event handler**; `(rf/dispatch [machine-id [event]])` | **The big one.** No actor object, no separate send mechanism — one router queue, one cascade. |
-| actions that imperatively `assign(...)` / fire effects | actions **return** `{:data ... :fx ...}` | The same data-shaped return as any `reg-event-fx` handler; effects are data, actioned by the runtime. |
+| actions that imperatively `assign(...)` / fire effects | actions **return** `{:data ... :fx ...}` | The same data-shaped return as any `reg-event` handler; effects are data, actioned by the runtime. |
 | state lives in the actor; `actor.getSnapshot()` | the snapshot is a value in runtime-db, read via `@(rf/sub-machine id)` | Time-travel, undo, persistence, and SSR hydration extend to machines for free. |
 | `setup({guards, actions})` | machine-local `:guards` / `:actions` maps inside the spec | Each machine carries its own, validated at registration; cross-machine reuse is ordinary Clojure vars, not a string registry. |
 
@@ -197,7 +197,7 @@ Here's a turnstile with two states and a counter riding in `:data`, live in your
 
 ## Guards, actions, tags, `:after` — the recognition kit
 
-**Guards and actions receive one context map** — `{:data :event :state :meta}` — and destructure what they need. A guard returns a boolean. An action returns `{:data ...}` (merged into the data slot), `:fx` (effects), both, or `nil` — the same contract as a `reg-event-fx` return. Each slot takes one fn or one keyword reference into the machine's own `:guards` / `:actions` map. There's deliberately no `{:and ...}` combinator DSL — compound logic is a named function instead, because the *name* is what a visualiser or an AI reads on the transition arrow.
+**Guards and actions receive one context map** — `{:data :event :state :meta}` — and destructure what they need. A guard returns a boolean. An action returns `{:data ...}` (merged into the data slot), `:fx` (effects), both, or `nil` — the same contract as a `reg-event` return. Each slot takes one fn or one keyword reference into the machine's own `:guards` / `:actions` map. There's deliberately no `{:and ...}` combinator DSL — compound logic is a named function instead, because the *name* is what a visualiser or an AI reads on the transition arrow.
 
 **Facts from the world are declared, not grabbed.** This one trips people up. A guard or action that needs the time (or a random draw) must not call `(js/Date.now)`, because that buries nondeterminism where replay can't reach it — and replay is what makes time-travel and SSR hydration work. Instead, declare the fact on a *named* entry and destructure it from the context map:
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -41,7 +41,7 @@ Everything else on this page is a refinement of those three moves: query strings
 
 ## A route is a registry entry
 
-`reg-route` registers a route the same way `reg-event-db` registers an event: an id plus a metadata map. The `:path` grammar is deliberately small enough to parse in your head — literal segments (`/articles`), named params (`:id`), an optional group (`{/:slug}?`), a catch-all splat (`*rest`), and the root (`/`). The `:params` and `:query` keys take schemas, which validate and coerce for you, so `?page=2` arrives as the integer `2` rather than the string `"2"`. That coercion is the part people forget to do by hand, so it's worth letting the schema own it.
+`reg-route` registers a route the same way `reg-event` registers an event: an id plus a metadata map. The `:path` grammar is deliberately small enough to parse in your head — literal segments (`/articles`), named params (`:id`), an optional group (`{/:slug}?`), a catch-all splat (`*rest`), and the root (`/`). The `:params` and `:query` keys take schemas, which validate and coerce for you, so `?page=2` arrives as the integer `2` rather than the string `"2"`. That coercion is the part people forget to do by hand, so it's worth letting the schema own it.
 
 ```clojure
 (rf/reg-route :app/search

--- a/docs/guide/concepts/server-state.md
+++ b/docs/guide/concepts/server-state.md
@@ -186,7 +186,7 @@ The cross-session leak — user B sees user A's dashboard — has a structural f
 
 ```clojure
 ;; Adapted from examples/reagent/realworld_resources/auth.cljs
-(rf/reg-event-fx :auth/logout
+(rf/reg-event :auth/logout
   (fn [{:keys [db]} _]
     (let [old-scope (rf/resolve-resource-scope db :realworld/session)]
       {:db (dissoc db :auth)

--- a/docs/guide/concepts/ssr.md
+++ b/docs/guide/concepts/ssr.md
@@ -49,7 +49,7 @@ Handlers read the request the way they read any outside fact — through a decla
 
 ```clojure
 ;; Adapted from examples/reagent/ssr/core.cljc
-(rf/reg-event-fx :rf/server-init
+(rf/reg-event :rf/server-init
   {:platforms        #{:server}
    :rf.cofx/requires [:rf.server/request]}
   (fn [{:keys [db rf.server/request]} _]

--- a/docs/guide/concepts/subscriptions.md
+++ b/docs/guide/concepts/subscriptions.md
@@ -92,14 +92,14 @@ The gate scales further than you'd guess. The [Cells spreadsheet example](../../
 Reading about a circuit breaker is one thing; watching one branch stay silent while its neighbour fires is better. Drop this into your app. It's self-contained: two independent app-db slices, one extractor and one derivation per branch, one view reading both. (`rf/reg-view` registers the view and injects the frame-aware `dispatch` / `subscribe` locals its body uses — [Views](views.md) tells that story.)
 
 ```clojure
-(rf/reg-event-db :pulse/initialise
-  (fn [db _]
-    (assoc db
-           :pulse/ticks 0                            ;; this slice will change
-           :pulse/motto "facts in, conclusions out"))) ;; this one never does
+(rf/reg-event :pulse/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db
+                :pulse/ticks 0                            ;; this slice will change
+                :pulse/motto "facts in, conclusions out")})) ;; this one never does
 
-(rf/reg-event-db :pulse/tick
-  (fn [db _] (update db :pulse/ticks inc)))
+(rf/reg-event :pulse/tick
+  (fn [{:keys [db]} _] {:db (update db :pulse/ticks inc)}))
 
 ;; Layer 1 — one tiny extractor per slice.
 (rf/reg-sub :pulse/ticks (fn [db _] (:pulse/ticks db)))
@@ -130,7 +130,7 @@ Now **observe**. With Xray attached (the one-line setup is in [Debug with Xray](
 
 Every tick is a brand-new app-db value, and both branches are attached to it. The difference between them is the gate. Change flows exactly as far as values actually move, and not one node further.
 
-> **Try it.** Register a deliberate no-op — `(rf/reg-event-db :pulse/restate (fn [db _] (assoc db :pulse/motto "facts in, conclusions out")))` — give it a button, and dispatch it. The event row appears and the cascade ends immediately: app-db is `=` to before, so nothing recomputed and nothing re-rendered. The graph proved nothing changed and went back to sleep.
+> **Try it.** Register a deliberate no-op — `(rf/reg-event :pulse/restate (fn [{:keys [db]} _] {:db (assoc db :pulse/motto "facts in, conclusions out")}))` — give it a button, and dispatch it. The event row appears and the cascade ends immediately: app-db is `=` to before, so nothing recomputed and nothing re-rendered. The graph proved nothing changed and went back to sleep.
 
 ## Parametric inputs: the two-function form
 

--- a/docs/guide/concepts/views.md
+++ b/docs/guide/concepts/views.md
@@ -74,14 +74,14 @@ Here is a `defn` view doing its whole job: subscribe in, dispatch out, hiccup be
          '[re-frame.core :as rf])
 
 ;; Adapted from examples/reagent/counter/core.cljs (defn spelling for the cell).
-(rf/reg-event-db :views.counter/initialise
-  (fn [db _event] (assoc db :views.counter/value 5)))
+(rf/reg-event :views.counter/initialise
+  (fn [{:keys [db]} _event] {:db (assoc db :views.counter/value 5)}))
 
-(rf/reg-event-db :views.counter/inc
-  (fn [db _event] (update db :views.counter/value inc)))
+(rf/reg-event :views.counter/inc
+  (fn [{:keys [db]} _event] {:db (update db :views.counter/value inc)}))
 
-(rf/reg-event-db :views.counter/dec
-  (fn [db _event] (update db :views.counter/value dec)))
+(rf/reg-event :views.counter/dec
+  (fn [{:keys [db]} _event] {:db (update db :views.counter/value dec)}))
 
 (rf/reg-sub :views.counter/value
   (fn [db _query] (:views.counter/value db)))

--- a/docs/guide/explanation/continuations-are-data.md
+++ b/docs/guide/explanation/continuations-are-data.md
@@ -24,7 +24,7 @@ Before the payoffs, the bug — because this is the part that actually bites peo
 
 ```clojure
 ;; THE TRAP — do not copy.
-(rf/reg-event-fx :checkout/quote
+(rf/reg-event :checkout/quote
   (fn [{:keys [db]} _]
     (-> (js/fetch "/api/checkout/quote")
         (.then #(.json %))
@@ -46,7 +46,7 @@ The `.then` closure captured `db` (your app-db, the single state map handed to t
 Now the same intent with the continuation as data:
 
 ```clojure
-(rf/reg-event-fx :checkout/quote
+(rf/reg-event :checkout/quote
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:checkout :status] :quoting)
      :fx [[:rf.http/managed
@@ -54,18 +54,18 @@ Now the same intent with the continuation as data:
             :on-success [:checkout/quoted]
             :on-failure [:checkout/quote-failed]}]]}))
 
-(rf/reg-event-db :checkout/quoted
-  (fn [db [_ {:keys [value]}]]
+(rf/reg-event :checkout/quoted
+  (fn [{:keys [db]} [_ {:keys [value]}]]
     ;; This `db` is current — handed to the handler at ARRIVAL time.
-    (if (= (:cart/version db) (:cart-version value))
-      (assoc-in db [:checkout :quote] value)
-      (assoc-in db [:checkout :status] :cart-changed))))
+    {:db (if (= (:cart/version db) (:cart-version value))
+           (assoc-in db [:checkout :quote] value)
+           (assoc-in db [:checkout :status] :cart-changed))}))
 
-(rf/reg-event-db :checkout/quote-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:checkout :status] :error)
-        (assoc-in [:checkout :error]  failure))))
+(rf/reg-event :checkout/quote-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
+             (assoc-in [:checkout :status] :error)
+             (assoc-in [:checkout :error]  failure))}))
 ```
 
 A closure **closes over the past; a handler receives the present.** The reply handler (the function registered to run when the answer arrives) is given the db of the moment the reply lands. So "did the cart change while we waited?" is a live comparison, not a memory. It takes no discipline on your part — there is simply no mechanism by which the old db can leak into the new decision.

--- a/docs/guide/how-to/add-auth.md
+++ b/docs/guide/how-to/add-auth.md
@@ -45,7 +45,7 @@ Reading the saved token *back* at boot is a world read — a [coeffect](../conce
 The form is exactly [Build a form](build-a-form.md) — same slice shape, same seven events, same error-visibility rule. That recipe's running example is already this login form at `[:auth :login]`. Auth changes just one thing: **success establishes a session**. So upgrade that page's `:form.login/submit-success` to an fx handler — a handler is the function that runs when an event is dispatched — that stores the user and token, persists, and bounces the user onward:
 
 ```clojure
-(rf/reg-event-fx :form.login/submit-success
+(rf/reg-event :form.login/submit-success
   (fn [{:keys [db]} [_ {:keys [value]}]]
     (let [user (:user value)]            ;; server reply: {:user {... :token "..."}}
       {:db (-> db
@@ -154,7 +154,7 @@ An auth guard's headline feature is returning the user to exactly where they wer
 
 ```clojure
 ;; Adapted from examples/reagent/realworld/auth.cljs
-(rf/reg-event-fx :auth/post-login-redirect
+(rf/reg-event :auth/post-login-redirect
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
@@ -169,7 +169,7 @@ Logout has to clear three things: the session slice, the persisted token, *and* 
 
 ```clojure
 ;; Scope resolution per Spec 016; :my-app/session is your reg-resource-scope resolver.
-(rf/reg-event-fx :auth/logout
+(rf/reg-event :auth/logout
   (fn [{:keys [db]} _]
     (let [old-scope (rf/resolve-resource-scope db :my-app/session)]
       {:db (-> db

--- a/docs/guide/how-to/build-a-form.md
+++ b/docs/guide/how-to/build-a-form.md
@@ -15,16 +15,16 @@ The running example is a login form, and it lives at `[:auth :login]`. A form sl
 ```clojure
 (def login-defaults {:email "" :password ""})
 
-(rf/reg-event-db :form.login/initialise
-  (fn [db _]
-    (assoc-in db [:auth :login]
-              {:draft             login-defaults ;; what the user is typing
-               :submitted         nil       ;; last server-accepted snapshot
-               :submit-attempted? false     ;; latches true on first submit, stays true
-               :status            :idle     ;; :idle | :submitting | :submitted | :error
-               :errors            {}        ;; {<field> ["msg" ...]}; :_form for form-level
-               :touched           #{}       ;; fields the user has interacted with
-               :submit-error      nil})))   ;; transport failure (network down, timeout)
+(rf/reg-event :form.login/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :login]
+                   {:draft             login-defaults ;; what the user is typing
+                    :submitted         nil       ;; last server-accepted snapshot
+                    :submit-attempted? false     ;; latches true on first submit, stays true
+                    :status            :idle     ;; :idle | :submitting | :submitted | :error
+                    :errors            {}        ;; {<field> ["msg" ...]}; :_form for form-level
+                    :touched           #{}       ;; fields the user has interacted with
+                    :submit-error      nil})}))  ;; transport failure (network down, timeout)
 ```
 
 Each key earns its place — drop one and the user notices. Three of them carry nuance the comments alone can't. `:submitted` turns the fuzzy question "is this form dirty?" into a plain value comparison. `:errors` holds renderable validation outcomes, whichever validator produced them. And `:submit-error` is deliberately kept separate, because it's for failures that aren't about any single field — the network being down, say, rather than a bad email address.
@@ -68,22 +68,22 @@ With those bound, a `:status` outside the enum, or a malformed draft, now fails 
 The keystroke handler does both of its jobs in one atomic step — it updates the draft and marks the field touched together, so the two never drift apart. (A handler is the function that runs in response to an event.)
 
 ```clojure
-(rf/reg-event-db :form.login/edit-field
+(rf/reg-event :form.login/edit-field
   {:schema [:cat [:= :form.login/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
-        (assoc-in  [:auth :login :draft field] value)
-        (update-in [:auth :login :touched] (fnil conj #{}) field))))
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
+             (assoc-in  [:auth :login :draft field] value)
+             (update-in [:auth :login :touched] (fnil conj #{}) field))}))
 ```
 
 `:blur-field` and `:reset` are mechanical, but here they are once so the set is complete:
 
 ```clojure
-(rf/reg-event-db :form.login/blur-field
-  (fn [db [_ field]]
-    (update-in db [:auth :login :touched] (fnil conj #{}) field)))
+(rf/reg-event :form.login/blur-field
+  (fn [{:keys [db]} [_ field]]
+    {:db (update-in db [:auth :login :touched] (fnil conj #{}) field)}))
 
-(rf/reg-event-fx :form.login/reset
+(rf/reg-event :form.login/reset
   (fn [_ _] {:fx [[:dispatch [:form.login/initialise]]]}))
 ```
 
@@ -100,7 +100,7 @@ Validation itself is a pure function. The convention fixes only the *result* sha
 Submit validates and latches. Only when the draft is clean does it fire the request through [managed HTTP](../concepts/http.md) — an effect that performs the network call for you and dispatches a result event when it returns. (An effect is a description of a side-effect the framework runs on your behalf, which keeps your handler pure and easy to test.)
 
 ```clojure
-(rf/reg-event-fx :form.login/submit
+(rf/reg-event :form.login/submit
   (fn [{:keys [db]} _]
     (let [draft  (get-in db [:auth :login :draft])
           errors (validate LoginForm draft)
@@ -123,12 +123,12 @@ Submit validates and latches. Only when the draft is clean does it fire the requ
 When the call succeeds, the reply arrives as the event's last argument, shaped `{:kind :success :value <decoded body>}`:
 
 ```clojure
-(rf/reg-event-db :form.login/submit-success
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:auth :login :status]    :submitted)
-        (assoc-in [:auth :login :submitted] (get-in db [:auth :login :draft]))
-        (assoc-in [:auth :user]             (:user value)))))
+(rf/reg-event :form.login/submit-success
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc-in [:auth :login :status]    :submitted)
+             (assoc-in [:auth :login :submitted] (get-in db [:auth :login :draft]))
+             (assoc-in [:auth :user]             (:user value)))}))
 ```
 
 ### The validation-vs-transport split
@@ -150,12 +150,12 @@ The failure handler has to sort two genuinely different kinds of failure, and th
         (when (map? errors) errors))
       (catch :default _ nil))))
 
-(rf/reg-event-db :form.login/submit-error
-  (fn [db [_ {:keys [failure]}]]
+(rf/reg-event :form.login/submit-error
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
     (let [errors (server-field-errors failure)]
-      (cond-> (assoc-in db [:auth :login :status] :error)
-        errors       (assoc-in [:auth :login :errors] errors)
-        (not errors) (assoc-in [:auth :login :submit-error] failure)))))
+      {:db (cond-> (assoc-in db [:auth :login :status] :error)
+             errors       (assoc-in [:auth :login :errors] errors)
+             (not errors) (assoc-in [:auth :login :submit-error] failure))})))
 ```
 
 The payoff is that the view never learns which validator complained. Client schema and server rejection flow through one code path, so the markup that renders an error doesn't care where the error came from.

--- a/docs/guide/how-to/keep-secrets-out-of-traces.md
+++ b/docs/guide/how-to/keep-secrets-out-of-traces.md
@@ -32,7 +32,7 @@ A path declared both sensitive and large redacts as sensitive, because even "the
 Values that flow *through* the cascade are owned by the registration that introduces their shape. That covers event args, subscription outputs (a subscription is a derived, read-only view onto app-db), and flow outputs:
 
 ```clojure
-(rf/reg-event-fx :auth/sign-in
+(rf/reg-event :auth/sign-in
   {:sensitive [[:password]]}        ;; paths into the event arg-map
   (fn [{:keys [db]} [_ {:keys [email password]}]]
     {:db (assoc db :auth/pending? true)

--- a/docs/guide/how-to/paginate-a-feed.md
+++ b/docs/guide/how-to/paginate-a-feed.md
@@ -58,7 +58,7 @@ Now route entry loads the right page, owns it while you're there, and releases i
 Here's the mental shift: changing pages is a navigation, not a fetch. Swap only `?page=`. Drop it for page 1 so the first page has one canonical URL, rather than `/` and `/?page=1` both pointing at the same list:
 
 ```clojure
-(rf/reg-event-fx :home/go-to-page
+(rf/reg-event :home/go-to-page
   (fn [_ [_ page]]
     {:fx [[:dispatch [:rf.route/navigate :app/home {}
                       {:query (if (> page 1) {:page page} {})}]]]}))
@@ -113,7 +113,7 @@ Now watch it work. Click through to page 2 with Xray open. The navigation event 
 A load-more feed breaks the cache model on purpose, so it's worth understanding why before you reach for resources here. What's on screen is no longer "the server's page N". It's everything this user has loaded so far this session. That accumulated list is a session fact, and facts live in app-db. So don't contort resources into this shape. Instead, use a [managed HTTP request](../concepts/http.md) — an effect the framework runs and routes the reply back through an event — whose reply event appends:
 
 ```clojure
-(rf/reg-event-fx :feed/load-more
+(rf/reg-event :feed/load-more
   (fn [{:keys [db]} _]
     (if (:feed/loading-more? db)
       {}                                       ;; already in flight — ignore the click
@@ -129,18 +129,18 @@ A load-more feed breaks the cache model on purpose, so it's worth understanding 
 
 ;; The runtime APPENDS the reply payload as the final event argument —
 ;; the continuation is data on the event tape, not a callback.
-(rf/reg-event-db :feed/page-loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (update :feed/articles (fnil into []) (:articles value))
-        (assoc  :feed/total (:total value))
-        (dissoc :feed/loading-more? :feed/load-error))))
+(rf/reg-event :feed/page-loaded
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (-> db
+             (update :feed/articles (fnil into []) (:articles value))
+             (assoc  :feed/total (:total value))
+             (dissoc :feed/loading-more? :feed/load-error))}))
 
-(rf/reg-event-db :feed/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc  :feed/load-error failure)
-        (dissoc :feed/loading-more?))))
+(rf/reg-event :feed/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (-> db
+             (assoc  :feed/load-error failure)
+             (dissoc :feed/loading-more?))}))
 ```
 
 That `:on-success` target — an event, the thing your handler reacts to — receives the uniform reply envelope, appended for you. Every managed effect completes through this same no-`await` shape, explained in [No await: continuations are data](../explanation/continuations-are-data.md). And the *next* page needs no counter, because the offset is derived from how many rows are already loaded.

--- a/docs/guide/how-to/test-a-cascade.md
+++ b/docs/guide/how-to/test-a-cascade.md
@@ -11,8 +11,8 @@ Your JavaScript anchor here is **MSW**. With MSW you don't mock your own modules
 Every cascade test is the same three moves: a fresh frame, a `dispatch-sync`, an assertion against the frame's `app-db`. (A frame is one isolated instance of your running app — its own `app-db`, its own event queue. A `dispatch` is how you send an event into it.)
 
 ```clojure
-(rf/reg-event-db :counter/inc
-  (fn [db _] (update db :count (fnil inc 0))))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _] {:db (update db :count (fnil inc 0))}))
 
 (deftest counter-walk
   (rf/with-new-frame [f (rf/make-frame {})]
@@ -37,7 +37,7 @@ We'll use a RealWorld-style login. The handlers live in a `.cljc` file so the JV
   (:require [re-frame.core :as rf]
             [re-frame.http-managed]))   ;; registers :rf.http/managed
 
-(rf/reg-event-fx :session/login
+(rf/reg-event :session/login
   {:doc "Submit credentials; record when we tried."
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} [_ {:keys [email password]}]]
@@ -50,15 +50,15 @@ We'll use a RealWorld-style login. The handlers live in a `.cljc` file so the JV
             :on-success [:session/login-ok]
             :on-failure [:session/login-failed]}]]}))
 
-(rf/reg-event-db :session/login-ok
-  (fn [db [_ {:keys [value]}]]
-    (assoc db :session/status :authed
-              :session/user   (:user value))))
+(rf/reg-event :session/login-ok
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc db :session/status :authed
+                   :session/user   (:user value))}))
 
-(rf/reg-event-db :session/login-failed
-  (fn [db [_ {:keys [failure]}]]
-    (assoc db :session/status :error
-              :session/error  (:kind failure))))
+(rf/reg-event :session/login-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (assoc db :session/status :error
+                   :session/error  (:kind failure))}))
 ```
 
 Both seams the test will use are already visible in that code. First, the handler **declares** the clock with `:rf.cofx/requires [:rf/time-ms]` and reads it as a delivered fact — a coeffect, an input the world hands the handler — instead of calling the host directly. That's what lets a test hand it an exact value. Second, the HTTP request is an **effect description** in the returned map, which is what lets a test answer it without a network. The model behind both is [Effects and coeffects](../concepts/effects-and-coeffects.md).
@@ -103,7 +103,7 @@ Run it with your project's JVM test runner (`clojure -M:test`). Both tests cover
 
 `:rf/time-ms` is stamped onto every dispatch automatically, which is why the second test runs fine without ever mentioning it. But left alone its value would be the live clock, and an assertion on `:session/attempted-at` would flake. So the first test pins it. Facts supplied under `:rf.cofx` in the dispatch opts **win**: the runtime fills only what's missing and never overwrites. With the clock supplied there's no ambient time left to read, which means the test gives the same answer at 14:00 and at 23:59:59.
 
-Delivery is declared-only — the clock included. A handler receives exactly the facts its `:rf.cofx/requires` names, flat in the coeffects map, and nothing else. So that `requires` vector is effectively the test's **fixture checklist**; you can read it off `(rf/handler-meta :event :session/login)`. This part trips people up, so it's worth saying plainly: a declared fact the runtime can't satisfy fails loudly with `:rf.error/missing-required-cofx`, never a silent `nil`. And note the handler form — needing the world is exactly what graduates a handler from `reg-event-db` to `reg-event-fx`. A db handler takes no delivery.
+Delivery is declared-only — the clock included. A handler receives exactly the facts its `:rf.cofx/requires` names, flat in the coeffects map, and nothing else. So that `requires` vector is effectively the test's **fixture checklist**; you can read it off `(rf/handler-meta :event :session/login)`. This part trips people up, so it's worth saying plainly: a declared fact the runtime can't satisfy fails loudly with `:rf.error/missing-required-cofx`, never a silent `nil`. And note that this is the same `reg-event` as a pure state handler — declaring a world fact is metadata, not a different registration form.
 
 ### Answer the HTTP: canned replies by method + URL
 

--- a/docs/guide/how-to/test-an-event-handler.md
+++ b/docs/guide/how-to/test-an-event-handler.md
@@ -10,7 +10,7 @@ Here's the one idea to hold on to as you read:
 
 ## 1. Pluck the handler and call it
 
-When you register a handler, it lands in a registry — a process-wide table that maps an event id to the function you wrote. `handler-meta` reads those registrations back, and its `:handler-fn` is your function, exactly as you wrote it. Your test namespace needs three requires: `clojure.test`, `re-frame.core`, and the app namespace whose load performs the registrations. That last one matters, because requiring the namespace is what runs the `reg-event-*` calls and puts your handler in the registry in the first place.
+When you register a handler, it lands in a registry — a process-wide table that maps an event id to the function you wrote. `handler-meta` reads those registrations back, and its `:handler-fn` is your function, exactly as you wrote it. Your test namespace needs three requires: `clojure.test`, `re-frame.core`, and the app namespace whose load performs the registrations. That last one matters, because requiring the namespace is what runs the `reg-event` calls and puts your handler in the registry in the first place.
 
 ```clojure
 (ns my-app.articles-test
@@ -20,22 +20,22 @@ When you register a handler, it lands in a registry — a process-wide table tha
             [my-app.articles]))   ;; loading the ns registers the handlers
 ```
 
-Start with a plain `reg-event-db` handler — the simplest kind, which takes the current app-db (your app's single state map) and returns the next one:
+Start with the simplest handler — one that only touches state. It takes the **coeffects** (the facts it's handed; `:db`, the current app-db, is one) and returns an effects map whose `:db` is the next state:
 
 ```clojure
 ;; my-app/articles.cljs
-(rf/reg-event-db :articles/page-changed
-  (fn [db [_ page]]
-    (assoc-in db [:articles :page] page)))
+(rf/reg-event :articles/page-changed
+  (fn [{:keys [db]} [_ page]]
+    {:db (assoc-in db [:articles :page] page)}))
 ```
 
-The test plucks it, calls it with a db value and an event vector, and asserts on the db it returns:
+The test plucks it, calls it with a coeffects map and an event vector, and asserts on the `:db` it returns:
 
 ```clojure
 (deftest page-changed-sets-page
   (let [handler (:handler-fn (rf/handler-meta :event :articles/page-changed))
-        after   (handler {:articles {:page 1}} [:articles/page-changed 3])]
-    (is (= 3 (get-in after [:articles :page])))))
+        result  (handler {:db {:articles {:page 1}}} [:articles/page-changed 3])]
+    (is (= 3 (get-in result [:db :articles :page])))))
 ```
 
 There's no frame, no dispatch, no runtime here — it's just a function call. Which means these tests run wherever your test runner runs. That includes the JVM, where most re-frame2 suites live, because nothing in them touches a browser.
@@ -46,7 +46,7 @@ Some handlers need to know things about the outside world — the current time, 
 
 ```clojure
 ;; my-app/articles.cljs — adapted from examples/reagent/realworld/articles.cljs
-(rf/reg-event-fx :articles/refresh
+(rf/reg-event :articles/refresh
   {:doc "User asked for a fresh feed: stamp when, issue the request."
    :rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} _event]
@@ -56,7 +56,7 @@ Some handlers need to know things about the outside world — the current time, 
                              :on-failure [:articles/load-failed]}]]}))
 ```
 
-`:rf.cofx/requires` lists the coeffects — the world facts the handler reads in — that this handler consumes. Here that's just the clock. They arrive **flat** in its first argument, the coeffects map, alongside `:db`. One thing worth knowing: only the fx form can declare requires. A `reg-event-db` handler receives the db and nothing else, so the moment a handler needs the world, it graduates to `reg-event-fx`.
+`:rf.cofx/requires` lists the coeffects — the world facts the handler reads in — that this handler consumes. Here that's just the clock. They arrive **flat** in its first argument, the coeffects map, alongside `:db`. Note that this handler is registered with the very same `reg-event` as the one above — declaring a world fact is just a line of metadata and an `:fx` vector when there's an effect to issue, not a different registration form.
 
 That declaration doubles as your fixture checklist — the list of facts the test must hand in. You can read it straight off the registry:
 
@@ -108,7 +108,7 @@ Two dispatch options do the work that the literal coeffects map did back in step
 
 ## 4. The trap: frames don't isolate registrations
 
-There's a footgun here worth slowing down for. `with-new-frame` gives each test its own app-db, but it does **not** give each test its own registry. `reg-event-fx` and its siblings register into a process-global registrar — one table shared across the whole test run.
+There's a footgun here worth slowing down for. `with-new-frame` gives each test its own app-db, but it does **not** give each test its own registry. `reg-event` and its siblings register into a process-global registrar — one table shared across the whole test run.
 
 !!! warning "Same id, last load wins"
 

--- a/docs/guide/how-to/validate-with-schemas.md
+++ b/docs/guide/how-to/validate-with-schemas.md
@@ -62,16 +62,16 @@ These compose. A status field is an `:enum`. A form draft is a `[:map …]` of c
 
 ## Put a schema on the event too
 
-Every `reg-event-*` takes an optional metadata map between the id and the handler. The `:schema` key there describes the **event vector**, positionally, with `[:cat …]`:
+`reg-event` takes an optional metadata map between the id and the handler. The `:schema` key there describes the **event vector**, positionally, with `[:cat …]`:
 
 ```clojure
 ;; examples/reagent/realworld/auth.cljs
-(rf/reg-event-db :auth.login-form/edit-field
+(rf/reg-event :auth.login-form/edit-field
   {:schema [:cat [:= :auth.login-form/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
-        (assoc-in [:auth :login-form :draft field] value)
-        (update-in [:auth :login-form :touched] (fnil conj #{}) field))))
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
+             (assoc-in [:auth :login-form :draft field] value)
+             (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 ```
 
 The first position is the event id itself, pinned with `[:= …]`. Then a keyword, then a string. So if you dispatch `[:auth.login-form/edit-field "email" 42]`, the check fails *before* the handler runs: you get `:where :event`, the handler never runs, and the rest of the event queue keeps draining. Here's the contrast worth holding onto: app-db schemas check writes after the fact, while event schemas refuse bad input up front.
@@ -92,28 +92,28 @@ Here's a counter whose count must never go below zero — live. The rule appears
    [:count   [:int {:min 0}]]
    [:history [:vector [:int {:min 0}]]]])
 
-(rf/reg-event-db :howto.schema/initialise
+(rf/reg-event :howto.schema/initialise
   {:schema [:cat [:= :howto.schema/initialise]]}
-  (fn [db _] (assoc db :howto.schema/counter {:count 3 :history [3]})))
+  (fn [{:keys [db]} _] {:db (assoc db :howto.schema/counter {:count 3 :history [3]})}))
 
-(rf/reg-event-db :howto.schema/inc
+(rf/reg-event :howto.schema/inc
   {:schema [:cat [:= :howto.schema/inc]]}
-  (fn [db _]
+  (fn [{:keys [db]} _]
     (let [n (inc (get-in db [:howto.schema/counter :count]))]
-      (-> db
-          (assoc-in  [:howto.schema/counter :count] n)
-          (update-in [:howto.schema/counter :history] conj n)))))
+      {:db (-> db
+               (assoc-in  [:howto.schema/counter :count] n)
+               (update-in [:howto.schema/counter :history] conj n))})))
 
 ;; The handler OWNS the never-below-zero rule — this guard ships to production.
-(rf/reg-event-db :howto.schema/dec
+(rf/reg-event :howto.schema/dec
   {:schema [:cat [:= :howto.schema/dec]]}
-  (fn [db _]
+  (fn [{:keys [db]} _]
     (let [n (get-in db [:howto.schema/counter :count])]
-      (if (pos? n)
-        (-> db
-            (assoc-in  [:howto.schema/counter :count] (dec n))
-            (update-in [:howto.schema/counter :history] conj (dec n)))
-        db))))
+      {:db (if (pos? n)
+             (-> db
+                 (assoc-in  [:howto.schema/counter :count] (dec n))
+                 (update-in [:howto.schema/counter :history] conj (dec n)))
+             db)})))
 
 (rf/reg-sub :howto.schema/count
   (fn [db _] (get-in db [:howto.schema/counter :count])))
@@ -147,7 +147,7 @@ Dev builds check every registered schema at every validation point. That's the w
 One place does want production validation, though: untrusted data crossing a system boundary, like an HTTP response, a websocket message, or a `postMessage` payload. For those handlers, add the boundary interceptor, which forces the handler's own `:schema` check regardless of the build flags:
 
 ```clojure
-(rf/reg-event-fx :api/tags-received
+(rf/reg-event :api/tags-received
   {:schema [:cat [:= :api/tags-received] [:map [:tags [:vector :string]]]]
    :interceptors [rf/validate-at-boundary-interceptor]}
   (fn [{:keys [db]} [_ body]]

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -4,7 +4,7 @@ You'll build the classic counter, and then you'll give it something most counter
 
 **The takeaway: state changes only through events, handlers stay pure, world facts arrive recorded — and time travel falls out for free.**
 
-> **Coming from Redux?** `reg-event-db` is your reducer — but there's no store to wire, no action creators, and no `useSelector` memo dance: subscriptions *are* the selector layer, built in and cached by input.
+> **Coming from Redux?** A `reg-event` handler is your reducer — but there's no store to wire, no action creators, and no `useSelector` memo dance: subscriptions *are* the selector layer, built in and cached by input. The one shape difference: a re-frame2 handler returns `{:db next-state}` — the next state *and* anything else to do — rather than returning the state bare.
 
 ## Beat 1 — the whole machine in 20 lines
 
@@ -15,15 +15,21 @@ Here's the entire app. Read it once top to bottom, then we'll walk through what 
   (:require [re-frame.core :as rf])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
-;; EVENTS — the only way state changes. Plain data in, new state out.
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:counter/value 0}))
+;; STATE TRANSITIONS — pure functions of state, easy to read and to test.
+(defn inc-value [db] (update db :counter/value inc))
+(defn dec-value [db] (update db :counter/value dec))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+;; EVENTS — the only way state changes. A handler takes the coeffects (the
+;; facts it's given — :db is one) and returns a map: the next state under
+;; :db, plus anything else to do. Here the only thing to do is update state.
+(rf/reg-event :counter/initialise
+  (fn [_cofx _event] {:db {:counter/value 0}}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :counter/value dec)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (inc-value db)}))
+
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event] {:db (dec-value db)}))
 
 ;; SUBSCRIPTION — a named, derived read. Views never touch app-db directly.
 (rf/reg-sub :counter/value
@@ -38,7 +44,9 @@ Here's the entire app. Read it once top to bottom, then we'll walk through what 
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 ```
 
-A few words on the moving parts. An **event** is a plain-data message describing something that happened — here, `[:counter/inc]`. To **dispatch** is to drop that message onto the queue. A **handler** is the pure function that receives it and computes the next state. The **app-db** is your app's single state map, the one place all state lives. A **subscription** is a named, derived read of that state, and a **view** is a component that renders from subscriptions and dispatches events back.
+A few words on the moving parts. An **event** is a plain-data message describing something that happened — here, `[:counter/inc]`. To **dispatch** is to drop that message onto the queue. A **handler** is the pure function that receives it and returns a map describing what should happen next: `{:db next-state}` here, where `:db` is the new value of app-db. Read that map as *"the next state, and anything else to do"* — for the counter there's nothing else, so it's just `:db`, but the same shape grows to carry an HTTP request or a follow-up event without changing the handler's signature. The **app-db** is your app's single state map, the one place all state lives. A **subscription** is a named, derived read of that state, and a **view** is a component that renders from subscriptions and dispatches events back.
+
+Notice the two little `inc-value` / `dec-value` functions above the events. The pure state transition lives in a plain `(fn [db] …)` — "events are pure functions of state" stated literally — and the handler is the thin wrapper that hands it `:db` and wraps the result as `{:db …}`. You don't have to factor it out for something this small, but it's a habit worth forming early: the bare function is trivially testable (`(inc-value {:counter/value 5})` → `{:counter/value 6}`, no runtime), and the handler stays one obvious line.
 
 Now click a button and watch what happens. The loop you just ran is this: **a view dispatches an event → a pure handler computes the next state → the subscription delivers the change back to the view.** That one-way loop is the whole framework. Everything else in this guide just refines it.
 
@@ -48,15 +56,19 @@ Now click a button and watch what happens. The loop you just ran is this: **a vi
 (require '[reagent2.core :as r]
          '[re-frame.core :as rf])
 
-;; Events
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:counter/value 0}))
+;; State transitions — pure functions of state
+(defn inc-value [db] (update db :counter/value inc))
+(defn dec-value [db] (update db :counter/value dec))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :counter/value inc)))
+;; Events — coeffects in, an effects map out ({:db next-state} here)
+(rf/reg-event :counter/initialise
+  (fn [_cofx _event] {:db {:counter/value 0}}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :counter/value dec)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event] {:db (inc-value db)}))
+
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event] {:db (dec-value db)}))
 
 ;; Subscription
 (rf/reg-sub :counter/value
@@ -103,7 +115,7 @@ Let's show when a button was last clicked. It looks like a throwaway bit of deco
 Here's the constraint. A pure handler must not read the clock — because if it did, replaying the same event tomorrow would compute different state, and the history you're about to inspect in Beat 4 would be a lie. So re-frame2 reads the time once, as the event enters the queue, and stamps it **onto the event** itself. A handler that wants the time then *declares* it:
 
 ```clojure
-(rf/reg-event-fx :counter/inc
+(rf/reg-event :counter/inc
   {:rf.cofx/requires [:rf/time-ms]}
   (fn [{:keys [db rf/time-ms]} _event]
     {:db (-> db
@@ -121,9 +133,9 @@ And at the bottom of the view:
   [:p "last clicked " (.toLocaleTimeString (js/Date. t))])
 ```
 
-Two things changed here, and they're worth naming. First, the handler became `reg-event-fx`. It now receives the **coeffects** map — the bundle of outside-world facts a handler is allowed to know, like the current time or a random seed. A `reg-event-db` handler sees only db and event; the moment a handler needs the world, it graduates to the fx form. Second, it **declares** `:rf.cofx/requires [:rf/time-ms]`. Delivery is declared-only, so `time-ms` arrives flat in the coeffects map, already read at the instant the click entered the system and frozen onto the event's record. Replay this event next week and `last-clicked-at` comes out byte-for-byte identical. Notice the recorded fact is the raw milliseconds — formatting with `.toLocaleTimeString` lives in the view, because pretty-printing is presentation, not state.
+One thing changed, and it's worth naming what *didn't*. The handler is still a `reg-event` — same registration, same `(fn [coeffects event] {:db …})` shape. All we added is a line of metadata: `:rf.cofx/requires [:rf/time-ms]`. That's the payoff of one event form — needing the world is adding a key to a map, not converting to a different registration. The first argument, the `{:keys [db]}` you've been destructuring all along, is the **coeffects** map: the bundle of outside-world facts a handler is allowed to know, like the current time or a random seed. `:db` and `:event` are always there; everything else is declared. Delivery is declared-only, so once we ask for `:rf/time-ms` it arrives flat in that map, already read at the instant the click entered the system and frozen onto the event's record. Replay this event next week and `last-clicked-at` comes out byte-for-byte identical. Notice the recorded fact is the raw milliseconds — formatting with `.toLocaleTimeString` lives in the view, because pretty-printing is presentation, not state.
 
-> **Coming from re-frame v1?** You'd reach for `(inject-cofx :now)` — same purity instinct, but it was opt-in per handler and the value wasn't recorded, so replay re-rolled it. Declaring `:rf/time-ms` makes the same idea a recorded guarantee.
+> **Coming from re-frame v1?** You'd reach for `(inject-cofx :now)` — same purity instinct, but it was opt-in per handler and the value wasn't recorded, so replay re-rolled it. Declaring `:rf/time-ms` makes the same idea a recorded guarantee. (And there's no `reg-event-db`/`reg-event-fx` fork to navigate any more — `reg-event` is the one form, with `:db` returned in the effects map.)
 
 ## Beat 4 — open the inspector: your app has a history
 
@@ -161,7 +173,7 @@ A **frame** is one isolated world — its own app-db, registrations, and subscri
 
 **You can now:**
 
-- change state with events and pure handlers (`reg-event-db` / `reg-event-fx`)
+- change state with events and pure handlers (`reg-event`, returning `{:db …}`)
 - derive values instead of storing them (`reg-sub`, `:<-`)
 - record a world fact the replay-safe way (`:rf.cofx/requires [:rf/time-ms]`)
 - read your app's history in Xray and travel in it

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -19,7 +19,7 @@ Every public surface gets one row below. The API page gives signatures with intu
 
 | Domain | What it covers | API page | Owning spec |
 |---|---|---|---|
-| Core | `reg-event-db` / `reg-event-fx`, `reg-sub`, `dispatch`, `subscribe`, frames — the loop's registration and verb surface | [01 — Core](../api/01-core.md) | [001-Registration](../../spec/001-Registration.md), [002-Frames](../../spec/002-Frames.md) |
+| Core | `reg-event`, `reg-sub`, `dispatch`, `subscribe`, frames — the loop's registration and verb surface | [01 — Core](../api/01-core.md) | [001-Registration](../../spec/001-Registration.md), [002-Frames](../../spec/002-Frames.md) |
 | Views | `reg-view` and the substrate-agnostic pure-view contract | [02 — Views](../api/02-views.md) | [004-Views](../../spec/004-Views.md) |
 | Effects and interceptors | The closed `:db` + `:fx` effect map, `reg-fx` / `reg-cofx`, interceptors, fx-overrides | [03 — Effects](../api/03-effects.md) | [002-Frames](../../spec/002-Frames.md) |
 | State machines | `reg-machine` and the transition-table grammar — hierarchy, `:after`, `:spawn`, parallel regions | [04 — Machines](../api/04-machines.md) | [005-StateMachines](../../spec/005-StateMachines.md) |

--- a/docs/guide/tutorial/01-pages-and-state.md
+++ b/docs/guide/tutorial/01-pages-and-state.md
@@ -50,16 +50,16 @@ State only ever changes one way here. An **event** — a named record that somet
     :createdAt   "2026-06-03T09:00:00Z"
     :author      {:username "octocat"}}])
 
-(rf/reg-event-db :app/initialise
+(rf/reg-event :app/initialise
   {:doc "Seed app-db at boot. Part 2 replaces the canned articles
          with a real fetch."}
-  (fn [_db _event]
-    {:articles {:status :loaded
-                :data   seed-articles
-                :error  nil}}))
+  (fn [_cofx _event]
+    {:db {:articles {:status :loaded
+                     :data   seed-articles
+                     :error  nil}}}))
 ```
 
-`reg-event-db` registers the simplest kind of event handler: a pure function from `(current-db, event)` to the next db. This one ignores both arguments and returns the whole initial map, which is all an initialise event really is. Notice that nothing here touches the DOM, the network, or a clock. A handler that needs the outside world uses a different registration form, and you'll meet it in Part 2.
+`reg-event` registers an event handler: a pure function from the **coeffects** (the facts it's handed — `:db`, the current app-db, is one) and the event, to a map describing what should happen next. That map's `:db` key is the new app-db. Read it as *"the next state, and anything else to do"* — this handler only seeds state, so it returns `{:db …}` and nothing else. It ignores both arguments and hands back the whole initial map, which is all an initialise event really is. Notice that nothing here touches the DOM, the network, or a clock. A handler that needs the outside world adds a line of metadata to declare it — same `reg-event`, you'll meet that in Part 2.
 
 This replaces the placeholder `:app/initialise` that setup put in `core.cljs`. Delete that old registration now, so the two don't fight over the same id — Step 4 rewrites the rest of that file anyway.
 

--- a/docs/guide/tutorial/02-server-data.md
+++ b/docs/guide/tutorial/02-server-data.md
@@ -70,9 +70,9 @@ Four keys carry the model. `:params-schema` is the read's *identity* — every v
 Now delete Part 1's `seed-articles`, the `{:status …}` seed in `:app/initialise`, and the three `:articles/*` subs. The resource replaces all of them, so `:app/initialise` shrinks to an empty seed. This is the part that surprises people the first time: the article data no longer lives in app-db — app-db being your app's single state map — at all. It lives in the framework-owned runtime cache instead.
 
 ```clojure
-(rf/reg-event-db :app/initialise
+(rf/reg-event :app/initialise
   {:doc "Boot seed. Resources own server data now; app-db starts empty."}
-  (fn [_db _event] {}))
+  (fn [_cofx _event] {:db {}}))
 ```
 
 ## Step 3 — let the routes cause the fetch

--- a/docs/guide/tutorial/03-auth-and-forms.md
+++ b/docs/guide/tutorial/03-auth-and-forms.md
@@ -30,16 +30,16 @@ Add two routes first. Each `:on-match` seeds its form's slice — its little cor
 Every form lives at one app-db path with one standard shape. The initialise event — an event being just a named thing-that-happened your app reacts to — doubles as its own documentation:
 
 ```clojure
-(rf/reg-event-db :auth.login-form/initialise
-  (fn [db _]
-    (assoc-in db [:auth :login-form]
-              {:draft             {:email "" :password ""}  ;; what's being typed
-               :submitted         nil      ;; last server-accepted draft
-               :status            :idle    ;; :idle | :submitting | :submitted | :error
-               :errors            {}       ;; {field ["msg" ...]}; :_form for form-level
-               :touched           #{}      ;; fields the user has touched
-               :submit-attempted? false    ;; latches on the first submit click
-               :submit-error      nil})))  ;; transport failure (network down)
+(rf/reg-event :auth.login-form/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :login-form]
+                   {:draft             {:email "" :password ""}  ;; what's being typed
+                    :submitted         nil      ;; last server-accepted draft
+                    :status            :idle    ;; :idle | :submitting | :submitted | :error
+                    :errors            {}       ;; {field ["msg" ...]}; :_form for form-level
+                    :touched           #{}      ;; fields the user has touched
+                    :submit-attempted? false    ;; latches on the first submit click
+                    :submit-error      nil})}))  ;; transport failure (network down)
 ```
 
 A quick tour of the seven keys, because each earns its place. `:status` is the machine under the trenchcoat. `:errors` holds renderable validation results — they can be client- or server-produced, and the view won't care which. `:_form` is reserved for complaints that no single field owns. And `:submit-error` stays separate, because a transport failure has nothing field-shaped to render.
@@ -47,12 +47,12 @@ A quick tour of the seven keys, because each earns its place. `:status` is the m
 Every keystroke is one event. It updates the draft and marks the field touched in one step:
 
 ```clojure
-(rf/reg-event-db :auth.login-form/edit-field
+(rf/reg-event :auth.login-form/edit-field
   {:schema [:cat [:= :auth.login-form/edit-field] :keyword :string]}
-  (fn [db [_ field value]]
-    (-> db
-        (assoc-in  [:auth :login-form :draft field] value)
-        (update-in [:auth :login-form :touched] (fnil conj #{}) field))))
+  (fn [{:keys [db]} [_ field value]]
+    {:db (-> db
+             (assoc-in  [:auth :login-form :draft field] value)
+             (update-in [:auth :login-form :touched] (fnil conj #{}) field))}))
 ```
 
 > **Coming from React Hook Form?** `register`, `handleSubmit`, and `formState.errors` collapse into this one map and a handful of events you own outright.
@@ -94,7 +94,7 @@ Login is a one-shot command, not cached server state. So it's a plain managed re
     (not (re-find #".+@.+" email)) (assoc :email ["is invalid"])
     (str/blank? password)          (assoc :password ["can't be blank"])))
 
-(rf/reg-event-fx :auth.login-form/submit
+(rf/reg-event :auth.login-form/submit
   (fn [{:keys [db]} _]
     (let [draft  (get-in db [:auth :login-form :draft])
           errors (validate-login draft)
@@ -122,7 +122,7 @@ The `:submit-attempted?` latch flips on *every* submit click, valid or not — t
 On success Conduit replies `{:user {... :token "<jwt>"}}`. One handler — the plain function that runs when an event fires — stores the session, snapshots the draft, persists the token, and sends the user on. Where to? To wherever the guard intercepted them (the stash is below), or home if nothing was stashed:
 
 ```clojure
-(rf/reg-event-fx :auth.login-form/submit-success
+(rf/reg-event :auth.login-form/submit-success
   (fn [{:keys [db]} [_ {:keys [value]}]]
     (let [user      (:user value)
           return-to (get-in db [:auth :return-to])]
@@ -155,13 +155,13 @@ Failure sorts into two shapes, and here's the second rule the part leans on. **S
                          (update m :_form (fnil into []) msgs))))
                    {} errs)))))
 
-(rf/reg-event-db :auth.login-form/submit-failed
-  (fn [db [_ {:keys [failure]}]]
+(rf/reg-event :auth.login-form/submit-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
     (let [structured (failure->form-errors failure)]
-      (cond-> (assoc-in db [:auth :login-form :status] :error)
-        structured       (assoc-in [:auth :login-form :errors] structured)
-        (not structured) (assoc-in [:auth :login-form :submit-error]
-                                   "Couldn't reach the server — please try again.")))))
+      {:db (cond-> (assoc-in db [:auth :login-form :status] :error)
+             structured       (assoc-in [:auth :login-form :errors] structured)
+             (not structured) (assoc-in [:auth :login-form :submit-error]
+                                        "Couldn't reach the server — please try again."))})))
 ```
 
 ## The login page
@@ -224,7 +224,7 @@ A login that evaporates on reload isn't really a session. You need three pieces:
   (fn []
     (some-> (.-localStorage js/globalThis) (.getItem "jwtToken"))))
 
-(rf/reg-event-fx :auth/initialise
+(rf/reg-event :auth/initialise
   {:rf.cofx/requires [:auth.session/token]}
   (fn [{:keys [db auth.session/token]} _]
     (cond-> {:db (assoc db :auth {:user nil :token token})}
@@ -234,17 +234,17 @@ A login that evaporates on reload isn't really a session. You need three pieces:
                           :on-success [:auth/session-restored]
                           :on-failure [:auth/session-expired]}]]))))
 
-(rf/reg-event-db :auth/session-restored
-  (fn [db [_ {:keys [value]}]]
-    (assoc-in db [:auth :user] (:user value))))
+(rf/reg-event :auth/session-restored
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc-in db [:auth :user] (:user value))}))
 
-(rf/reg-event-fx :auth/session-expired
+(rf/reg-event :auth/session-expired
   (fn [{:keys [db]} _]
     {:db (update db :auth assoc :user nil :token nil)  ;; targeted: form slices survive
      :fx [[:auth.session/persist {:token nil}]]}))
 ```
 
-Delivery is declared-only: a handler receives exactly the facts in `:rf.cofx/requires`, and nothing it didn't ask for. Even the framework clock works this way — `:rf/time-ms` rides every dispatch, but a handler must declare it to read it. One detail worth knowing: this token read registers as an *ambient* coeffect, meaning it's re-read live, never recorded, and tests stub it by re-registering the supplier. Ambient is safe here only because the read runs once at boot, before any epoch you'd replay. A fact folded into durable state mid-session would instead register `:recordable? true`, so replay re-presents the recorded value rather than re-reading the world. One more thing about the registration: it had to be `reg-event-fx`, because a `reg-event-db` handler sees only db and event — needing the world is exactly what graduates a handler to the fx form. Dispatch `[:auth/initialise]` from boot, after Part 1's `[:app/initialise]`.
+Delivery is declared-only: a handler receives exactly the facts in `:rf.cofx/requires`, and nothing it didn't ask for. Even the framework clock works this way — `:rf/time-ms` rides every dispatch, but a handler must declare it to read it. One detail worth knowing: this token read registers as an *ambient* coeffect, meaning it's re-read live, never recorded, and tests stub it by re-registering the supplier. Ambient is safe here only because the read runs once at boot, before any epoch you'd replay. A fact folded into durable state mid-session would instead register `:recordable? true`, so replay re-presents the recorded value rather than re-reading the world. One more thing about the registration: declaring `:rf.cofx/requires` is just a line of metadata on an ordinary `reg-event` — the same form every handler uses — so reaching for a world fact never changes the handler's shape. Dispatch `[:auth/initialise]` from boot, after Part 1's `[:app/initialise]`.
 
 > **Coming from re-frame v1?** The injection helper is gone — declare `:rf.cofx/requires` on the registration and the runtime assembles the value before the handler runs.
 
@@ -341,7 +341,7 @@ Watch it fire. Signed out, click *Settings*. In Xray the navigation's event row 
 Teardown is just setup reversed, in one event. Wire `(dispatch [:auth/logout])` to the navbar:
 
 ```clojure
-(rf/reg-event-fx :auth/logout
+(rf/reg-event :auth/logout
   (fn [{:keys [db]} _]
     {:db (assoc db :auth {:user nil :token nil})
      :fx [[:auth.session/persist {:token nil}]

--- a/docs/guide/tutorial/04-mutations-and-invalidation.md
+++ b/docs/guide/tutorial/04-mutations-and-invalidation.md
@@ -86,7 +86,7 @@ A resource is "a sub you read and a cause you fire." A mutation is the mirror im
 ```clojure
 ;; src/conduit/views.cljs
 ;; cf. examples/reagent/realworld_resources/views.cljs
-(rf/reg-event-fx :ui/favorite
+(rf/reg-event :ui/favorite
   (fn [{:keys [db]} [_ slug favorited?]]
     (if (nil? (get-in db [:auth :user]))
       ;; Logged out, a favorite click goes to login instead of a 401.
@@ -182,7 +182,7 @@ The editor's `app-db` slice is an ordinary form in Part 3's mold: a `:draft` the
 
 ;; The editor route's :on-match (registered below): fresh slice, prior
 ;; save instance cleared.
-(rf/reg-event-fx :editor/initialise
+(rf/reg-event :editor/initialise
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
      :fx [[:dispatch [:rf.mutation/clear {:instance :editor/save}]]]}))
@@ -191,7 +191,7 @@ The editor's `app-db` slice is an ordinary form in Part 3's mold: a `:draft` the
 Submit validates, then fires the mutation. The continuation is named right at the call site:
 
 ```clojure
-(rf/reg-event-fx :editor/submit
+(rf/reg-event :editor/submit
   (fn [{:keys [db]} _]
     (let [{:keys [slug draft baseline]} (:editor db)
           errors (validate-draft draft)]
@@ -217,7 +217,7 @@ Submit validates, then fires the mutation. The continuation is named right at th
 When the runtime accepts the write's reply, it dispatches `[:editor/replied reply]` — your event target, with one canonical **reply map** appended as the final argument:
 
 ```clojure
-(rf/reg-event-fx :editor/replied
+(rf/reg-event :editor/replied
   (fn [{:keys [db]} [_ {:keys [status value]}]]
     (if (not= :ok status)
       ;; Failure already shows on the form via the instance's :error state.

--- a/docs/guide/tutorial/05-test-and-ship.md
+++ b/docs/guide/tutorial/05-test-and-ship.md
@@ -50,17 +50,17 @@ Then create the test namespace. One fixture resets the whole runtime — registr
 
 ## 2. Test a handler: it's a function, so call it
 
-Start with the smallest possible test. A `reg-event-db` handler is `(db, event) → db` — give it the current state and the event (a vector naming what happened), and it returns the next state. Pull it out of the registry with `handler-meta` and call it:
+Start with the smallest possible test. An event handler is a pure function from the coeffects (the facts handed in — `:db`, the current state, is one) and the event (a vector naming what happened) to an effects map. Give the simplest one a coeffects map and the event, and it returns `{:db next-state}`. Pull it out of the registry with `handler-meta` and call it:
 
 ```clojure
 (deftest edit-field-updates-the-draft
   (let [handler (:handler-fn (rf/handler-meta :event :auth.login-form/edit-field))
-        db'     (handler {:auth {:login-form {:draft {:email "" :password ""}}}}
+        result  (handler {:db {:auth {:login-form {:draft {:email "" :password ""}}}}}
                          [:auth.login-form/edit-field :email "ada@example.com"])]
-    (is (= "ada@example.com" (get-in db' [:auth :login-form :draft :email])))))
+    (is (= "ada@example.com" (get-in result [:db :auth :login-form :draft :email])))))
 ```
 
-No frame, no dispatch, no runtime. A map went in. You assert on the map that came out.
+No frame, no dispatch, no runtime. A coeffects map went in — `:db` holds the current state. You assert on the effects map that came out: its `:db` is the next state.
 
 Now the interesting case: a handler that needs something from the world. Recall the boot handler from [Part 3](03-auth-and-forms.md). The saved JWT is a fact from outside the event, so it's registered as a **provided recordable coeffect** — a coeffect being one of those facts-from-the-world a handler reads in. The boot site reads localStorage once and stamps the value onto the dispatch. The handler **declares** it:
 
@@ -72,14 +72,14 @@ Now the interesting case: a handler that needs something from the world. Recall 
    :doc "The saved JWT (or nil). Read once at the boot boundary and stamped
          onto the boot dispatch — never read ambiently by a handler."})
 
-(rf/reg-event-fx :auth/initialise
+(rf/reg-event :auth/initialise
   {:rf.cofx/requires [:auth.session/token]}
   (fn [{:keys [db auth.session/token]} _]
     {:db (assoc db :auth {:user nil :token token})
      :fx [[:dispatch [:auth/flow [:auth/restore token]]]]}))
 ```
 
-A `reg-event-fx` handler is also just a function — from a **coeffects map** (the facts coming in) to an effects map (the changes going out, where an effect is a piece of data describing something the runtime should do). Delivery is flat and declared-only, so you know exactly what the input map contains: `:db`, `:event`, plus precisely the facts in `:rf.cofx/requires`. So the fixture is a literal:
+A handler that declares coeffects tests exactly the same way — it's the same `reg-event`, just with more facts in the input map. It's a function from a **coeffects map** (the facts coming in) to an effects map (the changes going out, where an effect is a piece of data describing something the runtime should do). Delivery is flat and declared-only, so you know exactly what the input map contains: `:db`, `:event`, plus precisely the facts in `:rf.cofx/requires`. So the fixture is a literal:
 
 ```clojure
 (deftest initialise-seeds-the-session-and-kicks-restore
@@ -105,7 +105,7 @@ Whatever appears there is what your literal map (or your dispatch, below) suppli
 
 ??? note "Freezing the clock"
 
-    Time is a declared fact like any other. There is no implicit clock. A handler that stamps a timestamp declares `:rf.cofx/requires [:rf/time-ms]` and reads it flat. A test supplies `{:rf/time-ms 1781078400123}` in the literal map, and the answer is identical at 14:00 and at 23:59:59. There's no `js/Date` to monkey-patch because the handler never reads one. (And a `reg-event-db` handler can't declare requires at all — needing the world is exactly what graduates a handler to the fx form.)
+    Time is a declared fact like any other. There is no implicit clock. A handler that stamps a timestamp declares `:rf.cofx/requires [:rf/time-ms]` and reads it flat. A test supplies `{:rf/time-ms 1781078400123}` in the literal map, and the answer is identical at 14:00 and at 23:59:59. There's no `js/Date` to monkey-patch because the handler never reads one. (Every `reg-event` can declare requires — there's no second-class form that needing the world forces you to convert away from.)
 
 > **Coming from re-frame v1?** The interceptor-based coeffect injection is gone: declaration moved into registration metadata, and tests supply values on the dispatch instead of stubbing handlers. The full delta is in [From re-frame v1](../25-from-re-frame-v1.md).
 

--- a/docs/guide/tutorial/index.md
+++ b/docs/guide/tutorial/index.md
@@ -131,9 +131,9 @@ Your page owns the layout; Xray owns only the content inside `[data-rf-xray-host
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; --- The boot event: seeds the initial app-db value ---
-(rf/reg-event-db :app/initialise
-  (fn [_db _event]
-    {:session {:user nil}}))          ;; nobody is signed in yet
+(rf/reg-event :app/initialise
+  (fn [_cofx _event]
+    {:db {:session {:user nil}}}))    ;; nobody is signed in yet
 
 ;; --- Subscription: who is signed in? ---
 (rf/reg-sub :session/user


### PR DESCRIPTION
## Summary

EP-0018 slice **L** (rf2-xhfxcs.12) — the `/docs/guide` propagation tail. Rewrites the guide's event material around the single `reg-event` form (semantically the old `reg-event-fx`: coeffects in, a closed effects map out), retiring `reg-event-db` / `reg-event-fx` from the teaching surface.

Carries EP-0018 D1's two accepted pedagogy mitigations:

- **(a) Positive framing** of the `{:db …}` return — taught as *"the next state, and anything else to do"* rather than apologising for the wrap.
- **(b) Pure state helpers** — the counter quickstart extracts `(defn inc-value [db] …)` and registers `(fn [{:keys [db]} _] {:db (inc-value db)})`, keeping "events are pure functions of state" literally true and bare-callable in tests; the wrapper stays one line.

The recurring "needing the world *graduates* a handler from `reg-event-db` to `reg-event-fx`" idiom is removed everywhere — with one form, any `reg-event` can declare `:rf.cofx/requires`; adding a world fact is a line of metadata, not a form change.

## Chapters updated (32 files, all under `docs/guide/`)

- **Pedagogy keystones (hand-reworked prose):** `quickstart.md`, `concepts/events-and-the-cascade.md`, `concepts/effects-and-coeffects.md`, `concepts/index.md`, `concepts/app-db.md`, `concepts/frames.md`, `concepts/http.md`, `concepts/machines.md`, `concepts/subscriptions.md`.
- **Tutorial:** `tutorial/01`–`05` + `tutorial/index.md` — registrations migrated; the handler-unit-test fixtures in 05 updated to pass a coeffects map and read `:db` from the effects-map return.
- **Migration chapter:** `25-from-re-frame-v1.md` — new **"One event registration form"** category documenting the M-73 codemod (`reg-event-fx` rename; simple `reg-event-db` → `{:db BODY}` wrap; nil-capable `-db` and all `-ctx` *flagged* for human review), linking `migration/from-re-frame-v1/codemod/`.
- **Remaining concept / how-to / explanation pages:** `concepts/{errors,flows,routing,server-state,ssr,interceptors,views}.md`, `how-to/{add-auth,build-a-form,keep-secrets-out-of-traces,paginate-a-feed,test-a-cascade,test-an-event-handler,validate-with-schemas}.md`, `explanation/continuations-are-data.md`, `reference.md` — code blocks migrated (per the codemod rules), prose idioms reworded.

Code blocks were moved using the merged Slice-E codemod's transformation rules (`-fx` rename; `-db` → destructure `:db` + `{:db BODY}` wrap, metadata middle-slot preserved); prose hand-edited for tutorial quality. All Clojure code blocks verified paren/brace-balanced.

## Quality gates

- `mkdocs build --strict` — **PASS** (clean; staged via `rm -rf docs/spec && cp -r spec docs/spec` + same for `migration/`, reproducing the CI step). Only INFO-level notes (links into source `examples/` and the codemod README, matching pre-existing guide conventions); no WARNING/ERROR.
- `scripts/check_doc_slugs.py` — **PASS** (450 markdown files, no broken links/anchors).
- `scripts/check_readme_links.py` — **PASS** (no output).
- `scripts/check_inject_cofx_residue.py` — **PASS** (no live retired-spelling residue on the teaching surface).
- `npm run test:cljs` — **N/A / unaffected** (docs-only change; no code under `implementation/` touched).

doc-guide-check: code referencing the old forms still resolves during the B-add additive window, but the new prose prefers `rf/reg-event` throughout.
