### PR TITLE
test(core): EP-0018 M — migrate framework test corpus to reg-event (rf2-xhfxcs.13)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -321,7 +321,7 @@
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (reset! probe-frame-provider-observed [])
               (rf/reg-frame frame-kw {:doc "rf2-7kii2 trailing-children frame-provider probe"})
-              (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
+              (rf/reg-event ::dollar-shape-seed (fn [{:keys [db]} _] {:db {:k :wrapped}}))
               (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
               (rf/reg-sub (first query-v) (fn [db _] (:k db)))
               (let [mount-node (.createElement js/document "div")

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
@@ -88,7 +88,7 @@
     ;; counter-with-stories shape (one frame per Story variant).
     (rf/reg-frame :walk/a {})
     (rf/reg-frame :walk/b {})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed 1] {:frame :walk/a})
@@ -147,7 +147,7 @@
   is caught at the slim surface too (slim claims drop-in Reagent parity)."
     (rf/reg-frame :walk/a {})
     (rf/reg-frame :walk/b {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed] {:frame :walk/a})

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_render_dom_cljs_test.cljs
@@ -84,8 +84,8 @@
         (is (fn? flush!)
             "the reagent-slim adapter map exposes :flush-render! (rf2-0bz5ah contract slot)")
         (rf/reg-frame frame-kw {:doc "flush-render! synchronous-commit probe frame"})
-        (rf/reg-event-db ::seed (fn [_ _] {:n 1}))
-        (rf/reg-event-db ::inc  (fn [db _] (update db :n inc)))
+        (rf/reg-event ::seed (fn [{:keys [db]} _] {:db {:n 1}}))
+        (rf/reg-event ::inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
         (rf/dispatch-sync [::seed] {:frame frame-kw})
         (rf/reg-sub ::n (fn [db _] (:n db)))
         (rf/reg-view* :rf.reagent-slim-flush-render/probe

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/server_subscribe_ssr_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/server_subscribe_ssr_cljs_test.cljs
@@ -74,10 +74,10 @@
 ;; the body (the defn-shape macro), exactly as the example's views use them.
 
 (defn- register-counter! []
-  (rf/reg-event-db :counter/initialise
-    (fn [_db _event] {:counter/value 5}))
-  (rf/reg-event-db :counter/inc
-    (fn [db _event] (update db :counter/value inc)))
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
+  (rf/reg-event :counter/inc
+    (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
   (rf/reg-sub :counter/value
     (fn [db _query] (:counter/value db)))
   (reg-view counter-buttons []
@@ -97,10 +97,10 @@
 ;; the subscribe ever ran. Now the inner closure is recalled and its
 ;; subscribing hiccup rides into the markup.
 (defn- register-form2-counter! []
-  (rf/reg-event-db :counter/initialise
-    (fn [_db _event] {:counter/value 5}))
-  (rf/reg-event-db :counter/inc
-    (fn [db _event] (update db :counter/value inc)))
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
+  (rf/reg-event :counter/inc
+    (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
   (rf/reg-sub :counter/value
     (fn [db _query] (:counter/value db)))
   ;; Form-2: outer setup returns the inner render closure.

--- a/implementation/adapters/reagent/test/re_frame/adapter_flush_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_flush_render_dom_cljs_test.cljs
@@ -62,8 +62,8 @@
         (is (fn? flush!)
             "the Reagent adapter map exposes :flush-render! (rf2-40a84 contract slot)")
         (rf/reg-frame frame-kw {:doc "flush-render! synchronous-commit probe frame"})
-        (rf/reg-event-db ::seed (fn [_ _] {:n 1}))
-        (rf/reg-event-db ::inc  (fn [db _] (update db :n inc)))
+        (rf/reg-event ::seed (fn [{:keys [db]} _] {:db {:n 1}}))
+        (rf/reg-event ::inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
         (rf/dispatch-sync [::seed] {:frame frame-kw})
         (rf/reg-sub ::n (fn [db _] (:n db)))
         (rf/reg-view* :rf.reagent-flush-render/probe

--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -326,5 +326,5 @@
 ;; A tiny event used only by the test above to write a malformed [:config]
 ;; app-db slice, so the app-db slice schema's :where :app-db boundary is
 ;; exercised distinctly from the machine :data boundary.
-(rf/reg-event-db ::write-bad-config
-  (fn [db _] (assoc db :config {:api-base "/api"})))   ;; missing required Config keys
+(rf/reg-event ::write-bad-config
+  (fn [{:keys [db]} _] {:db (assoc db :config {:api-base "/api"})}))   ;; missing required Config keys

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -96,7 +96,7 @@
    machine, carrying :reason :parent-frame-destroyed."
   (rf/reg-frame :tenant-x {:doc "tenant frame with two machines"})
   ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-  (rf/reg-event-fx :seed
+  (rf/reg-event :seed
     (fn [{rt :rf.db/runtime} _]
       {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]
                                 {:flow/login    {:state :authed   :data {}}
@@ -128,7 +128,7 @@
   "#2 Sub-cache hit inside a machine microstep —
    subscribe inside an action body sees the pre-cascade app-db, not the
    in-flight :data."
-  (rf/reg-event-db :seed (fn [_ _] {:user/role :admin}))
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user/role :admin}}))
   (rf/reg-sub :user-role (fn [db _] (:user/role db)))
   (rf/dispatch-sync [:seed])
   (let [observed-by-action (atom nil)
@@ -162,7 +162,7 @@
   ;; This test pins that property: a frame's :on-create event reaches a
   ;; live sub-cache and the spawned machine's snapshot lands in app-db.
   ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-  (rf/reg-event-fx :init-shape
+  (rf/reg-event :init-shape
     (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:snapshots {:flow/boot {:state :armed
                                                                             :data  {}}}}}}))
   ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
@@ -239,7 +239,7 @@
    coherent runtime-db write (the payload carries an app-db slice + a
    runtime-db slice) — they survive the standard hydration with the rest of
    the frame-state, no separate machine channel."
-  (rf/reg-event-fx :hydrate-payload
+  (rf/reg-event :hydrate-payload
     (fn [_ [_ {:keys [app-db runtime-db]}]]
       {:db app-db :rf.db/runtime runtime-db}))
   (let [server-app-db {:user/id 7}
@@ -271,7 +271,7 @@
   (rf/reg-fx :rf.nav/push-url
     {:platforms #{:client}}
     (fn [_ _] :should-not-run-on-server))
-  (rf/reg-event-fx :emit-nav
+  (rf/reg-event :emit-nav
     (fn [_ _]
       {:fx [[:rf.nav/push-url "/users/42"]]}))
   (with-trace-recorder! [traces]
@@ -356,7 +356,7 @@
                                     :data-db          (pr-str db)}
                             "ok"]))]
       (rf/reg-frame target-frame {:doc "frame destroyed mid-render"})
-      (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
       (rf/dispatch-sync [:seed] {:frame target-frame})
       (with-trace-recorder! [traces]
         ;; Mount under frame-provider so the subtree is scoped to
@@ -466,7 +466,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target-frame :tenant-plain-fn-warn]
       (rf/reg-frame target-frame {:doc "non-default frame for plain-fn no-frame-context test"})
-      (rf/reg-event-db :seed-plain-fn (fn [_ _] {:n 7}))
+      (rf/reg-event :seed-plain-fn (fn [{:keys [db]} _] {:db {:n 7}}))
       (rf/dispatch-sync [:seed-plain-fn] {:frame target-frame})
       (rf/reg-sub :plain-fn-test/n (fn [db _] (:n db)))
       (let [render-error (atom nil)
@@ -515,7 +515,7 @@
   (if-not (browser?)
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (do
-      (rf/reg-event-db :seed-plain-default (fn [_ _] {:m 9}))
+      (rf/reg-event :seed-plain-default (fn [{:keys [db]} _] {:db {:m 9}}))
       (rf/reg-sub :plain-default-test/m (fn [db _] (:m db)))
       (let [render-error (atom nil)
             plain-default (fn plain-default-impl []
@@ -554,7 +554,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target-frame :tenant-reg-view-no-warn]
       (rf/reg-frame target-frame {:doc "non-default frame for reg-view negative test"})
-      (rf/reg-event-db :seed-reg-view (fn [_ _] {:k 11}))
+      (rf/reg-event :seed-reg-view (fn [{:keys [db]} _] {:db {:k 11}}))
       (rf/dispatch-sync [:seed-reg-view] {:frame target-frame})
       (rf/reg-sub :reg-view-test/k (fn [db _] (:k db)))
       (when-let [clear! (re-frame.late-bind/get-fn
@@ -614,8 +614,8 @@
       ;; Two distinct frames whose app-dbs hold different values so the
       ;; subscribed reaction tells us unambiguously which one served it.
       (rf/reg-frame target-frame {:doc "non-default frame — :v 42"})
-      (rf/reg-event-db :seed-target (fn [_ _] {:v 42}))
-      (rf/reg-event-db :seed-default (fn [_ _] {:v 7}))
+      (rf/reg-event :seed-target (fn [{:keys [db]} _] {:db {:v 42}}))
+      (rf/reg-event :seed-default (fn [{:keys [db]} _] {:db {:v 7}}))
       (rf/dispatch-sync [:seed-target]  {:frame target-frame})
       (rf/dispatch-sync [:seed-default] {:frame :rf/default})
       (rf/reg-sub :rf2-d4sf/v (fn [db _] (:v db)))
@@ -661,7 +661,7 @@
   (if-not (browser?)
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (do
-      (rf/reg-event-db :seed-no-provider (fn [_ _] {:w 99}))
+      (rf/reg-event :seed-no-provider (fn [{:keys [db]} _] {:db {:w 99}}))
       (rf/dispatch-sync [:seed-no-provider])
       (rf/reg-sub :rf2-d4sf/w (fn [db _] (:w db)))
       (let [resolved-frame (atom nil)
@@ -758,7 +758,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target-frame :tenant-d4sf-dispatch]
       (rf/reg-frame target-frame {:doc "non-default frame for dispatch routing test"})
-      (rf/reg-event-db :rf2-d4sf/record-here (fn [db _] (assoc db :stamped :here)))
+      (rf/reg-event :rf2-d4sf/record-here (fn [{:keys [db]} _] {:db (assoc db :stamped :here)}))
       (rf/reg-view* :rf.cross-spec-d4sf/dispatcher-probe
                     (fn dispatcher-probe-impl []
                       ;; Dispatch with no :frame opt — must route to the
@@ -796,7 +796,7 @@
    as :rf.error/machine-action-exception (machine-scoped, distinct
    from the generic :rf.error/handler-exception). The pre-action
    machine snapshot is preserved; no :db effect commits."
-  (rf/reg-event-db :seed-state (fn [_ _] {:val :before}))
+  (rf/reg-event :seed-state (fn [{:keys [db]} _] {:db {:val :before}}))
   (rf/dispatch-sync [:seed-state])
   (let [machine {:initial :idle
                  :data    {}
@@ -901,8 +901,8 @@
    :rf.error/dispatch-sync-in-handler. (The render-time variant of this
    is identical at the runtime layer.)"
   (with-trace-recorder! [traces]
-    (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
-    (rf/reg-event-fx :nested
+    (rf/reg-event :outer (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
+    (rf/reg-event :nested
       (fn [_ _]
         (rf/dispatch-sync [:outer])
         {}))
@@ -979,7 +979,7 @@
    re-frame.ssr-end-to-end-test/ssr-default-error-projector-handler-
    exception."
   (rf/reg-frame :req {:preset :ssr-server})
-  (rf/reg-event-fx :handler-throws
+  (rf/reg-event :handler-throws
     (fn [_ _] (throw (ex-info "boom" {}))))
   (with-trace-recorder! [traces]
     (rf/dispatch-sync [:handler-throws] {:frame :req})
@@ -1051,7 +1051,7 @@
    re-registering a sub disposes the cache slot and the next subscribe
    sees the new body, even when an active subscriber was holding a
    reaction on the old version."
-  (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
   (rf/reg-sub :answer (fn [db _] (:n db)))
   (rf/dispatch-sync [:seed])
   (is (= 7 (rf/subscribe-once [:answer]))
@@ -1078,7 +1078,7 @@
     (rf/reg-fx :rf.test/http-stub (fn [_ args] (swap! seen conj [:stub args])))
     ;; Frame with an id-valued override: :http is rerouted to :rf.test/http-stub.
     (rf/reg-frame :story-frame {:fx-overrides {:http :rf.test/http-stub}})
-    (rf/reg-event-fx :go (fn [_ _] {:fx [[:http {:url "/x"}]]}))
+    (rf/reg-event :go (fn [_ _] {:fx [[:http {:url "/x"}]]}))
     (rf/dispatch-sync [:go] {:frame :story-frame})
     (is (= [[:stub {:url "/x"}]] @seen)
         "the id-valued override redirected :http → :rf.test/http-stub")))

--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -73,8 +73,8 @@
   []
   (rf/reg-frame :rf-l5q3/tenant-a {:doc "tenant-a frame"})
   (rf/reg-frame :rf-l5q3/tenant-b {:doc "tenant-b frame"})
-  (rf/reg-event-db :rf-l5q3/seed
-                   (fn [_ [_ marker]] {:marker marker :received []}))
+  (rf/reg-event :rf-l5q3/seed
+                   (fn [{:keys [db]} [_ marker]] {:db {:marker marker :received []}}))
   (rf/dispatch-sync [:rf-l5q3/seed :rf/default] {:frame :rf/default})
   (rf/dispatch-sync [:rf-l5q3/seed :tenant-a] {:frame :rf-l5q3/tenant-a})
   (rf/dispatch-sync [:rf-l5q3/seed :tenant-b] {:frame :rf-l5q3/tenant-b}))
@@ -100,13 +100,13 @@
 (deftest sync-dispatch-from-handler-body-routes-to-handlers-frame
   (testing "rf/dispatch called synchronously from inside a handler routes to that handler's frame"
     (seed-frames!)
-    (rf/reg-event-fx :rf-l5q3/parent
+    (rf/reg-event :rf-l5q3/parent
                      (fn [_ _]
                        (rf/dispatch [:rf-l5q3/landed])
                        {}))
-    (rf/reg-event-db :rf-l5q3/landed
-                     (fn [db _]
-                       (update db :received (fnil conj []) :landed-sync)))
+    (rf/reg-event :rf-l5q3/landed
+                     (fn [{:keys [db]} _]
+                       {:db (update db :received (fnil conj []) :landed-sync)}))
     ;; Fire the parent under :tenant-a; the synchronous dispatch inside
     ;; its body MUST route to :tenant-a too. dispatch-sync drains the
     ;; full cascade before returning.
@@ -145,7 +145,7 @@
     (async done
       (seed-frames!)
       (let [raised (atom nil)]
-        (rf/reg-event-fx :rf-l5q3/defer-raw
+        (rf/reg-event :rf-l5q3/defer-raw
                          (fn [_ _]
                            (js/setTimeout
                              (fn []
@@ -154,9 +154,9 @@
                                       (reset! raised (:rf.error/id (ex-data e))))))
                              0)
                            {}))
-        (rf/reg-event-db :rf-l5q3/landed-raw
-                         (fn [db _]
-                           (update db :received (fnil conj []) :landed-raw)))
+        (rf/reg-event :rf-l5q3/landed-raw
+                         (fn [{:keys [db]} _]
+                           {:db (update db :received (fnil conj []) :landed-raw)}))
         (rf/dispatch-sync [:rf-l5q3/defer-raw] {:frame :rf-l5q3/tenant-a})
         ;; Wait two macrotasks: one for the setTimeout(0), one for the
         ;; router's next-tick drain (had the dispatch enqueued).
@@ -192,12 +192,12 @@
 (deftest fx-dispatch-from-handler-routes-to-handlers-frame
   (testing ":fx [[:dispatch ...]] routes to the handler's frame — canonical pattern"
     (seed-frames!)
-    (rf/reg-event-fx :rf-l5q3/parent-fx
+    (rf/reg-event :rf-l5q3/parent-fx
                      (fn [_ _]
                        {:fx [[:dispatch [:rf-l5q3/landed-fx]]]}))
-    (rf/reg-event-db :rf-l5q3/landed-fx
-                     (fn [db _]
-                       (update db :received (fnil conj []) :landed-fx)))
+    (rf/reg-event :rf-l5q3/landed-fx
+                     (fn [{:keys [db]} _]
+                       {:db (update db :received (fnil conj []) :landed-fx)}))
     (rf/dispatch-sync [:rf-l5q3/parent-fx] {:frame :rf-l5q3/tenant-a})
     (is (= [:landed-fx] (received :rf-l5q3/tenant-a))
         ":fx [[:dispatch ...]] threads the frame through fx/do-fx — lands on :tenant-a")
@@ -216,14 +216,14 @@
   (testing ":dispatch-later threads :frame through the closure — survives the async escape"
     (async done
       (seed-frames!)
-      (rf/reg-event-fx :rf-l5q3/parent-later
+      (rf/reg-event :rf-l5q3/parent-later
                        (fn [_ _]
                          {:fx [[:dispatch-later
                                 {:ms    0
                                  :event [:rf-l5q3/landed-later]}]]}))
-      (rf/reg-event-db :rf-l5q3/landed-later
-                       (fn [db _]
-                         (update db :received (fnil conj []) :landed-later)))
+      (rf/reg-event :rf-l5q3/landed-later
+                       (fn [{:keys [db]} _]
+                         {:db (update db :received (fnil conj []) :landed-later)}))
       (rf/dispatch-sync [:rf-l5q3/parent-later] {:frame :rf-l5q3/tenant-a})
       ;; Wait long enough for the setTimeout(0) and the resulting
       ;; next-tick drain (goog.async.nextTick). Two 50ms macrotasks
@@ -255,16 +255,16 @@
   (testing "(:dispatch (rf/frame-handle)) captures the in-flight frame; the captured fn is safe to call from setTimeout"
     (async done
       (seed-frames!)
-      (rf/reg-event-fx :rf-l5q3/parent-bound
+      (rf/reg-event :rf-l5q3/parent-bound
                        (fn [_ _]
                          (let [d (:dispatch (rf/frame-handle))]
                            (js/setTimeout
                              (fn [] (d [:rf-l5q3/landed-bound]))
                              0))
                          {}))
-      (rf/reg-event-db :rf-l5q3/landed-bound
-                       (fn [db _]
-                         (update db :received (fnil conj []) :landed-bound)))
+      (rf/reg-event :rf-l5q3/landed-bound
+                       (fn [{:keys [db]} _]
+                         {:db (update db :received (fnil conj []) :landed-bound)}))
       (rf/dispatch-sync [:rf-l5q3/parent-bound] {:frame :rf-l5q3/tenant-a})
       (js/setTimeout
         (fn []
@@ -290,13 +290,13 @@
 (deftest sync-dispatch-isolation-between-frames
   (testing "synchronous dispatch from :tenant-a handler stays in :tenant-a; :tenant-b is untouched"
     (seed-frames!)
-    (rf/reg-event-fx :rf-l5q3/fan
+    (rf/reg-event :rf-l5q3/fan
                      (fn [_ [_ payload]]
                        (rf/dispatch [:rf-l5q3/leaf payload])
                        {}))
-    (rf/reg-event-db :rf-l5q3/leaf
-                     (fn [db [_ payload]]
-                       (update db :received (fnil conj []) payload)))
+    (rf/reg-event :rf-l5q3/leaf
+                     (fn [{:keys [db]} [_ payload]]
+                       {:db (update db :received (fnil conj []) payload)}))
     (rf/dispatch-sync [:rf-l5q3/fan :a-payload] {:frame :rf-l5q3/tenant-a})
     (rf/dispatch-sync [:rf-l5q3/fan :b-payload] {:frame :rf-l5q3/tenant-b})
     (is (= [:a-payload] (received :rf-l5q3/tenant-a))

--- a/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
@@ -90,7 +90,7 @@
     ;; counter-with-stories shape (one frame per Story variant).
     (rf/reg-frame :walk/a {})
     (rf/reg-frame :walk/b {})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed 1] {:frame :walk/a})
@@ -145,7 +145,7 @@
   (testing "a throwing per-entry dispose does NOT abort the rest of the walk"
     (rf/reg-frame :walk/a {})
     (rf/reg-frame :walk/b {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed] {:frame :walk/a})

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -139,7 +139,7 @@
           inner :rf-22ds-1-inner]
       (rf/reg-frame outer {:doc "outer scenario-1 frame"})
       (rf/reg-frame inner {:doc "inner scenario-1 frame"})
-      (rf/reg-event-db :seed-1 (fn [_ [_ v]] {:v v}))
+      (rf/reg-event :seed-1 (fn [{:keys [db]} [_ v]] {:db {:v v}}))
       ;; Each frame's app-db carries a distinct value so the subscribe
       ;; tells us unambiguously which frame served the read.
       (rf/dispatch-sync [:seed-1 :outer-app-db] {:frame outer})
@@ -197,7 +197,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target :rf-22ds-2-scope]
       (rf/reg-frame target {:doc "scenario-2 explicit-scope frame"})
-      (rf/reg-event-db :seed-2 (fn [_ _] {:n 99}))
+      (rf/reg-event :seed-2 (fn [{:keys [db]} _] {:db {:n 99}}))
       (rf/dispatch-sync [:seed-2] {:frame target})
       (rf/reg-sub :scenario-2/n (fn [db _] (:n db)))
       ;; (a) No provider → the probe's current-frame-id / subscribe raise
@@ -376,7 +376,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target :rf-22ds-4-wrapped]
       (rf/reg-frame target {:doc "scenario-4 wrapped frame"})
-      (rf/reg-event-db :seed-4 (fn [_ [_ v]] {:s v}))
+      (rf/reg-event :seed-4 (fn [{:keys [db]} [_ v]] {:db {:s v}}))
       ;; Seed the wrapped frame explicitly. EP-0002 (rf2-69r7ui): no bare
       ;; `:rf/default` seed — the assertion is that the wrapped-frame
       ;; subscribe resolves to the wrapped value, which the single scoped
@@ -428,7 +428,7 @@
       ;; sibling frame to prove the dispatch did NOT leak outside the
       ;; provider scope.
       (rf/reg-frame sibling {:doc "scenario-5 sibling (no provider above)"})
-      (rf/reg-event-db :scenario-5/stamp (fn [db _] (assoc db :stamped :here)))
+      (rf/reg-event :scenario-5/stamp (fn [{:keys [db]} _] {:db (assoc db :stamped :here)}))
 
       (rf/reg-view* :rf.22ds-5/probe
                     (fn []
@@ -479,7 +479,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target :rf-22ds-6-strict]
       (rf/reg-frame target {:doc "scenario-6 strict-mode frame"})
-      (rf/reg-event-db :seed-6 (fn [_ _] {:s :strict-mode-app-db}))
+      (rf/reg-event :seed-6 (fn [{:keys [db]} _] {:db {:s :strict-mode-app-db}}))
       (rf/dispatch-sync [:seed-6] {:frame target})
       (rf/reg-sub :scenario-6/s (fn [db _] (:s db)))
 
@@ -575,8 +575,8 @@
         (is true (str "act() not reachable from this test runner; "
                       "scenario-7 skipped — bead filed (see suite docstring)."))
         (let [_ (rf/reg-frame target {:doc "scenario-7 concurrent frame"})
-              _ (rf/reg-event-db :seed-7 (fn [_ _] {:n 1}))
-              _ (rf/reg-event-db :inc-7  (fn [db _] (update db :n inc)))
+              _ (rf/reg-event :seed-7 (fn [{:keys [db]} _] {:db {:n 1}}))
+              _ (rf/reg-event :inc-7  (fn [{:keys [db]} _] {:db (update db :n inc)}))
               _ (rf/dispatch-sync [:seed-7] {:frame target})
               _ (rf/reg-sub :scenario-7/n (fn [db _] (:n db)))
               observed-frames (atom [])
@@ -673,7 +673,7 @@
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")
     (let [target :rf-22ds-ns/tenant-admin]
       (rf/reg-frame target {:doc "namespaced frame-id regression"})
-      (rf/reg-event-db :rf-22ds-ns/seed (fn [_ [_ v]] {:tag v}))
+      (rf/reg-event :rf-22ds-ns/seed (fn [{:keys [db]} [_ v]] {:db {:tag v}}))
       (rf/dispatch-sync [:rf-22ds-ns/seed :wrapped-value] {:frame target})
       (rf/reg-sub :rf-22ds-ns/tag (fn [db _] (:tag db)))
 

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -60,7 +60,7 @@
 
 (deftest canned-success-default-reply-addressing-cljs
   (testing "the canned-success stub dispatches a default reply (originating event-id with :rf/reply)"
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           (case (:kind reply)
@@ -79,14 +79,14 @@
 
 (deftest canned-failure-explicit-on-failure-cljs
   (testing "explicit :on-failure routes the failure reply to the named handler"
-    (rf/reg-event-fx :auth/login
+    (rf/reg-event :auth/login
       (fn [_ _]
         {:fx [[:rf.http/managed
                {:request    {:method :post :url "/auth/login"}
                 :on-failure [:auth/login-error]}]]}))
-    (rf/reg-event-db :auth/login-error
-      (fn [db [_ payload]]
-        (assoc db :auth-error payload)))
+    (rf/reg-event :auth/login-error
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :auth-error payload)}))
     (rf/dispatch-sync [:auth/login]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
     (let [db (rf/app-db-value :rf/default)]
@@ -98,14 +98,14 @@
 
 (deftest canned-success-explicit-on-success-cljs
   (testing "explicit :on-success routes the success reply to the named handler"
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [_ _]
         {:fx [[:rf.http/managed
                {:request    {:method :get :url "/articles/hello"}
                 :on-success [:article/loaded]}]]}))
-    (rf/reg-event-db :article/loaded
-      (fn [db [_ payload]]
-        (assoc db :article payload)))
+    (rf/reg-event :article/loaded
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :article payload)}))
     (rf/dispatch-sync [:article/load]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
     (let [db (rf/app-db-value :rf/default)]
@@ -117,7 +117,7 @@
 (deftest silenced-reply-on-success-nil-cljs
   (testing "explicit :on-success nil swallows the reply silently"
     (let [seen (atom 0)]
-      (rf/reg-event-fx :ping
+      (rf/reg-event :ping
         (fn [_ _]
           (swap! seen inc)
           {:fx [[:rf.http/managed
@@ -132,7 +132,7 @@
 
 (deftest decode-reflection-metadata-cljs
   (testing ":rf.http/decode-schemas declared on the handler is queryable via handler-meta"
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       {:doc                    "Load an article."
        :rf.http/decode-schemas [::ArticleResponse ::ArticleSummary]}
       (fn [_ _] {}))
@@ -147,7 +147,7 @@
   (testing "rf2-rzqan — with-managed-request-stubs* routes [method url] → reply
             with NO per-call :fx-overrides (the helper installs the
             :rf.http/managed override for the thunk's dynamic extent)"
-    (rf/reg-event-fx :articles/list
+    (rf/reg-event :articles/list
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:result reply}}
@@ -178,7 +178,7 @@
     (let [real-fx-invoked? (atom false)]
       (rf/reg-fx :rf.http/managed
                  (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
-      (rf/reg-event-fx :rzqan/load
+      (rf/reg-event :rzqan/load
         (fn [_ [_ msg]]
           (if-let [reply (:rf/reply msg)]
             {:db {:result reply}}
@@ -201,7 +201,7 @@
 
 (deftest with-managed-request-stubs-failure-cljs
   (testing "with-managed-request-stubs* synthesises a failure reply when {:reply {:failure ...}}"
-    (rf/reg-event-fx :articles/list
+    (rf/reg-event :articles/list
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:result reply}}
@@ -223,7 +223,7 @@
 
 (deftest with-managed-request-stubs-unmatched-cljs
   (testing "an unmatched [method url] under stubs synthesises a :rf.http/transport failure"
-    (rf/reg-event-fx :unmatched/load
+    (rf/reg-event :unmatched/load
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:result reply}}
@@ -246,7 +246,7 @@
 
 (deftest canned-failure-custom-kind-cljs
   (testing ":rf.http/managed-canned-failure honours :kind and :tags args"
-    (rf/reg-event-fx :flaky/load
+    (rf/reg-event :flaky/load
       (fn [_ _]
         {:fx [[:rf.http/managed-canned-failure
                {:on-failure [:flaky/load-error]
@@ -255,9 +255,9 @@
                              :status-text "Service Unavailable"
                              :body        {:err true}
                              :headers     {}}}]]}))
-    (rf/reg-event-db :flaky/load-error
-      (fn [db [_ payload]]
-        (assoc db :error payload)))
+    (rf/reg-event :flaky/load-error
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :error payload)}))
     (rf/dispatch-sync [:flaky/load])
     (let [db (rf/app-db-value :rf/default)]
       (is (= :failure (get-in db [:error :kind])))
@@ -268,7 +268,7 @@
 
 (deftest multi-frame-reply-isolation-cljs
   (testing "managed requests issued from frame A reply into frame A's app-db"
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:article (:value reply)}}

--- a/implementation/adapters/reagent/test/re_frame/pair_dispatch_and_settle_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/pair_dispatch_and_settle_dom_cljs_test.cljs
@@ -91,9 +91,9 @@
         ;; not depend on ambient config).
         (rf/configure! :epoch-history {:depth 50})
         (rf/reg-frame frame-kw {:doc "dispatch-and-settle! probe frame"})
-        (rf/reg-event-db ::seed (fn [_ _] {:show? false}))
-        (rf/reg-event-db ::show (fn [db _] (assoc db :show? true)))
-        (rf/reg-event-db ::hide (fn [db _] (assoc db :show? false)))
+        (rf/reg-event ::seed (fn [{:keys [db]} _] {:db {:show? false}}))
+        (rf/reg-event ::show (fn [{:keys [db]} _] {:db (assoc db :show? true)}))
+        (rf/reg-event ::hide (fn [{:keys [db]} _] {:db (assoc db :show? false)}))
         (rf/reg-sub ::show? (fn [db _] (:show? db)))
         ;; The child whose mount/unmount we drive. Distinct registered id
         ;; so its render/unmount emits carry an identifying :view-id tag.

--- a/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
@@ -50,8 +50,8 @@
   ;; reducer + sub that pivot on a per-frame slot so a routing leak is
   ;; visible as 'reducer ran on wrong frame's db'.
   (rf/reg-frame :rf/xray {:doc "Xray surrogate for the routing tests"})
-  (rf/reg-event-db :rf-tvu99/set-mode
-                   (fn [db [_ mode]] (assoc db :mode mode)))
+  (rf/reg-event :rf-tvu99/set-mode
+                   (fn [{:keys [db]} [_ mode]] {:db (assoc db :mode mode)}))
   (rf/reg-sub      :rf-tvu99/mode
                    (fn [db _] (get db :mode :diff))))
 

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -275,7 +275,7 @@
       (reset! last-managed-args nil)
       ;; capture the :reply-to continuation
       (let [replied (atom [])]
-        (rf/reg-event-fx :test/favorited
+        (rf/reg-event :test/favorited
           (fn [_ ev] (swap! replied conj ev) {}))
         (rf/dispatch-sync [:rf.mutation/execute
                            {:mutation :realworld/favorite

--- a/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
@@ -58,8 +58,8 @@
                     {:path     "/cljs/articles/:id"
                      :params   [:map [:id :string]]
                      :on-match [[:cljs/article-load]]})
-      (rf/reg-event-db :cljs/article-load
-                       (fn [db _] (assoc db :article-loaded? true)))
+      (rf/reg-event :cljs/article-load
+                       (fn [{:keys [db]} _] {:db (assoc db :article-loaded? true)}))
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db
       ;; state — these custom subs read the runtime-db partition.
       (subs/reg-runtime-sub :rf.cljs.route/id

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -52,8 +52,8 @@
 
 (deftest dispatch-sync-cljs
   (testing "dispatch-sync runs an event-db handler under the Reagent adapter"
-    (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :counter/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:counter/init])
     (rf/dispatch-sync [:counter/inc])
     (rf/dispatch-sync [:counter/inc])
@@ -61,7 +61,7 @@
 
 (deftest sub-chain-cljs
   (testing "layer-1 + layer-2 subs return computed values"
-    (rf/reg-event-db :seed (fn [_ _] {:items [10 20 30]}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items [10 20 30]}}))
     (rf/reg-sub :items     (fn [db _] (:items db)))
     (rf/reg-sub :item-sum  :<- [:items] (fn [items _] (reduce + items)))
     (rf/dispatch-sync [:seed])
@@ -86,7 +86,7 @@
 (deftest frame-bound-fn-captures-frame
   (testing "frame-bound-fn captures the current frame and re-binds it inside the body"
     (rf/reg-frame :side {:doc "side frame"})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/dispatch-sync [:seed 99] {:frame :side})
     (let [captured (with-frame :side (frame-bound-fn [] (rf/current-frame-id)))]
       ;; Outside the with-frame, dynamic var has reverted; the frame-bound-fn
@@ -194,8 +194,8 @@
   (testing "two frames carry independent app-db state, share handler registry"
     (rf/reg-frame :left  {:doc "left frame"})
     (rf/reg-frame :right {:doc "right frame"})
-    (rf/reg-event-db :counter/init (fn [_ [_ n]] {:count n}))
-    (rf/reg-event-db :counter/inc  (fn [db _] (update db :count inc)))
+    (rf/reg-event :counter/init (fn [{:keys [db]} [_ n]] {:db {:count n}}))
+    (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :count inc)}))
     (rf/reg-sub :count (fn [db _] (:count db)))
     (rf/dispatch-sync [:counter/init 10] {:frame :left})
     (rf/dispatch-sync [:counter/init 100] {:frame :right})
@@ -211,8 +211,8 @@
 
 (deftest reactive-sub-tracks-changes
   (testing "a Reagent reaction's deref reflects post-event state"
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r (rf/subscribe [:n])]
@@ -231,7 +231,7 @@
 
 (deftest sub-hot-reload-cljs
   (testing "re-registering a sub flips the next subscribe-once to the new body"
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :answer (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (is (= 7 (rf/subscribe-once [:answer])))
@@ -247,9 +247,9 @@
 
 (deftest flow-recomputes
   (testing "a flow recomputes when its inputs change"
-    (rf/reg-event-db :init (fn [_ _] {:w 0 :h 0}))
-    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
-    (rf/reg-event-db :h!   (fn [db [_ h]] (assoc db :h h)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:w 0 :h 0}}))
+    (rf/reg-event :w!   (fn [{:keys [db]} [_ w]] {:db (assoc db :w w)}))
+    (rf/reg-event :h!   (fn [{:keys [db]} [_ h]] {:db (assoc db :h h)}))
     (rf/reg-flow {:id     :rect/area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -286,7 +286,7 @@
 
 (deftest sub-exception-recovers-to-nil
   (testing "a sub whose body throws emits :rf.error/sub-exception and resolves to nil"
-    (rf/reg-event-db :init (fn [_ _] {:items "broken"}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:items "broken"}}))
     (rf/reg-sub :items (fn [db _] (:items db)))
     (rf/reg-sub :items-count :<- [:items]
       (fn [items _]
@@ -321,7 +321,7 @@
 
 (deftest ssr-end-to-end-cljs
   (testing "complete SSR flow runs against the Reagent adapter on CLJS"
-    (rf/reg-event-db :seed (fn [_ _] {:items ["a" "b" "c"]}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items ["a" "b" "c"]}}))
     (rf/reg-sub :items (fn [db _] (:items db)))
     (rf/reg-view ^{:rf/id :pages/list} pages-list []
       [:ul
@@ -348,7 +348,7 @@
 
 (deftest sub-topology-glitch-free-diamond
   (testing "diamond: app-db -> {a,b} -> c — c never sees a half-propagated state"
-    (rf/reg-event-db :diamond/init (fn [_ _] {:x 1 :y 2}))
+    (rf/reg-event :diamond/init (fn [{:keys [db]} _] {:db {:x 1 :y 2}}))
     (rf/reg-event-db :diamond/swap (fn [{:keys [x y] :as db} _]
                                      (assoc db :x y :y x)))
     (rf/reg-sub :diamond/a (fn [db _] (:x db)))
@@ -381,8 +381,8 @@
 
 (deftest sub-topology-glitch-free-chain
   (testing "chain: app-db -> a -> b -> c — each transition produces one final post-update value, no intermediates"
-    (rf/reg-event-db :chain/init (fn [_ _] {:n 10}))
-    (rf/reg-event-db :chain/set  (fn [db [_ n]] (assoc db :n n)))
+    (rf/reg-event :chain/init (fn [{:keys [db]} _] {:db {:n 10}}))
+    (rf/reg-event :chain/set  (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
     (rf/reg-sub :chain/a (fn [db _] (:n db)))
     (rf/reg-sub :chain/b :<- [:chain/a] (fn [a _] (* a 2)))
     (rf/reg-sub :chain/c :<- [:chain/b] (fn [b _] (inc b)))
@@ -408,11 +408,11 @@
   (testing "[Spec 006 §No-op via value equality, rf2-719e] a value-equal app-db replacement does NOT re-run the body fn of a layer-2 sub whose resolved input is value-equal — the wrapper short-circuits to the cached return value"
     (let [a-runs       (atom 0)
           squared-runs (atom 0)]
-      (rf/reg-event-db :stable/init (fn [_ _] {:n 5 :unrelated "z"}))
-      (rf/reg-event-db :stable/touch-unrelated
-                       (fn [db _] (assoc db :unrelated "z")))   ;; same value
-      (rf/reg-event-db :stable/bump-n
-                       (fn [db _] (update db :n inc)))          ;; real change
+      (rf/reg-event :stable/init (fn [{:keys [db]} _] {:db {:n 5 :unrelated "z"}}))
+      (rf/reg-event :stable/touch-unrelated
+                       (fn [{:keys [db]} _] {:db (assoc db :unrelated "z")}))   ;; same value
+      (rf/reg-event :stable/bump-n
+                       (fn [{:keys [db]} _] {:db (update db :n inc)}))          ;; real change
       (rf/reg-sub :stable/a
                   (fn [db _] (swap! a-runs inc) (:n db)))
       (rf/reg-sub :stable/squared
@@ -476,14 +476,14 @@
 
 (defn- reg-fw-runtime-handler!
   [id f]
-  (rf/reg-event-fx id {:doc "framework-authority" :rf/machine? true} f))
+  (rf/reg-event id {:doc "framework-authority" :rf/machine? true} f))
 
 (deftest runtime-only-commit-does-not-rerun-app-subs-cljs
   (testing "[EP-0001 #7, rf2-0sr0ai] a runtime-only commit leaves the app-db
   projection `=` and does NOT re-run an app-db layer-1 sub body under the
   Reagent reactive substrate"
     (let [runs (atom 0)]
-      (rf/reg-event-db :inval/seed-app (fn [_ _] {:n 1}))
+      (rf/reg-event :inval/seed-app (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/dispatch-sync [:inval/seed-app])
       (rf/reg-sub :inval/app-sub (fn [db _] (swap! runs inc) (:n db)))
       (let [r (rf/subscribe [:inval/app-sub])]
@@ -519,7 +519,7 @@
         (add-watch r ::touch (fn [_ _ _ _] nil))
         (is (= :home @r) "precondition: runtime-db sub primes to the seeded route id")
         (let [after-prime @runs]
-          (rf/reg-event-db :inval/app-write (fn [db _] (assoc db :touched? true)))
+          (rf/reg-event :inval/app-write (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
           (rf/dispatch-sync [:inval/app-write])
           (r/flush)
           @r
@@ -537,7 +537,7 @@
   partition's — under the Reagent reactive substrate"
     (let [app-runs (atom 0)
           rt-runs  (atom 0)]
-      (rf/reg-event-db :inval/seed-app2 (fn [_ _] {:n 1}))
+      (rf/reg-event :inval/seed-app2 (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/dispatch-sync [:inval/seed-app2])
       (reg-fw-runtime-handler! :inval/seed-rt2
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
@@ -554,7 +554,7 @@
         (let [app-baseline @app-runs
               rt-baseline  @rt-runs]
           ;; Real app-db change.
-          (rf/reg-event-db :inval/app-write2 (fn [db _] (update db :n inc)))
+          (rf/reg-event :inval/app-write2 (fn [{:keys [db]} _] {:db (update db :n inc)}))
           (rf/dispatch-sync [:inval/app-write2])
           (r/flush)
           (is (= 2 @ra) "the app sub re-derived to the new app-db value")
@@ -581,8 +581,8 @@
   (testing "calling dispatch-sync from inside a handler raises a structured error"
     (let [traces (atom [])]
       (trace-tooling/register-listener! ::dsih (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
-      (rf/reg-event-fx :nested
+      (rf/reg-event :outer (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
+      (rf/reg-event :nested
         (fn [_ _]
           (rf/dispatch-sync [:outer])
           {}))
@@ -600,7 +600,7 @@
   (testing "(rf/sub-cache frame-id) returns
            {query-v {:value v :ref-count n :input-kind k :realized-inputs [...]}}
            for every materialised subscription in the named frame"
-    (rf/reg-event-db :seed (fn [_ _] {:n 7 :name "ada"}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7 :name "ada"}}))
     (rf/reg-sub :n     (fn [db _] (:n db)))
     (rf/reg-sub :name* (fn [db _] (:name db)))
     (rf/dispatch-sync [:seed])
@@ -635,7 +635,7 @@
 
 (deftest sub-cache-surfaces-static-realized-inputs
   (testing "a :static :<- sub surfaces :input-kind :static + the literal realized edges"
-    (rf/reg-event-db :seed2 (fn [_ _] {:items [1 2 3] :filter :all}))
+    (rf/reg-event :seed2 (fn [{:keys [db]} _] {:db {:items [1 2 3] :filter :all}}))
     (rf/reg-sub :items  (fn [db _] (:items db)))
     (rf/reg-sub :filter (fn [db _] (:filter db)))
     (rf/reg-sub :visible-items
@@ -655,9 +655,9 @@
 (deftest sub-cache-surfaces-parametric-realized-inputs
   (testing "a :parametric input-fn sub surfaces :input-kind :parametric +
            the REALIZED input query-vectors for the concrete outer query-v"
-    (rf/reg-event-db :seed3 (fn [_ _] {:articles {:a1 {:title "T"}}
+    (rf/reg-event :seed3 (fn [{:keys [db]} _] {:db {:articles {:a1 {:title "T"}}
                                        :comments {:a1 [:c1]}
-                                       :viewer   {:edit? true}}))
+                                       :viewer   {:edit? true}}}))
     (rf/reg-sub :article/by-id        (fn [db [_ id]] (get-in db [:articles id])))
     (rf/reg-sub :comments/for-article (fn [db [_ id]] (get-in db [:comments id])))
     (rf/reg-sub :viewer/current       (fn [db _] (:viewer db)))
@@ -698,7 +698,7 @@
 (deftest sub-cache-algebra-view-exposes-the-live-node
   (testing "a live sub-cache entry exposes the full ephemeral / on-demand /
            cache-entry algebra node, keyed by its concrete query vector"
-    (rf/reg-event-db :seed-av (fn [_ _] {:n 7 :name "ada"}))
+    (rf/reg-event :seed-av (fn [{:keys [db]} _] {:db {:n 7 :name "ada"}}))
     (rf/reg-sub :n     (fn [db _] (:n db)))
     (rf/reg-sub :name* (fn [db _] (:name db)))
     (rf/dispatch-sync [:seed-av])
@@ -741,7 +741,7 @@
 
 (deftest sub-cache-algebra-view-lowers-static-realized-edges
   (testing "a static :<- entry lowers its literal realized inputs to [:sub q] edges"
-    (rf/reg-event-db :seed-av2 (fn [_ _] {:items [1 2 3] :filter :all}))
+    (rf/reg-event :seed-av2 (fn [{:keys [db]} _] {:db {:items [1 2 3] :filter :all}}))
     (rf/reg-sub :items  (fn [db _] (:items db)))
     (rf/reg-sub :filter (fn [db _] (:filter db)))
     (rf/reg-sub :visible-items
@@ -762,8 +762,8 @@
     ;; This is the load-bearing static/live distinction: the static
     ;; `sub-algebra-view` reports the :parametric marker; the live view
     ;; reports the concrete realized [:sub …] edges for THIS query vector.
-    (rf/reg-event-db :seed-av3 (fn [_ _] {:articles {:a1 {:title "T"}}
-                                          :comments {:a1 [:c1]}}))
+    (rf/reg-event :seed-av3 (fn [{:keys [db]} _] {:db {:articles {:a1 {:title "T"}}
+                                          :comments {:a1 [:c1]}}}))
     (rf/reg-sub :article/by-id        (fn [db [_ id]] (get-in db [:articles id])))
     (rf/reg-sub :comments/for-article (fn [db [_ id]] (get-in db [:comments id])))
     (rf/reg-sub :article/page
@@ -796,8 +796,8 @@
 (deftest epoch-history-cljs
   (testing "drain-settle commits a record; register-epoch-listener! fires per-cascade"
     (rf/reg-frame :epoch/cljs {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::w (fn [r] (swap! seen conj r)))
@@ -938,7 +938,7 @@
 
 (deftest sub-cache-sync-disposes-on-last-unsubscribe
   (testing "ref-count → 0 disposes the slot synchronously (rf2-cmfln)"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
     (rf/subscribe [:n])
@@ -968,8 +968,8 @@
   to the restored value — proving the restore goes through the same
   reactive-graph notification path as a drain :db commit."
     (rf/reg-frame :restore/cljs {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed] {:frame :restore/cljs})  ;; n=0
@@ -993,8 +993,8 @@
   substrate."
     (rf/reg-frame :restore/a {})
     (rf/reg-frame :restore/b {})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed 0]   {:frame :restore/a})

--- a/implementation/adapters/reagent/test/re_frame/standard_epochs_diamond_recompute_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/standard_epochs_diamond_recompute_cljs_test.cljs
@@ -85,11 +85,11 @@
       (+ a b))))
 
 (defn- register-diamond-events! []
-  (rf/reg-event-db :standard-epochs/seed
-    (fn [_ _] {:views {:diamond-root 0}}))
+  (rf/reg-event :standard-epochs/seed
+    (fn [{:keys [db]} _] {:db {:views {:diamond-root 0}}}))
   ;; Button #24 — bump :views/diamond-root once.
-  (rf/reg-event-db :standard-epochs/bump-diamond
-    (fn [db _] (update-in db [:views :diamond-root] (fnil inc 0)))))
+  (rf/reg-event :standard-epochs/bump-diamond
+    (fn [{:keys [db]} _] {:db (update-in db [:views :diamond-root] (fnil inc 0))})))
 
 ;; ===========================================================================
 ;; The diamond join recomputes EXACTLY ONCE per single root change

--- a/implementation/adapters/reagent/test/re_frame/standard_epochs_views_subs_lifecycle_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/standard_epochs_views_subs_lifecycle_cljs_test.cljs
@@ -87,14 +87,14 @@
     (fn [root [_ threshold]] (> root threshold))))
 
 (defn- register-section-events! []
-  (rf/reg-event-db :standard-epochs/seed
-    (fn [_ _] {:views {:a-mounted?  false
+  (rf/reg-event :standard-epochs/seed
+    (fn [{:keys [db]} _] {:db {:views {:a-mounted?  false
                        :b-mounted?  false
                        :threshold   5
                        :chain-input 1
-                       :b-prop      "alpha"}}))
-  (rf/reg-event-db :standard-epochs/perturb-chain
-    (fn [db _] (update-in db [:views :chain-input] inc))))
+                       :b-prop      "alpha"}}}))
+  (rf/reg-event :standard-epochs/perturb-chain
+    (fn [{:keys [db]} _] {:db (update-in db [:views :chain-input] inc)})))
 
 ;; Child A's full read-set, stood up as the view's mount-time subscribes.
 ;; Returns the held reactions so a test can deref / unsubscribe them as a
@@ -334,7 +334,7 @@
       ;; [:standard-epochs/chain-labelled]. The intersection resolves
       ;; :triggered-by to A's own changed sub.
       (let [render-a (rf/view :standard-epochs/child-a)]
-        (rf/reg-event-fx :standard-epochs/perturb-then-render-a
+        (rf/reg-event :standard-epochs/perturb-then-render-a
           (fn [_ _]
             @(rf/subscribe [:standard-epochs/chain-labelled])
             (render-a 5)
@@ -344,7 +344,7 @@
       ;; B renders INSIDE a cascade too, but reads NO sub. Its render
       ;; is driven by the prop it was handed.
       (let [render-b (rf/view :standard-epochs/child-b)]
-        (rf/reg-event-fx :standard-epochs/render-b
+        (rf/reg-event :standard-epochs/render-b
           (fn [_ _]
             (render-b "beta")
             {}))

--- a/implementation/adapters/reagent/test/re_frame/sub_dispose_view_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/sub_dispose_view_cljs_test.cljs
@@ -95,7 +95,7 @@
    the JVM cascade test's emit count + payload shape, but with the
    Reagent adapter installed so the path under test is the substrate
    integration end-to-end"
-    (rf/reg-event-db :rf2-e9g4g/init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :rf2-e9g4g/init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :rf2-e9g4g.view/a (fn [db _] (:a db)))
     (rf/reg-sub :rf2-e9g4g.view/b (fn [db _] (:b db)))
     (rf/reg-sub :rf2-e9g4g.view/sum
@@ -153,7 +153,7 @@
    evicts with :reason :no-more-derefers. The component-stays-mounted
    shape is the rf2-mrnur audit's explicit gap from the JVM-only
    cache tests"
-    (rf/reg-event-db :rf2-e9g4g/init (fn [_ _] {:n 7 :a 1 :b 2}))
+    (rf/reg-event :rf2-e9g4g/init (fn [{:keys [db]} _] {:db {:n 7 :a 1 :b 2}}))
     (rf/reg-sub :rf2-e9g4g.cond/n (fn [db _] (:n db)))
     (rf/reg-sub :rf2-e9g4g.cond/a (fn [db _] (:a db)))
     (rf/reg-sub :rf2-e9g4g.cond/b (fn [db _] (:b db)))
@@ -216,7 +216,7 @@
    :rf.sub/dispose — the slot's ref-count drops 2→1 but stays > 0.
    Only the second unsubscribe (the last derefer dropping 1→0)
    emits"
-    (rf/reg-event-db :rf2-e9g4g/init (fn [_ _] {:v 42}))
+    (rf/reg-event :rf2-e9g4g/init (fn [{:keys [db]} _] {:db {:v 42}}))
     (rf/reg-sub :rf2-e9g4g.multi/v (fn [db _] (:v db)))
     (rf/reg-sub :rf2-e9g4g.multi/doubled
       :<- [:rf2-e9g4g.multi/v]
@@ -293,7 +293,7 @@
    watcher on componentWillUnmount) drives the production teardown
    sequence: `compute-and-cache!`'s `add-on-dispose!` callback fires,
    input refs release, input slots evict + emit `:rf.sub/dispose`."
-    (rf/reg-event-db :rf2-b2bxk/init (fn [_ _] {:a 11 :b 13}))
+    (rf/reg-event :rf2-b2bxk/init (fn [{:keys [db]} _] {:db {:a 11 :b 13}}))
     (rf/reg-sub :rf2-b2bxk.rea/a (fn [db _] (:a db)))
     (rf/reg-sub :rf2-b2bxk.rea/b (fn [db _] (:b db)))
     (rf/reg-sub :rf2-b2bxk.rea/sum
@@ -361,7 +361,7 @@
    `reaction-disposal-fires-rf-sub-dispose` test above (which
    exercises Reagent's reap-on-no-watchers leg via direct
    `interop/dispose!`)."
-    (rf/reg-event-db :rf2-b2bxk/init (fn [_ _] {:n 5 :a 3 :b 4}))
+    (rf/reg-event :rf2-b2bxk/init (fn [{:keys [db]} _] {:db {:n 5 :a 3 :b 4}}))
     (rf/reg-sub :rf2-b2bxk.cond-rea/n (fn [db _] (:n db)))
     (rf/reg-sub :rf2-b2bxk.cond-rea/a (fn [db _] (:a db)))
     (rf/reg-sub :rf2-b2bxk.cond-rea/b (fn [db _] (:b db)))

--- a/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
@@ -84,7 +84,7 @@
       ;; Render INSIDE a dispatched event so the in-flight cascade
       ;; buffer has the :event/run-start the attribution walk consumes.
       (let [render (rf/view :rf2-25zo2/with-cause)]
-        (rf/reg-event-fx :rf2-25zo2/render-during-cascade
+        (rf/reg-event :rf2-25zo2/render-during-cascade
           (fn [_ _]
             (render)
             {}))
@@ -113,7 +113,7 @@
         [:span "x"])
 
       (let [render (rf/view :rf2-25zo2/with-upstream-sub)]
-        (rf/reg-event-fx :rf2-25zo2/cascade-with-sub
+        (rf/reg-event :rf2-25zo2/cascade-with-sub
           (fn [_ _]
             ;; Run a sub from inside the handler so :rf.sub/run lands in
             ;; the cascade buffer BEFORE the render emits.
@@ -212,7 +212,7 @@
                                      :shape :by-op}]
       (rf/reg-sub :rf2-hhh92/n (fn [_ _] 42))
       ;; A fresh subscribe forces the body's first recompute → :rf.sub/run.
-      (rf/reg-event-fx :rf2-hhh92/touch-sub
+      (rf/reg-event :rf2-hhh92/touch-sub
         (fn [_ _]
           @(rf/subscribe [:rf2-hhh92/n])
           {}))
@@ -245,7 +245,7 @@
       ;; then render the view (its deref-sink records [:rf2-8wrzz1/n]). The
       ;; intersection resolves :triggered-by to the changed own-sub.
       (let [render (rf/view :rf2-8wrzz1/reader)]
-        (rf/reg-event-fx :rf2-8wrzz1/run-then-render
+        (rf/reg-event :rf2-8wrzz1/run-then-render
           (fn [_ _]
             @(rf/subscribe [:rf2-8wrzz1/n])
             (render)

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -140,7 +140,7 @@
   (rf/reg-sub :ws/queue-depth    :<- [:ws/snapshot] (fn [snap _] (count (get-in snap [:data :queue]))))
   (rf/reg-sub :ws/retries        :<- [:ws/snapshot] (fn [snap _] (get-in snap [:data :retries])))
   (rf/reg-sub :ws/error          :<- [:ws/snapshot] (fn [snap _] (get-in snap [:data :error])))
-  (rf/reg-event-fx :ws.connection/initialise
+  (rf/reg-event :ws.connection/initialise
     (fn handler-ws-connection-initialise [_ _]
       {:fx [[:dispatch [:ws/connection [:ws/noop]]]]}))
 
@@ -156,11 +156,11 @@
             (assoc-in [:messages :rx-count] (inc rx-seq))
             (cond-> (:request-id body)
               (assoc-in [:messages :last-reply] body))))))
-  (rf/reg-event-fx :ws.app/send
+  (rf/reg-event :ws.app/send
     (fn handler-app-send [{:keys [db]} [_ body]]
       {:db (assoc-in db [:messages :draft] "")
        :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
-  (rf/reg-event-fx :ws.app/request
+  (rf/reg-event :ws.app/request
     (fn handler-app-request [_ [_ body]]
       (let [rid (random-uuid)]
         {:fx [[:dispatch [:ws/connection
@@ -169,16 +169,16 @@
                                                      :body body}
                                         :reply      [:ws.app/request-reply]
                                         :timeout-ms 5000}]]]]})))
-  (rf/reg-event-db :ws.app/request-reply
-    (fn handler-app-request-reply [db [_ body]]
-      (assoc-in db [:messages :last-reply] body)))
-  (rf/reg-event-fx :ws.app/subscribe-demo
+  (rf/reg-event :ws.app/request-reply
+    (fn handler-app-request-reply [{:keys [db]} [_ body]]
+      {:db (assoc-in db [:messages :last-reply] body)}))
+  (rf/reg-event :ws.app/subscribe-demo
     (fn handler-app-subscribe-demo [_ _]
       {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
-  (rf/reg-event-db :ws.app/edit-draft
-    (fn handler-app-edit-draft [db [_ text]]
-      (assoc-in db [:messages :draft] text)))
-  (rf/reg-event-fx :ws.messages/initialise
+  (rf/reg-event :ws.app/edit-draft
+    (fn handler-app-edit-draft [{:keys [db]} [_ text]]
+      {:db (assoc-in db [:messages :draft] text)}))
+  (rf/reg-event :ws.messages/initialise
     (fn handler-messages-initialise [{:keys [db]} _]
       {:db (assoc db :messages {:draft "" :received [] :last-reply nil :rx-count 0})}))
   (rf/reg-sub :messages            (fn [db _] (:messages db)))
@@ -187,7 +187,7 @@
   (rf/reg-sub :messages/last-reply :<- [:messages] (fn [m _] (:last-reply m)))
 
   ;; --- websocket.core ----------------------------------------------------
-  (rf/reg-event-fx :ws.app/initialise
+  (rf/reg-event :ws.app/initialise
     {:doc "App boot. Seeds the messages slice + materialises the
            connection machine's initial `:disconnected` snapshot.
 

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
@@ -46,7 +46,7 @@
   (testing "rf2-ghfkkk — test-react dispose-adapter! disposes + clears every
             live frame's sub-cache; a re-subscribe after reinstall recomputes
             from the current app-db (no stale cross-lifecycle read)"
-    (rf/reg-event-db ::seed (fn [_ [_ v]] {:n v}))
+    (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
     (rf/dispatch-sync [::seed 1])
 
@@ -77,7 +77,7 @@
   (testing "rf2-ghfkkk — the walk covers EVERY live frame, not just
             :rf/default: a per-instance frame's materialised slot is disposed
             and cleared by the same dispose-adapter! call"
-    (rf/reg-event-db ::seed (fn [_ [_ v]] {:n v}))
+    (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
     (let [other (frame/make-frame {:doc "second frame"})]
       ;; Seed + subscribe in BOTH frames so each carries a live cache slot.

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
@@ -242,7 +242,7 @@
     ;; :rf/default frame exists under it.
     (reset! frame/frames {})
     (frame/ensure-default-frame!)
-    (rf/reg-event-db ::seed (fn [_ [_ v]] {:n v}))
+    (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
     (try
       ;; Seed app-db = {:n 1} and materialise a sub-cache entry by subscribing.

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -319,7 +319,7 @@
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (reset! probe-frame-provider-observed [])
               (rf/reg-frame frame-kw {:doc "rf2-7kii2 trailing-children frame-provider probe"})
-              (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
+              (rf/reg-event ::dollar-shape-seed (fn [{:keys [db]} _] {:db {:k :wrapped}}))
               (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
               (rf/reg-sub (first query-v) (fn [db _] (:k db)))
               (let [mount-node (.createElement js/document "div")

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -225,7 +225,7 @@
   (testing (str name " — MUST (1): dispose clears sub-caches across live frames")
     (let [fid (mint-kw substrate-kw "walk-a")]
       (rf/reg-frame fid {})
-      (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
       (rf/reg-sub :n (fn [db _] (:n db)))
       (rf/dispatch-sync [:seed] {:frame fid})
       (let [r-a (rf/subscribe fid [:n])]
@@ -260,7 +260,7 @@
           fid-b (mint-kw substrate-kw "best-effort-b")]
       (rf/reg-frame fid-a {})
       (rf/reg-frame fid-b {})
-      (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/reg-sub :n (fn [db _] (:n db)))
       (rf/dispatch-sync [:seed] {:frame fid-a})
       (rf/dispatch-sync [:seed] {:frame fid-b})
@@ -937,7 +937,7 @@
         (is (= "Superset form." (:doc meta)))
         (is (= [:test/noop :rf/db-handler] (mapv :id (:interceptors meta))))))
     (testing (str name " — reg-event-fx metadata-map :interceptors threads the chain")
-      (rf/reg-event-fx fx-id
+      (rf/reg-event fx-id
         {:interceptors [noop-icpt]}
         (fn [_ _] {:db {}}))
       (is (= [:test/noop :rf/fx-handler]
@@ -1214,7 +1214,7 @@
                     {:path     art-path
                      :params   [:map [:id :string]]
                      :on-match [[load-ev]]})
-      (rf/reg-event-db load-ev (fn [db _] (assoc db :article-loaded? true)))
+      (rf/reg-event load-ev (fn [{:keys [db]} _] {:db (assoc db :article-loaded? true)}))
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
       (subs/reg-runtime-sub id-sub     (fn [rt _] (get-in rt [:rf.runtime/routing :current :route-id])))
       (subs/reg-runtime-sub params-sub (fn [rt _] (get-in rt [:rf.runtime/routing :current :params])))
@@ -1277,8 +1277,8 @@
   "dispatch-sync runs an event-db handler under the installed adapter."
   [{:keys [name]}]
   (testing (str name " — dispatch-sync runs an event-db handler")
-    (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :counter/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:counter/init])
     (rf/dispatch-sync [:counter/inc])
     (rf/dispatch-sync [:counter/inc])
@@ -1288,7 +1288,7 @@
   "layer-1 + layer-2 subs return computed values under the adapter."
   [{:keys [name]}]
   (testing (str name " — layer-1 + layer-2 subs return computed values")
-    (rf/reg-event-db :seed (fn [_ _] {:items [10 20 30]}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items [10 20 30]}}))
     (rf/reg-sub :items     (fn [db _] (:items db)))
     (rf/reg-sub :item-sum  :<- [:items] (fn [items _] (reduce + items)))
     (rf/dispatch-sync [:seed])
@@ -1314,7 +1314,7 @@
   [{:keys [name]}]
   (testing (str name " — frame-bound-fn captures the current frame")
     (rf/reg-frame :side {:doc "side frame"})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/dispatch-sync [:seed 99] {:frame :side})
     (let [captured (with-frame :side (frame-bound-fn [] (rf/current-frame-id)))]
       (is (= :rf/default (rf/current-frame-id)))
@@ -1326,8 +1326,8 @@
   (testing (str name " — two frames carry independent app-db state")
     (rf/reg-frame :left  {:doc "left frame"})
     (rf/reg-frame :right {:doc "right frame"})
-    (rf/reg-event-db :counter/init (fn [_ [_ n]] {:count n}))
-    (rf/reg-event-db :counter/inc  (fn [db _] (update db :count inc)))
+    (rf/reg-event :counter/init (fn [{:keys [db]} [_ n]] {:db {:count n}}))
+    (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :count inc)}))
     (rf/reg-sub :count (fn [db _] (:count db)))
     (rf/dispatch-sync [:counter/init 10] {:frame :left})
     (rf/dispatch-sync [:counter/init 100] {:frame :right})
@@ -1343,8 +1343,8 @@
   spine's make-derived-value (IDeref+IWatchable), NOT a Reagent reaction."
   [{:keys [name]}]
   (testing (str name " — a subscription's deref reflects post-event state")
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r (rf/subscribe [:n])]
@@ -1360,7 +1360,7 @@
   "Re-registering a sub flips the next subscribe-once to the new body."
   [{:keys [name]}]
   (testing (str name " — re-registering a sub flips the next subscribe-once")
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :answer (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (is (= 7 (rf/subscribe-once [:answer])))
@@ -1388,7 +1388,7 @@
   nil under :replaced-with-default recovery."
   [{:keys [name]}]
   (testing (str name " — a throwing sub recovers to nil + emits :rf.error/sub-exception")
-    (rf/reg-event-db :init (fn [_ _] {:items "broken"}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:items "broken"}}))
     (rf/reg-sub :items (fn [db _] (:items db)))
     ;; Deliberate broken sub: `items` resolves to the string "broken",
     ;; which has no `.something` method, so the call throws a TypeError
@@ -1450,7 +1450,7 @@
       (rf/reg-sub n-sub (fn [_ _] 1))
       (rf/reg-view* view-id (fn [] (React/createElement "span" #js {} "x")))
       (let [render (rf/view view-id)]
-        (rf/reg-event-fx cascade-ev
+        (rf/reg-event cascade-ev
           (fn [_ _]
             @(rf/subscribe [n-sub])
             (render)
@@ -1730,7 +1730,7 @@
   without tripping the dev runtime-write diagnostic (it keys on the same
   `:rf/machine? true` marker the machine registrar mints)."
   [id f]
-  (rf/reg-event-fx id {:doc "framework-authority" :rf/machine? true} f))
+  (rf/reg-event id {:doc "framework-authority" :rf/machine? true} f))
 
 (defn assert-runtime-only-commit-does-not-rerun-app-subs
   "(1) A runtime-only commit recomputes the app-db projection, finds it
@@ -1747,7 +1747,7 @@
           rt-id   (mint-kw substrate-kw "inval-app-touch-rt")
           runs    (atom 0)]
       (rf/reg-frame fid {})
-      (rf/reg-event-db seed-id (fn [_ _] {:n 1}))
+      (rf/reg-event seed-id (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/dispatch-sync [seed-id] {:frame fid})
       (rf/reg-sub app-id (fn [db _] (swap! runs inc) (:n db)))
       (let [r (rf/subscribe fid [app-id])]
@@ -1792,7 +1792,7 @@
         (is (= :home @r) "precondition: runtime-db sub primes to the seeded route id")
         (let [after-prime @runs]
           ;; App-only commit: replaces app-db, leaves runtime-db `=`.
-          (rf/reg-event-db app-id (fn [db _] (assoc db :touched? true)))
+          (rf/reg-event app-id (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
           (rf/dispatch-sync [app-id] {:frame fid})
           (is (= :home @r) "the runtime-db sub still derefs to the unchanged route id")
           (is (= after-prime @runs)
@@ -1820,7 +1820,7 @@
           app-runs  (atom 0)
           rt-runs   (atom 0)]
       (rf/reg-frame fid {})
-      (rf/reg-event-db seed-app (fn [_ _] {:n 1}))
+      (rf/reg-event seed-app (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/dispatch-sync [seed-app] {:frame fid})
       (reg-fw-runtime-handler! seed-rt
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
@@ -1835,7 +1835,7 @@
         (let [app-baseline @app-runs
               rt-baseline  @rt-runs]
           ;; Real app-db change.
-          (rf/reg-event-db app-write (fn [db _] (update db :n inc)))
+          (rf/reg-event app-write (fn [{:keys [db]} _] {:db (update db :n inc)}))
           (rf/dispatch-sync [app-write] {:frame fid})
           (is (= 2 @ra) "the app sub re-derived to the new app-db value")
           (is (= (inc app-baseline) @app-runs)
@@ -1922,7 +1922,7 @@
   "canned-success stub dispatches a default reply (Spec 014)."
   [{:keys [name]}]
   (testing (str name " — canned-success default reply addressing")
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           (case (:kind reply)
@@ -1939,11 +1939,11 @@
   "Explicit :on-failure routes the failure reply to the named handler."
   [{:keys [name]}]
   (testing (str name " — canned-failure explicit :on-failure")
-    (rf/reg-event-fx :auth/login
+    (rf/reg-event :auth/login
       (fn [_ _]
         {:fx [[:rf.http/managed
                {:request {:method :post :url "/auth/login"} :on-failure [:auth/login-error]}]]}))
-    (rf/reg-event-db :auth/login-error (fn [db [_ payload]] (assoc db :auth-error payload)))
+    (rf/reg-event :auth/login-error (fn [{:keys [db]} [_ payload]] {:db (assoc db :auth-error payload)}))
     (rf/dispatch-sync [:auth/login]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
     (let [db (rf/app-db-value :rf/default)]
@@ -1955,11 +1955,11 @@
   "Explicit :on-success routes the success reply to the named handler."
   [{:keys [name]}]
   (testing (str name " — canned-success explicit :on-success")
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [_ _]
         {:fx [[:rf.http/managed
                {:request {:method :get :url "/articles/hello"} :on-success [:article/loaded]}]]}))
-    (rf/reg-event-db :article/loaded (fn [db [_ payload]] (assoc db :article payload)))
+    (rf/reg-event :article/loaded (fn [{:keys [db]} [_ payload]] {:db (assoc db :article payload)}))
     (rf/dispatch-sync [:article/load]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
     (let [db (rf/app-db-value :rf/default)]
@@ -1971,7 +1971,7 @@
   [{:keys [name]}]
   (testing (str name " — :on-success nil swallows the reply")
     (let [seen (atom 0)]
-      (rf/reg-event-fx :ping
+      (rf/reg-event :ping
         (fn [_ _]
           (swap! seen inc)
           {:fx [[:rf.http/managed {:request {:url "/ping"} :on-success nil}]]}))
@@ -1983,7 +1983,7 @@
   "with-managed-request-stubs* installs a per-call fx."
   [{:keys [name]}]
   (testing (str name " — with-managed-request-stubs* installs a per-call fx")
-    (rf/reg-event-fx :articles/list
+    (rf/reg-event :articles/list
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:result reply}}
@@ -2005,7 +2005,7 @@
   {:reply {:failure ...}}."
   [{:keys [name]}]
   (testing (str name " — with-managed-request-stubs* failure mapping")
-    (rf/reg-event-fx :articles/list
+    (rf/reg-event :articles/list
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:result reply}}
@@ -2025,7 +2025,7 @@
   "Managed requests issued from frame A reply into frame A's app-db."
   [{:keys [name]}]
   (testing (str name " — managed requests reply into the issuing frame's app-db")
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db {:article (:value reply)}}
@@ -2058,7 +2058,7 @@
   (testing (str name " — #1 frame disposal with active machine instances")
     (rf/reg-frame :tenant-x {:doc "tenant frame with two machines"})
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]
                                   {:flow/login    {:state :authed  :data {}}
@@ -2078,7 +2078,7 @@
   "#2 Sub-cache hit inside a machine microstep."
   [{:keys [name]}]
   (testing (str name " — #2 sub-cache hit inside a machine microstep")
-    (rf/reg-event-db :seed (fn [_ _] {:user/role :admin}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user/role :admin}}))
     (rf/reg-sub :user-role (fn [db _] (:user/role db)))
     (rf/dispatch-sync [:seed])
     (let [observed-by-action (atom nil)
@@ -2096,7 +2096,7 @@
   "#3 Machine spawn at boot before substrate adapter ready."
   [{:keys [name]}]
   (testing (str name " — #3 machine spawn at boot before adapter ready")
-    (rf/reg-event-fx :init-shape
+    (rf/reg-event :init-shape
       (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:snapshots {:flow/boot {:state :armed :data {}}}}}}))
     ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
     ;; `*current-frame*` :rf/default scope. `reg-frame`'s `:on-create` dispatch
@@ -2158,7 +2158,7 @@
   "#11 Machine action throws."
   [{:keys [name]}]
   (testing (str name " — #11 machine action throws")
-    (rf/reg-event-db :seed-state (fn [_ _] {:val :before}))
+    (rf/reg-event :seed-state (fn [{:keys [db]} _] {:db {:val :before}}))
     (rf/dispatch-sync [:seed-state])
     (let [machine {:initial :idle :data {}
                    :states  {:idle {:on {:bang {:target :angry :action :boom}}} :angry {}}
@@ -2220,8 +2220,8 @@
   [{:keys [name]}]
   (testing (str name " — #14 re-entrant dispatch-sync from inside a handler")
     (let [traces (collect-traces ::xspec-14)]
-      (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
-      (rf/reg-event-fx :nested (fn [_ _] (rf/dispatch-sync [:outer]) {}))
+      (rf/reg-event :outer (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
+      (rf/reg-event :nested (fn [_ _] (rf/dispatch-sync [:outer]) {}))
       (rf/dispatch-sync [:nested])
       (stop-traces ::xspec-14)
       (is (some (fn [ev] (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
@@ -2253,7 +2253,7 @@
   [{:keys [name]}]
   (testing (str name " — #16 error projection on the server")
     (rf/reg-frame :req {:preset :ssr-server})
-    (rf/reg-event-fx :handler-throws (fn [_ _] (throw (ex-info "boom" {}))))
+    (rf/reg-event :handler-throws (fn [_ _] (throw (ex-info "boom" {}))))
     (let [traces (collect-traces ::xspec-16)]
       (rf/dispatch-sync [:handler-throws] {:frame :req})
       (stop-traces ::xspec-16)
@@ -2272,7 +2272,7 @@
   "#18 Re-registering a sub mid-cascade."
   [{:keys [name]}]
   (testing (str name " — #18 re-registering a sub mid-cascade")
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :answer (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (is (= 7 (rf/subscribe-once [:answer])) "the v1 sub computes from app-db")
@@ -2289,7 +2289,7 @@
       (rf/reg-fx :http             (fn [_ args] (swap! seen conj [:real-http args])))
       (rf/reg-fx :rf.test/http-stub (fn [_ args] (swap! seen conj [:stub args])))
       (rf/reg-frame :story-frame {:fx-overrides {:http :rf.test/http-stub}})
-      (rf/reg-event-fx :go (fn [_ _] {:fx [[:http {:url "/x"}]]}))
+      (rf/reg-event :go (fn [_ _] {:fx [[:http {:url "/x"}]]}))
       (rf/dispatch-sync [:go] {:frame :story-frame})
       (is (= [[:stub {:url "/x"}]] @seen)
           "the id-valued override redirected :http → :rf.test/http-stub"))))
@@ -2434,7 +2434,7 @@
     (frame/ensure-default-frame!)
     (rf/reg-frame tenant-a {:doc "tenant-a frame"})
     (rf/reg-frame tenant-b {:doc "tenant-b frame"})
-    (rf/reg-event-db seed (fn [_ [_ marker]] {:marker marker :received []}))
+    (rf/reg-event seed (fn [{:keys [db]} [_ marker]] {:db {:marker marker :received []}}))
     (rf/dispatch-sync [seed :rf/default] {:frame :rf/default})
     (rf/dispatch-sync [seed :tenant-a]  {:frame tenant-a})
     (rf/dispatch-sync [seed :tenant-b]  {:frame tenant-b})
@@ -2450,8 +2450,8 @@
     (let [{:keys [tenant-a]} (dfc-seed-frames! substrate-kw)
           parent (mint-kw substrate-kw "dfc-parent")
           landed (mint-kw substrate-kw "dfc-landed")]
-      (rf/reg-event-fx parent (fn [_ _] (rf/dispatch [landed]) {}))
-      (rf/reg-event-db landed (fn [db _] (update db :received (fnil conj []) :landed-sync)))
+      (rf/reg-event parent (fn [_ _] (rf/dispatch [landed]) {}))
+      (rf/reg-event landed (fn [{:keys [db]} _] {:db (update db :received (fnil conj []) :landed-sync)}))
       (rf/dispatch-sync [parent] {:frame tenant-a})
       (is (= [:landed-sync] (dfc-received tenant-a))
           "the :landed event must land on tenant-a, not :rf/default")
@@ -2465,8 +2465,8 @@
     (let [{:keys [tenant-a]} (dfc-seed-frames! substrate-kw)
           parent (mint-kw substrate-kw "dfc-parent-fx")
           landed (mint-kw substrate-kw "dfc-landed-fx")]
-      (rf/reg-event-fx parent (fn [_ _] {:fx [[:dispatch [landed]]]}))
-      (rf/reg-event-db landed (fn [db _] (update db :received (fnil conj []) :landed-fx)))
+      (rf/reg-event parent (fn [_ _] {:fx [[:dispatch [landed]]]}))
+      (rf/reg-event landed (fn [{:keys [db]} _] {:db (update db :received (fnil conj []) :landed-fx)}))
       (rf/dispatch-sync [parent] {:frame tenant-a})
       (is (= [:landed-fx] (dfc-received tenant-a))
           ":fx [[:dispatch ...]] threads the frame through fx/do-fx — lands on tenant-a")
@@ -2480,8 +2480,8 @@
     (let [{:keys [tenant-a tenant-b]} (dfc-seed-frames! substrate-kw)
           fan  (mint-kw substrate-kw "dfc-fan")
           leaf (mint-kw substrate-kw "dfc-leaf")]
-      (rf/reg-event-fx fan (fn [_ [_ payload]] (rf/dispatch [leaf payload]) {}))
-      (rf/reg-event-db leaf (fn [db [_ payload]] (update db :received (fnil conj []) payload)))
+      (rf/reg-event fan (fn [_ [_ payload]] (rf/dispatch [leaf payload]) {}))
+      (rf/reg-event leaf (fn [{:keys [db]} [_ payload]] {:db (update db :received (fnil conj []) payload)}))
       (rf/dispatch-sync [fan :a-payload] {:frame tenant-a})
       (rf/dispatch-sync [fan :b-payload] {:frame tenant-b})
       (is (= [:a-payload] (dfc-received tenant-a)) "tenant-a only sees its own :a-payload")
@@ -2505,7 +2505,7 @@
           defer  (mint-kw substrate-kw "dfc-defer-raw")
           landed (mint-kw substrate-kw "dfc-landed-raw")
           raised (atom nil)]
-      (rf/reg-event-fx defer
+      (rf/reg-event defer
         (fn [_ _]
           (js/setTimeout
             (fn []
@@ -2516,7 +2516,7 @@
                    (catch :default e (reset! raised (:rf.error/id (ex-data e))))))
             0)
           {}))
-      (rf/reg-event-db landed (fn [db _] (update db :received (fnil conj []) :landed-raw)))
+      (rf/reg-event landed (fn [{:keys [db]} _] {:db (update db :received (fnil conj []) :landed-raw)}))
       (rf/dispatch-sync [defer] {:frame tenant-a})
       (js/setTimeout
         (fn []
@@ -2540,9 +2540,9 @@
     (let [{:keys [tenant-a]} (dfc-seed-frames! substrate-kw)
           parent (mint-kw substrate-kw "dfc-parent-later")
           landed (mint-kw substrate-kw "dfc-landed-later")]
-      (rf/reg-event-fx parent
+      (rf/reg-event parent
         (fn [_ _] {:fx [[:dispatch-later {:ms 0 :event [landed]}]]}))
-      (rf/reg-event-db landed (fn [db _] (update db :received (fnil conj []) :landed-later)))
+      (rf/reg-event landed (fn [{:keys [db]} _] {:db (update db :received (fnil conj []) :landed-later)}))
       (rf/dispatch-sync [parent] {:frame tenant-a})
       (js/setTimeout
         (fn []
@@ -2563,12 +2563,12 @@
     (let [{:keys [tenant-a]} (dfc-seed-frames! substrate-kw)
           parent (mint-kw substrate-kw "dfc-parent-bound")
           landed (mint-kw substrate-kw "dfc-landed-bound")]
-      (rf/reg-event-fx parent
+      (rf/reg-event parent
         (fn [_ _]
           (let [d (:dispatch (rf/frame-handle))]
             (js/setTimeout (fn [] (d [landed])) 0))
           {}))
-      (rf/reg-event-db landed (fn [db _] (update db :received (fnil conj []) :landed-bound)))
+      (rf/reg-event landed (fn [{:keys [db]} _] {:db (update db :received (fnil conj []) :landed-bound)}))
       (rf/dispatch-sync [parent] {:frame tenant-a})
       (js/setTimeout
         (fn []
@@ -2931,8 +2931,8 @@
       (reset! probe-observed [])
       (reset! refcount-target us-frame)
       (rf/reg-frame us-frame {:doc "use-subscribe probe frame"})
-      (rf/reg-event-db ::us-seed (fn [_ _] {:n 1}))
-      (rf/reg-event-db ::us-inc  (fn [db _] (update db :n inc)))
+      (rf/reg-event ::us-seed (fn [{:keys [db]} _] {:db {:n 1}}))
+      (rf/reg-event ::us-inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
       (rf/dispatch-sync [::us-seed] {:frame us-frame})
       (rf/reg-sub us-query (fn [db _] (:n db)))
       (let [mount-node (make-mount-node!)
@@ -2991,8 +2991,8 @@
             (enable-react-act-env!)
             (reset! refcount-target fr-frame)
             (rf/reg-frame fr-frame {:doc "flush-render! synchronous-commit probe frame"})
-            (rf/reg-event-db ::fr-seed (fn [_ _] {:n 1}))
-            (rf/reg-event-db ::fr-inc  (fn [db _] (update db :n inc)))
+            (rf/reg-event ::fr-seed (fn [{:keys [db]} _] {:db {:n 1}}))
+            (rf/reg-event ::fr-inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
             (rf/dispatch-sync [::fr-seed] {:frame fr-frame})
             (rf/reg-sub fr-query (fn [db _] (:n db)))
             (let [mount-node (make-mount-node!)
@@ -3066,7 +3066,7 @@
       (binding [frame/*current-frame* nil]
         (reset! probe-frame-provider-observed [])
         (rf/reg-frame frame-provider-frame {:doc "use-subscribe frame-provider probe frame"})
-        (rf/reg-event-db ::frame-provider-seed (fn [_ _] {:k :wrapped}))
+        (rf/reg-event ::frame-provider-seed (fn [{:keys [db]} _] {:db {:k :wrapped}}))
         (rf/dispatch-sync [::frame-provider-seed] {:frame frame-provider-frame})
         (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
         (let [mount-node (make-mount-node!)
@@ -3105,7 +3105,7 @@
       (reset! probe-2arg-b-observed [])
       (rf/reg-frame tenant-a-frame {:doc "tenant-a"})
       (rf/reg-frame tenant-b-frame {:doc "tenant-b"})
-      (rf/reg-event-db ::explicit-pin-seed (fn [_ [_ n]] {:n n}))
+      (rf/reg-event ::explicit-pin-seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
       (rf/dispatch-sync [::explicit-pin-seed 10]  {:frame tenant-a-frame})
       (rf/dispatch-sync [::explicit-pin-seed 100] {:frame tenant-b-frame})
       (rf/reg-sub explicit-pin-query (fn [db _] (:n db)))
@@ -3182,7 +3182,7 @@
       (binding [frame/*current-frame* nil]
         (reset! probe-frame-provider-observed [])
         (rf/reg-frame provider-tier-frame {:doc "rf2-4mi2zj provider-tier (ambient cleared) frame"})
-        (rf/reg-event-db ::provider-tier-seed (fn [_ _] {:k :from-provider}))
+        (rf/reg-event ::provider-tier-seed (fn [{:keys [db]} _] {:db {:k :from-provider}}))
         (rf/dispatch-sync [::provider-tier-seed] {:frame provider-tier-frame})
         (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
         (let [mount-node (make-mount-node!)
@@ -3234,7 +3234,7 @@
       (reset! probe-frame-provider-observed [])
       (rf/reg-frame dynamic-precedence-provider-frame {:doc "rf2-4mi2zj provider (precedence loser)"})
       (rf/reg-frame dynamic-precedence-dynamic-frame  {:doc "rf2-4mi2zj dynamic-var (precedence winner)"})
-      (rf/reg-event-db ::precedence-seed (fn [_ [_ v]] {:k v}))
+      (rf/reg-event ::precedence-seed (fn [{:keys [db]} [_ v]] {:db {:k v}}))
       (rf/dispatch-sync [::precedence-seed :from-provider] {:frame dynamic-precedence-provider-frame})
       (rf/dispatch-sync [::precedence-seed :from-dynamic]  {:frame dynamic-precedence-dynamic-frame})
       (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
@@ -3334,7 +3334,7 @@
      (fn [act-fn]
       (reset! refcount-target rc-frame)
       (rf/reg-frame rc-frame {:doc "refcount probe frame"})
-      (rf/reg-event-db ::rc-seed (fn [_ _] {:m 0}))
+      (rf/reg-event ::rc-seed (fn [{:keys [db]} _] {:db {:m 0}}))
       (rf/dispatch-sync [::rc-seed] {:frame rc-frame})
       (rf/reg-sub rc-query (fn [db _] (:m db)))
       (let [cache-key-v [rc-query]
@@ -3401,8 +3401,8 @@
       (reset! siblings-observed-b [])
       (reset! refcount-target sib-frame)
       (rf/reg-frame sib-frame {:doc "rf2-e4pyb sibling-collision probe frame"})
-      (rf/reg-event-db ::sib-seed (fn [_ _] {:n 1}))
-      (rf/reg-event-db ::sib-inc  (fn [db _] (update db :n inc)))
+      (rf/reg-event ::sib-seed (fn [{:keys [db]} _] {:db {:n 1}}))
+      (rf/reg-event ::sib-inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
       (rf/dispatch-sync [::sib-seed] {:frame sib-frame})
       (rf/reg-sub sib-query (fn [db _] (:n db)))
       (let [cache-key-v [sib-query]
@@ -3455,7 +3455,7 @@
      (fn [act-fn]
       (reset! stable-deps-set-tick nil)
       (rf/reg-frame stable-deps-frame {:doc "rf2-mwft2 stable-deps probe frame"})
-      (rf/reg-event-db ::stable-deps-seed (fn [_ _] {:p 0}))
+      (rf/reg-event ::stable-deps-seed (fn [{:keys [db]} _] {:db {:p 0}}))
       (rf/dispatch-sync [::stable-deps-seed] {:frame stable-deps-frame})
       (rf/reg-sub stable-deps-query (fn [db _] (:p db)))
       (let [subscribe-calls   (atom 0)
@@ -3577,7 +3577,7 @@
      (fn [act-fn]
       (reset! refcount-target rc-frame)
       (rf/reg-frame rc-frame {:doc "rf2-nymuy StrictMode refcount probe frame"})
-      (rf/reg-event-db ::sm-seed (fn [_ _] {:m 7}))
+      (rf/reg-event ::sm-seed (fn [{:keys [db]} _] {:db {:m 7}}))
       (rf/dispatch-sync [::sm-seed] {:frame rc-frame})
       (rf/reg-sub rc-query (fn [db _] (:m db)))
       (let [subscribe-calls   (atom 0)
@@ -3695,7 +3695,7 @@
      (fn [act-fn]
       (reset! refcount-target rc-frame)
       (rf/reg-frame rc-frame {:doc "rf2-8u8tx.2 memo-recompute refcount probe frame"})
-      (rf/reg-event-db ::mr-seed (fn [_ _] {:m 0}))
+      (rf/reg-event ::mr-seed (fn [{:keys [db]} _] {:db {:m 0}}))
       (rf/dispatch-sync [::mr-seed] {:frame rc-frame})
       (rf/reg-sub rc-query (fn [db _] (:m db)))
       (let [cache-key-v [rc-query]
@@ -3755,7 +3755,7 @@
      (fn [act-fn]
       (reset! refcount-target rc-frame)
       (rf/reg-frame rc-frame {:doc "rf2-879fe abandoned-render refcount probe frame"})
-      (rf/reg-event-db ::ar-seed (fn [_ _] {:m 0}))
+      (rf/reg-event ::ar-seed (fn [{:keys [db]} _] {:db {:m 0}}))
       (rf/dispatch-sync [::ar-seed] {:frame rc-frame})
       (rf/reg-sub rc-query (fn [db _] (:m db)))
       (let [cache-key-v   [rc-query]
@@ -3820,7 +3820,7 @@
      (fn [act-fn]
       (reset! stable-deps-set-tick nil)
       (rf/reg-frame stable-deps-frame {:doc "rf2-gizlj arity probe frame"})
-      (rf/reg-event-db ::gizlj-seed (fn [_ _] {:p 0}))
+      (rf/reg-event ::gizlj-seed (fn [{:keys [db]} _] {:db {:p 0}}))
       (rf/dispatch-sync [::gizlj-seed] {:frame stable-deps-frame})
       (rf/reg-sub stable-deps-query (fn [db _] (:p db)))
       (let [unsubscribe-arg-counts (atom [])

--- a/implementation/core/test/re_frame/app_value_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_cljs_test.cljc
@@ -66,9 +66,9 @@
             id / handler lifted out of :handler-fn, source coords lifted into
             :source, the rest of the Spec 001 metadata under :metadata, each
             fact carried exactly once"
-    (rf/reg-event-db :av/add
+    (rf/reg-event :av/add
       {:doc "Add an item."}
-      (fn add-handler [db _] (update db :items (fnil conj []) :x)))
+      (fn add-handler [{:keys [db]} _] {:db (update db :items (fnil conj []) :x)}))
     (let [d (get-in (av/app-value) [:registrations :event :av/add])]
       (is (= :event (:kind d)) "the descriptor carries the kind")
       (is (= :av/add (:id d)) "the descriptor carries the id")
@@ -81,8 +81,10 @@
       ;; DESCRIPTION, not framework book-keeping.
       (is (= "Add an item." (get-in d [:metadata :doc]))
           ":doc is preserved under :metadata")
-      (is (= :db (get-in d [:metadata :event/kind]))
-          "the kind-specific :event/kind extra is preserved under :metadata")
+      (is (= :fx (get-in d [:metadata :event/kind]))
+          "the kind-specific :event/kind extra is preserved under :metadata
+           (reg-event shares the reg-event-fx path during the EP-0018 additive
+           window, so :event/kind is :fx)")
       ;; The handler and source-coord slots are NOT double-carried in :metadata.
       (is (not (contains? (:metadata d) :handler-fn))
           ":handler-fn is removed from :metadata (carried under :handler)")
@@ -260,7 +262,7 @@
             app-value projection is read-only and adds no registration-path
             behaviour (zero ergonomic regression)"
     (rf/reg-frame :av/app {:doc "ergonomics app"})
-    (rf/reg-event-db :av/set {:doc "set n"} (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :av/set {:doc "set n"} (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-sub :av/read-n {:doc "read n"} (fn [db _] (:n db)))
     ;; Dispatch + subscribe against the default-realm frame — unchanged.
     (rf/dispatch-sync [:av/set 9] {:frame :av/app})

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -309,7 +309,7 @@
     ;; explicitly (an ordinary id) and runs ambient ops inside an explicit
     ;; :rf/default scope, exactly as a single-frame app would.
     (rf/init! plain-atom/adapter)
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/reg-sub      :n    (fn [db _] (:n db)))
     (rf/reg-frame :rf/default {:doc "explicit app frame"})
     (rf/reg-frame :tenant-a {:doc "tenant-a"})

--- a/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
+++ b/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
@@ -70,7 +70,7 @@
 (deftest dispatch-id-rides-every-event-in-the-cascade
   (testing "every trace event emitted while a drain is in flight carries the cascade's :rf.trace/dispatch-id"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
                      (fn [_ _]
                        {:db {:n 1}
                         :fx [[:test/incr :go]]}))
@@ -111,10 +111,10 @@
 (deftest child-dispatch-gets-its-own-dispatch-id-and-parents-the-outer
   (testing "child dispatches from inside fx handlers get a fresh :rf.trace/dispatch-id and the parent's id rides on :rf.trace/parent-dispatch-id"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-fx :parent
+    (rf/reg-event :parent
                      (fn [_ _]
                        {:fx [[:dispatch [:child]]]}))
-    (rf/reg-event-db :child (fn [db _] (assoc db :got-child true)))
+    (rf/reg-event :child (fn [{:keys [db]} _] {:db (assoc db :got-child true)}))
     (let [evs        (record-traces
                        (fn [] (rf/dispatch-sync [:parent] {:frame :test/main})))
           dispatches (vec (events-of evs #(= :rf.event/dispatched (:operation %))))
@@ -133,8 +133,8 @@
 (deftest parent-dispatch-id-only-on-event-dispatched
   (testing ":rf.trace/parent-dispatch-id is scoped to :rf.event/dispatched events only — not on :rf.sub/run, :rf.event/db-changed, :rf.fx/handled, etc."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-fx :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
-    (rf/reg-event-db :inner (fn [db _] (assoc db :v 1)))
+    (rf/reg-event :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
+    (rf/reg-event :inner (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
     (let [evs (record-traces
                 (fn [] (rf/dispatch-sync [:outer] {:frame :test/main})))]
       (doseq [ev evs
@@ -169,7 +169,7 @@
 (deftest dispatch-id-is-fresh-across-cascade-boundaries
   (testing "two sequential dispatches get distinct :dispatch-ids on every event in their respective cascades"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :bump (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [evs1 (record-traces
                  (fn [] (rf/dispatch-sync [:bump] {:frame :test/main})))
           evs2 (record-traces

--- a/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
+++ b/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
@@ -62,11 +62,11 @@
         (fn [_ args] (swap! http-fired conj args)))
       (rf/reg-fx :test/http.stub
         (fn [_ args] (swap! http-stub conj args)))
-      (rf/reg-event-fx :test/parent
+      (rf/reg-event :test/parent
         (fn [_ _]
           {:fx [[:test/http {:tag :from-parent}]
                 [:dispatch [:test/child]]]}))
-      (rf/reg-event-fx :test/child
+      (rf/reg-event :test/child
         (fn [_ _]
           {:fx [[:test/http {:tag :from-child}]]}))
 
@@ -84,15 +84,15 @@
       (rf/reg-fx :test/http  (fn [_ _]))
       (rf/reg-fx :test/http.stub
         (fn [_ args] (swap! http-stub conj args)))
-      (rf/reg-event-fx :test/lvl-0
+      (rf/reg-event :test/lvl-0
         (fn [_ _]
           {:fx [[:test/http {:lvl 0}]
                 [:dispatch [:test/lvl-1]]]}))
-      (rf/reg-event-fx :test/lvl-1
+      (rf/reg-event :test/lvl-1
         (fn [_ _]
           {:fx [[:test/http {:lvl 1}]
                 [:dispatch [:test/lvl-2]]]}))
-      (rf/reg-event-fx :test/lvl-2
+      (rf/reg-event :test/lvl-2
         (fn [_ _]
           {:fx [[:test/http {:lvl 2}]]}))
 
@@ -119,7 +119,7 @@
     (let [seen (atom [])]
       (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
       (try
-        (rf/reg-event-fx :test/parent
+        (rf/reg-event :test/parent
           (fn [_ _]
             {:fx [[:dispatch [:test/child]]]}))
         (rf/reg-event-db :test/child (fn [db _] db))
@@ -152,7 +152,7 @@
     (let [captured-envelopes (atom [])]
       (rf/reg-fx :test/capture-envelope
         (fn [m _args] (swap! captured-envelopes conj (:envelope m))))
-      (rf/reg-event-fx :test/run
+      (rf/reg-event :test/run
         (fn [_ _]
           {:fx [[:test/capture-envelope]]}))
 
@@ -187,10 +187,10 @@
         (fn [_ args]
           (swap! stub-fired conj args)
           (deliver done :fired)))
-      (rf/reg-event-fx :test/parent
+      (rf/reg-event :test/parent
         (fn [_ _]
           {:fx [[:dispatch-later {:ms 1 :event [:test/child]}]]}))
-      (rf/reg-event-fx :test/child
+      (rf/reg-event :test/child
         (fn [_ _]
           {:fx [[:test/http {:tag :deferred}]]}))
 

--- a/implementation/core/test/re_frame/cofx_cljs_test.cljc
+++ b/implementation/core/test/re_frame/cofx_cljs_test.cljc
@@ -67,7 +67,7 @@
       (rf/reg-cofx :cofx-test/locale
         {:doc "Ambient supplier."}
         (fn [] "en-AU"))
-      (rf/reg-event-fx :cofx-test/read-locale
+      (rf/reg-event :cofx-test/read-locale
         {:rf.cofx/requires [:cofx-test/locale]}
         (fn [{:keys [cofx-test/locale]} _]
           (reset! seen locale)
@@ -82,7 +82,7 @@
     (let [seen (atom ::unset)]
       (rf/reg-cofx :cofx-test/echo
         (fn [arg] (str "echo:" arg)))
-      (rf/reg-event-fx :cofx-test/read-echo
+      (rf/reg-event :cofx-test/read-echo
         {:rf.cofx/requires [[:cofx-test/echo "hi"]]}
         (fn [{:keys [cofx-test/echo]} _]
           (reset! seen echo)
@@ -101,7 +101,7 @@
             declared-only delivery; no silent green-in-test coupling)"
     (let [seen-time (atom ::unset)
           seen-undeclared (atom ::unset)]
-      (rf/reg-event-fx :cofx-test/declares-only-time
+      (rf/reg-event :cofx-test/declares-only-time
         {:rf.cofx/requires [:rf/time-ms]}
         (fn [{:keys [rf/time-ms] :as cofx} _]
           (reset! seen-time time-ms)
@@ -122,7 +122,7 @@
             :db / :event / framework keys — no recordable leaf is staged flat,
             even one present on the token"
     (let [had-time? (atom ::unset)]
-      (rf/reg-event-fx :cofx-test/declares-nothing
+      (rf/reg-event :cofx-test/declares-nothing
         (fn [{:keys [rf/time-ms] :as cofx} _]
           (reset! had-time? (contains? cofx :rf/time-ms))
           (is (nil? time-ms)
@@ -163,7 +163,7 @@
       ;; grouped seats never shipped a producer), so declared-only delivery
       ;; must FAIL CLOSED on it as an unregistered id rather than silently
       ;; dig `4` out of the grouped sub-map and stage it flat.
-      (rf/reg-event-fx :cofx-test/declares-nested-leaf
+      (rf/reg-event :cofx-test/declares-nested-leaf
         {:rf.cofx/requires [:random/roll]}
         (fn [{:keys [random/roll] :as cofx} _]
           (reset! staged-leaf? (contains? cofx :random/roll))
@@ -202,7 +202,7 @@
     ;; have to be REGISTERED to be delivered; the retired group seat is not.)
     (let [staged? (atom ::unset)
           ex      (atom ::unset)]
-      (rf/reg-event-fx :cofx-test/declares-group-owner
+      (rf/reg-event :cofx-test/declares-group-owner
         {:rf.cofx/requires [:random]}
         (fn [{:keys [random] :as cofx} _]
           (reset! staged? (contains? cofx :random))
@@ -232,7 +232,7 @@
       (rf/reg-cofx :cofx-test/boot-token
         {:recordable? true :provided? true
          :doc "Provided boundary fact."})
-      (rf/reg-event-fx :cofx-test/read-boot
+      (rf/reg-event :cofx-test/read-boot
         {:rf.cofx/requires [:cofx-test/boot-token]}
         (fn [{:keys [cofx-test/boot-token]} _]
           (reset! seen boot-token)
@@ -247,7 +247,7 @@
             registration; declaring it delivers the router-stamped value flat
             (EP-0017 §2)"
     (let [seen (atom ::unset)]
-      (rf/reg-event-fx :cofx-test/read-time
+      (rf/reg-event :cofx-test/read-time
         {:rf.cofx/requires [:rf/time-ms]}
         (fn [{:keys [rf/time-ms]} _]
           (reset! seen time-ms)
@@ -290,7 +290,7 @@
       ;; :rf/time-ms so we can prove the reply does NOT inherit it. Its
       ;; handler dispatches the completion ("reply") event — the reply
       ;; envelope re-enters build-envelope and is stamped fresh.
-      (rf/reg-event-fx :cofx-test/request
+      (rf/reg-event :cofx-test/request
         (fn [_ _]
           {:fx [[:dispatch [:cofx-test/replied {:status :ok :value {:title "Welcome"}}]]]}))
       (rf/reg-event-db :cofx-test/replied (fn [db _] db))
@@ -340,7 +340,7 @@
           fired? (atom false)]
       (rf/reg-cofx :cofx-test/required-boundary
         {:recordable? true :provided? true})
-      (rf/reg-event-fx :cofx-test/needs-boundary
+      (rf/reg-event :cofx-test/needs-boundary
         {:rf.cofx/requires [:cofx-test/required-boundary]}
         (fn [_ _] (reset! fired? true) {}))
       ;; Dispatch WITHOUT supplying the provided fact on the token.
@@ -370,7 +370,7 @@
             fact). The two-error split is the EP-0017 §7 contract."
     (let [traces (collect-traces! ::typo)]
       ;; :cofx-test/typpo is NOT registered anywhere — a typo.
-      (rf/reg-event-fx :cofx-test/has-typo
+      (rf/reg-event :cofx-test/has-typo
         {:rf.cofx/requires [:cofx-test/typpo]}
         (fn [_ _] {}))
       (let [ex (try (rf/dispatch-sync [:cofx-test/has-typo]) nil
@@ -390,10 +390,10 @@
             missing-required; an UNREGISTERED id → unregistered-cofx — never
             conflated"
     (rf/reg-cofx :cofx-test/registered-provided {:recordable? true :provided? true})
-    (rf/reg-event-fx :cofx-test/absent-registered
+    (rf/reg-event :cofx-test/absent-registered
       {:rf.cofx/requires [:cofx-test/registered-provided]}
       (fn [_ _] {}))
-    (rf/reg-event-fx :cofx-test/absent-unregistered
+    (rf/reg-event :cofx-test/absent-unregistered
       {:rf.cofx/requires [:cofx-test/never-reg]}
       (fn [_ _] {}))
     (let [missing-id   (-> (try (rf/dispatch-sync [:cofx-test/absent-registered]) nil
@@ -428,13 +428,13 @@
   (testing "a non-vector / non-id `:rf.cofx/requires` is
             `:rf.error/cofx-request-invalid` at registration"
     (is (= :rf.error/cofx-request-invalid
-           (-> (try (rf/reg-event-fx :cofx-test/bad-requires-1
+           (-> (try (rf/reg-event :cofx-test/bad-requires-1
                       {:rf.cofx/requires :not-a-vector}
                       (fn [_ _] {}))
                     nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))
                ex-data :rf.error/id)))
     (is (= :rf.error/cofx-request-invalid
-           (-> (try (rf/reg-event-fx :cofx-test/bad-requires-2
+           (-> (try (rf/reg-event :cofx-test/bad-requires-2
                       {:rf.cofx/requires [42]}
                       (fn [_ _] {}))
                     nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))
@@ -444,7 +444,7 @@
   (testing "declaring the same id twice in one consumer scope is
             `:rf.error/cofx-name-collision` (EP-0017 §4)"
     (is (= :rf.error/cofx-name-collision
-           (-> (try (rf/reg-event-fx :cofx-test/dup-requires
+           (-> (try (rf/reg-event :cofx-test/dup-requires
                       {:rf.cofx/requires [:rf/time-ms :rf/time-ms]}
                       (fn [_ _] {}))
                     nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))
@@ -596,7 +596,7 @@
       ;; storage key; the produced value is what it reads back.
       (rf/reg-cofx :cofx-test/local-pref
         (fn [storage-key] (str "value-for-" storage-key)))
-      (rf/reg-event-fx :cofx-test/read-pref
+      (rf/reg-event :cofx-test/read-pref
         {:rf.cofx/requires [[:cofx-test/local-pref "theme"]]}
         (fn [_ _] {}))
       (rf/dispatch-sync [:cofx-test/read-pref])
@@ -617,7 +617,7 @@
             the prior arg-omission on the 1-arity path)"
     (let [traces (collect-traces! ::run-noarg)]
       (rf/reg-cofx :cofx-test/locale2 (fn [] "en-AU"))
-      (rf/reg-event-fx :cofx-test/read-locale2
+      (rf/reg-event :cofx-test/read-locale2
         {:rf.cofx/requires [:cofx-test/locale2]}
         (fn [_ _] {}))
       (rf/dispatch-sync [:cofx-test/read-locale2])
@@ -644,7 +644,7 @@
       (rf/reg-cofx :cofx-test/session
         {:sensitive [[:token]]}
         (fn [] {:token "super-secret-jwt" :public "ok"}))
-      (rf/reg-event-fx :cofx-test/read-session
+      (rf/reg-event :cofx-test/read-session
         {:rf.cofx/requires [:cofx-test/session]}
         (fn [_ _] {}))
       (rf/dispatch-sync [:cofx-test/read-session])
@@ -697,7 +697,7 @@
 (deftest world-inputs-dispatch-opt-renamed
   (testing "supplying the retired `:rf.world/inputs` dispatch opt is the hard
             error `:rf.error/world-inputs-renamed` naming `:rf.cofx` (EP-0017 §3)"
-    (rf/reg-event-fx :cofx-test/wi-renamed (fn [_ _] {}))
+    (rf/reg-event :cofx-test/wi-renamed (fn [_ _] {}))
     (let [ex (try (rf/dispatch-sync [:cofx-test/wi-renamed]
                                     {:rf.world/inputs {:rf/time-ms 1}})
                   nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
@@ -730,7 +730,7 @@
           (rf/reg-cofx :cofx-test/browser-locale
             {:platforms #{:client}}
             (fn [] (reset! cofx-fired? true) "en-US"))
-          (rf/reg-event-fx :cofx-test/read-browser-locale
+          (rf/reg-event :cofx-test/read-browser-locale
             {:rf.cofx/requires [:cofx-test/browser-locale]}
             (fn [{:keys [cofx-test/browser-locale] :as cofx} _]
               (reset! event-fired? true)
@@ -754,7 +754,7 @@
 (deftest handler-meta-surfaces-requires
   (testing "`:rf.cofx/requires` surfaces in handler-meta exactly as authored
             (Spec 009 §9 — the complete consumption record)"
-    (rf/reg-event-fx :cofx-test/reflective
+    (rf/reg-event :cofx-test/reflective
       {:rf.cofx/requires [:rf/time-ms]}
       (fn [_ _] {}))
     (let [meta (registrar/lookup :event :cofx-test/reflective)]
@@ -773,7 +773,7 @@
             :rf.error/no-frame-context (no :rf/default floor); the handler
             never runs"
     (let [fired? (atom false)]
-      (rf/reg-event-fx :cofx-test/frameless
+      (rf/reg-event :cofx-test/frameless
         {:rf.cofx/requires [:rf/time-ms]}
         (fn [_ _] (reset! fired? true) {}))
       (binding [frame/*current-frame* nil]
@@ -833,7 +833,7 @@
       (rf/reg-cofx :gen-test/delta
         {:recordable? true :doc "A generator-backed replayable delta."}
         (fn [] (swap! gen-calls inc) 7))
-      (rf/reg-event-fx :gen-test/inc
+      (rf/reg-event :gen-test/inc
         {:rf.cofx/requires [:rf/time-ms :gen-test/delta]}
         (fn [{:keys [rf/time-ms gen-test/delta] :as cofx} _]
           (reset! seen-delta delta)
@@ -861,7 +861,7 @@
       (rf/reg-cofx :gen-test/supplied-delta
         {:recordable? true}
         (fn [] (swap! gen-calls inc) 99))
-      (rf/reg-event-fx :gen-test/use-supplied
+      (rf/reg-event :gen-test/use-supplied
         {:rf.cofx/requires [:gen-test/supplied-delta]}
         (fn [{:keys [gen-test/supplied-delta]} _]
           (reset! seen-delta supplied-delta) {}))
@@ -880,7 +880,7 @@
       (rf/reg-cofx :gen-test/traced
         {:recordable? true}
         (fn [] 42))
-      (rf/reg-event-fx :gen-test/traced-evt
+      (rf/reg-event :gen-test/traced-evt
         {:rf.cofx/requires [:gen-test/traced]}
         (fn [_ _] {}))
       (rf/dispatch-sync [:gen-test/traced-evt])
@@ -914,7 +914,7 @@
           (rf/reg-cofx :gen-test/bad
             {:recordable? true :schema :gen-test/positive}
             (fn [] -1))                          ;; violates the schema
-          (rf/reg-event-fx :gen-test/uses-bad
+          (rf/reg-event :gen-test/uses-bad
             {:rf.cofx/requires [:gen-test/bad]}
             (fn [_ _] (reset! fired? true) {}))
           (let [ex (try (rf/dispatch-sync [:gen-test/uses-bad]) nil
@@ -947,7 +947,7 @@
           (rf/reg-cofx :gen-test/checked
             {:recordable? true :schema :gen-test/positive}
             (fn [] 5))
-          (rf/reg-event-fx :gen-test/uses-checked
+          (rf/reg-event :gen-test/uses-checked
             {:rf.cofx/requires [:gen-test/checked]}
             (fn [_ _] (reset! fired? true) {}))
           ;; Supply an out-of-contract value (-9) on the token.
@@ -971,7 +971,7 @@
           (rf/reg-cofx :gen-test/good
             {:recordable? true :schema :gen-test/positive}
             (fn [] 11))
-          (rf/reg-event-fx :gen-test/uses-good
+          (rf/reg-event :gen-test/uses-good
             {:rf.cofx/requires [:gen-test/good]}
             (fn [{:keys [gen-test/good]} _] (reset! seen good) {}))
           (rf/dispatch-sync [:gen-test/uses-good])
@@ -1049,7 +1049,7 @@
       (rf/reg-cofx :mint-test/live-delta
         {:recordable? true :doc "Generator-backed, exercised under :live."}
         (fn [] (swap! gen-calls inc) 7))
-      (rf/reg-event-fx :mint-test/live-evt
+      (rf/reg-event :mint-test/live-evt
         {:rf.cofx/requires [:mint-test/live-delta]}
         (fn [{:keys [mint-test/live-delta]} _] (reset! seen-delta live-delta) {}))
       ;; The fixture's ambient frame is :rf/default (no preset → no mint-policy
@@ -1070,7 +1070,7 @@
       (rf/reg-cofx :mint-test/strict-delta
         {:recordable? true}
         (fn [] (swap! gen-calls inc) 3))
-      (rf/reg-event-fx :mint-test/strict-evt
+      (rf/reg-event :mint-test/strict-evt
         {:rf.cofx/requires [:mint-test/strict-delta]}
         (fn [_ _] (reset! fired? true) {}))
       (let [ex (try (rf/dispatch-sync [:mint-test/strict-evt]
@@ -1098,7 +1098,7 @@
       (rf/reg-cofx :mint-test/replay-delta
         {:recordable? true}
         (fn [] (swap! gen-calls inc) 5))
-      (rf/reg-event-fx :mint-test/replay-evt
+      (rf/reg-event :mint-test/replay-evt
         {:rf.cofx/requires [:mint-test/replay-delta]}
         (fn [_ _] (reset! fired? true) {}))
       ;; The ambient :rf/default frame is :live; the per-call :strict opt — the
@@ -1121,7 +1121,7 @@
         (reset! gen-calls 0)
         (reset! fired? false)
         (let [seen (atom nil)]
-          (rf/reg-event-fx :mint-test/replay-evt
+          (rf/reg-event :mint-test/replay-evt
             {:rf.cofx/requires [:mint-test/replay-delta]}
             (fn [{:keys [mint-test/replay-delta]} _]
               (reset! fired? true) (reset! seen replay-delta) {}))
@@ -1145,7 +1145,7 @@
       (rf/reg-cofx :mint-test/escape-delta
         {:recordable? true}
         (fn [] (swap! gen-calls inc) 9))
-      (rf/reg-event-fx :mint-test/escape-evt
+      (rf/reg-event :mint-test/escape-evt
         {:rf.cofx/requires [:mint-test/escape-delta]}
         (fn [{:keys [mint-test/escape-delta]} _] (reset! seen-delta escape-delta) {}))
       ;; Without the opt this :test frame would be :strict → missing-required

--- a/implementation/core/test/re_frame/concurrency_stress_test.clj
+++ b/implementation/core/test/re_frame/concurrency_stress_test.clj
@@ -106,12 +106,12 @@
           current-cnt (atom (atom 0))
           ;; How many :b/leaf events each :a/cross-fire fans out.
           fanout      4]
-      (rf/reg-event-db :b/leaf
+      (rf/reg-event :b/leaf
         {:frame :rgj.exec/b}
-        (fn [db _]
+        (fn [{:keys [db]} _]
           (swap! @current-cnt inc)
-          (update db :n (fnil inc 0))))
-      (rf/reg-event-fx :a/cross-fire
+          {:db (update db :n (fnil inc 0))}))
+      (rf/reg-event :a/cross-fire
         {:frame :rgj.exec/a}
         (fn [_ _]
           ;; Returning fx with N cross-frame :dispatch fxs.
@@ -200,8 +200,8 @@
                                 :drain-depth 200000})
     (rf/reg-frame :rgj.sync/b {:doc "frame B — main-thread sync drainer"
                                 :drain-depth 200000})
-    (rf/reg-event-db :bump
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :bump
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
 
     (let [warnings    (atom 0)
           n-a         stress-iters

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -511,8 +511,8 @@
                 (rf/reg-event-db id event-meta handler)
                 (rf/reg-event-db id handler))
           :fx (if (seq event-meta)
-                (rf/reg-event-fx id event-meta handler)
-                (rf/reg-event-fx id handler)))))
+                (rf/reg-event id event-meta handler)
+                (rf/reg-event id handler)))))
     ;; sub registrations
     (doseq [[id steps] (get handlers-map :sub)]
       (let [{:keys [kind inputs body]} (conformance/realise-sub steps)

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -549,8 +549,8 @@
                 (rf/reg-event-db id event-meta handler)
                 (rf/reg-event-db id handler))
           :fx (if (seq event-meta)
-                (rf/reg-event-fx id event-meta handler)
-                (rf/reg-event-fx id handler)))))
+                (rf/reg-event id event-meta handler)
+                (rf/reg-event id handler)))))
     (doseq [[id steps] (get handlers-map :sub)]
       (let [{:keys [kind inputs body]} (conformance/realise-sub steps)
             ;; Per Spec 010 §step 6 (rf2-wcam): pull :schema from the

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -89,7 +89,7 @@
   (testing "subscriber called inside (with-frame :k ...) captures :k"
     (rf/reg-frame :wf/left  {:doc "left"})
     (rf/reg-frame :wf/right {:doc "right"})
-    (rf/reg-event-db :wf/seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :wf/seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/reg-sub :wf/n (fn [db _] (:n db)))
     (rf/dispatch-sync [:wf/seed 7]  {:frame :wf/left})
     (rf/dispatch-sync [:wf/seed 99] {:frame :wf/right})
@@ -141,7 +141,7 @@
   (testing "(with-new-frame [f (make-frame {:on-create [...]})] body) —
             on-create fires before body, body sees the seeded state,
             destroy runs after"
-    (rf/reg-event-db :wf/initialise (fn [_ _] {:counter 42}))
+    (rf/reg-event :wf/initialise (fn [{:keys [db]} _] {:db {:counter 42}}))
     (let [captured-db (atom nil)]
       (rf/with-new-frame [f (rf/make-frame {:on-create [:wf/initialise]})]
         (reset! captured-db (rf/app-db-value f)))

--- a/implementation/core/test/re_frame/cross_frame_dispatch_sync_warn_test.clj
+++ b/implementation/core/test/re_frame/cross_frame_dispatch_sync_warn_test.clj
@@ -65,13 +65,13 @@
     (rf/reg-frame :cfx.test/b {:doc "target frame"})
 
     (let [b-ran (atom false)]
-      (rf/reg-event-db :b/leaf
+      (rf/reg-event :b/leaf
         {:frame :cfx.test/b}
-        (fn [db _]
+        (fn [{:keys [db]} _]
           (reset! b-ran true)
-          (assoc db :b-ran? true)))
+          {:db (assoc db :b-ran? true)}))
 
-      (rf/reg-event-fx :a/cross
+      (rf/reg-event :a/cross
         {:frame :cfx.test/a}
         (fn [_ _]
           ;; A is mid-drain here; this dispatch-sync! lands on B.
@@ -123,8 +123,8 @@
     ;; reentry guard (rather than raising :rf.error/no-frame-context for a
     ;; frameless call — there is no longer a :rf/default floor).
     (rf/reg-frame :cfx.test/a {:doc "same-frame reentry frame"})
-    (rf/reg-event-db :leaf {:frame :cfx.test/a} (fn [db _] (assoc db :leaf? true)))
-    (rf/reg-event-fx :nested-same-frame
+    (rf/reg-event :leaf {:frame :cfx.test/a} (fn [{:keys [db]} _] {:db (assoc db :leaf? true)}))
+    (rf/reg-event :nested-same-frame
       {:frame :cfx.test/a}
       (fn [_ _]
         ;; Same frame, explicit :frame opt — hits the same-frame reentry
@@ -147,8 +147,8 @@
     ;; the warning is specifically for the IN-FLIGHT-DRAIN case.
     (rf/reg-frame :cfx.test/a {})
     (rf/reg-frame :cfx.test/b {})
-    (rf/reg-event-db :b/leaf {:frame :cfx.test/b}
-      (fn [db _] (assoc db :b-ran? true)))
+    (rf/reg-event :b/leaf {:frame :cfx.test/b}
+      (fn [{:keys [db]} _] {:db (assoc db :b-ran? true)}))
 
     (let [recorded (record-traces! ::no-drain-no-warn)]
       ;; Plain top-level dispatch-sync against B — no frame is mid-drain.
@@ -176,7 +176,7 @@
         (fn [db _]
           (reset! b-ran true)
           db))
-      (rf/reg-event-fx :a/touch-b
+      (rf/reg-event :a/touch-b
         {:frame :cfx.test/a}
         (fn [_ _]
           (rf/dispatch-sync [:b/leaf] {:frame :cfx.test/b})

--- a/implementation/core/test/re_frame/db_noop_commit_test.clj
+++ b/implementation/core/test/re_frame/db_noop_commit_test.clj
@@ -66,7 +66,7 @@
    is identical? before and after the dispatch — and emits :rf.event/db-noop
    (NOT :rf.event/db-changed)"
     ;; Seed a known app-db first.
-    (rf/reg-event-db :noop/seed (fn [_ _] {:counter 1 :seeded? true}))
+    (rf/reg-event :noop/seed (fn [{:keys [db]} _] {:db {:counter 1 :seeded? true}}))
     ;; The classic no-change idiom: the else-arm returns `db` UNCHANGED
     ;; (identical object), so the commit is a genuine no-op.
     (rf/reg-event-db :noop/maybe-inc
@@ -96,7 +96,7 @@
   (testing "the SAME handler on the do-it? = true path returns a CHANGED db
    → :rf.event/db-changed fires, :rf.event/db-noop does NOT, and the write
    lands (a new frame-state object is installed)"
-    (rf/reg-event-db :noop/seed (fn [_ _] {:counter 1}))
+    (rf/reg-event :noop/seed (fn [{:keys [db]} _] {:db {:counter 1}}))
     (rf/reg-event-db :noop/maybe-inc
       (fn [db [_ do-it?]] (if do-it? (update db :counter inc) db)))
     (rf/dispatch-sync [:noop/seed])
@@ -124,10 +124,10 @@
    change-DETECTION (`=`) reports no app-db change, so :rf.event/db-noop
    fires — but the WRITE was NOT skipped (only identical? skips), so the
    stored frame-state object identity changes."
-    (rf/reg-event-db :eq/seed (fn [_ _] {:counter 1 :tag :a}))
+    (rf/reg-event :eq/seed (fn [{:keys [db]} _] {:db {:counter 1 :tag :a}}))
     ;; Rebuild an equal-but-DISTINCT map (not the same object) every call.
-    (rf/reg-event-db :eq/rebuild-equal
-      (fn [_db _] {:counter 1 :tag :a}))
+    (rf/reg-event :eq/rebuild-equal
+      (fn [{:keys [db]} _] {:db {:counter 1 :tag :a}}))
     (rf/dispatch-sync [:eq/seed])
     (let [db-before-obj (frame/frame-app-db-value :rf/default)
           fs-before     (frame/frame-state-value :rf/default)
@@ -158,7 +158,7 @@
 (deftest db-nil-coerced-to-empty-map-with-diagnostic
   (testing "{:db nil} is coerced to {} (app-db is ALWAYS a map, never nil)
    and emits the :rf.warning/db-nil-coerced dev diagnostic"
-    (rf/reg-event-db :nil/seed (fn [_ _] {:counter 7}))
+    (rf/reg-event :nil/seed (fn [{:keys [db]} _] {:db {:counter 7}}))
     ;; A reg-event-db returning nil → {:db nil} effect.
     (rf/reg-event-db :nil/return-nil (fn [_ _] nil))
     (rf/dispatch-sync [:nil/seed])
@@ -181,8 +181,8 @@
 (deftest deliberate-empty-clear-does-not-fire-diagnostic
   (testing "a DELIBERATE clear ({:db {}}) commits {} WITHOUT firing the
    db-nil-coerced diagnostic — only the literal {:db nil} form is flagged"
-    (rf/reg-event-db :clear/seed (fn [_ _] {:counter 7}))
-    (rf/reg-event-db :clear/empty (fn [_ _] {}))
+    (rf/reg-event :clear/seed (fn [{:keys [db]} _] {:db {:counter 7}}))
+    (rf/reg-event :clear/empty (fn [{:keys [db]} _] {:db {}}))
     (rf/dispatch-sync [:clear/seed])
     (let [acc (collect-traces! ::deliberate-clear)]
       (try
@@ -202,7 +202,7 @@
    = to current → the coerced commit is a NO-OP (db-noop), and the
    diagnostic STILL fires (the nil was supplied regardless of the no-op
    outcome). The partition is never nil."
-    (rf/reg-event-db :nilnoop/seed (fn [_ _] {}))
+    (rf/reg-event :nilnoop/seed (fn [{:keys [db]} _] {:db {}}))
     (rf/reg-event-db :nilnoop/return-nil (fn [_ _] nil))
     (rf/dispatch-sync [:nilnoop/seed])
     (let [acc (collect-traces! ::nil-noop)]

--- a/implementation/core/test/re_frame/db_pending_trace_test.clj
+++ b/implementation/core/test/re_frame/db_pending_trace_test.clj
@@ -63,8 +63,8 @@
 (deftest t1-emits-when-handler-returns-db
   (testing ":rf.event/db-pending fires once per dispatch when the handler
    returned a :db slot, carrying the returned value under :tags :rf.event/db"
-    (rf/reg-event-db :t1/seed-db
-      (fn [_ _] {:counter 42 :seeded? true}))
+    (rf/reg-event :t1/seed-db
+      (fn [{:keys [db]} _] {:db {:counter 42 :seeded? true}}))
     (let [acc (collect-traces! ::t1-db-only)]
       (try
         (rf/dispatch-sync [:t1/seed-db])
@@ -86,7 +86,7 @@
    :rf.event/db-pending — mirrors how :rf.event/db-present? rides on
    :rf.fx/do-fx as `false` when no :db was returned"
     (rf/reg-fx :t1/noop (fn [_ _] :ok))
-    (rf/reg-event-fx :t1/fx-only
+    (rf/reg-event :t1/fx-only
       (fn [_ _] {:fx [[:t1/noop {}]]}))
     (let [acc (collect-traces! ::t1-fx-only)]
       (try
@@ -127,7 +127,7 @@
    :rf.fx/do-fx). The atomicity-contract pipeline is reflected in the trace
    stream order: handler returns :db -> [t1] -> flows -> commit -> fx -> tail"
     (rf/reg-fx :t1/tail-fx (fn [_ _] :ok))
-    (rf/reg-event-fx :t1/order-probe
+    (rf/reg-event :t1/order-probe
       (fn [_ _] {:db {:tick 1}
                  :fx [[:t1/tail-fx {}]]}))
     (let [acc (collect-traces! ::t1-order)]
@@ -159,7 +159,7 @@
    value. The flows artefact is NOT a dependency of the core test fixture
    (no `(require 're-frame.flows :reload)` above), so this confirms the
    no-flows-app posture."
-    (rf/reg-event-db :t2/seed (fn [_ _] {:x 1}))
+    (rf/reg-event :t2/seed (fn [{:keys [db]} _] {:db {:x 1}}))
     (let [acc (collect-traces! ::t2-no-flows)]
       (try
         (rf/dispatch-sync [:t2/seed])
@@ -176,8 +176,8 @@
    — top level is reserved for substrate-hoisted slots
    (:rf.trace/call-site, :rf.trace/trigger-handler, :source, etc.).
    Mirrors the rf2-twt7m Change 2 placement of :rf.event/fx on :rf.fx/do-fx."
-    (rf/reg-event-db :t1/payload-shape
-      (fn [_ _] {:x 9}))
+    (rf/reg-event :t1/payload-shape
+      (fn [{:keys [db]} _] {:db {:x 9}}))
     (let [acc (collect-traces! ::payload-shape)]
       (try
         (rf/dispatch-sync [:t1/payload-shape])

--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -54,7 +54,7 @@
       ;; then pushes :outer-post BEFORE the inner handler can run. Run-to-
       ;; completion guarantees the outer handler completes (both pre and
       ;; post entries land) before :inner is dequeued.
-      (rf/reg-event-fx :outer
+      (rf/reg-event :outer
         (fn [_ _]
           (swap! order conj :outer-pre)
           ;; Returning :fx with a :dispatch — the inner event is appended
@@ -63,7 +63,7 @@
           (let [fx-result {:fx [[:dispatch [:inner]]]}]
             (swap! order conj :outer-post)
             fx-result)))
-      (rf/reg-event-fx :inner
+      (rf/reg-event :inner
         (fn [_ _]
           (swap! order conj :inner)
           {}))
@@ -73,19 +73,19 @@
 
   (testing "deeper chain — every outer's :fx :dispatch waits for the outer to return"
     (let [order (atom [])]
-      (rf/reg-event-fx :a
+      (rf/reg-event :a
         (fn [_ _]
           (swap! order conj :a-start)
           (let [r {:fx [[:dispatch [:b]]]}]
             (swap! order conj :a-end)
             r)))
-      (rf/reg-event-fx :b
+      (rf/reg-event :b
         (fn [_ _]
           (swap! order conj :b-start)
           (let [r {:fx [[:dispatch [:c]]]}]
             (swap! order conj :b-end)
             r)))
-      (rf/reg-event-fx :c
+      (rf/reg-event :c
         (fn [_ _]
           (swap! order conj :c)
           {}))
@@ -108,7 +108,7 @@
       (rf/register-listener! ::depth (fn [ev] (swap! traces conj ev)))
       ;; Reg a frame with a small drain-depth so the test runs quickly.
       (rf/reg-frame :drain.test/loop {:drain-depth 8})
-      (rf/reg-event-fx :loop-forever
+      (rf/reg-event :loop-forever
         (fn [_ _]
           {:fx [[:dispatch [:loop-forever]]]}))
       (rf/dispatch-sync [:loop-forever] {:frame :drain.test/loop})
@@ -135,7 +135,7 @@
     (let [traces (atom [])]
       (rf/register-listener! ::depth-2 (fn [ev] (swap! traces conj ev)))
       (rf/reg-frame :drain.test/loop2 {:drain-depth 4})
-      (rf/reg-event-fx :loop2
+      (rf/reg-event :loop2
         (fn [_ _]
           {:fx [[:dispatch [:loop2]]]}))
       (rf/dispatch-sync [:loop2] {:frame :drain.test/loop2})
@@ -160,8 +160,8 @@
   ;; the per-event boundary — see rf2-nj6p7.
   (testing "a chain that overflows leaves :db with the durable per-event writes"
     ;; Frame seeded via :on-create so the baseline is non-empty.
-    (rf/reg-event-db :seed/init
-      (fn [_ _] {:step :pre-drain :counter 0}))
+    (rf/reg-event :seed/init
+      (fn [{:keys [db]} _] {:db {:step :pre-drain :counter 0}}))
     (rf/reg-frame :drain.rollback/main
       {:on-create   [:seed/init]
        :drain-depth 4})
@@ -171,7 +171,7 @@
       ;; :counter) AND re-dispatches itself. Each iteration is its own
       ;; dequeued event = its own durable epoch + db write. After the
       ;; 4-event limit, :counter == 4 and :step == :mid-drain survive.
-      (rf/reg-event-fx :overflow
+      (rf/reg-event :overflow
         (fn [{:keys [db]} _]
           {:db {:step :mid-drain :counter (inc (:counter db 0))}
            :fx [[:dispatch [:overflow]]]}))
@@ -199,19 +199,19 @@
     ;; with a self-dispatching event: the earlier clean drain stays
     ;; durable AND the overflow drain's own per-event writes stay durable
     ;; (no rollback).
-    (rf/reg-event-db :seed2/init (fn [_ _] {:phase :seeded :n 0}))
+    (rf/reg-event :seed2/init (fn [{:keys [db]} _] {:db {:phase :seeded :n 0}}))
     (rf/reg-frame :drain.rollback/two
       {:on-create   [:seed2/init]
        :drain-depth 3})
     ;; First drain: a clean settle that mutates :phase.
-    (rf/reg-event-db :advance (fn [db _] (assoc db :phase :first-settled)))
+    (rf/reg-event :advance (fn [{:keys [db]} _] {:db (assoc db :phase :first-settled)}))
     (rf/dispatch-sync [:advance] {:frame :drain.rollback/two})
     (is (= {:phase :first-settled :n 0}
            (rf/app-db-value :drain.rollback/two))
         "first drain settled cleanly; that's the new baseline")
     ;; Second drain: trip the depth limit. Per rf2-nj6p7 the three events
     ;; that ran each made a durable :n write — no rollback.
-    (rf/reg-event-fx :overflow2
+    (rf/reg-event :overflow2
       (fn [{:keys [db]} _]
         {:db (assoc db :phase :poisoned :n (inc (:n db 0)))
          :fx [[:dispatch [:overflow2]]]}))
@@ -240,7 +240,7 @@
             event-id (keyword "drain.count" (str "tick-" n))]
         (rf/register-listener! ::count (fn [ev] (swap! traces conj ev)))
         (rf/reg-frame frame-id {:drain-depth n})
-        (rf/reg-event-fx event-id
+        (rf/reg-event event-id
           (fn [_ _]
             (swap! runs inc)
             {:fx [[:dispatch [event-id]]]}))
@@ -275,8 +275,8 @@
   (testing "directly calling rf/dispatch-sync from a handler raises the structured error"
     (let [traces (atom [])]
       (rf/register-listener! ::dsih-direct (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-db :leaf (fn [db _] (assoc db :leaf? true)))
-      (rf/reg-event-fx :nested-direct
+      (rf/reg-event :leaf (fn [{:keys [db]} _] {:db (assoc db :leaf? true)}))
+      (rf/reg-event :nested-direct
         (fn [_ _]
           (rf/dispatch-sync [:leaf])
           {}))
@@ -296,7 +296,7 @@
     ;; primary guard, not the call-stack depth.
     (let [traces (atom [])]
       (rf/register-listener! ::dsih-fx (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-db :leaf2 (fn [db _] (assoc db :leaf2? true)))
+      (rf/reg-event :leaf2 (fn [{:keys [db]} _] {:db (assoc db :leaf2? true)}))
       (rf/reg-fx :user.fx/sync-dispatch
         {:platforms #{:server :client}}
         (fn [_ ev]
@@ -304,7 +304,7 @@
           ;; effects map. The router must still emit the structured
           ;; error so the bug is observable.
           (rf/dispatch-sync ev)))
-      (rf/reg-event-fx :nested-via-fx
+      (rf/reg-event :nested-via-fx
         (fn [_ _]
           {:fx [[:user.fx/sync-dispatch [:leaf2]]]}))
       (rf/dispatch-sync [:nested-via-fx])
@@ -325,7 +325,7 @@
   ;;   up in this same drain cycle (run-to-completion).\""
   (testing ":fx [[:dispatch ...]] events drain in-cycle; the cascade is observed atomically"
     (let [order (atom [])]
-      (rf/reg-event-fx :seed
+      (rf/reg-event :seed
         (fn [_ _]
           (swap! order conj :seed)
           ;; Two fx-side dispatches plus a :db update. All must drain
@@ -333,10 +333,10 @@
           {:db {:n 0}
            :fx [[:dispatch [:bump]]
                 [:dispatch [:bump]]]}))
-      (rf/reg-event-db :bump
-        (fn [db _]
+      (rf/reg-event :bump
+        (fn [{:keys [db]} _]
           (swap! order conj :bump)
-          (update db :n inc)))
+          {:db (update db :n inc)}))
       (rf/dispatch-sync [:seed])
       (is (= [:seed :bump :bump] @order)
           "both :fx-side :dispatch events ran inside the same dispatch-sync cycle")
@@ -366,11 +366,11 @@
     (let [order          (atom [])
           done           (promise)
           captured-ticks (atom [])]
-      (rf/reg-event-db :outside-async
-        (fn [db _]
+      (rf/reg-event :outside-async
+        (fn [{:keys [db]} _]
           (swap! order conj :outside-async)
           (deliver done :ok)
-          (assoc db :outside? true)))
+          {:db (assoc db :outside? true)}))
       (rf/reg-event-db :sync-only
         (fn [db _]
           (swap! order conj :sync-only)
@@ -413,19 +413,19 @@
     (rf/reg-frame :drain.test/B {:doc "frame B"})
     (let [order (atom [])
           b-done (promise)]
-      (rf/reg-event-db :A/work
-        (fn [db _]
+      (rf/reg-event :A/work
+        (fn [{:keys [db]} _]
           (swap! order conj :A-start)
           ;; Dispatch a cross-frame event — this hits frame B's queue
           ;; via the async path. It must not run as part of A's drain.
           (rf/dispatch [:B/work] {:frame :drain.test/B})
           (swap! order conj :A-end)
-          (assoc db :a-ran? true)))
-      (rf/reg-event-db :B/work
-        (fn [db _]
+          {:db (assoc db :a-ran? true)}))
+      (rf/reg-event :B/work
+        (fn [{:keys [db]} _]
           (swap! order conj :B)
           (deliver b-done :ok)
-          (assoc db :b-ran? true)))
+          {:db (assoc db :b-ran? true)}))
       (rf/dispatch-sync [:A/work] {:frame :drain.test/A})
       ;; The moment dispatch-sync returns, A's cascade has settled. B's
       ;; cascade may still be in flight on the executor.
@@ -447,7 +447,7 @@
     ;; queue and :scheduled?/:in-drain? flags.
     (rf/reg-frame :drain.test/X {:doc "X"})
     (rf/reg-frame :drain.test/Y {:doc "Y"})
-    (rf/reg-event-db :tick (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :tick (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/dispatch-sync [:tick] {:frame :drain.test/X})
     (rf/dispatch-sync [:tick] {:frame :drain.test/Y})
     (rf/dispatch-sync [:tick] {:frame :drain.test/X})
@@ -468,8 +468,8 @@
   (testing "depth-exceed on frame :B rolls back :B's app-db only; :A's
             app-db is byte-identical to its pre-dispatch state; the
             depth-exceeded trace carries :B"
-    (rf/reg-event-db :seed/A (fn [_ _] {:where :A :counter 0 :marker :pristine}))
-    (rf/reg-event-db :seed/B (fn [_ _] {:where :B :counter 0 :marker :pristine}))
+    (rf/reg-event :seed/A (fn [{:keys [db]} _] {:db {:where :A :counter 0 :marker :pristine}}))
+    (rf/reg-event :seed/B (fn [{:keys [db]} _] {:db {:where :B :counter 0 :marker :pristine}}))
     (rf/reg-frame :drain.iso/A
                   {:on-create   [:seed/A]
                    :drain-depth 50})
@@ -486,7 +486,7 @@
       ;; Register a loop event under :B that infinitely self-dispatches.
       ;; Each iteration writes to :B's :db, so we can see whether the
       ;; rollback actually fires.
-      (rf/reg-event-fx :loop/B
+      (rf/reg-event :loop/B
         (fn [{:keys [db]} _]
           {:db {:where :B
                 :counter (inc (:counter db 0))

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -93,13 +93,13 @@
 (defn ^:export touch-registrar! []
   ;; reg-event-db / dispatch-sync exercise registrar/register! and the
   ;; router/events/fx trace emit sites in one shot.
-  (rf/reg-event-db :probe/init  (fn [_db _ev] {:counter 0}))
-  (rf/reg-event-db :probe/inc   (fn [db _ev] (update db :counter inc)))
+  (rf/reg-event :probe/init  (fn [{:keys [db]} _ev] {:db {:counter 0}}))
+  (rf/reg-event :probe/inc   (fn [{:keys [db]} _ev] {:db (update db :counter inc)}))
   (rf/reg-sub      :probe/count (fn [db _q] (:counter db)))
   (rf/dispatch-sync [:probe/init])
   (rf/dispatch-sync [:probe/inc])
   ;; Re-register to fire :rf.registry/handler-replaced.
-  (rf/reg-event-db :probe/inc   (fn [db _ev] (update db :counter (fnil inc 0))))
+  (rf/reg-event :probe/inc   (fn [{:keys [db]} _ev] {:db (update db :counter (fnil inc 0))}))
   ;; Exercise the registrar's unregister!/clear-kind! emit sites so that
   ;; the :rf.registry/handler-cleared keyword has a path into the
   ;; reachability graph too.
@@ -149,7 +149,7 @@
   ;; the test-support namespace that registers them is NEVER required by
   ;; the probe. That is exactly what we want to assert lives only in the
   ;; control bundle.
-  (rf/reg-event-fx :probe/http-abort-touch
+  (rf/reg-event :probe/http-abort-touch
     (fn [_ _]
       {:fx [[:rf.http/managed-abort :probe/never-issued-request]]}))
   (rf/dispatch-sync [:probe/http-abort-touch])
@@ -222,7 +222,7 @@
   ;; under DEBUG=true, exercising the gated body's literal
   ;; reachability through an actual call site rather than relying
   ;; on require-closure alone.
-  (rf/reg-event-db :probe/redact-fire (fn [_db _ev] {:redact :fired}))
+  (rf/reg-event :probe/redact-fire (fn [{:keys [db]} _ev] {:db {:redact :fired}}))
   (rf/dispatch-sync [:probe/redact-fire])
   ;; Clear so subsequent probe sites (replace-app-db! below,
   ;; on-frame-destroyed!) are not perturbed by the throwing fn.

--- a/implementation/core/test/re_frame/event_context_partition_test.clj
+++ b/implementation/core/test/re_frame/event_context_partition_test.clj
@@ -115,7 +115,7 @@
     (let [recorded (record-traces! ::no-shape-err)]
       ;; :rf/machine? marks framework-write authority (machine registrar mints
       ;; framework-authority handlers — Spec 002 §Write authority).
-      (rf/reg-event-fx :ctx/fw-runtime
+      (rf/reg-event :ctx/fw-runtime
         {:doc "framework-authority runtime write" :rf/machine? true}
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {}} :fx []}))
       (rf/dispatch-sync [:ctx/fw-runtime] {:frame :ctx/runtime-fx})
@@ -126,7 +126,7 @@
   (testing "a foreign top-level key (legacy :http) is still policed after the widening"
     (rf/reg-frame :ctx/foreign-fx {:doc "ctx"})
     (let [recorded (record-traces! ::foreign-err)]
-      (rf/reg-event-fx :ctx/foreign
+      (rf/reg-event :ctx/foreign
         (fn [_ _] {:db {:ok? true} :http {:url "/api"}}))
       (rf/dispatch-sync [:ctx/foreign] {:frame :ctx/foreign-fx})
       (let [errs (error-events recorded :rf.error/effect-map-shape)]
@@ -146,7 +146,7 @@
   (testing "an ORDINARY app handler returning :rf.db/runtime fires the dev diagnostic"
     (rf/reg-frame :ctx/app-runtime {:doc "ctx"})
     (let [recorded (record-traces! ::app-warn)]
-      (rf/reg-event-fx :ctx/app-emits-runtime
+      (rf/reg-event :ctx/app-emits-runtime
         (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {}}}))
       (rf/dispatch-sync [:ctx/app-emits-runtime] {:frame :ctx/app-runtime})
       (let [warns (warning-events recorded :rf.warning/app-handler-runtime-effect)]
@@ -166,7 +166,7 @@
   (testing "a framework-authority handler (:rf/machine? true) does NOT fire the diagnostic"
     (rf/reg-frame :ctx/fw-authority {:doc "ctx"})
     (let [recorded (record-traces! ::fw-quiet)]
-      (rf/reg-event-fx :ctx/fw-emits-runtime
+      (rf/reg-event :ctx/fw-emits-runtime
         {:doc "framework-authority" :rf/machine? true}
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {}}}))
       (rf/dispatch-sync [:ctx/fw-emits-runtime] {:frame :ctx/fw-authority})
@@ -177,7 +177,7 @@
   (testing "an ordinary handler that does NOT return :rf.db/runtime stays silent"
     (rf/reg-frame :ctx/plain {:doc "ctx"})
     (let [recorded (record-traces! ::plain-quiet)]
-      (rf/reg-event-fx :ctx/plain-db
+      (rf/reg-event :ctx/plain-db
         (fn [{:keys [db]} _] {:db (assoc db :touched? true) :fx []}))
       (rf/dispatch-sync [:ctx/plain-db] {:frame :ctx/plain})
       (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
@@ -224,8 +224,8 @@
   (testing "a reg-event-db handler returning a :rf/runtime root surfaces :rf.error/legacy-runtime-root"
     (rf/reg-frame :ctx/legacy-db {:doc "ctx"})
     (let [recorded (record-traces! ::legacy-db)]
-      (rf/reg-event-db :ctx/writes-legacy-root
-        (fn [db _] (assoc db :rf/runtime {:rf.runtime/machines {:m 1}})))
+      (rf/reg-event :ctx/writes-legacy-root
+        (fn [{:keys [db]} _] {:db (assoc db :rf/runtime {:rf.runtime/machines {:m 1}})}))
       (rf/dispatch-sync [:ctx/writes-legacy-root] {:frame :ctx/legacy-db})
       ;; The throw is captured by the interceptor machinery and surfaced as
       ;; :rf.error/handler-exception carrying the original ex-info.
@@ -242,7 +242,7 @@
   (testing "a reg-event-fx handler whose :db effect carries :rf/runtime surfaces the hard error"
     (rf/reg-frame :ctx/legacy-fx {:doc "ctx"})
     (let [recorded (record-traces! ::legacy-fx)]
-      (rf/reg-event-fx :ctx/fx-writes-legacy-root
+      (rf/reg-event :ctx/fx-writes-legacy-root
         (fn [{:keys [db]} _] {:db (assoc db :rf/runtime {:rf.runtime/routing {}})}))
       (rf/dispatch-sync [:ctx/fx-writes-legacy-root] {:frame :ctx/legacy-fx})
       (let [errs (error-events recorded :rf.error/handler-exception)
@@ -256,7 +256,7 @@
   (testing "a framework :rf.db/runtime effect (the NEW partition) is NOT the legacy-root hard error"
     (rf/reg-frame :ctx/new-runtime {:doc "ctx"})
     (let [recorded (record-traces! ::new-runtime)]
-      (rf/reg-event-fx :ctx/fw-runtime
+      (rf/reg-event :ctx/fw-runtime
         {:doc "framework-authority" :rf/machine? true}
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
       (rf/dispatch-sync [:ctx/fw-runtime] {:frame :ctx/new-runtime})
@@ -302,12 +302,12 @@
           ;; `commit-fx-effects`/`fx-value-ok?` never saw this value.
           bad-fx   (after-icpt (fn [ctx]
                                  (interceptor/assoc-effect ctx :fx :oops)))]
-      (rf/reg-event-fx :ctx/writes-db
+      (rf/reg-event :ctx/writes-db
         {:interceptors [bad-fx]}
         (fn [{:keys [db]} _] {:db (assoc db :committed? true)
                               :fx []}))
       ;; A downstream event proves the drain was not abandoned by a raw throw.
-      (rf/reg-event-db :ctx/downstream (fn [db _] (assoc db :downstream? true)))
+      (rf/reg-event :ctx/downstream (fn [{:keys [db]} _] {:db (assoc db :downstream? true)}))
       (rf/dispatch-sync [:ctx/writes-db] {:frame :ctx/after-bad-fx})
       (rf/dispatch-sync [:ctx/downstream] {:frame :ctx/after-bad-fx})
       (let [errs (error-events recorded :rf.error/effect-map-shape)]
@@ -327,7 +327,7 @@
     (let [recorded (record-traces! ::after-foreign)
           foreign  (after-icpt (fn [ctx]
                                  (interceptor/assoc-effect ctx :http {:url "/api"})))]
-      (rf/reg-event-fx :ctx/writes-db2
+      (rf/reg-event :ctx/writes-db2
         {:interceptors [foreign]}
         (fn [{:keys [db]} _] {:db (assoc db :ok? true)}))
       (rf/dispatch-sync [:ctx/writes-db2] {:frame :ctx/after-foreign})
@@ -349,10 +349,10 @@
                                  (let [db (interceptor/get-effect ctx :db)]
                                    (interceptor/assoc-effect
                                      ctx :db (assoc db :rf/runtime {:rf.runtime/machines {}})))))]
-      (rf/reg-event-db :ctx/clean-db
+      (rf/reg-event :ctx/clean-db
         {:interceptors [legacy]}
-        (fn [db _] (assoc db :user/id 7)))
-      (rf/reg-event-db :ctx/after-legacy-downstream (fn [db _] (assoc db :downstream? true)))
+        (fn [{:keys [db]} _] {:db (assoc db :user/id 7)}))
+      (rf/reg-event :ctx/after-legacy-downstream (fn [{:keys [db]} _] {:db (assoc db :downstream? true)}))
       (rf/dispatch-sync [:ctx/clean-db] {:frame :ctx/after-legacy})
       (rf/dispatch-sync [:ctx/after-legacy-downstream] {:frame :ctx/after-legacy})
       (let [errs (error-events recorded :rf.error/legacy-runtime-root)]
@@ -410,7 +410,7 @@
     (rf/reg-frame :ctx/clean-final {:doc "ctx"})
     (let [recorded (record-traces! ::clean-final)]
       (rf/reg-fx :ctx/noop-fx (fn [_ _]))
-      (rf/reg-event-fx :ctx/clean
+      (rf/reg-event :ctx/clean
         (fn [{:keys [db]} _] {:db (assoc db :n 1)
                               :fx [[:ctx/noop-fx {}]]}))
       (rf/dispatch-sync [:ctx/clean] {:frame :ctx/clean-final})

--- a/implementation/core/test/re_frame/event_emit_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/event_emit_elision_prod_test.cljs
@@ -41,8 +41,8 @@
       (rf/register-event-listener!
         :prod/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :prod/inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod/inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod/inc])
       (is (= 1 (count @seen))
           "listener fired exactly once for the dispatched event — prod-elision contract holds")
@@ -107,8 +107,8 @@
       (rf/register-event-listener!
         :prod/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :prod/normal
-                       (fn [db _] (assoc db :touched true)))
+      (rf/reg-event :prod/normal
+                       (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
       (rf/dispatch-sync [:prod/normal "payload"])
       (is (= 1 (count @seen))
           "handler fans out under prod")

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -64,8 +64,8 @@
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :evt/inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :evt/inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:evt/inc])
       (is (= 1 (count @seen))
           "listener fired exactly once for one dispatch")
@@ -121,8 +121,8 @@
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :evt/writes
-                       (fn [db _] (assoc db :n 1)))
+      (rf/reg-event :evt/writes
+                       (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
       (rf/dispatch-sync [:evt/writes])
       (is (= 1 (count @seen)) "listener fired once for the dispatch")
       (let [outcome (:outcome (first @seen))]
@@ -153,8 +153,8 @@
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :evt/writes
-                       (fn [db _] (assoc db :n 1)))
+      (rf/reg-event :evt/writes
+                       (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
       (rf/dispatch-sync [:evt/writes])
       (is (= 1 (count @seen)) "listener fired once for the dispatch")
       (let [outcome (:outcome (first @seen))]
@@ -179,8 +179,8 @@
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :evt/writes
-                       (fn [db _] (assoc db :n 1)))
+      (rf/reg-event :evt/writes
+                       (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
       (rf/dispatch-sync [:evt/writes])
       (is (= 1 (count @seen)))
       (is (= :ok (:outcome (first @seen)))
@@ -305,8 +305,8 @@
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :evt/normal
-                       (fn [db _] (assoc db :touched true)))
+      (rf/reg-event :evt/normal
+                       (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
       (rf/dispatch-sync [:evt/normal "payload"])
       (is (= 1 (count @seen))
           "handler fans out normally")

--- a/implementation/core/test/re_frame/flow_eval_exception_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/flow_eval_exception_elision_prod_test.cljs
@@ -63,8 +63,8 @@
       (rf/register-error-listener!
         :prod/flow-recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :prod/flow-throw
-                       (fn [_db _] {:token "string-value"}))
+      (rf/reg-event :prod/flow-throw
+                       (fn [{:keys [db]} _] {:db {:token "string-value"}}))
       (rf/reg-flow {:id     :str-len
                     :inputs [[:token]]
                     :output (fn [t]

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -92,7 +92,7 @@
     ;; :rf.machine.lifecycle/destroyed events in addition to
     ;; :rf.frame/destroyed.
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx :composed/seed-machines
+    (rf/reg-event :composed/seed-machines
                      (fn [{rt :rf.db/runtime} _]
                        {:rf.db/runtime
                         (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]
@@ -224,7 +224,7 @@
   (testing "a reaction whose dispose! throws does NOT prevent other reactions
             from being disposed; the sub-cache is cleared either way"
     (rf/reg-frame :composed/sub-throw {:doc "sub-throw"})
-    (rf/reg-event-db :composed/seed (fn [_ _] {:a 1 :b 2}))
+    (rf/reg-event :composed/seed (fn [{:keys [db]} _] {:db {:a 1 :b 2}}))
     (rf/reg-sub :composed/a (fn [db _] (:a db)))
     (rf/reg-sub :composed/b (fn [db _] (:b db)))
     (rf/dispatch-sync [:composed/seed] {:frame :composed/sub-throw})
@@ -277,7 +277,7 @@
             tears the frame down — reason :frame-destroy, correct :frame
             + :rf.sub/query-v (rf2-x3m8c finding 2)"
     (rf/reg-frame :composed/dispose-emit {:doc "dispose-emit"})
-    (rf/reg-event-db :composed/seed2 (fn [_ _] {:a 1 :b 2}))
+    (rf/reg-event :composed/seed2 (fn [{:keys [db]} _] {:db {:a 1 :b 2}}))
     (rf/reg-sub :composed/da (fn [db _] (:a db)))
     (rf/reg-sub :composed/db (fn [db _] (:b db)))
     (rf/dispatch-sync [:composed/seed2] {:frame :composed/dispose-emit})
@@ -376,10 +376,10 @@
   (testing ":on-destroy that dispatch-syncs across frames: sibling commits,
             warn fires, original frame still tears down cleanly"
     (rf/reg-frame :composed/parent {:doc "parent"})
-    (rf/reg-event-db :composed/notify-parent
-                     (fn [db [_ payload]]
-                       (assoc db :last-notification payload)))
-    (rf/reg-event-fx :composed/teardown
+    (rf/reg-event :composed/notify-parent
+                     (fn [{:keys [db]} [_ payload]]
+                       {:db (assoc db :last-notification payload)}))
+    (rf/reg-event :composed/teardown
                      (fn [_ _]
                        ;; Mid-drain on :composed/child; dispatch-sync across
                        ;; to :composed/parent.
@@ -445,7 +445,7 @@
         "precondition: schema row exists for the frame")
 
     ;; --- flows: register a flow rooted at the frame -----------------------
-    (rf/reg-event-db :composed/seed-leak (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :composed/seed-leak (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :composed/area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* (or w 0) (or h 0)))

--- a/implementation/core/test/re_frame/frame_handle_test.clj
+++ b/implementation/core/test/re_frame/frame_handle_test.clj
@@ -57,7 +57,7 @@
   (testing "(frame-handle) captures the active frame at CREATION; the bundle's
             :dispatch routes to THAT frame after the with-frame scope unwinds"
     (rf/reg-frame :fh/A {:doc "frame A — the capture target"})
-    (rf/reg-event-db :fh/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :fh/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     ;; Capture inside :fh/A; fire OUTSIDE.
     (let [{:keys [dispatch]} (rf/with-frame :fh/A (rf/frame-handle))]
       ;; The dynamic-var binding has unwound. The captured op must still
@@ -75,7 +75,7 @@
   (testing "the bundle's :subscribe op resolves against the captured frame
             after the with-frame scope unwinds"
     (rf/reg-frame :fh/B {:doc "frame B — the subscribe target"})
-    (rf/reg-event-db :fh/seed (fn [_ [_ v]] {:value v}))
+    (rf/reg-event :fh/seed (fn [{:keys [db]} [_ v]] {:db {:value v}}))
     (rf/reg-sub :fh/value (fn [db _] (:value db)))
     (rf/dispatch-sync [:fh/seed :B-value] {:frame :fh/B})
     ;; Seed :rf/default explicitly (EP-0002: no ambient :rf/default floor)
@@ -94,7 +94,7 @@
             frame — the handle is LOCKED to one frame"
     (rf/reg-frame :fh/locked {:doc "the locked target"})
     (rf/reg-frame :fh/other  {:doc "the would-be override"})
-    (rf/reg-event-db :fh/touch (fn [db _] (assoc db :touched? true)))
+    (rf/reg-event :fh/touch (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
     (let [{:keys [dispatch]} (rf/frame-handle :fh/locked)]
       ;; Attempt to redirect to :fh/other via a per-call :frame opt.
       (dispatch [:fh/touch] {:frame :fh/other})
@@ -126,7 +126,7 @@
 (deftest frame-handle-explicit-frame-works-outside-scope
   (testing "(frame-handle frame-id) needs no scope — the explicit-id capture
             shape for async callbacks / tools / tests (rf2-jue6sp)"
-    (rf/reg-event-db :fh/explicit-touch (fn [db _] (assoc db :touched? true)))
+    (rf/reg-event :fh/explicit-touch (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
     (is (nil? frame/*current-frame*) "no scope established")
     (let [h (rf/frame-handle :rf/default)]
       (is (= :rf/default (:frame h))
@@ -143,7 +143,7 @@
   (testing "(frame-bound-fn [args] body) captures the current frame and
             re-establishes it inside the body after the scope unwinds"
     (rf/reg-frame :fbf/A {:doc "macro capture target"})
-    (rf/reg-event-db :fbf/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :fbf/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [cb (rf/with-frame :fbf/A
                (rf/frame-bound-fn [] (rf/dispatch [:fbf/inc])))]
       (is (nil? frame/*current-frame*) "the with-frame scope has unwound")
@@ -156,7 +156,7 @@
 (deftest frame-bound-fn*-one-arity-captures-frame
   (testing "(frame-bound-fn* f) captures the current frame at wrap time"
     (rf/reg-frame :fbf/B {:doc "*-1-arity target"})
-    (rf/reg-event-db :fbf/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :fbf/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [cb (rf/with-frame :fbf/B
                (rf/frame-bound-fn* (fn [] (rf/dispatch [:fbf/inc]))))]
       (cb)
@@ -169,7 +169,7 @@
   (testing "(frame-bound-fn* frame-id f) binds an explicit frame, no
             surrounding with-frame needed"
     (rf/reg-frame :fbf/C {:doc "*-2-arity explicit target"})
-    (rf/reg-event-db :fbf/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :fbf/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [cb (rf/frame-bound-fn* :fbf/C (fn [] (rf/dispatch [:fbf/inc])))]
       (is (nil? frame/*current-frame*) "no with-frame scope was ever entered")
       (cb)
@@ -216,7 +216,7 @@
 (deftest app-db-value-returns-a-value
   (testing "(app-db-value frame-id) returns the app-db VALUE (a plain map), not a container"
     (rf/reg-frame :fdb/probe {:doc "probe"})
-    (rf/reg-event-db :fdb/seed (fn [_ _] {:k :v}))
+    (rf/reg-event :fdb/seed (fn [{:keys [db]} _] {:db {:k :v}}))
     (rf/dispatch-sync [:fdb/seed] {:frame :fdb/probe})
     (let [db (rf/app-db-value :fdb/probe)]
       (is (map? db) "app-db-value returns a plain map value")

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -38,7 +38,7 @@
   (testing "re-registering a live frame replaces metadata but preserves app-db, sub-cache, and queue"
     ;; Set up a frame with live state.
     (rf/reg-frame :tenant {:doc "v1 metadata" :preset :default})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n :payload "live"}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n :payload "live"}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     ;; Populate app-db.
     (rf/dispatch-sync [:seed 42] {:frame :tenant})
@@ -141,7 +141,7 @@
     ;; Seed three machine snapshots directly into app-db so we don't
     ;; depend on a full machine-runtime invocation.
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx :seed-machines
+    (rf/reg-event :seed-machines
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime
          (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]
@@ -239,7 +239,7 @@
 (deftest destroy-frame-with-live-subscribers
   (testing "destroy clears the sub-cache, fires on-dispose, and post-destroy subs return nil"
     (rf/reg-frame :live {:doc "live"})
-    (rf/reg-event-db :seed (fn [_ _] {:answer 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:answer 7}}))
     (rf/reg-sub :answer (fn [db _] (:answer db)))
     (rf/dispatch-sync [:seed] {:frame :live})
     (let [r1            (rf/subscribe :live [:answer])
@@ -324,7 +324,7 @@
       (rf/reg-fx :http.stub-B
                  {:platforms #{:server :client}}
                  (fn [_ args] (swap! calls-B conj args)))
-      (rf/reg-event-fx :go
+      (rf/reg-event :go
         (fn [_ [_ payload]]
           {:fx [[:http payload]]}))
 
@@ -358,9 +358,9 @@
 (deftest reg-frame-on-create-runs-synchronously
   (testing ":on-create completes inside reg-frame; app-db is fully populated by the time it returns"
     (let [observed (atom nil)]
-      (rf/reg-event-db :boot
-        (fn [_ [_ payload]]
-          {:booted? true :payload payload :seq [:a :b :c]}))
+      (rf/reg-event :boot
+        (fn [{:keys [db]} [_ payload]]
+          {:db {:booted? true :payload payload :seq [:a :b :c]}}))
       ;; Hook a trace listener so we can assert the ordering between
       ;; :on-create dispatch and :rf.frame/created emission. Per Spec 002
       ;; §reg-frame is atomic — :on-create runs first, then :rf.frame/created
@@ -423,14 +423,14 @@
           traces        (atom [])
           captured-tick (atom [])]
       ;; Plain mutator — runs whenever the drain dequeues.
-      (rf/reg-event-db :drain-int/tick
-        (fn [db _]
+      (rf/reg-event :drain-int/tick
+        (fn [{:keys [db]} _]
           (swap! ran conj :tick)
-          (update db :n (fnil inc 0))))
+          {:db (update db :n (fnil inc 0))}))
       ;; Handler that destroys its own frame mid-cascade. The first
       ;; tick has already run; destroy mid-drain MUST interrupt the
       ;; remainder.
-      (rf/reg-event-fx :drain-int/self-destruct
+      (rf/reg-event :drain-int/self-destruct
         (fn [_ _]
           (swap! ran conj :self-destruct)
           ;; Call destroy-frame! directly — bypasses the
@@ -505,7 +505,7 @@
       ;;   (c) sets the completion flag at the very end
       ;; Per run-to-completion, ALL of (a)-(c) must observe in order;
       ;; the drain interrupt only fires AFTER this handler returns.
-      (rf/reg-event-fx :rtc/work-then-destroy
+      (rf/reg-event :rtc/work-then-destroy
         (fn [_ _]
           (frame/destroy-frame! :rtc/worker)
           ;; Post-destroy bookkeeping still runs inside this handler.
@@ -587,11 +587,11 @@
     (rf/reg-frame :rf/default {})
     (let [event-order  (atom [])
           captured-tick (atom [])]
-      (rf/reg-event-db :child/boot
-        (fn [db _]
+      (rf/reg-event :child/boot
+        (fn [{:keys [db]} _]
           (swap! event-order conj :child/boot-ran)
-          (assoc db :child-booted? true)))
-      (rf/reg-event-fx :parent/spawn-child
+          {:db (assoc db :child-booted? true)}))
+      (rf/reg-event :parent/spawn-child
         (fn [_ _]
           (swap! event-order conj :parent/before-reg-frame)
           (rf/reg-frame :child {:on-create [:child/boot]})
@@ -638,10 +638,10 @@
   (testing "Top-level reg-frame (NOT inside a handler) still dispatch-sync's
             :on-create — the rf2-cufbh fix preserves the fast path"
     (let [order (atom [])]
-      (rf/reg-event-db :top/init
-        (fn [_ _]
+      (rf/reg-event :top/init
+        (fn [{:keys [db]} _]
           (swap! order conj :top/init-ran)
-          {:initialised? true}))
+          {:db {:initialised? true}}))
       ;; No in-flight handler; *current-frame* is nil. :on-create must run
       ;; synchronously, before reg-frame returns.
       (rf/reg-frame :top {:on-create [:top/init]})
@@ -661,11 +661,11 @@
     (let [order         (atom [])
           captured-tick (atom [])
           child-id      (atom nil)]
-      (rf/reg-event-db :sub-actor/boot
-        (fn [db _]
+      (rf/reg-event :sub-actor/boot
+        (fn [{:keys [db]} _]
           (swap! order conj :sub-actor/boot-ran)
-          (assoc db :booted? true)))
-      (rf/reg-event-fx :parent/spawn-sub-actor
+          {:db (assoc db :booted? true)}))
+      (rf/reg-event :parent/spawn-sub-actor
         (fn [_ _]
           (swap! order conj :parent/before-make-frame)
           (reset! child-id (rf/make-frame {:on-create [:sub-actor/boot]}))
@@ -814,9 +814,9 @@
       (rf/reg-frame :race/frame {:doc "rf2-ft2b reproducer frame"})
       ;; A simple :db-writing event handler. The drain that processes
       ;; this event is what we want to land AFTER destroy.
-      (rf/reg-event-db :write
-        (fn [_db _]
-          {:committed? true}))
+      (rf/reg-event :write
+        (fn [{:keys [db]} _]
+          {:db {:committed? true}}))
       (with-redefs [interop/next-tick (fn [f] (reset! captured-tick f) nil)]
         ;; Async dispatch — schedules the drain via next-tick. The
         ;; with-redefs binding captures the drain thunk into
@@ -1060,10 +1060,10 @@
   (testing "rf/reset-frame!: app-db is reset, config metadata is preserved,
             :on-create re-runs, frame remains queryable"
     (let [boot-count (atom 0)]
-      (rf/reg-event-db :seed
-        (fn [_ [_ payload]]
+      (rf/reg-event :seed
+        (fn [{:keys [db]} [_ payload]]
           (swap! boot-count inc)
-          {:booted? true :payload payload :extra :seeded}))
+          {:db {:booted? true :payload payload :extra :seeded}}))
       (rf/reg-frame :app/main
                     {:doc       "frame with on-create"
                      :on-create [:seed {:hello "world"}]
@@ -1075,7 +1075,7 @@
           "app-db reflects :on-create commit")
 
       ;; Mutate app-db: a subsequent event extends the value.
-      (rf/reg-event-db :extend (fn [db _] (assoc db :runtime-write? true)))
+      (rf/reg-event :extend (fn [{:keys [db]} _] {:db (assoc db :runtime-write? true)}))
       (rf/dispatch-sync [:extend] {:frame :app/main})
       (is (true? (:runtime-write? (rf/app-db-value :app/main)))
           "mutation is visible before reset-frame!")
@@ -1151,7 +1151,7 @@
       (fn [_ _]
         (throw (ex-info ":throwy/intentional" {:purpose :test-fixture}))))
     ;; Pin a live subscription so we can verify sub-cache disposal still ran.
-    (rf/reg-event-db :throwy/seed (fn [_ _] {:n 42}))
+    (rf/reg-event :throwy/seed (fn [{:keys [db]} _] {:db {:n 42}}))
     (rf/reg-sub :throwy/n (fn [db _] (:n db)))
     (rf/dispatch-sync [:throwy/seed] {:frame :throwy/worker})
     (let [pinned         (rf/subscribe :throwy/worker [:throwy/n])
@@ -1239,7 +1239,7 @@
       ;; The :on-destroy handler itself calls destroy-frame! on its own
       ;; frame. Without the re-entrancy guard this would recurse
       ;; indefinitely (or until a stack overflow).
-      (rf/reg-event-fx :reent/cleanup
+      (rf/reg-event :reent/cleanup
         (fn [_ _]
           (swap! on-destroy-count inc)
           (frame/destroy-frame! :reent/worker)
@@ -1274,7 +1274,7 @@
     (rf/reg-frame :reent.a/worker {:on-destroy [:reent.a/cleanup]})
     (rf/reg-frame :reent.b/worker {})
     (let [b-still-alive-during-a (atom nil)]
-      (rf/reg-event-fx :reent.a/cleanup
+      (rf/reg-event :reent.a/cleanup
         (fn [_ _]
           ;; Sanity: B is alive at the start of A's :on-destroy.
           (reset! b-still-alive-during-a (some? (frame/frame :reent.b/worker)))

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -100,7 +100,7 @@
       (rf/reg-fx :fx-test/a (fn [_ _] (swap! log conj :a)))
       (rf/reg-fx :fx-test/b (fn [_ _] (swap! log conj :b)))
       (rf/reg-fx :fx-test/c (fn [_ _] (swap! log conj :c)))
-      (rf/reg-event-fx :fx-test/run-mixed
+      (rf/reg-event :fx-test/run-mixed
         (fn [{:keys [db]} _]
           {:db (assoc db :seeded? true)
            :fx [[:fx-test/a]
@@ -123,7 +123,7 @@
         (fn [db _] (swap! log conj :queued-a) db))
       (rf/reg-event-db :fx-test/queued-b
         (fn [db _] (swap! log conj :queued-b) db))
-      (rf/reg-event-fx :fx-test/run-interleaved
+      (rf/reg-event :fx-test/run-interleaved
         (fn [_ _]
           {:fx [[:fx-test/sync-a]
                 [:dispatch [:fx-test/queued-a]]
@@ -158,7 +158,7 @@
       (rf/reg-fx :fx-test/email.call
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! fired conj :per-call)))
-      (rf/reg-event-fx :fx-test/send
+      (rf/reg-event :fx-test/send
         (fn [_ _] {:fx [[:fx-test/email {:to "alice"}]]}))
 
       (testing "no overrides — registered fx fires"
@@ -199,7 +199,7 @@
       (rf/reg-fx :fx-test/wo-email.call
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! fired conj :per-call)))
-      (rf/reg-event-fx :fx-test/wo-send
+      (rf/reg-event :fx-test/wo-send
         (fn [_ _] {:fx [[:fx-test/wo-email {:to "alice"}]]}))
 
       (testing "outside with-fx-overrides the registered fx fires"
@@ -243,7 +243,7 @@
       (rf/reg-fx :fx-test/comp-email.stub
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! fired conj :stub)))
-      (rf/reg-event-fx :fx-test/comp-send
+      (rf/reg-event :fx-test/comp-send
         (fn [_ _] {:fx [[:fx-test/comp-email]]}))
       (rf/reg-frame :wo/A {:doc "frame A"})
 
@@ -270,7 +270,7 @@
         (fn [_ _] (throw (ex-info "kaboom" {:why :test}))))
       (rf/reg-fx :fx-test/after
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/with-bad-fx
+      (rf/reg-event :fx-test/with-bad-fx
         (fn [_ _]
           {:fx [[:fx-test/boom  {:reason :first}]
                 [:fx-test/after {:reason :sibling}]]}))
@@ -309,7 +309,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/sibling
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/missing
+      (rf/reg-event :fx-test/missing
         (fn [_ _]
           {:fx [[:fx-test/never-registered  {:k 1}]
                 [:fx-test/sibling           {:k 2}]]}))
@@ -344,7 +344,7 @@
       (rf/reg-fx :fx-test/local-storage
         {:platforms #{:client}}
         (fn [_ _] (reset! fired? true)))
-      (rf/reg-event-fx :fx-test/save
+      (rf/reg-event :fx-test/save
         (fn [_ _] {:fx [[:fx-test/local-storage {:k "key" :v "val"}]]}))
       (rf/dispatch-sync [:fx-test/save])
       (rf/unregister-listener! ::plat)
@@ -387,7 +387,7 @@
       ;; — the M-8 contract says it must NOT.
       (rf/reg-event-db :fx-test/sentinel
         (fn [db _] (reset! fired? true) db))
-      (rf/reg-event-fx :fx-test/legacy-dispatch
+      (rf/reg-event :fx-test/legacy-dispatch
         (fn [_ _]
           ;; Legacy v1 shape — top-level :dispatch.
           {:dispatch [:fx-test/sentinel]}))
@@ -432,7 +432,7 @@
       (rf/reg-fx :test.634y/touch
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! counter inc)))
-      (rf/reg-event-fx :test.634y/run
+      (rf/reg-event :test.634y/run
                        (fn [_ _] {:fx [[:test.634y/touch :payload]]}))
 
       ;; 1. Pre-clear: dispatch increments the counter.
@@ -482,7 +482,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/sibling
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/multi-legacy
+      (rf/reg-event :fx-test/multi-legacy
         (fn [{:keys [db]} _]
           ;; Mixed: legal :db and :fx alongside two legacy keys.
           {:db (assoc db :seeded? true)
@@ -528,7 +528,7 @@
   (testing "{:fx :oops} (a bare keyword instead of a vector) is policed —
             structured :rf.error/effect-map-shape, NOT a raw host exception"
     (let [traces (collect-traces! ::fx-val-kw)]
-      (rf/reg-event-fx :fx-test/fx-is-keyword
+      (rf/reg-event :fx-test/fx-is-keyword
         (fn [{:keys [db]} _]
           ;; Forgot-the-outer-vector typo: :fx is a bare keyword.
           {:db (assoc db :seeded? true)
@@ -569,7 +569,7 @@
       ;; would flip — it must NOT (the whole :fx value is malformed + dropped).
       (rf/reg-event-db :fx-test/fx-sentinel
         (fn [db _] (reset! fired? true) db))
-      (rf/reg-event-fx :fx-test/fx-is-map
+      (rf/reg-event :fx-test/fx-is-map
         (fn [_ _]
           ;; Forgot the outer + inner vector nesting: :fx is a map.
           {:fx {:dispatch [:fx-test/fx-sentinel]}}))
@@ -595,7 +595,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/touch-ok
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/fx-is-vector
+      (rf/reg-event :fx-test/fx-is-vector
         (fn [{:keys [db]} _]
           {:db (assoc db :seeded? true)
            :fx [[:fx-test/touch-ok {:k :v}]]}))
@@ -613,7 +613,7 @@
     ;; nil/absent :fx must NOT be flagged (it is equivalent to omitting :fx);
     ;; only a non-nil, non-sequential value is the typo we police.
     (let [traces (collect-traces! ::fx-val-nil)]
-      (rf/reg-event-fx :fx-test/fx-is-nil
+      (rf/reg-event :fx-test/fx-is-nil
         (fn [{:keys [db]} _]
           {:db (assoc db :seeded? true)
            :fx nil}))
@@ -651,7 +651,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/entry-sibling
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/entry-is-keyword
+      (rf/reg-event :fx-test/entry-is-keyword
         (fn [{:keys [db]} _]
           ;; :good fires; :oops is a bare keyword (forgot the inner vector)
           ;; — it must be policed + skipped, NOT silently dropped.
@@ -697,7 +697,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/entry-ok
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/entry-is-map
+      (rf/reg-event :fx-test/entry-is-map
         (fn [_ _]
           {:fx [{:dispatch [:whatever]}      ;; a map where a [fx-id args] pair belongs
                 [:fx-test/entry-ok {:k :v}]]}))
@@ -727,7 +727,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/entry-noop-ok
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/entry-nil-empty
+      (rf/reg-event :fx-test/entry-nil-empty
         (fn [_ _]
           {:fx [[:fx-test/entry-noop-ok {:k 1}]
                 nil                                 ;; conditional no-op
@@ -747,7 +747,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/multi-a (fn [_ _] (swap! fired conj :a)))
       (rf/reg-fx :fx-test/multi-b (fn [_ _] (swap! fired conj :b)))
-      (rf/reg-event-fx :fx-test/multi-ok
+      (rf/reg-event :fx-test/multi-ok
         (fn [_ _]
           {:fx [[:fx-test/multi-a]
                 [:fx-test/multi-b]]}))
@@ -791,7 +791,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/entry-nonkw-sibling
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/entry-non-keyword-head
+      (rf/reg-event :fx-test/entry-non-keyword-head
         (fn [{:keys [db]} _]
           {:db (assoc db :seeded? true)
            :fx [[:fx-test/entry-nonkw-sibling {:k 1}]
@@ -834,7 +834,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/entry-arity3-sink
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/entry-surplus-field
+      (rf/reg-event :fx-test/entry-surplus-field
         (fn [{:keys [db]} _]
           {:db (assoc db :seeded? true)
            :fx [[:fx-test/entry-arity3-sink {:k 1}]
@@ -875,7 +875,7 @@
           fired  (atom [])]
       (rf/reg-fx :fx-test/noargs-sink
         (fn [_ args] (swap! fired conj args)))
-      (rf/reg-event-fx :fx-test/entry-noargs
+      (rf/reg-event :fx-test/entry-noargs
         (fn [_ _] {:fx [[:fx-test/noargs-sink]]}))
       (rf/dispatch-sync [:fx-test/entry-noargs])
       (rf/unregister-listener! ::fx-entry-noargs)
@@ -909,7 +909,7 @@
           target-ran (atom 0)]
       (rf/reg-event-db :fx-test.tbuov/target
         (fn [db _] (swap! target-ran inc) db))
-      (rf/reg-event-fx :fx-test.tbuov/emits-malformed-dispatch
+      (rf/reg-event :fx-test.tbuov/emits-malformed-dispatch
         (fn [{:keys [db]} _]
           {:db (assoc db :seeded? true)
            ;; The exact wild malformation: a surplus `{:frame …}` 3rd slot on
@@ -971,7 +971,7 @@
       (rf/reg-fx :fx-test/http
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! original-fired inc)))
-      (rf/reg-event-fx :fx-test/issue-request
+      (rf/reg-event :fx-test/issue-request
         (fn [_ _] {:fx [[:fx-test/http {:method :get :url "/me"}]]}))
       (rf/dispatch-sync
         [:fx-test/issue-request]
@@ -994,7 +994,7 @@
       (rf/reg-fx :fx-test/http-redir-stub
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! fired conj :stub)))
-      (rf/reg-event-fx :fx-test/issue-redir
+      (rf/reg-event :fx-test/issue-redir
         (fn [_ _] {:fx [[:fx-test/http-redir {}]]}))
       (rf/dispatch-sync
         [:fx-test/issue-redir]
@@ -1010,7 +1010,7 @@
       (rf/reg-fx :fx-test/http-nil-override
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! fired inc)))
-      (rf/reg-event-fx :fx-test/issue-nil-override
+      (rf/reg-event :fx-test/issue-nil-override
         (fn [_ _] {:fx [[:fx-test/http-nil-override {}]]}))
       (rf/dispatch-sync
         [:fx-test/issue-nil-override]
@@ -1024,7 +1024,7 @@
       (rf/reg-fx :fx-test/http-traced
                  {:platforms #{:client :server}}
                  (fn [_ _] nil))
-      (rf/reg-event-fx :fx-test/issue-traced
+      (rf/reg-event :fx-test/issue-traced
         (fn [_ _] {:fx [[:fx-test/http-traced {}]]}))
       (rf/dispatch-sync
         [:fx-test/issue-traced]
@@ -1047,7 +1047,7 @@
       (rf/reg-fx :fx-test/http-with-event
                  {:platforms #{:client :server}}
                  (fn [_ _] nil))
-      (rf/reg-event-fx :fx-test/issue-with-event
+      (rf/reg-event :fx-test/issue-with-event
         (fn [_ _] {:fx [[:fx-test/http-with-event {:url "/x"}]]}))
       (rf/dispatch-sync
         [:fx-test/issue-with-event :payload-1]
@@ -1083,7 +1083,7 @@
           target-ran    (atom 0)]
       (rf/reg-event-db :fx-test.nrpj1/target
         (fn [db _] (swap! target-ran inc) db))
-      (rf/reg-event-fx :fx-test.nrpj1/emits-dispatch
+      (rf/reg-event :fx-test.nrpj1/emits-dispatch
         (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/target :payload]]]}))
       (rf/dispatch-sync
         [:fx-test.nrpj1/emits-dispatch]
@@ -1099,7 +1099,7 @@
 
   (testing ":dispatch-later fn-value override pre-empts the reserved body too"
     (let [later-args (atom nil)]
-      (rf/reg-event-fx :fx-test.nrpj1/emits-later
+      (rf/reg-event :fx-test.nrpj1/emits-later
         (fn [_ _] {:fx [[:dispatch-later {:ms 50 :event [:fx-test.nrpj1/target]}]]}))
       (rf/dispatch-sync
         [:fx-test.nrpj1/emits-later]
@@ -1114,7 +1114,7 @@
     ;; invocation — fires when the override applies, absent otherwise.
     (let [traces (collect-traces! ::reserved-override-trace)]
       (rf/reg-event-db :fx-test.nrpj1/sink (fn [db _] db))
-      (rf/reg-event-fx :fx-test.nrpj1/traced-dispatch
+      (rf/reg-event :fx-test.nrpj1/traced-dispatch
         (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/sink]]]}))
       (rf/dispatch-sync
         [:fx-test.nrpj1/traced-dispatch]
@@ -1134,7 +1134,7 @@
     (let [target-ran (atom 0)]
       (rf/reg-event-db :fx-test.nrpj1/plain-target
         (fn [db _] (swap! target-ran inc) db))
-      (rf/reg-event-fx :fx-test.nrpj1/plain-dispatch
+      (rf/reg-event :fx-test.nrpj1/plain-dispatch
         (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/plain-target]]]}))
       (rf/dispatch-sync [:fx-test.nrpj1/plain-dispatch])
       (is (= 1 @target-ran)
@@ -1152,7 +1152,7 @@
       (rf/reg-fx :fx-test.nrpj1/my-fx
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! original-fired inc)))
-      (rf/reg-event-fx :fx-test.nrpj1/issue-redirect
+      (rf/reg-event :fx-test.nrpj1/issue-redirect
         (fn [_ _] {:fx [[:fx-test.nrpj1/my-fx {}]]}))
       (rf/dispatch-sync
         [:fx-test.nrpj1/issue-redirect]
@@ -1190,7 +1190,7 @@
                          :inputs [[:fx-test.snsup5 :seed]]
                          :output (fn [_] 42)
                          :path   [:fx-test.snsup5 :out]}]
-      (rf/reg-event-fx :fx-test.snsup5/install-flow
+      (rf/reg-event :fx-test.snsup5/install-flow
         (fn [_ _] {:fx [[:rf.fx/reg-flow flow]]}))
       (rf/dispatch-sync
         [:fx-test.snsup5/install-flow]
@@ -1215,7 +1215,7 @@
       (rf/reg-fx :fx-test.snsup5/redir-target
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! redir-ran inc)))
-      (rf/reg-event-fx :fx-test.snsup5/install-flow-2
+      (rf/reg-event :fx-test.snsup5/install-flow-2
         (fn [_ _] {:fx [[:rf.fx/reg-flow {:id     :fx-test.snsup5/b-flow
                                           :inputs [[:fx-test.snsup5 :seed]]
                                           :output (fn [_] 1)
@@ -1246,7 +1246,7 @@
   (testing "the real fn-value reject producer fans :rf.error/reserved-fx-override
             out through register-error-listener! with event/id/frame context"
     (let [errors (collect-errors! ::reject-always-on)]
-      (rf/reg-event-fx :fx-test.uh5ic5/install-flow
+      (rf/reg-event :fx-test.uh5ic5/install-flow
         (fn [_ _] {:fx [[:rf.fx/reg-flow {:id     :fx-test.uh5ic5/a-flow
                                           :inputs [[:fx-test.uh5ic5 :seed]]
                                           :output (fn [_] 7)
@@ -1276,7 +1276,7 @@
       (rf/reg-fx :fx-test.uh5ic5/redir-target
                  {:platforms #{:client :server}}
                  (fn [_ _] :should-not-fire))
-      (rf/reg-event-fx :fx-test.uh5ic5/install-flow-2
+      (rf/reg-event :fx-test.uh5ic5/install-flow-2
         (fn [_ _] {:fx [[:rf.fx/reg-flow {:id     :fx-test.uh5ic5/b-flow
                                           :inputs [[:fx-test.uh5ic5 :seed]]
                                           :output (fn [_] 1)
@@ -1302,7 +1302,7 @@
           target-ran (atom 0)
           traces     (collect-traces! ::overridable-no-reject)]
       (rf/reg-event-db :fx-test.snsup5/target (fn [db _] (swap! target-ran inc) db))
-      (rf/reg-event-fx :fx-test.snsup5/emits-dispatch
+      (rf/reg-event :fx-test.snsup5/emits-dispatch
         (fn [_ _] {:fx [[:dispatch [:fx-test.snsup5/target]]]}))
       (rf/dispatch-sync
         [:fx-test.snsup5/emits-dispatch]
@@ -1357,12 +1357,12 @@
     ;; reject-tier override is gone by the time the child cascade resolves.
     (let [traces      (collect-traces! ::cascade-exclude)
           child-stub  (atom 0)]
-      (rf/reg-event-fx :fx-test.snsup5/child-installs-flow
+      (rf/reg-event :fx-test.snsup5/child-installs-flow
         (fn [_ _] {:fx [[:rf.fx/reg-flow {:id     :fx-test.snsup5/child-flow
                                           :inputs [[:fx-test.snsup5 :seed]]
                                           :output (fn [_] 7)
                                           :path   [:fx-test.snsup5 :child]}]]}))
-      (rf/reg-event-fx :fx-test.snsup5/parent-cascades
+      (rf/reg-event :fx-test.snsup5/parent-cascades
         (fn [_ _] {:fx [[:dispatch [:fx-test.snsup5/child-installs-flow]]]}))
       ;; The parent carries a reject-tier :rf.fx/reg-flow override. At the
       ;; parent it is rejected (per-call) AND excluded from the child opts.
@@ -1400,7 +1400,7 @@
    with :fx (the vector) and :db-present? true under :tags (same slot
    placement as :frame — payload-shaped tags ride under :tags)"
     (rf/reg-fx :fx-test/do-fx-shape (fn [_ _] :ok))
-    (rf/reg-event-fx :fx-test/returns-db-and-fx
+    (rf/reg-event :fx-test/returns-db-and-fx
       (fn [_ _]
         {:db {:seeded? true}
          :fx [[:fx-test/do-fx-shape {:k 1}]]}))
@@ -1421,7 +1421,7 @@
   (testing "reg-event-fx returning {:fx [...]} only (no :db slot) stamps
    :db-present? false and :fx with the vector"
     (rf/reg-fx :fx-test/no-db-fx (fn [_ _] :ok))
-    (rf/reg-event-fx :fx-test/fx-only
+    (rf/reg-event :fx-test/fx-only
       (fn [_ _]
         {:fx [[:fx-test/no-db-fx {}]]}))
     (let [acc (collect-traces! ::no-db)]
@@ -1443,7 +1443,7 @@
    slot on a trace event is placed; top-level is reserved for
    substrate-hoisted slots like :rf.trace/call-site,
    :rf.trace/trigger-handler, :source, :recovery, :sensitive?)"
-    (rf/reg-event-fx :fx-test/top-level-shape
+    (rf/reg-event :fx-test/top-level-shape
       (fn [_ _] {:db {:x 1} :fx []}))
     (let [acc (collect-traces! ::top-level)]
       (try
@@ -1484,7 +1484,7 @@
     (rf/reg-fx :fx-test/cofx-sink (fn [_ _] :ok))
     (rf/reg-cofx :fx-test/now    (fn [] "2026-05-18T19:00:00Z"))
     (rf/reg-cofx :fx-test/locale (fn [] :en-AU))
-    (rf/reg-event-fx :fx-test/uses-user-cofx
+    (rf/reg-event :fx-test/uses-user-cofx
       {:rf.cofx/requires [:fx-test/now :fx-test/locale]}
       (fn [_ _] {:db {:k 1}
                  :fx [[:fx-test/cofx-sink :go]]}))
@@ -1515,7 +1515,7 @@
    so the COEFFECTS section was empty for textbook handlers like
    :counter/inc — the cofx never reached the Xray Event lens)"
     (rf/reg-cofx :fx-test/now (fn [] "2026-05-18T19:00:00Z"))
-    (rf/reg-event-fx :fx-test/db-only-with-cofx
+    (rf/reg-event :fx-test/db-only-with-cofx
       {:rf.cofx/requires [:fx-test/now]}
       (fn [{:keys [fx-test/now]} _]
         {:db {:stamped-at now}}))
@@ -1539,8 +1539,8 @@
   (testing "a handler with no inject-cofx has its :rf.event/run-end fire
    WITHOUT a :rf.event/coeffects stamp (silent-by-default — distinct
    from a stamped empty map)"
-    (rf/reg-event-db :fx-test/no-user-cofx
-      (fn [db _] (assoc db :k 1)))
+    (rf/reg-event :fx-test/no-user-cofx
+      (fn [{:keys [db]} _] {:db (assoc db :k 1)}))
     (let [acc (collect-traces! ::no-cofx)]
       (try
         (rf/dispatch-sync [:fx-test/no-user-cofx])

--- a/implementation/core/test/re_frame/handler_source_cljs_test.cljs
+++ b/implementation/core/test/re_frame/handler_source_cljs_test.cljs
@@ -46,7 +46,7 @@
 
 (deftest reg-event-fx-captures-form-source-cljs
   (testing "rf2-xgfuy: CLJS reg-event-fx stamps :rf.handler/source under DEBUG=true"
-    (rf/reg-event-fx :rf2-xgfuy.cljs/event-fx
+    (rf/reg-event :rf2-xgfuy.cljs/event-fx
                      (fn [_cofx _ev] {:db {:n 0}}))
     (let [src (:rf.handler/source
                (rf/handler-meta :event :rf2-xgfuy.cljs/event-fx))]

--- a/implementation/core/test/re_frame/handler_source_cljs_test.cljs
+++ b/implementation/core/test/re_frame/handler_source_cljs_test.cljs
@@ -46,7 +46,7 @@
 
 (deftest reg-event-fx-captures-form-source-cljs
   (testing "rf2-xgfuy: CLJS reg-event-fx stamps :rf.handler/source under DEBUG=true"
-    (rf/reg-event :rf2-xgfuy.cljs/event-fx
+    (rf/reg-event-fx :rf2-xgfuy.cljs/event-fx
                      (fn [_cofx _ev] {:db {:n 0}}))
     (let [src (:rf.handler/source
                (rf/handler-meta :event :rf2-xgfuy.cljs/event-fx))]

--- a/implementation/core/test/re_frame/handler_source_test.clj
+++ b/implementation/core/test/re_frame/handler_source_test.clj
@@ -73,7 +73,7 @@
 
 (deftest reg-event-fx-captures-form-source
   (testing "rf2-xgfuy: reg-event-fx stamps :rf.handler/source on JVM"
-    (rf/reg-event-fx :rf2-xgfuy/event-fx-sample
+    (rf/reg-event :rf2-xgfuy/event-fx-sample
                      (fn [_cofx _ev] {:db {:n 0}}))
     (assert-source :event :rf2-xgfuy/event-fx-sample "reg-event-fx")
     (let [src (:rf.handler/source
@@ -107,7 +107,7 @@
 
 (deftest captures-form-source-with-metadata-interceptors
   (testing "rf2-xgfuy: metadata :interceptors round-trips into :rf.handler/source"
-    (rf/reg-event-fx :rf2-xgfuy/event-with-icpts
+    (rf/reg-event :rf2-xgfuy/event-with-icpts
                      {:interceptors [rf/unwrap-interceptor]}
                      (fn [_cofx {:keys [v]}] {:db {:v v}}))
     (let [src (:rf.handler/source

--- a/implementation/core/test/re_frame/handler_source_test.clj
+++ b/implementation/core/test/re_frame/handler_source_test.clj
@@ -73,7 +73,7 @@
 
 (deftest reg-event-fx-captures-form-source
   (testing "rf2-xgfuy: reg-event-fx stamps :rf.handler/source on JVM"
-    (rf/reg-event :rf2-xgfuy/event-fx-sample
+    (rf/reg-event-fx :rf2-xgfuy/event-fx-sample
                      (fn [_cofx _ev] {:db {:n 0}}))
     (assert-source :event :rf2-xgfuy/event-fx-sample "reg-event-fx")
     (let [src (:rf.handler/source

--- a/implementation/core/test/re_frame/hot_reload_test.clj
+++ b/implementation/core/test/re_frame/hot_reload_test.clj
@@ -120,10 +120,10 @@
           v1-fn (fn v1 [db [_ n]]
                   (swap! observations conj [:v1-pre n])
                   ;; Mid-handler self re-registration.
-                  (rf/reg-event-db :tick
-                    (fn v2 [db [_ n]]
+                  (rf/reg-event :tick
+                    (fn v2 [{:keys [db]} [_ n]]
                       (swap! observations conj [:v2 n])
-                      (assoc db :seen-version :v2)))
+                      {:db (assoc db :seen-version :v2)}))
                   ;; The remainder of THIS invocation runs in the v1 closure.
                   (swap! observations conj [:v1-post n])
                   (assoc db :seen-version :v1))]
@@ -144,7 +144,7 @@
   (testing "re-registering a :sub disposes its cached reaction in every frame"
     (rf/reg-frame :left  {:doc "left frame"})
     (rf/reg-frame :right {:doc "right frame"})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     ;; Two frames each carrying their own :n.
     (rf/dispatch-sync [:seed 3] {:frame :left})
     (rf/dispatch-sync [:seed 5] {:frame :right})
@@ -189,7 +189,7 @@
 (deftest sub-re-register-evicts-transitive-dependents
   (testing "re-registering an upstream sub evicts its DOWNSTREAM :<- dependents
             so they recompute against the new upstream body"
-    (rf/reg-event-db :seed (fn [_ _] {:n 10}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 10}}))
     (rf/dispatch-sync [:seed] {:frame :rf/default})
     ;; v1 of :a is the identity over :n (= 10); :sum is :a + 0 (= 10).
     (rf/reg-sub :a (fn [db _] (:n db)))
@@ -230,7 +230,7 @@
     ;; registrar permits the registrations; we synthesise the cyclic cache
     ;; entries directly so the closure walk is exercised against a cycle
     ;; without needing the reactive build to succeed.
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/dispatch-sync [:seed] {:frame :rf/default})
     (rf/reg-sub :base (fn [db _] (:n db)))
     (let [cache (:sub-cache (frame/frame :rf/default))]
@@ -262,7 +262,7 @@
     ;; Build a tiny machine and dispatch into it so [:rf.runtime/machines :snapshots] is
     ;; populated. We use a machine handler so the snapshot lands at
     ;; [:rf.runtime/machines :snapshots :traffic-light] per Spec 005.
-    (rf/reg-event-fx :traffic-light
+    (rf/reg-event :traffic-light
       (machines/make-machine-handler
         {:initial :red
          :data    {:ticks 0}

--- a/implementation/core/test/re_frame/init_platform_test.clj
+++ b/implementation/core/test/re_frame/init_platform_test.clj
@@ -72,7 +72,7 @@
       (rf/reg-fx :init-platform-test/browser-only
         {:platforms #{:client}}
         (fn [_ _] (reset! fired? true)))
-      (rf/reg-event-fx :init-platform-test/save
+      (rf/reg-event :init-platform-test/save
         (fn [_ _] {:fx [[:init-platform-test/browser-only {}]]}))
 
       (rf/init-platform :client)
@@ -98,7 +98,7 @@
       (rf/reg-fx :init-platform-test/browser-only
         {:platforms #{:client}}
         (fn [_ _] (reset! fired? true)))
-      (rf/reg-event-fx :init-platform-test/save
+      (rf/reg-event :init-platform-test/save
         (fn [_ _] {:fx [[:init-platform-test/browser-only {}]]}))
 
       ;; reset-runtime already set :server; assert defensively.

--- a/implementation/core/test/re_frame/installed_app_read_seam_cljs_test.cljc
+++ b/implementation/core/test/re_frame/installed_app_read_seam_cljs_test.cljc
@@ -120,7 +120,7 @@
             (load-order registrations declare no module). The honest
             no-provenance case."
     ;; reg-* sugar — writes the default realm's registrar in place, no install!.
-    (rf/reg-event-db :sugar/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :sugar/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [running (rf/installed-app)]
       (is (contains? (rf/app-registrations running :event) :sugar/inc)
           "the projection enumerates the sugar-registered event")

--- a/implementation/core/test/re_frame/interceptor_overrides_test.clj
+++ b/implementation/core/test/re_frame/interceptor_overrides_test.clj
@@ -60,10 +60,10 @@
 (deftest per-call-interceptor-override-removes-by-id
   (testing "per-call {:icpt nil} drops the interceptor from the chain"
     (let [log (atom [])]
-      (rf/reg-event-db :test/run
+      (rf/reg-event :test/run
         {:interceptors [(logger-interceptor log ::log-a)
                         (logger-interceptor log ::log-b)]}
-        (fn [db _] (assoc db :ran? true)))
+        (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
 
       (rf/dispatch-sync [:test/run]
                         {:interceptor-overrides {::log-a nil}})

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -51,11 +51,11 @@
   (testing "(path :foo :bar) scopes a handler to the [:foo :bar] sub-tree:
             the handler sees only the slice as :db, and its returned value
             is spliced back at that path."
-    (rf/reg-event-db :path-test/init
-                     (fn [_ _]
-                       {:foo {:bar  10
+    (rf/reg-event :path-test/init
+                     (fn [{:keys [db]} _]
+                       {:db {:foo {:bar  10
                               :keep :untouched}
-                        :other :preserved}))
+                        :other :preserved}}))
     (rf/reg-event-db :path-test/inc
                      {:interceptors [(rf/path :foo :bar)]}
                      ;; The handler's `db` is the SLICE value, not the full
@@ -83,7 +83,7 @@
       ;; A spy interceptor sandwiched between `path` and the handler runs
       ;; AFTER path's :before, so the context it sees must carry the stash
       ;; under :rf/path-stack — not the bare :path-stack.
-      (rf/reg-event-db :path-ns/init (fn [_ _] {:foo {:bar 10}}))
+      (rf/reg-event :path-ns/init (fn [{:keys [db]} _] {:db {:foo {:bar 10}}}))
       (rf/reg-event-db :path-ns/inc
                        {:interceptors [(rf/path :foo :bar)
                                        (interceptor/->interceptor*
@@ -110,7 +110,7 @@
             restores the outer slice and the outer :after splices back into
             the full app-db. Pins the stack semantics independent of the
             slot-key rename (rf2-mn0qc)."
-    (rf/reg-event-db :path-nest/init (fn [_ _] {:a {:b {:c 7} :sib :keep}}))
+    (rf/reg-event :path-nest/init (fn [{:keys [db]} _] {:db {:a {:b {:c 7} :sib :keep}}}))
     (rf/reg-event-db :path-nest/inc
                      ;; The outer `path` focuses to {:b {:c 7} :sib :keep};
                      ;; the inner `path` focuses to 7. The handler returns 8.
@@ -140,13 +140,13 @@
             emits none — `:fx`-only handlers stay `:fx`-only through
             the path interceptor"
     (let [final-ctx (atom nil)]
-      (rf/reg-event-db :path-noop/init
-                       (fn [_ _] {:foo {:bar 10} :other :preserved}))
+      (rf/reg-event :path-noop/init
+                       (fn [{:keys [db]} _] {:db {:foo {:bar 10} :other :preserved}}))
       ;; A `reg-event-fx` handler that emits ONLY `:fx`, no `:db`.
       ;; Pre-fix the path interceptor would have spliced the unchanged
       ;; slice back into `:effects :db` regardless — producing a
       ;; spurious DB write the handler never asked for.
-      (rf/reg-event-fx :path-noop/fx-only
+      (rf/reg-event :path-noop/fx-only
                        {:interceptors [(rf/path :foo :bar)
                                        ;; Sandwich-spy that captures the effects map
                                        ;; produced by the handler-side chain — i.e.
@@ -180,8 +180,8 @@
 (deftest path-interceptor-still-splices-back-when-handler-emits-db
   (testing "(path ...) still splices when the handler DOES emit :db —
             rf2-rwlj2 fix preserves the happy path"
-    (rf/reg-event-db :path-emit/init (fn [_ _] {:foo {:bar 10}}))
-    (rf/reg-event-fx :path-emit/inc
+    (rf/reg-event :path-emit/init (fn [{:keys [db]} _] {:db {:foo {:bar 10}}}))
+    (rf/reg-event :path-emit/inc
                      {:interceptors [(rf/path :foo :bar)]}
                      (fn [{:keys [db]} _]
                        ;; Explicitly emit `:db` (the slice + 1).
@@ -237,7 +237,7 @@
   (testing "[unwrap] replaces the :event coeffect with the payload map from
             the canonical [event-id payload-map] envelope shape."
     (let [seen-event (atom ::not-set)]
-      (rf/reg-event-fx :unwrap-test/consume
+      (rf/reg-event :unwrap-test/consume
                        {:interceptors [rf/unwrap-interceptor]}
                        ;; With unwrap, the second arg is the payload map
                        ;; itself — not the [id payload] vector.
@@ -266,7 +266,7 @@
     (let [traces     (atom [])
           seen-event (atom ::not-set)]
       (rf/register-listener! ::unwrap-bad (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-fx :unwrap-bad-test/consume
+      (rf/reg-event :unwrap-bad-test/consume
                        {:interceptors [rf/unwrap-interceptor]}
                        (fn [_cofx event-arg]
                          (reset! seen-event event-arg)
@@ -301,7 +301,7 @@
     (let [traces     (atom [])
           seen-event (atom ::not-set)]
       (rf/register-listener! ::unwrap-arity (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-fx :unwrap-bad-test/arity
+      (rf/reg-event :unwrap-bad-test/arity
                        {:interceptors [rf/unwrap-interceptor]}
                        (fn [_cofx event-arg]
                          (reset! seen-event event-arg)
@@ -319,7 +319,7 @@
     ;; coverage above is genuinely catching the negative branch.
     (let [traces (atom [])]
       (rf/register-listener! ::unwrap-ok (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-fx :unwrap-bad-test/ok
+      (rf/reg-event :unwrap-bad-test/ok
                        {:interceptors [rf/unwrap-interceptor]}
                        (fn [_ _] {}))
       (rf/dispatch-sync [:unwrap-bad-test/ok {:k 1}])
@@ -342,7 +342,7 @@
             alongside the standard :db / :event coeffects (EP-0017 §5)"
     (rf/reg-cofx :now (fn [] 1234567890))
     (let [seen-cofx (atom nil)]
-      (rf/reg-event-fx :cofx-test/read-now
+      (rf/reg-event :cofx-test/read-now
                        {:rf.cofx/requires [:now]}
                        (fn [cofx _event]
                          (reset! seen-cofx cofx)
@@ -358,7 +358,7 @@
   (testing "a `[id arg]` declaration passes the arg to the supplier's 1-arity"
     (rf/reg-cofx :greeting (fn [greeting] greeting))
     (let [seen (atom nil)]
-      (rf/reg-event-fx :cofx-test/use-greeting
+      (rf/reg-event :cofx-test/use-greeting
                        {:rf.cofx/requires [[:greeting "hello"]]}
                        (fn [cofx _]
                          (reset! seen (:greeting cofx))
@@ -386,7 +386,7 @@
                  :after  (fn [ctx]
                            (swap! trail conj [:after tag])
                            ctx)))]
-      (rf/reg-event-fx :primitive/run
+      (rf/reg-event :primitive/run
                        {:interceptors [(mk :a) (mk :b) (mk :c)]}
                        (fn [_ _]
                          (swap! trail conj :handler)

--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -36,8 +36,8 @@
             retain-N ring buffer. The buffer surface becomes
             inert — no allocation, no append, no storage."
     (with-redefs [interop/debug-enabled? false]
-      (rf/reg-event-db :prod-gate/inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod-gate/inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate/inc])
       (is (empty? (trace/trace-buffer :rf/default))
           "trace buffer is empty under disabled gate — no event
@@ -53,8 +53,8 @@
         (rf/register-listener!
           :prod-gate/recorder
           (fn [event] (swap! seen conj event)))
-        (rf/reg-event-db :prod-gate/silent
-                         (fn [db _] (update db :n (fnil inc 0))))
+        (rf/reg-event :prod-gate/silent
+                         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         (rf/dispatch-sync [:prod-gate/silent])
         (rf/unregister-listener! :prod-gate/recorder)
         (is (empty? @seen)
@@ -72,8 +72,8 @@
         (rf/register-event-listener!
           :prod-gate/event-rec
           (fn [record] (swap! seen conj record)))
-        (rf/reg-event-db :prod-gate/observable
-                         (fn [db _] (update db :n (fnil inc 0))))
+        (rf/reg-event :prod-gate/observable
+                         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         (rf/dispatch-sync [:prod-gate/observable])
         (is (= 1 (count @seen))
             "event-emit substrate fired under disabled debug gate

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -164,7 +164,7 @@
     (is (= [[:upload]] (:large m)))))
 
 (deftest reg-event-fx-stashes-marks
-  (rf/reg-event-fx :evt
+  (rf/reg-event :evt
     {:sensitive [[:totp]]}
     (fn [_ _] {}))
   (is (= [[:totp]] (:sensitive (marks/marks-for :event :evt)))))
@@ -559,7 +559,7 @@
 
 (deftest event-arg-sensitive-path-redacts-in-trace
   ;; Spec 015 conformance fixture #1
-  (rf/reg-event-fx :auth/log-in
+  (rf/reg-event :auth/log-in
     {:sensitive [[:password]]}
     (fn [_ _] {}))
   (let [traces (collect-traces! :evt-redact)]
@@ -575,7 +575,7 @@
   (rf/reg-fx :myfx
     {:sensitive [[:headers :authorization]]}
     (fn [_ _]))
-  (rf/reg-event-fx :send
+  (rf/reg-event :send
     (fn [_ _] {:fx [[:myfx {:headers {:authorization "Bearer xyz"
                                       :other "ok"}}]]}))
   (let [traces (collect-traces! :fx-redact)]
@@ -588,7 +588,7 @@
     (trace-tooling/unregister-listener! :fx-redact)))
 
 (deftest large-path-emits-marker
-  (rf/reg-event-fx :evt
+  (rf/reg-event :evt
     {:large [[:blob]]}
     (fn [_ _] {}))
   (let [traces (collect-traces! :large-marker)
@@ -604,7 +604,7 @@
     (trace-tooling/unregister-listener! :large-marker)))
 
 (deftest empty-path-redacts-whole-arg
-  (rf/reg-event-fx :evt
+  (rf/reg-event :evt
     {:sensitive [[]]}
     (fn [_ _] {}))
   (let [traces (collect-traces! :whole)]
@@ -630,11 +630,11 @@
 ;; (mirrors `sub-auto-propagates-when-app-db-has-sensitive-marks`).
 
 (deftest db-pending-sensitive-app-db-path-redacts
-  (rf/reg-event-db :db/seed (fn [_ _] {:user {:ssn nil :name "A"}}))
+  (rf/reg-event :db/seed (fn [{:keys [db]} _] {:db {:user {:ssn nil :name "A"}}}))
   (rf/dispatch-sync [:db/seed])
   (marks/set-marks :rf/default {[:user :ssn] :sensitive})
-  (rf/reg-event-db :db/write-ssn
-    (fn [db _] (assoc-in db [:user :ssn] "123-45-6789")))
+  (rf/reg-event :db/write-ssn
+    (fn [{:keys [db]} _] {:db (assoc-in db [:user :ssn] "123-45-6789")}))
   (let [traces (collect-traces! :db-sensitive)]
     (rf/dispatch-sync [:db/write-ssn])
     (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)
@@ -647,12 +647,12 @@
     (trace-tooling/unregister-listener! :db-sensitive)))
 
 (deftest db-pending-large-app-db-path-emits-marker
-  (rf/reg-event-db :db/seed (fn [_ _] {:docs {:csv nil :note "ok"}}))
+  (rf/reg-event :db/seed (fn [{:keys [db]} _] {:db {:docs {:csv nil :note "ok"}}}))
   (rf/dispatch-sync [:db/seed])
   (marks/set-marks :rf/default {[:docs :csv] :large})
   (let [big (apply str (repeat 500 "X"))]
-    (rf/reg-event-db :db/write-csv
-      (fn [db _] (assoc-in db [:docs :csv] big)))
+    (rf/reg-event :db/write-csv
+      (fn [{:keys [db]} _] {:db (assoc-in db [:docs :csv] big)}))
     (let [traces (collect-traces! :db-large)]
       (rf/dispatch-sync [:db/write-csv])
       (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)
@@ -687,8 +687,8 @@
   (frame-class/install! :rf/default
     (frame-class/validate+extract :rf/default
       {:sensitive {:app-db [[:auth :token]]}}))
-  (rf/reg-event-db :db/login
-    (fn [db _] (assoc-in db [:auth :token] "Bearer xyz")))
+  (rf/reg-event :db/login
+    (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "Bearer xyz")}))
   (let [traces (collect-traces! :db-schema-sensitive)]
     (rf/dispatch-sync [:db/login])
     (let [[t1] (filterv #(= :rf.event/db-pending (:operation %)) @traces)]
@@ -772,7 +772,7 @@
   ;; NB: the elision declaration registry lives in the runtime-db partition
   ;; (`[:rf.runtime/elision]`, EP-0001), so an app-db replacement no longer
   ;; wipes it; seed first, then mark, as for schema-driven elision.
-  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user {:ssn "X" :name "A"}}}))
   (rf/dispatch-sync [:seed])
   (marks/set-marks :rf/default {[:user :ssn] :sensitive})
   (rf/reg-sub :all-users (fn [db _] (:user db)))
@@ -786,7 +786,7 @@
   ;; sensitive input with `:rf.egress/output-sensitivity :rf.egress/public`
   ;; DECLASSIFIES — its output is NOT marked sensitive despite the sensitive
   ;; input (replaces the rejected `:sensitive? false` spelling).
-  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user {:ssn "X" :name "A"}}}))
   (rf/dispatch-sync [:seed])
   (marks/set-marks :rf/default {[:user :ssn] :sensitive})
   (rf/reg-sub :safe
@@ -830,7 +830,7 @@
   ;; `derived-output-inherits-sensitivity.edn` fixture: a sub reading a
   ;; sensitive input with NO `:rf.egress/output-sensitivity` (the `:inherit`
   ;; default) propagates — its output IS marked sensitive.
-  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user {:ssn "X" :name "A"}}}))
   (rf/dispatch-sync [:seed])
   (marks/set-marks :rf/default {[:user :ssn] :sensitive})
   (rf/reg-sub :inheriting
@@ -842,7 +842,7 @@
 ;; ---- composed: subs propagation through layer-2 ------------------------
 
 (deftest layer-2-inherits-from-input-sub
-  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user {:ssn "X" :name "A"}}}))
   (rf/dispatch-sync [:seed])
   (marks/set-marks :rf/default {[:user :ssn] :sensitive})
   (rf/reg-sub :u (fn [db _] (:user db)))
@@ -878,7 +878,7 @@
   (rf/reg-cofx :auth/jwt
     {:sensitive [[]]}
     (fn [] "real-jwt"))
-  (rf/reg-event-fx :uses-jwt
+  (rf/reg-event :uses-jwt
     {:rf.cofx/requires [:auth/jwt]}
     (fn [_ _] {}))
   ;; Cofx mark stashed
@@ -937,13 +937,13 @@
 ;; ---- registrar interaction ---------------------------------------------
 
 (deftest re-registration-clears-prior-marks
-  (rf/reg-event-fx :evt {:sensitive [[:a]]} (fn [_ _] {}))
+  (rf/reg-event :evt {:sensitive [[:a]]} (fn [_ _] {}))
   (is (= [[:a]] (:sensitive (marks/marks-for :event :evt))))
   ;; Re-register without marks — clears stashed entry
-  (rf/reg-event-fx :evt (fn [_ _] {}))
+  (rf/reg-event :evt (fn [_ _] {}))
   (is (nil? (marks/marks-for :event :evt))))
 
 (deftest re-registration-replaces-marks
-  (rf/reg-event-fx :evt {:sensitive [[:a]]} (fn [_ _] {}))
-  (rf/reg-event-fx :evt {:sensitive [[:b]]} (fn [_ _] {}))
+  (rf/reg-event :evt {:sensitive [[:a]]} (fn [_ _] {}))
+  (rf/reg-event :evt {:sensitive [[:b]]} (fn [_ _] {}))
   (is (= [[:b]] (:sensitive (marks/marks-for :event :evt)))))

--- a/implementation/core/test/re_frame/multi_frame_isolation_cljs_test.cljs
+++ b/implementation/core/test/re_frame/multi_frame_isolation_cljs_test.cljs
@@ -77,19 +77,19 @@
 (defn- install-handlers! []
   ;; `:initialise` seeds the per-frame counter + tick slots so the
   ;; first sub read does not return nil.
-  (rf/reg-event-db ::initialise
-    (fn [_db _ev] {:counter 0 :ticks 0}))
+  (rf/reg-event ::initialise
+    (fn [{:keys [db]} _ev] {:db {:counter 0 :ticks 0}}))
 
   ;; Counter handlers (Spec 002 §Per-instance frames — same handler,
   ;; per-frame state).
-  (rf/reg-event-db ::counter-inc
-    (fn [db _ev] (update db :counter (fnil inc 0))))
+  (rf/reg-event ::counter-inc
+    (fn [{:keys [db]} _ev] {:db (update db :counter (fnil inc 0))}))
 
   ;; Clock-tick handler (rf2-gxgmt — on-demand parallel-frames Tick
   ;; button) — same shape as counter, different slot. Mirrors the
   ;; testbed's per-frame tick semantics without the dispatch chain.
-  (rf/reg-event-db ::clock-tick
-    (fn [db _ev] (update db :ticks (fnil inc 0))))
+  (rf/reg-event ::clock-tick
+    (fn [{:keys [db]} _ev] {:db (update db :ticks (fnil inc 0))}))
 
   (rf/reg-sub ::counter (fn [db _] (:counter db)))
   (rf/reg-sub ::ticks   (fn [db _] (:ticks db))))

--- a/implementation/core/test/re_frame/observability_routing_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observability_routing_cljs_test.cljc
@@ -76,9 +76,9 @@
                             :rf.egress/profile :rf.egress/off-box-observability
                             :opts {:service "checkout-spa"}}]}
          :sensitive {:app-db [[:auth :token]]}})
-      (rf/reg-event-db :auth/login
+      (rf/reg-event :auth/login
                        {:frame :obs/main}
-                       (fn [db _] (assoc-in db [:auth :token] "super-secret")))
+                       (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "super-secret")}))
       (rf/dispatch-sync [:auth/login {:password "hunter2"}] {:frame :obs/main})
       (is (= 1 (count @seen)) "the declared sink fired exactly once")
       (let [r (first @seen)]

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -313,7 +313,7 @@
                                    (fn [record] (swap! seen conj record)))
       (rf/reg-fx :goum9x/prod-throwing-fx
                  (fn [_ _] (throw (ex-info "fx-boom" {}))))
-      (rf/reg-event-fx :goum9x/prod-run-throwing-fx
+      (rf/reg-event :goum9x/prod-run-throwing-fx
                        (fn [_ _] {:fx [[:goum9x/prod-throwing-fx]]}))
       (rf/dispatch-sync [:goum9x/prod-run-throwing-fx])
       (let [r (some (fn [x] (when (= :rf.error/fx-handler-exception (:error x)) x)) @seen)]
@@ -328,7 +328,7 @@
     (let [seen (atom [])]
       (rf/register-error-listener! :prod/recorder
                                    (fn [record] (swap! seen conj record)))
-      (rf/reg-event-fx :goum9x/prod-unknown-fx
+      (rf/reg-event :goum9x/prod-unknown-fx
                        (fn [_ _] {:fx [[:goum9x/prod-never {}]]}))
       (rf/dispatch-sync [:goum9x/prod-unknown-fx])
       (let [r (some (fn [x] (when (= :rf.error/no-such-fx (:error x)) x)) @seen)]
@@ -344,7 +344,7 @@
       (rf/register-error-listener! :prod/recorder
                                    (fn [record] (swap! seen conj record)))
       (rf/reg-fx :goum9x/prod-real-fx (fn [_ _] nil))
-      (rf/reg-event-fx :goum9x/prod-bad-override
+      (rf/reg-event :goum9x/prod-bad-override
                        (fn [_ _] {:fx [[:goum9x/prod-real-fx]]}))
       (rf/dispatch-sync [:goum9x/prod-bad-override]
                         {:fx-overrides {:goum9x/prod-real-fx :goum9x/prod-missing}})
@@ -370,7 +370,7 @@
                                    (fn [record] (swap! seen conj record)))
       ;; :rf.fx/reg-flow is a REJECT-tier reserved fx (installs durable
       ;; per-frame flow-registry state). A prod build cannot stub it out.
-      (rf/reg-event-fx :uh5ic5/install-flow
+      (rf/reg-event :uh5ic5/install-flow
                        (fn [_ _] {:fx [[:rf.fx/reg-flow
                                         {:id     :uh5ic5/prod-flow
                                          :inputs [[:uh5ic5 :seed]]
@@ -395,7 +395,7 @@
     (let [seen (atom [])]
       (rf/register-error-listener! :prod/recorder
                                    (fn [record] (swap! seen conj record)))
-      (rf/reg-event-fx :goum9x/prod-unknown-cofx
+      (rf/reg-event :goum9x/prod-unknown-cofx
                        {:rf.cofx/requires [:goum9x/prod-no-cofx]}
                        (fn [_ _] {}))
       (try (rf/dispatch-sync [:goum9x/prod-unknown-cofx])

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -341,7 +341,7 @@
                                    (fn [record] (swap! seen conj record)))
       (rf/reg-fx :goum9x/throwing-fx
                  (fn [_ _] (throw (ex-info "fx-boom" {:cause :test}))))
-      (rf/reg-event-fx :goum9x/run-throwing-fx
+      (rf/reg-event :goum9x/run-throwing-fx
                        (fn [_ _] {:fx [[:goum9x/throwing-fx {:to "alice"}]]}))
       (rf/dispatch-sync [:goum9x/run-throwing-fx])
       (let [r (some (fn [x] (when (= :rf.error/fx-handler-exception (:error x)) x)) @seen)]
@@ -363,7 +363,7 @@
       (rf/reg-fx :goum9x/ok-a   (fn [_ _] (swap! fired conj :a)))
       (rf/reg-fx :goum9x/boom   (fn [_ _] (throw (ex-info "boom" {}))))
       (rf/reg-fx :goum9x/ok-b   (fn [_ _] (swap! fired conj :b)))
-      (rf/reg-event-fx :goum9x/mixed
+      (rf/reg-event :goum9x/mixed
                        (fn [{:keys [db]} _]
                          {:db (assoc db :committed? true)
                           :fx [[:goum9x/ok-a]
@@ -382,7 +382,7 @@
     (let [seen (atom [])]
       (rf/register-error-listener! :test/recorder
                                    (fn [record] (swap! seen conj record)))
-      (rf/reg-event-fx :goum9x/run-unknown-fx
+      (rf/reg-event :goum9x/run-unknown-fx
                        (fn [_ _] {:fx [[:goum9x/never-registered {:x 1}]]}))
       (rf/dispatch-sync [:goum9x/run-unknown-fx])
       (let [r (some (fn [x] (when (= :rf.error/no-such-fx (:error x)) x)) @seen)]
@@ -401,7 +401,7 @@
       (rf/register-error-listener! :test/recorder
                                    (fn [record] (swap! seen conj record)))
       (rf/reg-fx :goum9x/real-fx (fn [_ _] (reset! fired true)))
-      (rf/reg-event-fx :goum9x/run-bad-override
+      (rf/reg-event :goum9x/run-bad-override
                        (fn [_ _] {:fx [[:goum9x/real-fx]]}))
       ;; Per-call override redirects :goum9x/real-fx to an id that is NOT
       ;; registered → override-fallthrough; runtime uses :goum9x/real-fx.
@@ -424,7 +424,7 @@
     (let [seen (atom [])]
       (rf/register-error-listener! :test/recorder
                                    (fn [record] (swap! seen conj record)))
-      (rf/reg-event-fx :goum9x/run-unknown-cofx
+      (rf/reg-event :goum9x/run-unknown-cofx
                        {:rf.cofx/requires [:goum9x/never-registered-cofx]}
                        (fn [_ _] {}))
       (try (rf/dispatch-sync [:goum9x/run-unknown-cofx])
@@ -546,7 +546,7 @@
             is UNCHANGED and NO :rf.event/db-changed is emitted."
     (let [traces (atom [])]
       ;; Seed a known app-db value via a clean dispatch first.
-      (rf/reg-event-db :seed (fn [_ _] {:seeded 1}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:seeded 1}}))
       (rf/dispatch-sync [:seed])
       (is (= {:seeded 1} (rf/app-db-value :rf/default)) "seeded")
       ;; Now register a handler that mutates :db and then throws. Even
@@ -577,15 +577,15 @@
           boom-after (rf/->interceptor
                        :id :test/boom-after
                        :after (fn [_ctx] (throw (ex-info "after boom" {}))))]
-      (rf/reg-event-db :seed (fn [_ _] {:seeded 1}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:seeded 1}}))
       (rf/dispatch-sync [:seed])
       (is (= {:seeded 1} (rf/app-db-value :rf/default)) "seeded")
       ;; This handler successfully writes :db; the interceptor's :after
       ;; then throws — so a :db effect IS present when the throw fires,
       ;; yet nothing installs (the error path returns before the commit).
-      (rf/reg-event-db :writes-then-after-throws
+      (rf/reg-event :writes-then-after-throws
                        {:interceptors [boom-after]}
-                       (fn [db _] (assoc db :written 99)))
+                       (fn [{:keys [db]} _] {:db (assoc db :written 99)}))
       (rf/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
       (try
         (rf/dispatch-sync [:writes-then-after-throws])

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -76,7 +76,7 @@
 ;; emit `:rf.db/runtime` without firing the dev diagnostic. We use the same
 ;; `:rf/machine? true` marker the diagnostic keys on.
 (defn- reg-fw-runtime-handler! [id f]
-  (rf/reg-event-fx id {:doc "framework-authority" :rf/machine? true} f))
+  (rf/reg-event id {:doc "framework-authority" :rf/machine? true} f))
 
 ;; ===========================================================================
 ;; 1 — one physical container + two projection reactions (decision #3)
@@ -125,7 +125,7 @@
            (rf/runtime-db-value :pc/scope)))
     ;; A fresh-map app handler — the classic footgun shape — must NOT drop
     ;; runtime-db, because :db is scoped to the app-db partition.
-    (rf/reg-event-db :pc/fresh (fn [_ _] {:session :anonymous}))
+    (rf/reg-event :pc/fresh (fn [{:keys [db]} _] {:db {:session :anonymous}}))
     (rf/dispatch-sync [:pc/fresh] {:frame :pc/scope})
     (is (= {:session :anonymous} (rf/app-db-value :pc/scope))
         "app-db replaced wholesale")
@@ -140,7 +140,7 @@
 (deftest runtime-db-effect-whole-value-commit
   (testing "a framework :rf.db/runtime effect commits the runtime-db partition (whole-value)"
     (rf/reg-frame :pc/rtfx {:doc "rtfx"})
-    (rf/reg-event-db :pc/seed-app (fn [_ _] {:app :data}))
+    (rf/reg-event :pc/seed-app (fn [{:keys [db]} _] {:db {:app :data}}))
     (rf/dispatch-sync [:pc/seed-app] {:frame :pc/rtfx})
     (reg-fw-runtime-handler! :pc/write-rt
       (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}))
@@ -198,7 +198,7 @@
   (testing "a runtime-only commit leaves app-db `=` and does not recompute app subs"
     ;; Use :rf/default + with-frame so subscribe resolves a derefable reaction
     ;; (the {:frame …} subscribe opt has a separate JVM resolution path).
-    (rf/reg-event-db :pc/seed (fn [_ _] {:n 1}))
+    (rf/reg-event :pc/seed (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/dispatch-sync [:pc/seed])
     (let [runs (atom 0)]
       (rf/reg-sub :pc/app-sub (fn [db _] (swap! runs inc) (:n db)))
@@ -224,7 +224,7 @@
     (rf/dispatch-sync [:pc/seed-rt2] {:frame :pc/inval-rt})
     (let [rt-before (rf/runtime-db-value :pc/inval-rt)]
       ;; app-only commit
-      (rf/reg-event-db :pc/app-write (fn [db _] (assoc db :touched? true)))
+      (rf/reg-event :pc/app-write (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
       (rf/dispatch-sync [:pc/app-write] {:frame :pc/inval-rt})
       (is (true? (:touched? (rf/app-db-value :pc/inval-rt))))
       (is (identical? rt-before (rf/runtime-db-value :pc/inval-rt))
@@ -238,7 +238,7 @@
   (testing "an app-only commit emits db-changed AND frame-state-changed #{:app-db}"
     (rf/reg-frame :pc/tr-app {:doc "tr-app"})
     (let [recorded (record-traces! ::tr-app)]
-      (rf/reg-event-db :pc/app-only (fn [db _] (assoc db :k 1)))
+      (rf/reg-event :pc/app-only (fn [{:keys [db]} _] {:db (assoc db :k 1)}))
       (rf/dispatch-sync [:pc/app-only] {:frame :pc/tr-app})
       (let [dbc (events-of recorded :rf.event/db-changed)
             fsc (events-of recorded :rf.event/frame-state-changed)]
@@ -281,7 +281,7 @@
 (deftest no-op-partition-commit-emits-no-change-trace
   (testing "a :db effect equal to the current app-db emits neither change trace"
     (rf/reg-frame :pc/tr-noop {:doc "tr-noop"})
-    (rf/reg-event-db :pc/seed (fn [_ _] {:k 1}))
+    (rf/reg-event :pc/seed (fn [{:keys [db]} _] {:db {:k 1}}))
     (rf/dispatch-sync [:pc/seed] {:frame :pc/tr-noop})
     (let [recorded (record-traces! ::tr-noop)]
       ;; return the SAME app-db value

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -48,32 +48,32 @@
   (testing "form slice transitions through documented states"
     (let [defaults {:email "" :password ""}
           slice    [:auth :login]]
-      (rf/reg-event-db :form.login/initialise
-        (fn [db _]
-          (assoc-in db slice {:draft defaults :submitted nil
+      (rf/reg-event :form.login/initialise
+        (fn [{:keys [db]} _]
+          {:db (assoc-in db slice {:draft defaults :submitted nil
                               :submit-attempted? false :status :idle
-                              :errors {} :touched #{} :submit-error nil})))
-      (rf/reg-event-db :form.login/edit-field
-        (fn [db [_ field value]]
-          (-> db (assoc-in (conj slice :draft field) value)
-                 (update-in (conj slice :touched) conj field))))
-      (rf/reg-event-db :form.login/blur-field
-        (fn [db [_ field]] (update-in db (conj slice :touched) conj field)))
-      (rf/reg-event-db :form.login/submit
-        (fn [db _] (-> db (assoc-in (conj slice :submit-attempted?) true)
-                          (assoc-in (conj slice :status) :submitting))))
-      (rf/reg-event-db :form.login/submit-success
-        (fn [db _] (-> db (assoc-in (conj slice :status) :submitted)
+                              :errors {} :touched #{} :submit-error nil})}))
+      (rf/reg-event :form.login/edit-field
+        (fn [{:keys [db]} [_ field value]]
+          {:db (-> db (assoc-in (conj slice :draft field) value)
+                 (update-in (conj slice :touched) conj field))}))
+      (rf/reg-event :form.login/blur-field
+        (fn [{:keys [db]} [_ field]] {:db (update-in db (conj slice :touched) conj field)}))
+      (rf/reg-event :form.login/submit
+        (fn [{:keys [db]} _] {:db (-> db (assoc-in (conj slice :submit-attempted?) true)
+                          (assoc-in (conj slice :status) :submitting))}))
+      (rf/reg-event :form.login/submit-success
+        (fn [{:keys [db]} _] {:db (-> db (assoc-in (conj slice :status) :submitted)
                           (assoc-in (conj slice :submitted)
-                                    (get-in db (conj slice :draft))))))
-      (rf/reg-event-db :form.login/submit-error
-        (fn [db [_ err]] (-> db (assoc-in (conj slice :status) :error)
-                                (assoc-in (conj slice :submit-error) err))))
-      (rf/reg-event-db :form.login/reset
-        (fn [db _] (assoc-in db slice {:draft defaults :submitted nil
+                                    (get-in db (conj slice :draft))))}))
+      (rf/reg-event :form.login/submit-error
+        (fn [{:keys [db]} [_ err]] {:db (-> db (assoc-in (conj slice :status) :error)
+                                (assoc-in (conj slice :submit-error) err))}))
+      (rf/reg-event :form.login/reset
+        (fn [{:keys [db]} _] {:db (assoc-in db slice {:draft defaults :submitted nil
                                        :submit-attempted? false :status :idle
                                        :errors {} :touched #{}
-                                       :submit-error nil})))
+                                       :submit-error nil})}))
       ;; Lifecycle: init → :idle, edit/blur build up :touched, submit flips
       ;; :submit-attempted? and :status, success snapshots :draft → :submitted,
       ;; error sets :status :error + :submit-error, reset returns to :idle.
@@ -113,19 +113,19 @@
   variant for trivial boots and the canonical machine variant exercising
   :configuring → :loading → :ready driven by :on-create."
   (testing "chained-events boot — :on-create dispatch threads through to :ready"
-    (rf/reg-event-fx :app/init
+    (rf/reg-event :app/init
       (fn [_ _] {:fx [[:dispatch [:config/load]]]}))
-    (rf/reg-event-fx :config/load
+    (rf/reg-event :config/load
       (fn [{:keys [db]} _] {:db (assoc db :config {:loaded? true})
                             :fx [[:dispatch [:app/ready]]]}))
-    (rf/reg-event-db :app/ready
-      (fn [db _] (assoc db :app/booted? true)))
+    (rf/reg-event :app/ready
+      (fn [{:keys [db]} _] {:db (assoc db :app/booted? true)}))
     (let [f (rf/make-frame {:on-create [:app/init]})
           db (rf/app-db-value f)]
       (is (true? (:app/booted? db)) "chained-events boot reached :app/ready")
       (is (= {:loaded? true} (:config db)))))
   (testing "machine boot — :configuring → :loading → :ready"
-    (rf/reg-event-fx :app/boot
+    (rf/reg-event :app/boot
       (machines/make-machine-handler
         {:initial :configuring
          :data    {:config nil}
@@ -154,29 +154,29 @@
   :loaded-at :attempt), the status enum {:idle :loading :fetching :loaded
   :error}, and the load / loaded / load-failed / reset event lifecycle."
   (let [path [:articles]]
-    (rf/reg-event-db :articles/initialise
-      (fn [db _] (assoc-in db path {:status :idle :data nil :error nil
-                                    :loaded-at nil :attempt 0})))
-    (rf/reg-event-db :articles/load
-      (fn [db _]
-        (let [has-data? (some? (get-in db (conj path :data)))]
+    (rf/reg-event :articles/initialise
+      (fn [{:keys [db]} _] {:db (assoc-in db path {:status :idle :data nil :error nil
+                                    :loaded-at nil :attempt 0})}))
+    (rf/reg-event :articles/load
+      (fn [{:keys [db]} _]
+        {:db (let [has-data? (some? (get-in db (conj path :data)))]
           (-> db
               (assoc-in (conj path :status)  (if has-data? :fetching :loading))
               (assoc-in (conj path :error)   nil)
-              (update-in (conj path :attempt) inc)))))
-    (rf/reg-event-db :articles/loaded
-      (fn [db [_ data]]
-        (-> db (assoc-in (conj path :status) :loaded)
+              (update-in (conj path :attempt) inc)))}))
+    (rf/reg-event :articles/loaded
+      (fn [{:keys [db]} [_ data]]
+        {:db (-> db (assoc-in (conj path :status) :loaded)
                (assoc-in (conj path :data) data)
                (assoc-in (conj path :loaded-at) 1234)
-               (assoc-in (conj path :error) nil))))
-    (rf/reg-event-db :articles/load-failed
-      (fn [db [_ err]]
-        (-> db (assoc-in (conj path :status) :error)
-               (assoc-in (conj path :error) err))))
-    (rf/reg-event-db :articles/reset
-      (fn [db _] (assoc-in db path {:status :idle :data nil :error nil
-                                    :loaded-at nil :attempt 0})))
+               (assoc-in (conj path :error) nil))}))
+    (rf/reg-event :articles/load-failed
+      (fn [{:keys [db]} [_ err]]
+        {:db (-> db (assoc-in (conj path :status) :error)
+               (assoc-in (conj path :error) err))}))
+    (rf/reg-event :articles/reset
+      (fn [{:keys [db]} _] {:db (assoc-in db path {:status :idle :data nil :error nil
+                                    :loaded-at nil :attempt 0})}))
     (rf/dispatch-sync [:articles/initialise])
     (let [s0 (get-in (rf/app-db-value :rf/default) path)]
       (is (= #{:status :data :error :loaded-at :attempt} (set (keys s0)))

--- a/implementation/core/test/re_frame/performance_emit_nightly_test.cljs
+++ b/implementation/core/test/re_frame/performance_emit_nightly_test.cljs
@@ -106,8 +106,8 @@
             `re-frame.router/run-chain`)."
     (when performance/enabled?
       (clear-measures!)
-      (rf/reg-event-db :perf.emit-test/inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :perf.emit-test/inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:perf.emit-test/inc])
       (let [counts (bucket-counts)]
         (is (pos? (get counts "event" 0))
@@ -125,8 +125,8 @@
             is enough for the bracket to fire."
     (when performance/enabled?
       (clear-measures!)
-      (rf/reg-event-db :perf.emit-test/seed
-                       (fn [_ _] {:n 7}))
+      (rf/reg-event :perf.emit-test/seed
+                       (fn [{:keys [db]} _] {:db {:n 7}}))
       (rf/reg-sub :perf.emit-test/n
                   (fn [db _] (:n db)))
       (rf/dispatch-sync [:perf.emit-test/seed])
@@ -155,7 +155,7 @@
       (let [calls (atom [])]
         (rf/reg-fx :perf.emit-test/log
                    (fn [_ctx args] (swap! calls conj args)))
-        (rf/reg-event-fx :perf.emit-test/run-fx
+        (rf/reg-event :perf.emit-test/run-fx
                         (fn [_ctx _event]
                           {:fx [[:perf.emit-test/log :hello]]}))
         (rf/dispatch-sync [:perf.emit-test/run-fx])
@@ -182,7 +182,7 @@
       (let [log-calls (atom [])]
         (rf/reg-fx :perf.emit-test/counter-log
                    (fn [_ctx args] (swap! log-calls conj args)))
-        (rf/reg-event-fx :perf.emit-test/initialise
+        (rf/reg-event :perf.emit-test/initialise
                         (fn [_ctx _event]
                           {:db {:count 5}
                            :fx [[:perf.emit-test/counter-log :initialised]]}))

--- a/implementation/core/test/re_frame/plain_atom_dispose_cljs_test.cljs
+++ b/implementation/core/test/re_frame/plain_atom_dispose_cljs_test.cljs
@@ -38,7 +38,7 @@
   (testing "rf2-uatcy — disposing a layer-2 sub on the CLJS-plain-atom
             adapter decrements ref-counts on every :<- input and cascades
             their disposal, mirroring the JVM contract"
-    (rf/reg-event-db :init(fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init(fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum
@@ -74,7 +74,7 @@
   (testing "rf2-uatcy — a shared input is decremented by exactly one when
             one of its layer-2 holders disposes; it survives while another
             holder remains"
-    (rf/reg-event-db :init(fn [_ _] {:a 2 :b 3 :c 4}))
+    (rf/reg-event :init(fn [{:keys [db]} _] {:db {:a 2 :b 3 :c 4}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :c (fn [db _] (:c db)))
@@ -105,7 +105,7 @@
 (deftest layer-3-disposal-cascades-on-cljs-plain-atom
   (testing "rf2-uatcy — disposal cascades recursively through a layer-3
             chain on the CLJS-plain-atom adapter"
-    (rf/reg-event-db :init(fn [_ _] {:a 2}))
+    (rf/reg-event :init(fn [{:keys [db]} _] {:db {:a 2}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :a*2 :<- [:a]   (fn [a _] (* 2 a)))
     (rf/reg-sub :a*4 :<- [:a*2] (fn [a2 _] (* 2 a2)))

--- a/implementation/core/test/re_frame/realm_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_cljs_test.cljc
@@ -102,9 +102,9 @@
   (testing "the registry shape + read API are byte-stable — a registration
             made through the public reg-* surface is visible through the
             existing registrar read API the EP-0014 tooling sibling uses"
-    (rf/reg-event-db :realm-test/inc
+    (rf/reg-event :realm-test/inc
       {:doc "increment counter"}
-      (fn [db _] (update db :n (fnil inc 0))))
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/reg-sub :realm-test/n
       {:doc "the counter"}
       (fn [db _] (:n db)))
@@ -125,9 +125,9 @@
   (testing "reg-* / dispatch / subscribe work UNCHANGED through the default
             realm — the zero-ergonomic-regression headline"
     (rf/reg-frame :realm-test/app {:doc "transparency app"})
-    (rf/reg-event-db :realm-test/set
+    (rf/reg-event :realm-test/set
       {:doc "set n"}
-      (fn [db [_ v]] (assoc db :n v)))
+      (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-sub :realm-test/read-n
       {:doc "read n"}
       (fn [db _] (:n db)))

--- a/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
@@ -447,7 +447,7 @@
   (testing "the ordinary reg-* sugar path + full dispatch through a default-realm
             frame still works end-to-end (no regression from the realm seam)"
     (rf/reg-frame :conf/app {:doc "conf app"})
-    (rf/reg-event-db :conf/set {:doc "set"} (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :conf/set {:doc "set"} (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-sub :conf/read {:doc "read"} (fn [db _] (:n db)))
     (rf/dispatch-sync [:conf/set 7] {:frame :conf/app})
     (is (= {:n 7} (rf/app-db-value :conf/app))

--- a/implementation/core/test/re_frame/realm_query_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_query_cljs_test.cljc
@@ -63,7 +63,7 @@
 (deftest default-realm-keyword-arities-unchanged
   (testing "the existing keyword arities behave exactly as before — a
             single-realm caller never spells a realm"
-    (rf/reg-event-db :rq/inc {:doc "inc"} (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :rq/inc {:doc "inc"} (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/reg-sub :rq/n {:doc "n"} (fn [db _] (:n db)))
     ;; (registrations kind)
     (is (contains? (rf/registrations :event) :rq/inc)
@@ -91,7 +91,7 @@
 (deftest map-form-default-realm-equals-keyword-arity
   (testing "the {:realm … :kind …} form with an absent / nil / explicit-default
             realm equals the default-realm keyword arity (absence = default)"
-    (rf/reg-event-db :rq/set {:doc "set"} (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :rq/set {:doc "set"} (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-sub :rq/read {:doc "read"} (fn [db _] (:n db)))
     ;; :realm absent → default realm
     (is (= (rf/registrations :event)

--- a/implementation/core/test/re_frame/redact_interceptor_test.clj
+++ b/implementation/core/test/re_frame/redact_interceptor_test.clj
@@ -91,11 +91,11 @@
   (testing "the handler's `:event` coeffect is the raw payload; every trace
             surface that uses `redacted-event-from-ctx` sees the scrub"
     (let [seen (atom nil)]
-      (rf/reg-event-db :auth/login
+      (rf/reg-event :auth/login
         {:interceptors [(privacy/redact-interceptor [[:password] [:token]])]}
-        (fn [db [_ payload]]
+        (fn [{:keys [db]} [_ payload]]
           (reset! seen payload)
-          (assoc db :last-login payload)))
+          {:db (assoc db :last-login payload)}))
       (let [evs        (record-traces
                          #(rf/dispatch-sync
                             [:auth/login {:username "ada"
@@ -119,9 +119,9 @@
             written as `:rf/redacted`, even when absent from the source
             payload. Opt-in privacy is additive, not conditional;
             consistent with the schema-redaction helper's `redact-path`."
-    (rf/reg-event-db :neutral/save
+    (rf/reg-event :neutral/save
       {:interceptors [(privacy/redact-interceptor [[:declared]])]}
-      (fn [db [_ payload]] (assoc db :saved payload)))
+      (fn [{:keys [db]} [_ payload]] {:db (assoc db :saved payload)}))
     (let [evs        (record-traces
                        #(rf/dispatch-sync [:neutral/save {:keep "me"}]))
           db-changed (first (events-of evs :rf.event/db-changed))]
@@ -134,8 +134,8 @@
 
 (deftest handler-without-redact-interceptor-sees-no-redaction
   (testing "negative — a plain handler emits trace events with the raw payload"
-    (rf/reg-event-db :plain/save
-      (fn [db [_ payload]] (assoc db :saved payload)))
+    (rf/reg-event :plain/save
+      (fn [{:keys [db]} [_ payload]] {:db (assoc db :saved payload)}))
     (let [evs        (record-traces
                        #(rf/dispatch-sync [:plain/save {:password "shh"}]))
           db-changed (first (events-of evs :rf.event/db-changed))]
@@ -144,9 +144,9 @@
 
 (deftest empty-path-scrubs-entire-payload
   (testing "an empty path is the documented 'scrub everything' form"
-    (rf/reg-event-db :whole/payload
+    (rf/reg-event :whole/payload
       {:interceptors [(privacy/redact-interceptor [[]])]}
-      (fn [db _] (assoc db :ran? true)))
+      (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
     (let [evs        (record-traces
                        #(rf/dispatch-sync [:whole/payload {:any "thing"}]))
           db-changed (first (events-of evs :rf.event/db-changed))]
@@ -156,9 +156,9 @@
   (testing "non-map payload shapes are out of scope (the canonical M-19 form
             is `[id payload-map ...]`); the interceptor must not throw or
             mangle a non-conforming event"
-    (rf/reg-event-db :raw/vec-payload
+    (rf/reg-event :raw/vec-payload
       {:interceptors [(privacy/redact-interceptor [[:password]])]}
-      (fn [db _] (assoc db :ran? true)))
+      (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
     (let [evs        (record-traces
                        #(rf/dispatch-sync [:raw/vec-payload "scalar"]))
           db-changed (first (events-of evs :rf.event/db-changed))]
@@ -178,11 +178,11 @@
       ;; Redact path [:auth :password] but the payload's :auth is a SCALAR
       ;; string, so the parent (get-in payload [:auth]) is non-nil but
       ;; non-associative — the exact mis-declaration the bead calls out.
-      (rf/reg-event-db :auth/scalar-parent
+      (rf/reg-event :auth/scalar-parent
         {:interceptors [(privacy/redact-interceptor [[:auth :password]])]}
-        (fn [db [_ payload]]
+        (fn [{:keys [db]} [_ payload]]
           (reset! seen payload)
-          (assoc db :committed payload)))
+          {:db (assoc db :committed payload)}))
       (let [evs        (record-traces
                          #(rf/dispatch-sync
                             [:auth/scalar-parent {:auth "a-token-string"}]))
@@ -220,15 +220,15 @@
       (frame-class/validate+extract :rf/default
         {:sensitive {:app-db [[:auth :password]]}}))
     (let [seen (atom nil)]
-      (rf/reg-event-db :auth/login+token
+      (rf/reg-event :auth/login+token
         ;; `path` focuses on `:auth`, which makes the auto-redaction
         ;; install for `:password` (frame-declared sensitive). The user
         ;; `redact-interceptor` adds `:token` (NOT frame-declared).
         {:interceptors [(rf/path :auth)
                         (privacy/redact-interceptor [[:token]])]}
-        (fn [auth [_ payload]]
+        (fn [{:keys [db]} [_ payload]]
           (reset! seen payload)
-          (assoc auth :last payload)))
+          {:db (assoc auth :last payload)}))
       (let [evs        (record-traces
                          #(rf/dispatch-sync
                             [:auth/login+token {:username "ada"
@@ -295,10 +295,10 @@
             the union of their paths. Useful when an interceptor library
             ships its own privacy interceptor and the registration also
             wants per-call scrubs."
-    (rf/reg-event-db :auth/dual
+    (rf/reg-event :auth/dual
       {:interceptors [(privacy/redact-interceptor [[:password]])
                       (privacy/redact-interceptor [[:token]])]}
-      (fn [db _] (assoc db :ran? true)))
+      (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
     (let [evs        (record-traces
                        #(rf/dispatch-sync
                           [:auth/dual {:username "ada"

--- a/implementation/core/test/re_frame/redact_interceptor_test.clj
+++ b/implementation/core/test/re_frame/redact_interceptor_test.clj
@@ -228,7 +228,7 @@
                         (privacy/redact-interceptor [[:token]])]}
         (fn [{:keys [db]} [_ payload]]
           (reset! seen payload)
-          {:db (assoc auth :last payload)}))
+          {:db (assoc db :last payload)}))
       (let [evs        (record-traces
                          #(rf/dispatch-sync
                             [:auth/login+token {:username "ada"

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -138,7 +138,7 @@
         (fn []
           (rf/reg-event-db :ev/same-id (fn [db _] db))
           ;; Save-triggered re-eval — same id, still no :doc; warning is silent.
-          (rf/reg-event-db :ev/same-id (fn [db _] (assoc db :touched? true)))
+          (rf/reg-event :ev/same-id (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
           (rf/reg-event-db :ev/same-id (fn [db _] db))))
       (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))
           "exactly one warning across three registrations of the same id"))))
@@ -210,8 +210,8 @@
     (let [recorded (record-traces! ::collision-different)]
       (with-stamped-coords
         (fn []
-          (rf/reg-event-db :collide/id {:doc "first"}  (fn [db _] (assoc db :v 1)))
-          (rf/reg-event-db :collide/id {:doc "second"} (fn [db _] (assoc db :v 2)))))
+          (rf/reg-event :collide/id {:doc "first"}  (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
+          (rf/reg-event :collide/id {:doc "second"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))))
       (let [warns (warnings-of recorded :rf.warning/registration-collision)]
         (is (= 1 (count warns))
             "exactly one collision warning fires on the second registration")
@@ -229,10 +229,10 @@
     (let [recorded (record-traces! ::collision-suppressed)]
       (with-stamped-coords
         (fn []
-          (rf/reg-event-db :churn/id {:doc "a"} (fn [db _] (assoc db :v 1)))
-          (rf/reg-event-db :churn/id {:doc "b"} (fn [db _] (assoc db :v 2)))
-          (rf/reg-event-db :churn/id {:doc "c"} (fn [db _] (assoc db :v 3)))
-          (rf/reg-event-db :churn/id {:doc "d"} (fn [db _] (assoc db :v 4)))))
+          (rf/reg-event :churn/id {:doc "a"} (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
+          (rf/reg-event :churn/id {:doc "b"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))
+          (rf/reg-event :churn/id {:doc "c"} (fn [{:keys [db]} _] {:db (assoc db :v 3)}))
+          (rf/reg-event :churn/id {:doc "d"} (fn [{:keys [db]} _] {:db (assoc db :v 4)}))))
       (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
           "warn-once: only the first different-fn re-registration emits"))))
 
@@ -245,9 +245,9 @@
     (let [recorded (record-traces! ::coexist)]
       (with-stamped-coords
         (fn []
-          (rf/reg-event-db :coex/id {:doc "1"} (fn [db _] (assoc db :v 1)))
-          (rf/reg-event-db :coex/id {:doc "2"} (fn [db _] (assoc db :v 2)))
-          (rf/reg-event-db :coex/id {:doc "3"} (fn [db _] (assoc db :v 3)))))
+          (rf/reg-event :coex/id {:doc "1"} (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
+          (rf/reg-event :coex/id {:doc "2"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))
+          (rf/reg-event :coex/id {:doc "3"} (fn [{:keys [db]} _] {:db (assoc db :v 3)}))))
       (let [replaced (filterv (fn [ev]
                                 (and (= :rf.registry (:op-type ev))
                                      (= :rf.registry/handler-replaced

--- a/implementation/core/test/re_frame/router_carried_frame_cljs_test.cljs
+++ b/implementation/core/test/re_frame/router_carried_frame_cljs_test.cljs
@@ -64,8 +64,8 @@
   (testing "with no dynamic binding and no explicit frame, the router
             resolves the enclosing frame-provider (React-context) frame"
     (rf/reg-frame :app/provided {:doc "frame the provider supplies"})
-    (rf/reg-event-db :app/inc {:frame :app/provided}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/provided}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     ;; Simulate being inside a `frame-provider {:frame :app/provided}`
     ;; render: the React-context tier reports the frame, the dynamic var
     ;; is unbound.
@@ -97,8 +97,8 @@
             provider frame (override beats scope)"
     (rf/reg-frame :app/provided {:doc "provider frame"})
     (rf/reg-frame :app/explicit {:doc "explicit override target"})
-    (rf/reg-event-db :app/inc {:frame :app/explicit}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/explicit}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (reset! provider-frame :app/provided)
     (binding [frame/*current-frame* nil]
       (rf/dispatch-sync [:app/inc] {:frame :app/explicit}))

--- a/implementation/core/test/re_frame/router_carried_frame_test.clj
+++ b/implementation/core/test/re_frame/router_carried_frame_test.clj
@@ -114,8 +114,8 @@
   (testing "a dispatch inside `with-frame` resolves the scope frame and
             runs the handler against it"
     (rf/reg-frame :app/main {:doc "scope frame"})
-    (rf/reg-event-db :app/inc {:frame :app/main}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/main}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/with-frame :app/main
       (rf/dispatch-sync [:app/inc]))
     (is (= 1 (:n (rf/app-db-value :app/main)))
@@ -125,8 +125,8 @@
   (testing "a dispatch under a *current-frame* binding (the dynamic-var
             scope tier with-frame expands to) resolves that frame"
     (rf/reg-frame :app/main {:doc "scope frame"})
-    (rf/reg-event-db :app/inc {:frame :app/main}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/main}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (binding [frame/*current-frame* :app/main]
       (rf/dispatch-sync [:app/inc]))
     (is (= 1 (:n (rf/app-db-value :app/main))))))
@@ -158,8 +158,8 @@
             stamp as a VALUE; calling its `:dispatch` after the scope
             unwinds still targets the captured frame (the hold tier)"
     (rf/reg-frame :app/main {:doc "scope frame"})
-    (rf/reg-event-db :app/inc {:frame :app/main}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/main}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [handle (rf/with-frame :app/main
                    (rf/frame-handle))]            ;; no-arg capture inside scope
       (is (= :app/main (:frame handle))
@@ -174,8 +174,8 @@
   (testing "a frame-bound-fn* wrapper re-establishes the captured scope so
             an inner bare dispatch resolves the captured frame after unwind"
     (rf/reg-frame :app/main {:doc "scope frame"})
-    (rf/reg-event-db :app/inc {:frame :app/main}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/main}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [bound (rf/with-frame :app/main
                   (rf/frame-bound-fn* (fn [] (rf/dispatch-sync [:app/inc]))))]
       (binding [frame/*current-frame* nil]
@@ -189,8 +189,8 @@
   (testing "explicit `{:frame :rf/default}` is an override and works when
             `:rf/default` is registered as an ordinary frame"
     (rf/reg-frame :rf/default {:doc "ordinary explicit frame"})
-    (rf/reg-event-db :app/inc {:frame :rf/default}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :rf/default}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     ;; No surrounding scope — the explicit override carries the stamp.
     (binding [frame/*current-frame* nil]
       (rf/dispatch-sync [:app/inc] {:frame :rf/default}))
@@ -226,8 +226,8 @@
             with-frame scope (override beats scope)"
     (rf/reg-frame :app/main  {:doc "scope frame"})
     (rf/reg-frame :app/other {:doc "override target"})
-    (rf/reg-event-db :app/inc {:frame :app/other}
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :app/inc {:frame :app/other}
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/with-frame :app/main
       (rf/dispatch-sync [:app/inc] {:frame :app/other}))
     (is (= 1 (:n (rf/app-db-value :app/other)))

--- a/implementation/core/test/re_frame/router_drain_race_test.clj
+++ b/implementation/core/test/re_frame/router_drain_race_test.clj
@@ -67,10 +67,10 @@
   ;; ordering); this test pins the underlying race fix.
   (testing (str "no [:sync-only :sync-only] corruption across "
                 stress-iters " iterations")
-    (rf/reg-event-db :outside-async
-      (fn [db _] (assoc db :outside? true)))
-    (rf/reg-event-db :sync-only
-      (fn [db _] (assoc db :sync? true)))
+    (rf/reg-event :outside-async
+      (fn [{:keys [db]} _] {:db (assoc db :outside? true)}))
+    (rf/reg-event :sync-only
+      (fn [{:keys [db]} _] {:db (assoc db :sync? true)}))
 
     (let [failures (atom [])
           ;; Capture the per-iter `order` atom through a global indirection
@@ -78,15 +78,15 @@
           ;; can race with leftover envelopes from a prior iter).
           current-order (atom (atom []))
           done-promise  (atom (promise))]
-      (rf/reg-event-db :outside-async-stress
-        (fn [db _]
+      (rf/reg-event :outside-async-stress
+        (fn [{:keys [db]} _]
           (swap! @current-order conj :outside-async)
           (deliver @done-promise :ok)
-          (assoc db :outside? true)))
-      (rf/reg-event-db :sync-only-stress
-        (fn [db _]
+          {:db (assoc db :outside? true)}))
+      (rf/reg-event :sync-only-stress
+        (fn [{:keys [db]} _]
           (swap! @current-order conj :sync-only)
-          (assoc db :sync? true)))
+          {:db (assoc db :sync? true)}))
       (dotimes [i stress-iters]
         (let [order (atom [])
               done  (promise)]
@@ -140,8 +140,8 @@
       ;; This test is about the single-drainer invariant, not depth-
       ;; limit behaviour.
       (rf/reg-frame :stress.race/main {:drain-depth (* 4 (+ total 2))})
-      (rf/reg-event-db :bump
-        (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :bump
+        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       ;; Spin up submitter threads. They all dispatch concurrently.
       (let [latch   (java.util.concurrent.CountDownLatch. 1)
             futures (vec (for [_ (range n-submitters)]

--- a/implementation/core/test/re_frame/router_front_of_queue_test.cljc
+++ b/implementation/core/test/re_frame/router_front_of_queue_test.cljc
@@ -46,7 +46,7 @@
 (defn- reg-marker
   "Register a no-op event handler that records its id into `run-log`."
   [id]
-  (rf/reg-event-fx id (fn [_ _] (log! id) {})))
+  (rf/reg-event id (fn [_ _] (log! id) {})))
 
 ;; ---- (1) flagged dispatch leap-frogs a pending external event -------------
 
@@ -59,7 +59,7 @@
     ;; Seed handler enqueues an EXTERNAL event first, THEN a machine-
     ;; internal continuation. Arrival order is [:ext :cont]; FIFO would
     ;; run :ext before :cont, but front-of-queue must run :cont first.
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         (rf/dispatch* [:ext] {})
@@ -77,7 +77,7 @@
     (reset! run-log [])
     (reg-marker :ext)
     (reg-marker :plain)
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         (rf/dispatch* [:ext] {})
@@ -97,7 +97,7 @@
     (reg-marker :ext)
     (reg-marker :a)
     (reg-marker :b)
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         (rf/dispatch* [:ext] {})
@@ -131,7 +131,7 @@
     (reg-marker :ext)
     (reg-marker :c1)
     (reg-marker :c2)
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         (rf/dispatch* [:ext] {})

--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -68,7 +68,7 @@
             below). A handler-meta `:sensitive?` value is preserved on
             the registrar's stored meta (registry is opaque) but is no
             longer consulted by the trace surface."
-  (rf/reg-event-fx :sensitive/cross-cutting
+  (rf/reg-event :sensitive/cross-cutting
                    {:sensitive? true}   ;; stored, not consulted
                    (fn [{:keys [db]} _]
                      {:db (assoc db :ran? true)
@@ -89,11 +89,11 @@
             raw payload."
     (install-sensitive! :rf/default [[:auth :password]])
     (let [seen (atom nil)]
-      (rf/reg-event-db :auth/login
+      (rf/reg-event :auth/login
                        {:interceptors [(rf/path :auth)]}
-                       (fn [auth [_ payload]]
+                       (fn [{:keys [db]} [_ payload]]
                          (reset! seen payload)
-                         (assoc auth :last-login payload)))
+                         {:db (assoc auth :last-login payload)}))
       (let [evs (record-traces
                   #(rf/dispatch-sync
                      [:auth/login {:username "ada" :password "shh"}]))
@@ -124,10 +124,10 @@
 
 (deftest frame-class-auto-redaction-does-not-affect-unrelated-paths
   (install-sensitive! :rf/default [[:auth :password]])
-  (rf/reg-event-db :profile/save
+  (rf/reg-event :profile/save
                    {:interceptors [(rf/path :profile)]}
-                   (fn [profile [_ payload]]
-                     (assoc profile :saved payload)))
+                   (fn [{:keys [db]} [_ payload]]
+                     {:db (assoc profile :saved payload)}))
   (let [evs (record-traces
               #(rf/dispatch-sync
                  [:profile/save {:password "not-auth"}]))

--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -93,7 +93,7 @@
                        {:interceptors [(rf/path :auth)]}
                        (fn [{:keys [db]} [_ payload]]
                          (reset! seen payload)
-                         {:db (assoc auth :last-login payload)}))
+                         {:db (assoc db :last-login payload)}))
       (let [evs (record-traces
                   #(rf/dispatch-sync
                      [:auth/login {:username "ada" :password "shh"}]))
@@ -127,7 +127,7 @@
   (rf/reg-event :profile/save
                    {:interceptors [(rf/path :profile)]}
                    (fn [{:keys [db]} [_ payload]]
-                     {:db (assoc profile :saved payload)}))
+                     {:db (assoc db :saved payload)}))
   (let [evs (record-traces
               #(rf/dispatch-sync
                  [:profile/save {:password "not-auth"}]))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -58,18 +58,20 @@
 
 (deftest registrar-round-trip
   (testing "registering and looking up a handler"
-    (rf/reg-event-db :counter/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [meta (rf/handler-meta :event :counter/inc)]
       (is (some? meta))
       (is (fn? (:handler-fn meta)))
-      (is (= :db (:event/kind meta))))))
+      ;; reg-event shares the reg-event-fx path during the EP-0018 additive
+      ;; window, so :event/kind is :fx.
+      (is (= :fx (:event/kind meta))))))
 
 ;; ---- end-to-end dispatch --------------------------------------------------
 
 (deftest dispatch-sync-event-db
   (testing "dispatch-sync runs an event-db handler and commits :db"
-    (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :counter/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:counter/init])
     (rf/dispatch-sync [:counter/inc])
     (rf/dispatch-sync [:counter/inc])
@@ -80,7 +82,7 @@
     (let [fired (atom 0)]
       (rf/reg-fx :test/incr-counter
                  (fn [_ _] (swap! fired inc)))
-      (rf/reg-event-fx :do-it
+      (rf/reg-event :do-it
         (fn [_ _]
           {:db {:flag :set}
            :fx [[:test/incr-counter :go]]}))
@@ -177,7 +179,7 @@
   (testing "subscriber closes over the current frame so closures don't need to thread it"
     (rf/reg-frame :left  {:doc "left frame"})
     (rf/reg-frame :right {:doc "right frame"})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     ;; Seed each frame synchronously so the assertions are deterministic.
     (rf/dispatch-sync [:seed 7]  {:frame :left})
@@ -194,8 +196,8 @@
   (testing "calling dispatch-sync from inside a handler raises a structured error"
     (let [traces (atom [])]
       (rf/register-listener! ::dsih (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
-      (rf/reg-event-fx :nested
+      (rf/reg-event :outer (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
+      (rf/reg-event :nested
         (fn [_ _]
           ;; Calling dispatch-sync from inside a handler should NOT silently
           ;; interleave; it must raise :rf.error/dispatch-sync-in-handler.
@@ -222,18 +224,18 @@
   (testing "(rf/dispatch ...) called synchronously from inside a handler routes to that handler's frame"
     (rf/reg-frame :rf-l5q3.jvm/tenant-a {:doc "tenant-a frame"})
     (rf/reg-frame :rf-l5q3.jvm/tenant-b {:doc "tenant-b frame"})
-    (rf/reg-event-db :rf-l5q3.jvm/seed
-                     (fn [_ _] {:received []}))
+    (rf/reg-event :rf-l5q3.jvm/seed
+                     (fn [{:keys [db]} _] {:db {:received []}}))
     (rf/dispatch-sync [:rf-l5q3.jvm/seed] {:frame :rf-l5q3.jvm/tenant-a})
     (rf/dispatch-sync [:rf-l5q3.jvm/seed] {:frame :rf-l5q3.jvm/tenant-b})
     (rf/dispatch-sync [:rf-l5q3.jvm/seed]) ;; :rf/default
-    (rf/reg-event-fx :rf-l5q3.jvm/parent
+    (rf/reg-event :rf-l5q3.jvm/parent
                      (fn [_ _]
                        (rf/dispatch [:rf-l5q3.jvm/landed])
                        {}))
-    (rf/reg-event-db :rf-l5q3.jvm/landed
-                     (fn [db _]
-                       (update db :received (fnil conj []) :landed)))
+    (rf/reg-event :rf-l5q3.jvm/landed
+                     (fn [{:keys [db]} _]
+                       {:db (update db :received (fnil conj []) :landed)}))
     (rf/dispatch-sync [:rf-l5q3.jvm/parent] {:frame :rf-l5q3.jvm/tenant-a})
     (is (= [:landed] (:received (rf/app-db-value :rf-l5q3.jvm/tenant-a)))
         ":landed event must land on :tenant-a, not :rf/default")
@@ -256,7 +258,7 @@
   (testing "(rf/current-frame-id) inside a handler reports the handler's frame"
     (rf/reg-frame :rf-l5q3.jvm.cf/tenant-a {:doc "tenant-a frame"})
     (let [observed-current-frame (atom nil)]
-      (rf/reg-event-fx :rf-l5q3.jvm.cf/observe
+      (rf/reg-event :rf-l5q3.jvm.cf/observe
                        (fn [_ _]
                          (reset! observed-current-frame (rf/current-frame-id))
                          {}))
@@ -266,7 +268,7 @@
           "(rf/current-frame-id) inside a handler reports the handler's frame, not :rf/default"))
     (testing "and a handler running on :rf/default sees :rf/default"
       (let [observed-current-frame (atom nil)]
-        (rf/reg-event-fx :rf-l5q3.jvm.cf/observe-default
+        (rf/reg-event :rf-l5q3.jvm.cf/observe-default
                          (fn [_ _]
                            (reset! observed-current-frame (rf/current-frame-id))
                            {}))
@@ -277,8 +279,8 @@
 
 (deftest snapshot-of-reads-default-frame-app-db
   (testing "snapshot-of returns the value at a path in the active frame's app-db"
-    (rf/reg-event-db :seed (fn [_ _] {:user {:id 7 :name "ada"}
-                                      :counts {:hits 3}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:user {:id 7 :name "ada"}
+                                      :counts {:hits 3}}}))
     (rf/dispatch-sync [:seed])
     (is (= 7        (rf/snapshot-of [:user :id]))
         "single-arg form reads the active frame (defaults to :rf/default)")
@@ -291,7 +293,7 @@
   (testing "snapshot-of accepts {:frame frame-id} in opts"
     (rf/reg-frame :left  {:doc "left"})
     (rf/reg-frame :right {:doc "right"})
-    (rf/reg-event-db :seed-n (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed-n (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/dispatch-sync [:seed-n 11] {:frame :left})
     (rf/dispatch-sync [:seed-n 99] {:frame :right})
     (is (= 11 (rf/snapshot-of [:n] {:frame :left})))
@@ -340,7 +342,7 @@
 
 (deftest sub-topology-glitch-free-diamond-jvm
   (testing "diamond: app-db -> {a,b} -> c — c reads the post-swap state under compute-sub"
-    (rf/reg-event-db :diamond/init (fn [_ _] {:x 1 :y 2}))
+    (rf/reg-event :diamond/init (fn [{:keys [db]} _] {:db {:x 1 :y 2}}))
     (rf/reg-event-db :diamond/swap (fn [{:keys [x y] :as db} _]
                                      (assoc db :x y :y x)))
     (rf/reg-sub :diamond/a (fn [db _] (:x db)))
@@ -359,8 +361,8 @@
 
 (deftest sub-topology-glitch-free-chain-jvm
   (testing "chain: :n -> a -> (* 2) -> b -> inc -> c — compute-sub yields only the post-event value"
-    (rf/reg-event-db :chain/init (fn [_ _] {:n 10}))
-    (rf/reg-event-db :chain/set  (fn [db [_ n]] (assoc db :n n)))
+    (rf/reg-event :chain/init (fn [{:keys [db]} _] {:db {:n 10}}))
+    (rf/reg-event :chain/set  (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
     (rf/reg-sub :chain/a (fn [db _] (:n db)))
     (rf/reg-sub :chain/b :<- [:chain/a] (fn [a _] (* a 2)))
     (rf/reg-sub :chain/c :<- [:chain/b] (fn [b _] (inc b)))
@@ -374,9 +376,9 @@
 
 (deftest sub-correctness-on-value-equal-input-jvm
   (testing "a value-equal app-db replacement keeps the downstream sub value correct"
-    (rf/reg-event-db :stable/init (fn [_ _] {:n 5 :unrelated "z"}))
-    (rf/reg-event-db :stable/touch-unrelated
-                     (fn [db _] (assoc db :unrelated "z")))   ;; same value
+    (rf/reg-event :stable/init (fn [{:keys [db]} _] {:db {:n 5 :unrelated "z"}}))
+    (rf/reg-event :stable/touch-unrelated
+                     (fn [{:keys [db]} _] {:db (assoc db :unrelated "z")}))   ;; same value
     (rf/reg-sub :stable/a (fn [db _] (:n db)))
     (rf/reg-sub :stable/squared :<- [:stable/a] (fn [a _] (* a a)))
     (let [f (rf/make-frame {})]
@@ -450,7 +452,7 @@
 
 (deftest layer-1-and-layer-2-subs
   (testing "layer-1 and layer-2 subs return computed values"
-    (rf/reg-event-db :seed (fn [_ _] {:items [1 2 3 4 5]}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items [1 2 3 4 5]}}))
     (rf/reg-sub :items     (fn [db _] (:items db)))
     (rf/reg-sub :item-count :<- [:items] (fn [items _] (count items)))
     (rf/dispatch-sync [:seed])
@@ -469,9 +471,9 @@
 
 (deftest flow-rectangle-area
   (testing "a flow recomputes :area when :width or :height changes"
-    (rf/reg-event-db :init (fn [_ _] {:width 0 :height 0}))
-    (rf/reg-event-db :w! (fn [db [_ w]] (assoc db :width w)))
-    (rf/reg-event-db :h! (fn [db [_ h]] (assoc db :height h)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:width 0 :height 0}}))
+    (rf/reg-event :w! (fn [{:keys [db]} [_ w]] {:db (assoc db :width w)}))
+    (rf/reg-event :h! (fn [{:keys [db]} [_ h]] {:db (assoc db :height h)}))
     (rf/reg-flow {:id     :rect/area
                   :inputs [[:width] [:height]]
                   :output (fn [w h] (* w h))
@@ -594,7 +596,7 @@
     ;; Seed a machine snapshot directly into the RUNTIME-DB partition
     ;; (EP-0001 rf2-vzld77 — machine snapshots are durable runtime-db state)
     ;; so we don't need to run a full machine through this test.
-    (rf/reg-event-fx :seed-machines
+    (rf/reg-event :seed-machines
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime
          (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]
@@ -637,7 +639,7 @@
           handler (machines/make-machine-handler machine)]
       (rf/reg-frame :left  {:doc "left"})
       (rf/reg-frame :right {:doc "right"})
-      (rf/reg-event-fx :flow handler)
+      (rf/reg-event :flow handler)
       ;; Each frame's first invoke should get :worker#1.
       (let [traces (atom [])]
         (rf/register-listener! ::sids (fn [ev] (swap! traces conj ev)))
@@ -673,7 +675,7 @@
   (testing ":rf.machine/spawn and :rf.machine/destroy traverse fx without :rf.error/no-such-fx"
     (let [traces (atom [])]
       (rf/register-listener! ::spawn (fn [ev] (swap! traces conj ev)))
-      (rf/reg-event-fx :do-spawn
+      (rf/reg-event :do-spawn
         (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id :worker
                                             :id-prefix  :worker
                                             :start      [:begin]
@@ -715,7 +717,7 @@
 
       ;; The login machine. Mirrors the structure of examples/login/core.cljs's
       ;; :auth.login/flow — five states, deepest-wins, multi-guard branch.
-      (rf/reg-event-fx :auth.login/flow
+      (rf/reg-event :auth.login/flow
         (machines/make-machine-handler
           ;; Per Spec 005: spec map does NOT carry :id; the id comes
           ;; from the reg-event-fx call above.
@@ -899,7 +901,7 @@
             registration kind with the documented shape"
     ;; ---- :event --------------------------------------------------------
     (rf/reg-event-db :rf2-o1bp/evt1 (fn [db _] db))
-    (rf/reg-event-fx :rf2-o1bp/evt2 (fn [_ _] {}))
+    (rf/reg-event :rf2-o1bp/evt2 (fn [_ _] {}))
 
     ;; ---- :sub ---------------------------------------------------------
     (rf/reg-sub :rf2-o1bp/sub1 (fn [db _] db))

--- a/implementation/core/test/re_frame/source_coord_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_test.cljc
@@ -148,7 +148,7 @@
 (deftest dispatch-sync-macro-stamps-call-site-on-handler-exception
   (testing "dispatch-sync macro stamps the call-site through the envelope
    to errors emitted INSIDE the handler chain"
-    (rf/reg-event-fx :rf2-ts1a/throws
+    (rf/reg-event :rf2-ts1a/throws
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [evs (record-traces
@@ -160,7 +160,7 @@
 
 (deftest dispatch-sync-star-fn-omits-call-site-on-handler-exception
   (testing "the fn-form `dispatch-sync*` does NOT carry a call site"
-    (rf/reg-event-fx :rf2-ts1a/throws-fn
+    (rf/reg-event :rf2-ts1a/throws-fn
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [evs (record-traces
@@ -176,7 +176,7 @@
 (deftest call-site-rides-at-top-level
   (testing ":rf.trace/call-site lives at the top level, sibling of
    :rf.trace/trigger-handler — NOT nested under :tags"
-    (rf/reg-event-fx :rf2-ts1a/top-level
+    (rf/reg-event :rf2-ts1a/top-level
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [evs (record-traces

--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -80,7 +80,7 @@
 
 (deftest reg-event-fx-file-is-not-no-source-path
   (testing "rf2-mdjp: reg-event-fx emits a real :file under CLJS"
-    (rf/reg-event-fx :rf2-mdjp/reg-event-fx-sample
+    (rf/reg-event :rf2-mdjp/reg-event-fx-sample
                      (fn [_ _] {}))
     (let [f (:file (rf/handler-meta :event :rf2-mdjp/reg-event-fx-sample))]
       (is (not= "NO_SOURCE_PATH" f)))))

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -102,7 +102,7 @@
 
 (deftest source-coords-on-reg-event-fx
   (testing "reg-event-fx stamps :ns / :line / :file"
-    (rf/reg-event-fx :rf2-k84s/reg-event-fx-sample
+    (rf/reg-event :rf2-k84s/reg-event-fx-sample
                      (fn [_ _] {}))
     (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-fx-sample)
                    :event :rf2-k84s/reg-event-fx-sample)))

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -233,7 +233,7 @@
 ;; assert it under CAS contention rather than serialised calls.
 (deftest unsubscribe-drop-to-zero-no-spurious-fire-under-contention
   (testing "concurrent unsubscribe calls dispose exactly once per slot under contention"
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed] {:frame :rf/default})
 

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -67,7 +67,7 @@
 
 (deftest cache-entry-shape-matches-spec-006
   (testing "a freshly-built cache entry stores exactly :reaction :inputs :ref-count"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
@@ -96,7 +96,7 @@
 
 (deftest sync-disposal-on-last-unsubscribe
   (testing "ref-count → 0 disposes the cache slot synchronously (rf2-cmfln)"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -111,7 +111,7 @@
 
 (deftest sync-disposal-respects-multiple-subscribers
   (testing "only the LAST subscriber dropping disposes"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -141,8 +141,8 @@
             the sub's compute fn — the reaction has been disposed
             synchronously, its watch on app-db unwound (rf2-cmfln #2/#3)"
     (let [recompute-count (atom 0)]
-      (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
-      (rf/reg-event-db :update (fn [db [_ n]] (assoc db :n n)))
+      (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:n 0}}))
+      (rf/reg-event :update (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
       (rf/reg-sub :n (fn [db _]
                        (swap! recompute-count inc)
                        (:n db)))
@@ -186,7 +186,7 @@
 
 (deftest clear-subscription-cache-empties-the-cache
   (testing "clear-sub-cache! disposes every cached entry"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -200,7 +200,7 @@
 
 (deftest hot-reload-evicts-cached-entries
   (testing "re-registering a sub disposes the cached slot"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -221,7 +221,7 @@
 
 (deftest subscribe-once-disposes-synchronously
   (testing "subscribe-once's teardown is synchronous"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -233,7 +233,7 @@
 
 (deftest subscribe-once-respects-concurrent-subscriber
   (testing "subscribe-once's teardown only disposes when it drove the 1 → 0"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -265,7 +265,7 @@
 
 (deftest subscribe-before-register-does-not-cache
   (testing "subscribing before reg-sub does not cache; later registration is observed"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:init])
 
     ;; Subscribe BEFORE the sub is registered.
@@ -293,7 +293,7 @@
 
 (deftest subscribe-before-register-survives-multiple-misses
   (testing "repeated subscribe-before-register calls do not poison the cache"
-    (rf/reg-event-db :init (fn [_ _] {:n 11}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 11}}))
     (rf/dispatch-sync [:init])
 
     (dotimes [_ 3]
@@ -314,7 +314,7 @@
 
 (deftest clear-sub-id-leaves-cache-intact
   (testing "(clear-sub id) removes the registration but does not evict cache slots"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -342,7 +342,7 @@
 
 (deftest clear-sub-no-arg-leaves-cache-intact
   (testing "(clear-sub) clears every registration but leaves the cache untouched"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :a (fn [db _] (:n db)))
     (rf/reg-sub :b (fn [db _] (* 2 (:n db))))
     (rf/dispatch-sync [:init])
@@ -370,7 +370,7 @@
 
 (deftest unsubscribe-past-zero-is-idempotent
   (testing "calling unsubscribe more than once for the same sub-id does not throw or schedule extra work (rf2-zikr / rf2-cmfln)"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
 
@@ -390,7 +390,7 @@
         "repeated unsubscribe against a disposed slot is a no-op"))
 
   (testing "extra unsubscribe before any subscribe is a complete no-op"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
     ;; No subscribe — the entry doesn't exist; unsubscribe must not
@@ -413,7 +413,7 @@
 
 (deftest layer-2-disposal-decrements-input-ref-counts
   (testing "disposing a layer-2 sub decrements ref-counts on every :<- input"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum
@@ -443,7 +443,7 @@
 
 (deftest layer-2-disposal-respects-shared-inputs
   (testing "disposing one layer-2 sub decrements shared input only by one"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3 :c 4}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3 :c 4}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :c (fn [db _] (:c db)))
@@ -485,7 +485,7 @@
 
 (deftest layer-2-disposal-respects-externally-held-input
   (testing "an input also held by a direct subscribe is not over-disposed"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
@@ -517,7 +517,7 @@
 
 (deftest layer-3-disposal-cascades-through-chain
   (testing "disposal cascades recursively through a layer-3 chain"
-    (rf/reg-event-db :init (fn [_ _] {:a 2}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :a*2 :<- [:a]   (fn [a _] (* 2 a)))
     (rf/reg-sub :a*4 :<- [:a*2] (fn [a2 _] (* 2 a2)))
@@ -538,7 +538,7 @@
 
 (deftest layer-2-multi-subscriber-disposal-keeps-inputs-alive
   (testing "with two parent subscribers, dropping one keeps inputs at ref-count 1"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
@@ -586,7 +586,7 @@
 (deftest layer-2-input-refs-released-when-frame-destroyed-mid-build
   (testing "a layer-2 build whose parent cache-read sees a destroyed frame
             still releases the inputs it subscribed (no ref-count leak)"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
@@ -640,7 +640,7 @@
 
 (deftest no-such-sub-trace-tags-match-spec-009
   (testing "subscribing an unregistered sub emits Spec-009 tag-shape"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:init])
     (let [traces (atom [])]
       (rf/register-listener! ::no-such (fn [ev] (swap! traces conj ev)))
@@ -670,7 +670,7 @@
 
 (deftest sub-cache-ref-counting
   (testing "subscribe / unsubscribe pair tracks ref-count and disposes on zero"
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [cache (:sub-cache (frame/frame :rf/default))]
@@ -691,7 +691,7 @@
 
 (deftest sub-hot-reload-invalidates-cache
   (testing "re-registering a :sub disposes cached reactions and emits a trace"
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed])
     ;; v1 of :answer returns the value as-is.
     (rf/reg-sub :answer (fn [db _] (:n db)))
@@ -735,7 +735,7 @@
   (testing "1-arity subscribe / subscribe-once / unsubscribe / clear-sub-cache!
             under NO established scope raise :rf.error/no-frame-context
             instead of falling through to :rf/default (rf2-jue6sp)"
-    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     ;; Unwind the fixture's with-frame :rf/default scope → genuinely no
     ;; carried stamp and no React-context provider (JVM).
@@ -767,7 +767,7 @@
   (testing "1-arity subscribe under with-frame routes to the scope's frame —
             the ambient form still works INSIDE a real scope (rf2-jue6sp)"
     (rf/reg-frame :jue/scoped {:doc "explicit non-default scope"})
-    (rf/reg-event-db :seed (fn [_ [_ v]] {:v v}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ v]] {:db {:v v}}))
     (rf/reg-sub :v (fn [db _] (:v db)))
     (rf/dispatch-sync [:seed :scoped-value] {:frame :jue/scoped})
     ;; Unwind the fixture scope first, then establish :jue/scoped.
@@ -782,7 +782,7 @@
             (rf2-jue6sp; wrong-frame prevention for READS as well as writes)"
     (rf/reg-frame :jue/left  {:doc "left frame"})
     (rf/reg-frame :jue/right {:doc "right frame"})
-    (rf/reg-event-db :seed (fn [_ [_ v]] {:v v}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ v]] {:db {:v v}}))
     (rf/reg-sub :v (fn [db _] (:v db)))
     (rf/dispatch-sync [:seed :left-value]  {:frame :jue/left})
     (rf/dispatch-sync [:seed :right-value] {:frame :jue/right})

--- a/implementation/core/test/re_frame/sub_dispose_trace_test.clj
+++ b/implementation/core/test/re_frame/sub_dispose_trace_test.clj
@@ -80,7 +80,7 @@
             :no-more-derefers when the last subscriber detaches;
             carries the canonical tags (frame, id, query-v, reason);
             op-type rides :rf.sub"
-    (rf/reg-event-db :init (fn [_ _] {:a 42}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 42}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::layer-1-no-derefers)]
@@ -110,7 +110,7 @@
   (testing "with two subscribers, one unsubscribe does NOT emit
             :rf.sub/dispose — the slot's ref-count is still > 0; only
             the SECOND unsubscribe (the last derefer dropping) emits"
-    (rf/reg-event-db :init (fn [_ _] {:a 42}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 42}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::two-subs)]
@@ -132,7 +132,7 @@
   (testing "a layer-2 sub's disposal cascades to its layer-1 inputs —
             each evicted slot emits its own :rf.sub/dispose with
             :reason :no-more-derefers"
-    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/reg-sub :sub/b (fn [db _] (:b db)))
     (rf/reg-sub :sub/sum
@@ -165,7 +165,7 @@
             subscribe/unsubscribe cycle — only the one at the
             unsubscribe — but the rebuild does produce a NEW reaction
             (no identity equality with the disposed one)"
-    (rf/reg-event-db :init (fn [_ _] {:a 42}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 42}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::sync-dispose-then-resub)]
@@ -197,7 +197,7 @@
 (deftest dispose-emits-on-hot-reload
   (testing "re-registering a :sub fires :rf.sub/dispose with :reason
             :hot-reload for the affected slot (regardless of ref-count)"
-    (rf/reg-event-db :init (fn [_ _] {:a 42}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 42}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::hot-reload)]
@@ -222,7 +222,7 @@
   (testing "hot-reloading a sub with N cached query-arg variants fires
             N :rf.sub/dispose events, one per evicted slot, all with
             :reason :hot-reload"
-    (rf/reg-event-db :init (fn [_ _] {:items {:a 1 :b 2 :c 3}}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:items {:a 1 :b 2 :c 3}}}))
     (rf/reg-sub :sub/item
       (fn [db [_ k]] (get-in db [:items k])))
     (rf/dispatch-sync [:init])
@@ -255,7 +255,7 @@
 (deftest dispose-emits-on-clear-sub-cache
   (testing "(clear-sub-cache!) fires :rf.sub/dispose per evicted slot
             with :reason :cache-clear (regardless of ref-count)"
-    (rf/reg-event-db :init (fn [_ _] {:a 1 :b 2}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 1 :b 2}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/reg-sub :sub/b (fn [db _] (:b db)))
     (rf/dispatch-sync [:init])
@@ -287,7 +287,7 @@
             canonical tags + nothing extra: :frame, :rf.sub/id,
             :rf.sub/query-v, :rf.sub/reason. Required for consumer
             compatibility with rf2-wpfjo (Xray Epoch panel)."
-    (rf/reg-event-db :init (fn [_ _] {:a 1}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 1}}))
     (rf/reg-sub :sub/a (fn [db _] (:a db)))
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::tag-shape)]
@@ -324,7 +324,7 @@
 (deftest emits-fire-under-jvm-debug-enabled
   (testing "debug-enabled? is true on the JVM test runtime — dispose
             emits land in the trace stream"
-    (rf/reg-event-db :init (fn [_ _] {:x 1}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:x 1}}))
     (rf/reg-sub :sub/x (fn [db _] (:x db)))
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::elision-pin)]

--- a/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
@@ -50,7 +50,7 @@
 (deftest layer-1-memo-skips-recompute-on-equal-db
   (testing "two consecutive derefs against the same db value run the body once"
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
       (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
       (rf/dispatch-sync [:seed])
       (let [r (rf/subscribe [:n])]
@@ -67,8 +67,8 @@
 (deftest layer-1-memo-recomputes-on-changed-db
   (testing "deref after an app-db change runs the body again"
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
-      (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:n 0}}))
+      (rf/reg-event :update (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
       (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
       (rf/dispatch-sync [:seed])
       (let [r (rf/subscribe [:n])]
@@ -88,8 +88,8 @@
       ;; Two events that produce structurally-equal but non-identical maps.
       ;; `(assoc db :touched true)` would change the value; instead replace
       ;; with a fresh map that equals the old one.
-      (rf/reg-event-db :seed   (fn [_ _] {:n 42 :other :a}))
-      (rf/reg-event-db :reseed (fn [_ _] {:n 42 :other :a}))  ;; new map, =
+      (rf/reg-event :seed   (fn [{:keys [db]} _] {:db {:n 42 :other :a}}))
+      (rf/reg-event :reseed (fn [{:keys [db]} _] {:db {:n 42 :other :a}}))  ;; new map, =
       (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
       (rf/dispatch-sync [:seed])
       (let [r (rf/subscribe [:n])]
@@ -105,7 +105,7 @@
   (testing "the body fn still receives the canonical (db, query-v) shape
             under the specialised wrapper — no shape regression"
     (let [captured (atom nil)]
-      (rf/reg-event-db :seed (fn [_ _] {:n 99}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 99}}))
       (rf/reg-sub :n (fn [db query-v]
                        (reset! captured [db query-v])
                        (:n db)))
@@ -131,9 +131,9 @@
             coercion produces). The `{:db nil}` coercion itself is pinned
             in `re-frame.db-noop-commit-test`."
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed-false (fn [_ _] false))
-      (rf/reg-event-db :seed-empty (fn [_ _] {}))
-      (rf/reg-event-db :seed-map   (fn [_ _] {:n 1}))
+      (rf/reg-event :seed-false (fn [{:keys [db]} _] {:db false}))
+      (rf/reg-event :seed-empty (fn [{:keys [db]} _] {:db {}}))
+      (rf/reg-event :seed-map   (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/reg-sub :v (fn [db _] (swap! runs inc) db))
 
       (rf/dispatch-sync [:seed-false])
@@ -161,8 +161,8 @@
 (deftest layer-1-and-layer-2-produce-the-same-stream-of-values
   (testing "a layer-1 sub and a layer-2 sub chained off it produce the
             same stream of values across N db updates"
-    (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
-    (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:n 0}}))
+    (rf/reg-event :update (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-sub :n        (fn [db _] (:n db)))
     (rf/reg-sub :n-via-l2 :<- [:n] (fn [n _] n))
     (rf/dispatch-sync [:seed])

--- a/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
@@ -53,7 +53,7 @@
   (testing "two consecutive derefs against an unchanged upstream value
             run the layer-2 body once"
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
       (rf/reg-sub :n  (fn [db _] (:n db)))
       (rf/reg-sub :n*2 :<- [:n] (fn [n _] (swap! runs inc) (* 2 n)))
       (rf/dispatch-sync [:seed])
@@ -69,8 +69,8 @@
 (deftest layer-n-1-memo-recomputes-on-changed-upstream
   (testing "deref after an upstream change runs the body again"
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
-      (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:n 0}}))
+      (rf/reg-event :update (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
       (rf/reg-sub :n   (fn [db _] (:n db)))
       (rf/reg-sub :n*2 :<- [:n] (fn [n _] (swap! runs inc) (* 2 n)))
       (rf/dispatch-sync [:seed])
@@ -90,8 +90,8 @@
             This is the headline value of the no-op-by-equality contract
             — diamond-shape graphs do not over-compute downstream."
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed     (fn [_ _]      {:n 1 :other :a}))
-      (rf/reg-event-db :touch    (fn [db _]     (assoc db :other :b)))
+      (rf/reg-event :seed     (fn [{:keys [db]} _]      {:db {:n 1 :other :a}}))
+      (rf/reg-event :touch    (fn [{:keys [db]} _]     {:db (assoc db :other :b)}))
       (rf/reg-sub :n   (fn [db _] (:n db)))
       (rf/reg-sub :n*2 :<- [:n] (fn [n _] (swap! runs inc) (* 2 n)))
       (rf/dispatch-sync [:seed])
@@ -108,7 +108,7 @@
   (testing "the body fn still receives the canonical (upstream, query-v)
             shape under the specialised wrapper — no shape regression"
     (let [captured (atom nil)]
-      (rf/reg-event-db :seed (fn [_ _] {:n 99}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 99}}))
       (rf/reg-sub :n   (fn [db _] (:n db)))
       (rf/reg-sub :n*2 :<- [:n]
                   (fn [n query-v]
@@ -127,9 +127,9 @@
             sentinel — the body runs once for each, memo skips on
             repeat"
     (let [runs (atom 0)]
-      (rf/reg-event-db :seed-nil   (fn [_ _] {:n nil}))
-      (rf/reg-event-db :seed-false (fn [_ _] {:n false}))
-      (rf/reg-event-db :seed-val   (fn [_ _] {:n 1}))
+      (rf/reg-event :seed-nil   (fn [{:keys [db]} _] {:db {:n nil}}))
+      (rf/reg-event :seed-false (fn [{:keys [db]} _] {:db {:n false}}))
+      (rf/reg-event :seed-val   (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/reg-sub :n   (fn [db _] (:n db)))
       (rf/reg-sub :n-shadow :<- [:n]
                   (fn [n _] (swap! runs inc) n))
@@ -160,8 +160,8 @@
   (testing "a 1-input layer-2 sub and a 2-input layer-2 sub (one of the
             inputs constant) produce the same stream of values across
             N db updates"
-    (rf/reg-event-db :seed   (fn [_ _]      {:n 0 :k :stable}))
-    (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:n 0 :k :stable}}))
+    (rf/reg-event :update (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-sub :n  (fn [db _] (:n db)))
     (rf/reg-sub :k  (fn [db _] (:k db)))
     (rf/reg-sub :n*2-1 :<- [:n]
@@ -186,9 +186,9 @@
   (let [a-runs (atom 0)
         b-runs (atom 0)
         c-runs (atom 0)]
-    (rf/reg-event-db :seed   (fn [_ _]      {:n 1 :other :x}))
-    (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
-    (rf/reg-event-db :touch  (fn [db _]     (assoc db :other :y)))
+    (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:n 1 :other :x}}))
+    (rf/reg-event :update (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+    (rf/reg-event :touch  (fn [{:keys [db]} _]     {:db (assoc db :other :y)}))
     (rf/reg-sub :a (fn [db _] (swap! a-runs inc) (:n db)))
     (rf/reg-sub :b :<- [:a] (fn [a _] (swap! b-runs inc) (inc a)))
     (rf/reg-sub :c :<- [:b] (fn [b _] (swap! c-runs inc) (inc b)))

--- a/implementation/core/test/re_frame/sub_parametric_inputs_test.clj
+++ b/implementation/core/test/re_frame/sub_parametric_inputs_test.clj
@@ -165,7 +165,7 @@
                     (reset! seen query-v)
                     [[:leaf (second query-v)]])
                   (fn [[v] _] v))
-      (rf/reg-event-db :seed (fn [_ _] {:by-id {:a 1 :b 2}}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:by-id {:a 1 :b 2}}}))
       (rf/dispatch-sync [:seed])
       (is (= 1 (rf/subscribe-once [:wrap :a])))
       (is (= [:wrap :a] @seen)
@@ -180,7 +180,7 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))   ;; destructures [item]
-    (rf/reg-event-db :seed (fn [_ _] {:items {:x {:title "Hello"}}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items {:x {:title "Hello"}}}}))
     (rf/dispatch-sync [:seed])
     (is (= "Hello" (rf/subscribe-once [:item/title :x])))))
 
@@ -196,11 +196,11 @@
                    [:viewer]])
                 (fn [[article comments viewer] [_ id]]
                   {:id id :article article :comments comments :viewer viewer}))
-    (rf/reg-event-db :seed
-                     (fn [_ _]
-                       {:articles {:a1 {:title "T"}}
+    (rf/reg-event :seed
+                     (fn [{:keys [db]} _]
+                       {:db {:articles {:a1 {:title "T"}}
                         :comments {:a1 ["c1" "c2"]}
-                        :viewer   {:name "Mike"}}))
+                        :viewer   {:name "Mike"}}}))
     (rf/dispatch-sync [:seed])
     (is (= {:id :a1
             :article  {:title "T"}
@@ -215,8 +215,8 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))
-    (rf/reg-event-db :seed   (fn [_ _]        {:items {:x {:title "v1"}}}))
-    (rf/reg-event-db :rename (fn [db [_ t]]   (assoc-in db [:items :x :title] t)))
+    (rf/reg-event :seed   (fn [{:keys [db]} _]        {:db {:items {:x {:title "v1"}}}}))
+    (rf/reg-event :rename (fn [{:keys [db]} [_ t]]   {:db (assoc-in db [:items :x :title] t)}))
     (rf/dispatch-sync [:seed])
     (let [r (rf/subscribe [:item/title :x])]
       (is (= "v1" @r))
@@ -230,7 +230,7 @@
   (testing "static single :<- still delivers the BARE value (unchanged)"
     (rf/reg-sub :n  (fn [db _] (:n db)))
     (rf/reg-sub :n2 :<- [:n] (fn [n _] (* 2 n)))    ;; bare value, not [n]
-    (rf/reg-event-db :seed (fn [_ _] {:n 5}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 5}}))
     (rf/dispatch-sync [:seed])
     (is (= 10 (rf/subscribe-once [:n2])))))
 
@@ -239,7 +239,7 @@
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
-    (rf/reg-event-db :seed (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:a 2 :b 3}}))
     (rf/dispatch-sync [:seed])
     (is (= 5 (rf/subscribe-once [:sum])))))
 
@@ -253,10 +253,10 @@
                 (fn [[_ id]] [[:article/by-id id] [:viewer]])
                 (fn [[article viewer] [_ id]]
                   {:id id :article article :can-edit? (= id (:owns viewer))}))
-    (rf/reg-event-db :seed
-                     (fn [_ _]
-                       {:articles {:a1 {:title "T"}}
-                        :viewer   {:owns :a1}}))
+    (rf/reg-event :seed
+                     (fn [{:keys [db]} _]
+                       {:db {:articles {:a1 {:title "T"}}
+                        :viewer   {:owns :a1}}}))
     (rf/dispatch-sync [:seed])
     (let [db (rf/app-db-value :rf/default)]
       (is (= (rf/subscribe-once [:article/page :a1])
@@ -286,7 +286,7 @@
     (rf/reg-sub :article/page
                 (fn [[_ id]] [[:article/by-id id] [:comments/for id] [:viewer]])
                 (fn [[a c v] _] [a c v]))
-    (rf/reg-event-db :seed (fn [_ _] {:articles {} :comments {} :viewer nil}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:articles {} :comments {} :viewer nil}}))
     (rf/dispatch-sync [:seed])
     (rf/subscribe [:article/page :a1])
     (let [e (entry :rf/default [:article/page :a1])]
@@ -303,7 +303,7 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))
-    (rf/reg-event-db :seed (fn [_ _] {:items {:x {:title "X"} :y {:title "Y"}}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items {:x {:title "X"} :y {:title "Y"}}}}))
     (rf/dispatch-sync [:seed])
     (rf/subscribe [:item/title :x])
     (rf/subscribe [:item/title :y])
@@ -320,7 +320,7 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))
-    (rf/reg-event-db :seed (fn [_ _] {:items {:x {:title "X"}}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items {:x {:title "X"}}}}))
     (rf/dispatch-sync [:seed])
     (rf/subscribe [:item/title :x])
     ;; The realized upstream [:item/by-id :x] is now cached + ref-counted.
@@ -343,7 +343,7 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))
-    (rf/reg-event-db :seed (fn [_ _] {:items {:x {:title "Orig"}}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items {:x {:title "Orig"}}}}))
     (rf/dispatch-sync [:seed])
     (let [r (rf/subscribe [:item/title :x])]
       (is (= "Orig" @r))
@@ -365,7 +365,7 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))
-    (rf/reg-event-db :seed (fn [_ _] {:items {:x {:title "X" :name "n"}}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:items {:x {:title "X" :name "n"}}}}))
     (rf/dispatch-sync [:seed])
     (rf/subscribe [:item/title :x])
     (is (contains? (cache-keys :rf/default) [:item/title :x]))
@@ -389,7 +389,7 @@
     (rf/reg-sub :item/title
                 (fn [[_ id]] [[:item/by-id id]])
                 (fn [[item] _] (:title item)))
-    (rf/reg-event-db :seed (fn [_ [_ title]] {:items {:x {:title title}}}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ title]] {:db {:items {:x {:title title}}}}))
     (rf/dispatch-sync [:seed "A-title"] {:frame :frame-a})
     (rf/dispatch-sync [:seed "B-title"] {:frame :frame-b})
     ;; Each frame's parametric read resolves [:item/by-id :x] in its OWN
@@ -437,7 +437,7 @@
         (is (some #(= :compute-sub (get-in % [:tags :where])) @errs)
             "the compute-sub path emitted :rf.error/sub-input-fn-exception")
         ;; reactive path.
-        (rf/reg-event-db :seed (fn [_ _] {:leaf 1}))
+        (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:leaf 1}}))
         (rf/dispatch-sync [:seed])
         (is (nil? (rf/subscribe-once [:boom]))
             "the reactive path also recovers to nil")
@@ -459,7 +459,7 @@
         ;; compute-sub path.
         (is (nil? (rf/compute-sub [:bad-shape] {:leaf 1})))
         ;; reactive path.
-        (rf/reg-event-db :seed (fn [_ _] {:leaf 1}))
+        (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:leaf 1}}))
         (rf/dispatch-sync [:seed])
         (is (nil? (rf/subscribe-once [:bad-shape])))
         (let [wheres (set (map #(get-in % [:tags :where]) @errs))]
@@ -506,7 +506,7 @@
       (is (not (contains? m :input-fn))
           "a meta-map + single fn is NOT misread as input-fn + computation-fn")
       (is (= "a layer-1 sub" (:doc m)) "the meta-map survived onto the registration"))
-    (rf/reg-event-db :seed-m1 (fn [_ _] {:n 7}))
+    (rf/reg-event :seed-m1 (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed-m1])
     (is (= 7 (rf/subscribe-once [:m1])))))
 
@@ -520,7 +520,7 @@
       (is (= [[:base]] (:input-signals m)))
       (is (not (contains? m :input-fn)))
       (is (= "doubled" (:doc m))))
-    (rf/reg-event-db :seed-m2 (fn [_ _] {:n 5}))
+    (rf/reg-event :seed-m2 (fn [{:keys [db]} _] {:db {:n 5}}))
     (rf/dispatch-sync [:seed-m2])
     (is (= 10 (rf/subscribe-once [:m2])))))
 
@@ -534,7 +534,7 @@
     (let [m (sub-meta :vh)]
       (is (= :db (:input-kind m)))
       (is (var? (:handler-fn m)) "the Var handler is stored as-is"))
-    (rf/reg-event-db :seed-vh (fn [_ _] {:v 42}))
+    (rf/reg-event :seed-vh (fn [{:keys [db]} _] {:db {:v 42}}))
     (rf/dispatch-sync [:seed-vh])
     (is (= 42 (rf/subscribe-once [:vh])))))
 
@@ -549,6 +549,6 @@
       (is (= :parametric (:input-kind m)))
       (is (fn? (:input-fn m)))
       (is (= "parametric with meta" (:doc m))))
-    (rf/reg-event-db :seed-p1 (fn [_ _] {:by-id {:a 99}}))
+    (rf/reg-event :seed-p1 (fn [{:keys [db]} _] {:db {:by-id {:a 99}}}))
     (rf/dispatch-sync [:seed-p1])
     (is (= 99 (rf/subscribe-once [:p1 :a])))))

--- a/implementation/core/test/re_frame/substrate_source_test.clj
+++ b/implementation/core/test/re_frame/substrate_source_test.clj
@@ -57,7 +57,7 @@
     (let [seen (atom [])]
       (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
       (try
-        (rf/reg-event-fx :test/parent
+        (rf/reg-event :test/parent
           (fn [_ _]
             {:fx [[:dispatch [:test/child]]]}))
         (rf/reg-event-db :test/child (fn [db _] db))
@@ -81,8 +81,8 @@
     (let [seen (atom [])]
       (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
       (try
-        (rf/reg-event-fx :test/lvl-0 (fn [_ _] {:fx [[:dispatch [:test/lvl-1]]]}))
-        (rf/reg-event-fx :test/lvl-1 (fn [_ _] {:fx [[:dispatch [:test/lvl-2]]]}))
+        (rf/reg-event :test/lvl-0 (fn [_ _] {:fx [[:dispatch [:test/lvl-1]]]}))
+        (rf/reg-event :test/lvl-1 (fn [_ _] {:fx [[:dispatch [:test/lvl-2]]]}))
         (rf/reg-event-db :test/lvl-2 (fn [db _] db))
 
         (rf/dispatch-sync [:test/lvl-0] {:source :ui})
@@ -101,7 +101,7 @@
     (let [seen (atom [])]
       (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
       (try
-        (rf/reg-event-fx :test/parent (fn [_ _] {:fx [[:dispatch [:test/child]]]}))
+        (rf/reg-event :test/parent (fn [_ _] {:fx [[:dispatch [:test/child]]]}))
         (rf/reg-event-db :test/child  (fn [db _] db))
 
         (rf/dispatch-sync [:test/parent] {:source :ui :origin :pair})
@@ -130,7 +130,7 @@
                      (= [:test/child] (get-in ev [:tags :rf.event/v])))
             (deliver done :seen))))
       (try
-        (rf/reg-event-fx :test/parent
+        (rf/reg-event :test/parent
           (fn [_ _]
             {:fx [[:dispatch-later {:ms 1 :event [:test/child]}]]}))
         (rf/reg-event-db :test/child (fn [db _] db))

--- a/implementation/core/test/re_frame/success_path_call_site_test.clj
+++ b/implementation/core/test/re_frame/success_path_call_site_test.clj
@@ -120,7 +120,7 @@
    dispatch's call-site — rf2-twt7m Change 1 widens the hoist to
    match the trigger-handler treatment (rf2-lf84g)"
     (rf/reg-fx :rf2-twt7m/my-fx (fn [_ _] :ok))
-    (rf/reg-event-fx :rf2-twt7m/cascade
+    (rf/reg-event :rf2-twt7m/cascade
                      (fn [_ _] {:db {:n 1} :fx [[:rf2-twt7m/my-fx {}]]}))
     (let [evs       (record-traces
                       (fn []

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -94,7 +94,7 @@
    the fx vector"
     (rf/reg-fx :rf2-lf84g/my-fx
                (fn [_ctx _args] :ok))
-    (rf/reg-event-fx :rf2-lf84g/uses-my-fx
+    (rf/reg-event :rf2-lf84g/uses-my-fx
                      (fn [_cofx _event]
                        {:fx [[:rf2-lf84g/my-fx {:k 1}]]}))
     (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/uses-my-fx]))
@@ -106,7 +106,7 @@
   (testing ":rf.trace/trigger-handler is a top-level field on success
    traces, NOT nested under :tags — mirrors the error path shape"
     (rf/reg-fx :rf2-lf84g/top-level-fx (fn [_ _] :ok))
-    (rf/reg-event-fx :rf2-lf84g/use-top-level
+    (rf/reg-event :rf2-lf84g/use-top-level
                      (fn [_ _] {:fx [[:rf2-lf84g/top-level-fx {}]]}))
     (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/use-top-level]))
           [handled] (events-of evs :rf.fx/handled)]
@@ -119,7 +119,7 @@
   (testing "the :source-coord under :rf.trace/trigger-handler on
    :rf.fx/handled equals what the fx registrar holds"
     (rf/reg-fx :rf2-lf84g/coord-fx (fn [_ _] :ok))
-    (rf/reg-event-fx :rf2-lf84g/use-coord
+    (rf/reg-event :rf2-lf84g/use-coord
                      (fn [_ _] {:fx [[:rf2-lf84g/coord-fx {}]]}))
     (let [fx-meta (rf/handler-meta :fx :rf2-lf84g/coord-fx)
           evs     (record-traces #(rf/dispatch-sync [:rf2-lf84g/use-coord]))
@@ -136,9 +136,9 @@
   (testing "the reserved fx-id `:dispatch` has no registration of its
    own — the trigger-handler is the enclosing event handler. Reserved
    fx-id success traces stamp the outermost in-scope handler."
-    (rf/reg-event-fx :rf2-lf84g/parent
+    (rf/reg-event :rf2-lf84g/parent
                      (fn [_ _] {:fx [[:dispatch [:rf2-lf84g/child]]]}))
-    (rf/reg-event-db :rf2-lf84g/child (fn [db _] (assoc db :child? true)))
+    (rf/reg-event :rf2-lf84g/child (fn [{:keys [db]} _] {:db (assoc db :child? true)}))
     (let [evs       (record-traces #(rf/dispatch-sync [:rf2-lf84g/parent]))
           handled   (events-of evs :rf.fx/handled)
           parent-fx (first (filter #(= :dispatch (get-in % [:tags :rf.fx/id])) handled))]
@@ -177,7 +177,7 @@
   (testing "`:rf.event/db-changed` and `:rf.fx/do-fx` fire inside the event
    handler's *current-trigger-handler* binding — they carry the event
    handler's registration coord under :rf.trace/trigger-handler"
-    (rf/reg-event-fx :rf2-lf84g/changes-db
+    (rf/reg-event :rf2-lf84g/changes-db
                      (fn [_ _] {:db {:n 1} :fx []}))
     (let [evs   (record-traces #(rf/dispatch-sync [:rf2-lf84g/changes-db]))
           [dbc] (events-of evs :rf.event/db-changed)
@@ -344,7 +344,7 @@
                    ;; the enclosing event handler's).
                    (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {:from :cofx})
                    :ok))
-    (rf/reg-event-fx :rf2-npm2p/uses-cofx
+    (rf/reg-event :rf2-npm2p/uses-cofx
                      {:rf.cofx/requires [:rf2-npm2p/instrumented-cofx]}
                      (fn [_cofx _event] {}))
     (let [evs     (record-traces
@@ -360,7 +360,7 @@
                  (fn []
                    (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {})
                    :ok))
-    (rf/reg-event-fx :rf2-npm2p/use-top-level-cofx
+    (rf/reg-event :rf2-npm2p/use-top-level-cofx
                      {:rf.cofx/requires [:rf2-npm2p/top-level-cofx]}
                      (fn [_ _] {}))
     (let [evs     (record-traces
@@ -379,7 +379,7 @@
                  (fn []
                    (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {})
                    :ok))
-    (rf/reg-event-fx :rf2-npm2p/use-coord-cofx
+    (rf/reg-event :rf2-npm2p/use-coord-cofx
                      {:rf.cofx/requires [:rf2-npm2p/coord-cofx]}
                      (fn [_ _] {}))
     (let [cofx-meta (rf/handler-meta :cofx :rf2-npm2p/coord-cofx)
@@ -403,7 +403,7 @@
               (fn []
                 (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {})
                 :ok)))
-    (rf/reg-event-fx :rf2-npm2p/use-prog-cofx
+    (rf/reg-event :rf2-npm2p/use-prog-cofx
                      {:rf.cofx/requires [:rf2-npm2p/prog-cofx]}
                      (fn [_ _] {}))
     (let [evs     (record-traces

--- a/implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc
@@ -64,8 +64,8 @@
 (defn- counter-install!
   "Tiny app — :counter/inc bumps :n; :counter/init seeds to zero."
   []
-  (rf/reg-event-db ::counter-init (fn [db _]   (assoc db :n 0)))
-  (rf/reg-event-db ::counter-inc  (fn [db _]   (update db :n inc)))
+  (rf/reg-event ::counter-init (fn [{:keys [db]} _]   {:db (assoc db :n 0)}))
+  (rf/reg-event ::counter-inc  (fn [{:keys [db]} _]   {:db (update db :n inc)}))
   (rf/dispatch-sync [::counter-init]))
 
 (defn- counter-view

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -67,11 +67,11 @@
     @recorded))
 
 (defn- register-counter-handlers! []
-  (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
-  (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
-  (rf/reg-event-db :counter/dec  (fn [db _] (update db :n dec)))
-  (rf/reg-event-db :counter/add
-    (fn [db [_ amt]] (update db :n + amt))))
+  (rf/reg-event :counter/init (fn [{:keys [db]} _] {:db {:n 0}}))
+  (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+  (rf/reg-event :counter/dec  (fn [{:keys [db]} _] {:db (update db :n dec)}))
+  (rf/reg-event :counter/add
+    (fn [{:keys [db]} [_ amt]] {:db (update db :n + amt)})))
 
 ;; ---- dispatch-sequence ----------------------------------------------------
 

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -67,7 +67,7 @@
 
 (deftest trace-buffer-appends-events-as-cascades
   (testing "every emit lands in its frame's ring, grouped by :dispatch-id"
-    (rf/reg-event-db :ping (fn [db _] (assoc db :seen? true)))
+    (rf/reg-event :ping (fn [{:keys [db]} _] {:db (assoc db :seen? true)}))
     (rf/dispatch-sync [:ping])
     (let [cascades (rf/trace-buffer :rf/default)]
       (is (vector? cascades) "trace-buffer returns a vector")
@@ -500,8 +500,8 @@
     (is (nil? (get-in ev [:tags :rf.trace/parent-dispatch-id])))))
 
 (deftest fx-dispatch-inherits-parent-dispatch-id
-  (rf/reg-event-fx :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
-  (rf/reg-event-db :inner (fn [db _] (assoc db :inner? true)))
+  (rf/reg-event :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
+  (rf/reg-event :inner (fn [{:keys [db]} _] {:db (assoc db :inner? true)}))
   (rf/dispatch-sync [:outer])
   (let [evs   (dispatched-events (flat-events :rf/default))
         outer (->> evs
@@ -576,7 +576,7 @@
     ;; `:source :fx-dispatch` on the child envelope (the actor-message
     ;; path stamps `:machine-action` instead). Per rf2-1ve9h these are
     ;; the surviving axes after the `:rf/dispatch-origin` collapse.
-    (rf/reg-event-fx :parent (fn [_ _] {:fx [[:dispatch [:child]]]}))
+    (rf/reg-event :parent (fn [_ _] {:fx [[:dispatch [:child]]]}))
     (rf/reg-event-db :child (fn [db _] db))
     (rf/dispatch-sync [:parent] {:source :ui})
     (let [parent-ev (->> (flat-events :rf/default)
@@ -597,7 +597,7 @@
 (deftest tool-frame-emits-no-trace
   (testing "a frame registered :rf.trace/frame-no-emit? true grows the ring by 0"
     (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
-    (rf/reg-event-db :tool/work (fn [db _] (assoc db :ran? true)))
+    (rf/reg-event :tool/work (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
     (rf/clear-trace-buffer! :tool/inspector)
     (rf/dispatch-sync [:tool/work] {:frame :tool/inspector})
     (is (= [] (rf/trace-buffer :tool/inspector))
@@ -607,7 +607,7 @@
   (testing "an app frame's cascade DOES grow its ring; the tool frame's does NOT"
     (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
     (rf/reg-frame :app/main {:doc "ordinary application frame"})
-    (rf/reg-event-db :work (fn [db _] (assoc db :ran? true)))
+    (rf/reg-event :work (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
     (rf/clear-trace-buffer! :app/main)
     (rf/clear-trace-buffer! :tool/inspector)
     (dotimes [_ 20] (rf/dispatch-sync [:work] {:frame :tool/inspector}))
@@ -640,10 +640,10 @@
                                (when (= :rf.registry/handler-replaced
                                         (:operation ev))
                                  (swap! recv conj ev))))
-      (rf/reg-event-db :ev/hot {:doc "v1"} (fn [db _] (assoc db :v 1)))
+      (rf/reg-event :ev/hot {:doc "v1"} (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
       (reset! recv [])
       ;; Real edit — different handler-fn body.
-      (rf/reg-event-db :ev/hot {:doc "v1"} (fn [db _] (assoc db :v 2)))
+      (rf/reg-event :ev/hot {:doc "v1"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))
       (rf/unregister-listener! ::probe)
       (is (= 1 (count @recv))
           "exactly one :rf.registry/handler-replaced emitted on real edit")

--- a/implementation/core/test/re_frame/trace_bus_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/trace_bus_elision_prod_test.cljs
@@ -44,8 +44,8 @@
             ring buffer. Every emit site's body sits inside the
             `interop/debug-enabled?` gate; the buffer's push site
             (inside `deliver!`) does not run."
-    (rf/reg-event-db :prod-bus/inc
-                     (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :prod-bus/inc
+                     (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/dispatch-sync [:prod-bus/inc])
     (rf/dispatch-sync [:prod-bus/inc])
     (rf/dispatch-sync [:prod-bus/inc])

--- a/implementation/core/test/re_frame/trace_cascade_captured_test.clj
+++ b/implementation/core/test/re_frame/trace_cascade_captured_test.clj
@@ -66,7 +66,7 @@
 
 (deftest layer-1-memo-hit-emits-sub-skip
   (testing "a layer-1 sub deref against an unchanged db emits :rf.sub/skip"
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [events (collect-trace
@@ -93,7 +93,7 @@
 
 (deftest layer-2-memo-hit-emits-sub-skip-with-upstream
   (testing "layer-2 sub on memo-hit names its upstream input(s) in :rf.sub/input-paths-unchanged"
-    (rf/reg-event-db :seed (fn [_ _] {:n 3}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 3}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/reg-sub :doubled
       :<- [:n]
@@ -116,8 +116,8 @@
 
 (deftest flow-skip-emits-input-paths-unchanged
   (testing ":rf.flow/skip carries :rf.sub/input-paths-unchanged naming the flow's input paths"
-    (rf/reg-event-db :seed   (fn [_ _]      {:x 0 :y 0}))
-    (rf/reg-event-db :bump-z (fn [db _]     (assoc db :z (inc (or (:z db) 0)))))
+    (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:x 0 :y 0}}))
+    (rf/reg-event :bump-z (fn [{:keys [db]} _]     {:db (assoc db :z (inc (or (:z db) 0)))}))
     (rf/reg-flow {:id     :sum
                   :inputs [[:x] [:y]]
                   :output (fn [x y] (+ x y))
@@ -139,8 +139,8 @@
 
 (deftest cascade-captured-does-not-fire-when-no-focus
   (testing "default focus-predicate returns false → no :rf.cascade/captured emits"
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [events (collect-trace
@@ -155,8 +155,8 @@
 
 (deftest cascade-captured-fires-when-focused
   (testing "installed focus-predicate matching the cascade → :rf.cascade/captured emits"
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (cascade/set-focus-predicate!
       (fn [_frame _epoch _event] true))
@@ -224,8 +224,8 @@
 
 (deftest sub-run-value-changed-attribution
   (testing "a layer-1 recompute whose value CHANGED stamps :rf.sub/value-changed? true + :prev/:value, :rf.sub/cascade? false, :rf.sub/cause-sub nil"
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
@@ -250,8 +250,8 @@
     ;; identity (layer-1 reads app-db directly), so a db write to an
     ;; unrelated key forces the body to re-run, but the body returns a
     ;; `=`-equal value for this sub.
-    (rf/reg-event-db :seed   (fn [_ _] {:n 5 :other 0}))
-    (rf/reg-event-db :bump-other (fn [db _] (update db :other inc)))
+    (rf/reg-event :seed   (fn [{:keys [db]} _] {:db {:n 5 :other 0}}))
+    (rf/reg-event :bump-other (fn [{:keys [db]} _] {:db (update db :other inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
@@ -271,8 +271,8 @@
 
 (deftest sub-run-cascade-attribution-layer-2
   (testing "a layer-2 sub recomputed by an upstream sub change stamps :rf.sub/cascade? true + :rf.sub/cause-sub naming the upstream"
-    (rf/reg-event-db :seed (fn [_ _] {:n 2}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 2}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/reg-sub :doubled
       :<- [:n]
@@ -296,8 +296,8 @@
 
 (deftest sub-run-cascade-attribution-layer-2-multi-input
   (testing "a multi-input layer-2 sub names the SPECIFIC upstream that changed"
-    (rf/reg-event-db :seed (fn [_ _] {:a 1 :b 10}))
-    (rf/reg-event-db :inc-b (fn [db _] (update db :b inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:a 1 :b 10}}))
+    (rf/reg-event :inc-b (fn [{:keys [db]} _] {:db (update db :b inc)}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
     (rf/reg-sub :sum
@@ -325,7 +325,7 @@
             stamps :rf.sub/first-run? true on :rf.sub/run. Disambiguates
             a value-change row (`← was X`) from a fresh-cache-entry row
             (`:added`) for the Xray SUBSCRIPTIONS leaf-scalar renderer."
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     ;; First subscribe + deref → this is the run that creates the
@@ -353,8 +353,8 @@
             already-existing cache slot) stamps :rf.sub/first-run? false.
             Pairs with the true-case test above — the boolean must
             actually flip on the second run, not stay true."
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
@@ -380,7 +380,7 @@
             :rf.sub/first-run? true on the run that allocated their
             cache slot. The discriminator is universal across all
             memo wrappers (layer-1, layer-n-1, layer-n)."
-    (rf/reg-event-db :seed (fn [_ _] {:n 2}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 2}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/reg-sub :doubled
       :<- [:n]
@@ -399,8 +399,8 @@
 
 (deftest sub-run-layer-1-no-cause-sub
   (testing "a layer-1 sub never carries a :rf.sub/cause-sub (app-db-driven, not a cascade)"
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
@@ -417,8 +417,8 @@
 
 (deftest sub-run-base-shape-still-emitted
   (testing "the :rf.sub/run op-type vocabulary is unchanged — the base tags still ride"
-    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
@@ -460,7 +460,7 @@
             the :epoch/cascade-cause lookup consumes. Mirrors the
             views-side precedent at view_rendered_op_cljs_test/
             rf-view-rendered-carries-cause-event-id-in-cascade."
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r     (rf/subscribe [:n])
@@ -469,7 +469,7 @@
       ;; §The binary fx-handler signature — ctx carries `:frame`,
       ;; `:event`, `:envelope`; args is the value from the `:fx` vector.
       (rf/reg-fx :deref-fx (fn [_ctx _args] @r))
-      (rf/reg-event-fx :bump-and-deref
+      (rf/reg-event :bump-and-deref
         (fn [_ _]
           ;; The event handler returns the canonical `:db` / `:fx` shape
           ;; (re-frame2 rejects arbitrary top-level keys per
@@ -494,7 +494,7 @@
             absent (key not present), not nil, so consumers can read
             `(contains? tags :rf.sub/cause-event-id)` to discriminate
             in-cascade vs no-cascade recomputes."
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     ;; The seed dispatch has settled. The subscribe + deref below runs
@@ -519,7 +519,7 @@
             event) — distinct from :rf.sub/cause-sub (the upstream sub
             that propagated the change, which differs per sub in the
             chain). Two-sub fixture proves the slots are complementary."
-    (rf/reg-event-db :seed (fn [_ _] {:n 2}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 2}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/reg-sub :doubled
       :<- [:n]
@@ -530,7 +530,7 @@
           _         @r-n
           _         @r-doubled]
       (rf/reg-fx :deref-both-fx (fn [_ctx _args] @r-n @r-doubled))
-      (rf/reg-event-fx :bump-and-deref-both
+      (rf/reg-event :bump-and-deref-both
         (fn [_ _]
           {:db {:n 3}
            :fx [[:deref-both-fx true]]}))

--- a/implementation/core/test/re_frame/trace_listener_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/trace_listener_elision_prod_test.cljs
@@ -48,8 +48,8 @@
     (let [seen (atom [])]
       (trace-tooling/register-listener! ::prod-no-trace
         (fn [ev] (swap! seen conj ev)))
-      (rf/reg-event-db :prod/ping
-                       (fn [db _] (assoc db :pinged? true)))
+      (rf/reg-event :prod/ping
+                       (fn [{:keys [db]} _] {:db (assoc db :pinged? true)}))
       ;; The handler still runs (router is not elision-gated; only the
       ;; trace surface is).
       (rf/dispatch-sync [:prod/ping])

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -96,7 +96,7 @@
   (testing "listener has been called by the time dispatch-sync returns — no async wait"
     (let [seen (atom [])]
       (rf/register-listener! ::sync (fn [ev] (swap! seen conj ev)))
-      (rf/reg-event-db :sync/ping (fn [db _] (assoc db :pinged? true)))
+      (rf/reg-event :sync/ping (fn [{:keys [db]} _] {:db (assoc db :pinged? true)}))
       ;; The contract: dispatch-sync returns only after every listener has
       ;; been invoked for every emitted trace event in the cascade. No
       ;; sleep, no Thread/yield, no future deref. If `(seq @seen)` is empty
@@ -160,8 +160,8 @@
   (testing "a listener sees events in the same order the runtime fired them"
     (let [seen (atom [])]
       (rf/register-listener! ::ordered (fn [ev] (swap! seen conj ev)))
-      (rf/reg-event-db :ord/init (fn [_ _] {:n 0}))
-      (rf/reg-event-db :ord/inc  (fn [db _] (update db :n inc)))
+      (rf/reg-event :ord/init (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/reg-event :ord/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
       (rf/dispatch-sync [:ord/init])
       (rf/dispatch-sync [:ord/inc])
       (rf/dispatch-sync [:ord/inc])
@@ -179,7 +179,7 @@
   (testing "every emitted event has the canonical point-event keys and NO span-shape keys"
     (let [seen (atom [])]
       (rf/register-listener! ::shape (fn [ev] (swap! seen conj ev)))
-      (rf/reg-event-fx :shape/handler (fn [_ _] {:db {:n 1}
+      (rf/reg-event :shape/handler (fn [_ _] {:db {:n 1}
                                                  :fx []}))
       (rf/dispatch-sync [:shape/handler])
       (let [evs @seen]
@@ -213,7 +213,7 @@
     (let [seen (atom [])]
       (rf/reg-frame :frame/scoped {:doc "scoped"})
       (rf/register-listener! ::framed (fn [ev] (swap! seen conj ev)))
-      (rf/reg-event-db :framed/ping (fn [db _] (assoc db :ping? true)))
+      (rf/reg-event :framed/ping (fn [{:keys [db]} _] {:db (assoc db :ping? true)}))
       (rf/dispatch-sync [:framed/ping] {:frame :frame/scoped})
       (let [dispatched (->> @seen
                             dispatched-events
@@ -279,7 +279,7 @@
       (rf/register-listener! ::clear-a (fn [ev] (swap! seen-a conj ev)))
       (rf/register-listener! ::clear-b (fn [ev] (swap! seen-b conj ev)))
       (rf/register-listener! ::clear-c (fn [ev] (swap! seen-c conj ev)))
-      (rf/reg-event-db :clear/seed (fn [db _] (assoc db :seeded? true)))
+      (rf/reg-event :clear/seed (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
 
       ;; First dispatch — every listener observes the cascade.
       (rf/dispatch-sync [:clear/seed])

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -121,11 +121,11 @@
       (rf/reg-frame :test/main {:doc "comprehensive flow frame (rev 2)"})
 
       ;; ---- Event handlers --------------------------------------------------
-      (rf/reg-event-db :seed (fn [_ _] {:n 0 :items [1 2 3]}))
-      (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0 :items [1 2 3]}}))
+      (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
       ;; Re-register :inc with a different fn body to fire
       ;; :rf.registry/handler-replaced.
-      (rf/reg-event-db :inc  (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
 
       ;; Subs (used to demonstrate the absence of :sub/run / :sub/create
       ;; emit — see rf2-hyxg).
@@ -135,7 +135,7 @@
       ;; ---- A user-registered fx fires :event/do-fx wrapping the walk ------
       (let [fx-fired (atom 0)]
         (rf/reg-fx :test/incr (fn [_ _] (swap! fx-fired inc)))
-        (rf/reg-event-fx :do-fx-event
+        (rf/reg-event :do-fx-event
           (fn [_ _]
             {:db {:n 99}
              :fx [[:test/incr :go]]}))
@@ -145,7 +145,7 @@
       ;; ---- :rf.fx/override-applied ----------------------------------------
       (rf/reg-fx :prod/sender   (fn [_ _] :prod-fired))
       (rf/reg-fx :stub/sender   (fn [_ _] :stub-fired))
-      (rf/reg-event-fx :send
+      (rf/reg-event :send
         (fn [_ _] {:fx [[:prod/sender :payload]]}))
       (rf/dispatch-sync [:send]
                         {:frame        :test/main
@@ -159,7 +159,7 @@
                          :fx-overrides {:prod/sender :no-such/fx}})
 
       ;; ---- :rf.error/no-such-fx -------------------------------------------
-      (rf/reg-event-fx :send-broken
+      (rf/reg-event :send-broken
         (fn [_ _] {:fx [[:nonexistent/fx :payload]]}))
       (rf/dispatch-sync [:send-broken] {:frame :test/main})
 
@@ -172,7 +172,7 @@
 
       ;; ---- :rf.error/fx-handler-exception ---------------------------------
       (rf/reg-fx :throwing-fx (fn [_ _] (throw (ex-info "fx blew" {}))))
-      (rf/reg-event-fx :run-throwing-fx
+      (rf/reg-event :run-throwing-fx
         (fn [_ _] {:fx [[:throwing-fx :ignored]]}))
       (rf/dispatch-sync [:run-throwing-fx] {:frame :test/main})
 
@@ -180,7 +180,7 @@
       (rf/reg-fx :client-only-fx
                  {:platforms #{:client}}
                  (fn [_ _] :nope))
-      (rf/reg-event-fx :run-client-fx
+      (rf/reg-event :run-client-fx
         (fn [_ _] {:fx [[:client-only-fx :payload]]}))
       ;; The plain-atom adapter on JVM uses :server platform by default, so
       ;; this should skip-and-warn rather than execute.
@@ -199,7 +199,7 @@
       (rf/subscribe-once :test/main [:throwing-sub])
 
       ;; ---- :rf.error/dispatch-sync-in-handler -----------------------------
-      (rf/reg-event-fx :nested-sync
+      (rf/reg-event :nested-sync
         (fn [_ _]
           (rf/dispatch-sync [:inc] {:frame :test/main})
           {}))
@@ -212,7 +212,7 @@
       ;; ---- :rf.error/drain-depth-exceeded ---------------------------------
       ;; A handler that re-dispatches itself; the drain bound (default 100)
       ;; trips and emits the structured error.
-      (rf/reg-event-fx :loop-forever
+      (rf/reg-event :loop-forever
         (fn [_ _]
           {:fx [[:dispatch [:loop-forever]]]}))
       (rf/dispatch-sync [:loop-forever] {:frame :test/main})
@@ -265,10 +265,10 @@
         ;; Seed and trigger first tick.
         (rf/dispatch-sync [:seed] {:frame :test/main})
         ;; Initialise machine snapshot in app-db.
-        (rf/reg-event-db :machine/init
-          (fn [db _]
-            (assoc-in db [:rf.runtime/machines :snapshots :machine/tl]
-                      {:state :red :data {}})))
+        (rf/reg-event :machine/init
+          (fn [{:keys [db]} _]
+            {:db (assoc-in db [:rf.runtime/machines :snapshots :machine/tl]
+                      {:state :red :data {}})}))
         (rf/dispatch-sync [:machine/init] {:frame :test/main})
         (rf/dispatch-sync [:machine/tl [:tick]] {:frame :test/main})
         (rf/dispatch-sync [:machine/tl [:tick]] {:frame :test/main}))
@@ -569,7 +569,7 @@
                     :output (fn [n] (* 2 (or n 0)))
                     :path   [:doubled]})
       (rf/reg-fx :timing/side (fn [_ _] :ok))
-      (rf/reg-event-fx :timing/seed
+      (rf/reg-event :timing/seed
         (fn [_ _]
           {:db {:n 1}
            :fx [[:timing/side :go]]}))
@@ -607,7 +607,7 @@
       (rf/register-listener! ::b (fn [ev] (swap! b-events conj ev)))
       (rf/register-listener! ::c (fn [ev] (swap! c-events conj ev)))
 
-      (rf/reg-event-db :ping (fn [db _] (assoc db :ping? true)))
+      (rf/reg-event :ping (fn [{:keys [db]} _] {:db (assoc db :ping? true)}))
       (rf/dispatch-sync [:ping])
       (let [a1 (count @a-events)
             b1 (count @b-events)
@@ -648,8 +648,8 @@
       (rf/register-listener! ::survivor
         (fn [ev] (swap! survivor-events conj ev)))
 
-      (rf/reg-event-db :init (fn [_ _] {:n 0}))
-      (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+      (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
       ;; The dispatch flow MUST proceed despite the throwing listener.
       (rf/dispatch-sync [:init])
@@ -696,9 +696,9 @@
             run-end, not on db-commit (`:event/db-changed`), not for
             any in-cascade emit. Per Spec 009 §Trace-emission opt-out
             and rf2-qsjda."
-    (rf/reg-event-db :rf2-qsjda/internal-bookkeeping
+    (rf/reg-event :rf2-qsjda/internal-bookkeeping
                      {:rf.trace/no-emit? true}
-                     (fn [db _] (assoc db :bookkeeping/ran? true)))
+                     (fn [{:keys [db]} _] {:db (assoc db :bookkeeping/ran? true)}))
 
     (let [recorded (atom [])]
       (rf/register-listener! ::rec (fn [ev] (swap! recorded conj ev)))
@@ -736,9 +736,9 @@
             `:rf.trace/no-emit? true` produces the normal cascade
             traces (`:event/dispatched`, run-start, run-end,
             `:event/db-changed`). Pins the opt-out as the difference."
-    (rf/reg-event-db :rf2-qsjda/normal
+    (rf/reg-event :rf2-qsjda/normal
                      {:doc "without :rf.trace/no-emit?"}
-                     (fn [db _] (assoc db :normal/ran? true)))
+                     (fn [{:keys [db]} _] {:db (assoc db :normal/ran? true)}))
 
     (let [recorded (atom [])]
       (rf/register-listener! ::rec (fn [ev] (swap! recorded conj ev)))

--- a/implementation/core/test/re_frame/trigger_handler_coord_test.clj
+++ b/implementation/core/test/re_frame/trigger_handler_coord_test.clj
@@ -98,7 +98,7 @@
 
 (deftest trigger-handler-rides-at-top-level
   (testing ":rf.trace/trigger-handler is a top-level field, not nested under :tags"
-    (rf/reg-event-fx :rf2-3nn8/throws
+    (rf/reg-event :rf2-3nn8/throws
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [evs (record-traces
@@ -115,7 +115,7 @@
 
 (deftest event-handler-exception-carries-trigger-handler
   (testing ":rf.error/handler-exception carries the event handler's coord"
-    (rf/reg-event-fx :rf2-3nn8/throwing-event
+    (rf/reg-event :rf2-3nn8/throwing-event
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/throwing-event]))
@@ -127,7 +127,7 @@
    not the enclosing event (the fx body is what threw)"
     (rf/reg-fx :rf2-3nn8/throwing-fx
                (fn [_ctx _args] (throw (ex-info "fx boom" {}))))
-    (rf/reg-event-fx :rf2-3nn8/use-throwing-fx
+    (rf/reg-event :rf2-3nn8/use-throwing-fx
                      (fn [_cofx _event]
                        {:fx [[:rf2-3nn8/throwing-fx {}]]}))
     (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/use-throwing-fx]))
@@ -152,7 +152,7 @@
 (deftest no-such-fx-carries-enclosing-event-trigger-handler
   (testing ":rf.error/no-such-fx fires from the fx walker while the event
    handler scope is still bound — the enclosing event's coord is carried"
-    (rf/reg-event-fx :rf2-3nn8/uses-missing-fx
+    (rf/reg-event :rf2-3nn8/uses-missing-fx
                      (fn [_cofx _event]
                        {:fx [[:rf2-3nn8/no-such-fx {}]]}))
     (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/uses-missing-fx]))
@@ -176,7 +176,7 @@
 (deftest source-coord-matches-registration-site
   (testing "the :source-coord under :rf.trace/trigger-handler equals the
    value the registrar holds on the handler's slot"
-    (rf/reg-event-fx :rf2-3nn8/registration-site
+    (rf/reg-event :rf2-3nn8/registration-site
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [reg-meta (rf/handler-meta :event :rf2-3nn8/registration-site)

--- a/implementation/core/test/re_frame/world_inputs_test.clj
+++ b/implementation/core/test/re_frame/world_inputs_test.clj
@@ -389,11 +389,11 @@
       ;; so we read both the parent's and child's stamped world map.
       (rf/reg-fx :wi/capture-env
         (fn [m _args] (swap! envelopes conj (:envelope m))))
-      (rf/reg-event-fx :wi/parent
+      (rf/reg-event :wi/parent
         (fn [_ _]
           {:fx [[:wi/capture-env]
                 [:dispatch [:wi/child]]]}))
-      (rf/reg-event-fx :wi/child
+      (rf/reg-event :wi/child
         (fn [_ _]
           {:fx [[:wi/capture-env]]}))
 
@@ -457,10 +457,10 @@
       ;; uses — so we observe the world-inputs map the router stamped for it.
       (rf/reg-fx :wi.later/capture-env
         (fn [m _args] (reset! captured-child (:envelope m))))
-      (rf/reg-event-fx :wi.later/parent
+      (rf/reg-event :wi.later/parent
         (fn [_ _]
           {:fx [[:dispatch-later {:ms 50 :event [:wi.later/child]}]]}))
-      (rf/reg-event-fx :wi.later/child
+      (rf/reg-event :wi.later/child
         (fn [_ _]
           {:fx [[:wi.later/capture-env]]}))
 
@@ -656,7 +656,7 @@
     ;; the world-input coeffect (NOT an ambient `random-uuid` / `rand-nth`) and
     ;; folds them into a durable app-db entity. `reg-event-fx` so we can read
     ;; the `:rf.cofx` framework coeffect off the cofx map.
-    (rf/reg-event-fx :todo/create
+    (rf/reg-event :todo/create
       (fn [{:keys [db] cofx :rf.cofx} [_ text]]
         (let [id    (:todo/id cofx)
               color (:todo/color cofx)]
@@ -684,7 +684,7 @@
             (replay-stable), where an ambient random-uuid / rand-nth would have
             diverged run-to-run (EP-0010 §Restore, Replay, And Hydration)"
     (rf/reg-frame :wi/replay {:doc "ctx"})
-    (rf/reg-event-fx :todo/create-from-token
+    (rf/reg-event :todo/create-from-token
       (fn [{:keys [db] cofx :rf.cofx} _]
         (let [id    (:todo/id cofx)
               color (:todo/color cofx)]
@@ -745,7 +745,7 @@
   (testing "same causal token under two different ambient clocks → durable
             :committed-at EQUAL while the diagnostic trace :time DIFFERS"
     (rf/reg-frame :wi/split {:doc "ctx"})
-    (rf/reg-event-db :wi/note (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :wi/note (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [token-time   1781078400123     ; the supplied causal token :rf/time-ms
           ;; capture the diagnostic trace :time of THIS frame's :wi/note event
           ;; per run — the trace `:time` is stamped from the ambient

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -258,9 +258,9 @@
 (defn- register-one-of-each! []
   ;; the seed event for the whole-value law (registered per-test, inside the
   ;; fixture's restored registrar baseline).
-  (rf/reg-event-db ::seed-cart
-                   (fn [db [_ items]]
-                     (assoc-in db [:cart :items] items)))
+  (rf/reg-event ::seed-cart
+                   (fn [{:keys [db]} [_ items]]
+                     {:db (assoc-in db [:cart :items] items)}))
   ;; :subs — a layer-1 `:db` reader, a static `:<-` derivation over it (the
   ;; :input edge source carrying the shared sum-cart fn), a PARAMETRIC
   ;; input-fn sub (the don't-execute / parametric-marker subject), and a

--- a/implementation/epoch/test/re_frame/actor_revertibility_restore_test.clj
+++ b/implementation/epoch/test/re_frame/actor_revertibility_restore_test.clj
@@ -106,7 +106,7 @@
     (rf/reg-machine :rev/parent (parent))
     ;; Seed an epoch that PRE-DATES the spawn (a no-op self-event on a
     ;; trivial handler so there is a clean :ok epoch to rewind to).
-    (rf/reg-event-db :test/noop (fn [db _] (assoc db :seeded true)))
+    (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db (assoc db :seeded true)}))
     (rf/dispatch-sync [:test/noop] {:frame :test/main})
     (let [pre-spawn-epoch (last-epoch-id)]
       ;; Spawn the actor.
@@ -305,7 +305,7 @@
       ;; definition's :rf/machine-type :meta version (the "current" def). This
       ;; mirrors a hot-reload where an inline-spawned actor's definition moved
       ;; forward while an older recorded snapshot is being restored.
-      (rf/reg-event-fx :forge-drift
+      (rf/reg-event :forge-drift
         (fn [{rt :rf.db/runtime} _]
           (let [snap (get-in rt [:rf.runtime/machines :snapshots :rev/child#1])
                 bumped (-> snap

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -247,9 +247,9 @@
             assertion the whole class of escapes was missing — pre-fix A's
             sub-run leaked into B's epoch (the one-epoch lag)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed         (fn [_ _] {:title "a" :counter 0}))
-    (rf/reg-event-db :title-loaded (fn [db _] (assoc db :title "loaded")))
-    (rf/reg-event-db :counter-inc  (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed         (fn [{:keys [db]} _] {:db {:title "a" :counter 0}}))
+    (rf/reg-event :title-loaded (fn [{:keys [db]} _] {:db (assoc db :title "loaded")}))
+    (rf/reg-event :counter-inc  (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
@@ -288,15 +288,15 @@
             Pins that the post-settle back-fill does not poach in-flight
             sub-runs."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :sub-during
-      (fn [db _]
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :sub-during
+      (fn [{:keys [db]} _]
         (trace/emit! :rf.sub :rf.sub/run
                      {:rf.sub/id :inline-sub :rf.sub/query-v [:inline-sub]
                       :frame :test/main :rf.sub/value-changed? true
                       :rf.sub/prev-value nil :rf.sub/value :computed
                       :rf.sub/cascade? false :rf.sub/cause-sub nil})
-        (update db :n inc)))
+        {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:sub-during] {:frame :test/main})
@@ -368,8 +368,8 @@
             stayed stale-false — a coarse drop-gate consumer would not drop
             a record whose only sensitive content arrived via back-fill."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
@@ -399,8 +399,8 @@
             flip the rollup (the OR is fail-CLOSED, not fail-open): a clean
             cascade with a clean back-fill stays false."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
@@ -428,9 +428,9 @@
             title-view render leaked into B's epoch — a counter-inc epoch
             reporting title-view, which is IMPOSSIBLE."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed         (fn [_ _] {:title "a" :counter 0}))
-    (rf/reg-event-db :title-loaded (fn [db _] (assoc db :title "loaded")))
-    (rf/reg-event-db :counter-inc  (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed         (fn [{:keys [db]} _] {:db {:title "a" :counter 0}}))
+    (rf/reg-event :title-loaded (fn [{:keys [db]} _] {:db (assoc db :title "loaded")}))
+    (rf/reg-event :counter-inc  (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
@@ -462,12 +462,12 @@
             (synchronous flush — SSR / a render inside the cascade) belongs to
             that cascade and is buffered normally, NOT back-filled."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :render-during
-      (fn [db _]
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :render-during
+      (fn [{:keys [db]} _]
         (trace/emit! :rf.view :rf.view/rendered
                      {:rf.view/render-key [:inline-view 0] :frame :test/main})
-        (update db :n inc)))
+        {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:render-during] {:frame :test/main})
@@ -506,8 +506,8 @@
             never a view that mounts in epoch A and commits a late mount-burst
             tail in epoch B with unchanged inputs."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
-    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     ;; MOUNT epoch: seed settles, both views mount (render + first sub
     ;; recompute, synchronous in-render deref → reader-render-key stamped →
@@ -556,8 +556,8 @@
             mount epoch (where the instance already rendered) is de-duped: it
             does not add a second :renders row for the same render-key."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
-    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (emit-render! :test/main tv-rk)
@@ -585,8 +585,8 @@
             mount-epoch anchor only governs mount-burst tails — it must not
             over-reach and collapse genuine re-renders."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
-    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (emit-render! :test/main cv-rk)
@@ -624,8 +624,8 @@
             the raw stream is absent, so the render lands on the CURRENT epoch."
     (rf/configure! :epoch-history {:trace-events-keep 0})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
-    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     ;; Mount: seed cascade + the synchronous in-render deref that teaches the
     ;; view's read-set (`:counter`). The render-deps learning is independent of
@@ -684,8 +684,8 @@
             Two cascades, distinct values + distinct cause-subs, each pinned to
             its own epoch."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
-    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
@@ -735,8 +735,8 @@
             :rf.sub/value-changed? attribution. Without the re-fan a cached panel
             would show the stale settle-time record (the value-change absent)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
@@ -761,8 +761,8 @@
             post-settle render re-fans the corrected record so the Xray Views
             / Reactive panel re-syncs to the corrected :renders."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
@@ -795,8 +795,8 @@
             mounted in an earlier epoch, so the discriminator is the value
             change alone, not the mount anchor."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed        (fn [_ _] {:counter 0 :sidebar :open}))
-    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+    (rf/reg-event :seed        (fn [{:keys [db]} _] {:db {:counter 0 :sidebar :open}}))
+    (rf/reg-event :counter-inc (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
     ;; Epoch 1: seed. Both views mount here (read-set learned).
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -866,8 +866,8 @@
             frame with an :on-create, then dispatch a user event; that event's
             :trace-events must begin with its OWN ops, not [:frame
             :rf.frame/created]."
-    (rf/reg-event-db :app/init (fn [_ _] {:booted true :n 0}))
-    (rf/reg-event-db :inc      (fn [db _] (update db :n inc)))
+    (rf/reg-event :app/init (fn [{:keys [db]} _] {:db {:booted true :n 0}}))
+    (rf/reg-event :inc      (fn [{:keys [db]} _] {:db (update db :n inc)}))
     ;; reg-frame dispatch-syncs :on-create (settles epoch 1), THEN emits the
     ;; orphan :rf.frame/created.
     (rf/reg-frame :test/main {:on-create [:app/init]})
@@ -897,8 +897,8 @@
             :trace-events should reference it. Belt-and-braces on the
             correlation contract: walk every retained epoch's :trace-events
             and assert none is a :frame op."
-    (rf/reg-event-db :app/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc      (fn [db _] (update db :n inc)))
+    (rf/reg-event :app/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc      (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-frame :test/main {:on-create [:app/init]})
     (rf/dispatch-sync [:inc] {:frame :test/main})
     (rf/dispatch-sync [:inc] {:frame :test/main})
@@ -1167,8 +1167,8 @@
       (is (not (trace/frame-trace-disabled? app))
           "the inspected app frame is NOT trace-disabled")
 
-      (rf/reg-event-db :app/seed (fn [_ _] {:counter 0}))
-      (rf/reg-event-db :app/inc  (fn [db _] (update db :counter inc)))
+      (rf/reg-event :app/seed (fn [{:keys [db]} _] {:db {:counter 0}}))
+      (rf/reg-event :app/inc  (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
       ;; The app frame produces a boot epoch (a last-settled epoch the
       ;; back-fill would attribute to).
@@ -1201,8 +1201,8 @@
             the exact leak the bug exhibited."
     (let [app :test/app]
       (rf/reg-frame app {})
-      (rf/reg-event-db :app/seed (fn [_ _] {:counter 0}))
-      (rf/reg-event-db :app/inc  (fn [db _] (update db :counter inc)))
+      (rf/reg-event :app/seed (fn [{:keys [db]} _] {:db {:counter 0}}))
+      (rf/reg-event :app/inc  (fn [{:keys [db]} _] {:db (update db :counter inc)}))
 
       (rf/dispatch-sync [:app/seed] {:frame app})
       (rf/dispatch-sync [:app/inc]  {:frame app})
@@ -1235,7 +1235,7 @@
             carries this data (the render-START :rf.view/render carries only the
             render-key)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     ;; Post-settle :rf.view/rendered carrying cause + timing (React-commit
@@ -1262,7 +1262,7 @@
             the op — none of the view's own subs changed) lands a :renders row
             WITHOUT :triggered-by; :elapsed-ms still rides."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (trace/emit! :rf.view :rf.view/rendered
@@ -1298,7 +1298,7 @@
             the slot the Story :view causal surface reads. Pre-fix render-row
             dropped it and the surface silently measured 0 (false GREEN)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     ;; Post-settle :rf.view/rendered carrying the cause attribution (mirrors
@@ -1322,7 +1322,7 @@
             WITHOUT :cause-event-id. OMITTED-vs-nil parity with the sub-row:
             absent tag → absent slot, never an attributed nil."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (trace/emit! :rf.view :rf.view/rendered
@@ -1458,8 +1458,8 @@
             until whole-frame destroy. Pre-fix every ever-mounted instance
             left a permanent entry; the map grew without bound across churn."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed       (fn [_ _] {:rows (vec (range 5))}))
-    (rf/reg-event-db :drop-rows  (fn [db _] (assoc db :rows [])))
+    (rf/reg-event :seed       (fn [{:keys [db]} _] {:db {:rows (vec (range 5))}}))
+    (rf/reg-event :drop-rows  (fn [{:keys [db]} _] {:db (assoc db :rows [])}))
 
     ;; A real settled cascade so the frame has a last-settled epoch the
     ;; unmount back-fill can land in (the live-frame path, not just the
@@ -1553,8 +1553,8 @@
             the orphan-drop branch and produced no signal, so Xray's VIEWS
             step had nothing to surface (button-deck button 13)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed         (fn [_ _] {:show-child? true}))
-    (rf/reg-event-db :hide-child   (fn [db _] (assoc db :show-child? false)))
+    (rf/reg-event :seed         (fn [{:keys [db]} _] {:db {:show-child? true}}))
+    (rf/reg-event :hide-child   (fn [{:keys [db]} _] {:db (assoc db :show-child? false)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     ;; The cascade that removes the child view from the tree. It settles,
@@ -1581,9 +1581,9 @@
             it (no one-epoch lag, no cross-attribution). The multi-cascade
             assertion mirroring inv-2 for renders."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed       (fn [_ _] {:a? true :b? true}))
-    (rf/reg-event-db :hide-a     (fn [db _] (assoc db :a? false)))
-    (rf/reg-event-db :hide-b     (fn [db _] (assoc db :b? false)))
+    (rf/reg-event :seed       (fn [{:keys [db]} _] {:db {:a? true :b? true}}))
+    (rf/reg-event :hide-a     (fn [{:keys [db]} _] {:db (assoc db :a? false)}))
+    (rf/reg-event :hide-b     (fn [{:keys [db]} _] {:db (assoc db :b? false)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
@@ -1614,14 +1614,14 @@
             is buffered normally, NOT back-filled. Pins that the post-settle
             routing does not poach an in-flight unmount."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :unmount-during
-      (fn [db _]
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :unmount-during
+      (fn [{:keys [db]} _]
         (trace/emit! :rf.view :rf.view/unmounted
                      {:rf.view/id         :inline-view
                       :rf.view/render-key [:inline-view 0]
                       :frame              :test/main})
-        (update db :n inc)))
+        {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:unmount-during] {:frame :test/main})

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -78,8 +78,8 @@
   (testing "dispatch a single event under CLJS — exactly one record
             lands in the ring with the canonical shape (`:event-id`,
             `:db-before`, `:db-after`, `:effects`, `:outcome :ok`)"
-    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:n/init])
     (rf/dispatch-sync [:n/inc])
@@ -129,9 +129,9 @@
             :trace-events (parity with :where :app-db)"
     (rf/reg-app-schema [:auth] [:map [:token :string]])
     (let [calls (atom 0)]
-      (rf/reg-event-db :lo28u/bad-event-args
+      (rf/reg-event :lo28u/bad-event-args
         {:schema [:cat [:= :lo28u/bad-event-args] pos-int?]}
-        (fn [db _ev] (swap! calls inc) (assoc db :baseline 1)))
+        (fn [{:keys [db]} _ev] (swap! calls inc) {:db (assoc db :baseline 1)}))
 
       (rf/dispatch-sync [:lo28u/bad-event-args "not-a-number"])
 
@@ -158,8 +158,8 @@
 (deftest restore-rewinds-app-db-cljs
   (testing "dispatch three events, restore to the second — app-db
             matches the recorded :db-after"
-    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:n/init])             ;; n=0
     (rf/dispatch-sync [:n/inc])              ;; n=1
@@ -182,8 +182,8 @@
 (deftest ring-depth-evicts-oldest-cljs
   (testing "configure :depth 3, dispatch 5 events, oldest 2 are dropped"
     (rf/configure! :epoch-history {:depth 3})
-    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:n/init])             ;; n=0, would-be record #1
     (dotimes [_ 4] (rf/dispatch-sync [:n/inc])) ;; n=1..4, records #2..#5
@@ -202,8 +202,8 @@
             contract Xray's preload (`:rf.xray/epoch-recorded`)
             routes through. The companion `:rf.epoch/snapshotted`
             trace also fires once per dispatch."
-    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [cb-seen    (atom [])
           trace-seen (atom [])]
@@ -258,7 +258,7 @@
     ;; assertion; pairing it with the framework-level grep gives the
     ;; cross-mode pin (`gate=true` => surface lives; `gate=false`
     ;; => bundle elided).
-    (rf/reg-event-db :probe/init (fn [_ _] {:n 0}))
+    (rf/reg-event :probe/init (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:probe/init])
     (is (pos? (count (rf/epoch-history :rf/default)))
         "with the gate ON, a dispatch lands a record in the ring")))

--- a/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
@@ -67,8 +67,8 @@
             JVM-benign but would land :committed-at ~12 orders of magnitude
             low here and fail this band — the blind spot rf2-2elcw3 exposed
             for resources, now closed for the durable :committed-at field."
-    (rf/reg-event-db :clk/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :clk/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :clk/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :clk/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     ;; Capture js/Date.now() bracketing the dispatch so the comparison band
     ;; is tight and robust to scheduling. The dispatch is intentionally

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -203,8 +203,8 @@
       (doseq [{:keys [frame-id]} per-thread]
         (rf/reg-frame frame-id
                       {:doc "per-thread frame for epoch settle stress"}))
-      (rf/reg-event-db :bump (fn [db [_ i]]
-                               (assoc db :last i)))
+      (rf/reg-event :bump (fn [{:keys [db]} [_ i]]
+                               {:db (assoc db :last i)}))
 
       (let [latch   (CountDownLatch. 1)
             futures (vec
@@ -293,8 +293,8 @@
     ;; `ring-depth-evicts-oldest` pin.
     (rf/configure! :epoch-history {:depth (* 2 stress-iters)})
     (rf/reg-frame :rd7a7.fanout/main {:doc "fanout-stress frame"})
-    (rf/reg-event-db :bump (fn [db [_ i]]
-                             (assoc db :last i)))
+    (rf/reg-event :bump (fn [{:keys [db]} [_ i]]
+                             {:db (assoc db :last i)}))
 
     ;; Two pinned listeners share one `let`-scope so both atoms stay
     ;; live through the assertion phase below:
@@ -429,8 +429,8 @@
     ;; covers the cap behaviour.
     (rf/configure! :epoch-history {:depth (* 2 stress-iters)})
     (rf/reg-frame :rd7a7.race/main {:doc "ring-buffer race frame"})
-    (rf/reg-event-db :bump (fn [db [_ i]]
-                             (assoc db :last i)))
+    (rf/reg-event :bump (fn [{:keys [db]} [_ i]]
+                             {:db (assoc db :last i)}))
 
     (let [consumer-stop  (atom false)
           consumer-error (atom nil)
@@ -585,7 +585,7 @@
           frames (mapv (fn [t] (keyword "ep0015.cas" (str "frame-" t)))
                        (range n))]
       ;; Seed each frame with one settled epoch (the back-fill target).
-      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
       (doseq [frame-id frames]
         (rf/reg-frame frame-id {})
         (rf/dispatch-sync [:seed] {:frame frame-id}))

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -124,7 +124,7 @@
             the not-emit-redacted shapes (pinned by the unit tests)"
     (rf/reg-frame :test/eg {})
     (install-sensitive-schema! :test/eg)
-    (rf/reg-event-db :login (fn [db _] (assoc-in db [:auth :password] secret)))
+    (rf/reg-event :login (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret)}))
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
     (let [raw    (last (rf/epoch-history :test/eg))
@@ -156,7 +156,7 @@
             redacted (pinned directly by the unit tests below)"
     (rf/reg-frame :test/eg {})
     (install-sensitive-schema! :test/eg)
-    (rf/reg-event-db :login (fn [db _] (assoc-in db [:auth :password] secret)))
+    (rf/reg-event :login (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret)}))
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
     (let [raw       (last (rf/epoch-history :test/eg))
@@ -182,8 +182,8 @@
             :rf.event/db tag"
     (rf/reg-frame :test/eg {})
     (install-sensitive-schema! :test/eg)
-    (rf/reg-event-db :seed  (fn [_ _] {}))
-    (rf/reg-event-db :login (fn [db _] (assoc-in db [:auth :password] secret)))
+    (rf/reg-event :seed  (fn [{:keys [db]} _] {:db {}}))
+    (rf/reg-event :login (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret)}))
     (rf/dispatch-sync [:seed]  {:frame :test/eg})
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
@@ -362,7 +362,7 @@
             double-project do not corrupt or re-leak the nested slot"
     (rf/reg-frame :test/eg {})
     (install-sensitive-schema! :test/eg)
-    (rf/reg-event-db :login (fn [db _] (assoc-in db [:auth :password] secret)))
+    (rf/reg-event :login (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret)}))
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
     (let [raw    (last (rf/epoch-history :test/eg))

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -63,8 +63,8 @@
             `(when interop/debug-enabled? ...)` — the per-frame
             history vector stays empty."
     (rf/configure! :epoch-history {:depth 100})
-    (rf/reg-event-db :prod-epoch/inc
-                     (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :prod-epoch/inc
+                     (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/dispatch-sync [:prod-epoch/inc])
     (rf/dispatch-sync [:prod-epoch/inc])
     (rf/dispatch-sync [:prod-epoch/inc])
@@ -84,8 +84,8 @@
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::prod-epoch-listener
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :prod-epoch/ping
-                       (fn [db _] (assoc db :pinged? true)))
+      (rf/reg-event :prod-epoch/ping
+                       (fn [{:keys [db]} _] {:db (assoc db :pinged? true)}))
       (rf/dispatch-sync [:prod-epoch/ping])
       (rf/dispatch-sync [:prod-epoch/ping])
       (is (empty? @seen)
@@ -116,8 +116,8 @@
             via an `(if-not …)` early-return. Under prod it returns
             `false` WITHOUT mutating app-db — the dev-only Pair-tool
             write surface is firewalled from production state."
-    (rf/reg-event-db :prod-epoch/seed
-                     (fn [_db _] {:original true}))
+    (rf/reg-event :prod-epoch/seed
+                     (fn [{:keys [db]} _] {:db {:original true}}))
     (rf/dispatch-sync [:prod-epoch/seed])
     (is (= {:original true}
            (rf/app-db-value :rf/default))

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -53,8 +53,8 @@
             primary motivating concern of the audit (tokens / PII /
             secrets retained in SSR process memory) is addressed."
     (with-redefs [interop/debug-enabled? false]
-      (rf/reg-event-db :prod-gate.epoch/inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod-gate.epoch/inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.epoch/inc])
       (rf/dispatch-sync [:prod-gate.epoch/inc])
       (rf/dispatch-sync [:prod-gate.epoch/inc])
@@ -71,8 +71,8 @@
         (epoch/register-epoch-listener!
           :prod-gate.epoch/recorder
           (fn [record] (swap! seen conj record)))
-        (rf/reg-event-db :prod-gate.epoch/silent
-                         (fn [db _] (update db :n (fnil inc 0))))
+        (rf/reg-event :prod-gate.epoch/silent
+                         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         (rf/dispatch-sync [:prod-gate.epoch/silent])
         (is (empty? @seen)
             "epoch listener silent under disabled debug gate")))))
@@ -101,8 +101,8 @@
             (dev parity), epoch recording continues to work. This
             test fails fast if a future refactor accidentally
             disables the surface in dev."
-    (rf/reg-event-db :prod-gate.epoch/dev-inc
-                     (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :prod-gate.epoch/dev-inc
+                     (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/dispatch-sync [:prod-gate.epoch/dev-inc])
     (is (pos? (count (epoch/epoch-history :rf/default)))
         "epoch ring has at least one record under default gate")))
@@ -118,8 +118,8 @@
             no consumer can reach a record through under the disabled
             gate."
     (with-redefs [interop/debug-enabled? false]
-      (rf/reg-event-db :prod-gate.priv/silent
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod-gate.priv/silent
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.priv/silent])
       (is (= [] (epoch/projected-history :rf/default))
           "empty projected-history under the disabled gate"))))
@@ -131,9 +131,9 @@
             runs. We verify by asserting the ring stays empty — no
             record means no rollup compute path was reached."
     (with-redefs [interop/debug-enabled? false]
-      (rf/reg-event-db :prod-gate.priv/sensitive
+      (rf/reg-event :prod-gate.priv/sensitive
                        {:sensitive? true}
-                       (fn [db _] (assoc db :token "shh")))
+                       (fn [{:keys [db]} _] {:db (assoc db :token "shh")}))
       (rf/dispatch-sync [:prod-gate.priv/sensitive])
       (is (empty? (epoch/epoch-history :rf/default))
           "no record assembled — rollup never reached"))))
@@ -159,8 +159,8 @@
                       {:redact-fn (fn [r]
                                     (swap! invocations inc)
                                     r)})
-        (rf/reg-event-db :prod-gate.redact/inc
-                         (fn [db _] (update db :n (fnil inc 0))))
+        (rf/reg-event :prod-gate.redact/inc
+                         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         (rf/dispatch-sync [:prod-gate.redact/inc])
         (rf/dispatch-sync [:prod-gate.redact/inc])
         (rf/dispatch-sync [:prod-gate.redact/inc])
@@ -180,8 +180,8 @@
       (rf/reg-frame :prod-gate.dev/frame {})
       (rf/configure! :epoch-history
                     {:redact-fn (fn [r] (swap! invocations inc) r)})
-      (rf/reg-event-db :prod-gate.redact/dev-inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod-gate.redact/dev-inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.redact/dev-inc] {:frame :prod-gate.dev/frame})
       (is (zero? @invocations)
           ":redact-fn NOT invoked by settle — it is projection-side only")
@@ -225,8 +225,8 @@
                                  (swap! warnings conj ev))))
       (rf/configure! :epoch-history
                     {:redact-fn (fn [_r] (throw (ex-info "boom" {})))})
-      (rf/reg-event-db :prod-gate.redact/throw
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod-gate.redact/throw
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.redact/throw] {:frame :prod-gate.throw/frame})
       (rf/dispatch-sync [:prod-gate.redact/throw] {:frame :prod-gate.throw/frame})
       (let [redact-warns (filter (fn [ev]

--- a/implementation/epoch/test/re_frame/epoch_late_bind_missing_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_late_bind_missing_cljs_test.cljs
@@ -87,7 +87,7 @@
             surface does NOT raise. Without this pair, the missing-
             hook assertion above could pass for the wrong reason
             (e.g. a typo'd hook key that's never wired)."
-    (rf/reg-event-db :seed/cljs (fn [_ _] {:n 0}))
+    (rf/reg-event :seed/cljs (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed/cljs])
     ;; Replace the live db with a fresh value; surface returns true
     ;; (no exception).

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -120,10 +120,10 @@
   Returns the resulting `(epoch-history frame-id)` for direct comparison
   with `(projected-history frame-id)`."
   [frame-id]
-  (rf/reg-event-db :seed   (fn [_ _] {:n 0}))
-  (rf/reg-event-db :login  (fn [db _] (assoc-in db [:auth :password] secret-password)))
-  (rf/reg-event-db :upload (fn [db _] (assoc-in db [:blob :payload] (big-string payload-size))))
-  (rf/reg-event-db :inc    (fn [db _] (update db :n (fnil inc 0))))
+  (rf/reg-event :seed   (fn [{:keys [db]} _] {:db {:n 0}}))
+  (rf/reg-event :login  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret-password)}))
+  (rf/reg-event :upload (fn [{:keys [db]} _] {:db (assoc-in db [:blob :payload] (big-string payload-size))}))
+  (rf/reg-event :inc    (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
   (rf/dispatch-sync [:seed]   {:frame frame-id})
   (rf/dispatch-sync [:login]  {:frame frame-id})
   (rf/dispatch-sync [:upload] {:frame frame-id})
@@ -497,7 +497,7 @@
       (rf/reg-fx :fxp/login (fn [_ _] nil))
       ;; Write the app-db sensitive path AND fire a payload-bearing fx whose
       ;; :args carry the same secret bytes.
-      (rf/reg-event-fx :do-login
+      (rf/reg-event :do-login
                        (fn [_ [_ c]]
                          {:db {:auth {:password (:password c)}}
                           :fx [[:fxp/login c]]}))
@@ -525,7 +525,7 @@
     (install-fx-and-runtime-schemas! :test/mcp)
     ;; Write BOTH the app-db sensitive leaf and a runtime-db partition value
     ;; (via the reserved :rf.db/runtime effect) in one cascade.
-    (rf/reg-event-fx :seed-both
+    (rf/reg-event :seed-both
                      (fn [{rt :rf.db/runtime} _]
                        {:db            {:auth {:password secret-password}}
                         :rf.db/runtime (assoc-in (or rt {})
@@ -564,9 +564,9 @@
             the sensitive opt-in must not pull the full payload off-box."
     (rf/reg-frame :test/mcp {})
     (install-fx-and-runtime-schemas! :test/mcp)
-    (rf/reg-event-db :seed-large
-                     (fn [_ _] {:auth {:password secret-password}
-                                :blob {:payload (big-string payload-size)}}))
+    (rf/reg-event :seed-large
+                     (fn [{:keys [db]} _] {:db {:auth {:password secret-password}
+                                :blob {:payload (big-string payload-size)}}}))
     (rf/dispatch-sync [:seed-large] {:frame :test/mcp})
     (let [raw  (last (rf/epoch-history :test/mcp))
           proj (epoch/projected-record raw {:include-sensitive? true})]
@@ -597,8 +597,8 @@
     (rf/configure! :epoch-history
                    {:redact-fn (fn [record]
                                  (assoc record :rf.test/redact-fn-ran true))})
-    (rf/reg-event-db :seed-sensitive
-                     (fn [_ _] {:auth {:password secret-password}}))
+    (rf/reg-event :seed-sensitive
+                     (fn [{:keys [db]} _] {:db {:auth {:password secret-password}}}))
     (rf/dispatch-sync [:seed-sensitive] {:frame :test/mcp})
     (let [raw  (last (rf/epoch-history :test/mcp))
           proj (epoch/projected-record raw {:include-sensitive? true})]

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -105,7 +105,7 @@
   (testing "no sensitive handler, no frame-declared sensitive path —
             rollup reads strict false"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (false? (:rf.epoch/sensitive? r)))
@@ -120,9 +120,9 @@
             false for a cascade whose only sensitive signal was the
             (now-ignored) handler annotation."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :secret-write
+    (rf/reg-event :secret-write
                      {:sensitive? true}   ;; stored, no longer consulted
-                     (fn [db _] (assoc db :token "shh")))
+                     (fn [{:keys [db]} _] {:db (assoc db :token "shh")}))
     (rf/dispatch-sync [:secret-write] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (false? (:rf.epoch/sensitive? r))
@@ -134,8 +134,8 @@
             in scope is sensitive"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (true? (:rf.epoch/sensitive? r))))))
@@ -147,7 +147,7 @@
             cascade carried no actual sensitive material)"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :unrelated (fn [db _] (assoc db :n 42)))
+    (rf/reg-event :unrelated (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
     (rf/dispatch-sync [:unrelated] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (false? (:rf.epoch/sensitive? r))
@@ -160,10 +160,10 @@
             the value during the cascade"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :seed
-                     (fn [_ _] {:auth {:password "old-secret"}}))
-    (rf/reg-event-db :clear-pw
-                     (fn [db _] (update db :auth dissoc :password)))
+    (rf/reg-event :seed
+                     (fn [{:keys [db]} _] {:db {:auth {:password "old-secret"}}}))
+    (rf/reg-event :clear-pw
+                     (fn [{:keys [db]} _] {:db (update db :auth dissoc :password)}))
 
     (rf/dispatch-sync [:seed]     {:frame :test/main})
     (rf/dispatch-sync [:clear-pw] {:frame :test/main})
@@ -203,7 +203,7 @@
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::halt-watcher
                              (fn [r] (swap! seen conj r)))
-      (rf/reg-event-fx :destroy-self
+      (rf/reg-event :destroy-self
                        (fn [_ _]
                          (frame/destroy-frame! :test/main)
                          {}))
@@ -259,8 +259,8 @@
             :rf/redacted in the projected record"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
@@ -276,9 +276,9 @@
             record"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :seed
-                     (fn [_ _] {:auth {:password "original-secret"}}))
-    (rf/reg-event-db :inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :seed
+                     (fn [{:keys [db]} _] {:db {:auth {:password "original-secret"}}}))
+    (rf/reg-event :inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
@@ -297,9 +297,9 @@
             :rf.size/large-elided marker in the projected record"
     (rf/reg-frame :test/main {})
     (install-large-schema! :test/main)
-    (rf/reg-event-db :store
-                     (fn [db [_ payload]]
-                       (assoc-in db [:blob :payload] payload)))
+    (rf/reg-event :store
+                     (fn [{:keys [db]} [_ payload]]
+                       {:db (assoc-in db [:blob :payload] payload)}))
     (rf/dispatch-sync [:store (big-string 50000)] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
@@ -326,7 +326,7 @@
             (`:sub-id`, `:query-v`, `:value-changed?`, `:cascade?`) is
             preserved, and the now-spent `:large?` row flag is stripped."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     ;; A whole-output `:large?` sub: its output is treated as large for
     ;; downstream egress regardless of any per-path declaration. The
     ;; reactive sub-cache records this via `mark-sub-output!` at build
@@ -337,7 +337,7 @@
     ;; Read the sub inside a handler so a `:rf.sub/run` lands in the
     ;; cascade's structured `:sub-runs` (mirrors epoch_test's
     ;; sub-runs-projection).
-    (rf/reg-event-fx :read-big
+    (rf/reg-event :read-big
                      (fn [_ _]
                        (let [_v (rf/subscribe-once :test/main [:big])]
                          {})))
@@ -395,8 +395,8 @@
             projection only mutates payload-bearing slots"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
@@ -421,8 +421,8 @@
             pinned by the rf2-rlt3sv tests below.)"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
@@ -453,7 +453,7 @@
     (rf/reg-frame :test/main {})
     (let [secret {:password "topsecret" :token "abc123"}]
       (rf/reg-fx :fxp/login (fn [_ _] nil))
-      (rf/reg-event-fx :do-login
+      (rf/reg-event :do-login
                        (fn [_ [_ creds]] {:fx [[:fxp/login creds]]}))
       (rf/dispatch-sync [:do-login secret] {:frame :test/main})
 
@@ -484,7 +484,7 @@
     (let [secret {:k "session-key" :v "secret-value"}]
       ;; :client-only fx is skipped on the JVM (:server) host.
       (rf/reg-fx :fxp/local-storage {:platforms #{:client}} (fn [_ _] nil))
-      (rf/reg-event-fx :save
+      (rf/reg-event :save
                        (fn [_ [_ payload]] {:fx [[:fxp/local-storage payload]]}))
       (rf/dispatch-sync [:save secret] {:frame :test/main})
 
@@ -505,7 +505,7 @@
     (rf/reg-frame :test/main {})
     (let [secret {:card "4111-1111-1111-1111"}]
       ;; No fx registered under :fxp/missing → :rf.error/no-such-fx.
-      (rf/reg-event-fx :charge
+      (rf/reg-event :charge
                        (fn [_ [_ payload]] {:fx [[:fxp/missing payload]]}))
       (rf/dispatch-sync [:charge secret] {:frame :test/main})
 
@@ -528,7 +528,7 @@
     (rf/reg-frame :test/main {})
     (let [secret {:ssn "123-45-6789"}]
       (rf/reg-fx :fxp/boom (fn [_ _] (throw (ex-info "boom" {}))))
-      (rf/reg-event-fx :explode
+      (rf/reg-event :explode
                        (fn [_ [_ payload]] {:fx [[:fxp/boom payload]]}))
       (rf/dispatch-sync [:explode secret] {:frame :test/main})
 
@@ -550,7 +550,7 @@
             :rf/redacted sentinel (no drift under double-projection)"
     (rf/reg-frame :test/main {})
     (rf/reg-fx :fxp/login (fn [_ _] nil))
-    (rf/reg-event-fx :do-login
+    (rf/reg-event :do-login
                      (fn [_ [_ creds]] {:fx [[:fxp/login creds]]}))
     (rf/dispatch-sync [:do-login {:password "topsecret"}] {:frame :test/main})
 
@@ -576,8 +576,8 @@
     ;; This test pins that the projection RAN against :trigger-event
     ;; (the slot exists in the projected record) — what it changes
     ;; depends on the registered declarations.
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
@@ -600,9 +600,9 @@
       (frame-class/validate+extract :test/main
         {:sensitive {:app-db [[:secret-pdf]]}
          :large     {:app-db [[:secret-pdf]]}}))
-    (rf/reg-event-db :store-pdf
-                     (fn [db [_ payload]]
-                       (assoc db :secret-pdf payload)))
+    (rf/reg-event :store-pdf
+                     (fn [{:keys [db]} [_ payload]]
+                       {:db (assoc db :secret-pdf payload)}))
     (rf/dispatch-sync [:store-pdf (big-string 50000)] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
@@ -648,9 +648,9 @@
             entry, in oldest-first order"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :seed (fn [_ _] {}))
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {}}))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
 
     (rf/dispatch-sync [:seed]              {:frame :test/main})
     (rf/dispatch-sync [:login "secret-1"]  {:frame :test/main})
@@ -687,8 +687,8 @@
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::raw-listener
                              (fn [r] (swap! seen conj r)))
-      (rf/reg-event-db :login
-                       (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+      (rf/reg-event :login
+                       (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
       (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
       (is (= 1 (count @seen)) "listener fired once")
       (is (= "topsecret"
@@ -707,8 +707,8 @@
                     ;; Tool-side forwarder body — project here.
                     (swap! shipped conj (epoch/projected-record record)))]
       (rf/register-epoch-listener! ::forwarder ship!)
-      (rf/reg-event-db :login
-                       (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+      (rf/reg-event :login
+                       (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
       (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
       (is (= 1 (count @shipped)))
       (is (= :rf/redacted
@@ -724,8 +724,8 @@
             oldest records lose :trace-events but keep the structured
             projections (per rf2-mrsck)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (is (= 5 (:trace-events-keep (epoch/current-config)))
         "fixture OVERRIDE — the shipped runtime default is 50 (= :depth)")
@@ -750,8 +750,8 @@
             record — the structured projections survive"
     (rf/configure! :epoch-history {:trace-events-keep 0})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
@@ -769,8 +769,8 @@
             keeps every record's :trace-events — the opt-back-in path"
     (rf/configure! :epoch-history {:trace-events-keep 100})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (dotimes [_ 6] (rf/dispatch-sync [:inc] {:frame :test/main}))
@@ -789,8 +789,8 @@
             an empty ring is the empty vector — projected-record never
             gets called against a record."
     (with-redefs [interop/debug-enabled? false]
-      (rf/reg-event-db :prod.priv/inc
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod.priv/inc
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod.priv/inc])
       (is (= [] (epoch/projected-history :rf/default))
           "no records to project under disabled gate"))))
@@ -828,8 +828,8 @@
             path drops the entire surface — the rollup is dev-only
             because the records are dev-only."
     (with-redefs [interop/debug-enabled? false]
-      (rf/reg-event-db :prod.priv/silent
-                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/reg-event :prod.priv/silent
+                       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod.priv/silent])
       (is (empty? (rf/epoch-history :rf/default))
           "ring stays empty — rollup never computed"))))

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -102,11 +102,11 @@
                                     (get-in r [:db-after :session :token])
                                     (assoc-in [:db-after :session :token]
                                               :rf/redacted)))})
-      (rf/reg-event-db :login
-                       (fn [db [_ pw tok]]
-                         (-> db
+      (rf/reg-event :login
+                       (fn [{:keys [db]} [_ pw tok]]
+                         {:db (-> db
                              (assoc-in [:auth :password] pw)
-                             (assoc-in [:session :token] tok))))
+                             (assoc-in [:session :token] tok))}))
       (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
       (let [r         (last-record :test/main)
@@ -136,8 +136,8 @@
     (install-sensitive-schema! :test/main)
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r] (assoc r :db-after :rf/redacted))})
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r          (last-record :test/main)
@@ -170,12 +170,12 @@
                                   (get-in r [:db-after :session :token])
                                   (assoc-in [:db-after :session :token]
                                             :rf/redacted)))})
-    (rf/reg-event-db :login
-                     (fn [db [_ pw tk]]
-                       (-> db
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw tk]]
+                       {:db (-> db
                            (assoc-in [:auth :password]  pw)
                            (assoc-in [:session :token]  tk)
-                           (assoc-in [:public :name]    "alice"))))
+                           (assoc-in [:public :name]    "alice"))}))
     (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
@@ -205,8 +205,8 @@
     (install-sensitive-schema! :test/main)
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r] (assoc r :db-after :rf/redacted))})
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
@@ -247,8 +247,8 @@
   (testing "with no frame-declared sensitive paths registered, the
             counter is 0 (the empty-paths short-circuit)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
 
@@ -261,11 +261,11 @@
             across the cascade — the counter is 0."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :seed (fn [_ _]
-                             {:auth   {:password "topsecret"}
-                              :public {:counter 0}}))
-    (rf/reg-event-db :touch-public
-                     (fn [db _] (update-in db [:public :counter] inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _]
+                             {:db {:auth   {:password "topsecret"}
+                              :public {:counter 0}}}))
+    (rf/reg-event :touch-public
+                     (fn [{:keys [db]} _] {:db (update-in db [:public :counter] inc)}))
     (rf/dispatch-sync [:seed]         {:frame :test/main})
     (rf/dispatch-sync [:touch-public] {:frame :test/main})
 
@@ -278,8 +278,8 @@
             counter is 1. The :rf.epoch/sensitive? rollup also reads true."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r (last-record :test/main)]
@@ -293,11 +293,11 @@
             not — the counter is 1."
     (rf/reg-frame :test/main {})
     (install-two-sensitive-paths-schema! :test/main)
-    (rf/reg-event-db :seed
-                     (fn [_ _]
-                       {:auth {:password "pw-1" :token "tk-1"}}))
-    (rf/reg-event-db :rotate-token
-                     (fn [db [_ tk]] (assoc-in db [:auth :token] tk)))
+    (rf/reg-event :seed
+                     (fn [{:keys [db]} _]
+                       {:db {:auth {:password "pw-1" :token "tk-1"}}}))
+    (rf/reg-event :rotate-token
+                     (fn [{:keys [db]} [_ tk]] {:db (assoc-in db [:auth :token] tk)}))
     (rf/dispatch-sync [:seed]                    {:frame :test/main})
     (rf/dispatch-sync [:rotate-token "tk-fresh"] {:frame :test/main})
 
@@ -308,11 +308,11 @@
   (testing "both declared paths change in the same cascade — counter is 2"
     (rf/reg-frame :test/main {})
     (install-two-sensitive-paths-schema! :test/main)
-    (rf/reg-event-db :login-both
-                     (fn [db [_ pw tk]]
-                       (-> db
+    (rf/reg-event :login-both
+                     (fn [{:keys [db]} [_ pw tk]]
+                       {:db (-> db
                            (assoc-in [:auth :password] pw)
-                           (assoc-in [:auth :token]    tk))))
+                           (assoc-in [:auth :token]    tk))}))
     (rf/dispatch-sync [:login-both "topsecret" "tok-xyz"]
                       {:frame :test/main})
 
@@ -326,8 +326,8 @@
             bookkeeping, parallel to :rf.epoch/sensitive?."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
@@ -438,9 +438,9 @@
             redacts at egress. Ordering and shape are preserved."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
 
     (rf/dispatch-sync [:seed]              {:frame :test/main})
     (rf/dispatch-sync [:login "secret-1"]  {:frame :test/main})
@@ -508,11 +508,11 @@
                                   (get-in r [:db-after :session :token])
                                   (assoc-in [:db-after :session :token]
                                             :rf/redacted)))})
-    (rf/reg-event-db :login
-                     (fn [db [_ pw tk]]
-                       (-> db
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw tk]]
+                       {:db (-> db
                            (assoc-in [:auth :password] pw)
-                           (assoc-in [:session :token] tk))))
+                           (assoc-in [:session :token] tk))}))
     (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
     (let [r          (last-record :test/main)

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -177,8 +177,8 @@
     ;; A :redact-fn that WOULD wipe :db-after if it ran at storage time.
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r] (assoc r :db-after :rf/redacted))})
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r (last-record :test/main)]
@@ -195,8 +195,8 @@
       (rf/configure! :epoch-history
                     {:redact-fn (fn [r] (assoc r :db-after :rf/redacted))})
       (rf/register-epoch-listener! ::watch (fn [r] (reset! seen r)))
-      (rf/reg-event-db :login
-                       (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+      (rf/reg-event :login
+                       (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
       (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
       (is (= {:auth {:password "topsecret"}} (:db-after @seen))
@@ -215,7 +215,7 @@
       (rf/configure! :epoch-history
                     {:redact-fn (fn [r] (swap! invocations inc) r)})
       (rf/register-epoch-listener! ::watch (fn [_] nil))
-      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
       (rf/dispatch-sync [:seed] {:frame :test/main})
 
       (is (= 0 @invocations)
@@ -236,7 +236,7 @@
                     {:redact-fn (fn [r]
                                   (swap! invocations inc)
                                   (assoc r :rf/test-tag :redacted))})
-      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
       (rf/dispatch-sync [:seed] {:frame :test/main})
 
       (let [r         (last-record :test/main)
@@ -267,11 +267,11 @@
                                     (get-in r [:db-after :session :token])
                                     (assoc-in [:db-after :session :token]
                                               :rf/redacted)))})
-      (rf/reg-event-db :login
-                       (fn [db [_ pw tok]]
-                         (-> db
+      (rf/reg-event :login
+                       (fn [{:keys [db]} [_ pw tok]]
+                         {:db (-> db
                              (assoc-in [:auth :password] pw)
-                             (assoc-in [:session :token] tok))))
+                             (assoc-in [:session :token] tok))}))
       (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
       (let [r         (last-record :test/main)
@@ -295,7 +295,7 @@
     (let [invocations (atom 0)]
       (rf/configure! :epoch-history
                     {:redact-fn (fn [r] (swap! invocations inc) r)})
-      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
       (rf/dispatch-sync [:seed] {:frame :test/main})
 
       (let [r (last-record :test/main)]
@@ -315,8 +315,8 @@
             projection-side redaction."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
@@ -338,8 +338,8 @@
             egress breaks, and the RAW ring record is untouched."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
 
     (let [warnings (record-warnings!)]
       (rf/configure! :epoch-history
@@ -378,7 +378,7 @@
             re-attempts (the registration is not removed on first throw;
             the framework's posture is 'log and continue')."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [call-count (atom 0)]
@@ -404,11 +404,11 @@
             passes through."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]]
-                       (-> db
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]]
+                       {:db (-> db
                            (assoc-in [:auth :password] pw)
-                           (assoc-in [:public :name] "alice"))))
+                           (assoc-in [:public :name] "alice"))}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
@@ -425,7 +425,7 @@
             the raw shape (the default-nil posture — apps opt in to the
             advanced override explicitly)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (= {:n 0} (:db-after r))
@@ -444,7 +444,7 @@
     (rf/reg-frame :test/main {})
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (is (not (contains? (last-record :test/main) :rf/test-tag))
         "settle! path: ring record is RAW (override not applied at storage)")
@@ -488,7 +488,7 @@
                                  (swap! halted-records conj r))))
       (rf/configure! :epoch-history
                     {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))})
-      (rf/reg-event-fx :destroy-self
+      (rf/reg-event :destroy-self
                        (fn [_ _]
                          (frame/destroy-frame! :test/main)
                          {}))
@@ -515,7 +515,7 @@
             no override stage."
     (rf/reg-frame :test/main {})
     (rf/configure! :epoch-history {:redact-fn nil})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (= {:n 0} (:db-after r)))
@@ -562,8 +562,8 @@
     ;; A :redact-fn that WOULD scrub the value if it ran at storage time.
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r] (assoc r :rf/scrubbed true))})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
@@ -610,8 +610,8 @@
                                                       (assoc row :value :rf/redacted)
                                                       row))
                                                   rows)))))})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
     (emit-sub-run! :test/main :secret nil "topsecret")
@@ -634,8 +634,8 @@
             projection unchanged (the attribution behaviour is intact;
             redaction is opt-in via the override or schema classification)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
@@ -687,10 +687,10 @@
     (install-sensitive-schema! :test/main)
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r] (assoc r :db-after :rf/redacted))})
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
-    (rf/reg-event-db :logout
-                     (fn [db _] (assoc-in db [:auth :password] nil)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
+    (rf/reg-event :logout
+                     (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] nil)}))
 
     ;; (a) Dispatch a sensitive event — the password lands at the
     ;; frame-sensitive [:auth :password] path.

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -136,8 +136,8 @@
 (deftest record-on-drain-settle
   (testing "every drain-settle commits exactly one :rf/epoch-record"
     (rf/reg-frame :test/main {:doc "epoch test frame"})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
@@ -154,8 +154,8 @@
 (deftest record-shape-canonical
   (testing "an :rf/epoch-record carries the canonical shape"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
@@ -199,7 +199,7 @@
             token's `:rf.cofx` :time-ms — NOT an ambient now-ms
             read at assembly time (rf2-bh56rc / EP-0010 §Time)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (let [token-time 1781078400123      ; the supplied causal token time
           clock-time 9999999999999]     ; the (wrong) ambient clock sentinel
       ;; Stub BOTH host clocks (the elapsed `interop/now-ms` AND the
@@ -225,8 +225,8 @@
             equal :committed-at even as the wall clock advances — the
             replay-stability EP-0010 §Time guarantees (rf2-bh56rc)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (let [token-time 1781078400123]
       ;; First commit under one wall-clock, second under a DIFFERENT one —
       ;; both supply the SAME causal token :time-ms (the replay scenario).
@@ -256,12 +256,12 @@
             the parent's is its supplied token time (rf2-bh56rc / EP-0010
             §Dispatch Envelope Stamping — children are distinct causal tokens)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:order []}))
-    (rf/reg-event-fx :parent
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:order []}}))
+    (rf/reg-event :parent
       (fn [{:keys [db]} _]
         {:db (update db :order conj :parent)
          :fx [[:dispatch [:child]]]}))
-    (rf/reg-event-db :child (fn [db _] (update db :order conj :child)))
+    (rf/reg-event :child (fn [{:keys [db]} _] {:db (update db :order conj :child)}))
     (let [parent-time 1781078400123
           ;; The child has no supplied token, so the router stamps its
           ;; :time-ms fresh at the causal boundary (envelope construction) from
@@ -289,14 +289,14 @@
             :fx [[:dispatch …]] child is a separate dequeued event, so it
             yields a separate record, NOT folded into the parent's epoch"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:order []}))
-    (rf/reg-event-fx :outer
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:order []}}))
+    (rf/reg-event :outer
       (fn [{:keys [db]} _]
         {:db (update db :order conj :outer)
          :fx [[:dispatch [:inner-1]]
               [:dispatch [:inner-2]]]}))
-    (rf/reg-event-db :inner-1 (fn [db _] (update db :order conj :inner-1)))
-    (rf/reg-event-db :inner-2 (fn [db _] (update db :order conj :inner-2)))
+    (rf/reg-event :inner-1 (fn [{:keys [db]} _] {:db (update db :order conj :inner-1)}))
+    (rf/reg-event :inner-2 (fn [{:keys [db]} _] {:db (update db :order conj :inner-2)}))
 
     (rf/dispatch-sync [:seed]  {:frame :test/main})
     ;; ONE drain: :outer runs, then its two :fx-dispatched children
@@ -352,8 +352,8 @@
   (testing "per rf2-nj6p7 (Spec 002 §Drain versus event): the frame-creation
             :on-create event is itself a dequeued event, so it commits its
             OWN epoch — distinct from any later user dispatch's epoch"
-    (rf/reg-event-db :app/init (fn [_ _] {:booted true :n 0}))
-    (rf/reg-event-db :inc      (fn [db _] (update db :n inc)))
+    (rf/reg-event :app/init (fn [{:keys [db]} _] {:db {:booted true :n 0}}))
+    (rf/reg-event :inc      (fn [{:keys [db]} _] {:db (update db :n inc)}))
     ;; reg-frame dispatch-syncs the :on-create event at registration.
     (rf/reg-frame :test/main {:on-create [:app/init]})
 
@@ -432,8 +432,8 @@
   (testing "each frame has its own epoch ring; cascades don't co-mingle"
     (rf/reg-frame :frame/a {})
     (rf/reg-frame :frame/b {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :frame/a})
     (rf/dispatch-sync [:inc]  {:frame :frame/a})
@@ -454,8 +454,8 @@
   (testing "when the ring fills, oldest records are evicted FIFO"
     (rf/configure! :epoch-history {:depth 3})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (dotimes [_ 5] (rf/dispatch-sync [:inc] {:frame :test/main}))
@@ -483,8 +483,8 @@
     (let [depth 3]
       (rf/configure! :epoch-history {:depth depth})
       (rf/reg-frame :test/main {})
-      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-      (rf/reg-event-db :inc  (fn [db [_ i]] (assoc db :n i)))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/reg-event :inc  (fn [{:keys [db]} [_ i]] {:db (assoc db :n i)}))
 
       (rf/dispatch-sync [:seed] {:frame :test/main})
       ;; Drive far more events than the depth so the cap fires many times.
@@ -513,7 +513,7 @@
   (testing "depth 0 disables ring recording"
     (rf/configure! :epoch-history {:depth 0})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
@@ -524,8 +524,8 @@
 (deftest listener-fires-per-drain-settle
   (testing "register-epoch-listener! fires once per drain-settle with the assembled record"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
@@ -546,7 +546,7 @@
 (deftest listener-same-key-replaces
   (testing "register-epoch-listener! under the same key replaces the prior listener"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [a (atom 0)
           b (atom 0)]
@@ -583,7 +583,7 @@
             under the same id resets BOTH the listener entry and the
             observed-frames entry"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [observed (deref #'state/observed-frames-by-cb)
           a        (atom 0)
@@ -627,7 +627,7 @@
 (deftest listener-remove
   (testing "unregister-epoch-listener! stops the listener"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (let [count-a (atom 0)]
       (rf/register-epoch-listener! ::w (fn [_] (swap! count-a inc)))
       (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -639,7 +639,7 @@
 (deftest listener-exception-isolation
   (testing "a throwing epoch listener does not crash other listeners or the runtime"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [survivor (atom 0)
           throws   (atom 0)]
@@ -662,7 +662,7 @@
             invocation, carrying :cb-id, :frame, :rf.epoch/id; isolation
             still holds (other listeners continue to fire)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [recorded (record-trace!)
           survivor (atom 0)]
@@ -706,8 +706,8 @@
 (deftest restore-rewinds-app-db
   (testing "restore-epoch! sets app-db to the named epoch's :db-after"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})       ;; n=1
@@ -739,7 +739,7 @@
     (rf/reg-frame :test/main {})
     ;; A handler that writes BOTH partitions in one cascade — app-db via :db,
     ;; runtime-db via the reserved :rf.db/runtime effect.
-    (rf/reg-event-fx :seed-both
+    (rf/reg-event :seed-both
       (fn [{rt :rf.db/runtime} _]
         {:db            {:app-value 1}
          :rf.db/runtime (assoc-in (or rt {})
@@ -772,13 +772,13 @@
     (rf/reg-machine :m/x
       {:initial :live :states {:live {} :gone {}}})
     ;; Seed a known snapshot into the runtime-db partition + a marker in app-db.
-    (rf/reg-event-fx :put-machine
+    (rf/reg-event :put-machine
       (fn [{rt :rf.db/runtime} _]
         {:db {:phase :machine-alive}
          :rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/machines :snapshots :m/x]
                                   {:state :live :data {} :meta {}})}))
-    (rf/reg-event-fx :drop-machine
+    (rf/reg-event :drop-machine
       (fn [{rt :rf.db/runtime} _]
         {:db {:phase :machine-gone}
          :rf.db/runtime (update-in (or rt {}) [:rf.runtime/machines :snapshots]
@@ -882,13 +882,13 @@
             to install, so the FRAME's restored runtime-db carries the reconciled
             value (a mid-flight slice never installs verbatim)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-fx :put-resource
+    (rf/reg-event :put-resource
       (fn [{rt :rf.db/runtime} _]
         {:db {:phase :mid-flight}
          :rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/resources :entries :k]
                                   {:status :loading :current-work [:w 1]})}))
-    (rf/reg-event-db :clear (fn [_ _] {:phase :cleared}))
+    (rf/reg-event :clear (fn [{:keys [db]} _] {:db {:phase :cleared}}))
 
     (let [hook-key :resources/reconcile-on-restore
           original (late-bind/get-fn hook-key)]
@@ -927,13 +927,13 @@
             the durable field comes from a causal input rather than an ambient
             world read at install (EP-0010 §Restore/Replay)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-fx :put-resource
+    (rf/reg-event :put-resource
       (fn [{rt :rf.db/runtime} _]
         {:db {:phase :mid-flight}
          :rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/resources :entries :k]
                                   {:status :loading :current-work [:w 1]})}))
-    (rf/reg-event-db :clear (fn [_ _] {:phase :cleared}))
+    (rf/reg-event :clear (fn [{:keys [db]} _] {:db {:phase :cleared}}))
 
     (let [hook-key   :resources/reconcile-on-restore
           original   (late-bind/get-fn hook-key)
@@ -983,7 +983,7 @@
 (deftest restore-failure-unknown-epoch
   (testing "restore-epoch! with an epoch-id not in history fires :rf.epoch/restore-unknown-epoch"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [pre        (rf/app-db-value :test/main)
@@ -1000,13 +1000,13 @@
 (deftest restore-failure-schema-mismatch
   (testing "restore-epoch! on a db that no longer validates fires :rf.epoch/restore-schema-mismatch"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :set-bad
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :set-bad
       ;; Commit a value that LATER fails a tightened schema. We dispatch
       ;; this BEFORE the schema is registered so the pre-restore commit
       ;; succeeds; tightening the schema happens between dispatch and
       ;; restore.
-      (fn [db _] (assoc db :n "not-an-int")))
+      (fn [{:keys [db]} _] {:db (assoc db :n "not-an-int")}))
 
     (rf/dispatch-sync [:seed]    {:frame :test/main})
     (rf/dispatch-sync [:set-bad] {:frame :test/main})
@@ -1043,8 +1043,8 @@
             the :rf.epoch/restore-schema-mismatch trace carries non-nil
             :schema-digest-recorded and :schema-digest-current tags."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed    (fn [_ _]  {:n 0}))
-    (rf/reg-event-db :set-bad (fn [db _] (assoc db :n "not-an-int")))
+    (rf/reg-event :seed    (fn [{:keys [db]} _]  {:db {:n 0}}))
+    (rf/reg-event :set-bad (fn [{:keys [db]} _] {:db (assoc db :n "not-an-int")}))
 
     ;; Record an epoch with NO schemas registered yet — its
     ;; :schema-digest is the empty-set digest (still non-nil — Spec 010
@@ -1087,7 +1087,7 @@
             record carries a :schema-digest pinned at record time."
     (rf/reg-frame :test/digest {})
     (rf/reg-app-schema [:n] [:int] {:frame :test/digest})
-    (rf/reg-event-db :init (fn [_ _] {:n 0}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:init] {:frame :test/digest})
     (let [r (last (rf/epoch-history :test/digest))]
       (is (some? r) "an epoch record was committed")
@@ -1106,7 +1106,7 @@
     ;; EP-0001 (rf2-vzld77 / rf2-3aizt1): the route slice is runtime-db state
     ;; at [:rf.runtime/routing :current]; bead 7's missing-references reads the
     ;; recorded frame-state's runtime-db partition.
-    (rf/reg-event-fx :route-to
+    (rf/reg-event :route-to
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
                                   {:route-id :route/users})}))
@@ -1224,7 +1224,7 @@
     ;; runtime-db partition (EP-0001 rf2-vzld77 — machine snapshots are
     ;; runtime-db state; bead 7 reads the runtime-db partition of the recorded
     ;; frame-state for the version-drift precondition).
-    (rf/reg-event-fx :put-snap
+    (rf/reg-event :put-snap
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime
          (assoc-in (or rt {}) [:rf.runtime/machines :snapshots :machine/tl]
@@ -1255,17 +1255,17 @@
 (deftest restore-failure-during-drain
   (testing "restore-epoch! called from inside a drain fires :rf.epoch/restore-during-drain"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [target   (last (rf/epoch-history :test/main))
           recorded (record-trace!)
           attempt  (atom nil)]
       ;; A handler that calls restore-epoch! synchronously during a drain.
-      (rf/reg-event-db :try-restore
-        (fn [db _]
+      (rf/reg-event :try-restore
+        (fn [{:keys [db]} _]
           (reset! attempt (rf/restore-epoch! :test/main (:epoch-id target)))
-          (assoc db :n 99)))
+          {:db (assoc db :n 99)}))
       (rf/dispatch-sync [:try-restore] {:frame :test/main})
 
       (is (false? @attempt) "restore returned false from inside the drain")
@@ -1281,7 +1281,7 @@
 (deftest sub-runs-projection
   (testing ":sub-runs reflects each :rf.sub/run trace under the cascade"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-sub :n     (fn [db _] (:n db)))
     (rf/reg-sub :n*2   :<- [:n] (fn [n _] (* 2 (or n 0))))
 
@@ -1289,7 +1289,7 @@
     ;; from compute-sub when no cache exists for the query, AND from the
     ;; reactive path when a fresh subscription materialises). Either
     ;; way, the cascade contains :rf.sub/run traces.
-    (rf/reg-event-fx :read-sub
+    (rf/reg-event :read-sub
       (fn [_ _]
         ;; Read both subs to exercise layer-1 and layer-2.
         (let [_v (rf/subscribe-once :test/main [:n*2])]
@@ -1402,7 +1402,7 @@
     (rf/reg-frame :test/main {})
     (rf/reg-fx :client-only-fx {:platforms #{:client}}
                (fn [_ _] :nope))
-    (rf/reg-event-fx :run
+    (rf/reg-event :run
       (fn [_ _] {:fx [[:client-only-fx :payload]]}))
 
     (rf/dispatch-sync [:run] {:frame :test/main})
@@ -1416,7 +1416,7 @@
 (deftest effects-projection-no-such-fx
   (testing ":effects captures :error outcomes for unknown fx-ids"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-fx :run
+    (rf/reg-event :run
       (fn [_ _] {:fx [[:no/such-fx :payload]]}))
     (rf/dispatch-sync [:run] {:frame :test/main})
 
@@ -1431,7 +1431,7 @@
   (testing ":effects captures :error outcomes for fx that throw"
     (rf/reg-frame :test/main {})
     (rf/reg-fx :throwing-fx (fn [_ _] (throw (ex-info "boom" {}))))
-    (rf/reg-event-fx :run
+    (rf/reg-event :run
       (fn [_ _] {:fx [[:throwing-fx :payload]]}))
 
     (rf/dispatch-sync [:run] {:frame :test/main})
@@ -1448,7 +1448,7 @@
     (rf/reg-frame :test/main {})
     (let [calls (atom 0)]
       (rf/reg-fx :tally-fx (fn [_ args] (swap! calls + args)))
-      (rf/reg-event-fx :run
+      (rf/reg-event :run
         (fn [_ _] {:fx [[:tally-fx 5]]}))
 
       (rf/dispatch-sync [:run] {:frame :test/main})
@@ -1466,9 +1466,9 @@
 (deftest effects-projection-records-reserved-fx-success
   (testing ":effects captures :ok outcomes for reserved fx-ids (:dispatch)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed   (fn [_ _]   {:n 0}))
-    (rf/reg-event-db :inc    (fn [db _]  (update db :n inc)))
-    (rf/reg-event-fx :outer
+    (rf/reg-event :seed   (fn [{:keys [db]} _]   {:db {:n 0}}))
+    (rf/reg-event :inc    (fn [{:keys [db]} _]  {:db (update db :n inc)}))
+    (rf/reg-event :outer
       (fn [_ _] {:fx [[:dispatch [:inc]]
                       [:dispatch [:inc]]]}))
 
@@ -1493,7 +1493,7 @@
     (rf/reg-fx :throwing-fx (fn [_ _] (throw (ex-info "boom" {}))))
     (rf/reg-fx :client-only {:platforms #{:client}}
                (fn [_ _] :nope))
-    (rf/reg-event-fx :run
+    (rf/reg-event :run
       (fn [_ _] {:fx [[:ok-fx       :a]
                       [:throwing-fx :b]
                       [:no/such-fx  :c]
@@ -1525,7 +1525,7 @@
             last-settled db. NOTE: this changes Spec 002 rule 3's pre-
             rf2-u6jsj whole-drain-rollback semantics — see report."
     (rf/reg-frame :test/main {:drain-depth 5})
-    (rf/reg-event-fx :loop
+    (rf/reg-event :loop
       (fn [{:keys [db]} _]
         {:db (update (or db {}) :n (fnil inc 0))
          :fx [[:dispatch [:loop]]]}))
@@ -1564,7 +1564,7 @@
             :ok event epoch as it settles, then the trailing :halted-depth
             marker."
     (rf/reg-frame :test/main {:drain-depth 5})
-    (rf/reg-event-fx :loop
+    (rf/reg-event :loop
       (fn [_ _] {:fx [[:dispatch [:loop]]]}))
 
     (let [received (atom [])]
@@ -1586,7 +1586,7 @@
             Emits :rf.epoch/restore-non-ok-record and leaves app-db
             unchanged."
     (rf/reg-frame :test/main {:drain-depth 5})
-    (rf/reg-event-fx :loop
+    (rf/reg-event :loop
       (fn [_ _] {:fx [[:dispatch [:loop]]]}))
 
     ;; Drive the halted cascade to land a non-:ok record in history.
@@ -1645,8 +1645,8 @@
             :outcome :ok tag. The two emits share the same :frame /
             :rf.epoch/id / :rf.trace/event-id so consumers can correlate."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [recorded (record-trace!)]
       (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -1671,7 +1671,7 @@
             projects to the :blocked consumer tier per rf2-18g1w).
             The durable :ok events that preceded it emit :outcome :ok."
     (rf/reg-frame :test/main {:drain-depth 5})
-    (rf/reg-event-fx :loop
+    (rf/reg-event :loop
       (fn [{:keys [db]} _]
         {:db (update (or db {}) :n (fnil inc 0))
          :fx [[:dispatch [:loop]]]}))
@@ -1696,7 +1696,7 @@
             same destroy step, so :epoch-history is empty — the outcome
             survives in the trace stream as evidence."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-fx :self-destruct
+    (rf/reg-event :self-destruct
       (fn [_ _]
         (rf/destroy-frame! :test/short-lived)
         {}))
@@ -1720,7 +1720,7 @@
             dropped in the same destroy step, so the record is observed via
             a register-epoch-listener! callback."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-fx :self-destruct
+    (rf/reg-event :self-destruct
       (fn [_ _]
         (rf/destroy-frame! :test/short-lived)
         {}))
@@ -1768,7 +1768,7 @@
             :trace-events. The schema-reserved :halted-handler-exception
             outcome is never committed by the reference runtime."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event-db :boom (fn [_ _] (throw (ex-info "handler blew" {:why :test}))))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -1836,11 +1836,11 @@
             handler-exception-settles-ok-never-halted-handler-exception),
             and :trace-events carries a :rf.error/flow-eval-exception entry"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     ;; Handler returns a :db effect (so the normal flow path would
     ;; transform it). The flow's :output throws, so the router DISCARDS
     ;; the pending :db wholesale.
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
     ;; Seed a clean baseline FIRST, then register the throwing flow — the
     ;; flow throws on every eval, so registering it after the seed keeps
     ;; the baseline untouched and isolates the throw to the :bump drain.
@@ -1887,8 +1887,8 @@
             so a future regression that left :db-after equal to :db-before
             for clean flow evals is caught alongside the throw-path pin."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:w 2 :h 3}))
-    (rf/reg-event-db :bump-w (fn [db _] (update db :w inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 2 :h 3}}))
+    (rf/reg-event :bump-w (fn [{:keys [db]} _] {:db (update db :w inc)}))
     (rf/reg-flow {:id     :rect/area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* (or w 0) (or h 0)))
@@ -1951,7 +1951,7 @@
 
     ;; A real cascade afterwards DOES commit — proving the skip is an
     ;; empty-buffer policy, not a frame-wide disable.
-    (rf/reg-event-db :real (fn [_ _] {:n 1}))
+    (rf/reg-event :real (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/dispatch-sync [:real] {:frame :test/main})
 
     (let [history (rf/epoch-history :test/main)]
@@ -1988,8 +1988,8 @@
             carry :trace-events; older records keep :sub-runs / :renders /
             :effects but drop :trace-events"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/configure! :epoch-history {:depth 10 :trace-events-keep 2})
 
@@ -2037,8 +2037,8 @@
             retained record drops its :trace-events. The fixture forces 5 so
             this elision path is reachable with a handful of dispatches."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     ;; Fixture-configured cap (NOT the shipped default of 50). Reset-runtime
     ;; forces :trace-events-keep 5 so this elision path is exercised cheaply.
@@ -2069,8 +2069,8 @@
             :trace-events (the opt-back-in path for apps that want the
             whole ring's raw streams)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     ;; Opt back into unbounded retention.
     (rf/configure! :epoch-history {:trace-events-keep 100})
@@ -2200,8 +2200,8 @@
   (testing "after restore-epoch!, subscribe-once reflects the restored db
   for both layer-1 and layer-2 subs (no manual cache invalidation)."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n   (fn [db _] (:n db)))
     (rf/reg-sub :n*2 :<- [:n] (fn [n _] (* 2 (or n 0))))
 
@@ -2229,8 +2229,8 @@
   subscription before the restore observes the rewind on the next deref
   without re-subscribing."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -2252,8 +2252,8 @@
   primitive — there is no global epoch sequence."
     (rf/reg-frame :frame/a {})
     (rf/reg-frame :frame/b {})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     ;; Drive A through 0 → 1 → 2; B through 100 → 101.
@@ -2279,8 +2279,8 @@
   the second call lands on the same db-after, every observable surface
   reads the same value, and the call still returns true."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -2309,9 +2309,9 @@
   it 'survives ... time-travel revert.' After restore-epoch!, the flow's
   output reads through the restored db match the recorded epoch's output."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :init (fn [_ _]      {:w 2 :h 3}))
-    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
-    (rf/reg-event-db :h!   (fn [db [_ h]] (assoc db :h h)))
+    (rf/reg-event :init (fn [{:keys [db]} _]      {:db {:w 2 :h 3}}))
+    (rf/reg-event :w!   (fn [{:keys [db]} [_ w]] {:db (assoc db :w w)}))
+    (rf/reg-event :h!   (fn [{:keys [db]} [_ h]] {:db (assoc db :h h)}))
     (rf/reg-flow {:id     :rect/area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* (or w 0) (or h 0)))
@@ -2339,8 +2339,8 @@
   in the next dispatch triggers recomputation. Pins that flow recompute
   state does not silently miss after a restore."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :init (fn [_ _]      {:w 1 :h 1}))
-    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
+    (rf/reg-event :init (fn [{:keys [db]} _]      {:db {:w 1 :h 1}}))
+    (rf/reg-event :w!   (fn [{:keys [db]} [_ w]] {:db (assoc db :w w)}))
     (rf/reg-flow {:id     :rect/area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* (or w 0) (or h 0)))
@@ -2379,12 +2379,12 @@
     ;; Framework-authority handlers write the route slice into the runtime-db
     ;; partition via the reserved :rf.db/runtime effect (Mike ruling #4 — the
     ;; routing subsystem is a framework/runtime-extension writer).
-    (rf/reg-event-fx :go-home
+    (rf/reg-event :go-home
       {:rf/machine? true}
       (fn [{:keys [rf.db/runtime]} _]
         {:rf.db/runtime (assoc-in (or runtime {}) [:rf.runtime/routing :current]
                                   {:route-id :route/home :params {}})}))
-    (rf/reg-event-fx :go-article
+    (rf/reg-event :go-article
       {:rf/machine? true}
       (fn [{:keys [rf.db/runtime]} [_ id]]
         {:rf.db/runtime (assoc-in (or runtime {}) [:rf.runtime/routing :current]
@@ -2431,7 +2431,7 @@
 (deftest replace-app-db!-replaces-container
   (testing "replace-app-db! replaces the underlying app-db value"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (is (= {:n 0} (rf/app-db-value :test/main)))
 
@@ -2444,7 +2444,7 @@
             runtime-db (machines / routes) survives (EP-0001 rf2-tfepxu,
             Mike ruling #10 — the app-db sibling of whole-frame reset-frame!)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7 :cart {:items [1 2]}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7 :cart {:items [1 2]}}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     ;; Seed a live runtime-db partition (framework-owned subsystem state).
     (rf/replace-runtime-db! :test/main {:rf.runtime/machines {:m 1}})
@@ -2462,7 +2462,7 @@
   (testing "reset-app-db! records a synthetic :rf.epoch/db-replaced epoch
             (it delegates to replace-app-db! with {})"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [pre   (count (rf/epoch-history :test/main))
           _     (rf/reset-app-db! :test/main)
@@ -2477,7 +2477,7 @@
   (testing "replace-app-db! records a synthetic epoch so restore-epoch!
             can rewind to the prior state"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [pre-history-count (count (rf/epoch-history :test/main))
@@ -2508,7 +2508,7 @@
   (testing "replace-app-db! emits :rf.epoch/db-replaced on success with
             :frame and :epoch-id tags"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [recorded (record-trace!)
@@ -2527,7 +2527,7 @@
   (testing "replace-app-db! fans out the assembled synthetic record to
             register-epoch-listener! listeners"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [received (atom [])]
@@ -2561,7 +2561,7 @@
             emits :rf.epoch/replace-during-drain; app-db unchanged
             by the rejected call"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [recorded (record-trace!)
@@ -2592,7 +2592,7 @@
     (rf/reg-frame :test/main {})
     ;; Per Spec 010 §Per-frame schemas — schema is frame-scoped.
     (rf/reg-app-schema [:n] [:int] {:frame :test/main})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [pre      (rf/app-db-value :test/main)
@@ -2617,7 +2617,7 @@
   (testing "When the frame has no registered schemas, replace-app-db!
             accepts any new-db (the validation step is a no-op)"
     (rf/reg-frame :test/loose {})
-    (rf/reg-event-db :seed (fn [_ _] {:anything 'goes}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:anything 'goes}}))
     (rf/dispatch-sync [:seed] {:frame :test/loose})
 
     (is (true? (rf/replace-app-db! :test/loose {:totally :different :shape true})))
@@ -2629,7 +2629,7 @@
             substrate's reactive container drives sub re-evaluation,
             same as restore-epoch!'s happy path)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/reg-sub :n*2 :<- [:n] (fn [n _] (* 2 (or n 0))))
 
@@ -2693,7 +2693,7 @@
   (testing "replace-runtime-db! replaces ONLY the runtime-db partition
             (app-db preserved); returns true on success"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7 :cart {:items [1 2]}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7 :cart {:items [1 2]}}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (is (= {:n 7 :cart {:items [1 2]}} (rf/app-db-value :test/main)))
 
@@ -2709,7 +2709,7 @@
   (testing "replace-runtime-db! records a synthetic :rf.epoch/db-replaced
             epoch so restore-epoch! can rewind PAST the runtime-db injection"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     ;; A real cascade that seeds a runtime-db value to rewind back to.
     (rf/replace-runtime-db! :test/main {:rf.runtime/routing {:current {:route-id :start}}})
@@ -2783,7 +2783,7 @@
             emits :rf.epoch/replace-during-drain (the shared
             four-mutator failure op); runtime-db unchanged by the rejected call"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [recorded (record-trace!)
@@ -2842,7 +2842,7 @@
   (testing "replace-frame-state! installs BOTH partitions atomically; returns
             true on success"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (is (true? (rf/replace-frame-state! :test/main
@@ -2859,7 +2859,7 @@
   (testing "replace-frame-state! records a synthetic :rf.epoch/db-replaced
             epoch so restore-epoch! can rewind PAST the full-frame injection"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [seed-record (some (fn [r] (when (= :seed (:event-id r)) r))
                             (rf/epoch-history :test/main))
@@ -2915,7 +2915,7 @@
        :data        {:n 1}
        :data-schema [:map [:n [:int {:min 0}]]]
        :states      {:idle {}}})
-    (rf/reg-event-db :seed (fn [_ _] {:ok true}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:ok true}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [pre-app (rf/app-db-value :test/main)
@@ -2955,8 +2955,8 @@
             :trigger-event is the actual next dispatched event (NOT
             [:rf.epoch/db-replaced] picked from a leaked buffer)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     ;; Cascade 1: a real event, lands a clean record.
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -3002,8 +3002,8 @@
     ;; Use the schema-mismatch path — easier to drive than during-drain.
     (rf/reg-frame :test/sm {})
     (rf/reg-app-schema [:n] [:int] {:frame :test/sm})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/sm})
 
     ;; This fails — new-db doesn't validate. Emits
@@ -3028,8 +3028,8 @@
             cascade with :frame tags. None may bleed into the next
             real cascade's :trace-events for that frame."
     (rf/reg-frame :test/r {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/r})
     (rf/dispatch-sync [:bump] {:frame :test/r})
@@ -3107,8 +3107,8 @@
   (testing "every restore-family trace tag carries :rf.epoch/id (Spec 009 /
             Spec-Schemas) and never the unqualified :epoch-id alias"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
 
@@ -3222,7 +3222,7 @@
   (testing "(rf/epoch-history frame-id) returns [] for a destroyed frame
             and for a never-registered frame — the read-empty contract"
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
     (is (seq (rf/epoch-history :test/short-lived))
         "before destroy, the frame has at least one recorded epoch")
@@ -3237,7 +3237,7 @@
   (testing "(rf/app-db-value frame-id) returns nil for a destroyed frame
             and for a never-registered frame"
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
     (is (some? (rf/app-db-value :test/short-lived))
         "before destroy, app-db-value returns the live app-db")
@@ -3252,7 +3252,7 @@
   (testing "(rf/restore-epoch! destroyed _) emits :rf.error/no-such-handler
             (kind :frame) and returns false"
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
     (let [eid (-> (rf/epoch-history :test/short-lived) first :epoch-id)]
       (rf/destroy-frame! :test/short-lived)
@@ -3276,7 +3276,7 @@
             destroyed-frame race specifically (the frame existed, then
             was destroyed)"
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
     (rf/destroy-frame! :test/short-lived)
 
@@ -3298,7 +3298,7 @@
             frame do not re-emit. The callback registration itself
             remains in place."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [received (atom [])
           recorded (record-trace!)]
@@ -3346,7 +3346,7 @@
   (testing "A repeat destroy of an already-destroyed frame does NOT
             re-emit :rf.epoch.cb/silenced-on-frame-destroy"
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [recorded (record-trace!)]
       (rf/register-epoch-listener! ::watcher (fn [_] nil))
@@ -3373,7 +3373,7 @@
             (there is nothing to silence)"
     (rf/reg-frame :test/observed     {})
     (rf/reg-frame :test/never-seen-by-cb {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
     (let [recorded (record-trace!)]
       (rf/register-epoch-listener! ::watcher (fn [_] nil))
@@ -3418,8 +3418,8 @@
             ring buffer regardless of whether the frame itself was
             destroyed via the usual frame/destroy-frame! path"
     (rf/reg-frame :test/other {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     ;; Populate :test/other's ring buffer.
     (rf/dispatch-sync [:seed] {:frame :test/other})
@@ -3449,7 +3449,7 @@
   (testing "on-frame-destroyed! is idempotent — repeated calls on the
             same frame are no-ops (no throw, no side-effect cascade)"
     (rf/reg-frame :test/repeat {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/repeat})
     (is (= 1 (count (rf/epoch-history :test/repeat))))
 
@@ -3496,8 +3496,8 @@
             replace-app-db! does NOT leak into the next cascade's
             harvested record for the same frame"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :foo  (fn [db _] (assoc db :foo? true)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :foo  (fn [{:keys [db]} _] {:db (assoc db :foo? true)}))
 
     ;; 1. Drive one cascade — clean record lands.
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -3624,7 +3624,7 @@
     (rf/reg-frame :test/main {})
     ;; Seed the frame so the pre-cascade app-db is a real, non-empty
     ;; value — proves the snapshots carry actual state, not {} / nil.
-    (rf/reg-event-db :seed (fn [_ _] {:n 7 :live true}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7 :live true}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [records (atom [])]
       (rf/register-epoch-listener! ::watch (fn [r] (swap! records conj r)))
@@ -3632,7 +3632,7 @@
       ;; committed db before destroying, so destroy-time db == pre-cascade
       ;; db here (the {:n 7 :live true} the :seed cascade settled) — both
       ;; REAL and non-nil, which is the contract (Spec-Schemas §Outcomes).
-      (rf/reg-event-fx :destroy-self
+      (rf/reg-event :destroy-self
                        (fn [_ _]
                          (frame/destroy-frame! :test/main)
                          {}))
@@ -3700,13 +3700,13 @@
       ;; Child: destroys the frame. Its pre-cascade db-before is whatever
       ;; the container held when it was dequeued — i.e. AFTER the parent's
       ;; {:phase :parent-done} write committed (per-event epoch boundary).
-      (rf/reg-event-fx :child-destroy
+      (rf/reg-event :child-destroy
                        (fn [_ _]
                          (frame/destroy-frame! :test/main)
                          {}))
       ;; Parent: commits a db write, then fx-dispatches the child. The
       ;; child runs as a SEPARATE dequeued event in the same drain.
-      (rf/reg-event-fx :parent-write-then-spawn
+      (rf/reg-event :parent-write-then-spawn
                        (fn [_ _]
                          {:db {:phase :parent-done :marker 42}
                           :fx [[:dispatch [:child-destroy]]]}))
@@ -3949,8 +3949,8 @@
             repeated drain-settles for a stable listener-observing-frame
             pairing leave the atom untouched (no watcher fires)"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [observed-atom @#'state/observed-frames-by-cb
           swap-count    (atom 0)]
@@ -4076,8 +4076,8 @@
             tags carry the current history-size, which equals depth)"
     (rf/configure! :epoch-history {:depth 3})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     ;; Capture the epoch-id of the FIRST cascade before later cascades
@@ -4123,8 +4123,8 @@
             still fans out to registered listeners"
     (rf/configure! :epoch-history {:depth 0})
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
     (let [seen (atom [])]
       (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
@@ -4165,8 +4165,8 @@
             rejection path) leaves the history vector untouched and
             does not fire registered listeners"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
 
@@ -4186,7 +4186,7 @@
             simplest rejection path that exercises the reset surface)
             leaves history untouched and does not fire listeners"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [history-before (rf/epoch-history :test/main)
@@ -4235,7 +4235,7 @@
   (testing "rf2-mrsck — :rf.epoch/sensitive? is false on records whose
             cascade involves no sensitive paths and no sensitive handlers"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [r (last (rf/epoch-history :test/main))]
@@ -4248,9 +4248,9 @@
             Path-marked classification (schema-slot `:sensitive?`)
             is the v2 mechanism."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :secret-write
+    (rf/reg-event :secret-write
                      {:sensitive? true}   ;; stored, no longer consulted
-                     (fn [db _] (assoc db :token "shhh")))
+                     (fn [{:keys [db]} _] {:db (assoc db :token "shhh")}))
     (rf/dispatch-sync [:secret-write] {:frame :test/main})
 
     (let [r (last (rf/epoch-history :test/main))]
@@ -4271,9 +4271,9 @@
     (frame-class/install! :test/main
       (frame-class/validate+extract :test/main
         {:sensitive {:app-db [[:auth :password]]}}))
-    (rf/reg-event-db :login
-                     (fn [db [_ pw]]
-                       (assoc-in db [:auth :password] pw)))
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]]
+                       {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last (rf/epoch-history :test/main))
@@ -4303,8 +4303,8 @@
   (testing "rf2-mrsck — projected-history walks the ring once and
             returns the projected vector"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (rf/dispatch-sync [:inc]  {:frame :test/main})
 
@@ -4389,8 +4389,8 @@
             :rf.epoch/restored. The drop is the no-op write
             adapter/replace-container! makes against the now-nil container."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
     (rf/dispatch-sync [:inc]  {:frame :test/short-lived})
 
@@ -4424,7 +4424,7 @@
             pass but BEFORE the container write. The precondition check is
             real; the destroy is injected into the validate→write window."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
@@ -4454,7 +4454,7 @@
             synthetic epoch, emit :rf.epoch/db-replaced, or fan a record to
             listeners for the destroyed frame."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     ;; (1) Validate against the LIVE frame — passes.
@@ -4499,7 +4499,7 @@
             frame is destroyed AFTER a live precondition pass but BEFORE the
             container write."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     (let [real-check tool-pair/check-replace-app-db-preconditions!
@@ -4551,8 +4551,8 @@
             write-boundary liveness check passes but BEFORE replace-frame-state!
             returns (the nil-return post-liveness teardown window)."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
     (rf/dispatch-sync [:inc]  {:frame :test/short-lived})
 
@@ -4641,14 +4641,14 @@
             even though resources rode in the snapshot — the reconcile deferred
             them and the commit only fires on a successful install."
     (rf/reg-frame :test/obi8rr-fail {})
-    (rf/reg-event-fx :seed-res
+    (rf/reg-event :seed-res
       (fn [{rt :rf.db/runtime} _]
         {:db {:n 0}
          :rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/resources :entries :k]
                                   {:status :loaded :data {:x 1}
                                    :active-owners #{[:route :r "nav-OLD"]}})}))
-    (rf/reg-event-db :clear-res (fn [_ _] {:n 1}))
+    (rf/reg-event :clear-res (fn [{:keys [db]} _] {:db {:n 1}}))
     (with-stub-resources-restore-hooks
       (fn []
         (rf/dispatch-sync [:seed-res] {:frame :test/obi8rr-fail})
@@ -4678,14 +4678,14 @@
             after the install landed) — the deferral does not drop them on the
             happy path."
     (rf/reg-frame :test/obi8rr-ok {})
-    (rf/reg-event-fx :seed-res2
+    (rf/reg-event :seed-res2
       (fn [{rt :rf.db/runtime} _]
         {:db {:n 0}
          :rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/resources :entries :k]
                                   {:status :loaded :data {:x 1}
                                    :active-owners #{[:route :r "nav-OLD"]}})}))
-    (rf/reg-event-db :clear-res2 (fn [_ _] {:n 1}))
+    (rf/reg-event :clear-res2 (fn [{:keys [db]} _] {:db {:n 1}}))
     (with-stub-resources-restore-hooks
       (fn []
         (rf/dispatch-sync [:seed-res2] {:frame :test/obi8rr-ok})
@@ -4708,7 +4708,7 @@
             synthetic epoch, emit :rf.epoch/db-replaced, or fan out a record
             when replace-app-db! returns nil AFTER the liveness check passed."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     (let [fanned   (atom [])]
@@ -4745,7 +4745,7 @@
             synthetic epoch when replace-runtime-db! returns nil AFTER the
             liveness check passed."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     (let [fanned   (atom [])]
@@ -4783,7 +4783,7 @@
             synthetic epoch when replace-frame-state! returns nil AFTER the
             liveness check passed."
     (rf/reg-frame :test/short-lived {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     (let [fanned   (atom [])]
@@ -4826,7 +4826,7 @@
             return, :rf.epoch/db-replaced emitted, synthetic epoch recorded —
             NOT a destroyed-frame drop."
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
     (let [recorded (record-trace!)

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -203,10 +203,10 @@
       ;; the dirty-check fires). These events are global (registrar
       ;; is global) but each thread reads from its own frame's
       ;; app-db, so the writes don't tangle.
-      (rf/reg-event-db :ztw5p.stress/seed
-                       (fn [_ [_ n]] {:n n}))
-      (rf/reg-event-db :ztw5p.stress/bump-input
-                       (fn [db [_ n]] (assoc db :n n)))
+      (rf/reg-event :ztw5p.stress/seed
+                       (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+      (rf/reg-event :ztw5p.stress/bump-input
+                       (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
 
       (let [latch   (CountDownLatch. 1)
             futures (vec

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -292,8 +292,8 @@
                 (rf/reg-event-db id meta handler)
                 (rf/reg-event-db id handler))
           :fx (if (seq meta)
-                (rf/reg-event-fx id meta handler)
-                (rf/reg-event-fx id handler)))))
+                (rf/reg-event id meta handler)
+                (rf/reg-event id handler)))))
     ;; ---- subs ----------------------------------------------------------
     (doseq [[id steps] (:sub hmap)]
       (let [{:keys [kind inputs body]} (conformance/realise-sub steps)

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -77,7 +77,7 @@
 (deftest destroy-frame-clears-last-inputs-rows-for-destroyed-frame
   (testing "destroying a frame removes the destroyed-frame entry from each flow's last-inputs row"
     (rf/reg-frame :fc/scratch {:doc "scratch frame for last-inputs teardown test"})
-    (rf/reg-event-db :fc/seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :fc/seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -101,8 +101,8 @@
   (testing "destroying frame A leaves frame B's last-inputs row for the same flow id intact"
     (rf/reg-frame :fc/a {:doc "frame A"})
     (rf/reg-frame :fc/b {:doc "frame B"})
-    (rf/reg-event-db :fc/seed-a (fn [_ _] {:w 2 :h 5}))
-    (rf/reg-event-db :fc/seed-b (fn [_ _] {:w 7 :h 9}))
+    (rf/reg-event :fc/seed-a (fn [{:keys [db]} _] {:db {:w 2 :h 5}}))
+    (rf/reg-event :fc/seed-b (fn [{:keys [db]} _] {:db {:w 7 :h 9}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -215,7 +215,7 @@
                         :output (fn [n] (or n 0))
                         :path   [:result]}
                        {:frame frame-id})
-          (rf/reg-event-db :fc/seed-churn (fn [_ [_ v]] {:n v}))
+          (rf/reg-event :fc/seed-churn (fn [{:keys [db]} [_ v]] {:db {:n v}}))
           (rf/dispatch-sync [:fc/seed-churn i] {:frame frame-id})
           (frame/destroy-frame! frame-id)))
       (is (empty? (flows/flows-snapshot))
@@ -230,7 +230,7 @@
 (deftest reg-frame-after-destroy-starts-clean
   (testing "registering a frame under a reused id after destroy starts with no leftover flow state"
     (rf/reg-frame :fc/scratch {:doc "first incarnation"})
-    (rf/reg-event-db :fc/seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :fc/seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* (or w 0) (or h 0)))
@@ -407,7 +407,7 @@
         "reg-flow on the dead frame is rejected")
     ;; Re-register the same id and drive a drain — the stale flow must NOT run.
     (rf/reg-frame :fc/scratch {:doc "second incarnation"})
-    (rf/reg-event-db :fc/set-n (fn [_ [_ v]] {:n v}))
+    (rf/reg-event :fc/set-n (fn [{:keys [db]} [_ v]] {:db {:n v}}))
     (rf/dispatch-sync [:fc/set-n 7] {:frame :fc/scratch})
     (is (not (contains? (flows/flows-snapshot) :fc/scratch))
         "the re-registered frame inherited no flow-registry slot")

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -107,8 +107,8 @@
           vacated     (CountDownLatch. 1)
           raced       (CountDownLatch. 1)
           release     (CountDownLatch. 1)]
-      (rf/reg-event-db :seed       (fn [_ _] {:n 5}))
-      (rf/reg-event-db :bump-input (fn [db [_ n]] (assoc db :n n)))
+      (rf/reg-event :seed       (fn [{:keys [db]} _] {:db {:n 5}}))
+      (rf/reg-event :bump-input (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
       (rf/reg-flow {:id     :doubled
                     :inputs [[:n]]
                     :output (fn [n] (* 2 (or n 0)))
@@ -201,8 +201,8 @@
           published     (CountDownLatch. 1)
           raced         (CountDownLatch. 1)
           release       (CountDownLatch. 1)]
-      (rf/reg-event-db :seed     (fn [_ _] {:n 5}))
-      (rf/reg-event-db :unrelated (fn [db _] (assoc db :touched true)))
+      (rf/reg-event :seed     (fn [{:keys [db]} _] {:db {:n 5}}))
+      (rf/reg-event :unrelated (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
       ;; Original flow: :out = 2 × :n.
       (rf/reg-flow {:id     :scaled
                     :inputs [[:n]]
@@ -312,7 +312,7 @@
   (testing "clear-flow vacates the replacement's NEW path, not the stale pre-lock OLD path"
     (let [in-handler (CountDownLatch. 1) ;; drain parked in handler, OLD flow live
           release    (CountDownLatch. 1)] ;; resume the handler → swap + materialise
-      (rf/reg-event-db :seed (fn [_ _] {:n 5}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 5}}))
       ;; OLD flow: :out-a = 2 × :n.
       (rf/reg-flow {:id     :scaled
                     :inputs [[:n]]
@@ -332,8 +332,8 @@
       ;; change vacate intends; the reentrant vacate writes the container
       ;; directly, but the drain's deferred commit installs THIS db, so the
       ;; dissoc here is what makes the move durable through the drain).
-      (rf/reg-event-db :replace-scaled
-                       (fn [db _]
+      (rf/reg-event :replace-scaled
+                       (fn [{:keys [db]} _]
                          (.countDown in-handler)
                          (await! release "replace-scaled handler release")
                          (rf/reg-flow {:id     :scaled
@@ -341,7 +341,7 @@
                                        :output (fn [n] (* 100 (or n 0)))
                                        :path   [:out-b]}
                                       {:frame :rf/default})
-                         (dissoc db :out-a)))
+                         {:db (dissoc db :out-a)}))
 
       (let [;; Thread A: the replacement drain. Parks in the handler holding
             ;; the drain-lock with the OLD flow still live.

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -105,7 +105,7 @@
   (testing "a flow declaring `:sensitive [[:secret]]` redacts the :secret
             sub-slot of its output on the :rf.flow/computed :result AND on
             the app-db destination egress, while a sibling slot rides raw"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id        :creds
                   :inputs    [[:n]]
                   :output    (fn [_] {:secret :S :public :P})
@@ -140,7 +140,7 @@
 (deftest reg-flow-whole-output-sensitive-redacts-entire-result
   (testing "a flow declaring `:rf.egress/output-sensitivity :rf.egress/sensitive` redacts its WHOLE output on
             :result and at the app-db destination slot"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id         :token
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "header.payload.sig"})
@@ -166,7 +166,7 @@
 (deftest reg-flow-large-whole-output-marks-result
   (testing "a flow declaring `:large? true` substitutes the
             :rf.size/large-elided marker for its whole output on :result"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id     :blob
                   :inputs [[:n]]
                   :output (fn [_] {:bytes "BIG"})
@@ -197,7 +197,7 @@
 
 (deftest reg-flow-large-subpath-marks-only-that-slot
   (testing "a flow declaring `:large [[:big]]` marks only the :big sub-slot"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id     :payload
                   :inputs [[:n]]
                   :output (fn [_] {:big {:k "BIG"} :small 1})
@@ -228,7 +228,7 @@
             declassify — where `:rf.egress/output-sensitivity :rf.egress/public` actively SUPPRESSES a
             propagated mark — is pinned in `propagation-explicit-false-...`
             below; rf2-ihfz9o.)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id         :mixed
                   :inputs     [[:n]]
                   :output     (fn [_] {:hashed :H :raw :R})
@@ -254,7 +254,7 @@
 (deftest reg-flow-no-marks-leaves-registry-untouched
   (testing "a plain flow (no classification keys) installs no declarations —
             the no-marks common case stays zero-overhead"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id     :plain
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -278,7 +278,7 @@
             output marks redacts independently per frame"
     (rf/reg-frame :left  {:doc "left"})
     (rf/reg-frame :right {:doc "right"})
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     ;; :left — whole output sensitive.
     (rf/reg-flow {:id         :shared
                   :inputs     [[:n]]
@@ -317,7 +317,7 @@
 
 (deftest clear-flow-drops-output-marks
   (testing "clear-flow removes the flow's :source :flow elision declarations"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id         :token
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "x"})
@@ -332,7 +332,7 @@
 (deftest clear-flow-preserves-other-sources
   (testing "clear-flow drops only :source :flow entries — schema- and
             add-marks-sourced declarations on adjacent paths survive"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     ;; An add-marks-sourced sensitive path the flow does not own.
     (marks/add-marks :rf/default {[:user :ssn] :sensitive})
     (rf/reg-flow {:id         :token
@@ -353,7 +353,7 @@
 (deftest reg-flow-path-change-moves-output-marks
   (testing "re-registering a flow with a NEW :path drops the OLD path's
             flow-sourced declaration and installs it at the new path"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id         :token
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "x"})
@@ -375,7 +375,7 @@
 (deftest reg-flow-re-register-with-fewer-marks-replaces-cleanly
   (testing "re-registering with a REDUCED mark set replaces the prior flow
             declarations wholesale (no stale leftovers)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (rf/reg-flow {:id        :creds
                   :inputs    [[:n]]
                   :output    (fn [_] {:a 1 :b 2})
@@ -419,7 +419,7 @@
   diagnostic — the same shape `partitioned_commit_test` uses to seed the
   runtime-db partition."
   [id f]
-  (rf/reg-event-fx id {:doc "framework-authority" :rf/machine? true} f))
+  (rf/reg-event id {:doc "framework-authority" :rf/machine? true} f))
 
 (defn- computed-result
   "The `:result` slot of the LAST `:rf.flow/computed` trace for `flow-id`."
@@ -436,7 +436,7 @@
             :computed/full-name shape. The propagated whole-output sensitive
             declaration is installed at the flow's :path, and the
             :rf.flow/computed :result is wholesale-redacted."
-    (rf/reg-event-db :init (fn [db _] (merge db {:user {:first "Ada" :last "Lovelace"}})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:user {:first "Ada" :last "Lovelace"}})}))
     ;; Mark the input slot sensitive BEFORE reg-flow (the realistic ordering).
     (marks/add-marks :rf/default {[:user :first] :sensitive})
     (rf/reg-flow {:id     :computed/full-name
@@ -456,7 +456,7 @@
   (testing "a sensitive mark added AFTER the flow registered still reaches the
             output — the drain-time topo refresh is the mark-mutation trigger a
             flow needs (it does not recompute on a mark-only change)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:secret-in "S"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:secret-in "S"})}))
     (rf/reg-flow {:id     :derive
                   :inputs [[:secret-in]]
                   :output (fn [s] (str s "-derived"))
@@ -476,7 +476,7 @@
 (deftest propagation-explicit-true-over-sensitive-input-holds
   (testing "explicit `:rf.egress/output-sensitivity :rf.egress/sensitive` over a sensitive input keeps the
             whole-output redaction (force-mark and propagation agree)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:tok "T"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:tok "T"})}))
     (marks/add-marks :rf/default {[:tok] :sensitive})
     (rf/reg-flow {:id         :wrap
                   :inputs     [[:tok]]
@@ -494,7 +494,7 @@
             declassify — it SUPPRESSES the propagated whole-output mark (the
             hash/mask/aggregate opt-out, Spec 015's :computed/hashed-token).
             Previously a no-op; rf2-ihfz9o makes it load-bearing."
-    (rf/reg-event-db :init (fn [db _] (merge db {:tok "secret-token"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:tok "secret-token"})}))
     (marks/add-marks :rf/default {[:tok] :sensitive})
     (rf/reg-flow {:id         :computed/hashed-token
                   :inputs     [[:tok]]
@@ -512,7 +512,7 @@
   (testing "a flow's `:rf.egress/output-sensitivity :rf.egress/public` declassify suppresses only the FLOW's
             own propagated/whole mark — it CANNOT unmark an add-marks-sourced
             declaration on the SAME output path (union semantics, Spec 015:295)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:in "x"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:in "x"})}))
     (marks/add-marks :rf/default {[:in] :sensitive})
     ;; An independent add-marks declaration directly on the flow's OUTPUT path.
     (marks/add-marks :rf/default {[:out] :sensitive})
@@ -533,7 +533,7 @@
 (deftest propagation-per-path-coexists-with-whole-output
   (testing "an explicit per-output-path `:sensitive [[:extra]]` declaration
             coexists with the propagated whole-output mark — both install"
-    (rf/reg-event-db :init (fn [db _] (merge db {:in "x"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:in "x"})}))
     (marks/add-marks :rf/default {[:in] :sensitive})
     (rf/reg-flow {:id        :combine
                   :inputs    [[:in]]
@@ -550,7 +550,7 @@
             does NOT auto-propagate :large to its output — a flow typically
             shrinks a large input (count / summary / first-N), so :large
             comes ONLY from explicit flow declarations."
-    (rf/reg-event-db :init (fn [db _] (merge db {:blob "BIG"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:blob "BIG"})}))
     (marks/add-marks :rf/default {[:blob] :large})
     (rf/reg-flow {:id     :summarise
                   :inputs [[:blob]]
@@ -564,7 +564,7 @@
 (deftest propagation-large-input-sensitive-sibling-marks-only-sensitive
   (testing "reading a SENSITIVE input and a LARGE input: only :sensitive
             propagates to the output (the asymmetry, cleanly separated)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:s "secret" :big "BIG"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:s "secret" :big "BIG"})}))
     (marks/add-marks :rf/default {[:s] :sensitive [:big] :large})
     (rf/reg-flow {:id     :mix
                   :inputs [[:s] [:big]]
@@ -603,7 +603,7 @@
   (testing "flow→flow DAG propagation: flow B reading flow A's sensitive
             output :path inherits A's propagated mark. The topo-ordered drain
             refresh resolves A before B so B sees A's freshly-installed mark."
-    (rf/reg-event-db :init (fn [db _] (merge db {:raw "secret"})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:raw "secret"})}))
     (marks/add-marks :rf/default {[:raw] :sensitive})
     ;; A: reads sensitive [:raw], writes [:step-a] (inherits sensitive).
     (rf/reg-flow {:id     :flow-a
@@ -631,7 +631,7 @@
             snapshot. Flows transform the pending :db before the single
             deferred install, so the output rides the t2 snapshot of that one
             event (the trace-facing assertion the bead requires)."
-    (rf/reg-event-db :init (fn [db _] (merge db {:user {:ssn "123-45-6789" :name "Ada"}})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:user {:ssn "123-45-6789" :name "Ada"}})}))
     (marks/add-marks :rf/default {[:user :ssn] :sensitive})
     (rf/reg-flow {:id     :ssn-echo
                   :inputs [[:user :ssn]]
@@ -653,8 +653,8 @@
   (testing "removing the input's sensitive mark (set-marks replacing it away)
             DROPS the propagated output mark on the next drain — propagation is
             re-resolved each drain, not latched"
-    (rf/reg-event-db :init (fn [db _] (merge db {:in "x"})))
-    (rf/reg-event-db :bump (fn [db _] (update db :in str "!")))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:in "x"})}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :in str "!")}))
     (marks/add-marks :rf/default {[:in] :sensitive})
     (rf/reg-flow {:id     :echo
                   :inputs [[:in]]
@@ -814,7 +814,7 @@
   (testing "the `[[]]` whole-output convention is VALID (a regression guard so
             the tightened validator does not reject the legitimate whole-value
             mark — [] is the one empty subpath that is legal)"
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1})}))
     (is (= :ok/whole
            (rf/reg-flow {:id        :ok/whole
                          :inputs    [[:n]]
@@ -834,7 +834,7 @@
   ;; is routed to the framework error handler, the post-condition is the same:
   ;; the registry and the elision registry stay clean.
   (testing ":rf.fx/reg-flow with malformed :sensitive installs no flow row / decl"
-    (rf/reg-event-fx :enter-bad-sens
+    (rf/reg-event :enter-bad-sens
       (fn [_ _]
         {:fx [[:rf.fx/reg-flow {:id        :fx/bad-sens
                                 :inputs    [[:n]]
@@ -847,7 +847,7 @@
     (is (no-decls?)
         "the malformed fx registration installed no elision declaration"))
   (testing ":rf.fx/reg-flow with malformed :sensitive? installs no flow row / decl"
-    (rf/reg-event-fx :enter-bad-sensq
+    (rf/reg-event :enter-bad-sensq
       (fn [_ _]
         {:fx [[:rf.fx/reg-flow {:id         :fx/bad-sensq
                                 :inputs     [[:n]]

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -183,7 +183,7 @@
     (rf/reg-frame :rf2-94ol5/a {:doc "throwing-flow frame"})
     (rf/reg-frame :rf2-94ol5/b {:doc "stable sibling frame"})
 
-    (rf/reg-event-db :rf2-94ol5/set-n (fn [db [_ n]] (assoc db :n n)))
+    (rf/reg-event :rf2-94ol5/set-n (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
 
     ;; Frame A: a flow that throws on every recompute. A's input changes
     ;; every iter so it ALWAYS recomputes (and therefore always rolls back).

--- a/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
+++ b/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
@@ -91,8 +91,8 @@
     ;; flip it, the slice passes.
     (let [reject-out? (atom false)]
       ;; The flow doubles :n into :out.
-      (rf/reg-event-db :seed       (fn [_ _] {:n 1}))
-      (rf/reg-event-db :touch-other (fn [db _] (assoc db :other true)))
+      (rf/reg-event :seed       (fn [{:keys [db]} _] {:db {:n 1}}))
+      (rf/reg-event :touch-other (fn [{:keys [db]} _] {:db (assoc db :other true)}))
       ;; App-db schema on the flow's OUTPUT slot: reject while the flag is
       ;; set, otherwise accept. A nil slice (output absent) always passes —
       ;; so the seeding dispatch (before :out exists / before the flow is
@@ -165,7 +165,7 @@
 (deftest durable-commit-leaves-dirty-check-advanced
   (testing "a flow whose output passes post-commit validation commits durably and advances last-inputs"
     (install-predicate-validator!)
-    (rf/reg-event-db :seed (fn [_ _] {:n 3}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 3}}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 (or n 0)))

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -91,7 +91,7 @@
 (deftest conforming-output-passes-silently
   (testing "a flow whose output conforms to :schema emits no violation and writes the value"
     (install-predicate-validator!)
-    (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -111,7 +111,7 @@
   (testing "a flow whose output violates :schema emits :where :flow-output and STILL writes (observational)"
     (install-predicate-validator!)
     ;; Output is negative; the schema demands a non-negative integer.
-    (rf/reg-event-db :seed (fn [_ _] {:w 3 :h -4}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h -4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -148,7 +148,7 @@
     (let [validator-calls (atom 0)]
       (schemas/set-schema-fns!
         {:validate (fn [_ _] (swap! validator-calls inc) false)})
-      (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
       (rf/reg-flow {:id     :area
                     :inputs [[:w] [:h]]
                     :output (fn [w h] (* w h))
@@ -168,7 +168,7 @@
     ;; nil validator => the `:schemas/validate-with-registered-fn` seam
     ;; treats 'no validator' as 'no validation' (Spec 010 soft-pass).
     (schemas/set-schema-validator! nil)
-    (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -187,7 +187,7 @@
 (deftest production-gate-elides-validation
   (testing "with debug-enabled? false the whole validation surface is silent (prod elision mirror)"
     (install-predicate-validator!)
-    (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -208,7 +208,7 @@
 (deftest each-flow-validates-its-own-output
   (testing "in a flow-reads-flow cascade each flow validates its own output against its own :schema"
     (install-predicate-validator!)
-    (rf/reg-event-db :seed (fn [_ _] {:cart {:items [{:price 10} {:price -5}]}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:cart {:items [{:price 10} {:price -5}]}}}))
     ;; subtotal sums the (here intentionally negative-capable) prices.
     (rf/reg-flow {:id     :cart/subtotal
                   :inputs [[:cart :items]]
@@ -231,7 +231,7 @@
     ;; also violates. Each surfaces independently with its own :rf.flow/id.
     (reset! *captured* [])
     (rf/dispatch-sync [:seed] )         ;; re-seed is a no-op write (same value)
-    (rf/reg-event-db :seed-neg (fn [_ _] {:cart {:items [{:price -100}]}}))
+    (rf/reg-event :seed-neg (fn [{:keys [db]} _] {:db {:cart {:items [{:price -100}]}}}))
     (rf/dispatch-sync [:seed-neg])
     (let [ids (set (map #(get-in % [:tags :rf.flow/id]) (violations)))]
       (is (= #{:cart/subtotal :cart/total} ids)

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -65,7 +65,7 @@
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
                   :path   [:doubled]})
-    (rf/reg-event-db :t2/set-n (fn [db _] (assoc db :n 7)))
+    (rf/reg-event :t2/set-n (fn [{:keys [db]} _] {:db (assoc db :n 7)}))
     (let [acc (collect-traces! ::t2-emit)]
       (try
         (rf/dispatch-sync [:t2/set-n])
@@ -92,7 +92,7 @@
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
                   :path   [:doubled]})
-    (rf/reg-event-db :t2/set-n (fn [db _] (assoc db :n 5)))
+    (rf/reg-event :t2/set-n (fn [{:keys [db]} _] {:db (assoc db :n 5)}))
     (rf/dispatch-sync [:t2/set-n])      ; prime
     (let [acc (collect-traces! ::t2-skip)]
       (try
@@ -116,7 +116,7 @@
                   :inputs [[:a] [:b]]
                   :output +
                   :path   [:sum]})
-    (rf/reg-event-db :t2/seed (fn [_ _] {:a 3 :b 4}))
+    (rf/reg-event :t2/seed (fn [{:keys [db]} _] {:db {:a 3 :b 4}}))
     (let [acc (collect-traces! ::t2-order)]
       (try
         (rf/dispatch-sync [:t2/seed])
@@ -145,7 +145,7 @@
                   :inputs [[:items]]
                   :output (fn [items] (count items))
                   :path   [:item-count]})
-    (rf/reg-event-db :t2/add-items (fn [_ _] {:items [:a :b :c]}))
+    (rf/reg-event :t2/add-items (fn [{:keys [db]} _] {:db {:items [:a :b :c]}}))
     (let [acc (collect-traces! ::t1-t2-pair)]
       (try
         (rf/dispatch-sync [:t2/add-items])
@@ -174,7 +174,7 @@
                   :inputs [[:x]]
                   :output (fn [_] (throw (ex-info "boom" {})))
                   :path   [:boom]})
-    (rf/reg-event-db :t2/trigger-boom (fn [_ _] {:x 1}))
+    (rf/reg-event :t2/trigger-boom (fn [{:keys [db]} _] {:db {:x 1}}))
     (let [acc (collect-traces! ::t2-throw)]
       (try
         (rf/dispatch-sync [:t2/trigger-boom])

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -84,7 +84,7 @@
     ;; rf2-aqt7: clear-flow's update-in path math is off-by-one for
     ;; single-element :path vectors. Use a two-element :path here so
     ;; the working branch (>= 2 elements) is exercised.
-    (rf/reg-event-db :seed (fn [_ _] {:rect {:w 3 :h 4}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:rect {:w 3 :h 4}}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:rect :w] [:rect :h]]
                   :output (fn [w h] (* w h))
@@ -127,13 +127,13 @@
   ;; flow's *value* is fully gone (the spec's "vacate the slot"
   ;; requirement); only the structural empty-map parent persists.
   (testing "clearing a flow whose leaf is the sole key under its parent leaves an empty parent map"
-    (rf/reg-event-db :seed-wizard (fn [_ _] {:wizard {}}))
+    (rf/reg-event :seed-wizard (fn [{:keys [db]} _] {:db {:wizard {}}}))
     (rf/reg-flow {:id     :wizard/result
                   :inputs [[:wizard :seed]]
                   :output (fn [_] 42)
                   :path   [:wizard :result]})
     ;; Drive a drain so the flow materialises [:wizard :result].
-    (rf/reg-event-db :touch-wizard (fn [db _] (assoc-in db [:wizard :seed] 1)))
+    (rf/reg-event :touch-wizard (fn [{:keys [db]} _] {:db (assoc-in db [:wizard :seed] 1)}))
     (rf/dispatch-sync [:seed-wizard])
     (rf/dispatch-sync [:touch-wizard])
     (is (= 42 (get-in (rf/app-db-value :rf/default) [:wizard :result]))
@@ -187,7 +187,7 @@
   ;; its `:path` slot stays absent. (Driving a drain would compute the
   ;; flow and materialise the slot, turning the clear into a real dissoc.)
   (testing "clearing a never-materialised nested-path flow leaves the app-db container reference identical (no rewrite, no sub-cache invalidation)"
-    (rf/reg-event-db :seed (fn [_ _] {:other 1}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:other 1}}))
     (rf/dispatch-sync [:seed])
     (rf/reg-flow {:id     :pending
                   :inputs [[:n]]
@@ -202,7 +202,7 @@
     ;; The length-1 branch (`(dissoc db (first path))`) is a no-op when the
     ;; key is absent — `(identical? new-db db)` holds, so the guard skips
     ;; the write here too. Same precondition: never drive the drain.
-    (rf/reg-event-db :seed2 (fn [_ _] {:other 1}))
+    (rf/reg-event :seed2 (fn [{:keys [db]} _] {:db {:other 1}}))
     (rf/dispatch-sync [:seed2])
     (rf/reg-flow {:id     :absent-top
                   :inputs [[:n]]
@@ -217,7 +217,7 @@
     ;; When the slot was actually written, the dissoc produces a NEW db
     ;; reference, so the write MUST fire — otherwise the cleared value
     ;; would linger in app-db and stale subs would never invalidate.
-    (rf/reg-event-db :seed3 (fn [_ _] {:rect {:w 3 :h 4}}))
+    (rf/reg-event :seed3 (fn [{:keys [db]} _] {:db {:rect {:w 3 :h 4}}}))
     (rf/reg-flow {:id     :area3
                   :inputs [[:rect :w] [:rect :h]]
                   :output (fn [w h] (* w h))
@@ -250,7 +250,7 @@
     ;; evaluation, so we register the flow AFTER seeding and never drain
     ;; it — its `:path` stays un-materialised, which is exactly the
     ;; non-map-intermediate case `clear-flow` must treat as a no-op.
-    (rf/reg-event-db :stamp-non-map (fn [_ _] {:step-2 1 :foo 3 :bar 4}))
+    (rf/reg-event :stamp-non-map (fn [{:keys [db]} _] {:db {:step-2 1 :foo 3 :bar 4}}))
     (rf/dispatch-sync [:stamp-non-map])
     ;; Register the flow (never drained) so the per-frame registry has the
     ;; entry to clear; its `:path` [:step-2 :result] never materialised.
@@ -272,7 +272,7 @@
     ;; The repro from rf2-aqt7: a flow whose :path is a one-element vector
     ;; [:area]. Before the fix, clear-flow's (update-in cur [] dissoc :area)
     ;; left :area in app-db (and silently introduced an {nil nil} entry).
-    (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -700,9 +700,9 @@
 
 (deftest flow-recomputes-on-input-change
   (testing "mutating an input path causes the flow to fire and the output to update"
-    (rf/reg-event-db :init (fn [_ _] {:w 0 :h 0}))
-    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
-    (rf/reg-event-db :h!   (fn [db [_ h]] (assoc db :h h)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:w 0 :h 0}}))
+    (rf/reg-event :w!   (fn [{:keys [db]} [_ w]] {:db (assoc db :w w)}))
+    (rf/reg-event :h!   (fn [{:keys [db]} [_ h]] {:db (assoc db :h h)}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -720,8 +720,8 @@
 (deftest flow-noop-on-equal-input-rewrite
   (testing "rewriting an input path with an =-equal value does NOT re-fire the flow"
     (let [calls (atom 0)]
-      (rf/reg-event-db :init      (fn [_ _] {:n 5}))
-      (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-event :init      (fn [{:keys [db]} _] {:db {:n 5}}))
+      (rf/reg-event :replace-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
       (rf/reg-flow {:id     :double
                     :inputs [[:n]]
                     :output (fn [n]
@@ -746,8 +746,8 @@
 (deftest flow-no-recompute-when-unrelated-path-changes
   (testing "writing an unrelated path does not re-fire a flow whose inputs are stable"
     (let [calls (atom 0)]
-      (rf/reg-event-db :init      (fn [_ _] {:user {:name "alice"} :other 0}))
-      (rf/reg-event-db :bump-other (fn [db _] (update db :other inc)))
+      (rf/reg-event :init      (fn [{:keys [db]} _] {:db {:user {:name "alice"} :other 0}}))
+      (rf/reg-event :bump-other (fn [{:keys [db]} _] {:db (update db :other inc)}))
       (rf/reg-flow {:id     :user/uppercase-name
                     :inputs [[:user :name]]
                     :output (fn [n]
@@ -768,8 +768,8 @@
 
 (deftest flow-topo-sort-cascades-in-one-drain
   (testing "B reads what A wrote; topo sort places A first; one drain settles both"
-    (rf/reg-event-db :init (fn [_ _] {:w 2 :h 3}))
-    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:w 2 :h 3}}))
+    (rf/reg-event :w!   (fn [{:keys [db]} [_ w]] {:db (assoc db :w w)}))
     ;; A: :area depends on :w :h, writes :rect/:area.
     (rf/reg-flow {:id     :rect/area
                   :inputs [[:w] [:h]]
@@ -791,7 +791,7 @@
 
 (deftest flow-topo-sort-handles-prefix-overlap
   (testing "B's :inputs is a prefix of A's :path — A still runs before B (Spec 013 §Dependency rule)"
-    (rf/reg-event-db :init (fn [_ _] {:user {:name "alice"} :note ""}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:user {:name "alice"} :note ""}}))
     ;; A writes deep at [:user :uppercase] — its :path is rooted in
     ;; the same prefix as B's input.
     (rf/reg-flow {:id     :user/uppercase
@@ -820,8 +820,8 @@
 
 (deftest flow-hot-reload-preserves-equivalent-output
   (testing "re-registering a flow with a body that produces the same output keeps the output stable"
-    (rf/reg-event-db :init (fn [_ _] {:n 5}))
-    (rf/reg-event-db :tick (fn [db _] (update db :tick (fnil inc 0))))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :tick (fn [{:keys [db]} _] {:db (update db :tick (fnil inc 0))}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -841,8 +841,8 @@
 
 (deftest flow-hot-reload-new-body-recomputes-on-next-drain
   (testing "if the new body would produce a different value, the next drain materialises it"
-    (rf/reg-event-db :init  (fn [_ _] {:n 5}))
-    (rf/reg-event-db :tick  (fn [db _] (update db :tick (fnil inc 0))))
+    (rf/reg-event :init  (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :tick  (fn [{:keys [db]} _] {:db (update db :tick (fnil inc 0))}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -864,15 +864,15 @@
 
 (deftest fx-reg-flow-and-clear-flow-round-trip
   (testing ":rf.fx/reg-flow registers; :rf.fx/clear-flow removes; the output path is dissoc'd"
-    (rf/reg-event-db :init  (fn [_ _] {:wizard {:foo 3 :bar 4}}))
-    (rf/reg-event-fx :enter (fn [_ _]
+    (rf/reg-event :init  (fn [{:keys [db]} _] {:db {:wizard {:foo 3 :bar 4}}}))
+    (rf/reg-event :enter (fn [_ _]
                               {:fx [[:rf.fx/reg-flow
                                      {:id     :step-2/computed
                                       :inputs [[:wizard :foo] [:wizard :bar]]
                                       :output (fn [foo bar] (+ foo bar))
                                       :path   [:wizard :result]}]]}))
-    (rf/reg-event-db :foo!  (fn [db [_ v]] (assoc-in db [:wizard :foo] v)))
-    (rf/reg-event-fx :leave (fn [_ _]
+    (rf/reg-event :foo!  (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:wizard :foo] v)}))
+    (rf/reg-event :leave (fn [_ _]
                               {:fx [[:rf.fx/clear-flow :step-2/computed]]}))
     (rf/dispatch-sync [:init])
     (is (nil? (get-in (rf/app-db-value :rf/default) [:wizard :result]))
@@ -902,9 +902,9 @@
   ;; handler) materialises the initial value on the dispatched event's
   ;; drain. Locks the lag so a future "synchronous re-walk" change can't
   ;; silently alter it without flipping this test.
-  (rf/reg-event-db :init (fn [_ _] {:wizard {:foo 3 :bar 4}}))
+  (rf/reg-event :init (fn [{:keys [db]} _] {:db {:wizard {:foo 3 :bar 4}}}))
   ;; Bare register — NO follow-up dispatch. Demonstrates the lag.
-  (rf/reg-event-fx :enter-bare
+  (rf/reg-event :enter-bare
     (fn [_ _]
       {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
                               :inputs [[:wizard :foo] [:wizard :bar]]
@@ -912,7 +912,7 @@
                               :path   [:wizard :result]}]]}))
   ;; Register + a follow-up no-op `:dispatch` on the same handler — the
   ;; documented "I need the value now" workaround.
-  (rf/reg-event-fx :enter-with-settle
+  (rf/reg-event :enter-with-settle
     (fn [_ _]
       {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
                               :inputs [[:wizard :foo] [:wizard :bar]]
@@ -956,7 +956,7 @@
   ;; then re-registering the same flow-id would silently no-op the
   ;; first evaluation when new-inputs =-equalled a leftover entry.
   (testing "reset-flows! drops both flow registry AND last-inputs in lockstep"
-    (rf/reg-event-db :init (fn [_ _] {:n 5}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -980,7 +980,7 @@
   ;; never ran.
   (testing "after reset-flows! the re-registered flow re-evaluates on next drain"
     (let [calls (atom 0)]
-      (rf/reg-event-db :init (fn [_ _] {:n 5}))
+      (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
       ;; First registration + drain — populates last-inputs.
       (rf/reg-flow {:id     :double
                     :inputs [[:n]]
@@ -1040,7 +1040,7 @@
   (testing "the same flow id registers independently against two frames"
     (rf/reg-frame :left  {:doc "left frame"})
     (rf/reg-frame :right {:doc "right frame"})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     ;; Register :compute against both frames with DIFFERENT :output fns
     ;; so sibling-frame-untouched is observable in the materialised output.
     (rf/reg-flow {:id     :compute
@@ -1158,7 +1158,7 @@
   (testing "Per rf2-jfpf3: re-register :shared on :left; :right's last-inputs row survives"
     (rf/reg-frame :left  {:doc "left frame"})
     (rf/reg-frame :right {:doc "right frame"})
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     ;; Register :shared against both frames with the same shape.
     (rf/reg-flow {:id     :shared
                   :inputs [[:n]]
@@ -1325,8 +1325,8 @@
   (testing "Per rf2-73pi1: re-registering on the same frame with a new :path
             clears the OLD path from app-db; the new path computes on the
             next drain"
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
-    (rf/reg-event-db :tick (fn [db _] (update db :tick (fnil inc 0))))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+    (rf/reg-event :tick (fn [{:keys [db]} _] {:db (update db :tick (fnil inc 0))}))
     ;; Register :move at [:old]; drain so [:old] materialises.
     (rf/reg-flow {:id :move :inputs [[:n]] :output (fn [n] (* 2 (or n 0)))
                   :path [:old]})
@@ -1351,7 +1351,7 @@
   (testing "Per rf2-73pi1: a same-frame re-registration that KEEPS the :path
             does NOT vacate the value (negative control — only a :path
             CHANGE triggers the vacate)"
-    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/reg-flow {:id :keep :inputs [[:n]] :output (fn [n] (* 2 (or n 0)))
                   :path [:out]})
     (rf/dispatch-sync [:seed 4])
@@ -1447,8 +1447,8 @@
 
 (deftest flow-hot-reload-invalidates-last-inputs
   (testing "re-registering a flow re-evaluates even when inputs are unchanged"
-    (rf/reg-event-db :init   (fn [_ _] {:n 5}))
-    (rf/reg-event-db :inc-n  (fn [db _] (update db :n inc)))
+    (rf/reg-event :init   (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :inc-n  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     ;; v1 flow: doubles :n at [:doubled].
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
@@ -1499,14 +1499,14 @@
     ;; flows are outermost so they read the full reshaped db; user :after
     ;; interceptors precede them.
     (let [seen-db (atom :unset)]
-      (rf/reg-event-db :init (fn [_ _] {:n 0}))
-      (rf/reg-event-db :set-n
+      (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/reg-event :set-n
         {:interceptors [(rf/->interceptor
                          :id    :test/capture-after
                          :after (fn [ctx]
                                   (reset! seen-db (rf/get-effect ctx :db))
                                   ctx))]}
-        (fn [db [_ v]] (assoc db :n v)))
+        (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
       (rf/reg-flow {:id     :double
                     :inputs [[:n]]
                     :output (fn [n] (* 2 n))
@@ -1540,8 +1540,8 @@
       (rf/reg-fx :test/peek-db
                  (fn [_m _args]
                    (reset! fx-saw (rf/app-db-value :rf/default))))
-      (rf/reg-event-db :init (fn [_ _] {:n 0}))
-      (rf/reg-event-fx :go
+      (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 0}}))
+      (rf/reg-event :go
                        (fn [_ [_ v]]
                          {:db {:n v}
                           :fx [[:test/peek-db {}]]}))
@@ -1556,8 +1556,8 @@
 
 (deftest reactive-cascade-sees-flow-derived-db
   (testing "rf2-u0zz5 (c): a subscription over the flow's :path sees the flow output"
-    (rf/reg-event-db :init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :set-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -1577,10 +1577,10 @@
     ;; interceptor splices the slice back), NOT the bare slice — otherwise
     ;; `(get-in slice [:counter :n])` would be nil and the flow would
     ;; mis-compute.
-    (rf/reg-event-db :seed (fn [_ _] {:counter {:n 0}}))
-    (rf/reg-event-db :inc
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:counter {:n 0}}}))
+    (rf/reg-event :inc
                      {:interceptors [(rf/path :counter)]}
-                     (fn [c _] (update c :n inc)))
+                     (fn [{:keys [db]} _] {:db (update c :n inc)}))
     (rf/reg-flow {:id     :counter/doubled
                   :inputs [[:counter :n]]
                   :output (fn [n] (* 2 (or n 0)))
@@ -1620,8 +1620,8 @@
             ;; reading the live app-db reflects the just-installed value.
             (reset! db-at-changed (rf/app-db-value :rf/default)))))
       (try
-        (rf/reg-event-db :init (fn [_ _] {:n 0}))
-        (rf/reg-event-db :set-n (fn [db [_ v]] (assoc db :n v)))
+        (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 0}}))
+        (rf/reg-event :set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
         (rf/reg-flow {:id     :double
                       :inputs [[:n]]
                       :output (fn [n] (* 2 n))

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -1580,7 +1580,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:counter {:n 0}}}))
     (rf/reg-event :inc
                      {:interceptors [(rf/path :counter)]}
-                     (fn [{:keys [db]} _] {:db (update c :n inc)}))
+                     (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-flow {:id     :counter/doubled
                   :inputs [[:counter :n]]
                   :output (fn [n] (* 2 (or n 0)))

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -109,8 +109,8 @@
             so the result/input-values payload construction elides too."
     (let [seen (listener-fixture
                  (fn []
-                   (rf/reg-event-db :prod-elision/seed-rect
-                     (fn [db _] (assoc db :w 3 :h 4)))
+                   (rf/reg-event :prod-elision/seed-rect
+                     (fn [{:keys [db]} _] {:db (assoc db :w 3 :h 4)}))
                    (rf/reg-flow
                      {:id     :prod-elision/area
                       :inputs [[:w] [:h]]
@@ -138,8 +138,8 @@
             nothing."
     (let [seen (listener-fixture
                  (fn []
-                   (rf/reg-event-db :prod-elision/seed-throw-input
-                     (fn [db _] (assoc db :trigger? true)))
+                   (rf/reg-event :prod-elision/seed-throw-input
+                     (fn [{:keys [db]} _] {:db (assoc db :trigger? true)}))
                    (rf/reg-flow
                      {:id     :prod-elision/throwing
                       :inputs [[:trigger?]]
@@ -160,10 +160,10 @@
             dirty-check still runs (it's necessary for correctness);
             only the trace emit elides."
     ;; First drain installs the flow + populates :last-inputs.
-    (rf/reg-event-db :prod-elision/seed-skip
-      (fn [db _] (assoc db :a 1)))
-    (rf/reg-event-db :prod-elision/touch-skip
-      (fn [db _] (update db :touched (fnil inc 0))))
+    (rf/reg-event :prod-elision/seed-skip
+      (fn [{:keys [db]} _] {:db (assoc db :a 1)}))
+    (rf/reg-event :prod-elision/touch-skip
+      (fn [{:keys [db]} _] {:db (update db :touched (fnil inc 0))}))
     (rf/reg-flow
       {:id     :prod-elision/skipper
        :inputs [[:a]]
@@ -211,8 +211,8 @@
     ;; Register a validator that REJECTS every value — if validation ran,
     ;; a violation would surface.
     (schemas/set-schema-fns! {:validate (fn [_ _] false)})
-    (rf/reg-event-db :prod-elision/seed-validate
-      (fn [db _] (assoc db :w 3 :h 4)))
+    (rf/reg-event :prod-elision/seed-validate
+      (fn [{:keys [db]} _] {:db (assoc db :w 3 :h 4)}))
     (rf/reg-flow
       {:id     :prod-elision/validated
        :inputs [[:w] [:h]]

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1158,7 +1158,7 @@
                   :path   [:auth :derived-user]})
     (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc db :token token)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:auth/signed-in "secret-token"])
     (let [computes (by-op :rf.flow/computed)]
@@ -1178,7 +1178,7 @@
                   :path   [:auth :derived-user]})
     (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc db :token token)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:auth/signed-in "secret-token"])
     (let [failures (by-op :rf.flow/failed)]
@@ -1197,7 +1197,7 @@
                   :path   [:auth :derived-user]})
     (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc db :token token)}))
     ;; First sign-in computes; second sign-in with the SAME token leaves
     ;; the input value-equal → `:rf.flow/skip` fires, still inside the
     ;; frame-sensitive handler scope.
@@ -1225,7 +1225,7 @@
                   :path   [:profile :greeting]})
     (rf/reg-event :profile/rename
                      {:interceptors [(rf/path :profile)]}
-                     (fn [{:keys [db]} [_ name]] {:db (assoc profile :name name)}))
+                     (fn [{:keys [db]} [_ name]] {:db (assoc db :name name)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:profile/rename "ada"])
     (let [computes (by-op :rf.flow/computed)]
@@ -1250,7 +1250,7 @@
                   :path   [:auth :derived-token]})
     (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc db :token token)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:auth/signed-in "secret-token"])
     (let [ev   (first (by-op :rf.flow/computed))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -230,7 +230,7 @@
 
 (deftest flow-computed-fires-on-input-change
   (testing "first drain after registration emits :rf.flow/computed with :input-values, :result, :path, :frame"
-    (rf/reg-event-db :init (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -281,8 +281,8 @@
 
 (deftest computed-before-equals-prior-result-on-second-compute
   (testing "second :rf.flow/computed's :before equals the first compute's :result"
-    (rf/reg-event-db :init      (fn [_ _] {:n 3}))
-    (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :init      (fn [{:keys [db]} _] {:db {:n 3}}))
+    (rf/reg-event :replace-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -305,7 +305,7 @@
     ;; Seed [:doubled] with a value the event handler put there before
     ;; the flow ever fires. The first compute's :before MUST be that
     ;; prior value — not nil — because the slot was non-empty.
-    (rf/reg-event-db :seed (fn [_ _] {:n 3 :doubled :preseeded}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 3 :doubled :preseeded}}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -320,8 +320,8 @@
 
 (deftest computed-before-on-nested-path
   (testing ":before reads the pre-write value at a deeply-nested :path"
-    (rf/reg-event-db :init  (fn [_ _] {:w 3 :h 4 :rect {:area :initial-area}}))
-    (rf/reg-event-db :grow  (fn [db _] (assoc db :w 5)))
+    (rf/reg-event :init  (fn [{:keys [db]} _] {:db {:w 3 :h 4 :rect {:area :initial-area}}}))
+    (rf/reg-event :grow  (fn [{:keys [db]} _] {:db (assoc db :w 5)}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -345,8 +345,8 @@
     ;; reflect the pre-drain value at [:b-out] (here nil on first
     ;; compute), NOT some intermediate state from :A's write. Each
     ;; flow's :before is independent — captured against its own :path.
-    (rf/reg-event-db :init (fn [_ _] {:n 3}))
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 3}}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-flow {:id     :A
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -383,8 +383,8 @@
 
 (deftest flow-skip-fires-on-value-equal-rewrite
   (testing "writing :n with =-equal value emits :rf.flow/skip not :rf.flow/computed"
-    (rf/reg-event-db :init       (fn [_ _] {:n 5}))
-    (rf/reg-event-db :replace-n  (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :init       (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :replace-n  (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -424,8 +424,8 @@
     ;; Two distinct input paths. On a value-equal rewrite the cascade-DAG
     ;; consumer must learn BOTH inputs were considered-and-unchanged, so
     ;; the tag must enumerate every declared input path.
-    (rf/reg-event-db :init       (fn [_ _] {:w 3 :h 4}))
-    (rf/reg-event-db :rewrite-wh (fn [db [_ w h]] (assoc db :w w :h h)))
+    (rf/reg-event :init       (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
+    (rf/reg-event :rewrite-wh (fn [{:keys [db]} [_ w h]] {:db (assoc db :w w :h h)}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -442,8 +442,8 @@
 
 (deftest flow-skip-then-computed-on-real-change
   (testing "skip fires on equal rewrite; subsequent real change fires :rf.flow/computed"
-    (rf/reg-event-db :init      (fn [_ _] {:n 5}))
-    (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :init      (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :replace-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -461,7 +461,7 @@
 
 (deftest clear-flow-emits-cleared-trace
   (testing "clear-flow emits :rf.flow/cleared with :flow-id, :path, :frame"
-    (rf/reg-event-db :seed (fn [_ _] {:rect {:w 3 :h 4}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:rect {:w 3 :h 4}}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:rect :w] [:rect :h]]
                   :output (fn [w h] (* w h))
@@ -487,8 +487,8 @@
 
 (deftest flow-failed-fires-when-output-throws
   (testing "a flow whose :output fn throws emits :rf.flow/failed; the exception propagates"
-    (rf/reg-event-db :init       (fn [_ _] {:n 1}))
-    (rf/reg-event-db :bump       (fn [db _] (update db :n inc)))
+    (rf/reg-event :init       (fn [{:keys [db]} _] {:db {:n 1}}))
+    (rf/reg-event :bump       (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-flow {:id     :boom
                   :inputs [[:n]]
                   :output (fn [_] (throw (ex-info "boom" {:why :test})))
@@ -539,7 +539,7 @@
       (rf/register-error-listener!
         :test/flow-eval-recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-db :init (fn [_ _] {:n 1}))
+      (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/reg-flow {:id     :boom
                     :inputs [[:n]]
                     :output (fn [_] (throw (ex-info "flow boom" {:why :test})))
@@ -607,7 +607,7 @@
                     :path   [:a-out]})
       ;; Now dispatch an event whose :fx registers :b such that
       ;; :b's :inputs overlap :a's :path → cycle.
-      (rf/reg-event-fx :introduce-cycle
+      (rf/reg-event :introduce-cycle
                        (fn [_ _]
                          {:fx [[:rf.fx/reg-flow
                                 {:id     :b
@@ -645,7 +645,7 @@
           (when (= :rf.error/flow-eval-exception (:operation ev))
             (reset! trace-saw ev))))
       (try
-        (rf/reg-event-db :init (fn [_ _] {:n 1}))
+        (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 1}}))
         (rf/reg-flow {:id     :boom
                       :inputs [[:n]]
                       :output (fn [_] (throw (ex-info "boom" {})))
@@ -665,8 +665,8 @@
 
 (deftest typical-lifecycle-fires-all-five-events
   (testing "register → first compute → skip on equal rewrite → real recompute → clear"
-    (rf/reg-event-db :init      (fn [_ _] {:n 3}))
-    (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :init      (fn [{:keys [db]} _] {:db {:n 3}}))
+    (rf/reg-event :replace-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -705,7 +705,7 @@
     ;; in app-db under `:rf/runtime`, where a replacing handler WOULD have
     ;; clobbered it; that footgun is structurally gone — see
     ;; `re-frame.events/reject-legacy-runtime-root!`.)
-    (rf/reg-event-db :init (fn [_ _] {:n 1}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/reg-flow {:id     :payload
                   :inputs [[:n]]
                   :output (fn [_] {:bytes "BIG"})
@@ -728,7 +728,7 @@
   (testing ":rf.flow/failed :inputs rides through elide-wire-value"
     ;; Register the flow that will throw; the input path is frame-
     ;; declared large so the walker substitutes the marker on emit.
-    (rf/reg-event-db :init (fn [_ _] {:payload {:big "value"}}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:payload {:big "value"}}}))
     (rf/reg-flow {:id     :boom
                   :inputs [[:payload]]
                   :output (fn [_] (throw (ex-info "boom" {})))
@@ -764,8 +764,8 @@
     ;; (A.path → B.input, B.path → C.input) pin topo order A → B → C.
     ;; Seed :n via a FIRST clean drain so we can prove the SECOND
     ;; (throwing) drain installs nothing on top of it.
-    (rf/reg-event-db :seed (fn [_ _] {:n 5}))
-    (rf/reg-event-db :touch (fn [db _] (assoc db :touched true)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 5}}))
+    (rf/reg-event :touch (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
     (rf/reg-flow {:id     :A
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -832,7 +832,7 @@
     ;; :init writes the SAME db each drain, so absent rollback :A's
     ;; dirty-check would suppress its recompute on the 2nd+ drain. Because
     ;; the throw rolls back last-inputs, :A recomputes on EVERY drain.
-    (rf/reg-event-db :init (fn [_ _] {:n 5}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 5}}))
     (let [a-calls (atom 0)
           b-calls (atom 0)]
       (rf/reg-flow {:id     :A
@@ -861,7 +861,7 @@
 
 (deftest failed-flow-app-db-unchanged-across-multiple-failing-drains
   (testing "across multiple failing drains, NOTHING lands — app-db stays unchanged (no partial commit)"
-    (rf/reg-event-db :n!   (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :n!   (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :A
                   :inputs [[:n]]
                   :output (fn [n] (* 10 n))
@@ -914,7 +914,7 @@
     (let [child-fired? (atom false)]
       (rf/reg-event-db :after-throw
                        (fn [db _] (reset! child-fired? true) db))
-      (rf/reg-event-fx :run-with-throwing-flow
+      (rf/reg-event :run-with-throwing-flow
                        (fn [_ _]
                          {:db {:n 2}
                           :fx [[:dispatch [:after-throw]]]}))
@@ -937,10 +937,10 @@
 (deftest fx-after-successful-flow-still-runs
   (testing "Per rf2-fslx0: when flows succeed, :fx still walks normally (negative control)"
     (let [child-fired? (atom false)]
-      (rf/reg-event-db :init (fn [_ _] {:n 1}))
+      (rf/reg-event :init (fn [{:keys [db]} _] {:db {:n 1}}))
       (rf/reg-event-db :after-ok
                        (fn [db _] (reset! child-fired? true) db))
-      (rf/reg-event-fx :run-with-ok-flow
+      (rf/reg-event :run-with-ok-flow
                        (fn [_ _]
                          {:db {:n 2}
                           :fx [[:dispatch [:after-ok]]]}))
@@ -965,7 +965,7 @@
       (rf/register-error-listener!
         :test/fx-skip-recorder
         (fn [record] (swap! seen conj record)))
-      (rf/reg-event-fx :run-with-throwing-flow
+      (rf/reg-event :run-with-throwing-flow
                        (fn [_ _]
                          {:db {:n 2}
                           :fx [[:dispatch [:must-not-fire]]]}))
@@ -1005,7 +1005,7 @@
       ;; Handler writes :n; flow :double reads :n and writes :doubled. The
       ;; :fx vector has a throwing fx alongside an ok fx — the throw must
       ;; NOT discard the already-committed handler :db or flow output.
-      (rf/reg-event-fx :commit-then-fx-throw
+      (rf/reg-event :commit-then-fx-throw
                        (fn [_ _]
                          {:db {:n 5}
                           :fx [[:test/ok-fx true]
@@ -1043,9 +1043,9 @@
             inputs are unchanged, emits ZERO :rf.event/db-changed"
     (rf/reg-fx :test/noop (fn [& _] nil))
     ;; Seed :n so the flow computes once on the seed drain.
-    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
     ;; This handler writes NO :db — only an :fx that is a noop.
-    (rf/reg-event-fx :no-write
+    (rf/reg-event :no-write
                      (fn [_ _] {:fx [[:test/noop true]]}))
     (rf/reg-flow {:id     :double
                   :inputs [[:n]]
@@ -1078,7 +1078,7 @@
   (testing "absent any declaration, :input-values and :result pass through unchanged"
     ;; Belt-and-braces against an over-eager rewrite — the walker must be
     ;; a no-op on plain values not nominated for elision.
-    (rf/reg-event-db :init (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow {:id     :area
                   :inputs [[:w] [:h]]
                   :output (fn [w h] (* w h))
@@ -1097,8 +1097,8 @@
     ;; nil on the FIRST flow drain we observe. Then bump :n to drive
     ;; a recompute whose :before reads the previous blob and is
     ;; therefore frame-large. The walker must substitute the marker.
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1 :derived {:blob {:bytes "PRESEEDED"}}})))
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :init (fn [{:keys [db]} _] {:db (merge db {:n 1 :derived {:blob {:bytes "PRESEEDED"}}})}))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-flow {:id     :payload
                   :inputs [[:n]]
                   :output (fn [n] {:bytes (str "blob-" n)})
@@ -1156,9 +1156,9 @@
                   :inputs [[:auth :token]]
                   :output (fn [t] (str "user-of-" t))
                   :path   [:auth :derived-user]})
-    (rf/reg-event-db :auth/signed-in
+    (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [auth [_ token]] (assoc auth :token token)))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:auth/signed-in "secret-token"])
     (let [computes (by-op :rf.flow/computed)]
@@ -1176,9 +1176,9 @@
                   :inputs [[:auth :token]]
                   :output (fn [_] (throw (ex-info "derive boom" {})))
                   :path   [:auth :derived-user]})
-    (rf/reg-event-db :auth/signed-in
+    (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [auth [_ token]] (assoc auth :token token)))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:auth/signed-in "secret-token"])
     (let [failures (by-op :rf.flow/failed)]
@@ -1195,9 +1195,9 @@
                   :inputs [[:auth :token]]
                   :output (fn [t] (str "user-of-" t))
                   :path   [:auth :derived-user]})
-    (rf/reg-event-db :auth/signed-in
+    (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [auth [_ token]] (assoc auth :token token)))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
     ;; First sign-in computes; second sign-in with the SAME token leaves
     ;; the input value-equal → `:rf.flow/skip` fires, still inside the
     ;; frame-sensitive handler scope.
@@ -1223,9 +1223,9 @@
                   :inputs [[:profile :name]]
                   :output (fn [n] (str "hello-" n))
                   :path   [:profile :greeting]})
-    (rf/reg-event-db :profile/rename
+    (rf/reg-event :profile/rename
                      {:interceptors [(rf/path :profile)]}
-                     (fn [profile [_ name]] (assoc profile :name name)))
+                     (fn [{:keys [db]} [_ name]] {:db (assoc profile :name name)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:profile/rename "ada"])
     (let [computes (by-op :rf.flow/computed)]
@@ -1248,9 +1248,9 @@
                   :inputs [[:auth :token]]
                   :output (fn [t] (str "derived-" t))
                   :path   [:auth :derived-token]})
-    (rf/reg-event-db :auth/signed-in
+    (rf/reg-event :auth/signed-in
                      {:interceptors [(rf/path :auth)]}
-                     (fn [auth [_ token]] (assoc auth :token token)))
+                     (fn [{:keys [db]} [_ token]] {:db (assoc auth :token token)}))
     (reset! *captured* [])
     (rf/dispatch-sync [:auth/signed-in "secret-token"])
     (let [ev   (first (by-op :rf.flow/computed))
@@ -1285,7 +1285,7 @@
                   ;; The handler writes :n AND prior flow :ok writes :a-out,
                   ;; so a :db effect + a prior-flow write both exist when
                   ;; :boom throws — proving that EVEN THEN nothing installs.
-                  (rf/reg-event-db :bump (fn [db _] (update db :n (fnil inc 0))))
+                  (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
                   (rf/reg-flow {:id     :ok
                                 :inputs [[:n]]
                                 :output (fn [n] (* 10 n))
@@ -1360,7 +1360,7 @@
                   ;; (user-registered) fx fires — so the cascade exercises
                   ;; install + flow + fx all on the success path.
                   (rf/reg-fx :test/noop (fn [& _] nil))
-                  (rf/reg-event-fx :go
+                  (rf/reg-event :go
                                    (fn [_ _]
                                      {:db {:n 3}
                                       :fx [[:test/noop true]]}))

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -111,7 +111,7 @@
         ;; carries a frame stamp (the carried invariant).
         (frame/ensure-default-frame!)
         (binding [frame/*current-frame* :rf/default]
-          (rf/reg-event-db :flows-absent/init (fn [_ _] {:probe :ok}))
+          (rf/reg-event :flows-absent/init (fn [{:keys [db]} _] {:db {:probe :ok}}))
           (is (do (rf/dispatch-sync [:flows-absent/init]) :ok)
               "dispatch completes without throwing when the run-flows! hook is absent")
           (is (= {:probe :ok} (rf/app-db-value :rf/default))

--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -178,14 +178,14 @@
       ;; can read the in-flight state. (We've already primed the side-
       ;; channel registry above; the app-db marker is the substrate the
       ;; flow drives off.)
-      (rf/reg-event-db :http/issue
-                       (fn [db [_ request-id]]
-                         (assoc-in db [:http/in-flight request-id] true)))
+      (rf/reg-event :http/issue
+                       (fn [{:keys [db]} [_ request-id]]
+                         {:db (assoc-in db [:http/in-flight request-id] true)}))
 
       ;; :cancel is the event the test exercises: dissoc app-db slot AND
       ;; emit :rf.http/managed-abort. Both compose with the flow's
       ;; outermost :after over the pending :db.
-      (rf/reg-event-fx :http/cancel
+      (rf/reg-event :http/cancel
                        (fn [{:keys [db]} [_ request-id]]
                          {:db (update db :http/in-flight dissoc request-id)
                           :fx [[:rf.http/managed-abort request-id]]}))
@@ -269,10 +269,10 @@
 
       ;; Mirror the in-flight state into app-db. Use :issue separately
       ;; (without the throwing flow registered) so the seed is clean.
-      (rf/reg-event-db :http/issue
-                       (fn [db [_ request-id]]
-                         (assoc-in db [:http/in-flight request-id] true)))
-      (rf/reg-event-fx :http/cancel
+      (rf/reg-event :http/issue
+                       (fn [{:keys [db]} [_ request-id]]
+                         {:db (assoc-in db [:http/in-flight request-id] true)}))
+      (rf/reg-event :http/cancel
                        (fn [{:keys [db]} [_ request-id]]
                          {:db (update db :http/in-flight dissoc request-id)
                           :fx [[:rf.http/managed-abort request-id]]}))

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -133,9 +133,9 @@
           decoder-may-throw (CountDownLatch. 1)
           replies           (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue
+        (rf/reg-event :issue
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/")}
@@ -151,7 +151,7 @@
                     :request-id :race
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/reg-event-fx :do/abort
+        (rf/reg-event :do/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :race]]}))
         (rf/dispatch-sync [:issue])
         ;; Wait for the decoder to enter — guarantees the response has
@@ -203,12 +203,12 @@
   (testing "rf2-wez75 — abort fired against an in-flight request to an unreachable host yields :rf.http/aborted, not :rf.http/transport"
     (let [closed-port (pick-closed-port!)
           replies     (atom [])]
-      (rf/reg-event-fx :reply/recorder
+      (rf/reg-event :reply/recorder
         (fn [_ [_ payload]] (swap! replies conj payload) {}))
       ;; Issue the request and then immediately fire the abort against
       ;; the same request-id. The transport hasn't finished resolving
       ;; the connection-refused error yet (sendAsync is async).
-      (rf/reg-event-fx :issue
+      (rf/reg-event :issue
         (fn [_ _]
           {:fx [[:rf.http/managed
                  {:request    {:url (str "http://127.0.0.1:" closed-port "/")}
@@ -255,7 +255,7 @@
           decoder-may-throw (CountDownLatch. 1)
           replies           (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; Child machine — :entry fires the managed request with a
         ;; latch-gated decoder. The decoder synthesises a decode-

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -138,7 +138,7 @@
           traces  (atom [])]
       (try
         (trace/register-listener! ::wvkn-1 (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]]
             (swap! replies conj payload)
             {}))
@@ -208,7 +208,7 @@
           traces  (atom [])]
       (try
         (trace/register-listener! ::wvkn-2 (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-machine :worker/multi
           {:initial :idle
@@ -267,7 +267,7 @@
           srv-b   (start-blocking-server! latch-b 200 "application/json" "{}")
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; Two independent worker machines, each with its own request.
         (rf/reg-machine :worker/proc-a
@@ -337,7 +337,7 @@
           {:keys [port] :as srv} (start-blocking-server! latch 200 "application/json" "{}")
           replies (atom [])]
       (try
-        (rf/reg-event-fx :direct/load
+        (rf/reg-event :direct/load
           (fn [_ [_ msg]]
             (if-let [reply (:rf/reply msg)]
               (do (swap! replies conj reply) {})
@@ -364,7 +364,7 @@
             "request still in flight")
         ;; The orthogonal app-level abort still works — driven through
         ;; an event handler that emits the `:rf.http/managed-abort` fx.
-        (rf/reg-event-fx :do/abort
+        (rf/reg-event :do/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :direct]]}))
         (rf/dispatch-sync [:do/abort])
         (await-condition! #(seq @replies))
@@ -383,7 +383,7 @@
           {:keys [port] :as srv} (start-blocking-server! latch 200 "application/json" "{}")
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-machine :worker/slow
           {:initial :idle
@@ -434,7 +434,7 @@
           {:keys [port] :as srv} (start-blocking-server! latch 200 "application/json" "{\"too\":\"late\"}")
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; Child machine: issues a managed request with NO :request-id.
         ;; record-in-flight! therefore skips the request-id index (the
@@ -592,7 +592,7 @@
           traces  (atom [])]
       (try
         (trace/register-listener! ::n877mb (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; Worker machine: on entry to :running its action fires an
         ;; :rf.http/managed request at the slow server. Spawned IMPERATIVELY
@@ -618,7 +618,7 @@
         ;; XState-`spawn`-equivalent imperative entry-point. The actor's
         ;; deterministic id is :worker/imp#1 (runtime-db spawn-counter
         ;; fallback). The :start event drives idle→running → :fire-request.
-        (rf/reg-event-fx :imp/spawn
+        (rf/reg-event :imp/spawn
           (fn [_ _]
             {:fx [[:rf.machine/spawn {:machine-id :worker/imp
                                       :id-prefix  :worker/imp
@@ -627,7 +627,7 @@
         ;; canonical [:rf.machine/destroy <actor-id>] keyword form (re-frame2's
         ;; stopChild). This is the destroy trigger that must cascade to the
         ;; HTTP abort.
-        (rf/reg-event-fx :imp/destroy
+        (rf/reg-event :imp/destroy
           (fn [_ _]
             {:fx [[:rf.machine/destroy :worker/imp#1]]}))
         (rf/dispatch-sync [:imp/spawn])

--- a/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
@@ -157,9 +157,9 @@
     (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-500-server!)
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue
+        (rf/reg-event :issue
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/")}
@@ -168,7 +168,7 @@
                     :request-id :race
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/reg-event-fx :do/abort
+        (rf/reg-event :do/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :race]]}))
         (rf/dispatch-sync [:issue])
         ;; Attempt #1 fails 500 → request sleeps in the backoff window.
@@ -198,7 +198,7 @@
     (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-500-server!)
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; Child actor issues the retrying request on entry.
         (rf/reg-machine :worker/race
@@ -252,9 +252,9 @@
           new-srv (start-counting-500-server!)
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue-old
+        (rf/reg-event :issue-old
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/")}
@@ -265,7 +265,7 @@
                     :on-success [:reply/recorder]}]]}))
         ;; The superseding request: same :request-id, no retry, points at a
         ;; second always-500 server. It runs ONE attempt then finalises.
-        (rf/reg-event-fx :issue-new
+        (rf/reg-event :issue-new
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port new-srv) "/")}
@@ -307,9 +307,9 @@
     (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-500-server!)
           replies (atom [])]
       (try
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue
+        (rf/reg-event :issue
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/")}

--- a/implementation/http/test/re_frame/http_body_prep_failure_test.clj
+++ b/implementation/http/test/re_frame/http_body_prep_failure_test.clj
@@ -69,9 +69,9 @@
           listener-id ::body-thunk]
       (try
         (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/throwing-thunk
+        (rf/reg-event :issue/throwing-thunk
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url    "http://127.0.0.1:0/x"
@@ -111,9 +111,9 @@
           listener-id ::encode-fail]
       (try
         (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/unencodable
+        (rf/reg-event :issue/unencodable
           (fn [_ _]
             {:fx [[:rf.http/managed
                    ;; :request-content-type :json forces a JSON encode of a
@@ -149,9 +149,9 @@
           listener-id ::retry-thunk]
       (try
         (trace/register-listener! listener-id (fn [_] nil))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/retry-thunk
+        (rf/reg-event :issue/retry-thunk
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url    "http://127.0.0.1:0/x"

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -591,9 +591,9 @@
                           :read-fired read-fired})
             orig       (.-fetch js/globalThis)]
         (set! (.-fetch js/globalThis) (fn [_url _init] (js/Promise.resolve resp)))
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/slow-body
+        (rf/reg-event :issue/slow-body
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url "/slow-body"}
@@ -666,9 +666,9 @@
             ;; 80ms backoff — long enough to abort inside deterministically,
             ;; short enough to keep the test fast.
             backoff-ms  80]
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue
+        (rf/reg-event :issue
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url "/always-500"}
@@ -680,7 +680,7 @@
                     :request-id :race
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/reg-event-fx :do/abort
+        (rf/reg-event :do/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :race]]}))
         (rf/dispatch-sync [:issue] {:frame :rf/default})
         ;; Poll (microtask-paced) until attempt #1 has fetched, failed 5xx,
@@ -770,9 +770,9 @@
       (http-managed/clear-all-in-flight!)
       (let [replies (atom [])
             restore (with-failing-fetch)]
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/throwing-thunk
+        (rf/reg-event :issue/throwing-thunk
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url    "/x"
@@ -821,9 +821,9 @@
             circular  (let [o (js-obj)]
                         (aset o "self" o)
                         o)]
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/unencodable
+        (rf/reg-event :issue/unencodable
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url    "/x"
@@ -865,9 +865,9 @@
       (let [replies     (atom [])
             invocations (atom 0)
             restore     (with-failing-fetch)]
-        (rf/reg-event-fx :reply/recorder
+        (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
-        (rf/reg-event-fx :issue/retry-thunk
+        (rf/reg-event :issue/retry-thunk
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url    "/x"

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -69,7 +69,7 @@
 
 (deftest helper-get-routes-through-managed
   (testing "(rf.http/get ...) in :fx is indistinguishable from a hand-written :rf.http/managed entry"
-    (rf/reg-event-fx :items/load
+    (rf/reg-event :items/load
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           (case (:kind reply)
@@ -85,15 +85,15 @@
 
 (deftest helper-post-routes-with-explicit-on-success
   (testing "(rf.http/post ...) with explicit :on-success dispatches there"
-    (rf/reg-event-fx :item/create
+    (rf/reg-event :item/create
       (fn [_ _]
         {:fx [(rf.http/post "/api/items"
                             {:request    {:body {:title "new"}
                                           :request-content-type :json}
                              :on-success [:item/created]})]}))
-    (rf/reg-event-db :item/created
-      (fn [db [_ payload]]
-        (assoc db :created payload)))
+    (rf/reg-event :item/created
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :created payload)}))
     (rf/dispatch-sync [:item/create]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
     (let [db (await-reply! #(some? (:created %)))]
@@ -103,13 +103,13 @@
 
 (deftest helper-delete-routes-with-explicit-on-failure
   (testing "(rf.http/delete ...) with explicit :on-failure dispatches there on failure"
-    (rf/reg-event-fx :item/delete
+    (rf/reg-event :item/delete
       (fn [_ _]
         {:fx [(rf.http/delete "/api/items/42"
                               {:on-failure [:item/delete-failed]})]}))
-    (rf/reg-event-db :item/delete-failed
-      (fn [db [_ payload]]
-        (assoc db :delete-error payload)))
+    (rf/reg-event :item/delete-failed
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :delete-error payload)}))
     (rf/dispatch-sync [:item/delete]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
     (let [db (await-reply! #(some? (:delete-error %)))]
@@ -138,7 +138,7 @@
 
 (deftest helper-get-minimal-default-reply-addressing
   (testing "(rf.http/get url) — no extra args; reply lands back at originating handler"
-    (rf/reg-event-fx :ping
+    (rf/reg-event :ping
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :pong (:value reply))}

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -107,7 +107,7 @@
           {:before (fn [ctx]
                      (assoc-in ctx [:request :headers "Authorization"]
                                "Bearer secret-token-42"))})
-        (rf/reg-event-fx :load
+        (rf/reg-event :load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -150,7 +150,7 @@
                      (swap! order conj :third)
                      (is (= "2" (get-in ctx [:request :headers "X-Two"])))
                      (assoc-in ctx [:request :headers "X-Three"] "3"))})
-        (rf/reg-event-fx :load
+        (rf/reg-event :load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -199,13 +199,13 @@
            :before (fn [ctx]
                      (assoc-in ctx [:request :headers "X-Marker"] "default-only"))})
         ;; Two events — one on each frame — both fire :rf.http/managed.
-        (rf/reg-event-fx :load-default
+        (rf/reg-event :load-default
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:url (str "http://127.0.0.1:" port "/from-default")}
                     :decode  :json
                     :on-success nil}]]}))
-        (rf/reg-event-fx :load-other
+        (rf/reg-event :load-other
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:url (str "http://127.0.0.1:" port "/from-other")}
@@ -244,7 +244,7 @@
         (rf/reg-http-interceptor :boom
           {:before (fn [_ctx]
                      (throw (ex-info "kaboom" {:detail :synthetic})))})
-        (rf/reg-event-fx :load
+        (rf/reg-event :load
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:url (str "http://127.0.0.1:" port "/x")}
@@ -290,7 +290,7 @@
         (rf/reg-http-interceptor :boom
           {:before (fn [_ctx]
                      (throw (ex-info "kaboom" {:detail :synthetic})))})
-        (rf/reg-event-fx :load
+        (rf/reg-event :load
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:url "https://api.example.invalid/v1?api_key=SECRET&page=2"}
@@ -331,7 +331,7 @@
           {:before (fn [ctx]
                      (assoc-in ctx [:request :headers "Authorization"]
                                "Bearer A"))})
-        (rf/reg-event-fx :load
+        (rf/reg-event :load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (-> db
@@ -393,7 +393,7 @@
         (rf/reg-http-interceptor :b {:before (fn [ctx] (swap! order conj :b)    ctx)})
         ;; Replace :a — should keep its position (first), not append.
         (rf/reg-http-interceptor :a {:before (fn [ctx] (swap! order conj :a-v2) ctx)})
-        (rf/reg-event-fx :load
+        (rf/reg-event :load
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:url (str "http://127.0.0.1:" port "/x")}
@@ -448,7 +448,7 @@
           (is (= [:b :c :a] (mapv :id chain))
               "after clear-then-reg, :a moved to the end (was first; now last)"))
 
-        (rf/reg-event-fx :kg5nw/load
+        (rf/reg-event :kg5nw/load
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" port "/x")}
@@ -564,7 +564,7 @@
                  (set (map :id chain)))
               "all three ids appear in the :rf/default chain"))
 
-        (rf/reg-event-fx :test.lfvi/load
+        (rf/reg-event :test.lfvi/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (-> db (update :replies (fnil conj []) reply))}
@@ -657,7 +657,7 @@
         ;; Second :before throws — fires AFTER the mark.
         (rf/reg-http-interceptor :boom
           {:before (fn [_ctx] (throw (ex-info "kaboom" {})))})
-        (rf/reg-event-fx :rznrz/load
+        (rf/reg-event :rznrz/load
           (fn [_ _]
             {:fx [[:rf.http/managed
                    ;; customer_email is NOT in the query-param denylist, so
@@ -713,7 +713,7 @@
         ;; adds :credentials into the request map.
         (rf/reg-http-interceptor :add-credentials
           {:before (fn [ctx] (assoc-in ctx [:request :credentials] :include))})
-        (rf/reg-event-fx :rznrz.cljsonly/load
+        (rf/reg-event :rznrz.cljsonly/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -746,7 +746,7 @@
   (testing "rf2-oyd1b — [:rf.fx/reg-http-interceptor {...}] adds an
             interceptor to the :rf/default frame's chain (observed via
             interceptors-snapshot)."
-    (rf/reg-event-fx :oyd1b/register
+    (rf/reg-event :oyd1b/register
       (fn [_ _]
         {:fx [[:rf.fx/reg-http-interceptor
                {:id     :oyd1b/auth
@@ -770,7 +770,7 @@
 
 (deftest reg-http-interceptor-fx-honours-explicit-frame-rf2-oyd1b
   (testing "rf2-oyd1b — explicit :frame routes to the named slot, not :rf/default"
-    (rf/reg-event-fx :oyd1b/register-on-named
+    (rf/reg-event :oyd1b/register-on-named
       (fn [_ _]
         {:fx [[:rf.fx/reg-http-interceptor
                {:frame  :rf/api
@@ -792,7 +792,7 @@
     (is (= 1 (count (http-managed/interceptors-snapshot :rf/default)))
         "pre-clear: the slot is present")
 
-    (rf/reg-event-fx :oyd1b/clear
+    (rf/reg-event :oyd1b/clear
       (fn [_ _]
         {:fx [[:rf.fx/clear-http-interceptor {:id :oyd1b/to-clear}]]}))
     (rf/dispatch-sync [:oyd1b/clear])
@@ -805,7 +805,7 @@
     (http-managed/reg-http-interceptor :oyd1b/scoped {:frame :rf/api :before identity})
     (http-managed/reg-http-interceptor :oyd1b/default-survivor {:before identity})
 
-    (rf/reg-event-fx :oyd1b/clear-on-named
+    (rf/reg-event :oyd1b/clear-on-named
       (fn [_ _]
         {:fx [[:rf.fx/clear-http-interceptor
                {:frame :rf/api :id :oyd1b/scoped}]]}))
@@ -820,7 +820,7 @@
   (testing "rf2-oyd1b — when :frame is nil/absent the fx routes to :rf/default
             (matching the fn-form behaviour)."
     (http-managed/reg-http-interceptor :oyd1b/dflt {:before identity})
-    (rf/reg-event-fx :oyd1b/clear-no-frame
+    (rf/reg-event :oyd1b/clear-no-frame
       (fn [_ _]
         ;; No :frame key — must default to :rf/default.
         {:fx [[:rf.fx/clear-http-interceptor {:id :oyd1b/dflt}]]}))
@@ -844,7 +844,7 @@
               (swap! errors conj ev))))
 
         ;; missing :id
-        (rf/reg-event-fx :oyd1b/bad-no-id
+        (rf/reg-event :oyd1b/bad-no-id
           (fn [_ _]
             {:fx [[:rf.fx/reg-http-interceptor {:before identity}]]}))
         (try (rf/dispatch-sync [:oyd1b/bad-no-id])
@@ -854,7 +854,7 @@
 
         ;; missing both :before AND :after (a no-op interceptor is rejected
         ;; under the rf2-uheqq shape-iii contract)
-        (rf/reg-event-fx :oyd1b/bad-no-fns
+        (rf/reg-event :oyd1b/bad-no-fns
           (fn [_ _]
             {:fx [[:rf.fx/reg-http-interceptor {:id :x}]]}))
         (try (rf/dispatch-sync [:oyd1b/bad-no-fns])
@@ -863,7 +863,7 @@
             "missing both :before and :after → no interceptor registered")
 
         ;; non-keyword :id
-        (rf/reg-event-fx :oyd1b/bad-string-id
+        (rf/reg-event :oyd1b/bad-string-id
           (fn [_ _]
             {:fx [[:rf.fx/reg-http-interceptor
                    {:id "not-a-keyword" :before identity}]]}))
@@ -878,7 +878,7 @@
 (deftest reg-and-clear-http-interceptor-fxs-roundtrip-rf2-oyd1b
   (testing "rf2-oyd1b — register-then-clear via fxs round-trips cleanly,
             mirroring the fn-form's idempotency."
-    (rf/reg-event-fx :oyd1b/round-trip
+    (rf/reg-event :oyd1b/round-trip
       (fn [_ _]
         {:fx [[:rf.fx/reg-http-interceptor
                {:id :oyd1b/rt :before identity}]
@@ -930,7 +930,7 @@
           {:after (fn [_ctx resp] (swap! order conj :b) resp)})
         (rf/reg-http-interceptor :c
           {:after (fn [_ctx resp] (swap! order conj :c) resp)})
-        (rf/reg-event-fx :uheqq/load
+        (rf/reg-event :uheqq/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -962,7 +962,7 @@
                               :delta-ns (- (System/nanoTime)
                                            (::start ctx))})
                      resp)})
-        (rf/reg-event-fx :uheqq/load-timing
+        (rf/reg-event :uheqq/load-timing
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -992,7 +992,7 @@
                     ;; the :on-success target saw the modified shape.
                     (update resp :value
                             (fn [v] (assoc v :touched-by :after))))})
-        (rf/reg-event-fx :uheqq/load-xform
+        (rf/reg-event :uheqq/load-xform
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1027,7 +1027,7 @@
           {:after (fn [_ctx resp]
                     (swap! order conj :after-only-fired)
                     resp)})
-        (rf/reg-event-fx :uheqq/load-transparent
+        (rf/reg-event :uheqq/load-transparent
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1080,7 +1080,7 @@
                             {:remaining 37
                              :limit     100
                              :ctx-aware (::rate-limit-aware ctx)}))})
-        (rf/reg-event-fx :uheqq/load-rate
+        (rf/reg-event :uheqq/load-rate
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1116,7 +1116,7 @@
                            delta   (- ended started)]
                        (reset! observed {:delta-ms delta :start started})
                        (assoc resp :telemetry {:elapsed-ms delta})))})
-        (rf/reg-event-fx :uheqq/load-telemetry
+        (rf/reg-event :uheqq/load-telemetry
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1156,7 +1156,7 @@
                     ;; structured :cache slot derived from a parse of
                     ;; the canonical form.
                     (assoc resp :cache {:max-age 600 :public? true}))})
-        (rf/reg-event-fx :uheqq/load-cache
+        (rf/reg-event :uheqq/load-cache
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1192,7 +1192,7 @@
                              (= 401 (get-in resp [:failure :status])))
                       (assoc resp :auth-refresh-required true)
                       resp))})
-        (rf/reg-event-fx :uheqq/load-401
+        (rf/reg-event :uheqq/load-401
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}

--- a/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
@@ -100,7 +100,7 @@
             (fn [^HttpExchange ex]
               (write-bytes! ex 200 "application/octet-stream" raw-bytes)))]
       (try
-        (rf/reg-event-fx :blob/load
+        (rf/reg-event :blob/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -124,7 +124,7 @@
             (fn [^HttpExchange ex]
               (write-bytes! ex 200 "application/octet-stream" raw-bytes)))]
       (try
-        (rf/reg-event-fx :ab/load
+        (rf/reg-event :ab/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -148,7 +148,7 @@
             (fn [^HttpExchange ex]
               (write-bytes! ex 200 "text/plain; charset=ISO-8859-1" latin1-bytes)))]
       (try
-        (rf/reg-event-fx :text/load
+        (rf/reg-event :text/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -216,7 +216,7 @@
               (write-bytes! ex 200 "application/json"
                             (.getBytes "{\"ok\":true}" "UTF-8"))))]
       (try
-        (rf/reg-event-fx :slow/load
+        (rf/reg-event :slow/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -330,7 +330,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :legacy/load
+        (rf/reg-event :legacy/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               (case (:kind reply)

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -122,7 +122,7 @@
 
 (deftest canned-success-default-reply-addressing
   (testing "the canned-success stub dispatches a default reply (originating event-id with :rf/reply)"
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           (case (:kind reply)
@@ -141,14 +141,14 @@
 
 (deftest canned-failure-explicit-on-failure
   (testing "explicit :on-failure routes the failure reply to the named handler"
-    (rf/reg-event-fx :auth/login
+    (rf/reg-event :auth/login
       (fn [_ _]
         {:fx [[:rf.http/managed
                {:request   {:method :post :url "/auth/login"}
                 :on-failure [:auth/login-error]}]]}))
-    (rf/reg-event-db :auth/login-error
-      (fn [db [_ payload]]
-        (assoc db :auth-error payload)))
+    (rf/reg-event :auth/login-error
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :auth-error payload)}))
     (rf/dispatch-sync [:auth/login]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
     (let [db (await-reply! #(some? (:auth-error %)))]
@@ -160,7 +160,7 @@
 (deftest silenced-reply-on-success-nil
   (testing "explicit :on-success nil swallows the reply silently"
     (let [seen (atom 0)]
-      (rf/reg-event-fx :ping
+      (rf/reg-event :ping
         (fn [_ _]
           (swap! seen inc)
           {:fx [[:rf.http/managed
@@ -190,7 +190,7 @@
   merged onto the managed args-map. Returns immediately; callers poll
   `await-reply!` for the landed reply."
   [extra-args]
-  (rf/reg-event-fx :j1mo4/load
+  (rf/reg-event :j1mo4/load
     (fn [{:keys [db]} [_ msg]]
       (if-let [reply (:rf/reply msg)]
         {:db (assoc-in db [:j1mo4 :value] (:value reply))}
@@ -255,14 +255,14 @@
 (deftest after-ms-positive-on-failure-defers
   (testing ":after-ms N also defers the canned-FAILURE reply by a
             :dispatch-later tick (symmetric with the success path)"
-    (rf/reg-event-fx :j1mo4/fail-delayed
+    (rf/reg-event :j1mo4/fail-delayed
       (fn [_ _]
         {:fx [[:rf.http/managed
                {:request    {:method :get :url "/j1mo4/fail"}
                 :after-ms   30
                 :on-failure [:j1mo4/failed]}]]}))
-    (rf/reg-event-db :j1mo4/failed
-      (fn [db [_ payload]] (assoc db :j1mo4-error payload)))
+    (rf/reg-event :j1mo4/failed
+      (fn [{:keys [db]} [_ payload]] {:db (assoc db :j1mo4-error payload)}))
     (rf/dispatch-sync [:j1mo4/fail-delayed]
                       {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
     ;; Deferred — not present synchronously after the dispatch-sync drain.
@@ -296,7 +296,7 @@
          :after  (fn [_ctx resp]
                    (swap! order conj :after)
                    (update resp :value assoc :touched-by :after))})
-      (rf/reg-event-fx :r5m22/load
+      (rf/reg-event :r5m22/load
         (fn [{:keys [db]} [_ msg]]
           (if-let [reply (:rf/reply msg)]
             {:db (assoc db :reply reply)}
@@ -325,7 +325,7 @@
          :after  (fn [ctx resp]
                    (reset! observed (::marker ctx))
                    resp)})
-      (rf/reg-event-fx :r5m22/load-corr
+      (rf/reg-event :r5m22/load-corr
         (fn [{:keys [db]} [_ msg]]
           (if-let [reply (:rf/reply msg)]
             {:db (assoc db :reply reply)}
@@ -350,7 +350,7 @@
                   (if (= :failure (:kind resp))
                     (assoc resp :tagged-by-after true)
                     resp))})
-      (rf/reg-event-fx :r5m22/fail
+      (rf/reg-event :r5m22/fail
         (fn [{:keys [db]} [_ msg]]
           (if-let [reply (:rf/reply msg)]
             {:db (assoc db :reply reply)}
@@ -375,7 +375,7 @@
               (write-response! ex 200 "application/json"
                                "{\"article\":{\"title\":\"hello\",\"id\":42}}")))]
       (try
-        (rf/reg-event-fx :article/load
+        (rf/reg-event :article/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               (case (:kind reply)
@@ -398,7 +398,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 404 "application/json" "{\"error\":\"not-found\"}")))]
       (try
-        (rf/reg-event-fx :article/load
+        (rf/reg-event :article/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -428,7 +428,7 @@
               (write-response! ex 404 "text/html"
                                "<!doctype html><html><body><h1>Not Found</h1></body></html>")))]
       (try
-        (rf/reg-event-fx :page/load
+        (rf/reg-event :page/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -463,7 +463,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :page/load
+        (rf/reg-event :page/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -501,7 +501,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "")))]
       (try
-        (rf/reg-event-fx :empty/load
+        (rf/reg-event :empty/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -543,7 +543,7 @@
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
         (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :upexd3/load
+        (rf/reg-event :upexd3/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -587,7 +587,7 @@
               (write-response! ex 500 "application/json" "{\"err\":true}")))]
       (try
         (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :upexd3b/load
+        (rf/reg-event :upexd3b/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -764,7 +764,7 @@
               (swap! hits inc)
               (write-response! ex 500 "application/json" "{\"err\":true}")))]
       (try
-        (rf/reg-event-fx :flaky/load
+        (rf/reg-event :flaky/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -795,7 +795,7 @@
                   (write-response! ex 500 "application/json" "{\"err\":true}")
                   (write-response! ex 200 "application/json" "{\"ok\":true}")))))]
       (try
-        (rf/reg-event-fx :recover/load
+        (rf/reg-event :recover/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -816,7 +816,7 @@
 
 (deftest jvm-transport-failure
   (testing "connection-refused classifies as :rf.http/transport"
-    (rf/reg-event-fx :load
+    (rf/reg-event :load
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :reply reply)}
@@ -853,7 +853,7 @@
         ;; If a reply ever dispatches the test will catch it (silently
         ;; ignored handler) — but the load-bearing assertion is that no
         ;; throw escapes the abort fx.
-        (rf/reg-event-fx :kdwnq/abort-never-issued
+        (rf/reg-event :kdwnq/abort-never-issued
           (fn [_ _]
             {:fx [[:rf.http/managed-abort :kdwnq/never-issued]]}))
         (rf/reg-event-db :kdwnq/some-reply
@@ -893,7 +893,7 @@
               (.await latch 5 TimeUnit/SECONDS)
               (write-response! ex 200 "application/json" "{\"too\":\"late\"}")))]
       (try
-        (rf/reg-event-fx :slow/load
+        (rf/reg-event :slow/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -901,7 +901,7 @@
                      {:request    {:url (str "http://127.0.0.1:" port "/slow")}
                       :request-id :slow
                       :decode     :json}]]})))
-        (rf/reg-event-fx :slow/abort
+        (rf/reg-event :slow/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :slow]]}))
         (rf/dispatch-sync [:slow/load])
         ;; Poll until the request is actually registered as in-flight —
@@ -957,7 +957,7 @@
               (write-response! ex 200 "application/json"
                                "{\"server\":\"responded-after-abort\"}")))]
       (try
-        (rf/reg-event-fx :on7sj/load
+        (rf/reg-event :on7sj/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               (do
@@ -968,7 +968,7 @@
                      {:request    {:url (str "http://127.0.0.1:" port "/slow")}
                       :request-id :on7sj/req
                       :decode     :json}]]})))
-        (rf/reg-event-fx :on7sj/abort
+        (rf/reg-event :on7sj/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :on7sj/req]]}))
 
         ;; Issue the request. Server blocks on the latch.
@@ -1023,7 +1023,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"echoed\":true}")))]
       (try
-        (rf/reg-event-fx :upload
+        (rf/reg-event :upload
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1049,7 +1049,7 @@
             wrapper contract: the helper installs the
             :rf.http/managed → :rf.http/managed-test-stub override for the
             body's dynamic extent, so plain dispatch-sync auto-routes)"
-    (rf/reg-event-fx :articles/list
+    (rf/reg-event :articles/list
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :result reply)}
@@ -1091,7 +1091,7 @@
       ;; the override was absent (the pre-fix bug). The stub path bypasses it.
       (rf/reg-fx :rf.http/managed
                  (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
-      (rf/reg-event-fx :rzqan/load
+      (rf/reg-event :rzqan/load
         (fn [{:keys [db]} [_ msg]]
           (if-let [reply (:rf/reply msg)]
             {:db (assoc db :result reply)}
@@ -1120,7 +1120,7 @@
       ;; A deliberately-supplied per-call override target.
       (rf/reg-fx :rzqan/explicit-override
                  (fn [_frame-ctx _args] (reset! chosen :explicit) nil))
-      (rf/reg-event-fx :rzqan/load-explicit
+      (rf/reg-event :rzqan/load-explicit
         (fn [_ _]
           {:fx [[:rf.http/managed
                  {:request {:method :get :url "/rzqan-explicit"}
@@ -1160,7 +1160,7 @@
       {:before (fn [ctx]
                  (update-in ctx [:request :url]
                             (fn [u] (clojure.string/replace u #"^/" "/v2/"))))})
-    (rf/reg-event-fx :azrcs/list
+    (rf/reg-event :azrcs/list
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :result reply)}
@@ -1186,7 +1186,7 @@
       {:before (fn [ctx]
                  (update-in ctx [:request :url]
                             (fn [u] (clojure.string/replace u #"^/" "/v2/"))))})
-    (rf/reg-event-fx :azrcs/list2
+    (rf/reg-event :azrcs/list2
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :result reply)}
@@ -1254,12 +1254,12 @@
             the A stub (pre-fix the inner's teardown cleared the shared fx and
             the outer dispatch hit a missing fx / wrong handler)"
     ;; Distinct event + route per call site so each scope keys off its own url.
-    (rf/reg-event-fx :vn8qjv/load-a
+    (rf/reg-event :vn8qjv/load-a
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :result-a reply)}
           {:fx [[:rf.http/managed {:request {:method :get :url "/a"} :decode :json}]]})))
-    (rf/reg-event-fx :vn8qjv/load-b
+    (rf/reg-event :vn8qjv/load-b
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
           {:db (assoc db :result-b reply)}
@@ -1367,7 +1367,7 @@
 
 (deftest decode-reflection-metadata
   (testing ":rf.http/decode-schemas declared on the handler is queryable via handler-meta"
-    (rf/reg-event-fx :article/load
+    (rf/reg-event :article/load
       {:doc                    "Load an article."
        :rf.http/decode-schemas [::ArticleResponse]}
       (fn [_ _] {}))
@@ -1509,7 +1509,7 @@
               (.await latch 10 TimeUnit/SECONDS)
               (write-response! ex 200 "application/json" "{\"too\":\"late\"}")))]
       (try
-        (rf/reg-event-fx :slow/load
+        (rf/reg-event :slow/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1549,7 +1549,7 @@
               (.await latch 5 TimeUnit/SECONDS)
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :search/run
+        (rf/reg-event :search/run
           (fn [_ [_ q]]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" port "/q?" q)}
@@ -1559,7 +1559,7 @@
                     ;; supersede-driven :on-failure dispatch is under test.
                     :on-success nil
                     :on-failure [:search/a-failed]}]]}))
-        (rf/reg-event-fx :search/run-superseding
+        (rf/reg-event :search/run-superseding
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" port "/q?fresh")}
@@ -1609,13 +1609,13 @@
                                   (fn [ev]
                                     (when (= :rf.http/aborted (:operation ev))
                                       (swap! events conj ev))))
-        (rf/reg-event-fx :search/run
+        (rf/reg-event :search/run
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" port "/q1")}
                     :request-id :search
                     :decode     :json}]]}))
-        (rf/reg-event-fx :search/run-superseding
+        (rf/reg-event :search/run-superseding
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" port "/q2")}
@@ -1656,14 +1656,14 @@
               (.await latch 5 TimeUnit/SECONDS)
               (write-response! ex 200 "application/json" "{}")))]
       (try
-        (rf/reg-event-fx :slow/load
+        (rf/reg-event :slow/load
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" port "/slow")}
                     :request-id :slow
                     :decode     :json
                     :on-failure [:slow/failed]}]]}))
-        (rf/reg-event-fx :slow/abort
+        (rf/reg-event :slow/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :slow]]}))
         (rf/reg-event-db :slow/failed
           (fn [db [_ payload]]
@@ -1724,7 +1724,7 @@
               ;; validation fails.
               (write-response! ex 200 "application/json" "{\"id\":\"oops\"}")))]
       (try
-        (rf/reg-event-fx :thing/load
+        (rf/reg-event :thing/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1751,7 +1751,7 @@
               (write-response! ex 200 "application/json"
                                "{\"id\":7,\"status\":\"active\"}")))]
       (try
-        (rf/reg-event-fx :thing/load
+        (rf/reg-event :thing/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1776,7 +1776,7 @@
               (write-response! ex 200 "application/json"
                                "{\"a\":1,\"b\":2,\"c\":3}")))]
       (try
-        (rf/reg-event-fx :thing/load
+        (rf/reg-event :thing/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1821,7 +1821,7 @@
               ;; NOT the structured :rf.error/malformed-json cap ex-info.
               (write-response! ex 200 "application/json" "{\"a\": ")))]
       (try
-        (rf/reg-event-fx :thing/load
+        (rf/reg-event :thing/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1856,7 +1856,7 @@
               (write-response! ex 200 "application/json"
                                "{\"ok\":false,\"reason\":\"quota\"}")))]
       (try
-        (rf/reg-event-fx :op/run
+        (rf/reg-event :op/run
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1896,7 +1896,7 @@
               (reset! seen-query (.getRawQuery (.getRequestURI ex)))
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :search/run
+        (rf/reg-event :search/run
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1927,7 +1927,7 @@
               (reset! seen-body (slurp (.getRequestBody ex)))
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :item/create
+        (rf/reg-event :item/create
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1959,7 +1959,7 @@
               (reset! seen-cts (vec (.get (.getRequestHeaders ex) "Content-Type")))
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :item/create
+        (rf/reg-event :item/create
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -1999,7 +1999,7 @@
               (reset! seen-accept (vec (.get (.getRequestHeaders ex) "X-Multi")))
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :multihdr/load
+        (rf/reg-event :multihdr/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -2030,7 +2030,7 @@
               (reset! seen (vec (.get (.getRequestHeaders ex) "X-One")))
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :scalarhdr/load
+        (rf/reg-event :scalarhdr/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -2063,7 +2063,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :acceptthrow/load
+        (rf/reg-event :acceptthrow/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -2095,7 +2095,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :acceptnil/load
+        (rf/reg-event :acceptnil/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -2124,7 +2124,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (rf/reg-event-fx :acceptbad/load
+        (rf/reg-event :acceptbad/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -2149,7 +2149,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"value\":42}")))]
       (try
-        (rf/reg-event-fx :acceptok/load
+        (rf/reg-event :acceptok/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -111,7 +111,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ [_ _msg]]
             ;; Handler itself is NOT sensitive; the per-call flag opts in.
             {:fx [[:rf.http/managed
@@ -147,7 +147,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ [_ _msg]]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -185,7 +185,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -227,7 +227,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -262,7 +262,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -303,7 +303,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :auth/login
+        (rf/reg-event :auth/login
           {:doc "Login op (handler-meta :sensitive? annotation removed)."}
           (fn [_ _]
             {:fx [[:rf.http/managed
@@ -346,7 +346,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -386,7 +386,7 @@
                                   (fn [ev] (swap! captured conj ev)))
         ;; The :decode schema is the owner's declaration: [:token] is
         ;; sensitive, [:user-id] is not. No per-call :sensitive? flag.
-        (rf/reg-event-fx :auth/login
+        (rf/reg-event :auth/login
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:method :get
@@ -395,7 +395,7 @@
                               [:token {:sensitive? true} :string]
                               [:user-id :int]]
                     :on-success [:auth/ok]}]]}))
-        (rf/reg-event-fx :auth/ok (fn [_ _] {}))
+        (rf/reg-event :auth/ok (fn [_ _] {}))
 
         (rf/dispatch-sync [:auth/login])
 
@@ -423,14 +423,14 @@
       (try
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
-        (rf/reg-event-fx :auth/refresh
+        (rf/reg-event :auth/refresh
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:method :get
                               :url    (str "http://127.0.0.1:" port "/refresh")}
                     :decode  [:string {:sensitive? true}]
                     :on-success [:auth/ok]}]]}))
-        (rf/reg-event-fx :auth/ok (fn [_ _] {}))
+        (rf/reg-event :auth/ok (fn [_ _] {}))
 
         (rf/dispatch-sync [:auth/refresh])
 
@@ -457,7 +457,7 @@
       (try
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
-        (rf/reg-event-fx :api/big
+        (rf/reg-event :api/big
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:method :get
@@ -466,7 +466,7 @@
                               [:blob {:large? true} :string]
                               [:user-id :int]]
                     :on-success [:api/ok]}]]}))
-        (rf/reg-event-fx :api/ok (fn [_ _] {}))
+        (rf/reg-event :api/ok (fn [_ _] {}))
 
         (rf/dispatch-sync [:api/big])
 
@@ -499,13 +499,13 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; No :decode ⇒ :auto ⇒ unschematized ⇒ off-box :omit.
-        (rf/reg-event-fx :api/opaque
+        (rf/reg-event :api/opaque
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:method :get
                               :url    (str "http://127.0.0.1:" port "/opaque")}
                     :on-success [:api/ok]}]]}))
-        (rf/reg-event-fx :api/ok (fn [_ _] {}))
+        (rf/reg-event :api/ok (fn [_ _] {}))
 
         (rf/dispatch-sync [:api/opaque])
 
@@ -534,7 +534,7 @@
       (try
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
-        (rf/reg-event-fx :api/login
+        (rf/reg-event :api/login
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request {:method :get
@@ -543,7 +543,7 @@
                               [:token {:sensitive? true} :string]
                               [:user-id :int]]
                     :on-success [:api/ok]}]]}))
-        (rf/reg-event-fx :api/ok (fn [_ _] {}))
+        (rf/reg-event :api/ok (fn [_ _] {}))
 
         (rf/dispatch-sync [:api/login])
 
@@ -585,7 +585,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; NO per-call :sensitive? flag — the disposition-5 fix must fire anyway.
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -620,7 +620,7 @@
       (try
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get
@@ -656,7 +656,7 @@
         (trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; :json decode of a non-JSON body throws → :rf.http/decode-failure.
-        (rf/reg-event-fx :api/fetch
+        (rf/reg-event :api/fetch
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:method :get

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -200,7 +200,7 @@
                   (write-response! ex 200 "application/json"
                                    "{\"title\":\"hello\",\"id\":42}")))]
       (try
-        (rf/reg-event-fx :article/load
+        (rf/reg-event :article/load
           (fn [{:keys [db]} [_ msg]]
             (if-let [reply (:rf/reply msg)]
               {:db (assoc db :reply reply)}
@@ -225,12 +225,12 @@
                 (fn [^HttpExchange ex]
                   (write-response! ex 503 "text/plain" "down")))]
       (try
-        (rf/reg-event-fx :svc/call
+        (rf/reg-event :svc/call
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/x")}
                     :on-failure [:svc/failed]}]]}))
-        (rf/reg-event-db :svc/failed (fn [db [_ payload]] (assoc db :got payload)))
+        (rf/reg-event :svc/failed (fn [{:keys [db]} [_ payload]] {:db (assoc db :got payload)}))
         (rf/dispatch-sync [:svc/call])
         (let [db (await-reply! #(some? (:got %)))]
           (is (= :failure (get-in db [:got :kind])))
@@ -248,7 +248,7 @@
           lid     ::replied-trace]
       (try
         (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
-        (rf/reg-event-fx :t/load
+        (rf/reg-event :t/load
           (fn [{:keys [db]} [_ msg]]
             (if (:rf/reply msg)
               {:db (assoc db :done true)}
@@ -296,7 +296,7 @@
           (fn [db [_ payload]]
             (swap! replies conj payload)
             db))
-        (rf/reg-event-fx :search/go
+        (rf/reg-event :search/go
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/s")}
@@ -338,7 +338,7 @@
         (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
         (rf/reg-event-db :search/replied
           (fn [db [_ payload]] (swap! replies conj payload) db))
-        (rf/reg-event-fx :search/go
+        (rf/reg-event :search/go
           (fn [_ _]
             {:fx [[:rf.http/managed
                    {:request    {:url (str "http://127.0.0.1:" (:port srv) "/s")}

--- a/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
+++ b/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
@@ -120,7 +120,7 @@
             dispatch surface."
     (let [seen (listener-fixture
                  (fn []
-                   (rf/reg-event-fx :prod-elision/abort-touch
+                   (rf/reg-event :prod-elision/abort-touch
                      (fn [_ _]
                        {:fx [[:rf.http/managed-abort
                               :prod-elision/no-such-req]]}))

--- a/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
+++ b/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
@@ -97,12 +97,12 @@
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
     ;; The user-facing handler that the wrapped reply commits to.
-    (rf/reg-event-db :article/loaded
-                     (fn [db [_ id payload]]
-                       (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
     ;; The :on-success bridge: captures the nav-token at request time
     ;; and wraps the inner :dispatch in :rf.route/with-nav-token.
-    (rf/reg-event-fx :article/loaded-bridge
+    (rf/reg-event :article/loaded-bridge
                      (fn [_ [_ {:keys [carried-token id payload]}]]
                        {:fx [[:rf.route/with-nav-token
                               {:do        [:dispatch [:article/loaded id payload]]
@@ -189,7 +189,7 @@
     (is (= :route/editor (get-in (rf/runtime-db-value :rf/default)
                                  [:rf.runtime/routing :current :route-id]))
         "precondition: landed on :route/editor")
-    (rf/reg-event-fx :editor/save
+    (rf/reg-event :editor/save
                      (fn [_ _]
                        {:fx [[:rf.http/managed
                               {:request    {:method :put
@@ -202,7 +202,7 @@
                                ;; against the registry's snapshot until
                                ;; we clear it.
                                :on-success [:editor/saved]}]]}))
-    (rf/reg-event-db :editor/saved (fn [db _] (assoc db :saved? true)))
+    (rf/reg-event :editor/saved (fn [{:keys [db]} _] {:db (assoc db :saved? true)}))
 
     ;; Trigger the save with the canned-success stub installed via
     ;; with-managed-request-stubs to drive a deterministic reply path.
@@ -352,10 +352,10 @@
                   {:path      "/articles/:id"
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
-    (rf/reg-event-db :article/loaded
-                     (fn [db [_ id payload]]
-                       (assoc db :article {:id id :payload payload})))
-    (rf/reg-event-fx :article/loaded-bridge
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
+    (rf/reg-event :article/loaded-bridge
                      (fn [_ [_ {:keys [carried-token id payload]}]]
                        {:fx [[:rf.route/with-nav-token
                               {:do        [:dispatch [:article/loaded id payload]]

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -587,7 +587,7 @@
   ;; Per rf2-cmfln sub-cache disposal is synchronous on derefer-count → 0,
   ;; so we observe the cache state without timing.
   (testing "sub-vec :after delay resolving to 0 unsubscribes (no sub-cache leak)"
-    (rf/reg-event-db :a/seed-bad (fn [db _] (assoc db :timeout-config 0)))
+    (rf/reg-event :a/seed-bad (fn [{:keys [db]} _] {:db (assoc db :timeout-config 0)}))
     (rf/reg-sub :a/timeout-config-0 (fn [db _] (:timeout-config db)))
     (rf/dispatch-sync [:a/seed-bad])
     (let [m {:initial :idle
@@ -748,7 +748,7 @@
         ;; A well-behaved sub returning a positive delay — subscribe
         ;; succeeds, deref returns 1000 (so the bad-delay branch
         ;; doesn't short-circuit before reaching add-watch).
-        (rf/reg-event-db :w/seed (fn [db _] (assoc db :delay-ms 1000)))
+        (rf/reg-event :w/seed (fn [{:keys [db]} _] {:db (assoc db :delay-ms 1000)}))
         (rf/reg-sub :s/well-behaved (fn [db _] (:delay-ms db)))
         (rf/dispatch-sync [:w/seed])
         (rf/reg-machine

--- a/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
@@ -95,7 +95,7 @@
       ;; Now — the contract-under-test. An explicit destroy fx for the
       ;; already-finished actor must NOT raise, must NOT emit a second
       ;; `:rf.machine/destroyed`, must leave the world unchanged.
-      (rf/reg-event-fx
+      (rf/reg-event
         ::explicit-destroy
         (fn [_ _]
           {:fx [[:rf.machine/destroy :rf2-lbjnz/finisher]]}))
@@ -145,7 +145,7 @@
       ;; Emit two destroy fxs against the same id in one cascade. The
       ;; first one tears the actor down; the second must be a silent
       ;; no-op — no second :rf.machine/destroyed, no error.
-      (rf/reg-event-fx
+      (rf/reg-event
         ::double-destroy
         (fn [_ _]
           {:fx [[:rf.machine/destroy :rf2-lbjnz/target]

--- a/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
@@ -89,7 +89,7 @@
     ;; A bare event handler emits the fx with a name nothing is bound to.
     ;; The walk must NOT raise :rf.error/no-such-fx (the fx is registered)
     ;; and must NOT throw — it simply finds no binding and does nothing.
-    (rf/reg-event-fx ::poke
+    (rf/reg-event ::poke
       (fn [_ _]
         {:fx [[:rf.machine/dispatch-to-system [:nobody [:whatever]]]]}))
     (is (nil? (rf/dispatch-sync [::poke]))

--- a/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
+++ b/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
@@ -92,7 +92,7 @@
     ;; scratch. Pre-migration this dropped the `:rf/runtime` app-db root and
     ;; with it the live :diag/m1 snapshot. Under the two-partition contract
     ;; the snapshot lives in runtime-db, which `:db` never holds.
-    (rf/reg-event-db :diag/reboot (fn [_db _] {:fresh-app-state true}))
+    (rf/reg-event :diag/reboot (fn [{:keys [db]} _] {:db {:fresh-app-state true}}))
     (let [warnings (with-recorder #(rf/dispatch-sync [:diag/reboot]))]
       (is (empty? warnings)
           "no runtime-state-dropped warning — the footgun is structurally gone")
@@ -138,7 +138,7 @@
     ;; server ran the machine, that slice carries the snapshot, so the live
     ;; machine is replaced-in-place, not dropped. Simulate that shape with a
     ;; framework-authority runtime-db effect.
-    (rf/reg-event-fx :diag/hydrate
+    (rf/reg-event :diag/hydrate
                      (fn [{rt :rf.db/runtime} _]
                        {:db {:server-state true}
                         :rf.db/runtime rt}))

--- a/implementation/machines/test/re_frame/machine_algebra_view_test.clj
+++ b/implementation/machines/test/re_frame/machine_algebra_view_test.clj
@@ -241,7 +241,7 @@
   hierarchical-test pattern). EP-0001: snapshots are durable runtime-db state."
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (name machine-id)))]
-    (rf/reg-event-fx seed-id
+    (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) (paths/snapshot-path machine-id) snap)}))
     (rf/dispatch-sync [seed-id])))

--- a/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
@@ -31,7 +31,7 @@
 (defn- log! [k] (swap! run-log conj k))
 
 (defn- reg-marker [id]
-  (rf/reg-event-fx id (fn [_ _] (log! id) {})))
+  (rf/reg-event id (fn [_ _] (log! id) {})))
 
 ;; ---- (1) a machine action's :fx [[:dispatch …]] leap-frogs a pending
 ;;          external event ----------------------------------------------------
@@ -52,7 +52,7 @@
                    {:fx [[:dispatch [:cont]]]})}
        :states  {:idle {:on {:go {:target :done :action :emit-cont}}}
                  :done {}}})
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         ;; Machine event queued FIRST, external event SECOND.
@@ -77,7 +77,7 @@
        :actions {:noop (fn [_] (log! :machine-ran) {})}
        :states  {:idle {:on {:go {:target :done :action :noop}}}
                  :done {}}})
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         ;; Both are EXTERNAL dispatches (origin = this plain handler's fx
@@ -103,7 +103,7 @@
     ;; (non-machine) handler — so :cont-2 is a BACK-of-queue dispatch.
     ;; This verifies the boundary precisely: only the machine-ORIGINATED
     ;; hop leap-frogs; once control leaves the machine, FIFO resumes.
-    (rf/reg-event-fx :cont-1
+    (rf/reg-event :cont-1
       (fn [_ _]
         (log! :cont-1)
         (rf/dispatch* [:cont-2] {}) ;; plain origin → back of queue
@@ -117,7 +117,7 @@
                          {:fx [[:dispatch [:cont-1]]]})}
        :states  {:idle {:on {:go {:target :done :action :fire}}}
                  :done {}}})
-    (rf/reg-event-fx :seed
+    (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
         (rf/dispatch* [:rf2-j20a7/quiesce [:go]] {})

--- a/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
@@ -229,9 +229,9 @@
 
 (deftest machine-after-subscription-delay-cljs
   (testing "subscription-vector delay: :scheduled trace carries :delay-source :sub + :rf.sub/id + :rf.sub/query-v"
-    (rf/reg-event-db
+    (rf/reg-event
       :a/sub-config-set
-      (fn [db [_ ms]] (assoc db :timeout-config ms)))
+      (fn [{:keys [db]} [_ ms]] {:db (assoc db :timeout-config ms)}))
     (rf/reg-sub
       :a/timeout-config
       (fn [db _] (:timeout-config db)))

--- a/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
@@ -46,7 +46,7 @@
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx seed-id
+    (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
     (rf/dispatch-sync [seed-id])))

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -36,7 +36,7 @@
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx seed-id
+    (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
     (rf/dispatch-sync [seed-id])))

--- a/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
@@ -35,7 +35,7 @@
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx seed-id
+    (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
     (rf/dispatch-sync [seed-id])))

--- a/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
@@ -110,12 +110,12 @@
           traces (atom [])]
       (rf/reg-machine :w/proc child)
       ;; First spawn under :primary
-      (rf/reg-event-fx ::spawn1
+      (rf/reg-event ::spawn1
         (fn [_ _]
           {:fx [[:rf.machine/spawn {:machine-id :w/proc
                                     :id-prefix  :w/proc
                                     :system-id  :primary}]]}))
-      (rf/reg-event-fx ::spawn2
+      (rf/reg-event ::spawn2
         (fn [_ _]
           {:fx [[:rf.machine/spawn {:machine-id :w/proc
                                     :id-prefix  :w/proc
@@ -139,7 +139,7 @@
   (testing "spawn-without-system-id leaves [:rf.runtime/machines :system-ids] empty"
     (let [child {:initial :running :data {} :states {:running {}}}]
       (rf/reg-machine :w2/proc child)
-      (rf/reg-event-fx ::spawn-anon
+      (rf/reg-event ::spawn-anon
         (fn [_ _]
           {:fx [[:rf.machine/spawn {:machine-id :w2/proc :id-prefix :w2/proc}]]}))
       (rf/dispatch-sync [::spawn-anon])

--- a/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
@@ -38,7 +38,7 @@
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
     ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.
-    (rf/reg-event-fx seed-id
+    (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots machine-id] snap)}))
     (rf/dispatch-sync [seed-id])))

--- a/implementation/machines/test/re_frame/substrate_source_machine_test.clj
+++ b/implementation/machines/test/re_frame/substrate_source_machine_test.clj
@@ -198,8 +198,8 @@
            {:idle    {:on {:go :acting}}
             :acting  {:entry :emit-action}}}
           seen (atom [])]
-      (rf/reg-event-db :downstream/note
-        (fn [db _] (assoc db :noted? true)))
+      (rf/reg-event :downstream/note
+        (fn [{:keys [db]} _] {:db (assoc db :noted? true)}))
       (rf/reg-machine :machine-action/parent parent-machine)
       (trace-tooling/register-listener! ::machine-action
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
@@ -224,11 +224,11 @@
     ;; that emit `:dispatch` keep the pre-rf2-c3990 `:fx-dispatch`
     ;; stamp — this regression-guards the discriminator.
     (let [seen (atom [])]
-      (rf/reg-event-fx :ordinary/parent
+      (rf/reg-event :ordinary/parent
         (fn [_ctx _]
           {:fx [[:dispatch [:downstream/from-ordinary]]]}))
-      (rf/reg-event-db :downstream/from-ordinary
-        (fn [db _] (assoc db :noted? true)))
+      (rf/reg-event :downstream/from-ordinary
+        (fn [{:keys [db]} _] {:db (assoc db :noted? true)}))
       (trace-tooling/register-listener! ::ordinary
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
                    (swap! seen conj ev))))

--- a/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
@@ -133,7 +133,7 @@
 
 (defn- register-log! []
   ;; (1) APP-DB entity create from the token's generated values.
-  (rf/reg-event-fx :repl/create
+  (rf/reg-event :repl/create
     (fn [{:keys [db] cofx :rf.cofx} [_ text]]
       (let [id    (:todo/id cofx)
             color (:todo/color cofx)
@@ -142,7 +142,7 @@
                        {:todo/id id :todo/color color
                         :todo/text text :todo/created-at at})})))
   ;; (3) APP-DB mutation — a second durable write folding the token time.
-  (rf/reg-event-fx :repl/touch
+  (rf/reg-event :repl/touch
     (fn [{:keys [db] cofx :rf.cofx} [_ id]]
       {:db (assoc-in db [:todos id :todo/touched-at] (:rf/time-ms cofx))}))
   ;; (2) RESOURCE — loaded-at / stale-at fold the success-reply token time;

--- a/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
@@ -76,8 +76,8 @@
                       {:request {:method :get :url "/feed" :params {:page page}}})
      :tags          (fn [_p _v] #{[:feed]})})
   ;; an app event that writes the logged-in user (the resolver's db input)
-  (rf/reg-event-db :t/login (fn [db [_ username]] (assoc-in db [:auth :user :username] username)))
-  (rf/reg-event-db :t/logout (fn [db _] (update db :auth dissoc :user))))
+  (rf/reg-event :t/login (fn [{:keys [db]} [_ username]] {:db (assoc-in db [:auth :user :username] username)}))
+  (rf/reg-event :t/logout (fn [{:keys [db]} _] {:db (update db :auth dissoc :user)})))
 
 (use-fixtures :each
   (core-test-support/make-reset-runtime-fixture

--- a/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
@@ -63,8 +63,8 @@
      :resolve (fn [{:keys [username]} _ctx]
                 (when username [:rf.scope/session {:username username}]))})
   ;; an app event that writes / removes the logged-in user (the resolver input)
-  (rf/reg-event-db :t/login (fn [db [_ username]] (assoc-in db [:auth :user :username] username)))
-  (rf/reg-event-db :t/logout (fn [db _] (update db :auth dissoc :user))))
+  (rf/reg-event :t/login (fn [{:keys [db]} [_ username]] {:db (assoc-in db [:auth :user :username] username)}))
+  (rf/reg-event :t/logout (fn [{:keys [db]} _] {:db (update db :auth dissoc :user)})))
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
@@ -250,7 +250,7 @@
   (let [replied (atom [])]
     (reg-article-resource!)
     (reg-feed-resource!)
-    (rf/reg-event-fx :test/saved (fn [_ event] (swap! replied conj event) {}))
+    (rf/reg-event :test/saved (fn [_ event] (swap! replied conj event) {}))
     (rf/dispatch-sync [:t/login "jake"])
     (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}
                                             :params {} :owner [:v :feed]}])

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -1082,7 +1082,7 @@
   observable)."
   []
   (reset! replied [])
-  (rf/reg-event-fx :test/save-replied
+  (rf/reg-event :test/save-replied
                    (fn [_ event] (swap! replied conj event) {})))
 
 (deftest reply-to-fires-on-accepted-success-and-carries-the-reply-map
@@ -1228,7 +1228,7 @@
                         :populates (fn [_params result] {(art-target) result})})
       ;; the continuation handler reads the runtime-db AT continuation time:
       ;; both the instance settle AND the populated entry must already be in.
-      (rf/reg-event-fx :test/save-replied
+      (rf/reg-event :test/save-replied
                        (fn [_ [_ reply]]
                          (reset! seen {:instance-status (:status (instance :pc1))
                                        :entry-status    (:status (entry rkey))

--- a/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
@@ -67,7 +67,7 @@
     {:inputs  {:username [:db [:auth :user :username]]}
      :resolve (fn [{:keys [username]} _ctx]
                 (when username [:rf.scope/session {:username username}]))})
-  (rf/reg-event-db :t/login (fn [db [_ username]] (assoc-in db [:auth :user :username] username))))
+  (rf/reg-event :t/login (fn [{:keys [db]} [_ username]] {:db (assoc-in db [:auth :user :username] username)})))
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
@@ -324,7 +324,7 @@
   (let [replied (atom [])]
     (reg-article-resource!)
     (reg-feed-resource!)
-    (rf/reg-event-fx :test/saved (fn [_ ev] (swap! replied conj ev) {}))
+    (rf/reg-event :test/saved (fn [_ ev] (swap! replied conj ev) {}))
     (rf/dispatch-sync [:t/login "jake"])
     ;; jake's feed is ownerless (so a {:from-db} descriptor leaves it stale)
     (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}

--- a/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
@@ -154,7 +154,7 @@
    :invalidates   (fn [{:keys [slug]} _r] #{[:article slug]})})
 
 (defn- seed-token! [token]
-  (rf/reg-event-db :test/login (fn [db _] (assoc-in db [:auth :token] token)))
+  (rf/reg-event :test/login (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] token)}))
   (rf/dispatch-sync [:test/login]))
 
 ;; ===========================================================================

--- a/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
@@ -86,8 +86,8 @@
      :request       (fn [{:keys [page]} _ctx]
                       {:request {:method :get :url "/feed" :params {:page page}}})
      :tags          (fn [_p _v] #{[:feed]})})
-  (rf/reg-event-db :t/login  (fn [db [_ tenant]] (assoc-in db [:viewer :tenant-id] tenant)))
-  (rf/reg-event-db :t/logout (fn [db _] (update db :viewer dissoc :tenant-id))))
+  (rf/reg-event :t/login  (fn [{:keys [db]} [_ tenant]] {:db (assoc-in db [:viewer :tenant-id] tenant)}))
+  (rf/reg-event :t/logout (fn [{:keys [db]} _] {:db (update db :viewer dissoc :tenant-id)})))
 
 (use-fixtures :each
   (core-test-support/make-reset-runtime-fixture

--- a/implementation/resources/test/re_frame/resources_scoped_lease_lifecycle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scoped_lease_lifecycle_cljs_test.cljc
@@ -70,8 +70,8 @@
      :request       (fn [{:keys [page]} _ctx]
                       {:request {:method :get :url "/feed" :params {:page page}}})
      :tags          (fn [_p _v] #{[:feed]})})
-  (rf/reg-event-db :t/switch-tenant
-    (fn [db [_ tenant]] (assoc-in db [:viewer :tenant-id] tenant))))
+  (rf/reg-event :t/switch-tenant
+    (fn [{:keys [db]} [_ tenant]] {:db (assoc-in db [:viewer :tenant-id] tenant)})))
 
 (use-fixtures :each
   (core-test-support/make-reset-runtime-fixture

--- a/implementation/routing/test/re_frame/routing_can_leave_test.clj
+++ b/implementation/routing/test/re_frame/routing_can_leave_test.clj
@@ -27,8 +27,8 @@
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
 
-    (rf/reg-event-db :editor/dirty
-                     (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty
+                     (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _]
                   ;; "OK to leave" = NOT dirty.
@@ -130,7 +130,7 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -160,7 +160,7 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -193,7 +193,7 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -223,7 +223,7 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/can-leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -247,7 +247,7 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/can-leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (let [pushed (atom [])]
@@ -272,7 +272,7 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/can-leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -294,7 +294,7 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/can-leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -337,14 +337,14 @@
                      :params    [:map [:id :string]]
                      :can-leave :editor/can-leave?})
       (rf/reg-route :route/cart {:path "/cart"})
-      (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+      (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
       (rf/reg-sub :editor/can-leave?
                   (fn [db _] (not (get-in db [:editor :dirty?]))))
       (rf/reg-fx :rf.nav/push-url
                  {:platforms #{:server :client}}
                  (fn [_ _] nil))
       ;; App registers its OWN handler over the framework default no-op.
-      (rf/reg-event-fx :rf.route/navigation-blocked
+      (rf/reg-event :rf.route/navigation-blocked
                        (fn [_ [_ pending-nav]]
                          (reset! seen pending-nav)
                          {}))
@@ -368,8 +368,8 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/set-dirty
-                     (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/set-dirty
+                     (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     ;; Polarity bug: returns a truthy non-boolean (42).
     (rf/reg-sub :editor/leave? (fn [db _] (get-in db [:editor :dirty?])))
     (rf/reg-fx :rf.nav/push-url
@@ -402,8 +402,8 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/set-dirty
-                     (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/set-dirty
+                     (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     ;; Polarity bug: return the dirty-flag directly (truthy when dirty).
     ;; A truthy non-boolean must BLOCK nav (rf2-5pyyl).
     (rf/reg-sub :editor/leave?
@@ -462,7 +462,7 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url
@@ -491,7 +491,7 @@
                    :params    [:map [:id :string]]
                    :can-leave [:editor/leave?]})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/set-dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/set-dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     ;; Polarity bug: return the dirty-flag directly → truthy non-boolean.
     (rf/reg-sub :editor/leave? (fn [db _] (get-in db [:editor :dirty?])))
     (rf/reg-fx :rf.nav/push-url

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -142,12 +142,12 @@
       (doseq [{:keys [frame-id tick-event counter]} per-thread]
         (rf/reg-frame frame-id {:doc        "per-thread frame"
                                 :url-bound? false})
-        (rf/reg-event-db tick-event
+        (rf/reg-event tick-event
                          {:frame frame-id}
-                         (fn [db _]
+                         (fn [{:keys [db]} _]
                            (.incrementAndGet global-counter)
                            (swap! counter inc)
-                           (update db :n (fnil inc 0)))))
+                           {:db (update db :n (fnil inc 0))})))
       ;; A single shared route. Each frame runs its own `:on-match` —
       ;; but the `:on-match` vector is the same across frames since
       ;; the framework dispatches each on-match event to the calling
@@ -264,12 +264,12 @@
       (doseq [{:keys [frame-id tick-event counter]} per-thread]
         (rf/reg-frame frame-id {:doc        "per-thread frame"
                                 :url-bound? false})
-        (rf/reg-event-db tick-event
+        (rf/reg-event tick-event
                          {:frame frame-id}
-                         (fn [db _]
+                         (fn [{:keys [db]} _]
                            (.incrementAndGet global-counter)
                            (swap! counter inc)
-                           (update db :n (fnil inc 0)))))
+                           {:db (update db :n (fnil inc 0))})))
       (doseq [{:keys [idx tick-event]} per-thread]
         (rf/reg-route (keyword "ksbur.pop" (str "route-" idx))
                       {:path     (str "/q" idx "/:slug")
@@ -384,11 +384,11 @@
       (doseq [{:keys [frame-id tick-event counter]} per-thread]
         (rf/reg-frame frame-id {:doc        "per-thread frame"
                                 :url-bound? false})
-        (rf/reg-event-db tick-event
+        (rf/reg-event tick-event
                          {:frame frame-id}
-                         (fn [db _]
+                         (fn [{:keys [db]} _]
                            (swap! counter inc)
-                           (update db :n (fnil inc 0)))))
+                           {:db (update db :n (fnil inc 0))})))
       ;; Stable route shared across all dispatcher threads. Each
       ;; thread's :on-match dispatch lands on its OWN frame (per
       ;; reg-event-db {:frame frame-id} above) — but the route

--- a/implementation/routing/test/re_frame/routing_framework_authority_test.clj
+++ b/implementation/routing/test/re_frame/routing_framework_authority_test.clj
@@ -88,8 +88,8 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty
-                     (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty
+                     (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (stub-push-url!)
@@ -141,7 +141,7 @@
   (testing "an ordinary app handler returning :rf.db/runtime DOES fire the diagnostic"
     ;; Proves the listener + diagnostic are live in this fixture — the
     ;; framework-quiet assertions above are not vacuously empty.
-    (rf/reg-event-fx :app/sneaky-runtime-write
+    (rf/reg-event :app/sneaky-runtime-write
                      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :hijacked}}}}))
     (let [warns (record-runtime-warnings! ::app-sneaky)]
       (rf/dispatch-sync [:app/sneaky-runtime-write])
@@ -156,7 +156,7 @@
 
 (deftest machine-handler-still-mints-authority
   (testing "a :rf/machine? true handler returning :rf.db/runtime stays silent (no regression)"
-    (rf/reg-event-fx :machine/runtime-write
+    (rf/reg-event :machine/runtime-write
                      {:doc "framework-authority" :rf/machine? true}
                      (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
     (let [warns (record-runtime-warnings! ::machine)]

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -568,7 +568,7 @@
     (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
                                 :params    [:map [:id :string]]
                                 :can-leave :hist/can-leave?})
-    (rf/reg-event-db :hist/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :hist/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :hist/can-leave?
                 (fn [db _]
                   ;; closed contract: explicit boolean. OK to leave = NOT dirty.
@@ -635,7 +635,7 @@
     (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
                                 :params    [:map [:id :string]]
                                 :can-leave :hist/can-leave?})
-    (rf/reg-event-db :hist/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :hist/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :hist/can-leave?
                 (fn [db _] (not (boolean (get-in db [:editor :dirty?])))))
 
@@ -680,7 +680,7 @@
     (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
                                 :params    [:map [:id :string]]
                                 :can-leave :hist/can-leave?})
-    (rf/reg-event-db :hist/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :hist/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :hist/can-leave?
                 (fn [db _] (not (boolean (get-in db [:editor :dirty?])))))
 

--- a/implementation/routing/test/re_frame/routing_nav_allocation_record_replay_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_allocation_record_replay_test.clj
@@ -160,7 +160,7 @@
             stale-suppression gate flips (suppresses a result that should
             commit)"
     (rf/reg-route :route/article {:path "/articles/:id" :params [:map [:id :string]]})
-    (rf/reg-event-db :article/loaded (fn [db [_ id payload]] (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded (fn [{:keys [db]} [_ id payload]] {:db (assoc db :article {:id id :payload payload})}))
     (let [traces (atom [])]
       (rf/register-listener! ::flip (fn [ev] (swap! traces conj ev)))
       ;; A PRIOR navigation advanced the host nav-token high-water to 5, so a
@@ -192,7 +192,7 @@
             matches current and the result commits (the gate decision is
             preserved across record→replay)"
     (rf/reg-route :route/article {:path "/articles/:id" :params [:map [:id :string]]})
-    (rf/reg-event-db :article/loaded (fn [db [_ id payload]] (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded (fn [{:keys [db]} [_ id payload]] {:db (assoc db :article {:id id :payload payload})}))
     ;; Same advanced host counter as the failing case — a re-mint WOULD give nav-6.
     (nav-counters/commit-counter! :rf/default :nav-token-counter 5)
     ;; REPLAY: the recorded token carries BOTH allocations (a `transitioned`

--- a/implementation/routing/test/re_frame/routing_nav_token_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_token_test.clj
@@ -22,9 +22,9 @@
     ;; it and emits :rf.route.nav-token/stale-suppressed.
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
-    (rf/reg-event-db :article/loaded
-                     (fn [db [_ id payload]]
-                       (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
 
     (let [traces (atom [])]
       (rf/register-listener! ::nav-token (fn [ev] (swap! traces conj ev)))
@@ -109,9 +109,9 @@
                                   :params [:map [:id :string]]})
     (rf/reg-route :route/profile {:path   "/profile/:id"
                                   :params [:map [:id :string]]})
-    (rf/reg-event-db :article/loaded
-                     (fn [db [_ id payload]]
-                       (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
 
     (let [traces (atom [])]
       (rf/register-listener! ::cross-route (fn [ev] (swap! traces conj ev)))
@@ -176,14 +176,14 @@
     ;; resulting app-db slice.
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
-    (rf/reg-event-db :article/loaded
-                     (fn [db [_ id payload]]
-                       (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
     ;; Bridge event: a real :on-success handler. Carries the token it
     ;; captured at request time and re-emits an `:rf.route/with-nav-token`
     ;; fx entry. The runtime then either dispatches `[:article/loaded ...]`
     ;; (match) or suppresses (mismatch).
-    (rf/reg-event-fx :article/loaded-via-nav-token
+    (rf/reg-event :article/loaded-via-nav-token
                      (fn [_ctx [_ {:keys [carried-token carried-route-id id payload]}]]
                        {:fx [[:rf.route/with-nav-token
                               {:do        [:dispatch [:article/loaded id payload]]
@@ -317,7 +317,7 @@
                (fn [_ _] nil))
     (let [seen (atom :unset)]
       ;; An :on-match-reached handler that captures the injected token.
-      (rf/reg-event-fx :article/capture-token
+      (rf/reg-event :article/capture-token
                        {:rf.cofx/requires [:rf.route/nav-token]}
                        (fn [{:rf.route/keys [nav-token]} _]
                          (reset! seen nav-token)
@@ -350,12 +350,12 @@
                {:platforms #{:server :client}}
                (fn [_ _] nil))
     ;; Terminal commit handler.
-    (rf/reg-event-db :article/loaded
-                     (fn [db [_ id payload]]
-                       (assoc db :article {:id id :payload payload})))
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
     ;; The async completion: threads a captured token through the framework
     ;; fx, which validates against the current slice.
-    (rf/reg-event-fx :article/completed
+    (rf/reg-event :article/completed
                      (fn [_ctx [_ {:keys [captured-token id payload]}]]
                        {:fx [[:rf.route/with-nav-token
                               {:do        [:dispatch [:article/loaded id payload]]
@@ -368,7 +368,7 @@
       ;; token at scheduling time (exactly the documented step-2 shape).
       ;; The capture closes over `captured` so the test replays the
       ;; completion later, out of order.
-      (rf/reg-event-fx :article/load
+      (rf/reg-event :article/load
                        {:rf.cofx/requires [:rf.route/nav-token]}
                        (fn [{:rf.route/keys [nav-token]} [_ id]]
                          (swap! captured assoc id nav-token)
@@ -431,10 +431,10 @@
                        (fn [_db _]
                          (swap! order conj :fail)
                          (throw (ex-info "first-boom" {:why :test}))))
-      (rf/reg-event-db :load/next
-                       (fn [db _]
+      (rf/reg-event :load/next
+                       (fn [{:keys [db]} _]
                          (swap! order conj :next)
-                         (assoc db :load/next-ran? true)))
+                         {:db (assoc db :load/next-ran? true)}))
       (rf/reg-route :route/two-loaders
                     {:path     "/two-loaders"
                      :on-match [[:load/fail] [:load/next]]})
@@ -493,8 +493,8 @@
             :error through its own commit, so a failure on the later
             navigation still records (failure-after-recovery is not
             suppressed)"
-    (rf/reg-event-db :load/ok
-                     (fn [db _] (assoc db :ok? true)))
+    (rf/reg-event :load/ok
+                     (fn [{:keys [db]} _] {:db (assoc db :ok? true)}))
     (rf/reg-event-db :load/late-fail
                      (fn [_db _] (throw (ex-info "late-boom" {}))))
     (rf/reg-route :route/clean {:path "/clean" :on-match [[:load/ok]]})

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -616,7 +616,7 @@
 (deftest transitioned-transition-loading-when-on-match-fires
   (testing ":rf.route/transitioned sets :transition :loading when the route
             declares :on-match events"
-    (rf/reg-event-db :prefs/loaded (fn [db _] (assoc db :prefs/loaded? true)))
+    (rf/reg-event :prefs/loaded (fn [{:keys [db]} _] {:db (assoc db :prefs/loaded? true)}))
     (rf/reg-route :route/cart
                   {:path     "/cart"
                    :on-match [[:prefs/loaded]]})
@@ -638,7 +638,7 @@
     (let [observed (atom nil)]
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db
       ;; state — the :on-match observer reads :transition off :rf.db/runtime.
-      (rf/reg-event-fx :prefs/loaded
+      (rf/reg-event :prefs/loaded
                        (fn [{:keys [db] rt :rf.db/runtime} _]
                          (reset! observed
                                  (get-in rt [:rf.runtime/routing :current :transition]))
@@ -741,11 +741,11 @@
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db
       ;; state, so the :on-match observers read `:transition` off the
       ;; `:rf.db/runtime` coeffect.
-      (rf/reg-event-fx :load/a
+      (rf/reg-event :load/a
                        (fn [{:keys [db] rt :rf.db/runtime} _]
                          (swap! observed conj [:a (get-in rt [:rf.runtime/routing :current :transition])])
                          {:db (assoc db :load/a-done? true)}))
-      (rf/reg-event-fx :load/b
+      (rf/reg-event :load/b
                        (fn [{:keys [db] rt :rf.db/runtime} _]
                          (swap! observed conj [:b (get-in rt [:rf.runtime/routing :current :transition])])
                          {:db (assoc db :load/b-done? true)}))

--- a/implementation/routing/test/re_frame/routing_on_match_error_test.clj
+++ b/implementation/routing/test/re_frame/routing_on_match_error_test.clj
@@ -47,7 +47,7 @@
                        (throw (ex-info "kaboom" {}))))
     ;; EP-0001 (rf2-vzld77): the route slice (with :error) is durable routing
     ;; runtime-db state, so the :on-error handler reads it off :rf.db/runtime.
-    (rf/reg-event-fx :route/cart-load-failed
+    (rf/reg-event :route/cart-load-failed
                      (fn [{:keys [db] rt :rf.db/runtime} _]
                        (let [err (get-in rt [:rf.runtime/routing :current :error])]
                          {:db (assoc db :handled-error err)})))
@@ -95,9 +95,9 @@
     (rf/reg-event-db :load/throw4
                      (fn [_db _]
                        (throw (ex-info "y" {}))))
-    (rf/reg-event-db :handle/error
-                     (fn [db _]
-                       (assoc db :handled? true)))
+    (rf/reg-event :handle/error
+                     (fn [{:keys [db]} _]
+                       {:db (assoc db :handled? true)}))
     (rf/reg-route :route/p
                   {:path     "/p"
                    :on-match [[:load/throw4]]
@@ -208,7 +208,7 @@
       ;; while the slice is still :loading (the realistic reproduction
       ;; window). The child carries DIFFERENT args than the route's
       ;; declared on-match vector.
-      (rf/reg-event-fx :app/load-x
+      (rf/reg-event :app/load-x
                        (fn [{:keys [db]} [_ origin]]
                          (if (= origin "button")
                            ;; The "button"-shaped dispatch throws — it is

--- a/implementation/routing/test/re_frame/routing_subs_test.clj
+++ b/implementation/routing/test/re_frame/routing_subs_test.clj
@@ -92,7 +92,7 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (rf/reg-fx :rf.nav/push-url

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -70,7 +70,7 @@
             body has DCE'd — only the boundary interceptor is enforcing
             the schema at this dispatch."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/strict
+      (rf/reg-event :api/strict
         {:schema [:cat [:= :api/strict] :int]
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! calls inc) {}))
@@ -85,7 +85,7 @@
             `:schema` flows through the boundary interceptor unchanged.
             The handler runs exactly once."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/strict
+      (rf/reg-event :api/strict
         {:schema [:cat [:= :api/strict] :int]
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! calls inc) {}))
@@ -106,7 +106,7 @@
             trace callback would never see a boundary emission because
             the entire emit body has DCE'd."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/strict
+      (rf/reg-event :api/strict
         {:schema [:cat [:= :api/strict] :int]
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! calls inc) {}))
@@ -130,7 +130,7 @@
             `:advanced` + `goog.DEBUG=false` (production), the
             `:before` slot's prod branch validates the event and sets
             `:rf/skip-handler?` on the context when the schema fails."
-    (rf/reg-event-fx :api/strict
+    (rf/reg-event :api/strict
       {:schema [:cat [:= :api/strict] :int]
        :interceptors [rf/validate-at-boundary-interceptor]}
       (fn [_ _] {}))
@@ -151,7 +151,7 @@
     (schemas/set-schema-validator! nil)
     (try
       (let [calls (atom 0)]
-        (rf/reg-event-fx :api/disabled
+        (rf/reg-event :api/disabled
           {:schema [:cat [:= :api/disabled] :int]
            :interceptors [rf/validate-at-boundary-interceptor]}
           (fn [_ _] (swap! calls inc) {}))

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -56,8 +56,8 @@
 (deftest live-dispatch-validates-app-db-under-reagent
   (testing "a malformed :db commit emits :rf.error/schema-validation-failure under the Reagent adapter"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event-db :n/init  (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (rf/reg-event :n/init  (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (let [traces (atom [])]
       (trace-tooling/register-listener! ::cljs-live (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/init])
@@ -81,8 +81,8 @@
 (deftest live-dispatch-well-typed-passes-silently
   (testing "well-typed :db commits trigger no schema-validation-failure trace"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (let [traces (atom [])]
       (trace-tooling/register-listener! ::cljs-ok (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/init])
@@ -119,8 +119,8 @@
             runtime `resolve` returned nil and Malli was never consulted,
             so this trace silently never fired."
     (rf/reg-app-schema [:user :age] :int)
-    (rf/reg-event-db :user/set-age-bad
-      (fn [db _] (assoc-in db [:user :age] "twenty-three")))
+    (rf/reg-event :user/set-age-bad
+      (fn [{:keys [db]} _] {:db (assoc-in db [:user :age] "twenty-three")}))
     (let [traces (atom [])]
       (trace-tooling/register-listener! ::t0hq (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:user/set-age-bad])
@@ -149,7 +149,7 @@
       (late-bind/set-fn! :schemas/malli-explain  nil)
       (try
         (rf/reg-app-schema [:n] :int)
-        (rf/reg-event-db :n/break (fn [db _] (assoc db :n "definitely-not-an-int")))
+        (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "definitely-not-an-int")}))
         (let [traces (atom [])]
           (trace-tooling/register-listener! ::no-adapter (fn [ev] (swap! traces conj ev)))
           (rf/dispatch-sync [:n/break])
@@ -297,9 +297,9 @@
     ;; inline `:schema` meta verbatim from button 18.
     (rf/reg-app-schema [:auth] [:map [:token :string]])
     (let [calls (atom 0)]
-      (rf/reg-event-db :rf2-lo28u/async-bad-event-args
+      (rf/reg-event :rf2-lo28u/async-bad-event-args
         {:schema [:cat [:= :rf2-lo28u/async-bad-event-args] pos-int?]}
-        (fn [db _ev] (swap! calls inc) (assoc db :baseline 1)))
+        (fn [{:keys [db]} _ev] (swap! calls inc) {:db (assoc db :baseline 1)}))
       (rf/reg-event-db :rf2-lo28u/noop (fn [db _] db))
       (let [traces (atom [])]
         (trace-tooling/register-listener! ::lo28u-async (fn [ev] (swap! traces conj ev)))
@@ -352,8 +352,8 @@
       (schemas/set-schema-validator! custom)
       (try
         (rf/reg-app-schema [:n] :int)
-        (rf/reg-event-db :n/init  (fn [_ _] {:n 42}))
-        (rf/reg-event-db :n/break (fn [db _] (assoc db :n 99)))
+        (rf/reg-event :n/init  (fn [{:keys [db]} _] {:db {:n 42}}))
+        (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n 99)}))
         (let [traces (atom [])]
           (trace-tooling/register-listener! ::cv (fn [ev] (swap! traces conj ev)))
           (rf/dispatch-sync [:n/init])
@@ -377,7 +377,7 @@
     (schemas/set-schema-validator! nil)
     (try
       (rf/reg-app-schema [:n] :int)
-      (rf/reg-event-db :n/break (fn [db _] (assoc db :n "definitely-not-an-int")))
+      (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "definitely-not-an-int")}))
       (let [traces (atom [])]
         (trace-tooling/register-listener! ::nv (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:n/break])
@@ -413,7 +413,7 @@
             :rf/skip-handler? and does NOT emit a boundary-tagged trace.
             Step-1 validation in the router is what enforces the schema
             in dev; the boundary interceptor's prod-mode body never runs."
-    (rf/reg-event-fx :api/strict
+    (rf/reg-event :api/strict
       {:schema [:cat [:= :api/strict] :int]
        :interceptors [rf/validate-at-boundary-interceptor]}
       (fn [_ _] {}))
@@ -445,7 +445,7 @@
             (router did its job) and the absence of a :source :boundary
             trace tag (boundary itself stayed quiet)."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/strict
+      (rf/reg-event :api/strict
         {:schema [:cat [:= :api/strict] :int]
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! calls inc) {}))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -304,8 +304,8 @@
                 (rf/reg-event-db id meta' handler)
                 (rf/reg-event-db id handler))
           :fx (if (seq meta')
-                (rf/reg-event-fx id meta' handler)
-                (rf/reg-event-fx id handler)))))
+                (rf/reg-event id meta' handler)
+                (rf/reg-event id handler)))))
     ;; ---- subs ----------------------------------------------------------
     ;; Per Spec 010 §step 6 (rf2-wcam): sub meta carries :schema; the
     ;; runtime calls `:schemas/validate-sub!` after each compute.

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -109,7 +109,7 @@
       {:schema [:vector]}
       (fn [ctx] (assoc-in ctx [:coeffects :cf/malformed] :whatever)))
     (let [calls (atom 0)]
-      (rf/reg-event-fx :use/malformed-cofx
+      (rf/reg-event :use/malformed-cofx
         {:interceptors [(rf/inject-cofx :cf/malformed)]}
         (fn [_ _] (swap! calls inc) {}))
       (let [traces (capture #(rf/dispatch-sync [:use/malformed-cofx]))]
@@ -132,7 +132,7 @@
         (fn [_ _] (swap! bad-calls inc)))
       (rf/reg-fx :fx/sibling
         (fn [_ _] (swap! good-calls inc)))
-      (rf/reg-event-fx :emit/both
+      (rf/reg-event :emit/both
         (fn [_ _] {:fx [[:fx/malformed {:any :thing}]
                         [:fx/sibling   :ok]]}))
       (let [traces (capture #(rf/dispatch-sync [:emit/both]))]
@@ -153,7 +153,7 @@
   (testing "rf2-a5kzs (finding 2) — a malformed sub :schema yields the default
             (nil) per :replaced-with-default recovery instead of returning the
             unvalidated value via throw-as-pass; a malformed-schema trace fires."
-    (rf/reg-event-db :sub/init (fn [_ _] {:items [1 2 3]}))
+    (rf/reg-event :sub/init (fn [{:keys [db]} _] {:db {:items [1 2 3]}}))
     (rf/reg-sub :sub/malformed
       {:schema [:vector]}                          ;; childless — throws at validate-time
       (fn [db _] (:items db)))
@@ -230,7 +230,7 @@
     (schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  throwing-explainer})
     (try
-      (rf/reg-event-db :s/init (fn [_ _] {:v [1 2 3]}))
+      (rf/reg-event :s/init (fn [{:keys [db]} _] {:db {:v [1 2 3]}}))
       (rf/reg-sub :s/strict
         {:schema [:vector :string]}
         (fn [db _] (:v db)))

--- a/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
@@ -85,7 +85,7 @@
     (rf/reg-app-schema [:count] [:int])
     (let [recorded (record-traces! ::bad-write)]
       (with-redefs [interop/debug-enabled? true]
-        (rf/reg-event-db :count/break (fn [db _] (assoc db :count "not-an-int")))
+        (rf/reg-event :count/break (fn [{:keys [db]} _] {:db (assoc db :count "not-an-int")}))
         ;; validate-app-schema! runs the registered app-db schema set over
         ;; the supplied db value, exactly as the post-handler step does.
         (re-frame.schemas/validate-app-schema! {:count "not-an-int"} :count/break))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -802,10 +802,10 @@
   (testing "Backward-compat — a handler without :sensitive? emits the
             unredacted trace (legacy behaviour for non-sensitive
             handlers)"
-    (rf/reg-event-db :user/register
+    (rf/reg-event :user/register
       {:schema [:cat [:= :user/register]
                    [:map [:email :string] [:age :int]]]}
-      (fn [db [_ payload]] (update db :users (fnil conj []) payload)))
+      (fn [{:keys [db]} [_ payload]] {:db (update db :users (fnil conj []) payload)}))
     (let [traces (atom [])]
       (rf/register-listener! ::reg (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:user/register {:email "carol@example.com" :age "no"}])
@@ -945,7 +945,7 @@
       ;; (string, not int) — the failing slot is the NON-sensitive sibling.
       (fn [ctx] (assoc-in ctx [:coeffects :auth/ctx]
                           {:token "SECRET-COFX-tok" :count "not-an-int"})))
-    (rf/reg-event-fx :auth/use-ctx
+    (rf/reg-event :auth/use-ctx
       {:interceptors [(rf/inject-cofx :auth/ctx)]}
       (fn [_ _] {}))
     (let [traces (atom [])]
@@ -974,7 +974,7 @@
       ;; :token fails (int, not string) — the FAILING slot IS sensitive.
       (fn [ctx] (assoc-in ctx [:coeffects :auth/ctx2]
                           {:token 1234 :count 3})))
-    (rf/reg-event-fx :auth/use-ctx2
+    (rf/reg-event :auth/use-ctx2
       {:interceptors [(rf/inject-cofx :auth/ctx2)]}
       (fn [_ _] {}))
     (let [traces (atom [])]
@@ -1226,7 +1226,7 @@
        :sensitive? true   ;; ignored — annotation removed
        :schema :string}
       (fn [ctx] (assoc-in ctx [:coeffects :auth/credentials] 42)))
-    (rf/reg-event-fx :auth/use-creds
+    (rf/reg-event :auth/use-creds
       {:interceptors [(rf/inject-cofx :auth/credentials)]}
       (fn [_ _] {}))
     (let [traces (atom [])]
@@ -1252,7 +1252,7 @@
     (rf/reg-cofx :secret-blob
       {:schema [:string {:sensitive? true}]}
       (fn [ctx] (assoc-in ctx [:coeffects :secret-blob] 99))) ; int, fails :string
-    (rf/reg-event-fx :use-secret
+    (rf/reg-event :use-secret
       {:interceptors [(rf/inject-cofx :secret-blob)]}
       (fn [_ _] {}))
     (let [traces (atom [])]
@@ -1273,8 +1273,8 @@
             [:string {:sensitive? true}]`) drives sub-return redaction
             now that the handler/sub-meta `:sensitive?` annotation has
             been removed."
-    (rf/reg-event-db :secrets/init (fn [_ _] {:secrets ["a-secret"]}))
-    (rf/reg-event-db :secrets/break (fn [db _] (assoc db :secrets [1 2 3])))
+    (rf/reg-event :secrets/init (fn [{:keys [db]} _] {:db {:secrets ["a-secret"]}}))
+    (rf/reg-event :secrets/break (fn [{:keys [db]} _] {:db (assoc db :secrets [1 2 3])}))
     (rf/reg-sub :secrets
       {:schema [:vector [:string {:sensitive? true}]]}
       (fn [db _] (:secrets db)))
@@ -1311,10 +1311,10 @@
             gating — user ids, auth tokens, document ids); without
             redaction the failure trace re-leaks it alongside the
             return value the existing clauses scrub."
-    (rf/reg-event-db :tokens/init  (fn [_ _]   {:tokens {"user-42-token" "ok"}}))
-    (rf/reg-event-db :tokens/break (fn [db _] (assoc-in db
+    (rf/reg-event :tokens/init  (fn [{:keys [db]} _]   {:db {:tokens {"user-42-token" "ok"}}}))
+    (rf/reg-event :tokens/break (fn [{:keys [db]} _] {:db (assoc-in db
                                                        [:tokens "user-42-token"]
-                                                       99))) ; int — fails :string
+                                                       99)})) ; int — fails :string
     (rf/reg-sub :token-for
       {:schema [:string {:sensitive? true}]}
       (fn [db [_ token]] (get-in db [:tokens token])))
@@ -1348,8 +1348,8 @@
   (testing "Backward-compat — a sub without :sensitive? emits :rf.sub/query-v
             verbatim on the validation-failure trace (legacy behaviour
             preserved for non-sensitive subs). Redaction is opt-in."
-    (rf/reg-event-db :widgets/init  (fn [_ _]   {:widgets {:w1 "ok"}}))
-    (rf/reg-event-db :widgets/break (fn [db _] (assoc-in db [:widgets :w1] 99)))
+    (rf/reg-event :widgets/init  (fn [{:keys [db]} _]   {:db {:widgets {:w1 "ok"}}}))
+    (rf/reg-event :widgets/break (fn [{:keys [db]} _] {:db (assoc-in db [:widgets :w1] 99)}))
     (rf/reg-sub :widget
       {:schema :string}                                  ; no :sensitive?
       (fn [db [_ wid]] (get-in db [:widgets wid])))
@@ -1452,8 +1452,8 @@
             omitted) on a sensitive failure, and the raw value never
             surfaces in the humanized slot"
     (let [secret "sub-secret-deadbeef"]
-      (rf/reg-event-db :secrets/init  (fn [_ _] {:secrets [secret]}))
-      (rf/reg-event-db :secrets/break (fn [db _] (assoc db :secrets [1 2 3])))
+      (rf/reg-event :secrets/init  (fn [{:keys [db]} _] {:db {:secrets [secret]}}))
+      (rf/reg-event :secrets/break (fn [{:keys [db]} _] {:db (assoc db :secrets [1 2 3])}))
       (rf/reg-sub :secrets
         {:schema [:vector [:string {:sensitive? true}]]}
         (fn [db _] (:secrets db)))
@@ -1479,8 +1479,8 @@
 (deftest non-sensitive-sub-return-failure-carries-humanized-payload
   (testing "rf2-qhq3f — backward-compat on the sub-return surface: a
             non-sensitive sub keeps the real humanized payload"
-    (rf/reg-event-db :widgets/init  (fn [_ _] {:widgets {:w1 "ok"}}))
-    (rf/reg-event-db :widgets/break (fn [db _] (assoc-in db [:widgets :w1] 99)))
+    (rf/reg-event :widgets/init  (fn [{:keys [db]} _] {:db {:widgets {:w1 "ok"}}}))
+    (rf/reg-event :widgets/break (fn [{:keys [db]} _] {:db (assoc-in db [:widgets :w1] 99)}))
     (rf/reg-sub :widget
       {:schema :string}                                  ;; no :sensitive?
       (fn [db [_ wid]] (get-in db [:widgets wid])))

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -118,8 +118,8 @@
 (deftest dispatch-fires-app-db-validation
   (testing "live dispatch through the runtime triggers app-db validation post-:db commit"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
-    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (let [traces (atom [])]
       (rf/register-listener! ::live (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/init])
@@ -143,9 +143,9 @@
             :db to the pre-handler value. The dispatch is treated as
             failed; the bad commit does NOT stand."
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event-db :n/init  (fn [_ _]  {:n 0}))
-    (rf/reg-event-db :n/ok    (fn [db _] (assoc db :n 42)))
-    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (rf/reg-event :n/init  (fn [{:keys [db]} _]  {:db {:n 0}}))
+    (rf/reg-event :n/ok    (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
+    (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (rf/dispatch-sync [:n/init])
     (is (= {:n 0} (rf/app-db-value (rf/current-frame-id)))
         "baseline post-init state")
@@ -165,9 +165,9 @@
     (let [fx-calls (atom [])]
       (rf/reg-fx :test/note (fn [v] (swap! fx-calls conj v)))
       (rf/reg-app-schema [:n] [:int])
-      (rf/reg-event-fx :n/init
+      (rf/reg-event :n/init
         (fn [_ _] {:db {:n 0}}))
-      (rf/reg-event-fx :n/break-with-fx
+      (rf/reg-event :n/break-with-fx
         (fn [_ _] {:db {:n "boom"}    ;; bad commit
                    :fx [[:test/note :should-not-fire]]}))
       (rf/dispatch-sync [:n/init])
@@ -184,8 +184,8 @@
             Trace ordering: forward db-changed → schema-failure error
             → rollback db-changed."
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event-db :n/init  (fn [_ _]  {:n 0}))
-    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (rf/reg-event :n/init  (fn [{:keys [db]} _]  {:db {:n 0}}))
+    (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (let [events (atom [])]
       (rf/register-listener! ::ord
         (fn [ev] (when (#{:rf.event/db-changed
@@ -232,12 +232,12 @@
             :rf.error/schema-validation-failure :where :event before the
             handler runs; the handler is NOT invoked"
     (let [calls (atom 0)]
-      (rf/reg-event-db :user/register
+      (rf/reg-event :user/register
         {:schema [:cat [:= :user/register]
                      [:map [:email :string] [:age :int]]]}
-        (fn [db [_ payload]]
+        (fn [{:keys [db]} [_ payload]]
           (swap! calls inc)
-          (update db :users (fnil conj []) payload)))
+          {:db (update db :users (fnil conj []) payload)}))
       (let [traces (atom [])]
         (rf/register-listener! ::ev (fn [ev] (swap! traces conj ev)))
         ;; Well-typed payload — passes; handler runs.
@@ -318,8 +318,8 @@
   (testing "Per Spec 010 §step 6 (rf2-wcam): a sub whose return value fails
             its :schema emits :rf.error/schema-validation-failure :where :sub-return
             and the caller sees nil (default :replaced-with-default recovery)"
-    (rf/reg-event-db :items/init (fn [_ _] {:items ["a" "b" "c"]}))
-    (rf/reg-event-db :items/break (fn [db _] (assoc db :items [1 2 3])))
+    (rf/reg-event :items/init (fn [{:keys [db]} _] {:db {:items ["a" "b" "c"]}}))
+    (rf/reg-event :items/break (fn [{:keys [db]} _] {:db (assoc db :items [1 2 3])}))
     (rf/reg-sub :items
       {:schema [:vector :string]}
       (fn [db _] (:items db)))
@@ -387,7 +387,7 @@
       (fn [ctx]
         (assoc-in ctx [:coeffects :app-version/bad] 42)))
     (let [calls (atom 0)]
-      (rf/reg-event-fx :cap/seed
+      (rf/reg-event :cap/seed
         {:interceptors [(rf/inject-cofx :app-version/bad)]}
         (fn [_cofx _]
           (swap! calls inc)
@@ -423,7 +423,7 @@
       (fn [ctx]
         (assoc-in ctx [:coeffects :app-version/well] "1.4.5")))
     (let [seen-version (atom nil)]
-      (rf/reg-event-fx :cap/seed-good
+      (rf/reg-event :cap/seed-good
         {:interceptors [(rf/inject-cofx :app-version/well)]}
         (fn [cofx _]
           (reset! seen-version (:app-version/well cofx))
@@ -453,7 +453,7 @@
         (fn [_ctx _args] (swap! bad-fx-calls inc)))
       (rf/reg-fx :my/log
         (fn [_ctx _args] (swap! good-fx-calls inc)))
-      (rf/reg-event-fx :ui/announce
+      (rf/reg-event :ui/announce
         (fn [_ _]
           {:fx [[:my/notify {:level "error"          ;; bad: needs keyword
                              :message "boom"}]
@@ -498,7 +498,7 @@
         (fn [_ctx args]
           (swap! calls inc)
           (reset! seen args)))
-      (rf/reg-event-fx :user/welcome
+      (rf/reg-event :user/welcome
         (fn [_ _]
           {:fx [[:my/email {:to "alice@example.com"}]]}))
       (let [traces (atom [])]
@@ -518,7 +518,7 @@
       (rf/reg-fx :strict/fx
         {:schema [:map [:x :int]]}
         (fn [_ctx _args] (swap! calls inc)))
-      (rf/reg-event-fx :strict/trigger
+      (rf/reg-event :strict/trigger
         (fn [_ _]
           {:fx [[:strict/fx {:x "not-an-int"}]]}))
       (let [traces (atom [])]
@@ -596,7 +596,7 @@
     (rf/reg-cofx :probe/cofx
       {:schema :string}
       (fn [ctx] (assoc-in ctx [:coeffects :probe/cofx] 42)))   ;; int, not string
-    (rf/reg-event-fx :probe/cofx-seed
+    (rf/reg-event :probe/cofx-seed
       {:interceptors [(rf/inject-cofx :probe/cofx)]}
       (fn [_ _] {}))
     (let [traces (atom [])]
@@ -617,7 +617,7 @@
     (rf/reg-fx :probe/fx
       {:schema [:map [:x :int]]}
       (fn [_ctx _args] nil))
-    (rf/reg-event-fx :probe/fx-seed
+    (rf/reg-event :probe/fx-seed
       (fn [_ _] {:fx [[:probe/fx {:x "bad"}]]}))   ;; string, not int
     (let [traces (atom [])]
       (rf/register-listener! ::fx-frame (fn [ev] (swap! traces conj ev)))
@@ -634,7 +634,7 @@
   (testing "rf2-9cm27 — a sub-return validation failure on a NAMED frame
             stamps the reaction's frame id on the trace (not :rf/default)."
     (rf/reg-frame :test/sub-frame {})
-    (rf/reg-event-db :probe/sub-break (fn [db _] (assoc db :items [1 2 3]))) ;; ints, not strings
+    (rf/reg-event :probe/sub-break (fn [{:keys [db]} _] {:db (assoc db :items [1 2 3])})) ;; ints, not strings
     (rf/reg-sub :probe/items
       {:schema [:vector :string]}
       (fn [db _] (:items db)))
@@ -981,7 +981,7 @@
     (rf/reg-frame :test/other {})
     ;; Schema only on :test/other; commit happens on :test/main.
     (rf/reg-app-schema [:n] [:int] {:frame :test/other})
-    (rf/reg-event-db :n/break-on-main (fn [db _] (assoc db :n "not-an-int")))
+    (rf/reg-event :n/break-on-main (fn [{:keys [db]} _] {:db (assoc db :n "not-an-int")}))
     (let [traces (atom [])]
       (rf/register-listener! ::sib (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/break-on-main] {:frame :test/main})
@@ -995,7 +995,7 @@
             frame the schema is registered against DOES fire the failure trace."
     (rf/reg-frame :test/main {})
     (rf/reg-app-schema [:n] [:int] {:frame :test/main})
-    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "not-an-int")))
+    (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "not-an-int")}))
     (let [traces (atom [])]
       (rf/register-listener! ::same (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/break] {:frame :test/main})
@@ -1565,7 +1565,7 @@
   (testing "Per Spec 010 §Production builds (rf2-r2uh) — a valid event
             against the handler's :schema passes through, the handler runs."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/response
+      (rf/reg-event :api/response
         {:schema [:cat [:= :api/response]
                      [:map [:status :int] [:body :string]]]
          :interceptors [rf/validate-at-boundary-interceptor]}
@@ -1599,7 +1599,7 @@
             true), but the handler-skip behaviour is what the spec
             promises in either path."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/response
+      (rf/reg-event :api/response
         {:schema [:cat [:= :api/response]
                      [:map [:status :int] [:body :string]]]
          :interceptors [rf/validate-at-boundary-interceptor]}
@@ -1624,7 +1624,7 @@
             boundary :before never reaches its emit body. Direct
             invocation isolates the boundary's emission for shape
             assertion."
-    (rf/reg-event-fx :api/strict
+    (rf/reg-event :api/strict
       {:schema [:cat [:= :api/strict] :int]
        :interceptors [rf/validate-at-boundary-interceptor]}
       (fn [_ _] {}))
@@ -1671,7 +1671,7 @@
             (validate-event! returning false), so the runtime's existing
             skip mechanism carries the boundary failure through without
             additional plumbing."
-    (rf/reg-event-fx :api/strict
+    (rf/reg-event :api/strict
       {:schema [:cat [:= :api/strict] :int]
        :interceptors [rf/validate-at-boundary-interceptor]}
       (fn [_ _] {}))
@@ -1705,7 +1705,7 @@
                    (= value [:api/custom :good]))
           handler-calls (atom 0)]
       (schemas/set-schema-validator! custom)
-      (rf/reg-event-fx :api/custom
+      (rf/reg-event :api/custom
         {:schema :rf/any                     ;; opaque to the custom validator
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! handler-calls inc) {}))
@@ -1730,7 +1730,7 @@
             interceptor. The handler runs even with a malformed payload."
     (schemas/set-schema-validator! nil)
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/disabled
+      (rf/reg-event :api/disabled
         {:schema [:cat [:= :api/disabled] :int]
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! calls inc) {}))
@@ -1752,7 +1752,7 @@
             validation in the router has already run; the boundary
             interceptor doesn't validate a second time."
     (let [calls (atom 0)]
-      (rf/reg-event-fx :api/dev
+      (rf/reg-event :api/dev
         {:schema [:cat [:= :api/dev] :int]
          :interceptors [rf/validate-at-boundary-interceptor]}
         (fn [_ _] (swap! calls inc) {}))
@@ -1784,16 +1784,16 @@
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #":rf\.error/at-boundary-missing-schema"
-              (rf/reg-event-fx :api/no-schema-2
+              (rf/reg-event :api/no-schema-2
                 {:interceptors [rf/validate-at-boundary-interceptor]}
                 (fn [_ _] (swap! calls inc) {}))))
-        (let [data (try (rf/reg-event-fx :api/no-schema-2-data
+        (let [data (try (rf/reg-event :api/no-schema-2-data
                           {:interceptors [rf/validate-at-boundary-interceptor]}
                           (fn [_ _] {}))
                         (catch clojure.lang.ExceptionInfo e
                           (ex-data e)))]
           (is (= :rf.error/at-boundary-missing-schema (:rf.error/id data)))
-          (is (= "reg-event-fx" (:reg-fn data)))
+          (is (= "reg-event" (:reg-fn data)))
           (is (= :api/no-schema-2-data (:id data)))
           (is (string? (:reason data)))
           (is (str/includes? (:reason data) ":rf.schema/at-boundary"))
@@ -1805,7 +1805,7 @@
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #":rf\.error/at-boundary-missing-schema"
-            (rf/reg-event-fx :api/no-schema-3
+            (rf/reg-event :api/no-schema-3
               {:doc "metadata-map but no :schema"
                :interceptors [rf/validate-at-boundary-interceptor]}
               (fn [_ _] {})))))
@@ -1826,7 +1826,7 @@
 
     (testing "registration with `:schema` + validate-at-boundary-interceptor completes silently"
       (is (= :api/with-schema
-             (rf/reg-event-fx :api/with-schema
+             (rf/reg-event :api/with-schema
                {:schema [:cat [:= :api/with-schema] :int]
                 :interceptors [rf/validate-at-boundary-interceptor]}
                (fn [_ _] {})))
@@ -1834,11 +1834,11 @@
 
     (testing "registration without validate-at-boundary-interceptor is unaffected by the new check"
       (is (= :api/no-boundary
-             (rf/reg-event-fx :api/no-boundary
+             (rf/reg-event :api/no-boundary
                (fn [_ _] {})))
           "no validate-at-boundary-interceptor, no schema, no error")
       (is (= :api/just-meta
-             (rf/reg-event-fx :api/just-meta
+             (rf/reg-event :api/just-meta
                {:doc "no boundary, no schema"}
                (fn [_ _] {})))
           "metadata-map without :schema is fine when validate-at-boundary-interceptor isn't attached"))))
@@ -2062,7 +2062,7 @@
     (is (= :rf.schema/at-boundary (:id rf/validate-at-boundary-interceptor))
         ":id of the boundary interceptor is :rf.schema/at-boundary (rf2-ieu0i)")
     ;; Canonical :schema path — validation reads :schema.
-    (rf/reg-event-fx :api/schema-key
+    (rf/reg-event :api/schema-key
       {:schema [:cat [:= :api/schema-key] :int]
        :interceptors [rf/validate-at-boundary-interceptor]}
       (fn [_ _] {}))

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -433,7 +433,7 @@
         ;; the :sensitive? output schema. The failing value carries the
         ;; sentinel so, absent redaction, it rides verbatim in :value /
         ;; :explain on the trace bus.
-        (rf/reg-event-db :flow/seed (fn [_ _] {:in failing-sensitive-value}))
+        (rf/reg-event :flow/seed (fn [{:keys [db]} _] {:db {:in failing-sensitive-value}}))
         (rf/reg-flow {:id     :flow/secret
                       :inputs [[:in]]
                       :output (fn [in] in)            ;; pass the bad value through

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -146,7 +146,7 @@
   ;; The `:rf.server/request` cofx is registered by `re-frame.ssr` at
   ;; ns-load and re-installed by the test-fixture's `:reload`; we
   ;; only register the handler that consumes it.
-  (rf/reg-event-fx :rf.test.ozhy9/init
+  (rf/reg-event :rf.test.ozhy9/init
     {:platforms        #{:server}
      :rf.cofx/requires [:rf.server/request]}
     (fn [{request :rf.server/request} _]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
@@ -89,7 +89,7 @@
       ;; Stronger than textual presence: the example opts map must pass
       ;; the live construction validator (with placeholder event/view
       ;; registered) — proving the example is actually constructible.
-      (rf/reg-event-fx :init/facade-example {:platforms #{:server}} (fn [_ _] {}))
+      (rf/reg-event :init/facade-example {:platforms #{:server}} (fn [_ _] {}))
       (rf/reg-view* :pages/facade-example (fn [] [:div "facade example"]))
       (is (= (assoc opts :on-create [:init/facade-example]
                          :root-view [:pages/facade-example])

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -422,7 +422,7 @@
 ;; ===========================================================================
 
 (defn- register-blank-app! []
-  (rf/reg-event-fx :init/mw-blank {:platforms #{:server}} (fn [_ _] {}))
+  (rf/reg-event :init/mw-blank {:platforms #{:server}} (fn [_ _] {}))
   (rf/reg-view* :pages/mw-blank (fn [] [:div "ssr body"])))
 
 (deftest middleware-default-match-renders-get

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -101,7 +101,7 @@
   `:rf/suspense-boundary`. Tests that need a different root override
   by re-registering `:test/root` after this runs."
   []
-  (rf/reg-event-fx :rf.test.server/init
+  (rf/reg-event :rf.test.server/init
     {:platforms #{:server}}
     (fn [_ _]
       {:db {:articles [{:id "a" :title "Article A"}
@@ -335,7 +335,7 @@
             request thread before the head commits, so a structural shell
             failure escalates to `:rf.error/ssr-render-failed` and projects
             a non-200 (Spec 011 §744/§748/§954)."
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [throwing-root  (fn root-view-fn []
@@ -502,7 +502,7 @@
     ;; The host materialiser's `cookie->set-cookie-header` carries the
     ;; primitive-long type contract (:expires → `Instant/ofEpochMilli`)
     ;; and throws `:rf.error/cookie-invalid-expires` at head materialise.
-    (rf/reg-event-fx :rf.test.server/init-bad-cookie
+    (rf/reg-event :rf.test.server/init-bad-cookie
       {:platforms #{:server}}
       (fn [_ _]
         {:db {}
@@ -587,7 +587,7 @@
         [:main.broken
          [:h1 "header that renders"]
          [:p (str "value: " v)]]))
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [handler (ssr-ring/stream-handler
@@ -637,7 +637,7 @@
             boundary streams the inner resolved chunk on the real Jetty
             wire, at the FIFO tail, with the outer resolved cleanly (not
             failed)."
-    (rf/reg-event-fx :rf.test.server/init-nested
+    (rf/reg-event :rf.test.server/init-nested
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (rf/reg-view ^{:rf/id :test/wire-inner} wire-inner []

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -138,7 +138,7 @@
             render fail-closed catch arm), not in a spawned-thread
             finally — the throw never reaches a writer thread. Without
             this every failed streaming request would leak a frame record."
-    (rf/reg-event-fx :rf.test.writer/init
+    (rf/reg-event :rf.test.writer/init
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [throwing-root (fn [] (throw (ex-info "shell-render teardown probe"
@@ -231,7 +231,7 @@
   (testing "rf2-l1qgjw: forcing different writer chunks to throw produces
             writer-failed traces with DISTINCT :phase tags (shell-prefix
             vs final-payload vs suffix), all marked :committed? true"
-    (rf/reg-event-fx :rf.test.phase/init
+    (rf/reg-event :rf.test.phase/init
       {:platforms #{:server}}
       (fn [_ _] {:db {:n 1}}))
     (rf/reg-sub :rf.test.phase/n (fn [db _] (:n db)))
@@ -279,7 +279,7 @@
   (testing "rf2-l1qgjw: a write throw during a continuation drain tags the
             trace :phase :continuation-template AND :boundary-id <id>, so
             ops correlate the failure to a specific deferred subtree"
-    (rf/reg-event-fx :rf.test.phase/init-sb
+    (rf/reg-event :rf.test.phase/init-sb
       {:platforms #{:server}}
       (fn [_ _] {:db {:items [:a :b]}}))
     (rf/reg-sub :rf.test.phase/items (fn [db _] (:items db)))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -157,7 +157,7 @@
     ;; matches NONE of them, so url-change-fx falls back to not-found and
     ;; emits the drain-time :rf.error/no-such-handler.
     (rf/reg-route :route/home {:path "/"})
-    (rf/reg-event-fx :init/route-to-missing
+    (rf/reg-event :init/route-to-missing
       {:platforms #{:server}}
       (fn [_ _]
         ;; Drain-time error: dispatch a URL-change to an unmatched URL.
@@ -237,7 +237,7 @@
         (rf/reg-fx :rf.nav/push-url
                    {:platforms #{:server :client}}
                    (fn [_ _url] nil))
-        (rf/reg-event-fx :init/navigate-bad-param
+        (rf/reg-event :init/navigate-bad-param
           {:platforms #{:server}}
           (fn [_ _]
             ;; Drain-time error: a navigate whose :id ("zoo") fails the
@@ -303,7 +303,7 @@
     ;; The :on-create reads the request URI via the :rf.server/request
     ;; cofx and routes a URL-change to it. A `/missing/*` URI matches no
     ;; route → drain-time 404; a `/` URI matches :route/home → 200.
-    (rf/reg-event-fx :init/route-from-uri
+    (rf/reg-event :init/route-from-uri
       {:platforms        #{:server}
        :rf.cofx/requires [:rf.server/request]}
       (fn [{request :rf.server/request} _]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -155,7 +155,7 @@
 (deftest e2e-bad-tag-name-keyword-projects-through-projector
   (testing "rf2-z7gor + rf2-zwgsv — hostile tag-name keyword surfaces as
             500 via the SSR error projector"
-    (rf/reg-event-fx :init/ok-bad-tag {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok-bad-tag {:platforms #{:server}} (fn [_ _] {}))
     ;; The view body intentionally emits a tag-name component carrying a
     ;; space — `validate-tag-name!` rejects anything outside
     ;; `[A-Za-z][A-Za-z0-9-]*`. We register the view via reg-view*
@@ -215,7 +215,7 @@
             throw produce identical projector-driven status + uniform
             body shape (both flow through `apply-error-projection!`)"
     ;; Path A: render-time throw via tag-name validator.
-    (rf/reg-event-fx :init/ok-render-throw {:platforms #{:server}}
+    (rf/reg-event :init/ok-render-throw {:platforms #{:server}}
       (fn [_ _] {}))
     (rf/reg-view* :pages/render-throw
                   (fn [] [(keyword "render throw")]))
@@ -229,7 +229,7 @@
           ;; Path B: drain-time throw via CRLF cookie value (separate
           ;; server so the per-frame projector buffer doesn't carry
           ;; state across).
-          (rf/reg-event-fx :init/drain-throw
+          (rf/reg-event :init/drain-throw
             {:platforms #{:server}}
             (fn [_ _]
               {:fx [[:rf.server/set-cookie
@@ -290,7 +290,7 @@
 
 (deftest e2e-crlf-bearing-cookie-value-rejected
   (testing "rf2-z7gor — CRLF in cookie :value rejected before any wire byte emitted"
-    (rf/reg-event-fx :init/bad-cookie
+    (rf/reg-event :init/bad-cookie
       {:platforms #{:server}}
       (fn [_ _]
         ;; The classic header-splitting payload — if this reached the
@@ -339,7 +339,7 @@
 
 (deftest e2e-crlf-bearing-header-value-rejected
   (testing "rf2-hbty2 — CRLF in header :value rejected before any wire byte emitted"
-    (rf/reg-event-fx :init/bad-header
+    (rf/reg-event :init/bad-header
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/set-header
@@ -388,7 +388,7 @@
 
 (deftest e2e-valid-render-path-returns-200
   (testing "sanity: a clean view → 200 + HTML + render-hash on the wire"
-    (rf/reg-event-fx :init/ok
+    (rf/reg-event :init/ok
       {:platforms #{:server}}
       (fn [_ _] {:db {:title "Greetings from JVM SSR"}}))
 

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
@@ -124,7 +124,7 @@
             BEFORE the render that buffers it, then dropped at
             frame-destroy)."
     (register-throwing-sub-view!)
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok]
                      :root-view [:pages/uses-throwing-sub]
@@ -170,7 +170,7 @@
       (fn []
         (let [v @(rf/subscribe [:clean-sub])]
           [:main [:h1 "clean"] [:p (str "value: " v)]])))
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok]
                      :root-view [:pages/uses-clean-sub]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -24,9 +24,9 @@
   [test-fn]
   (ts/reset-runtime
     (fn []
-      (rf/reg-event-db :rf.test/seed-articles
-        (fn [_ [_ arts]] {:articles arts}))
-      (rf/reg-event-fx :rf.test.server/init
+      (rf/reg-event :rf.test/seed-articles
+        (fn [{:keys [db]} [_ arts]] {:db {:articles arts}}))
+      (rf/reg-event :rf.test.server/init
         {:platforms #{:server}}
         (fn [_ _]
           {:db {:articles [{:id "a" :title "Article A"}
@@ -261,9 +261,9 @@
             script — not an inert `{}` chunk."
     ;; A db-mutating event the deferred subtree dispatches during its render
     ;; — produces a non-empty per-subtree delta for the :changed boundary.
-    (rf/reg-event-db :rf.test/bump-counter
+    (rf/reg-event :rf.test/bump-counter
       {:platforms #{:server}}
-      (fn [db _] (update db :counter (fnil inc 0))))
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
     ;; Subtree that mutates app-db during render → non-empty delta.
     (rf/reg-view ^{:rf/id :test/mutating-section} mutating-section []
       (rf/dispatch-sync [:rf.test/bump-counter])
@@ -328,7 +328,7 @@
             request frame inline — no frame / side-channel-slot leak.
             The redirect branch never spawns the writer thread, so the
             teardown CANNOT defer to the writer's finally."
-    (rf/reg-event-fx :rf.test.stream/redirect
+    (rf/reg-event :rf.test.stream/redirect
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
@@ -367,7 +367,7 @@
             non-streaming redirect path (which passes no default-content-
             type). A redirect has no body, so a defaulted Content-Type is
             meaningless; the two handlers must not diverge."
-    (rf/reg-event-fx :rf.test.stream/redirect-ct
+    (rf/reg-event :rf.test.stream/redirect-ct
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
@@ -433,7 +433,7 @@
             closed to a non-200 PROJECTED error response on the request
             thread — NOT a streamed 200. No InputStream body is handed
             out (the chunked response was never committed)."
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [throwing-root (fn root-view-fn []
@@ -460,7 +460,7 @@
             non-200 — the shell-walk throw is a structural failure that
             escalates per Spec 011 §954 (the inline-fallback boundary
             stops at continuations)."
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     ;; A view that throws during the shell walk — it is NOT wrapped in a
@@ -499,7 +499,7 @@
         [:main.broken
          [:h1 "header that renders"]
          [:p (str "value: " v)]]))
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [handler (ssr-ring/stream-handler
@@ -537,7 +537,7 @@
     (rf/reg-view ^{:rf/id :test/uses-clean-sub} uses-clean-sub []
       (let [v @(rf/subscribe [:clean-sub])]
         [:main [:h1 "clean"] [:p (str "value: " v)]]))
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [handler  (ssr-ring/stream-handler
@@ -589,7 +589,7 @@
   (testing "rf2-5knxf.1: a :redirect surfacing at the POST-SHELL get-response
             re-read ships a bodiless Location response (NOT a streamed
             body), spawns NO writer thread, and destroys the frame inline."
-    (rf/reg-event-fx :rf.test.server/init-min
+    (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (rf/reg-view ^{:rf/id :test/plain-root} plain-root []
@@ -671,7 +671,7 @@
             root view EQUALS the client's `#((rf/view :root))` hash — the
             suspense marker is NOT a divergence (render-tree-hash is a pure
             structural hash that does not expand or reject the marker)."
-    (rf/reg-event-fx :rf.test.server/init
+    (rf/reg-event :rf.test.server/init
       {:platforms #{:server}}
       (fn [_ _] {:db {:comments [{:body "First!"}]}}))
     (rf/reg-sub :comments (fn [db _] (:comments db)))
@@ -750,7 +750,7 @@
                    :path "/stream-head-throws"
                    :head :test.stream/head-throws})
     ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
-    (rf/reg-event-fx :rf.test.stream/seed-throwing-head-route
+    (rf/reg-event :rf.test.stream/seed-throwing-head-route
       {:platforms #{:server}}
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
@@ -828,7 +828,7 @@
             (case-insensitively) from the streamed response so the Ring
             server owns chunked-transfer framing; the body still streams in
             full with NO Content-Length header surviving"
-    (rf/reg-event-fx :rf.test.server/init-with-content-length
+    (rf/reg-event :rf.test.server/init-with-content-length
       {:platforms #{:server}}
       (fn [_ _]
         {:db {:articles [{:id "a" :title "Article A"}]
@@ -870,7 +870,7 @@
   (testing "rf2-h3dg0: stripping Content-Length leaves the other head
             machinery intact — Content-Type still rides the streamed
             response"
-    (rf/reg-event-fx :rf.test.server/init-cl-and-ct
+    (rf/reg-event :rf.test.server/init-cl-and-ct
       {:platforms #{:server}}
       (fn [_ _]
         {:db {:articles [] :comments []}

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -179,7 +179,7 @@
       (when on-success
         (rf/dispatch (conj on-success articles) {:frame frame}))))
 
-  (rf/reg-event-fx :rf/server-init
+  (rf/reg-event :rf/server-init
     {:platforms        #{:server}
      :rf.cofx/requires [:rf.server/request]}
     (fn [{:keys [db rf.server/request]} _]
@@ -187,9 +187,9 @@
        :fx [[:http/get {:url        "/api/articles"
                         :on-success [:articles/loaded]}]]}))
 
-  (rf/reg-event-db :articles/loaded
-    (fn [db [_ articles]]
-      (assoc db :articles articles)))
+  (rf/reg-event :articles/loaded
+    (fn [{:keys [db]} [_ articles]]
+      {:db (assoc db :articles articles)}))
 
   (rf/reg-sub :articles (fn [db _] (:articles db)))
 
@@ -271,7 +271,7 @@
 
 (deftest handler-redirect-short-circuits
   (testing ":rf.server/redirect emits status + Location with empty body"
-    (rf/reg-event-fx :init/redirect
+    (rf/reg-event :init/redirect
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
@@ -300,7 +300,7 @@
             the last line: it emits :rf.ssr/ssr-redirect-no-target so the
             defect is observable rather than silently shipping a broken
             redirect."
-    (rf/reg-event-fx :init/redirect-no-target
+    (rf/reg-event :init/redirect-no-target
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302}]]}))
@@ -329,7 +329,7 @@
 
 (deftest handler-cookies-become-set-cookie-headers
   (testing "structured cookies materialise to Set-Cookie wire form"
-    (rf/reg-event-fx :init/with-cookies
+    (rf/reg-event :init/with-cookies
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/set-cookie {:name      "session"
@@ -375,7 +375,7 @@
             SSR error projector (Spec 011 §View-time exceptions), not
             through the Ring :on-error hook. Wire body carries the
             projector's :message / :code, never .getMessage."
-    (rf/reg-event-fx :init/ok
+    (rf/reg-event :init/ok
       {:platforms #{:server}}
       (fn [_ _] {}))
 
@@ -420,7 +420,7 @@
             body via a custom :rf.error/* projector mapping, NOT via
             the :on-error Ring hook (which now only catches
             transport/projector-undeliverable failures)."
-    (rf/reg-event-fx :init/ok
+    (rf/reg-event :init/ok
       {:platforms #{:server}}
       (fn [_ _] {}))
 
@@ -466,7 +466,7 @@
             map as its single prop — replacing the hardcoded default
             error template. The public-error's :message rides the wire
             HTML-escaped (the emitter escapes text-node children)."
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/broken-ev
       (fn [] (throw (ex-info "boom-internal" {}))))
     (rf/reg-view* :myapp/error-page
@@ -498,7 +498,7 @@
 (deftest handler-render-error-view-as-fn
   (testing "rf2-ee38b.11: :error-view accepts a 1-arity fn receiving the
             public-error map and returning hiccup"
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/broken-evf
       (fn [] (throw (ex-info "boom" {}))))
     (let [handler  (ssr-ring/ssr-handler
@@ -520,7 +520,7 @@
             bypass the error boundary — the host falls back to the
             default error template and emits
             :rf.error/ssr-ring-error-view-failed on the trace bus."
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/broken-evt
       (fn [] (throw (ex-info "boom" {}))))
     (let [traces (atom [])]
@@ -565,7 +565,7 @@
 (deftest fn-form-root-view-invoked-exactly-once-per-request
   (testing "rf2-6t36h: a 0-arity fn :root-view fires exactly once per request"
     (let [call-count (atom 0)]
-      (rf/reg-event-fx :init/ok-once
+      (rf/reg-event :init/ok-once
         {:platforms #{:server}}
         (fn [_ _] {}))
 
@@ -590,7 +590,7 @@
             hash that matches the payload hash — the same tree is used for
             both, so the client mismatch check does NOT fire spuriously"
     (let [counter (atom 0)]
-      (rf/reg-event-fx :init/ok-noni
+      (rf/reg-event :init/ok-noni
         {:platforms #{:server}}
         (fn [_ _] {}))
 
@@ -710,10 +710,10 @@
     (rf/reg-head :head/variant-b (fn [_db _route] {:title "Route head B"}))
     (rf/reg-route :route/head-a {:doc "A" :path "/" :head :head/variant-a})
     (rf/reg-route :route/head-b {:doc "B" :path "/" :head :head/variant-b})
-    (rf/reg-event-fx :init/seed-head-a
+    (rf/reg-event :init/seed-head-a
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/head-a})}))
-    (rf/reg-event-fx :init/seed-head-b
+    (rf/reg-event :init/seed-head-b
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/head-b})}))
     (rf/reg-view* :pages/shared-body (fn [] [:div.body "same body, different head"]))
@@ -745,10 +745,10 @@
                  (fn [_db _route] {:title "T" :html-attrs {:lang "fr"}}))
     (rf/reg-route :route/attrs-a {:doc "A" :path "/" :head :head/attrs-a})
     (rf/reg-route :route/attrs-b {:doc "B" :path "/" :head :head/attrs-b})
-    (rf/reg-event-fx :init/seed-attrs-a
+    (rf/reg-event :init/seed-attrs-a
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/attrs-a})}))
-    (rf/reg-event-fx :init/seed-attrs-b
+    (rf/reg-event :init/seed-attrs-b
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/attrs-b})}))
     (rf/reg-view* :pages/attrs-body (fn [] [:div.body "body"]))
@@ -780,7 +780,7 @@
 (deftest handler-surfaces-request-via-cofx
   (testing "the Ring request map flows through to handlers via :rf.server/request"
     (let [captured (atom ::not-captured)]
-      (rf/reg-event-fx :init/capture-request-cofx
+      (rf/reg-event :init/capture-request-cofx
         {:platforms        #{:server}
          :rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]
@@ -804,7 +804,7 @@
 (deftest handler-clears-request-slot-after-response
   (testing "the per-frame request slot is dropped when the request frame is destroyed"
     (let [captured-fid (atom nil)]
-      (rf/reg-event-fx :init/capture-frame-id
+      (rf/reg-event :init/capture-frame-id
         {:platforms #{:server}}
         ;; The running frame's stamp reaches the event context under
         ;; :rf.frame/id (rf2-1m6rf1 — the bare :frame coeffect is retired).
@@ -827,7 +827,7 @@
 (deftest handler-isolates-request-slots-across-requests
   (testing "two sequential requests carry independent request data — no slot bleed"
     (let [observed (atom [])]
-      (rf/reg-event-fx :init/observe-request
+      (rf/reg-event :init/observe-request
         {:platforms        #{:server}
          :rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]
@@ -860,7 +860,7 @@
 (deftest handler-passes-through-ssr-opt-to-frame-meta
   (testing ":ssr opt → per-request frame's :ssr metadata (rf2-8cx3y)"
     (let [captured (atom :unset)]
-      (rf/reg-event-fx :init/capture-ssr-meta
+      (rf/reg-event :init/capture-ssr-meta
         {:platforms #{:server}}
         ;; The running frame's stamp reaches the event context under
         ;; :rf.frame/id (rf2-1m6rf1 — the bare :frame coeffect is retired).
@@ -889,7 +889,7 @@
 
 (deftest handler-payload-keys-slices-app-db
   (testing ":payload allowlist ships a subset of app-db in the hydration payload"
-    (rf/reg-event-fx :init/many-keys
+    (rf/reg-event :init/many-keys
       {:platforms #{:server}}
       (fn [_ _]
         {:db {:public/articles [:a :b :c]
@@ -925,7 +925,7 @@
   ;; coherent frame-state. Transient runtime-db state (scroll-position cache)
   ;; is excluded by `project-runtime-db`.
   (testing "the hydration payload carries the durable :rf/runtime-db slice and omits transient runtime-db state"
-    (rf/reg-event-fx :init/seed-runtime
+    (rf/reg-event :init/seed-runtime
       {:platforms #{:server}}
       (fn [{rt :rf.db/runtime} _]
         {:db {:public/page :dashboard}
@@ -992,7 +992,7 @@
             :rf.error/ssr-missing-payload-policy at construction time —
             the canonical fail-closed pattern. Misconfigured deployments
             fail at boot, not at first request."
-    (rf/reg-event-fx :init/no-policy {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/no-policy {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/no-policy (fn [] [:div "no policy"]))
 
     (is (thrown-with-msg?
@@ -1009,7 +1009,7 @@
   (testing "rf2-gtgf9: stream-handler shares the policy contract —
             mirror of ssr-handler-construction test for the chunked
             host adapter"
-    (rf/reg-event-fx :init/no-policy-stream {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/no-policy-stream {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/no-policy-stream (fn [] [:div "no policy stream"]))
 
     (is (thrown-with-msg?
@@ -1057,7 +1057,7 @@
             :rf.error/ssr-ring-missing-root-view at construction — pre-fix
             this surfaced only inside the writer thread, truncating the
             chunked response instead of failing at boot"
-    (rf/reg-event-fx :init/no-rootview-stream {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/no-rootview-stream {:platforms #{:server}} (fn [_ _] {}))
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-ring-missing-root-view"
@@ -1072,7 +1072,7 @@
             allowlist gate an unaudited new app-db key would silently
             ride the wire on every request — the allowlist is load-
             bearing."
-    (rf/reg-event-fx :init/with-secret
+    (rf/reg-event :init/with-secret
       {:platforms #{:server}}
       (fn [_ _]
         {:db {:public/articles          [{:id "a" :title "A"}]
@@ -1131,7 +1131,7 @@
   (testing "rf2-gtgf9: explicit :payload :rf.ssr.payload/whole-app-db is
             the documented opt-in for apps whose entire app-db is intended
             for the wire"
-    (rf/reg-event-fx :init/wholeapp
+    (rf/reg-event :init/wholeapp
       {:platforms #{:server}}
       (fn [_ _]
         {:db {:public/articles [:a :b :c]
@@ -1161,7 +1161,7 @@
 (deftest handler-construction-rejects-unknown-policy-keyword
   (testing "rf2-gtgf9 / rf2-pffil: a typo'd :payload keyword surfaces as a
             distinct error so the developer can tell the failure modes apart"
-    (rf/reg-event-fx :init/typo-policy {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/typo-policy {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/typo-policy (fn [] [:div]))
 
     (is (thrown-with-msg?
@@ -1197,7 +1197,7 @@
 (deftest handler-construction-rejects-non-string-trusted-shell-opts
   (testing "rf2-o6ndb: ssr-handler structural-shape-checks the four
             trusted-shell-hook opts at construction time"
-    (rf/reg-event-fx :init/trusted-opt-test
+    (rf/reg-event :init/trusted-opt-test
                      {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/trusted-opt-test (fn [] [:div]))
 
@@ -1277,7 +1277,7 @@
             structural contract — mirror of the ssr-handler test for the
             chunked host adapter. The streaming prefix/suffix injects
             the same four opts RAW into the rendered HTML envelope."
-    (rf/reg-event-fx :init/trusted-opt-stream
+    (rf/reg-event :init/trusted-opt-stream
                      {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/trusted-opt-stream (fn [] [:div]))
 
@@ -1383,7 +1383,7 @@
                    :path "/"
                    :head :head/main})
     ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
-    (rf/reg-event-fx :init/seed-route
+    (rf/reg-event :init/seed-route
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/x})}))
     (rf/reg-view* :pages/blank-for-title (fn [] [:div]))
@@ -1435,7 +1435,7 @@
                   {:doc  "Route no-title"
                    :path "/"
                    :head :head/no-title})
-    (rf/reg-event-fx :init/seed-no-title
+    (rf/reg-event :init/seed-no-title
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/no-title})}))
     (rf/reg-view* :pages/blank-no-title (fn [] [:div]))
@@ -1469,7 +1469,7 @@
                 {:doc  "Route exercising :html-attrs / :body-attrs"
                  :path "/"
                  :head :head/with-attrs})
-  (rf/reg-event-fx :init/seed-attrs-route
+  (rf/reg-event :init/seed-attrs-route
     (fn [{rt :rf.db/runtime} _] {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/with-attrs})}))
   (rf/reg-view* :pages/blank-attrs (fn [] [:div])))
 
@@ -1623,7 +1623,7 @@
   (testing "rf2-jbcmt: the :rf/response accumulator is side-channel — it
             never appears in the hydration payload, even when a login-shape
             request sets server-only cookies / headers / status"
-    (rf/reg-event-fx :auth/login
+    (rf/reg-event :auth/login
       {:platforms #{:server}}
       (fn [{:keys [db]} _]
         {:db (assoc db :public/article-title "Public Title"
@@ -1770,7 +1770,7 @@
             hydration payload script tag; the EDN reader still recovers
             the original string verbatim"
     (let [hostile "</script><script>alert('xss')</script>"]
-      (rf/reg-event-fx :init/hostile
+      (rf/reg-event :init/hostile
         {:platforms #{:server}}
         (fn [_ _]
           {:db {:public/article-title hostile}}))
@@ -2185,7 +2185,7 @@
                 {:doc  "Route whose head fn throws"
                  :path "/head-throws"
                  :head :head/throws})
-  (rf/reg-event-fx :init/seed-throwing-head-route
+  (rf/reg-event :init/seed-throwing-head-route
     {:platforms #{:server}}
     (fn [{rt :rf.db/runtime} _]
       {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
@@ -2530,7 +2530,7 @@
             catch (its error-path materialise re-folds the SAME bad
             cookie and throws again), reaching the handler body's
             :on-error catch — the success-path call site."
-    (rf/reg-event-fx :rf.test/init-bad-cookie
+    (rf/reg-event :rf.test/init-bad-cookie
       {:platforms #{:server}}
       (fn [_ _]
         ;; A non-integer :expires escapes the fx boundary
@@ -2596,7 +2596,7 @@
             under debug-off. Promotion adds the off-box record; the 5xx
             wire outcome is unchanged."
     (error-emit/clear-error-listeners!)
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/render-throws
       (fn [] (throw (ex-info "render boom" {}))))
     (let [seen (capture-always-on-categories!)]
@@ -2649,7 +2649,7 @@
             AND delivers a :rf.error/ssr-ring-error-view-failed record to
             register-error-listener! under debug-off."
     (error-emit/clear-error-listeners!)
-    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/broken-evt-hhutya
       (fn [] (throw (ex-info "boom" {}))))
     (let [seen (capture-always-on-categories!)]

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -269,10 +269,10 @@
             value"
     ;; Malli app-db schema: [:derived :doubled] must be a NON-NEGATIVE int.
     (rf/reg-app-schema [:derived] [:map [:doubled [:int {:min 0}]]])
-    (rf/reg-event-db :seed (fn [_ _] {:n 1 :derived {:doubled 0}}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1 :derived {:doubled 0}}}))
     ;; The handler writes :n; the flow reads :n and writes a value that the
     ;; app-db schema will REJECT (negative when :n is negative).
-    (rf/reg-event-db :set-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (rf/reg-flow {:id     :doubler
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -333,9 +333,9 @@
             is discarded, NO :rf.event/db-changed fires, the handler's own
             :db does NOT land — distinct from the schema-rollback signature
             (no commit at all, vs commit-then-unwind)"
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     ;; The handler writes :n; the flow reads :n and THROWS.
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
     ;; Seed a clean baseline FIRST, then register the throwing flow — the
     ;; flow throws on every eval, so registering it after the seed keeps the
     ;; baseline (and isolates the throw to the :bump drain we observe).
@@ -380,7 +380,7 @@
   (testing "under SSR's synchronous drain a sub over a flow's :path renders
             the flow-augmented value into the output HTML — the flow ran
             before install; the render reads the installed flow-augmented db"
-    (rf/reg-event-db :ssr/seed (fn [_ _] {:user {:first "Ada" :last "Lovelace"}}))
+    (rf/reg-event :ssr/seed (fn [{:keys [db]} _] {:db {:user {:first "Ada" :last "Lovelace"}}}))
     ;; A flow derives a display name from the user map into [:derived :full-name].
     (rf/reg-flow {:id     :user/full-name
                   :inputs [[:user :first] [:user :last]]
@@ -432,13 +432,13 @@
                     :output (fn [n] (swap! flow-inputs conj n) (* 10 n))
                     :path   [:derived :scaled]})
       ;; The parent writes :n=1 then :fx :dispatches the child.
-      (rf/reg-event-fx :parent
+      (rf/reg-event :parent
                        (fn [{:keys [db]} _]
                          {:db (assoc db :n 1)
                           :fx [[:dispatch [:child]]]}))
       ;; The child writes :n=2 — a DIFFERENT value, so the flow's dirty-
       ;; check recomputes for the child (proving an independent eval).
-      (rf/reg-event-db :child (fn [db _] (assoc db :n 2)))
+      (rf/reg-event :child (fn [{:keys [db]} _] {:db (assoc db :n 2)}))
 
       (reset! *captured* [])
       (rf/dispatch-sync [:parent])
@@ -571,10 +571,10 @@
             in the handler's :fx are NEVER walked (post-install stage
             skipped per the atomicity contract — rule a)"
     (let [on-match-fired (atom 0)]
-      (rf/reg-event-db :route/load-article
-                       (fn [db _]
+      (rf/reg-event :route/load-article
+                       (fn [{:keys [db]} _]
                          (swap! on-match-fired inc)
-                         (assoc db :article/loaded? true)))
+                         {:db (assoc db :article/loaded? true)}))
       ;; :route/article carries an :on-match — :rf.route/transitioned's
       ;; handler will return `[:dispatch [:route/load-article]]` inside :fx
       ;; for a successful transition. The flow throw must skip that :fx.
@@ -729,7 +729,7 @@
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
     (rf/reg-route :route/home    {:path "/"})
-    (rf/reg-event-db :set-greeting (fn [db [_ g]] (assoc db :greeting g)))
+    (rf/reg-event :set-greeting (fn [{:keys [db]} [_ g]] {:db (assoc db :greeting g)}))
     (let [flow-evals (atom [])]
       ;; Bare [:greeting] reads app-db; qualified route id reads runtime-db.
       (rf/reg-flow {:id     :nav/banner

--- a/implementation/ssr/test/re_frame/framework_zero_ownership_diagnostics_test.clj
+++ b/implementation/ssr/test/re_frame/framework_zero_ownership_diagnostics_test.clj
@@ -154,8 +154,8 @@
                    :params    [:map [:id :string]]
                    :can-leave :editor/can-leave?})
     (rf/reg-route :route/cart {:path "/cart"})
-    (rf/reg-event-db :editor/dirty
-                     (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-event :editor/dirty
+                     (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
     (rf/reg-sub :editor/can-leave?
                 (fn [db _] (not (get-in db [:editor :dirty?]))))
     (stub-push-url!)
@@ -301,7 +301,7 @@
     ;; Proves the recorder + diagnostic are live in this fixture — every
     ;; framework-quiet assertion above is therefore meaningful, not
     ;; vacuously empty.
-    (rf/reg-event-fx :app/sneaky-runtime-write
+    (rf/reg-event :app/sneaky-runtime-write
                      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :hijacked}}}}))
     (let [diags (record-ownership-diagnostics! ::app-sneaky)]
       (rf/dispatch-sync [:app/sneaky-runtime-write])

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -47,7 +47,7 @@
 
 (deftest check-version-matching-is-silent
   (testing "matching expected + actual → no :rf.ssr/version-mismatch trace"
-    (rf/reg-event-fx ::probe-check-version-match
+    (rf/reg-event ::probe-check-version-match
       {:platforms #{:client}}
       (fn [_ _]
         ;; rf2-g00l2t: :rf/version is canonically an INTEGER pattern-
@@ -67,7 +67,7 @@
 
 (deftest check-version-mismatch-emits-trace
   (testing "differing expected + actual → :rf.ssr/version-mismatch warning trace"
-    (rf/reg-event-fx ::probe-check-version-mismatch
+    (rf/reg-event ::probe-check-version-mismatch
       {:platforms #{:client}}
       (fn [_ _]
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 2}]]}))
@@ -103,7 +103,7 @@
 
 (deftest check-schema-digest-matching-is-silent
   (testing "matching expected + actual → no :rf.ssr/schema-digest-mismatch trace"
-    (rf/reg-event-fx ::probe-check-digest-match
+    (rf/reg-event ::probe-check-digest-match
       {:platforms #{:client}}
       (fn [_ _]
         {:fx [[:rf.ssr/check-schema-digest
@@ -122,7 +122,7 @@
 
 (deftest check-schema-digest-mismatch-emits-trace
   (testing "differing expected + actual → :rf.ssr/schema-digest-mismatch warning trace"
-    (rf/reg-event-fx ::probe-check-digest-mismatch
+    (rf/reg-event ::probe-check-digest-mismatch
       {:platforms #{:client}}
       (fn [_ _]
         {:fx [[:rf.ssr/check-schema-digest
@@ -161,7 +161,7 @@
 
 (deftest check-version-scalar-with-no-hook-emits-skipped
   (testing "scalar form + absent :rf2/runtime-version hook → :rf.ssr/compatibility-check-skipped"
-    (rf/reg-event-fx ::probe-check-version-scalar-no-hook
+    (rf/reg-event ::probe-check-version-scalar-no-hook
       {:platforms #{:client}}
       (fn [_ _]
         {:fx [[:rf.ssr/check-version 1]]}))
@@ -190,7 +190,7 @@
     ;; remove after to keep the hook table clean for the next test.
     (late-bind/set-fn! :rf2/runtime-version (constantly 2))
     (try
-      (rf/reg-event-fx ::probe-check-version-scalar-with-hook
+      (rf/reg-event ::probe-check-version-scalar-with-hook
         {:platforms #{:client}}
         (fn [_ _]
           {:fx [[:rf.ssr/check-version 1]]}))
@@ -223,7 +223,7 @@
     (let [prior-hook (late-bind/get-fn :schemas/app-schemas-digest)]
       (swap! late-bind/hooks dissoc :schemas/app-schemas-digest)
       (try
-        (rf/reg-event-fx ::probe-check-digest-scalar-no-hook
+        (rf/reg-event ::probe-check-digest-scalar-no-hook
           {:platforms #{:client}}
           (fn [_ _]
             {:fx [[:rf.ssr/check-schema-digest "sha256:deadbeefcafef00d"]]}))

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -279,8 +279,8 @@
                 (rf/reg-event-db id meta handler)
                 (rf/reg-event-db id handler))
           :fx (if (seq meta)
-                (rf/reg-event-fx id meta handler)
-                (rf/reg-event-fx id handler)))))
+                (rf/reg-event id meta handler)
+                (rf/reg-event id handler)))))
     ;; ---- subs ----------------------------------------------------------
     (doseq [[id steps] (:sub hmap)]
       (let [{:keys [kind inputs body]} (conformance/realise-sub steps)

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -93,7 +93,7 @@
                               {:id "b" :title "Article B" :body "Body B"}])
                        {:frame frame}))))
 
-    (rf/reg-event-fx :rf/server-init
+    (rf/reg-event :rf/server-init
       (fn [{:keys [db]} [_ request]]
         {:db (-> db
                  (assoc :request request)
@@ -101,9 +101,9 @@
          :fx [[:http/get {:url        "/api/articles"
                           :on-success [:articles/loaded]}]]}))
 
-    (rf/reg-event-db :articles/loaded
-      (fn [db [_ articles]]
-        (assoc db :articles articles)))
+    (rf/reg-event :articles/loaded
+      (fn [{:keys [db]} [_ articles]]
+        {:db (assoc db :articles articles)}))
 
     (rf/reg-sub :articles (fn [db _] (:articles db)))
     ;; Plain-fn surface (reg-view*): the SSR test references the view by
@@ -199,9 +199,9 @@
 
             ;; (7) Mutate the hydrated app-db; re-render; hash differs;
             ;;     verify-hydration! emits the mismatch trace.
-            (rf/reg-event-db :articles/append
-              (fn [db [_ extra]]
-                (update db :articles conj extra)))
+            (rf/reg-event :articles/append
+              (fn [{:keys [db]} [_ extra]]
+                {:db (update db :articles conj extra)}))
             (rf/dispatch-sync [:articles/append
                                {:id "c" :title "Article C" :body "Body C"}]
                               {:frame client-frame})
@@ -243,7 +243,7 @@
 (deftest ssr-set-status-precedence
   (testing "two :rf.server/set-status fx → last write wins + :rf.warning/multiple-status-set"
     (let [traces (atom [])]
-      (rf/reg-event-fx :auth/forbid
+      (rf/reg-event :auth/forbid
         (fn [_ _]
           {:fx [[:rf.server/set-status 401]
                 [:rf.server/set-status 403]]}))                          ;; second write replaces
@@ -271,7 +271,7 @@
 
 (deftest ssr-multi-cookie
   (testing "multiple :rf.server/set-cookie fxs accumulate; runtime stores structured maps not strings"
-    (rf/reg-event-fx :auth/establish
+    (rf/reg-event :auth/establish
       (fn [_ _]
         {:fx [[:rf.server/set-cookie {:name      "session"
                                       :value     "abc123"
@@ -317,7 +317,7 @@
 
 (deftest ssr-delete-cookie
   (testing ":rf.server/delete-cookie writes a structured cookie with :max-age 0 and empty :value"
-    (rf/reg-event-fx :auth/logout
+    (rf/reg-event :auth/logout
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie {:name "session" :path "/"}]]}))
 
@@ -336,13 +336,13 @@
 
 (deftest ssr-set-and-append-header
   (testing ":rf.server/set-header replaces case-insensitively; :rf.server/append-header preserves duplicates"
-    (rf/reg-event-fx :hdr/set-then-replace
+    (rf/reg-event :hdr/set-then-replace
       (fn [_ _]
         ;; First :set-header writes the default; the second replaces it
         ;; (case-insensitive name match per Spec 011 §Header replacement).
         {:fx [[:rf.server/set-header {:name "X-Foo" :value "first"}]
               [:rf.server/set-header {:name "x-foo" :value "second"}]]}))
-    (rf/reg-event-fx :hdr/append-twice
+    (rf/reg-event :hdr/append-twice
       (fn [_ _]
         {:fx [[:rf.server/append-header {:name "Set-Cookie" :value "a=1"}]
               [:rf.server/append-header {:name "Set-Cookie" :value "b=2"}]]}))
@@ -418,7 +418,7 @@
             cause of :rf.error/fx-handler-exception (fx exceptions are
             captured by the dispatch loop and re-emitted as traces;
             rf2-hbty2 throws at the fx boundary)"
-    (rf/reg-event-fx :hdr/inject-crlf
+    (rf/reg-event :hdr/inject-crlf
       (fn [_ _]
         {:fx [[:rf.server/set-header
                {:name  "X-Forwarded-For"
@@ -433,7 +433,7 @@
 
   (testing "rf2-hbty2 §P1.3 — bare LF / bare CR / NUL all rejected"
     (doseq [hostile ["lf\nbad" "cr\rbad" (str "nul" (char 0) "bad")]]
-      (rf/reg-event-fx :hdr/probe-injection
+      (rf/reg-event :hdr/probe-injection
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name "X-Probe" :value hostile}]]}))
       (let [f      (rf/make-frame {:platform :server})
@@ -446,7 +446,7 @@
 (deftest ssr-append-header-rejects-crlf-injection
   (testing "rf2-hbty2 §P1.3 — :rf.server/append-header with CR/LF in
             value surfaces :rf.error/header-invalid-value"
-    (rf/reg-event-fx :hdr/append-crlf
+    (rf/reg-event :hdr/append-crlf
       (fn [_ _]
         {:fx [[:rf.server/append-header
                {:name  "X-Audit"
@@ -463,7 +463,7 @@
             surfaces :rf.error/redirect-invalid-location. The standard
             exploit shape: a `?next=…` query param that URL-decodes into
             literal CRLF would split the Location header on the wire."
-    (rf/reg-event-fx :redirect/crlf-in-location
+    (rf/reg-event :redirect/crlf-in-location
       (fn [_ _]
         {:fx [[:rf.server/redirect
                {:location "https://example.com\r\nSet-Cookie: stolen=1"}]]}))
@@ -480,10 +480,10 @@
             error fires BEFORE the no-target warning path so the vocabulary
             mistake is loud, not hidden behind a malformed-redirect warning.
             (Pre-alpha EP-0007 one-name-per-fact prune — no back-compat alias.)"
-    (rf/reg-event-fx :redirect/via-url
+    (rf/reg-event :redirect/via-url
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/ok"}]]}))
-    (rf/reg-event-fx :redirect/via-to
+    (rf/reg-event :redirect/via-to
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/ok"}]]}))
     (doseq [ev [:redirect/via-url :redirect/via-to]]
@@ -500,7 +500,7 @@
             :location). This is the failure-mode lock: the error must point
             the programmer at the right spelling, and must be DISTINCT from
             the generic no-target/malformed-redirect warning path."
-    (rf/reg-event-fx :redirect/retired-spelling
+    (rf/reg-event :redirect/retired-spelling
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/login"}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -536,7 +536,7 @@
                          ["unbalanced brace"       "/path/{id"]
                          ["malformed percent-esc"  "/path%zz"]
                          ["bare control via %1"    "/path%1"]]]
-      (rf/reg-event-fx :redirect/malformed
+      (rf/reg-event :redirect/malformed
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
       (let [f      (rf/make-frame {:platform :server})
@@ -559,7 +559,7 @@
                  "dashboard"
                  "a/b/c"
                  "/path%20with%20encoded%20space"]]
-      (rf/reg-event-fx :redirect/well-formed
+      (rf/reg-event :redirect/well-formed
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
       (let [f    (rf/make-frame {:platform :server :on-create [:redirect/well-formed]})
@@ -571,7 +571,7 @@
   (testing "rf2-hbty2 — regression guard: legitimate header values still flow
             through. Whitespace, semicolons, quoted-strings, full URLs are
             all valid (only CR/LF/NUL is banned)."
-    (rf/reg-event-fx :hdr/clean
+    (rf/reg-event :hdr/clean
       (fn [_ _]
         {:fx [[:rf.server/set-header {:name "Cache-Control"
                                       :value "no-cache, must-revalidate, max-age=0"}]
@@ -596,7 +596,7 @@
 
 (deftest ssr-redirect-short-circuits
   (testing ":rf.server/redirect populates :redirect and the response payload omits HTML"
-    (rf/reg-event-fx :auth/check-session
+    (rf/reg-event :auth/check-session
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
 
@@ -626,7 +626,7 @@
               "no HTML body when redirected")))))
 
   (testing "a redirect with default :status defaults to 302"
-    (rf/reg-event-fx :auth/check-no-status
+    (rf/reg-event :auth/check-no-status
       (fn [_ _]
         {:fx [[:rf.server/redirect {:location "/login"}]]}))
     (let [f (rf/make-frame {:platform  :server
@@ -679,10 +679,10 @@
 
 (deftest ssr-default-error-projector-handler-exception
   (testing "a handler that throws → default projector → 500"
-    (rf/reg-event-fx :load/article
+    (rf/reg-event :load/article
       (fn [_ _]
         (throw (ex-info "Database connection failed: SECRET_TOKEN=xyz" {}))))
-    (rf/reg-event-fx :rf/server-init
+    (rf/reg-event :rf/server-init
       (fn [_ _]
         {:fx [[:dispatch [:load/article]]]}))
 
@@ -897,7 +897,7 @@
             `:rf.server/_status-writes` / `:rf.server/_redirect-writes`
             bookkeeping keys, so a host adapter never sees them on the wire
             shape."
-    (rf/reg-event-fx :resp/multi-status
+    (rf/reg-event :resp/multi-status
       (fn [_ _]
         {:fx [[:rf.server/set-status 201]
               [:rf.server/set-status 202]]}))
@@ -935,7 +935,7 @@
 (deftest ssr-multi-redirect
   (testing "two :rf.server/redirect fxs → last write wins + :rf.warning/multiple-redirects"
     (let [traces (atom [])]
-      (rf/reg-event-fx :auth/double-redirect
+      (rf/reg-event :auth/double-redirect
         (fn [_ _]
           {:fx [[:rf.server/redirect {:status 302 :location "/login"}]
                 [:rf.server/redirect {:status 301 :location "/canonical"}]]}))
@@ -1218,7 +1218,7 @@
   (testing "rf2-vngir: {:url \"...\"} is rejected with
             :rf.error/redirect-retired-target-key (naming :location); it is
             NOT normalised onto :location, and the :redirect slot stays unset"
-    (rf/reg-event-fx :retired/url-redirect
+    (rf/reg-event :retired/url-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/dashboard"}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -1234,7 +1234,7 @@
   (testing "rf2-vngir: {:to \"...\"} is rejected with
             :rf.error/redirect-retired-target-key, even with an explicit
             :status — the retired-key check fires before the status path"
-    (rf/reg-event-fx :retired/to-redirect
+    (rf/reg-event :retired/to-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/welcome" :status 301}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -1258,14 +1258,14 @@
 (deftest redirect-suppresses-projector-status-overwrite
   (testing "a request that redirects AND surfaces an error trace → response :status
             stays at the redirect's status; the projector does not overwrite it"
-    (rf/reg-event-fx :redirect-then-error
+    (rf/reg-event :redirect-then-error
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]
               ;; Then trigger a handler-exception trace — the default
               ;; projector maps this to 500. The redirect was set
               ;; first; the projector must NOT promote 302 → 500.
               [:dispatch [:throw-from-handler]]]}))
-    (rf/reg-event-fx :throw-from-handler
+    (rf/reg-event :throw-from-handler
       (fn [_ _] (throw (ex-info "post-redirect failure" {}))))
 
     (let [traces (atom [])
@@ -1335,7 +1335,7 @@
   (testing "rf2-2brsn step 1: a :location that cannot be parsed as a URL
             → :rf.error/safe-redirect-invalid-url trace AND no :redirect
             is set on the response (the fx is a no-op on rejection)"
-    (rf/reg-event-fx :sr/unparseable
+    (rf/reg-event :sr/unparseable
       (fn [_ _]
         ;; A space-after-colon makes this URISyntax-invalid in java.net.URI
         ;; (the colon makes it look like a scheme, but the space after is
@@ -1357,7 +1357,7 @@
 (deftest safe-redirect-rejects-javascript-scheme
   (testing "rf2-2brsn step 2: javascript: scheme → :rf.error/safe-redirect-scheme-rejected
             (XSS vector — script execution on click of the redirect)"
-    (rf/reg-event-fx :sr/javascript
+    (rf/reg-event :sr/javascript
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "javascript:alert(1)"}]]}))
@@ -1376,7 +1376,7 @@
 
 (deftest safe-redirect-rejects-data-scheme
   (testing "rf2-2brsn step 2: data: scheme rejected (data-URL phishing)"
-    (rf/reg-event-fx :sr/data
+    (rf/reg-event :sr/data
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "data:text/html,<script>alert(1)</script>"}]]}))
@@ -1390,7 +1390,7 @@
 
 (deftest safe-redirect-rejects-vbscript-scheme
   (testing "rf2-2brsn step 2: vbscript: scheme rejected (IE-era VBScript exec)"
-    (rf/reg-event-fx :sr/vbscript
+    (rf/reg-event :sr/vbscript
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "vbscript:msgbox(\"x\")"}]]}))
@@ -1406,7 +1406,7 @@
   (testing "rf2-2brsn step 2: JavaScript: / DATA: / VBScript: all rejected
             (case-insensitive scheme match per the lowercase-on-compare pattern)"
     (doseq [hostile ["JavaScript:alert(1)" "DATA:text/html,evil" "VBScript:evil"]]
-      (rf/reg-event-fx :sr/probe-case
+      (rf/reg-event :sr/probe-case
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect {:location hostile}]]}))
       (let [f      (rf/make-frame {:platform :server})
@@ -1421,7 +1421,7 @@
 (deftest safe-redirect-relative-only-rejects-absolute-url
   (testing "rf2-2brsn step 3: :relative-only? true AND URL has host →
             :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation)"
-    (rf/reg-event-fx :sr/abs-with-relative-only
+    (rf/reg-event :sr/abs-with-relative-only
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location       "https://evil.example.com/phish"
@@ -1445,7 +1445,7 @@
 (deftest safe-redirect-relative-only-accepts-relative-path
   (testing "rf2-2brsn step 3 happy path: :relative-only? true + relative URL →
             redirect succeeds (no trace)"
-    (rf/reg-event-fx :sr/relative-ok
+    (rf/reg-event :sr/relative-ok
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location       "/dashboard"
@@ -1466,7 +1466,7 @@
 (deftest safe-redirect-allowlist-rejects-off-allowlist-host
   (testing "rf2-2brsn step 4: :allow supplied AND URL's host NOT in allow →
             :rf.error/safe-redirect-host-disallowed (:reason :not-in-allowlist)"
-    (rf/reg-event-fx :sr/not-in-allow
+    (rf/reg-event :sr/not-in-allow
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "https://evil.example.com/phish"
@@ -1492,7 +1492,7 @@
 
 (deftest safe-redirect-allowlist-accepts-on-allowlist-host
   (testing "rf2-2brsn step 4 happy path: host IN allowlist → redirect succeeds"
-    (rf/reg-event-fx :sr/in-allow
+    (rf/reg-event :sr/in-allow
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
@@ -1511,7 +1511,7 @@
   (testing "rf2-lgmiw step 4: DNS hostnames are case-insensitive (RFC 1035
             §2.3.3) — a mixed-case host matches a lowercase :allow entry and
             the redirect succeeds with no trace"
-    (rf/reg-event-fx :sr/in-allow-mixed-case
+    (rf/reg-event :sr/in-allow-mixed-case
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "https://APP.Example.COM/dashboard"
@@ -1532,7 +1532,7 @@
   (testing "rf2-2brsn: a fundamentally-unparseable URL surfaces the parse
             error, NOT the scheme error (validation runs in order — see
             Spec 009 §Error event catalogue)"
-    (rf/reg-event-fx :sr/order-parse-first
+    (rf/reg-event :sr/order-parse-first
       (fn [_ _]
         ;; This is BOTH unparseable AND vaguely-javascript-shaped — the
         ;; parser-fail must fire FIRST because step 1 runs before step 2.
@@ -1553,7 +1553,7 @@
   (testing "rf2-2brsn step 1: an empty / blank :location string is rejected
             as :rf.error/safe-redirect-invalid-url — an empty redirect has
             no defensible interpretation"
-    (rf/reg-event-fx :sr/empty
+    (rf/reg-event :sr/empty
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location ""}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -1586,7 +1586,7 @@
     (doseq [[label policy] [["no-policy"      {}]
                             ["relative-only?" {:relative-only? true}]
                             ["allow"          {:allow ["app.example.com"]}]]]
-      (rf/reg-event-fx :sr/opaque-http
+      (rf/reg-event :sr/opaque-http
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "http:evil.example.com"} policy)]]}))
@@ -1604,7 +1604,7 @@
   (testing "rf2-v3eg3 finding 1: `https:evil.example.com` (opaque, host=nil)
             rejected as :rf.error/safe-redirect-invalid-url
             (:reason :scheme-without-host)"
-    (rf/reg-event-fx :sr/opaque-https
+    (rf/reg-event :sr/opaque-https
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "https:evil.example.com"}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -1621,7 +1621,7 @@
   (testing "rf2-v3eg3 finding 1: `mailto:user@example.com` — a non-http(s)
             scheme is rejected outright as scheme-rejected
             (:reason :scheme-not-allowed)"
-    (rf/reg-event-fx :sr/mailto
+    (rf/reg-event :sr/mailto
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "mailto:user@example.com"}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -1638,7 +1638,7 @@
 (deftest safe-redirect-rejects-ftp-scheme
   (testing "rf2-v3eg3 finding 1: `ftp:example.com` — non-http(s) scheme
             rejected outright (opaque form, host=nil)"
-    (rf/reg-event-fx :sr/ftp
+    (rf/reg-event :sr/ftp
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "ftp:example.com"}]]}))
     (let [f      (rf/make-frame {:platform :server})
@@ -1657,7 +1657,7 @@
     (doseq [[label policy expected-reason]
             [["relative-only?" {:relative-only? true} :relative-only-violation]
              ["allow"          {:allow ["app.example.com"]} :not-in-allowlist]]]
-      (rf/reg-event-fx :sr/protocol-relative
+      (rf/reg-event :sr/protocol-relative
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "//evil.example.com/path"} policy)]]}))
@@ -1676,7 +1676,7 @@
   (testing "rf2-v3eg3 finding 1 CONTROL: a normal relative path still passes
             cleanly under :relative-only? — the hardening did not over-reject
             the legitimate same-origin case"
-    (rf/reg-event-fx :sr/relative-control
+    (rf/reg-event :sr/relative-control
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/account/settings" :relative-only? true}]]}))
@@ -1695,7 +1695,7 @@
   (testing "rf2-v3eg3 finding 1 CONTROL: a well-formed absolute http(s) URL
             whose host IS in the allowlist still passes — the shape gate
             did not break the legitimate absolute-redirect path"
-    (rf/reg-event-fx :sr/abs-control
+    (rf/reg-event :sr/abs-control
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
@@ -1716,7 +1716,7 @@
             an attacker passing a CRLF-bearing location is presumably trying
             both vectors. Same fx-boundary throw as redirect-fx; the throw
             propagates as :rf.error/fx-handler-exception"
-    (rf/reg-event-fx :sr/crlf
+    (rf/reg-event :sr/crlf
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/path\r\nSet-Cookie: stolen=1"}]]}))
@@ -1819,7 +1819,7 @@
   (testing "rf2-z7gor — :rf.server/set-header with CRLF in :name surfaces
             :rf.error/header-invalid-name (sister gate to rf2-hbty2's
             header-value gate)"
-    (rf/reg-event-fx :hdr/crlf-in-name
+    (rf/reg-event :hdr/crlf-in-name
       (fn [_ _]
         {:fx [[:rf.server/set-header
                {:name  "X-Test\r\nSet-Cookie: evil=1"
@@ -1834,7 +1834,7 @@
   (testing "rf2-z7gor — separators / whitespace / empty all rejected"
     (doseq [hostile ["Bad: Name" "Bad Name" "" "with(parens)"
                      (str "nul" (char 0) "bad")]]
-      (rf/reg-event-fx :hdr/probe-name
+      (rf/reg-event :hdr/probe-name
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name hostile :value "ok"}]]}))
       (let [f      (rf/make-frame {:platform :server})
@@ -1847,7 +1847,7 @@
 (deftest ssr-append-header-rejects-invalid-name
   (testing "rf2-z7gor — :rf.server/append-header with CRLF in :name surfaces
             :rf.error/header-invalid-name (same gate as set-header)"
-    (rf/reg-event-fx :hdr/append-crlf-name
+    (rf/reg-event :hdr/append-crlf-name
       (fn [_ _]
         {:fx [[:rf.server/append-header
                {:name  "X-Audit\r\nSet-Cookie: forged=1"
@@ -1862,7 +1862,7 @@
 (deftest ssr-set-cookie-rejects-invalid-fields
   (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :name surfaces
             :rf.error/cookie-invalid-name (RFC 6265 §4.1.1 token grammar)"
-    (rf/reg-event-fx :ck/crlf-in-name
+    (rf/reg-event :ck/crlf-in-name
       (fn [_ _]
         {:fx [[:rf.server/set-cookie
                {:name  "session\r\nSet-Cookie: stolen=1"
@@ -1876,7 +1876,7 @@
 
   (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :value surfaces
             :rf.error/cookie-invalid-value"
-    (rf/reg-event-fx :ck/crlf-in-value
+    (rf/reg-event :ck/crlf-in-value
       (fn [_ _]
         {:fx [[:rf.server/set-cookie
                {:name  "session"
@@ -1890,7 +1890,7 @@
 
   (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :path surfaces
             :rf.error/cookie-invalid-path"
-    (rf/reg-event-fx :ck/crlf-in-path
+    (rf/reg-event :ck/crlf-in-path
       (fn [_ _]
         {:fx [[:rf.server/set-cookie
                {:name  "session"
@@ -1905,7 +1905,7 @@
 
   (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :domain surfaces
             :rf.error/cookie-invalid-domain"
-    (rf/reg-event-fx :ck/crlf-in-domain
+    (rf/reg-event :ck/crlf-in-domain
       (fn [_ _]
         {:fx [[:rf.server/set-cookie
                {:name   "session"
@@ -1921,7 +1921,7 @@
 (deftest ssr-delete-cookie-rejects-invalid-fields
   (testing "rf2-z7gor — :rf.server/delete-cookie runs the same validators
             as set-cookie (it's sugar over set-cookie)"
-    (rf/reg-event-fx :ck/del-crlf-path
+    (rf/reg-event :ck/del-crlf-path
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie
                {:name "session" :path "/admin\r\nbad"}]]}))
@@ -1942,7 +1942,7 @@
     ;; The concrete failing scenario from the bead: string :max-age
     ;; carrying a forged second Set-Cookie line.
     (testing ":max-age (string form) with CRLF → :rf.error/cookie-invalid-max-age"
-      (rf/reg-event-fx :ck/crlf-in-max-age
+      (rf/reg-event :ck/crlf-in-max-age
         (fn [_ _]
           {:fx [[:rf.server/set-cookie
                  {:name    "session"
@@ -1958,7 +1958,7 @@
             "no cookie lands on the accumulator — rejection is a no-op")))
 
     (testing ":same-site with CRLF → :rf.error/cookie-invalid-same-site"
-      (rf/reg-event-fx :ck/crlf-in-same-site
+      (rf/reg-event :ck/crlf-in-same-site
         (fn [_ _]
           {:fx [[:rf.server/set-cookie
                  {:name      "session"
@@ -1972,7 +1972,7 @@
           "set-cookie with CRLF in :same-site")))
 
     (testing ":expires with CRLF → :rf.error/cookie-invalid-expires"
-      (rf/reg-event-fx :ck/crlf-in-expires
+      (rf/reg-event :ck/crlf-in-expires
         (fn [_ _]
           {:fx [[:rf.server/set-cookie
                  {:name    "session"
@@ -1987,7 +1987,7 @@
 
     (testing "bare LF / bare CR / NUL in :max-age all rejected"
       (doseq [hostile ["lf\nbad" "cr\rbad" (str "nul" (char 0) "bad")]]
-        (rf/reg-event-fx :ck/probe-max-age
+        (rf/reg-event :ck/probe-max-age
           (fn [_ _]
             {:fx [[:rf.server/set-cookie
                    {:name "s" :value "x" :max-age hostile}]]}))
@@ -2003,7 +2003,7 @@
             flow — integer :max-age, keyword/string :same-site, a clean
             :expires string. The CRLF gate str-coerces and only bans
             CR/LF/NUL; benign values pass."
-    (rf/reg-event-fx :ck/clean-attrs
+    (rf/reg-event :ck/clean-attrs
       (fn [_ _]
         {:fx [[:rf.server/set-cookie
                {:name      "session"
@@ -2024,7 +2024,7 @@
 (deftest ssr-clean-names-still-accepted
   (testing "rf2-z7gor — regression guard: legitimate header names + cookie
             field shapes still flow"
-    (rf/reg-event-fx :clean/all
+    (rf/reg-event :clean/all
       (fn [_ _]
         {:fx [[:rf.server/set-header  {:name "Cache-Control"
                                        :value "no-cache"}]
@@ -2117,7 +2117,7 @@
       ;; onto the response — a clean, surfaced failure instead of a
       ;; malformed wire status. End-to-end, the fix turns a silent wire
       ;; defect into a proper 400.
-      (rf/reg-event-fx :bad/status
+      (rf/reg-event :bad/status
         (fn [_ _] {:fx [[:rf.server/set-status "not-an-int"]]}))
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2136,7 +2136,7 @@
             "schema-validation-failure projected to 400 :bad-request")))
 
     (testing ":rf.server/set-header missing :value → rejected + skipped"
-      (rf/reg-event-fx :bad/header
+      (rf/reg-event :bad/header
         (fn [_ _] {:fx [[:rf.server/set-header {:name "X-Foo"}]]}))   ;; :value absent
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2147,7 +2147,7 @@
             "the malformed header was skipped; nothing landed")))
 
     (testing ":rf.server/append-header with non-string :value → rejected"
-      (rf/reg-event-fx :bad/append
+      (rf/reg-event :bad/append
         (fn [_ _] {:fx [[:rf.server/append-header {:name "X-Bar" :value 42}]]}))
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2156,7 +2156,7 @@
           traces :rf.server/append-header ":rf.server/append-header non-string :value")))
 
     (testing ":rf.server/set-cookie missing :value → rejected via [:ref :rf.server/cookie]"
-      (rf/reg-event-fx :bad/cookie
+      (rf/reg-event :bad/cookie
         (fn [_ _] {:fx [[:rf.server/set-cookie {:name "session"}]]})) ;; :value absent
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2169,7 +2169,7 @@
     (testing ":rf.server/set-cookie with bogus :same-site keyword → rejected"
       ;; :same-site accepts the enum #{:strict :lax :none} (or a string,
       ;; per the documented divergence) — a bogus KEYWORD is neither.
-      (rf/reg-event-fx :bad/cookie-samesite
+      (rf/reg-event :bad/cookie-samesite
         (fn [_ _] {:fx [[:rf.server/set-cookie
                          {:name "s" :value "v" :same-site :bogus}]]}))
       (let [f      (rf/make-frame {:platform :server})
@@ -2179,7 +2179,7 @@
           traces :rf.server/set-cookie ":rf.server/set-cookie bogus :same-site keyword")))
 
     (testing ":rf.server/delete-cookie missing :name → rejected"
-      (rf/reg-event-fx :bad/delete
+      (rf/reg-event :bad/delete
         (fn [_ _] {:fx [[:rf.server/delete-cookie {:path "/"}]]}))    ;; :name absent
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2200,7 +2200,7 @@
       ;; target would 400 here BEFORE the warn→302 path runs, contradicting
       ;; ee38b.11; this test pins that the redirect schema stays a pure
       ;; shape check and does NOT reject the no-target redirect.
-      (rf/reg-event-fx :soft/redirect-no-target
+      (rf/reg-event :soft/redirect-no-target
         (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2218,7 +2218,7 @@
                  " downstream"))))
 
     (testing ":rf.server/redirect with non-int :status → rejected"
-      (rf/reg-event-fx :bad/redirect-status
+      (rf/reg-event :bad/redirect-status
         (fn [_ _] {:fx [[:rf.server/redirect {:location "/x" :status "oops"}]]}))
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2235,7 +2235,7 @@
       ;; :status surfaces at the Spec 010 §step-5 fx-args boundary, the fx
       ;; is SKIPPED, and the response is left unmodified — matching the
       ;; sibling six.
-      (rf/reg-event-fx :bad/safe-redirect-status
+      (rf/reg-event :bad/safe-redirect-status
         (fn [_ _] {:fx [[:rf.server/safe-redirect
                          {:location "/ok" :status "not-int"}]]}))
       (let [f      (rf/make-frame {:platform :server})
@@ -2255,7 +2255,7 @@
       ;; no-target graceful path that the caller-trusted :rf.server/redirect
       ;; carries. The schema marks :location required, so a no-location call
       ;; fails the shape gate.
-      (rf/reg-event-fx :bad/safe-redirect-no-location
+      (rf/reg-event :bad/safe-redirect-no-location
         (fn [_ _] {:fx [[:rf.server/safe-redirect {:status 302}]]}))
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
@@ -2268,7 +2268,7 @@
             the :schema boundary cleanly (no :rf.error/schema-validation-
             failure) and land on the accumulator. The boundary rejects the
             malformed and admits the valid — it is not a blanket gate."
-    (rf/reg-event-fx :good/all
+    (rf/reg-event :good/all
       (fn [_ _]
         {:fx [[:rf.server/set-status 201]
               [:rf.server/set-header  {:name "Cache-Control" :value "no-store"}]
@@ -2302,7 +2302,7 @@
             (string :location, int :status, boolean :relative-only?,
             vector :allow) passes the new :rf.fx.server/safe-redirect-args
             boundary cleanly and lands its redirect"
-    (rf/reg-event-fx :good/safe-redirect
+    (rf/reg-event :good/safe-redirect
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location       "https://app.example.com/dashboard"
@@ -2354,13 +2354,13 @@
         {:platforms #{:server :client}}
         (fn [_ _] nil))
 
-      (rf/reg-event-fx :rf/server-init
+      (rf/reg-event :rf/server-init
         (fn [{:keys [db]} [_ _request]]
           {:db (assoc-in db [:rf.runtime/routing :current] {:route-id :route/articles})
            :fx [[:http/get {:url "/api/articles"
                             :on-success [:articles/loaded]}]]}))
-      (rf/reg-event-db :articles/loaded
-        (fn [db [_ articles]] (assoc db :articles articles)))
+      (rf/reg-event :articles/loaded
+        (fn [{:keys [db]} [_ articles]] {:db (assoc db :articles articles)}))
 
       (let [traces (atom [])]
         (rf/register-listener! ::ssr (fn [ev] (swap! traces conj ev)))
@@ -2379,9 +2379,9 @@
   (testing "complete SSR flow: dispatch-sync → render-to-string → embedded hash"
     ;; Register a trivial articles app — an event seeds state, a sub
     ;; reads it, a view renders it.
-    (rf/reg-event-db :articles/seed
-      (fn [_ _] {:articles [{:id "a" :title "Article A" :body "Body A"}
-                            {:id "b" :title "Article B" :body "Body B"}]}))
+    (rf/reg-event :articles/seed
+      (fn [{:keys [db]} _] {:db {:articles [{:id "a" :title "Article A" :body "Body A"}
+                            {:id "b" :title "Article B" :body "Body B"}]}}))
     (rf/reg-sub :articles (fn [db _] (:articles db)))
     ;; Test exercises the keyword-id [:pages/articles] hiccup head — not
     ;; the macro shape — so it uses the plain-fn surface reg-view* with

--- a/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
@@ -100,8 +100,8 @@
   `tf/reset-runtime` fixture clears registrations before each test, so
   this runs inside the test body."
   []
-  (rf/reg-event-db ::inc       (fn [db _ev]   (update db :count (fnil inc 0))))
-  (rf/reg-event-db ::set-title (fn [db [_ t]] (assoc db :title t)))
+  (rf/reg-event ::inc       (fn [{:keys [db]} _ev]   {:db (update db :count (fnil inc 0))}))
+  (rf/reg-event ::set-title (fn [{:keys [db]} [_ t]] {:db (assoc db :title t)}))
   (rf/reg-sub :count (fn [db _] (or (:count db) 0)))
   (rf/reg-sub :title (fn [db _] (or (:title db) "untitled")))
   ;; EP-0001 (rf2-vzld77): hydration metadata is durable runtime-db state.

--- a/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
@@ -45,10 +45,10 @@
             substrate carries the projector install, not the dev-only
             trace surface. A server-frame handler that throws still
             stamps :status 500 onto :rf/response."
-    (rf/reg-event-fx :load/article
+    (rf/reg-event :load/article
       (fn [_ _]
         (throw (ex-info "Database connection failed" {}))))
-    (rf/reg-event-fx :rf/server-init
+    (rf/reg-event :rf/server-init
       (fn [_ _]
         {:fx [[:dispatch [:load/article]]]}))
 

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -81,7 +81,7 @@
                :on-create [:set-test-state]})]
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db
       ;; state — seed it via :rf.db/runtime; :articles stays in app-db.
-      (rf/reg-event-fx :set-test-state
+      (rf/reg-event :set-test-state
                        (fn [{:keys [db] rt :rf.db/runtime} _]
                          {:db (assoc-in db [:articles "123"]
                                         {:title   "Hello SSR"
@@ -155,7 +155,7 @@
       ;; directly — the framework's [:rf.runtime/routing :current] slice
       ;; populates via dispatch-driven routing.
       ;; We bypass with a one-shot event below.
-      (rf/reg-event-fx ::seed-route
+      (rf/reg-event ::seed-route
                        (fn [{rt :rf.db/runtime} _]
                          {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
                                                    {:route-id :route/article :params {:id "42"}})}))
@@ -169,7 +169,7 @@
                   {:doc  "Bare route"
                    :path "/"})
     (let [f (rf/make-frame {:doc "Default-head probe" :platform :server})]
-      (rf/reg-event-fx ::seed-route-no-head
+      (rf/reg-event ::seed-route-no-head
                        (fn [{rt :rf.db/runtime} _]
                          {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/no-head})}))
       (rf/dispatch-sync [::seed-route-no-head] {:frame f})
@@ -566,7 +566,7 @@
             :head :head/article; the head fn derives title/meta/link from
             app-db; active-head → head-model->html emits the tags in
             canonical order"
-    (rf/reg-event-fx :seed-article
+    (rf/reg-event :seed-article
                      (fn [{:keys [db] rt :rf.db/runtime} _]
                        {:db (assoc-in db [:articles "123"]
                                       {:title   "re-frame2 SSR"
@@ -630,7 +630,7 @@
                   {:doc  "French article page"
                    :path "/fr/articles/:id"
                    :head :head/with-attrs})
-    (rf/reg-event-fx :seed-fr
+    (rf/reg-event :seed-fr
                      (fn [{rt :rf.db/runtime} _]
                        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
                                                  {:route-id :route/article-fr :params {:id "1"}})}))

--- a/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
@@ -58,8 +58,8 @@
    :rf/app-db      {:count 0}})
 
 (defn- register-handlers! []
-  (rf/reg-event-db ::inc
-    (fn [db _ev] (update db :count (fnil inc 0))))
+  (rf/reg-event ::inc
+    (fn [{:keys [db]} _ev] {:db (update db :count (fnil inc 0))}))
   (rf/reg-sub :count     (fn [db _] (or (:count db) 0)))
   ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db state.
   (subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -76,10 +76,10 @@
 ;; ----------------------------------------------------------------------------
 
 (defn- register-baseline-handlers! []
-  (rf/reg-event-db ::inc
-    (fn [db _ev] (update db :count (fnil inc 0))))
-  (rf/reg-event-db ::set-title
-    (fn [db [_ t]] (assoc db :title t)))
+  (rf/reg-event ::inc
+    (fn [{:keys [db]} _ev] {:db (update db :count (fnil inc 0))}))
+  (rf/reg-event ::set-title
+    (fn [{:keys [db]} [_ t]] {:db (assoc db :title t)}))
   (rf/reg-sub :count       (fn [db _] (or (:count db) 0)))
   (rf/reg-sub :title       (fn [db _] (or (:title db) "untitled")))
   (rf/reg-sub :server-resp (fn [db _] (:server-response db)))
@@ -456,7 +456,7 @@
     ;; runtime partition SURVIVES a malformed-payload rejection. Registered
     ;; inside the test (the `tf/reset-runtime` fixture clears registrations
     ;; before each test, so a load-time registration would be wiped).
-    (rf/reg-event-fx ::seed-runtime
+    (rf/reg-event ::seed-runtime
       (fn [{:keys [db] rt :rf.db/runtime} _]
         {:db db
          :rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]

--- a/implementation/ssr/test/re_frame/ssr_multi_frame_isolation_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_multi_frame_isolation_test.clj
@@ -79,9 +79,9 @@
 ;; ----------------------------------------------------------------------------
 
 (defn- register-handlers! []
-  (rf/reg-event-db ::counter-init (fn [_db _ev] {:n 0}))
-  (rf/reg-event-db ::log-init     (fn [_db _ev] {:entries []}))
-  (rf/reg-event-db ::inc          (fn [db _ev] (update db :n (fnil inc 0))))
+  (rf/reg-event ::counter-init (fn [{:keys [db]} _ev] {:db {:n 0}}))
+  (rf/reg-event ::log-init     (fn [{:keys [db]} _ev] {:db {:entries []}}))
+  (rf/reg-event ::inc          (fn [{:keys [db]} _ev] {:db (update db :n (fnil inc 0))}))
   (rf/reg-sub :n         (fn [db _] (:n db)))
   (rf/reg-sub :entries   (fn [db _] (:entries db)))
   ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -77,7 +77,7 @@
       ;; Host adapter populates the slot.
       (ssr/set-request! server-frame request)
       ;; A server-side handler reads it via the cofx.
-      (rf/reg-event-fx :req-test/read
+      (rf/reg-event :req-test/read
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]
           (reset! observed request)
@@ -107,7 +107,7 @@
   (testing "cofx returns nil when no host adapter has populated the slot"
     (let [server-frame (rf/make-frame {:platform :server})
           observed     (atom :unset)]
-      (rf/reg-event-fx :req-test/read-empty
+      (rf/reg-event :req-test/read-empty
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request] :as ctx} _]
           (reset! observed
@@ -136,7 +136,7 @@
     (let [client-frame (rf/make-frame {:platform :client})
           traces       (collect-traces! ::req-client)
           observed     (atom :unset)]
-      (rf/reg-event-fx :req-test/read-on-client
+      (rf/reg-event :req-test/read-on-client
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request] :as ctx} _]
           (reset! observed
@@ -182,7 +182,7 @@
       (ssr/set-request! frame-a request-a)
       (ssr/set-request! frame-b request-b)
 
-      (rf/reg-event-fx :req-test/read-isolated
+      (rf/reg-event :req-test/read-isolated
         {:rf.cofx/requires [:rf.server/request]}
         ;; The running frame's stamp reaches the event context under
         ;; :rf.frame/id (rf2-1m6rf1 — the bare :frame coeffect is retired).
@@ -215,7 +215,7 @@
 
       ;; The cofx now injects nil.
       (let [observed (atom :unset)]
-        (rf/reg-event-fx :req-test/read-after-clear
+        (rf/reg-event :req-test/read-after-clear
           {:rf.cofx/requires [:rf.server/request]}
           (fn [{:keys [rf.server/request]} _]
             (reset! observed request)
@@ -239,7 +239,7 @@
           explicit     {:uri "/explicit" :headers {"x-test" "1"}}
           observed     (atom :unset)]
       (ssr/set-request! server-frame explicit)
-      (rf/reg-event-fx :req-test/read-explicit
+      (rf/reg-event :req-test/read-explicit
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]
           (reset! observed request)
@@ -261,7 +261,7 @@
           request      {:uri "/preset" :request-method :get}
           observed     (atom :unset)]
       (ssr/set-request! server-frame request)
-      (rf/reg-event-fx :req-test/read-preset
+      (rf/reg-event :req-test/read-preset
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]
           (reset! observed request)

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -419,8 +419,8 @@
             render, then after; the resulting :delta carries the keys
             that changed (per spec — :delta is the streaming hydration
             speed prop). Pins that the diff actually fires."
-    (rf/reg-event-db :test/mutate-during-render
-      (fn [db _] (assoc db :new-key :new-value)))
+    (rf/reg-event :test/mutate-during-render
+      (fn [{:keys [db]} _] {:db (assoc db :new-key :new-value)}))
     (let [fid     (make-server-frame {:initial :state})
           ;; A view that DISPATCHES (mutates app-db) during render —
           ;; the canonical streaming pattern for async data resolution.
@@ -561,7 +561,7 @@
             (rf2-jbcmt) — privacy boundary: response accumulator data
             (Set-Cookie, internal X-* headers) MUST NOT default-leak
             into the hydration payload via an app-db backing store."
-    (rf/reg-event-fx :test/server-write
+    (rf/reg-event :test/server-write
       {:platforms #{:server}}
       (fn [_ _]
         {:fx [[:rf.server/set-header {:name "X-Internal-Token" :value "secret"}]

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -118,8 +118,8 @@
             (into existing delta) merge is lossless (untouched sibling
             sub-keys are not silently dropped). Per Spec 011 §Hydration
             interleaving."
-    (rf/reg-event-db :rf.test/change-nested
-      (fn [db _] (assoc-in db [:user :name] "after")))
+    (rf/reg-event :rf.test/change-nested
+      (fn [{:keys [db]} _] {:db (assoc-in db [:user :name] "after")}))
     (let [;; before-db: {:user {:name "before" :role "admin"}}
           fid     (make-frame {:db {:user {:name "before" :role "admin"}
                                     :other :unchanged}})

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -166,7 +166,7 @@
   cleanup on frame destroy (per Spec 011 §Response storage substrate,
   rf2-jbcmt)."
   []
-  (rf/reg-event-fx :load-test/server-init
+  (rf/reg-event :load-test/server-init
     {:platforms #{:server}}
     (fn [{:keys [db]} [_ {:keys [i]}]]
       {:db (-> db


### PR DESCRIPTION
EP-0018 Slice **M** (rf2-xhfxcs.13): migrate the framework's OWN test corpus from `reg-event-db`/`-fx` to the one public `reg-event`, during the additive window (B-add merged; old forms still work; removal is Slice Z).

## What changed

Ran the merged Slice-E codemod (`migration/from-re-frame-v1/codemod`) over `implementation/*/test`:

- **`reg-event-fx` → `reg-event`** — pure rename (body byte-for-byte; `reg-event` *is* the fx path).
- **simple `reg-event-db` → `reg-event`** — `db` param destructured `{:keys [db]}`, body wrapped `{:db BODY}`; path-interceptor middle slots preserved.
- **flagged sites left untouched** — nil-capable (D7) / complex / all `reg-event-ctx` (per the codemod's conservative policy).

**Artefacts migrated** (202 test files): core, schemas, machines, routing, flows, http, ssr, ssr-ring, epoch, resources, security, derivation-conformance + adapters reagent / reagent-slim / uix / helix / test-react. Only `*/test/**` touched — **no `src`** (core src is owned by the concurrent C+D worker, now merged; rebased on top).

### Per-registration assertion fixes (additive-window-correct)

B-add is **additive and does not change internals** — `reg-event` shares the `reg-event-fx` path, so a rewritten `reg-event-db` now emits `:event/kind :fx` + the `:rf/fx-handler` wrapper (NOT the final Slice-Z `:rf/event-handler`; `:event/kind` removal is also Slice Z). Confirmed empirically against the runtime and against the C+D core.cljc comment. So the green-preserving assertion edits are:

- `app_value_cljs_test.cljc`, `smoke_test.clj`: `:event/kind :db` → `:fx`
- `schemas_test.clj`: `:reg-fn "reg-event-fx"` → `"reg-event"` (the `reg-event` registrar reports `"reg-event"`)

### Left on the old forms by design (registrar-machinery / coexistence suites)

These test the **still-public** `reg-event-db`/`-fx`/`-ctx` surface (removed only in Slice Z), so they stay on the old forms rather than being mechanically migrated:

- `reg_event_cljs_test.cljc` (B-add additive coexistence suite)
- `events_test.clj` / `events_cljs_test.cljs` (registrar arg-policing / wrapper-id / `:reg-fn` machinery)
- the `reg-event-fx-captures-form-source` deftests in `handler_source_test.clj` / `handler_source_cljs_test.cljs` (each macro stamps its OWN form text; C+D additively added a `reg-event` counterpart — both coexist after rebase)

### Codemod-defect fixes (filed-worthy)

The codemod mis-rewrote `reg-event-db` handlers whose first param was a **non-`db` plain symbol** (a path-scoped slice, e.g. `(fn [auth [_ t]] (assoc auth …))` under `{:interceptors [(rf/path :auth)]}`): it renamed the param to `{:keys [db]}` but left the body referencing the old name → unresolvable symbol. Faithfully fixed (old name → `db`) in `flows_test.clj`, `flows_trace_test.clj`, `redact_interceptor_test.clj`, `sensitive_stamping_test.clj`. A full `{:db (<op> <sym>)}` sweep across the JVM `.clj` corpus confirms none remain; the `.cljc`/`.cljs` corpus is validated clean by the cljs gate. (See follow-up note in the bead — the codemod should flag this shape as `:complex`.)

## Quality gates

All green on the rebased tree (rebased onto current `origin/main`, incl. the merged C+D slice):

- `npm run test:cljs` — **7163 tests / 29536 assertions, 0 failures, 0 errors** (the big one)
- core JVM (`clojure -M:test`) — **1471 / 6575, 0/0**
- schemas — 295 / 18764, 0/0
- machines — 697 / 2227, 0/0
- routing — 260 / 1280, 0/0
- flows — 202 / 4830, 0/0
- http — 423 / 1942, 0/0
- ssr — 337 / 1349, 0/0 · ssr-ring — 156 / 698, 0/0
- epoch — 329 / 1300, 0/0 · resources — 406 / 1609, 0/0
- security — 63 / 486, 0/0 · derivation-conformance — 15 / 324, 0/0 · reply-conformance — 16 / 287, 0/0
- api-manifest tests — 27 / 57, 0/0 · `api-manifest gen --check` — **in sync (506 public vars)**
