### PR TITLE
tools: EP-0018 K — migrate snippets/registrations to reg-event (rf2-xhfxcs.11)

### DIFF
--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -148,12 +148,15 @@ const TRACE_WINDOW_MS = 1_000_000_000_000_000;
 // path write through). We declare the path with `{:source :declared}` so
 // the declaration is owned by us, not a schema refresh.
 //
-// Registration uses the fn-form `re-frame.events/reg-event-db` rather than
-// the `re-frame.core/reg-event-db` MACRO: a runtime cljs-eval form cannot
+// Registration uses the fn-form `re-frame.events/reg-event` rather than
+// the `re-frame.core/reg-event` MACRO: a runtime cljs-eval form cannot
 // expand a macro the analyzer hasn't seen, so the macro call would yield
 // nil. The fn-form is a plain call against the events ns the fixture
-// already loads (transitively via re-frame.core). dispatch uses the
-// fn-form `re-frame.core/dispatch-sync*` (the macro's runtime counterpart).
+// already loads (transitively via re-frame.core). `reg-event` is the one
+// public event form after EP-0018 (semantically reg-event-fx): the handler
+// takes the coeffects map and returns a closed effects map (`{:db ...}`).
+// dispatch uses the fn-form `re-frame.core/dispatch-sync*` (the macro's
+// runtime counterpart).
 //
 // Epoch recording must be ACTIVE for the pull-mode tools to have a record
 // to egress. The tiny fixture (`counter.core`) neither requires
@@ -204,9 +207,9 @@ const SEED_FORM = `
       (assoc-in (or reg {})
                 [:sensitive-declarations [${SECRET_KEY}]]
                 {:source :declared})))
-  (re-frame.events/reg-event-db
+  (re-frame.events/reg-event
     :rf-conformance/write-secret
-    (fn [db _] (assoc db ${SECRET_KEY} "${SENTINEL}")))
+    (fn [{:keys [db]} _] {:db (assoc db ${SECRET_KEY} "${SENTINEL}")}))
   (re-frame.core/dispatch-sync* [:rf-conformance/write-secret] {:frame fid})
   {:frame fid
    :declared (re-frame.elision/sensitive-declarations fid)
@@ -296,14 +299,14 @@ const INNER_WRITE_FORM = `
   ;; an EMPTY sensitive-paths set when our epoch is built (rollup ⇒ false).
   (re-frame.elision/swap-elision-slot!
     fid (fn [reg] (assoc (or reg {}) :sensitive-declarations {})))
-  (re-frame.events/reg-event-db
+  (re-frame.events/reg-event
     :rf-conformance/write-inner-secret
-    (fn [db _]
+    (fn [{:keys [db]} _]
       ;; Drop any prior declared-sensitive slot's value too, so even a
       ;; stray lingering declaration can't find a non-nil leaf.
-      (-> db
-          (dissoc ${SECRET_KEY})
-          (assoc ${INNER_SECRET_KEY} "${INNER_SENTINEL}"))))
+      {:db (-> db
+               (dissoc ${SECRET_KEY})
+               (assoc ${INNER_SECRET_KEY} "${INNER_SENTINEL}"))}))
   (re-frame.core/dispatch-sync* [:rf-conformance/write-inner-secret] {:frame fid})
   {:frame fid
    :rollup-at-assembly

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -139,12 +139,12 @@
   ;; live variant frame regardless of the dispatch scope. Idempotent —
   ;; re-installing the same classification REPLACES the prior `:source
   ;; :frame` entries.
-  (rf/reg-event-db
+  (rf/reg-event
     ::reapply-frame-class
-    (fn [db [_ frame-id classification-config]]
+    (fn [{:keys [db]} [_ frame-id classification-config]]
       (frame-class/install! frame-id
         (frame-class/validate+extract frame-id classification-config))
-      db))
+      {:db db}))
   (t))
 
 (use-fixtures :each reset-story-and-config)
@@ -1692,8 +1692,8 @@
     ;; the race captured. We require at least one capture so the replay
     ;; path is genuinely exercised.
     (config/set-allow-writes! true)
-    ;; A real event-db handler whose effect is observable in app-db.
-    (rf/reg-event-db :test/bump (fn [db _] (update db :n (fnil inc 0))))
+    ;; A real event handler whose effect is observable in app-db.
+    (rf/reg-event :test/bump (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (drive-events-during-recording [[:test/bump] [:test/bump] [:test/bump]])
     (let [rec (invoke "record-as-variant"
                       {:variant-id     "story.button/primary"

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -1205,7 +1205,7 @@ discussion.
    :kind :frame-setup
    :init [[:auth/restore-session {:user "alice"}]]})
 
-(rf/reg-event-fx :story.auth/set-logged-in
+(rf/reg-event :story.auth/set-logged-in
   (fn [_ [_ v]]
     (if v
       {:fx [[:dispatch [:auth/restore-session {:user "alice"}]]]}
@@ -1240,7 +1240,7 @@ discussion.
 ### Loaders with `:loaders-complete-when`
 
 ```clojure
-(rf/reg-event-fx :charts.heatmap/subscribe
+(rf/reg-event :charts.heatmap/subscribe
   (fn [_ _]
     {:fx [[:websocket {:url     "wss://api/heatmap"
                        :on-message [:charts/heatmap-tick]}]]}))
@@ -1269,12 +1269,12 @@ the frame's `:frame-setup` decorator `:teardown` walk. Per
 #3.
 
 ```clojure
-(rf/reg-event-fx :charts.heatmap/subscribe
+(rf/reg-event :charts.heatmap/subscribe
   (fn [_ _]
     {:fx [[:websocket {:url        "wss://api/heatmap"
                        :on-message [:charts/heatmap-tick]}]]}))
 
-(rf/reg-event-fx :charts.heatmap/unsubscribe
+(rf/reg-event :charts.heatmap/unsubscribe
   (fn [_ _]
     {:fx [[:websocket-close {:url "wss://api/heatmap"}]]}))
 

--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -60,7 +60,7 @@ completion predicate, and the play-phase assertion bus all read them
 back during the four-phase run; clearing any of them mid-lifecycle
 corrupts the variant.
 
-**Rule.** A host application's `reg-event-db` handlers — and any
+**Rule.** A host application's `reg-event` handlers — and any
 other code path that writes `app-db` — MUST preserve the `:rf.story/*`
 namespace when seeding or resetting `db`. The hazard is the
 "replace-the-whole-db" idiom:
@@ -69,28 +69,29 @@ namespace when seeding or resetting `db`. The hazard is the
 ;; WRONG — wipes :rf.story/lifecycle, :rf.story/loaders-complete?,
 ;; :rf.story/assertions, and any future :rf.story/* slot. Safe in a
 ;; standalone app; corrupts every Story variant that runs this event.
-(rf/reg-event-db :app/initialise
-  (fn [_db _event]
-    {:app/items [] :app/discount nil}))
+(rf/reg-event :app/initialise
+  (fn [_cofx _event]
+    {:db {:app/items [] :app/discount nil}}))
 
 ;; RIGHT — preserves all reserved slots Story (or any other framework
 ;; tool) installs into the frame's app-db.
-(rf/reg-event-db :app/initialise
-  (fn [db _event]
-    (assoc db :app/items [] :app/discount nil)))
+(rf/reg-event :app/initialise
+  (fn [{:keys [db]} _event]
+    {:db (assoc db :app/items [] :app/discount nil)}))
 ```
 
-Equivalently, `(merge db {:app/items [] :app/discount nil})` is fine;
-the rule is "thread `db` through, do not throw it away". Domain-key
-clearing is the host's business; the reserved `:rf.story/*` namespace
-is Story's.
+Equivalently, `{:db (merge db {:app/items [] :app/discount nil})}` is
+fine; the rule is "thread `db` through, do not throw it away".
+Domain-key clearing is the host's business; the reserved `:rf.story/*`
+namespace is Story's.
 
 The originating evidence is commit `c2accadf` (rf2-2uwp1, cart-total
 Story slice): `:cart/initialise` was a whole-`db` replacement and wiped
 the variant frame's lifecycle slots the moment the variant ran the
-event. The fix swapped `(fn [_db _event] {...})` for
-`(fn [db _event] (assoc db ...))`. Host apps integrating Story SHOULD
-audit their init/reset events for the same anti-pattern.
+event. The fix threaded `db` through instead of throwing it away —
+`(fn [{:keys [db]} _event] {:db (assoc db ...)})`. Host apps
+integrating Story SHOULD audit their init/reset events for the same
+anti-pattern.
 
 ## Args resolution precedence
 
@@ -410,7 +411,7 @@ torn-down frame and may either no-op or surface as
    Story-side surface is needed — this works today.
 
    ```clojure
-   (rf/reg-event-fx :feed/subscribe
+   (rf/reg-event :feed/subscribe
      (fn [{:keys [db]} _]
        {:fx [[:rf.machine/spawn
               {:id        :feed.subscription
@@ -441,12 +442,12 @@ torn-down frame and may either no-op or surface as
    `dispatch-sync` of a `:foo/cancel` event).
 
    ```clojure
-   (rf/reg-event-fx :ws/subscribe
+   (rf/reg-event :ws/subscribe
      (fn [{:keys [db]} _]
        {:fx [[:rf.host/open-socket {:url "wss://..."}]]
         :db (assoc db :ws/subscribed? true)}))
 
-   (rf/reg-event-fx :ws/unsubscribe
+   (rf/reg-event :ws/unsubscribe
      (fn [{:keys [db]} _]
        {:fx [[:rf.host/close-socket]]
         :db (dissoc db :ws/subscribed?)}))

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -1,7 +1,7 @@
 # Story — Assertions and Play
 
 > The canonical `:rf.assert/*` events — seven dispatched as
-> `reg-event-fx` handlers plus one tape-evaluated (`:rf.assert/schema-error`),
+> `reg-event` handlers plus one tape-evaluated (`:rf.assert/schema-error`),
 > eight canonical ids in all; their record-don't-throw semantics;
 > play-sequence execution; the assertion-side interaction
 > with `force-fx-stub` (the decorator itself lives in
@@ -13,7 +13,7 @@
 Per
 [spec/007 §Assertion vocabulary](../../../spec/007-Stories.md) the
 canonical **dispatched seven** register at Story load. Each is a regular
-`reg-event-fx` against the variant's frame. All **record** results
+`reg-event` against the variant's frame. All **record** results
 into `:assertions` (see below) rather than throwing. A net-new eighth
 canonical id — `:rf.assert/schema-error` — is *recognised* but NOT
 dispatched; it is tape-evaluated in the result boundary (see
@@ -31,12 +31,12 @@ dispatched; it is tape-evaluated in the result boundary (see
 
 ### `:rf.assert/schema-error` — the tape-evaluated eighth
 
-The seven above are dispatched as `reg-event-fx` handlers. One further
+The seven above are dispatched as `reg-event` handlers. One further
 canonical id ships and rounds the canonical set out to **eight**:
 
 | Event id | Payload | Semantics |
 |---|---|---|
-| `:rf.assert/schema-error` | `[path malli-schema]` | EXPECTED-schema-violation declaration. Recognised so plan construction accepts it, but **not** installed as a `reg-event-fx` handler — it is **tape-evaluated in the result boundary** (`re-frame.story.result`) by multiset-consumption match against the run's `:rf.warn/schema` tape, NOT dispatched into the frame. Per [`017-Testing-Story.md`](017-Testing-Story.md) §Schema rule. |
+| `:rf.assert/schema-error` | `[path malli-schema]` | EXPECTED-schema-violation declaration. Recognised so plan construction accepts it, but **not** installed as a `reg-event` handler — it is **tape-evaluated in the result boundary** (`re-frame.story.result`) by multiset-consumption match against the run's `:rf.warn/schema` tape, NOT dispatched into the frame. Per [`017-Testing-Story.md`](017-Testing-Story.md) §Schema rule. |
 
 `re-frame.story.assertions/canonical-assertion-ids` is therefore a set
 of **eight** — the dispatched seven plus `:rf.assert/schema-error`.

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -238,7 +238,7 @@ Story core owns:
 - The render shell (when CLJS is the runtime).
 - The trace bus and panel registrations.
 - The snapshot-identity computation.
-- The eight canonical `:rf.assert/*` ids — seven dispatched as `reg-event-fx` plus the tape-evaluated `:rf.assert/schema-error`.
+- The eight canonical `:rf.assert/*` ids — seven dispatched as `reg-event` plus the tape-evaluated `:rf.assert/schema-error`.
 
 Stage 7's `tools/story-mcp/` is a thin adapter: takes JSON-RPC
 requests, calls Story's public CLJS / CLJC functions, serialises

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -42,7 +42,7 @@ code migration is not confused with greenfield design.
 | Surface | Status | Note |
 |---|---|---|
 | `reg-story` / `reg-variant`, data-shaped bodies | SHIPS | `tools/story/src/re_frame/story.cljc`, `schemas.cljc` (functions only behind ids). |
-| `:rf.assert/*` family (7 dispatched ids) | SHIPS | The seven **dispatched** `reg-event-fx` ids per [`004-Assertions.md`](004-Assertions.md); the canonical set is **eight** once the tape-evaluated `:rf.assert/schema-error` (next row, §Schema rule) is counted. |
+| `:rf.assert/*` family (7 dispatched ids) | SHIPS | The seven **dispatched** `reg-event` ids per [`004-Assertions.md`](004-Assertions.md); the canonical set is **eight** once the tape-evaluated `:rf.assert/schema-error` (next row, §Schema rule) is counted. |
 | `:assert-db` / `:assert-dom` script steps | SHIPS | Folded into the one assertion atom (§Assertions — one atom, two positions); do not drop them. |
 | bare event-vector script/setup shorthand | SHIPS (`play/runner.cljc` `coerce-script`) | P1 removes this authoring ambiguity; every setup/script step normalizes to a tagged step (§Script step grammar). |
 | `:events` / `:play-script` / `:plays` | SHIPS | Renamed to `:setup` / `:script` / named-scripts (§Public vocabulary). |
@@ -971,7 +971,7 @@ on caller.
   - **Dispatchable assertions** (the canonical handler-backed ids —
     `:rf.assert/path-equals` / `path-matches` / `sub-equals` /
     `dispatched?` / `state-is` / `no-warnings` / `effect-emitted`) are
-    DISPATCHED into the frame. The standard reg-event-fx handler
+    DISPATCHED into the frame. The standard reg-event handler
     (`re-frame.story.assertions`) records the canonical assertion record
     on the frame's `:rf.story/assertions` slot, and the checkpoint
     surfaces that record as the step's pass/fail. It records EXACTLY ONE
@@ -981,7 +981,7 @@ on caller.
   - **DOM-family assertions** (`:rf.assert/dom-visible` / `dom-hidden` /
     `dom-text`) are evaluated by the DOM executor directly (no dispatch);
     a no-DOM headless runner records `:cannot-run`.
-  - **Tape-evaluated assertions** carry NO reg-event-fx handler — they are
+  - **Tape-evaluated assertions** carry NO reg-event handler — they are
     minted by the result boundary against the epoch tape, NOT dispatched.
     This is the schema-error declaration (§Schema rule), the causal /
     cascade family (§Causal and cascade assertions), and the browser-tier
@@ -1042,7 +1042,7 @@ checkpoints use, so they evaluate by the SAME family rules
 - **Handler-backed (dispatchable) atoms** (`:rf.assert/path-equals` /
   `path-matches` / `sub-equals` / `dispatched?` / `state-is` /
   `no-warnings` / `effect-emitted`) are DISPATCHED into the frame; the
-  reg-event-fx handler records the canonical record.
+  reg-event handler records the canonical record.
 - **DOM-family atoms** are evaluated by the DOM executor (`:cannot-run`
   under a headless runner).
 - **Tape-evaluated atoms** (`:rf.assert/schema-error`, the causal / cascade
@@ -1414,7 +1414,7 @@ rows stamped with the dispatching cascade's `:cause-event-id` (Spec 009
 projection. They add **no new trace op-type and no new accumulator** — the
 tape is the source of truth (§Risks — evidence projections drift).
 
-Like `:rf.assert/schema-error` they carry NO `reg-event-fx` handler: they are
+Like `:rf.assert/schema-error` they carry NO `reg-event` handler: they are
 NOT dispatched into the frame. They are **tape-evaluated** in the result
 boundary (`re-frame.story.result/match-causal-expectations`) against the
 projected `:reactive-counts` / `:sub-runs` / `:renders`. The declared atom
@@ -1493,7 +1493,7 @@ an opt-in (rf2-5x1wt.21). It rests on three pieces, all pure data → data:
 - **`:rf.assert/schema-error` is recognised but NOT dispatched.** It is in
   `assertions/canonical-assertion-ids` (so plan construction accepts it) and
   requires the `:schema` capability token, but it is **not** installed as a
-  `reg-event-fx` handler — it carries no app-db semantics. It declares an
+  `reg-event` handler — it carries no app-db semantics. It declares an
   EXPECTED violation that the result boundary evaluates against the
   projected epoch-tape evidence, never a dispatched event into the frame.
   There is deliberately no `:rf.assert/no-schema-errors`: a schema-clean run

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -128,7 +128,7 @@ run so the runner never sees a key it does not own.
 | `list-tags` | `(list-tags)` | All registered tags (canonical + project). |
 | `list-modes` | `(list-modes)` | All registered modes. |
 | `canonical-tags` | `canonical-tags` | The seven canonical tags as a set. |
-| `canonical-assertion-ids` | `(canonical-assertion-ids)` | The eight canonical `:rf.assert/*` ids — the seven dispatched as `reg-event-fx` plus the tape-evaluated `:rf.assert/schema-error` (see [`004-Assertions.md`](004-Assertions.md) §`:rf.assert/schema-error`). |
+| `canonical-assertion-ids` | `(canonical-assertion-ids)` | The eight canonical `:rf.assert/*` ids — the seven dispatched as `reg-event` plus the tape-evaluated `:rf.assert/schema-error` (see [`004-Assertions.md`](004-Assertions.md) §`:rf.assert/schema-error`). |
 | `registered-substrates` | `(registered-substrates)` | CLJS-only. The substrate set as registered via `register-substrate!`. |
 
 ## Write helpers (used by MCP write surface and hot-reload tooling)

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -1084,18 +1084,18 @@
   (when config/enabled?
     ;; Internal event-db handler used by `record!`. Appends a record to
     ;; the variant frame's [:rf.story/assertions] slot.
-    (rf/reg-event-db
+    (rf/reg-event
       ::append
-      (fn [db [_ record]]
-        (update db :rf.story/assertions (fnil conj []) record)))
+      (fn [{:keys [db]} [_ record]]
+        {:db (update db :rf.story/assertions (fnil conj []) record)}))
     ;; The seven canonical handlers.
-    (rf/reg-event-fx id-path-equals     (handler-for-evaluator id-path-equals     :path-equals))
-    (rf/reg-event-fx id-path-matches    (handler-for-evaluator id-path-matches    :path-matches))
-    (rf/reg-event-fx id-sub-equals      (handler-for-evaluator id-sub-equals      :sub-equals))
-    (rf/reg-event-fx id-dispatched      (handler-for-evaluator id-dispatched      :dispatched?))
-    (rf/reg-event-fx id-state-is        (handler-for-evaluator id-state-is        :state-is))
-    (rf/reg-event-fx id-no-warnings     (handler-for-evaluator id-no-warnings     :no-warnings))
-    (rf/reg-event-fx id-effect-emitted  (handler-for-evaluator id-effect-emitted  :effect-emitted))
+    (rf/reg-event id-path-equals     (handler-for-evaluator id-path-equals     :path-equals))
+    (rf/reg-event id-path-matches    (handler-for-evaluator id-path-matches    :path-matches))
+    (rf/reg-event id-sub-equals      (handler-for-evaluator id-sub-equals      :sub-equals))
+    (rf/reg-event id-dispatched      (handler-for-evaluator id-dispatched      :dispatched?))
+    (rf/reg-event id-state-is        (handler-for-evaluator id-state-is        :state-is))
+    (rf/reg-event id-no-warnings     (handler-for-evaluator id-no-warnings     :no-warnings))
+    (rf/reg-event id-effect-emitted  (handler-for-evaluator id-effect-emitted  :effect-emitted))
     nil))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -506,14 +506,14 @@
   states what's installed."
   []
   (when config/enabled?
-    (rf/reg-event-db
+    (rf/reg-event
       ::apply-app-db-patch
-      (fn [db [_ patch]]
-        (reduce-kv
-          (fn [d path v]
-            (assoc-in d (if (vector? path) path [path]) v))
-          db
-          patch)))
+      (fn [{:keys [db]} [_ patch]]
+        {:db (reduce-kv
+               (fn [d path v]
+                 (assoc-in d (if (vector? path) path [path]) v))
+               db
+               patch)}))
     (rf/reg-event
       ::append-teardown-assertion
       (fn [{:keys [db]} [_ record]]

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -514,10 +514,10 @@
             (assoc-in d (if (vector? path) path [path]) v))
           db
           patch)))
-    (rf/reg-event-db
+    (rf/reg-event
       ::append-teardown-assertion
-      (fn [db [_ record]]
-        (update db :rf.story/assertions (fnil conj []) record)))))
+      (fn [{:keys [db]} [_ record]]
+        {:db (update db :rf.story/assertions (fnil conj []) record)}))))
 
 ;; ---- allocation -----------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -284,10 +284,10 @@
   Idempotent."
   []
   (when config/enabled?
-    (rf/reg-event-db
+    (rf/reg-event
       ::set-lifecycle-state-mirror
-      (fn [db [_ state]]
-        (assoc db :rf.story/lifecycle state)))))
+      (fn [{:keys [db]} [_ state]]
+        {:db (assoc db :rf.story/lifecycle state)}))))
 
 ;; ---- public driver helpers -----------------------------------------------
 ;;

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -402,10 +402,10 @@
   `install-helpers!` (rf2-152jq inline rename)."
   []
   (when config/enabled?
-    (rf/reg-event-db
+    (rf/reg-event
       ::append-assertion
-      (fn [db [_ record]]
-        (update db :rf.story/assertions (fnil conj []) record)))
+      (fn [{:keys [db]} [_ record]]
+        {:db (update db :rf.story/assertions (fnil conj []) record)}))
     ;; rf2-blw1q — the `:db-seed` direct app-db seed. Merges the resolved
     ;; `{path → value}` seed map into the frame's app-db via `assoc-in`
     ;; (a top-level keyword path is normalised to a 1-element vector), the

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -415,14 +415,14 @@
     ;; survive — the seed establishes the author's state on top, then
     ;; phase-2 `:setup` events run over it (the fidelity ladder composes:
     ;; `:db-seed` then `:real-setup`).
-    (rf/reg-event-db
+    (rf/reg-event
       ::apply-db-seed
-      (fn [db [_ seed]]
-        (reduce-kv
-          (fn [d path v]
-            (assoc-in d (if (vector? path) path [path]) v))
-          db
-          seed)))))
+      (fn [{:keys [db]} [_ seed]]
+        {:db (reduce-kv
+               (fn [d path v]
+                 (assoc-in d (if (vector? path) path [path]) v))
+               db
+               seed)}))))
 
 ;; ---- assertions read -----------------------------------------------------
 

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -537,7 +537,7 @@
   skip the registration."
   []
   (when config/enabled?
-    (rf/reg-event-fx
+    (rf/reg-event
       id-save-current-as-variant
       (fn [_cofx [_ opts]]
         (save-current-as-variant! opts)

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -446,7 +446,7 @@
   ;; recognises (bare map, `{:source-coord ...}` wrapper, or a
   ;; `"file:line"` display string). Resolves the URI through the
   ;; allowlist seam and routes it to `:rf.editor/open`.
-  (rf/reg-event-fx :rf.story/open-in-editor
+  (rf/reg-event :rf.story/open-in-editor
     (fn [_ctx [_event-id payload]]
       (let [coord (coerce-coord payload)]
         ;; Always emit the fx — even when the coord is unresolvable.

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -178,7 +178,7 @@
   (testing "replay-run-artifact replays the dispatch program into a FRESH
             frame, captures a NEW tape, and returns the shared run-result —
             the fresh frame is torn down before return"
-    (rf/reg-event-db :rep/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :rep/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [a   (artifact/make-run-artifact
                 {:event-program [[:dispatch [:rep/inc]] [:dispatch [:rep/inc]]]})
           res (artifact/replay-run-artifact a)]
@@ -203,7 +203,7 @@
                  (fn [_ _] (swap! hits conj :real)))
       (rf/reg-fx :rep.fx/stub {:platforms #{:client :server}}
                  (fn [_ _] (swap! hits conj :stub)))
-      (rf/reg-event-fx :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
+      (rf/reg-event :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
       (let [a   (artifact/make-run-artifact
                   {:event-program [[:dispatch [:rep/fire]]]
                    :fx-decisions  {:rep.fx/real :rep.fx/stub}})
@@ -233,7 +233,7 @@
                  (fn [_ _] (swap! fx-hits conj :real)))
       (rf/reg-fx :rep.fx/stub {:platforms #{:client :server}}
                  (fn [_ _] (swap! fx-hits conj :stub)))
-      (rf/reg-event-fx :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
+      (rf/reg-event :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
       (let [;; A richer adapter-style hooks map: a custom :dispatch! that
             ;; RECORDS it was invoked, then delegates to the real headless
             ;; drain so the replay still settles. `:provides :headless` so the
@@ -257,7 +257,7 @@
 (deftest replay-isolation-fresh-frame-each-time
   (testing "two replays of the same artifact each run into their own fresh
             frame — no shared app-db leaks between replays"
-    (rf/reg-event-db :rep/set (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event :rep/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (let [a    (artifact/make-run-artifact
                  {:event-program [[:dispatch [:rep/set 7]]]})
           r1   (artifact/replay-run-artifact a)
@@ -273,7 +273,7 @@
             run run-hash EQUALITY is .8's concern: it owns stripping the
             per-frame epoch ids from the tape; this bead pins only that the
             result canonicalizes deterministically and run-hash is stable.)"
-    (rf/reg-event-db :rep/seed (fn [db _] (assoc db :seeded true)))
+    (rf/reg-event :rep/seed (fn [{:keys [db]} _] {:db (assoc db :seeded true)}))
     (let [a   (artifact/replay-run-artifact
                 (artifact/make-run-artifact {:event-program [[:dispatch [:rep/seed]]]}))
           h   (fingerprint/run-hash a)]
@@ -301,7 +301,7 @@
 (deftest replay-into-caller-supplied-frame
   (testing "a caller-supplied :frame is replayed into and LEFT intact (the
             caller owns its lifecycle)"
-    (rf/reg-event-db :rep/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :rep/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/reg-frame :rep/caller-frame {:doc "caller-owned replay frame"})
     (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:rep/inc]]]})
           res (artifact/replay-run-artifact a {:frame :rep/caller-frame})]
@@ -337,7 +337,7 @@
   `:rf/reply` (Spec 014 §Reply addressing), so a re-installed stub's
   synthesised reply is observable in the replay's final app-db."
   [event-id [method url]]
-  (rf/reg-event-fx event-id
+  (rf/reg-event event-id
     (fn [{:keys [db]} [_ msg]]
       (if-let [reply (:rf/reply msg)]
         {:db (assoc db :got reply)}
@@ -403,7 +403,7 @@
   (testing "an artifact WITHOUT :network installs no stubs — with-network-stubs!
             runs the thunk unchanged so a plain replay never touches the
             test-support surface (rf2-tymyh)"
-    (rf/reg-event-db :net/noop (fn [db _] (assoc db :ran true)))
+    (rf/reg-event :net/noop (fn [{:keys [db]} _] {:db (assoc db :ran true)}))
     (let [art (artifact/make-run-artifact {:event-program [[:dispatch [:net/noop]]]})
           res (artifact/replay-run-artifact art)]
       (is (= :pass (:status res)))
@@ -451,10 +451,10 @@
             step's span — EXACT (`:rf.story/script-idx`), not the EVEN
             forward partition that mis-groups it (rf2-rkd14)"
     ;; :rkd/a — a plain leaf dispatch (1 epoch).
-    (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
+    (rf/reg-event :rkd/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
     ;; :rkd/c — re-dispatches :rkd/d, so step 1 settles to 2 epochs.
-    (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
-    (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+    (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+    (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
     (let [a   (artifact/make-run-artifact
                 {:event-program [[:dispatch [:rkd/a]]
                                  [:dispatch [:rkd/c]]]})
@@ -484,9 +484,9 @@
             and a stamp-free baseline canonicalize + run-hash IDENTICALLY
             (rf2-rkd14 determinism guard: :narrative is not in
             run-hash-input-keys AND the :epoch-tape slot stays raw)"
-    (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
-    (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
-    (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+    (rf/reg-event :rkd/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+    (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+    (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
     (let [a    (artifact/make-run-artifact
                  {:event-program [[:dispatch [:rkd/a]]
                                   [:dispatch [:rkd/c]]]})

--- a/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
@@ -74,8 +74,8 @@
 (deftest assertion-path-equals-redacts-sensitive-actual
   (testing "rf2-ee38b.3: :rf.assert/path-equals records :rf/redacted in
             :actual for a sensitive path (not the raw bearer token)"
-    (rf/reg-event-db :auth/login
-      (fn [db _] (assoc-in db [:auth :token] "BEARER-secret-12345")))
+    (rf/reg-event :auth/login
+      (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-12345")}))
     (story/reg-variant :story.redaction.path-equals/probe
       {:events [[:auth/login]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals
@@ -110,7 +110,7 @@
 (deftest assertion-path-equals-non-sensitive-passes-value-through
   (testing "rf2-ee38b.3: a NON-sensitive path records the raw value
             unchanged (redaction only fires on marked paths)"
-    (rf/reg-event-db :ui/set-label (fn [db _] (assoc db :label "hello")))
+    (rf/reg-event :ui/set-label (fn [{:keys [db]} _] {:db (assoc db :label "hello")}))
     (story/reg-variant :story.redaction.plain/probe
       {:events [[:ui/set-label]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:label] "hello"]]]})
@@ -137,8 +137,8 @@
             full sub-marker propagation (spec/015 §reg-sub) is a sub-
             engine feature tracked separately. The assertion layer
             redacts what its path-key reaches."
-    (rf/reg-event-db :session/save-pii
-      (fn [db _] (assoc-in db [:user :ssn] "123-45-6789")))
+    (rf/reg-event :session/save-pii
+      (fn [{:keys [db]} _] {:db (assoc-in db [:user :ssn] "123-45-6789")}))
     ;; Parameterised sub: reads the path passed as args.
     (rf/reg-sub :pii/at (fn [db [_ & path]] (get-in db (vec path))))
     (story/reg-variant :story.redaction.sub-equals/probe

--- a/tools/story/test/re_frame/story/determinism_test.cljc
+++ b/tools/story/test/re_frame/story/determinism_test.cljc
@@ -254,7 +254,7 @@
 (deftest gate-same-program-is-deterministic
   (testing "the SAME event program replayed twice is equal after
             canonicalization — :deterministic with one shared run-hash"
-    (rf/reg-event-db :det/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :det/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [a   (artifact/make-run-artifact
                 {:event-program [[:dispatch [:det/inc]] [:dispatch [:det/inc]]]})
           res (det/assert-deterministic a)]
@@ -266,8 +266,8 @@
 
 (deftest gate-accepts-a-normalized-plan
   (testing "a normalized plan (setup ⧺ script) is replayed deterministically"
-    (rf/reg-event-db :det/seed (fn [db [_ v]] (assoc db :v v)))
-    (rf/reg-event-db :det/bump (fn [db _] (update db :v inc)))
+    (rf/reg-event :det/seed (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
+    (rf/reg-event :det/bump (fn [{:keys [db]} _] {:db (update db :v inc)}))
     (let [plan {:variant/id :story.det/plan
                 :world  {:setup [[:dispatch [:det/seed 10]]]}
                 :script [[:dispatch [:det/bump]]]}
@@ -283,8 +283,8 @@
       ;; Each dispatch reads + bumps a shared atom, so replay 1 writes 1 and
       ;; replay 2 writes 2 into a FRESH frame's app-db — a genuine semantic
       ;; divergence the canonical strip must NOT mask.
-      (rf/reg-event-db :det/nondet
-                       (fn [db _] (assoc db :token (swap! counter inc))))
+      (rf/reg-event :det/nondet
+                       (fn [{:keys [db]} _] {:db (assoc db :token (swap! counter inc))}))
       (let [a   (artifact/make-run-artifact
                   {:event-program [[:dispatch [:det/nondet]]]})
             res (det/assert-deterministic a)]
@@ -300,7 +300,7 @@
   (testing "a purely-deterministic handler is :deterministic even though every
             replay stamps fresh epoch / dispatch / trace ids, a new frame id,
             and its own wall-clock — volatile fields cause NO false drift"
-    (rf/reg-event-db :det/pure (fn [db _] (assoc db :answer 42)))
+    (rf/reg-event :det/pure (fn [{:keys [db]} _] {:db (assoc db :answer 42)}))
     (let [a   (artifact/make-run-artifact
                 {:event-program [[:dispatch [:det/pure]] [:dispatch [:det/pure]]]})
           res (det/assert-deterministic a {:runs 4})]
@@ -312,7 +312,7 @@
 (deftest gate-refuses-bare-wall-clock-wait
   (testing "a plan containing a bare [:wait ms] returns :cannot-run for the
             determinism gate rather than a flaky verdict — and does NOT replay"
-    (rf/reg-event-db :det/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :det/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [a   (artifact/make-run-artifact
                 {:event-program [[:dispatch [:det/inc]]
                                  [:wait 50]
@@ -332,7 +332,7 @@
                  (fn [_ _] (swap! hits conj :real)))
       (rf/reg-fx :det.fx/stub {:platforms #{:client :server}}
                  (fn [_ _] (swap! hits conj :stub)))
-      (rf/reg-event-fx :det/fire (fn [_ _] {:fx [[:det.fx/real {}]]}))
+      (rf/reg-event :det/fire (fn [_ _] {:fx [[:det.fx/real {}]]}))
       (let [a   (artifact/make-run-artifact
                   {:event-program [[:dispatch [:det/fire]]]
                    :fx-decisions  {:det.fx/real :det.fx/stub}})

--- a/tools/story/test/re_frame/story/diff_test.cljc
+++ b/tools/story/test/re_frame/story/diff_test.cljc
@@ -566,7 +566,7 @@
 (deftest diff-run-artifacts-equal-programs-are-same
   (testing "replaying the SAME program twice into fresh frames diffs {:same? true}
             — fresh-frame volatile drift causes no false difference"
-    (rf/reg-event-db :diff/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :diff/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [a (artifact/make-run-artifact
               {:event-program [[:dispatch [:diff/inc]] [:dispatch [:diff/inc]]]})]
       (is (= {:same? true} (diff/diff-run-artifacts a a))
@@ -575,7 +575,7 @@
 (deftest diff-run-artifacts-divergent-program-surfaces-app-db-facet
   (testing "two programs producing different final app-db surface a readable
             :app-db facet"
-    (rf/reg-event-db :diff/set (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event :diff/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 1]]]})
           b (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 2]]]})
           d (diff/diff-run-artifacts a b)]
@@ -587,7 +587,7 @@
 (deftest diff-run-artifacts-accepts-a-run-result-directly
   (testing "a run-result side is used as-is (the pure path) — diffing an
             artifact replay against a hand-built result still works"
-    (rf/reg-event-db :diff/set (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event :diff/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (let [art    (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 9]]]})
           result {:status :pass :app-db {:v 9} :effects [] :sub-runs []
                   :epoch-tape []}

--- a/tools/story/test/re_frame/story/error_projection_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/error_projection_redaction_cljs_test.cljs
@@ -66,7 +66,7 @@
   (testing "rf2-294yq5.5: a handler that throws ex-info with a value at a
             path-marked-sensitive key records :rf/redacted in :error :data,
             NOT the raw secret; the :error :message survives verbatim"
-    (rf/reg-event-db :auth/boom
+    (rf/reg-event :auth/boom
       (fn [_ _]
         (throw (ex-info "Invalid credentials"
                         {:token  "BEARER-secret-12345"
@@ -108,7 +108,7 @@
 (deftest exception-ex-data-non-sensitive-passes-through
   (testing "rf2-294yq5.5: with NO marks, the captured ex-data passes through
             unredacted (frame-scoped elision only redacts marked paths)"
-    (rf/reg-event-db :plain/boom
+    (rf/reg-event :plain/boom
       (fn [_ _]
         (throw (ex-info "boom" {:detail "not-secret"}))))
     (story/reg-variant :story.err-plain/probe

--- a/tools/story/test/re_frame/story/generate_test.cljc
+++ b/tools/story/test/re_frame/story/generate_test.cljc
@@ -114,7 +114,7 @@
 (deftest check-property-passes-and-records-num-tests
   (testing "a property that always holds passes over N seeds"
     ;; A handler that always succeeds — every generated program passes.
-    (rf/reg-event-db :gen/ok (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :gen/ok (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [res (generate/check-property!
                 (fn [_seed] [[:dispatch [:gen/ok]]])
                 {:seed 7 :num-tests 5})]
@@ -129,7 +129,7 @@
 (defn- reg-boom! []
   (rf/reg-fx :gen.fx/boom {:platforms #{:client :server}}
              (fn [_ _] (throw (ex-info "fault: boom" {}))))
-  (rf/reg-event-fx :gen/boom (fn [_ _] {:fx [[:gen.fx/boom {}]]})))
+  (rf/reg-event :gen/boom (fn [_ _] {:fx [[:gen.fx/boom {}]]})))
 
 (deftest check-property-falsifies-and-emits-seed-bearing-artifact
   (testing "a property that fails yields a seed-bearing failing artifact"
@@ -148,7 +148,7 @@
   (testing "shrinking drops irrelevant steps, keeping the minimal failing case"
     ;; :gen/noise is harmless; :gen/boom emits the failing effect. A program
     ;; with many noise steps + one boom should shrink toward just the boom.
-    (rf/reg-event-db :gen/noise (fn [db _] (update db :noise (fnil inc 0))))
+    (rf/reg-event :gen/noise (fn [{:keys [db]} _] {:db (update db :noise (fnil inc 0))}))
     (reg-boom!)
     (let [program [[:dispatch [:gen/noise]] [:dispatch [:gen/noise]]
                    [:dispatch [:gen/boom]]
@@ -209,7 +209,7 @@
     (rf/reg-fx :app.fx/save-broken {:platforms #{:client :server}}
                (fn [_ _]
                  (throw (ex-info "fault: save failed" {}))))
-    (rf/reg-event-fx :app/save (fn [_ _] {:fx [[:app.fx/save {}]]}))
+    (rf/reg-event :app/save (fn [_ _] {:fx [[:app.fx/save {}]]}))
     (let [base   [[:dispatch [:app/save]]]
           lattice {:healthy {}
                    :save-fails {:app.fx/save :app.fx/save-broken}}
@@ -236,7 +236,7 @@
     (rf/reg-fx :app.fx/save {:platforms #{:client :server}} (fn [_ _] :ok))
     (rf/reg-fx :app.fx/save-broken {:platforms #{:client :server}}
                (fn [_ _] (throw (ex-info "fault: save failed" {}))))
-    (rf/reg-event-fx :app/save (fn [_ _] {:fx [[:app.fx/save {}]]}))
+    (rf/reg-event :app/save (fn [_ _] {:fx [[:app.fx/save {}]]}))
     (let [base        [[:dispatch [:app/save]]]
           ;; The SAME lattice in both shapes, in the same cell order.
           as-map      {:healthy {} :save-fails {:app.fx/save :app.fx/save-broken}}
@@ -303,7 +303,7 @@
      (testing "check-property-gen! drives the runner from a test.check generator:
                every drawn program passes, and the run records its reproducible
                root seed exactly as the dependency-free path does"
-       (rf/reg-event-db :gen/ok (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :gen/ok (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (let [program-gen (tcgen/vector
                           (tcgen/return [:dispatch [:gen/ok]]) 1 3)
              res (gen-tc/check-property-gen!
@@ -319,7 +319,7 @@
      (testing "a test.check-driven property that fails flows through the SAME
                shrink + seed-bearing-artifact + promotion bridge as the
                dependency-free path — the adapter is pure sugar over gen-fn"
-       (rf/reg-event-db :gen/noise (fn [db _] (update db :noise (fnil inc 0))))
+       (rf/reg-event :gen/noise (fn [{:keys [db]} _] {:db (update db :noise (fnil inc 0))}))
        (reg-boom!)
        ;; A generator that always includes the failing :gen/boom step amid
        ;; harmless noise — every drawn program falsifies, exercising the

--- a/tools/story/test/re_frame/story/golden_test.cljc
+++ b/tools/story/test/re_frame/story/golden_test.cljc
@@ -395,7 +395,7 @@
   (testing "a golden captured from an artifact (replayed into a fresh frame)
             matches a re-replay of the same program — fresh-frame volatile
             drift causes no false mismatch"
-    (rf/reg-event-db :golden/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :golden/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (let [art (artifact/make-run-artifact
                 {:event-program [[:dispatch [:golden/inc]] [:dispatch [:golden/inc]]]})
           g   (golden/capture-golden art {:keep-run-result true})]
@@ -407,7 +407,7 @@
 (deftest compare-golden-divergent-program-surfaces-app-db-facet
   (testing "a golden captured from one program does NOT match a divergent
             program, and the report surfaces a readable :app-db facet"
-    (rf/reg-event-db :golden/set (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event :golden/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 1]]]})
           b (artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 2]]]})
           g (golden/capture-golden a {:keep-run-result true})
@@ -427,8 +427,8 @@
             artifact + replayed into a fresh frame — its behavioural slice
             reflects the REAL run (a non-empty :app-db / :status), NOT a
             silently-frozen near-empty plan map (the rf2-vvub1 bug)"
-    (rf/reg-event-db :golden/seed (fn [db [_ v]] (assoc db :v v)))
-    (rf/reg-event-db :golden/bump (fn [db _] (update db :v inc)))
+    (rf/reg-event :golden/seed (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
+    (rf/reg-event :golden/bump (fn [{:keys [db]} _] {:db (update db :v inc)}))
     (let [plan {:variant/id :story.golden/plan
                 :world  {:setup [[:dispatch [:golden/seed 10]]]}
                 :script [[:dispatch [:golden/bump]]]}
@@ -448,7 +448,7 @@
       (is (true? (:match? (golden/compare-golden g plan))))))
 
   (testing "a golden captured from a plan does NOT match a divergent plan"
-    (rf/reg-event-db :golden/seed (fn [db [_ v]] (assoc db :v v)))
+    (rf/reg-event :golden/seed (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (let [plan-a {:variant/id :story.golden/a :world {} :script [[:dispatch [:golden/seed 1]]]}
           plan-b {:variant/id :story.golden/b :world {} :script [[:dispatch [:golden/seed 2]]]}
           g      (golden/capture-golden plan-a {:keep-run-result true})

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -41,8 +41,8 @@
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   ;; A tiny event the inline plans drive — the app under test.
-  (rf/reg-event-db :inline/set-status (fn [db [_ v]] (assoc db :status v)))
-  (rf/reg-event-db :inline/inc        (fn [db _]     (update db :n (fnil inc 0))))
+  (rf/reg-event :inline/set-status (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
+  (rf/reg-event :inline/inc        (fn [{:keys [db]} _]     {:db (update db :n (fnil inc 0))}))
   (test-fn))
 
 (use-fixtures :each reset-rf!)

--- a/tools/story/test/re_frame/story/invariants_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/invariants_cljs_test.cljs
@@ -77,8 +77,8 @@
 (deftest with-invariants-live-cljs
   (testing "the sentinel observes a real frame's epochs and reports once per failing epoch"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :dec  (fn [db _] (update db :n dec)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :dec  (fn [{:keys [db]} _] {:db (update db :n dec)}))
     (let [reports (with-captured-reports
                     (fn []
                       (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))]
@@ -91,8 +91,8 @@
 (deftest with-invariants-pass-and-destroy-cljs
   (testing "a holding invariant reports passes; destroying the frame mid-run is tolerated"
     (rf/reg-frame :test/main {})
-    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (let [done    (atom false)
           reports (with-captured-reports
                     (fn []

--- a/tools/story/test/re_frame/story/invariants_test.cljc
+++ b/tools/story/test/re_frame/story/invariants_test.cljc
@@ -279,8 +279,8 @@
    (deftest with-invariants-passes-across-multiple-dispatches
      (testing "a holding invariant across multiple dispatches reports only passes"
        (rf/reg-frame :test/main {})
-       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-       (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+       (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
        (let [reports (with-captured-reports
                        (fn []
                          (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))
@@ -297,8 +297,8 @@
    (deftest with-invariants-reports-once-per-failing-epoch
      (testing "a failing invariant reports exactly once per failing epoch"
        (rf/reg-frame :test/main {})
-       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-       (rf/reg-event-db :dec  (fn [db _] (update db :n dec)))
+       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+       (rf/reg-event :dec  (fn [{:keys [db]} _] {:db (update db :n dec)}))
        (let [reports (with-captured-reports
                        (fn []
                          (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))]
@@ -313,8 +313,8 @@
    (deftest with-invariants-isolates-listener-exception
      (testing "a throwing invariant predicate does not break the run; it reports"
        (rf/reg-frame :test/main {})
-       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-       (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+       (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
        (let [body-completed (atom false)
              reports        (with-captured-reports
                               (fn []
@@ -331,8 +331,8 @@
    (deftest with-invariants-listener-unregistered-after-body
      (testing "the sentinel listener is removed on exit — later epochs are not observed"
        (rf/reg-frame :test/main {})
-       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-       (rf/reg-event-db :dec  (fn [db _] (update db :n dec)))
+       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+       (rf/reg-event :dec  (fn [{:keys [db]} _] {:db (update db :n dec)}))
        (let [reports (with-captured-reports
                        (fn []
                          (with-invariants [(fn [e] (>= (:n (:db-after e)) 0))]
@@ -347,8 +347,8 @@
    (deftest with-invariants-works-with-destroyed-frame
      (testing "destroying the frame mid-run does not break the sentinel; the body completes"
        (rf/reg-frame :test/main {})
-       (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-       (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
+       (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
        (let [body-completed (atom false)]
          (with-captured-reports
            (fn []

--- a/tools/story/test/re_frame/story/panels_e2e/reg_variant_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/reg_variant_e2e_cljs_test.cljs
@@ -91,11 +91,11 @@
   ;; :rf.story.lifecycle/machine]` lives in the frame's runtime-db partition
   ;; (EP-0001 rf2-vzld77), so a `:db` (app-db) effect cannot touch it — same
   ;; note as `counter_with_stories/events.cljs` and the lifecycle test.
-  (rf/reg-event-db :counter/initialise
-    (fn [db [_ n]] (assoc db :count (or n 0))))
-  (rf/reg-event-db :counter/inc
-    (fn [db _] (update db :count inc)))
-  (rf/reg-event-fx :counter/save
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} [_ n]] {:db (assoc db :count (or n 0))}))
+  (rf/reg-event :counter/inc
+    (fn [{:keys [db]} _] {:db (update db :count inc)}))
+  (rf/reg-event :counter/save
     (fn [{:keys [db]} _]
       {:db (assoc db :saving? true)
        :fx [[:counter/sync-to-server {:value (:count db)}]]}))

--- a/tools/story/test/re_frame/story/panels_e2e/variant_lifecycle_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/variant_lifecycle_e2e_cljs_test.cljs
@@ -87,17 +87,17 @@
   ;; so a `:db` (app-db) effect cannot touch it regardless of assoc-vs-
   ;; replace. Same note inline at
   ;; `tools/story/testbeds/counter_with_stories/events.cljs`.
-  (rf/reg-event-db :counter/initialise
-    (fn [db [_ n]] (assoc db :count (or n 5))))
-  (rf/reg-event-db :counter/inc
-    (fn [db _] (update db :count inc)))
-  (rf/reg-event-db :counter/throw-loader-rejection
-    (fn [_db _]
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} [_ n]] {:db (assoc db :count (or n 5))}))
+  (rf/reg-event :counter/inc
+    (fn [{:keys [db]} _] {:db (update db :count inc)}))
+  (rf/reg-event :counter/throw-loader-rejection
+    (fn [_cofx _]
       (throw (ex-info "story-load deterministic loader rejection"
                       {:surface :story-load
                        :kind    :loader-rejection}))))
-  (rf/reg-event-db :counter/loader-never-ready?
-    (fn [db _] (assoc db :rf.story/loaders-complete? false))))
+  (rf/reg-event :counter/loader-never-ready?
+    (fn [{:keys [db]} _] {:db (assoc db :rf.story/loaders-complete? false)})))
 
 (defn- register-lifecycle-variants! []
   (install-counter-events!)

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -98,9 +98,9 @@
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (frame/reg-frame bridge-frame {:doc "outcome-matching bridge test frame"})
-  (rf/reg-event-db ::seed
-    (fn [db [_ rec]]
-      (update db :rf.story/assertions (fnil conj []) rec)))
+  (rf/reg-event ::seed
+    (fn [{:keys [db]} [_ rec]]
+      {:db (update db :rf.story/assertions (fnil conj []) rec)}))
   (test-fn))
 
 (use-fixtures :each bridge-reset!)
@@ -198,7 +198,7 @@
   (testing "run-terminal-assertions! dispatches each handler-backed terminal
             atom through the ONE executor, recording the canonical pass/fail
             record on :rf.story/assertions — no parallel evaluator"
-    (rf/reg-event-db ::seed-db (fn [db [_ m]] (merge db m)))
+    (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (seed-db! {:status :loaded})
     (re/run-terminal-assertions!
       bridge-frame
@@ -216,7 +216,7 @@
             reg-event-fx handler; the result boundary owns its verdict
             against the tape, so no handler-backed record is minted here
             (rf2-nyjoa critical guard against double-processing)"
-    (rf/reg-event-db ::seed-db (fn [db [_ m]] (merge db m)))
+    (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (seed-db! {:status :loaded})
     (re/run-terminal-assertions!
       bridge-frame
@@ -231,7 +231,7 @@
 
 (deftest run-terminal-assertions-empty-is-noop
   (testing "run-terminal-assertions! with no atoms records nothing"
-    (rf/reg-event-db ::seed-db (fn [db [_ m]] (merge db m)))
+    (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (seed-db! {:status :loaded})
     (re/run-terminal-assertions! bridge-frame [])
     (re/run-terminal-assertions! bridge-frame nil)
@@ -359,9 +359,9 @@
    (deftest dispatch-sync-fires-event
      (testing ":dispatch-sync step fires the event into the variant's frame"
        (let [seen (atom [])]
-         (rf/reg-event-db :rt/inc
-           (fn [db _] (swap! seen conj :hit)
-             (update db :n (fnil inc 0))))
+         (rf/reg-event :rt/inc
+           (fn [{:keys [db]} _] (swap! seen conj :hit)
+             {:db (update db :n (fnil inc 0))}))
          (story/reg-variant :story.runner/sync
            {:events []
             :play-script {:auto-run? false
@@ -380,8 +380,8 @@
               :assert-db step is rewritten to the canonical
               [:assert [:rf.assert/path-equals …]] checkpoint, so the
               recorded step type is :assert."
-       (rf/reg-event-db :rt/set-status
-         (fn [db [_ v]] (assoc db :status v)))
+       (rf/reg-event :rt/set-status
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
        (story/reg-variant :story.runner/assert-db
          {:events      []
           :play-script {:auto-run? false
@@ -425,8 +425,8 @@
      (testing "a failing folded :assert-db step records a :passed? false
               :rf.assert/path-equals record into :rf.story/assertions so the
               slot consumers + assertions-passing? observe the failure"
-       (rf/reg-event-db :rt/set-status
-         (fn [db [_ v]] (assoc db :status v)))
+       (rf/reg-event :rt/set-status
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
        (story/reg-variant :story.bridge/db-fail
          {:events      []
           :play-script {:auto-run? false
@@ -449,8 +449,8 @@
    (deftest assert-db-pass-lands-in-assertions-slot
      (testing "a passing folded :assert-db step records a :passed? true
               :rf.assert/path-equals entry so the slot is non-empty + passes"
-       (rf/reg-event-db :rt/set-status
-         (fn [db [_ v]] (assoc db :status v)))
+       (rf/reg-event :rt/set-status
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
        (story/reg-variant :story.bridge/db-pass
          {:events      []
           :play-script {:auto-run? false
@@ -470,8 +470,8 @@
               folded failure as a canonical :rf.assert/path-equals record —
               the cljs.test adapter path (assertions-passing? on the result)
               is no longer false-green; and the unified :status is :fail"
-       (rf/reg-event-db :rt/set-status
-         (fn [db [_ v]] (assoc db :status v)))
+       (rf/reg-event :rt/set-status
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
        (story/reg-variant :story.bridge/result
          {:events      []
           :play-script {:script [[:dispatch-sync [:rt/set-status :idle]]
@@ -503,10 +503,10 @@
      (testing "the unified result's :narrative attributes a re-dispatching
               step's fan-out to THAT step's span — EXACT, not the EVEN
               partition that mis-groups it (rf2-rkd14, live run path)"
-       (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
+       (rf/reg-event :rkd/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
        ;; :rkd/c re-dispatches :rkd/d, so step 1 settles to 2 epochs.
-       (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
-       (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+       (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+       (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
        (story/reg-variant :story.rkd/redispatch
          {:events      []
           :play-script {:script [[:dispatch-sync [:rkd/a]]
@@ -550,9 +550,9 @@
               projection — the EXACT-attributed result's run-hash equals its
               narrative-free baseline, and the :epoch-tape slot stays raw
               (rf2-rkd14 determinism guard)"
-       (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
-       (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
-       (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+       (rf/reg-event :rkd/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+       (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+       (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
        (story/reg-variant :story.rkd/hash
          {:events      []
           :play-script {:script [[:dispatch-sync [:rkd/a]]
@@ -584,12 +584,12 @@
               epoch beat to its OWN step across the concatenated script —
               earlier-play effects are NOT lost to setup, later-play effects
               are NOT mis-credited to earlier steps (rf2-76l69l)"
-       (rf/reg-event-db :ml/a (fn [db _] (assoc db :a true)))
-       (rf/reg-event-db :ml/b (fn [db _] (assoc db :b true)))
+       (rf/reg-event :ml/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+       (rf/reg-event :ml/b (fn [{:keys [db]} _] {:db (assoc db :b true)}))
        ;; :ml/c re-dispatches :ml/d, so the second play's second step settles
        ;; to two epochs — the discriminating re-dispatch the bead calls for.
-       (rf/reg-event-fx :ml/c (fn [_ _] {:fx [[:dispatch [:ml/d]]]}))
-       (rf/reg-event-db :ml/d (fn [db _] (assoc db :d true)))
+       (rf/reg-event :ml/c (fn [_ _] {:fx [[:dispatch [:ml/d]]]}))
+       (rf/reg-event :ml/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
        (story/reg-variant :story.ml/two-plays
          {:events []
           :plays  [{:name "alpha" :auto-run? true
@@ -673,8 +673,8 @@
    (deftest assert-db-pred-form
      (testing ":assert-db :pred folds to :rf.assert/path-matches [:fn sym];
               the symbol resolves at validation time (rf2-5x1wt.19)"
-       (rf/reg-event-db :rt/set-n
-         (fn [db [_ v]] (assoc db :n v)))
+       (rf/reg-event :rt/set-n
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
        (story/reg-variant :story.runner/pred
          {:events      []
           :play-script {:auto-run? false
@@ -697,8 +697,8 @@
      (testing ":assert-db :pred accepts a fn directly (rf2-inbad —
               advanced-CLJS-safe); it folds to :rf.assert/path-matches
               [:fn fn] which Malli validates by calling the fn (rf2-5x1wt.19)"
-       (rf/reg-event-db :rt/set-n
-         (fn [db [_ v]] (assoc db :n v)))
+       (rf/reg-event :rt/set-n
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
        (story/reg-variant :story.runner/pred-fn
          {:events      []
           :play-script {:auto-run? false
@@ -723,8 +723,8 @@
               it folds to :rf.assert/path-matches [:fn 'bogus]; the symbol
               cannot resolve, so the assertion reports a readable failure
               rather than an opaque sci error (rf2-5x1wt.19)"
-       (rf/reg-event-db :rt/set-n
-         (fn [db [_ v]] (assoc db :n v)))
+       (rf/reg-event :rt/set-n
+         (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
        (story/reg-variant :story.runner/pred-bogus
          {:events      []
           :play-script {:auto-run? false
@@ -741,8 +741,8 @@
 #?(:clj
    (deftest run-records-results-in-order
      (testing "results vector reflects step order"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :touches (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
        (story/reg-variant :story.runner/order
          {:events []
           :play-script
@@ -774,8 +774,8 @@
      (testing "two consecutive public `run!`s of the same play leave the
               frame's settle-boundaries reset to THIS run's worth — `run!`
               owns the reset, so the count does not accumulate (rf2-vkdam)"
-       (rf/reg-event-db :vk/touch
-         (fn [db _] (update db :touches (fnil inc 0))))
+       (rf/reg-event :vk/touch
+         (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
        (story/reg-variant :story.vkdam/rerun
          {:events []
           :play-script {:auto-run? false
@@ -837,8 +837,8 @@
    (deftest auto-run-skips-when-disabled
      (testing "auto-run! is a no-op when :auto-run? is false"
        (let [seen (atom 0)]
-         (rf/reg-event-db :rt/touch
-           (fn [db _] (swap! seen inc) db))
+         (rf/reg-event :rt/touch
+           (fn [{:keys [db]} _] (swap! seen inc) {:db db}))
          (story/reg-variant :story.runner/no-auto
            {:events []
             :play-script {:auto-run? false
@@ -852,8 +852,8 @@
 #?(:clj
    (deftest run-state-clears-and-resets
      (testing "successive runs reset :results and re-walk every step"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :touches (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
        (story/reg-variant :story.runner/reset
          {:events []
           :play-script {:auto-run? false
@@ -876,8 +876,8 @@
      (testing "the runner emits a :rf.story.play/step trace event per step"
        (let [trace-events (atom [])
              listener-id  ::play-trace-test]
-         (rf/reg-event-db :rt/touch
-           (fn [db _] (update db :touches (fnil inc 0))))
+         (rf/reg-event :rt/touch
+           (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
          (try
            (require '[re-frame.trace.tooling :as trace-tooling])
            (let [reg!  (resolve 're-frame.trace.tooling/register-listener!)
@@ -947,8 +947,8 @@
 #?(:clj
    (deftest variant-plays-resolves-plays-vector
      (testing "variant-plays returns a vector of parsed plays"
-       (rf/reg-event-db :rt/inc
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/inc
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.multi/two
          {:events []
           :plays  [{:name "happy"
@@ -979,8 +979,8 @@
 #?(:clj
    (deftest run-play-keys-state-per-play
      (testing "running each play stores state under [variant-id play-key]"
-       (rf/reg-event-db :rt/inc
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/inc
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.multi/keyed
          {:events []
           :plays  [{:name "first"  :auto-run? false
@@ -1005,8 +1005,8 @@
 #?(:clj
    (deftest run-play-sets-active-play
      (testing "run-play! also sets the active-play key the toolbar reads"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.multi/active
          {:events []
           :plays  [{:name "alpha" :auto-run? false
@@ -1020,8 +1020,8 @@
 #?(:clj
    (deftest select-play-without-running
      (testing "select-play! changes the active key but does not run"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.multi/select
          {:events []
           :plays  [{:name "one" :auto-run? false
@@ -1037,8 +1037,8 @@
 #?(:clj
    (deftest run-all-plays-sequences-runs
      (testing "run-all-plays! drives every play and resolves with per-play results"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.multi/all
          {:events []
           :plays  [{:name "a" :auto-run? false
@@ -1069,8 +1069,8 @@
 #?(:clj
    (deftest auto-run-multi-runs-only-opted-in-plays
      (testing "auto-run! runs only plays whose :auto-run? is true (per-position defaults)"
-       (rf/reg-event-db :rt/inc
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/inc
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.multi/auto
          {:events []
           :plays  [{:name "first-default-true"
@@ -1176,7 +1176,7 @@
    (deftest run-stamps-token-on-state
      (testing "run! writes a :run-token onto the started state map so
               concurrent-run detection can compare loops"
-       (rf/reg-event-db :rt/touch (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.runner/token
          {:events      []
           :play-script {:auto-run? false
@@ -1191,7 +1191,7 @@
      (testing "back-to-back run! calls stamp DIFFERENT tokens — the newer
               token wins and the stale loop (had it still been queued)
               would bail on mismatch"
-       (rf/reg-event-db :rt/touch (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.runner/token-rotate
          {:events      []
           :play-script {:auto-run? false
@@ -1213,7 +1213,7 @@
               dispatches sneak in mid-script. Probes the legacy execute-play!
               semantics the migration accidentally lost."
        (let [n (atom 0)]
-         (rf/reg-event-db :rt/inc (fn [db _] (swap! n inc) (update db :n (fnil inc 0))))
+         (rf/reg-event :rt/inc (fn [{:keys [db]} _] (swap! n inc) {:db (update db :n (fnil inc 0))}))
          (story/reg-variant :story.runner/sync-tight
            {:events      [[:rt/inc] [:rt/inc] [:rt/inc]] ; seed: n=3
             :play-script {:auto-run? false
@@ -1274,8 +1274,8 @@
      (testing "an in-script [:assert [:rf.assert/schema-error …]] checkpoint
               is recorded as a no-op step-skip — NOT dispatched into the
               frame — so no :rf.error/no-such-handler trace lands (rf2-8y47c)"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.tape/schema-error
          {:events      []
           :play-script {:auto-run? false
@@ -1304,8 +1304,8 @@
               checkpoint (the causal family) is a no-op step-skip — NOT
               dispatched — so no :rf.error/no-such-handler trace lands
               (rf2-fh7g4)"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.tape/no-cascade
          {:events      []
           :play-script {:auto-run? false
@@ -1332,8 +1332,8 @@
      (testing "an in-script [:assert [:rf.assert/caused …]] checkpoint is a
               no-op step-skip — NOT dispatched — so no
               :rf.error/no-such-handler trace lands (rf2-fh7g4)"
-       (rf/reg-event-db :rt/touch
-         (fn [db _] (update db :n (fnil inc 0))))
+       (rf/reg-event :rt/touch
+         (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (story/reg-variant :story.tape/caused
          {:events      []
           :play-script {:auto-run? false

--- a/tools/story/test/re_frame/story/play/settled_boundary_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/settled_boundary_cljs_test.cljs
@@ -47,16 +47,16 @@
             re-dispatches to fixed point on CLJS — the whole cascade is
             settled synchronously when the call returns, NO setTimeout
             tick (the legacy :dispatch step relied on a yield here)"
-    (rf/reg-event-fx :cljs.chain/a
+    (rf/reg-event :cljs.chain/a
       (fn [{:keys [db]} _]
         {:db (update db :hops (fnil conj []) :a)
          :fx [[:dispatch [:cljs.chain/b]]]}))
-    (rf/reg-event-fx :cljs.chain/b
+    (rf/reg-event :cljs.chain/b
       (fn [{:keys [db]} _]
         {:db (update db :hops (fnil conj []) :b)
          :fx [[:dispatch [:cljs.chain/c]]]}))
-    (rf/reg-event-db :cljs.chain/c
-      (fn [db _] (update db :hops (fnil conj []) :c)))
+    (rf/reg-event :cljs.chain/c
+      (fn [{:keys [db]} _] {:db (update db :hops (fnil conj []) :c)}))
     (let [res (boundary/dispatch-and-settle!
                 bf [:cljs.chain/a] boundary/headless-flush-hooks
                 :headless [:dispatch [:cljs.chain/a]])]
@@ -69,8 +69,8 @@
   (testing "a :dom-requiring step under the headless runner refuses with
             :cannot-run and does NOT dispatch the event on CLJS"
     (let [fired (atom false)]
-      (rf/reg-event-db :cljs.dom/should-not-fire
-        (fn [db _] (reset! fired true) db))
+      (rf/reg-event :cljs.dom/should-not-fire
+        (fn [{:keys [db]} _] (reset! fired true) {:db db}))
       (let [res (boundary/dispatch-and-settle!
                   bf [:cljs.dom/should-not-fire] boundary/headless-flush-hooks
                   :dom [:click "button"])]
@@ -84,7 +84,7 @@
     (let [hooks {:provides  :dom
                  :dispatch! (fn [frame-id evec] (boundary/drain-sync! frame-id evec))
                  :flush!    {:dom (fn [_] (throw (ex-info "cljs flush boom" {})))}}]
-      (rf/reg-event-db :cljs.dom/x (fn [db _] db))
+      (rf/reg-event :cljs.dom/x (fn [{:keys [db]} _] {:db db}))
       (let [res (boundary/dispatch-and-settle! bf [:cljs.dom/x] hooks :dom [:click "b"])]
         (is (= :error (:status res)))
         (is (re-find #"cljs flush boom" (:error res)))))))

--- a/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
+++ b/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
@@ -126,16 +126,16 @@
     ;; :chain/a re-dispatches :chain/b (queued); :chain/b re-dispatches
     ;; :chain/c. A run-to-fixed-point drain settles all three before
     ;; dispatch-and-settle! returns.
-    (rf/reg-event-fx :chain/a
+    (rf/reg-event :chain/a
       (fn [{:keys [db]} _]
         {:db (update db :hops (fnil conj []) :a)
          :fx [[:dispatch [:chain/b]]]}))
-    (rf/reg-event-fx :chain/b
+    (rf/reg-event :chain/b
       (fn [{:keys [db]} _]
         {:db (update db :hops (fnil conj []) :b)
          :fx [[:dispatch [:chain/c]]]}))
-    (rf/reg-event-db :chain/c
-      (fn [db _] (update db :hops (fnil conj []) :c)))
+    (rf/reg-event :chain/c
+      (fn [{:keys [db]} _] {:db (update db :hops (fnil conj []) :c)}))
     (let [res (boundary/dispatch-and-settle!
                 bf [:chain/a] boundary/headless-flush-hooks :headless [:dispatch [:chain/a]])]
       (is (= :settled (:status res)))
@@ -150,8 +150,8 @@
             :cannot-run and does NOT dispatch the event (fail-closed,
             never a silent pass)"
     (let [fired (atom false)]
-      (rf/reg-event-db :dom/should-not-fire
-        (fn [db _] (reset! fired true) db))
+      (rf/reg-event :dom/should-not-fire
+        (fn [{:keys [db]} _] (reset! fired true) {:db db}))
       (let [res (boundary/dispatch-and-settle!
                   bf [:dom/should-not-fire] boundary/headless-flush-hooks
                   :dom [:click "button"])]
@@ -171,7 +171,7 @@
                    :flush!    {:headless      (fn [_] (swap! flushed conj :headless))
                                :cljs-reactive (fn [_] (swap! flushed conj :reactive))
                                :dom           (fn [_] (swap! flushed conj :dom))}}]
-      (rf/reg-event-db :dom/click (fn [db _] (assoc db :clicked true)))
+      (rf/reg-event :dom/click (fn [{:keys [db]} _] {:db (assoc db :clicked true)}))
       (let [res (boundary/dispatch-and-settle! bf [:dom/click] hooks :dom [:click "b"])]
         (is (= :settled (:status res)))
         (is (= :dom     (:boundary res)))
@@ -185,7 +185,7 @@
     (let [hooks {:provides  :dom
                  :dispatch! (fn [frame-id evec] (boundary/drain-sync! frame-id evec))
                  :flush!    {:dom (fn [_] (throw (ex-info "flush boom" {})))}}]
-      (rf/reg-event-db :dom/x (fn [db _] db))
+      (rf/reg-event :dom/x (fn [{:keys [db]} _] {:db db}))
       (let [res (boundary/dispatch-and-settle! bf [:dom/x] hooks :dom [:click "b"])]
         (is (= :error (:status res)))
         (is (re-find #"flush boom" (:error res)))
@@ -207,7 +207,7 @@
                   :flush!     {:headless      (fn [_] (swap! ran conj :headless))
                                :cljs-reactive (fn [_] (swap! ran conj :reactive))
                                :dom           (fn [_] (swap! ran conj :dom))}}]
-      (rf/reg-event-db :timeout/fired (fn [db _] (assoc db :fired true)))
+      (rf/reg-event :timeout/fired (fn [{:keys [db]} _] {:db (assoc db :fired true)}))
       (let [res (boundary/dispatch-and-settle! bf [:timeout/fired] hooks :dom [:click "b"])]
         (is (= :cannot-run    (:status res)))
         (is (= :flush-timeout (:reason res)))
@@ -231,7 +231,7 @@
                                (boundary/drain-sync! frame-id evec))
                  :flush!     {:cljs-reactive (fn [_] (swap! ran conj :reactive))
                               :dom           (fn [_] (swap! ran conj :dom))}}]
-      (rf/reg-event-db :timeout/ok (fn [db _] (assoc db :ok true)))
+      (rf/reg-event :timeout/ok (fn [{:keys [db]} _] {:db (assoc db :ok true)}))
       (let [res (boundary/dispatch-and-settle! bf [:timeout/ok] hooks :dom [:click "b"])]
         (is (= :settled (:status res)))
         (is (= :dom     (:boundary res)))
@@ -241,7 +241,7 @@
 (deftest no-timeout-ms-is-unbounded
   (testing "with no :timeout-ms the flush phase is unbounded — settlement
             completes regardless of flush duration (the headless default)"
-    (rf/reg-event-db :noop (fn [db _] db))
+    (rf/reg-event :noop (fn [{:keys [db]} _] {:db db}))
     (let [res (boundary/dispatch-and-settle!
                 bf [:noop] boundary/headless-flush-hooks :headless [:dispatch [:noop]])]
       (is (= :settled (:status res))))))
@@ -249,11 +249,11 @@
 (deftest drain-sync-settles-synchronous-redispatch
   (testing "drain-sync! (the named headless boundary) is the framework
             dispatch-sync* drain — re-dispatched events settle before return"
-    (rf/reg-event-fx :seed/start
+    (rf/reg-event :seed/start
       (fn [{:keys [db]} _]
         {:db (assoc db :n 0)
          :fx [[:dispatch [:seed/bump]]]}))
-    (rf/reg-event-db :seed/bump (fn [db _] (update db :n inc)))
+    (rf/reg-event :seed/bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (boundary/drain-sync! bf [:seed/start])
     (is (= 1 (:n (rf/app-db-value bf)))
         "the queued :seed/bump drained synchronously within drain-sync!")))

--- a/tools/story/test/re_frame/story/play/step_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_runner_test.cljc
@@ -210,8 +210,8 @@
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (frame/reg-frame step-frame {:doc "tagged step-runner test frame"})
-  (rf/reg-event-db :step/inc (fn [db _] (update db :n (fnil inc 0))))
-  (rf/reg-event-db :step/set (fn [db [_ v]] (assoc db :v v)))
+  (rf/reg-event :step/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+  (rf/reg-event :step/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
   (test-fn))
 
 (use-fixtures :each reset-rf!)

--- a/tools/story/test/re_frame/story/promotion_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_test.cljc
@@ -266,7 +266,7 @@
   addressing). Mirrors the artifact_test helper so the round-trip exercises
   the same managed-HTTP fail-close path."
   [event-id [method url]]
-  (rf/reg-event-fx event-id
+  (rf/reg-event event-id
     (fn [{:keys [db]} [_ msg]]
       (if-let [reply (:rf/reply msg)]
         {:db (assoc db :got reply)}

--- a/tools/story/test/re_frame/story/runtime_db_seed_test.clj
+++ b/tools/story/test/re_frame/story/runtime_db_seed_test.clj
@@ -74,9 +74,9 @@
   (uninstall-schema-seam!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
-  (rf/reg-event-db :cart/add-item
-                   (fn [db [_ item]]
-                     (update-in db [:cart :items] (fnil conj []) item)))
+  (rf/reg-event :cart/add-item
+                   (fn [{:keys [db]} [_ item]]
+                     {:db (update-in db [:cart :items] (fnil conj []) item)}))
   (test-fn))
 
 (use-fixtures :each reset-rf!)

--- a/tools/story/test/re_frame/story/runtime_runpath_test.clj
+++ b/tools/story/test/re_frame/story/runtime_runpath_test.clj
@@ -43,8 +43,8 @@
   (swap! late-bind/hooks dissoc :render-hiccup)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
-  (rf/reg-event-db :rp/set-status (fn [db [_ v]] (assoc db :status v)))
-  (rf/reg-event-db :rp/set-value  (fn [db [_ v]] (assoc db :value v)))
+  (rf/reg-event :rp/set-status (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
+  (rf/reg-event :rp/set-value  (fn [{:keys [db]} [_ v]] {:db (assoc db :value v)}))
   (test-fn))
 
 (use-fixtures :each reset-rf!)

--- a/tools/story/test/re_frame/story/story_is_test.clj
+++ b/tools/story/test/re_frame/story/story_is_test.clj
@@ -31,7 +31,7 @@
   (reset! re/run-state {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
-  (rf/reg-event-db :is/set-status (fn [db [_ v]] (assoc db :status v)))
+  (rf/reg-event :is/set-status (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
   (test-fn))
 
 (use-fixtures :each reset-rf!)

--- a/tools/story/test/re_frame/story/story_xray_wiring_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/story_xray_wiring_cljs_test.cljs
@@ -86,8 +86,8 @@
   the canonical counter example: `:counter/initialise` seeds the slot
   at 5."
   []
-  (rf/reg-event-db :counter/initialise
-    (fn [_db _event] {:counter/value 5})))
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} _event] {:db {:counter/value 5}})))
 
 ;; Variant-id IS the frame-id per `re-frame.story.frames`.
 (def ^:private variant-id :story.counter/loaded)
@@ -172,10 +172,10 @@
     (e2e/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (rf/reg-event-db :counter/initialise
-           (fn [_db _event] {:counter/value 5}))
-         (rf/reg-event-db :counter/seed-ten
-           (fn [_db _event] {:counter/value 10}))
+         (rf/reg-event :counter/initialise
+           (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
+         (rf/reg-event :counter/seed-ten
+           (fn [{:keys [db]} _event] {:db {:counter/value 10}}))
          (story/reg-story :story.counter {})
          (story/reg-variant :story.counter/loaded
            {:events [[:counter/initialise]]})

--- a/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
@@ -159,7 +159,7 @@
        (rf/reg-sub :login/state (fn [db _] (get-in db [:login :state])))
        (rf/reg-sub :login/message (fn [db _] (get-in db [:login :message])))
        ;; Seed a REAL app-db value distinct from the override.
-       (rf/reg-event-db ::seed (fn [_ _] {:login {:state :ok}}))
+       (rf/reg-event ::seed (fn [{:keys [db]} _] {:db {:login {:state :ok}}}))
        ;; EP-0002 (rf2-9o48ih): the dispatch + the plain-fn view's subscribe
        ;; both need a carried frame. Bind the ambient `:rf/default` scope
        ;; (the fixture ensured the frame exists) around the seed dispatch and

--- a/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
@@ -254,8 +254,8 @@
      (testing "dispatching against a frame writes app-db via dispatch-sync"
        (let [vid :story.dispatch.test/v]
          (rf/reg-frame vid {})
-         (rf/reg-event-db :test/inc
-                          (fn [db _] (update db :counter (fnil inc 0))))
+         (rf/reg-event :test/inc
+                          (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
          (rf/reg-sub :test/counter
                      (fn [db _] (get db :counter 0)))
          (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
@@ -268,7 +268,7 @@
      (testing "every dispatch lands a history entry"
        (let [vid :story.history.test/v]
          (rf/reg-frame vid {})
-         (rf/reg-event-db :test/noop (fn [db _] db))
+         (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
          (dc/dispatch-event! vid [:test/noop {:k :v}] :dispatch-sync)
          (let [h (dc/current-history vid)]
            (is (= 1 (count h)))
@@ -281,8 +281,8 @@
      (testing "click-replay re-dispatches the recorded event"
        (let [vid :story.replay.test/v]
          (rf/reg-frame vid {})
-         (rf/reg-event-db :test/inc
-                          (fn [db _] (update db :counter (fnil inc 0))))
+         (rf/reg-event :test/inc
+                          (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
          (rf/reg-sub :test/counter
                      (fn [db _] (get db :counter 0)))
          (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
@@ -298,7 +298,7 @@
      (testing "a bad payload sets :error and does not dispatch"
        (let [vid :story.parse.err/v]
          (rf/reg-frame vid {})
-         (rf/reg-event-db :test/boom (fn [db _] (assoc db :boomed? true)))
+         (rf/reg-event :test/boom (fn [{:keys [db]} _] {:db (assoc db :boomed? true)}))
          (swap! dc/input-state assoc vid
                 {:event-id-input ":test/boom"
                  :payload-input  "{:bad"})
@@ -320,8 +320,8 @@
 #?(:cljs
    (deftest cljs-autocomplete-against-live-registrar
      (testing "registered-event-ids 0-arity surfaces registered handlers"
-       (rf/reg-event-db :ac.test/one (fn [db _] db))
-       (rf/reg-event-db :ac.test/two (fn [db _] db))
+       (rf/reg-event :ac.test/one (fn [{:keys [db]} _] {:db db}))
+       (rf/reg-event :ac.test/two (fn [{:keys [db]} _] {:db db}))
        (let [ids (dce/registered-event-ids)]
          (is (contains? ids :ac.test/one))
          (is (contains? ids :ac.test/two))))))

--- a/tools/story/test/re_frame/story/ui/test_mode_pane_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode_pane_cljs_test.cljs
@@ -165,8 +165,8 @@
 (deftest run-variant-pane-seeds-slot-on-mount
   (testing "run-variant-pane! against a fresh variant seeds the per-
             variant slot with all the renderer-required fields"
-    (rf/reg-event-db :test/set
-      (fn [db _] (assoc db :counter 7)))
+    (rf/reg-event :test/set
+      (fn [{:keys [db]} _] {:db (assoc db :counter 7)}))
     (story/reg-variant :story.pane.mount/v
       {:events [[:test/set]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:counter] 7]]]})
@@ -196,10 +196,10 @@
             independently — proves the slots are per-variant, not a
             singleton, so the pane's scroll-position / expanded set /
             scrubber state isolate"
-    (rf/reg-event-db :test/set-a
-      (fn [db _] (assoc db :v "a")))
-    (rf/reg-event-db :test/set-b
-      (fn [db _] (assoc db :v "b")))
+    (rf/reg-event :test/set-a
+      (fn [{:keys [db]} _] {:db (assoc db :v "a")}))
+    (rf/reg-event :test/set-b
+      (fn [{:keys [db]} _] {:db (assoc db :v "b")}))
     (story/reg-variant :story.pane.switch/a
       {:events [[:test/set-a]] :play-script [[:dispatch-sync [:rf.assert/path-equals [:v] "a"]]]})
     (story/reg-variant :story.pane.switch/b
@@ -256,7 +256,7 @@
             shell-state :tests :runs :status :running stamp the chrome
             widget reads against; this test pins the pane-local
             results-atom flag the pane's own Re-run button reads."
-    (rf/reg-event-db :test/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :test/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.pane.debounce/v
       {:events [[:test/inc]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
@@ -289,7 +289,7 @@
 (deftest run-variant-pane-records-on-resolve
   (testing "after a run resolves, :running? clears AND a fresh re-run is
             allowed (the gate is :running?, not a permanent lock)"
-    (rf/reg-event-db :test/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :test/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.pane.cycle/v
       {:events [[:test/inc]] :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
     (async done

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -60,8 +60,8 @@
 
 (deftest cljs-path-equals-pass
   (testing ":rf.assert/path-equals against an event-mutated app-db"
-    (rf/reg-event-db :test/set
-      (fn [db _] (assoc-in db [:user :name] "alice")))
+    (rf/reg-event :test/set
+      (fn [{:keys [db]} _] {:db (assoc-in db [:user :name] "alice")}))
     (story/reg-variant :story.cljs.assert/pe
       {:events [[:test/set]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:user :name] "alice"]]]})
@@ -78,7 +78,7 @@
 
 (deftest cljs-assertions-passing?-roundtrip
   (testing "assertions-passing? returns true on all-pass, false on any-fail"
-    (rf/reg-event-db :test/n2 (fn [db _] (assoc db :n 42)))
+    (rf/reg-event :test/n2 (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
     (story/reg-variant :story.cljs.passing/ok
       {:events [[:test/n2]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 42]]]})

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -94,8 +94,8 @@
 
 (deftest path-equals-pass
   (testing ":rf.assert/path-equals passes when value at path matches"
-    (rf/reg-event-db :test/set-status
-      (fn [db _] (assoc-in db [:auth :status] :authenticated)))
+    (rf/reg-event :test/set-status
+      (fn [{:keys [db]} _] {:db (assoc-in db [:auth :status] :authenticated)}))
     (story/reg-variant :story.auth/happy
       {:events [[:test/set-status]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:auth :status] :authenticated]]]})
@@ -123,8 +123,8 @@
 
 (deftest path-matches-pass
   (testing ":rf.assert/path-matches validates against malli"
-    (rf/reg-event-db :test/set-count
-      (fn [db _] (assoc db :n 42)))
+    (rf/reg-event :test/set-count
+      (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
     (story/reg-variant :story.malli/ok
       {:events [[:test/set-count]]
        :play-script [[:dispatch-sync [:rf.assert/path-matches [:n] :int]]]})
@@ -134,8 +134,8 @@
 
 (deftest path-matches-fail
   (testing ":rf.assert/path-matches records failure with explanation on schema mismatch"
-    (rf/reg-event-db :test/set-bad
-      (fn [db _] (assoc db :n "not a number")))
+    (rf/reg-event :test/set-bad
+      (fn [{:keys [db]} _] {:db (assoc db :n "not a number")}))
     (story/reg-variant :story.malli/bad
       {:events [[:test/set-bad]]
        :play-script [[:dispatch-sync [:rf.assert/path-matches [:n] :int]]]})
@@ -149,8 +149,8 @@
 
 (deftest sub-equals-pass
   (testing ":rf.assert/sub-equals passes when sub returns expected"
-    (rf/reg-event-db :test/init
-      (fn [db _] (assoc db :counter 7)))
+    (rf/reg-event :test/init
+      (fn [{:keys [db]} _] {:db (assoc db :counter 7)}))
     (rf/reg-sub :counter (fn [db _] (:counter db)))
     (story/reg-variant :story.sub/v
       {:events [[:test/init]]
@@ -162,8 +162,8 @@
 
 (deftest sub-equals-fail
   (testing ":rf.assert/sub-equals records the mismatch"
-    (rf/reg-event-db :test/init2
-      (fn [db _] (assoc db :counter 3)))
+    (rf/reg-event :test/init2
+      (fn [{:keys [db]} _] {:db (assoc db :counter 3)}))
     (rf/reg-sub :counter (fn [db _] (:counter db)))
     (story/reg-variant :story.sub/bad
       {:events [[:test/init2]]
@@ -182,7 +182,7 @@
   ;; runtime-db partition the sub belongs to.
   (testing ":rf.assert/sub-equals resolves a runtime-db-projection sub (not nil)"
     ;; Seed a machine snapshot into the runtime-db partition (EP-0001).
-    (rf/reg-event-fx :test/seed-machine-sub
+    (rf/reg-event :test/seed-machine-sub
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/machines :snapshots :traffic-light]
@@ -208,8 +208,8 @@
 
 (deftest dispatched-pass
   (testing ":rf.assert/dispatched? passes when an earlier event in :play-script fired"
-    (rf/reg-event-db :test/click
-      (fn [db _] (assoc db :clicked? true)))
+    (rf/reg-event :test/click
+      (fn [{:keys [db]} _] {:db (assoc db :clicked? true)}))
     (story/reg-variant :story.dispatched/v
       {:events []
        :play-script [[:dispatch-sync [:test/click]]
@@ -237,7 +237,7 @@
   (testing ":rf.assert/state-is passes when machine snapshot matches"
     ;; Seed a tiny machine snapshot manually into the runtime-db partition
     ;; (EP-0001 rf2-vzld77: machine snapshots are durable runtime-db state).
-    (rf/reg-event-fx :test/seed-machine
+    (rf/reg-event :test/seed-machine
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/machines :snapshots :traffic-light]
@@ -251,7 +251,7 @@
 
 (deftest state-is-fail
   (testing ":rf.assert/state-is records the mismatch when state differs"
-    (rf/reg-event-fx :test/seed-machine2
+    (rf/reg-event :test/seed-machine2
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/machines :snapshots :traffic-light]
@@ -297,7 +297,7 @@
 
 (deftest record-not-throw-on-failure
   (testing "a failing assertion never throws; the play sequence continues"
-    (rf/reg-event-db :test/touch (fn [db _] (assoc db :touched true)))
+    (rf/reg-event :test/touch (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
     (story/reg-variant :story.contract/v
       {:events []
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:nope] :unexpected]]
@@ -328,7 +328,7 @@
 
 (deftest assertions-passing-true-on-all-pass
   (testing "passing? returns true when every assertion has :passed? true"
-    (rf/reg-event-db :test/n (fn [db _] (assoc db :n 42)))
+    (rf/reg-event :test/n (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
     (story/reg-variant :story.all-pass/v
       {:events [[:test/n]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 42]]
@@ -341,7 +341,7 @@
 
 (deftest assertions-passing-false-on-any-fail
   (testing "passing? returns false when any assertion failed"
-    (rf/reg-event-db :test/n2 (fn [db _] (assoc db :n 1)))
+    (rf/reg-event :test/n2 (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
     (story/reg-variant :story.any-fail/v
       {:events [[:test/n2]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]
@@ -356,7 +356,7 @@
 
 (deftest record-shape
   (testing "an assertion record carries :assertion :payload :passed? :elapsed-ms :reason"
-    (rf/reg-event-db :test/init3 (fn [db _] (assoc db :x 1)))
+    (rf/reg-event :test/init3 (fn [{:keys [db]} _] {:db (assoc db :x 1)}))
     (story/reg-variant :story.shape/v
       {:events [[:test/init3]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:x] 1]]]})
@@ -375,7 +375,7 @@
 
 (deftest read-assertions-public
   (testing "story/read-assertions returns the live accumulator"
-    (rf/reg-event-db :test/q (fn [db _] (assoc db :q :ok)))
+    (rf/reg-event :test/q (fn [{:keys [db]} _] {:db (assoc db :q :ok)}))
     (story/reg-variant :story.read/v
       {:events [[:test/q]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:q] :ok]]]})
@@ -578,8 +578,8 @@
   (testing ":rf.assert/dispatched? reads the epoch-tape :trigger-event
             projection (the SSOT), matching both a literal vector and a
             bare keyword head — including a re-dispatched (nested) event"
-    (rf/reg-event-fx :ssot/outer (fn [_ _] {:fx [[:dispatch [:ssot/inner 42]]]}))
-    (rf/reg-event-db :ssot/inner (fn [db [_ n]] (assoc db :inner n)))
+    (rf/reg-event :ssot/outer (fn [_ _] {:fx [[:dispatch [:ssot/inner 42]]]}))
+    (rf/reg-event :ssot/inner (fn [{:keys [db]} [_ n]] {:db (assoc db :inner n)}))
     (story/reg-variant :story.ssot/dispatched
       {:events []
        :play-script [[:dispatch-sync [:ssot/outer]]
@@ -717,7 +717,7 @@
   (testing ":rf.assert/effect-emitted reads the epoch-tape :effects projection
             (the SSOT) for a real (non-stubbed) user fx"
     (rf/reg-fx :ssot.fx/real {:platforms #{:client :server}} (fn [_ _] nil))
-    (rf/reg-event-fx :ssot/emit-real (fn [_ _] {:fx [[:ssot.fx/real {:url "x"}]]}))
+    (rf/reg-event :ssot/emit-real (fn [_ _] {:fx [[:ssot.fx/real {:url "x"}]]}))
     (story/reg-variant :story.ssot/effect
       {:events []
        :play-script [[:dispatch-sync [:ssot/emit-real]]
@@ -756,7 +756,7 @@
   (testing ":rf.assert/effect-emitted sees a force-fx-stub'd fx via the
             stub-call log SSOT (the original fx-id, not the rewritten stub id)"
     (rf/reg-fx :ssot.fx/http {:platforms #{:client :server}} (fn [_ _] nil))
-    (rf/reg-event-fx :ssot/login (fn [_ _] {:fx [[:ssot.fx/http {:url "/login"}]]}))
+    (rf/reg-event :ssot/login (fn [_ _] {:fx [[:ssot.fx/http {:url "/login"}]]}))
     (story/reg-variant :story.ssot/stubbed
       {:decorators  [[:rf.story/force-fx-stub :ssot.fx/http {:status :ok}]]
        :events      []

--- a/tools/story/test/re_frame/story_authoring_surface_test.clj
+++ b/tools/story/test/re_frame/story_authoring_surface_test.clj
@@ -224,7 +224,7 @@
   (testing "the author-facing value-form actually intercepts the fx at
             runtime — proves the round-trip from declaration to live
             redirect is unbroken"
-    (rf/reg-event-fx :do/emit-http
+    (rf/reg-event :do/emit-http
       (fn [_ _] {:fx [[:http {:url "/probe"}]]}))
     (story/reg-variant :story.authfx-rt/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok}]]

--- a/tools/story/test/re_frame/story_decorator_chain_test.clj
+++ b/tools/story/test/re_frame/story_decorator_chain_test.clj
@@ -113,15 +113,15 @@
     (story/reg-decorator :centered-pane
       {:kind :hiccup :wrap (fn [body _] [:div.centered body])})
     ;; A :frame-setup decorator whose :init seeds app-db before :events.
-    (rf/reg-event-db :mock/seed
-      (fn [db _] (assoc db :mock-user {:name "alice" :role :admin})))
+    (rf/reg-event :mock/seed
+      (fn [{:keys [db]} _] {:db (assoc db :mock-user {:name "alice" :role :admin})}))
     (story/reg-decorator :seed-user
       {:kind :frame-setup :init [[:mock/seed]]})
     ;; An :fx-override decorator (the registered :rf.story/force-fx-stub
     ;; canonical) — stamps onto :fx-overrides at frame-allocate time.
-    (rf/reg-event-db :record/observed
-      (fn [db _] (assoc db :seen-user (:mock-user db))))
-    (rf/reg-event-fx :emit/track
+    (rf/reg-event :record/observed
+      (fn [{:keys [db]} _] {:db (assoc db :seen-user (:mock-user db))}))
+    (rf/reg-event :emit/track
       (fn [_ _] {:fx [[:analytics {:event :loaded}]]}))
     (story/reg-variant :story.multi-kind/v
       {:decorators [[:centered-pane]
@@ -222,11 +222,11 @@
             A leave B's app-db / :emitted-fx / :assertions / stub log
             untouched. Per spec/002 §Per-variant frame allocation."
     ;; Two :frame-setup decorators each seed a different counter start.
-    (rf/reg-event-db :seed/at-100
-      (fn [db _] (assoc db :counter 100)))
-    (rf/reg-event-db :seed/at-200
-      (fn [db _] (assoc db :counter 200)))
-    (rf/reg-event-fx :inc-and-track
+    (rf/reg-event :seed/at-100
+      (fn [{:keys [db]} _] {:db (assoc db :counter 100)}))
+    (rf/reg-event :seed/at-200
+      (fn [{:keys [db]} _] {:db (assoc db :counter 200)}))
+    (rf/reg-event :inc-and-track
       (fn [{:keys [db]} _]
         {:db (update db :counter inc)
          :fx [[:analytics {:event :inc :from (:counter db)}]]}))
@@ -303,7 +303,7 @@
 (deftest frame-isolation-pair-destroy-one-survives-other
   (testing "destroying frame A leaves frame B's app-db / state intact.
             Per spec/002 §Coexistence + §Per-variant frame allocation."
-    (rf/reg-event-db :ping (fn [db _] (update db :pings (fnil inc 0))))
+    (rf/reg-event :ping (fn [{:keys [db]} _] {:db (update db :pings (fnil inc 0))}))
     (story/reg-variant :story.iso2/A {:events [[:ping]]})
     (story/reg-variant :story.iso2/B {:events [[:ping]]})
     (async/deref-blocking (story/run-variant :story.iso2/A) 5000)

--- a/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
@@ -101,7 +101,7 @@
 
 (deftest http-fx-stub-scenario
   (testing ":http fx is intercepted by force-fx-stub end-to-end"
-    (rf/reg-event-fx :do/http-emit
+    (rf/reg-event :do/http-emit
       (fn [_ _] {:fx [[:http {:url "/api" :method :get}]]}))
     (story/reg-variant :story.fxscen.http/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {:n 1}}]]
@@ -115,7 +115,7 @@
 
 (deftest analytics-fx-stub-scenario
   (testing ":analytics fx is intercepted by force-fx-stub end-to-end"
-    (rf/reg-event-fx :do/analytics-emit
+    (rf/reg-event :do/analytics-emit
       (fn [_ _] {:fx [[:analytics {:event "page-view" :path "/home"}]]}))
     (story/reg-variant :story.fxscen.analytics/v
       {:decorators [[:rf.story/force-fx-stub :analytics {:ack? true}]]
@@ -129,7 +129,7 @@
 
 (deftest websocket-fx-stub-scenario
   (testing ":websocket fx is intercepted by force-fx-stub end-to-end"
-    (rf/reg-event-fx :do/websocket-emit
+    (rf/reg-event :do/websocket-emit
       (fn [_ _] {:fx [[:websocket {:topic "live" :payload {:tick 1}}]]}))
     (story/reg-variant :story.fxscen.websocket/v
       {:decorators [[:rf.story/force-fx-stub :websocket {:connected? true}]]
@@ -143,7 +143,7 @@
 
 (deftest navigation-fx-stub-scenario
   (testing ":navigation fx is intercepted by force-fx-stub end-to-end"
-    (rf/reg-event-fx :do/navigation-emit
+    (rf/reg-event :do/navigation-emit
       (fn [_ _] {:fx [[:navigation {:to "/dashboard" :replace? false}]]}))
     (story/reg-variant :story.fxscen.navigation/v
       {:decorators [[:rf.story/force-fx-stub :navigation {:landed? true}]]
@@ -185,7 +185,7 @@
           ;; loudly via the :events-phase exception projection too.
           (throw (ex-info "real :http fx must NOT run under force-fx-stub"
                           {:payload payload}))))
-      (rf/reg-event-fx :do/http-call
+      (rf/reg-event :do/http-call
         (fn [_ _]
           {:fx [[:http {:url "/should-not-hit-real" :method :get}]]}))
       (story/reg-variant :story.fxoverride/real
@@ -244,14 +244,14 @@
       ;; app-db along [:http-result]. The stub itself just absorbs the
       ;; call; the failure-shape contract is whatever the app under
       ;; test makes of the response.
-      (rf/reg-event-fx :do/http-emit-fail
+      (rf/reg-event :do/http-emit-fail
         (fn [_ _] {:fx [[:http {:url "/api/may-fail"}]]}))
       ;; Record the failure marker into app-db so :rf.assert/path-equals
       ;; can observe it. Mirrors the shape of an :on-failure event a
       ;; library like re-frame-http-fx would dispatch off a failed
       ;; managed-fx response.
-      (rf/reg-event-db :record/failure
-        (fn [db _] (assoc db :http-result failure-payload)))
+      (rf/reg-event :record/failure
+        (fn [{:keys [db]} _] {:db (assoc db :http-result failure-payload)}))
       (story/reg-variant :story.fxfail/v
         {:decorators [[:rf.story/force-fx-stub :http failure-payload]]
          :events     []

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -127,7 +127,7 @@
 
 (deftest force-fx-stub-emits-fx-into-accumulator
   (testing "a stubbed fx emits into the assertion accumulator so :rf.assert/effect-emitted passes"
-    (rf/reg-event-fx :do/http-call
+    (rf/reg-event :do/http-call
       (fn [_ _]
         {:fx [[:http {:url "/test" :method :get}]]}))
     (story/reg-variant :story.fxemit/v
@@ -147,7 +147,7 @@
 
 (deftest force-fx-stub-log-captures-payload
   (testing "the stub fx-handler records the fx payload + response in the per-frame stub-call log"
-    (rf/reg-event-fx :do/http-call2
+    (rf/reg-event :do/http-call2
       (fn [_ _]
         {:fx [[:http {:url "/api" :method :post}]]}))
     (story/reg-variant :story.fxlog/v
@@ -168,10 +168,10 @@
 
 (deftest force-fx-stub-log-is-per-frame
   (testing "two variants emitting the same fx id keep stub logs and effect assertions isolated by frame"
-    (rf/reg-event-fx :do/http-a
+    (rf/reg-event :do/http-a
       (fn [_ _]
         {:fx [[:http {:url "/a"}]]}))
-    (rf/reg-event-fx :do/http-b
+    (rf/reg-event :do/http-b
       (fn [_ _]
         {:fx [[:http {:url "/b"}]]}))
     (story/reg-variant :story.fxisolation/a

--- a/tools/story/test/re_frame/story_loaders_teardown_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_loaders_teardown_cljs_test.cljs
@@ -98,8 +98,8 @@
 (deftest loaders-teardown-events-fire-on-destroy
   (testing ":loaders-teardown events fire exactly once on destroy-variant!"
     (let [fired (atom [])]
-      (rf/reg-event-db :ws/open  (fn [db _] (assoc db :ws? :open)))
-      (rf/reg-event-db :ws/close (fn [db _] (swap! fired conj :ws/close) db))
+      (rf/reg-event :ws/open  (fn [{:keys [db]} _] {:db (assoc db :ws? :open)}))
+      (rf/reg-event :ws/close (fn [{:keys [db]} _] (swap! fired conj :ws/close) {:db db}))
       (story/reg-variant :story.lt.fires/v
         {:loaders          [[:ws/open]]
          :loaders-teardown [[:ws/close]]
@@ -120,9 +120,9 @@
   (testing "within `:loaders-teardown` events fire in DECLARED order —
             symmetric with `:loaders`"
     (let [fired (atom [])]
-      (rf/reg-event-db :step/one   (fn [db _] (swap! fired conj :one) db))
-      (rf/reg-event-db :step/two   (fn [db _] (swap! fired conj :two) db))
-      (rf/reg-event-db :step/three (fn [db _] (swap! fired conj :three) db))
+      (rf/reg-event :step/one   (fn [{:keys [db]} _] (swap! fired conj :one) {:db db}))
+      (rf/reg-event :step/two   (fn [{:keys [db]} _] (swap! fired conj :two) {:db db}))
+      (rf/reg-event :step/three (fn [{:keys [db]} _] (swap! fired conj :three) {:db db}))
       (story/reg-variant :story.lt.order/v
         {:loaders-teardown [[:step/one] [:step/two] [:step/three]]
          :events           []})
@@ -148,11 +148,11 @@
             wider (decorator-installed) cleanup. Per 002-Runtime.md
             §Loader teardown contract step ordering."
     (let [fired (atom [])]
-      (rf/reg-event-db :dec/teardown
-        (fn [db _] (swap! fired conj :decorator) db))
-      (rf/reg-event-db :dec/init    (fn [db _] db))
-      (rf/reg-event-db :lt/cleanup
-        (fn [db _] (swap! fired conj :loaders-teardown) db))
+      (rf/reg-event :dec/teardown
+        (fn [{:keys [db]} _] (swap! fired conj :decorator) {:db db}))
+      (rf/reg-event :dec/init    (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :lt/cleanup
+        (fn [{:keys [db]} _] (swap! fired conj :loaders-teardown) {:db db}))
       (story/reg-decorator :outer-dec
         {:kind     :frame-setup
          :init     [[:dec/init]]
@@ -179,7 +179,7 @@
   (testing "a `:loaders-teardown` event that throws is caught —
             destroy-frame! still runs to completion. Walk never aborts
             (002-Runtime.md §Loader teardown contract)."
-    (rf/reg-event-db :boom/cleanup
+    (rf/reg-event :boom/cleanup
       (fn [_ _] (throw (ex-info "loader-teardown boom" {:why :test}))))
     (story/reg-variant :story.lt.boom/v
       {:loaders-teardown [[:boom/cleanup]]
@@ -201,12 +201,12 @@
             subsequent events in the vector — the walk continues
             (symmetric with the `:teardown` decorator walk)"
     (let [fired (atom [])]
-      (rf/reg-event-db :step/before
-        (fn [db _] (swap! fired conj :before) db))
-      (rf/reg-event-db :step/boom
+      (rf/reg-event :step/before
+        (fn [{:keys [db]} _] (swap! fired conj :before) {:db db}))
+      (rf/reg-event :step/boom
         (fn [_ _] (throw (ex-info "boom" {}))))
-      (rf/reg-event-db :step/after
-        (fn [db _] (swap! fired conj :after) db))
+      (rf/reg-event :step/after
+        (fn [{:keys [db]} _] (swap! fired conj :after) {:db db}))
       (story/reg-variant :story.lt.continue/v
         {:loaders-teardown [[:step/before] [:step/boom] [:step/after]]
          :events           []})
@@ -232,13 +232,13 @@
             LAST (after `:loaders-teardown`) — by then the assertion
             record has already landed."
     (let [captured (atom nil)]
-      (rf/reg-event-db :boom/cleanup
+      (rf/reg-event :boom/cleanup
         (fn [_ _] (throw (ex-info "lt boom" {:why :test}))))
-      (rf/reg-event-db ::probe-init  (fn [db _] db))
-      (rf/reg-event-db ::probe-snapshot
-        (fn [db _]
+      (rf/reg-event ::probe-init  (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event ::probe-snapshot
+        (fn [{:keys [db]} _]
           (reset! captured (:rf.story/assertions db))
-          db))
+          {:db db}))
       (story/reg-decorator :lt-probe
         {:kind     :frame-setup
          :init     [[::probe-init]]
@@ -278,8 +278,8 @@
 (deftest variant-without-loaders-teardown-still-tears-down
   (testing "a variant declaring no `:loaders-teardown` slot still
             tears down cleanly — destroy! is a no-op for the new step"
-    (rf/reg-event-db :seed/init
-      (fn [db _] (assoc db :seeded? true)))
+    (rf/reg-event :seed/init
+      (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
     (story/reg-variant :story.lt.none/v
       {:events [[:seed/init]]})
     (let [p (story/run-variant :story.lt.none/v)]

--- a/tools/story/test/re_frame/story_mcp_surface_test.clj
+++ b/tools/story/test/re_frame/story_mcp_surface_test.clj
@@ -129,8 +129,8 @@
   (testing "spec/002 §run-variant + spec/006 §render-story: the result
             map carries :frame :app-db :assertions :elapsed-ms
             :snapshot :decorators :errors"
-    (rf/reg-event-db :mcp/seed
-      (fn [db [_ n]] (assoc db :n n)))
+    (rf/reg-event :mcp/seed
+      (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
     (story/reg-variant :story.mcp.run/probe
       {:events [[:mcp/seed 42]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 42]]]})
@@ -184,8 +184,8 @@
             registration), run-variant (allocate frame + seed app-db),
             then dispatch-sync with {:frame ...} — the agent observes
             the dispatch's effect on the frame's app-db"
-    (rf/reg-event-db :mcp.dispatch/set
-      (fn [db [_ v]] (assoc db :payload v)))
+    (rf/reg-event :mcp.dispatch/set
+      (fn [{:keys [db]} [_ v]] {:db (assoc db :payload v)}))
     ;; MCP write path: programmatic registration (no &form meta).
     (story/reg-variant* :story.mcp.dispatch/probe
       {:events []
@@ -211,8 +211,8 @@
   (testing "the MCP dispatch tool can fire a sequence of events into
             a single variant frame; each dispatch updates the frame's
             app-db in order"
-    (rf/reg-event-db :mcp.dispatch/push
-      (fn [db [_ v]] (update db :log (fnil conj []) v)))
+    (rf/reg-event :mcp.dispatch/push
+      (fn [{:keys [db]} [_ v]] {:db (update db :log (fnil conj []) v)}))
     (story/reg-variant* :story.mcp.dispatch.seq/probe {:events []})
     (story-async/deref-blocking
       (story/run-variant :story.mcp.dispatch.seq/probe) 5000)

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -62,9 +62,9 @@
 (deftest execute-play-dispatches-in-order
   (testing "play events dispatch in declared order"
     (let [order (atom [])]
-      (rf/reg-event-db :step/a (fn [db _] (swap! order conj :a) db))
-      (rf/reg-event-db :step/b (fn [db _] (swap! order conj :b) db))
-      (rf/reg-event-db :step/c (fn [db _] (swap! order conj :c) db))
+      (rf/reg-event :step/a (fn [{:keys [db]} _] (swap! order conj :a) {:db db}))
+      (rf/reg-event :step/b (fn [{:keys [db]} _] (swap! order conj :b) {:db db}))
+      (rf/reg-event :step/c (fn [{:keys [db]} _] (swap! order conj :c) {:db db}))
       (story/reg-variant :story.order/v
         {:events []
          :play-script [[:dispatch-sync [:step/a]]
@@ -76,8 +76,8 @@
 
 (deftest execute-play-mixes-dispatches-and-assertions
   (testing "mixed sequence of regular events + :rf.assert/* events"
-    (rf/reg-event-db :counter/inc
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.mix/v
       {:events []
        :play-script [[:dispatch-sync [:counter/inc]]
@@ -94,7 +94,7 @@
 
 (deftest execute-play-exception-records-phase-4
   (testing "an exception in a play event is captured + the script keeps walking"
-    (rf/reg-event-db :boom/now
+    (rf/reg-event :boom/now
       (fn [_ _] (throw (ex-info "boom" {:cause :test}))))
     (story/reg-variant :story.boom/v
       {:events []
@@ -125,7 +125,7 @@
 
 (deftest accumulators-reset-per-run
   (testing "trace-bus accumulators reset at the start of each play run"
-    (rf/reg-event-db :do/work (fn [db _] (assoc db :did? true)))
+    (rf/reg-event :do/work (fn [{:keys [db]} _] {:db (assoc db :did? true)}))
     (story/reg-variant :story.reset/v
       {:events []
        :play-script [[:dispatch-sync [:do/work]]
@@ -148,7 +148,7 @@
             FAILS rather than vacuously passing on every variant"
     ;; A plain event that returns {:db ...} — emits the framework :db fx
     ;; but no user fx-id.
-    (rf/reg-event-db :ee/touch (fn [db _] (assoc db :touched? true)))
+    (rf/reg-event :ee/touch (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
     (story/reg-variant :story.ee/db
       {:events []
        :play-script [[:dispatch-sync [:ee/touch]]
@@ -187,8 +187,8 @@
   (testing "begin-stepper! + step-once! drives the play one STEP at a time
             (rf2-ee38b.3: step-once! returns the executed STEP, not the
             bare event vector)"
-    (rf/reg-event-db :step/one (fn [db _] (assoc db :one? true)))
-    (rf/reg-event-db :step/two (fn [db _] (assoc db :two? true)))
+    (rf/reg-event :step/one (fn [{:keys [db]} _] {:db (assoc db :one? true)}))
+    (rf/reg-event :step/two (fn [{:keys [db]} _] {:db (assoc db :two? true)}))
     (story/reg-variant :story.stepper/v
       {:events []
        :play-script [[:dispatch-sync [:step/one]]
@@ -222,7 +222,7 @@
             rewritten to the canonical [:assert assertion-atom] checkpoint,
             so the recorded step type is :assert and the slot record carries
             the canonical :rf.assert/path-equals (no synthetic :rf.assert/db)."
-    (rf/reg-event-db :st/set-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event :st/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
     (story/reg-variant :story.stepper/full
       {:events []
        :play-script {:auto-run? false
@@ -301,7 +301,7 @@
 (deftest stepper-rewind-still-rewinds-an-active-session
   (testing "the guard does not break the real path — rewind on an ACTIVE
             session still resets the cursor (every step back to :remaining)"
-    (rf/reg-event-db :rw/one (fn [db _] (assoc db :one? true)))
+    (rf/reg-event :rw/one (fn [{:keys [db]} _] {:db (assoc db :one? true)}))
     (story/reg-variant :story.stepper/rw
       {:events []
        :play-script [[:dispatch-sync [:rw/one]]
@@ -326,13 +326,13 @@
 
 (deftest loaders-complete-when-registered-event
   (testing "registered event id form — handler sets :rf.story/loaders-complete?"
-    (rf/reg-event-db :my.fixture/ready?
-      (fn [db _]
+    (rf/reg-event :my.fixture/ready?
+      (fn [{:keys [db]} _]
         ;; The predicate event sets the completion slot to a custom
         ;; condition. Here: complete iff :loaded? is true.
-        (assoc db :rf.story/loaders-complete? (boolean (:loaded? db)))))
-    (rf/reg-event-db :test/mark-loaded
-      (fn [db _] (assoc db :loaded? true)))
+        {:db (assoc db :rf.story/loaders-complete? (boolean (:loaded? db)))}))
+    (rf/reg-event :test/mark-loaded
+      (fn [{:keys [db]} _] {:db (assoc db :loaded? true)}))
     (story/reg-variant :story.loaders/registered
       {:loaders                [[:test/mark-loaded]]
        :loaders-complete-when  :my.fixture/ready?
@@ -344,8 +344,8 @@
 
 (deftest loaders-complete-when-vector
   (testing "vector-of-events form — complete when ALL listed events fired"
-    (rf/reg-event-db :test/load-a (fn [db _] (assoc db :a? true)))
-    (rf/reg-event-db :test/load-b (fn [db _] (assoc db :b? true)))
+    (rf/reg-event :test/load-a (fn [{:keys [db]} _] {:db (assoc db :a? true)}))
+    (rf/reg-event :test/load-b (fn [{:keys [db]} _] {:db (assoc db :b? true)}))
     (story/reg-variant :story.loaders/vector
       {:loaders                [[:test/load-a] [:test/load-b]]
        :loaders-complete-when  [[:test/load-a] [:test/load-b]]
@@ -369,8 +369,8 @@
   ;; `:loading`. This test pins that lifecycle to `:ready` and
   ;; verifies the accumulator was populated with the loader event.
   (testing "the loaders-complete-when vector form matches loader-phase dispatches"
-    (rf/reg-event-db :fixture/loaded
-      (fn [db _] (assoc db :fixture-loaded? true)))
+    (rf/reg-event :fixture/loaded
+      (fn [{:keys [db]} _] {:db (assoc db :fixture-loaded? true)}))
     (story/reg-variant :story.v2g9/loader-vector
       {:loaders               [[:fixture/loaded]]
        :loaders-complete-when [[:fixture/loaded]]
@@ -426,4 +426,4 @@
 
 ;; Helper for the fn-form test above. Registered at top-level so the
 ;; dispatch in the test body can find it.
-(rf/reg-event-db ::set-done (fn [db _] (assoc db :done? true)))
+(rf/reg-event ::set-done (fn [{:keys [db]} _] {:db (assoc db :done? true)}))

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -520,10 +520,10 @@
 (deftest trace-listener-captures-dispatch-into-recording
   (testing "with a recording in flight, a dispatch against the target frame is captured"
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc
-      (fn [db _] (update db :n (fnil inc 0))))
-    (rf/reg-event-db :counter/dec
-      (fn [db _] (update db :n (fnil dec 0))))
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    (rf/reg-event :counter/dec
+      (fn [{:keys [db]} _] {:db (update db :n (fnil dec 0))}))
     (story/reg-variant :story.recorder/v {})
     ;; Allocate the variant frame + install the listener.
     (async/deref-blocking (story/run-variant :story.recorder/v) 5000)
@@ -554,8 +554,8 @@
 (deftest trace-listener-ignores-cross-frame-traffic
   (testing "dispatches to a non-target frame don't appear in the recording"
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.recorder/target {})
     (story/reg-variant :story.recorder/other  {})
     (async/deref-blocking (story/run-variant :story.recorder/target) 5000)
@@ -579,8 +579,8 @@
 (deftest trace-listener-skips-assertion-events
   (testing "with a recording active, :rf.assert/* dispatches don't leak into the captured :script body"
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.recorder/v {})
     (async/deref-blocking (story/run-variant :story.recorder/v) 5000)
     (recorder/install-trace-listener!)
@@ -604,12 +604,12 @@
             so sensitivity now flows via the `redact-interceptor`
             interceptor (or schema-marked paths)."
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     ;; Use `redact-interceptor` so the trace surface sees the redacted payload.
-    (rf/reg-event-db :auth/login
+    (rf/reg-event :auth/login
       {:interceptors [(privacy/redact-interceptor [[:password] [:totp]])]}
-      (fn [db _] db))
+      (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.recorder/sens-end-to-end {})
     (async/deref-blocking (story/run-variant :story.recorder/sens-end-to-end) 5000)
     (recorder/install-trace-listener!)
@@ -636,10 +636,10 @@
 (deftest end-to-end-recording-to-snippet
   (testing "the full record→stop→gen-play-snippet cycle produces a valid public :script body"
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc
-      (fn [db _] (update db :n (fnil inc 0))))
-    (rf/reg-event-db :counter/by
-      (fn [db [_ n]] (update db :n (fnil + 0) n)))
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    (rf/reg-event :counter/by
+      (fn [{:keys [db]} [_ n]] {:db (update db :n (fnil + 0) n)}))
     (story/reg-variant :story.recorder/source {})
     (async/deref-blocking (story/run-variant :story.recorder/source) 5000)
     (recorder/install-trace-listener!)
@@ -915,7 +915,7 @@
             captures NO :rf.realm/id and its play body replays unchanged —
             the absent-key round-trip (zero ceremony)"
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.realm/default {})
     (async/deref-blocking (story/run-variant :story.realm/default) 5000)
     (recorder/install-trace-listener!)
@@ -944,7 +944,7 @@
             :rf.realm/id stamp, and the stamp rides through to the replayable
             play body so replay targets the same realm"
     (reset-rf-state!)
-    (rf/reg-event-db :counter/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.realm/tenant {})
     (async/deref-blocking (story/run-variant :story.realm/tenant) 5000)
     ;; Simulate the frame living in a constructed realm (core seats no other

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -68,8 +68,8 @@
 
 (deftest cljs-run-variant-returns-promise
   (testing "run-variant returns a js/Promise"
-    (rf/reg-event-db :test/inc
-      (fn [db _] (update db :counter (fnil inc 0))))
+    (rf/reg-event :test/inc
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
     (story/reg-variant :story.cljs.run/v
       {:events [[:test/inc] [:test/inc]]})
     (let [p (story/run-variant :story.cljs.run/v)]
@@ -101,8 +101,8 @@
             CLJS too. Drives the regression's repro shape: a variant
             body declaring only `:events`, with no `:loaders` / no
             `:frame-setup` decorators / no `:loaders-complete-when`."
-    (rf/reg-event-db :test.eo/seed
-      (fn [db _] (assoc db :seeded? true)))
+    (rf/reg-event :test.eo/seed
+      (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
     (story/reg-variant :story.cljs.eo/v
       {:events [[:test.eo/seed]]})
     (let [p (story/run-variant :story.cljs.eo/v)]
@@ -156,8 +156,8 @@
   (testing "rf2-9x5fm — tearing the variant frame down DURING a play's
             `:wait` yield must still resolve the run-variant promise; the
             aborted run loop settles its continuation instead of hanging"
-    (rf/reg-event-db :test.hang/touch
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :test.hang/touch
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.cljs.hang/torn-down
       {:events      []
        :play-script {:script [[:dispatch-sync [:test.hang/touch]]
@@ -187,8 +187,8 @@
             (token swap, rf2-ftow6) DURING a play's `:wait` yield must still
             resolve the original run-variant promise; the stale loop settles
             its own continuation rather than stranding the chain"
-    (rf/reg-event-db :test.hang2/touch
-      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :test.hang2/touch
+      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.cljs.hang/token-swap
       {:events      []
        :play-script {:auto-run? false

--- a/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
+++ b/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
@@ -63,7 +63,7 @@
   ;; once per test so the loader-cascade path takes the classical
   ;; four-phase route rather than the events-only fast-path
   ;; introduced by rf2-043cm.
-  (rf/reg-event-db :test/noop (fn [db _] db))
+  (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
   (t))
 
 (use-fixtures :each reset-all)
@@ -168,7 +168,7 @@
 (deftest destroy-variant-removes-from-variant-frames
   (testing "after destroy-variant! the variant id no longer appears in
             (story/variant-frames) — the registry is in step with the runtime"
-    (rf/reg-event-db :test/nothing (fn [db _] db))
+    (rf/reg-event :test/nothing (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.destroy.list/v
       {:events [[:test/nothing]]})
     (let [_ (async/deref-blocking (story/run-variant :story.destroy.list/v) 5000)]
@@ -180,7 +180,7 @@
 
 (deftest destroy-variant-idempotent-on-running-frame
   (testing "calling destroy-variant! twice in a row does not throw"
-    (rf/reg-event-db :test/nothing (fn [db _] db))
+    (rf/reg-event :test/nothing (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.destroy.twice/v
       {:events [[:test/nothing]]})
     (async/deref-blocking (story/run-variant :story.destroy.twice/v) 5000)
@@ -196,7 +196,7 @@
 (deftest run-then-destroy-then-run-cycles-cleanly
   (testing "destroy + re-run leaves the lifecycle in :ready — the Stage 4
             UI shell relies on this for the 'reset' button affordance"
-    (rf/reg-event-db :test/inc (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event :test/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (story/reg-variant :story.cycle/v
       {:events [[:test/inc]]})
     ;; First run.

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -603,7 +603,7 @@
     ;; The events-only fast-path (`:pre-mount → :ready`) is exercised
     ;; separately by `lifecycle-events-only-fast-path-to-ready` /
     ;; `events-only-variant-classifier` below.
-    (rf/reg-event-db :test/noop (fn [db _] db))
+    (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.life/v {:events [] :loaders [[:test/noop]]})
     (let [r       (story/resolve-decorators :story.life/v)]
       (frames/allocate! :story.life/v r)
@@ -618,7 +618,7 @@
   (testing "the discrete state is mirrored to [:rf.story/lifecycle]"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
     ;; the test reaches `:loading`.
-    (rf/reg-event-db :test/noop (fn [db _] db))
+    (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.mirror/v {:loaders [[:test/noop]]})
     (let [r (story/resolve-decorators :story.mirror/v)]
       (frames/allocate! :story.mirror/v r)
@@ -631,7 +631,7 @@
   (testing "watch-variant callbacks see every transition"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
     ;; watchers observe the full transition cascade.
-    (rf/reg-event-db :test/noop (fn [db _] db))
+    (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.watch/v {:loaders [[:test/noop]]})
     (let [transitions (atom [])
           unsubscribe (story/watch-variant
@@ -734,7 +734,7 @@
   (testing "rf2-043cm — `run-variant` against an events-only body
             resolves to a result whose :lifecycle is :ready and whose
             :assertions vector is empty (no loader-incomplete projection)"
-    (rf/reg-event-db :test/seed (fn [db _] (assoc db :seeded? true)))
+    (rf/reg-event :test/seed (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
     (story/reg-variant :story.eo.run/v {:events [[:test/seed]]})
     (let [r (async/deref-blocking (story/run-variant :story.eo.run/v) 5000)]
       (is (= :ready (:lifecycle r))
@@ -768,8 +768,8 @@
 
 (deftest run-variant-basic
   (testing "run-variant returns a future of the result map"
-    (rf/reg-event-db :test/inc
-      (fn [db _] (update db :counter (fnil inc 0))))
+    (rf/reg-event :test/inc
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
     (story/reg-variant :story.run/v
       {:events [[:test/inc] [:test/inc]]})
     (let [fut (story/run-variant :story.run/v)
@@ -784,11 +784,11 @@
 
 (deftest run-variant-with-loaders-and-events
   (testing "run-variant drains loaders before events"
-    (rf/reg-event-db :test/load
-      (fn [db _] (assoc db :loaded? true)))
-    (rf/reg-event-db :test/use
-      (fn [db _]
-        (assoc db :used-loaded? (boolean (:loaded? db)))))
+    (rf/reg-event :test/load
+      (fn [{:keys [db]} _] {:db (assoc db :loaded? true)}))
+    (rf/reg-event :test/use
+      (fn [{:keys [db]} _]
+        {:db (assoc db :used-loaded? (boolean (:loaded? db)))}))
     (story/reg-variant :story.flow/v
       {:loaders [[:test/load]]
        :events  [[:test/use]]})
@@ -800,13 +800,13 @@
 
 (deftest run-variant-blocks-events-when-loaders-incomplete
   (testing "a false loaders-complete-when predicate keeps the variant in :loading and skips events/play"
-    (rf/reg-event-db :test/not-ready?
-      (fn [db _]
-        (assoc db :rf.story/loaders-complete? false)))
-    (rf/reg-event-db :test/load-but-not-ready
-      (fn [db _] (assoc db :loaded? true)))
-    (rf/reg-event-db :test/should-not-run
-      (fn [db _] (assoc db :events-ran? true)))
+    (rf/reg-event :test/not-ready?
+      (fn [{:keys [db]} _]
+        {:db (assoc db :rf.story/loaders-complete? false)}))
+    (rf/reg-event :test/load-but-not-ready
+      (fn [{:keys [db]} _] {:db (assoc db :loaded? true)}))
+    (rf/reg-event :test/should-not-run
+      (fn [{:keys [db]} _] {:db (assoc db :events-ran? true)}))
     (story/reg-variant :story.flow/blocked
       {:loaders               [[:test/load-but-not-ready]]
        :loaders-complete-when :test/not-ready?
@@ -831,10 +831,10 @@
 
 (deftest run-variant-frame-setup-decorator
   (testing ":frame-setup decorators fire :init events before loaders"
-    (rf/reg-event-db :test/mock-init
-      (fn [db _] (assoc db :mock {:user "alice"})))
-    (rf/reg-event-db :test/observe
-      (fn [db _] (assoc db :observed-mock (:mock db))))
+    (rf/reg-event :test/mock-init
+      (fn [{:keys [db]} _] {:db (assoc db :mock {:user "alice"})}))
+    (rf/reg-event :test/observe
+      (fn [{:keys [db]} _] {:db (assoc db :observed-mock (:mock db))}))
     (story/reg-decorator :mock-frame
       {:kind :frame-setup
        :init [[:test/mock-init]]})
@@ -855,8 +855,8 @@
 
 (deftest reset-variant-tears-down-then-runs-fresh
   (testing "reset-variant produces a fresh app-db"
-    (rf/reg-event-db :test/inc
-      (fn [db _] (update db :counter (fnil inc 0))))
+    (rf/reg-event :test/inc
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
     (story/reg-variant :story.reset/v
       {:events [[:test/inc]]})
     (let [r1 (async/deref-blocking (story/run-variant :story.reset/v) 5000)
@@ -882,10 +882,10 @@
 (deftest run-variant-public-setup-and-script-vocabulary
   (testing "a variant authored with the PUBLIC :setup / :script keys runs
             through the plan-routed runtime (setup applied, script asserts)"
-    (rf/reg-event-db :test/seed
-      (fn [db _] (assoc db :seeded? true :count 0)))
-    (rf/reg-event-db :test/bump
-      (fn [db _] (update db :count inc)))
+    (rf/reg-event :test/seed
+      (fn [{:keys [db]} _] {:db (assoc db :seeded? true :count 0)}))
+    (rf/reg-event :test/bump
+      (fn [{:keys [db]} _] {:db (update db :count inc)}))
     (story/reg-variant :story.public/v
       {:setup  [[:test/seed]]
        :script [[:dispatch [:test/bump]]
@@ -909,10 +909,10 @@
   (testing "a :compose fragment's :setup is executed in phase 2 — the plan
             compiler resolves :compose, so fragment preconditions land in
             the frame (the pre-migration runtime ignored :compose for setup)"
-    (rf/reg-event-db :test/frag-seed
-      (fn [db _] (assoc db :from-fragment :alice)))
-    (rf/reg-event-db :test/observe-frag
-      (fn [db _] (assoc db :observed (:from-fragment db))))
+    (rf/reg-event :test/frag-seed
+      (fn [{:keys [db]} _] {:db (assoc db :from-fragment :alice)}))
+    (rf/reg-event :test/observe-frag
+      (fn [{:keys [db]} _] {:db (assoc db :observed (:from-fragment db))}))
     (story/reg-fragment :fragment.test/seeded
       {:setup [[:test/frag-seed]]})
     (story/reg-variant :story.compose/v
@@ -931,8 +931,8 @@
   (testing "a variant's named :plays are driven as named scripts from the
             plan's [:world :scripts] (auto-run? default: first true, rest
             false — only the first auto-play executes on run)"
-    (rf/reg-event-db :test/init-n
-      (fn [db [_ n]] (assoc db :n n)))
+    (rf/reg-event :test/init-n
+      (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
     (story/reg-variant :story.plays/v
       {:plays [{:name      "happy"
                 :script    [[:dispatch-sync [:test/init-n 3]]
@@ -968,8 +968,8 @@
             terminal :assertions block (no in-script [:assert], no :script)
             now AUTO-RUNS the terminal assertion against the FINAL settled
             state and produces a :pass verdict (rf2-nyjoa)"
-    (rf/reg-event-db :test/seed-state
-      (fn [db _] (assoc-in db [:checkout :state] :submitted)))
+    (rf/reg-event :test/seed-state
+      (fn [{:keys [db]} _] {:db (assoc-in db [:checkout :state] :submitted)}))
     (story/reg-variant :story.nyjoa/pass
       {:setup      [[:test/seed-state]]
        :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
@@ -990,8 +990,8 @@
 (deftest run-variant-terminal-assertions-only-fail
   (testing "a FAILING terminal assertion (no in-script [:assert]) flips the
             unified verdict to :fail (rf2-nyjoa)"
-    (rf/reg-event-db :test/seed-other
-      (fn [db _] (assoc-in db [:checkout :state] :draft)))
+    (rf/reg-event :test/seed-other
+      (fn [{:keys [db]} _] {:db (assoc-in db [:checkout :state] :draft)}))
     (story/reg-variant :story.nyjoa/fail
       {:setup      [[:test/seed-other]]
        :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
@@ -1011,7 +1011,7 @@
   (testing "a terminal assertion evaluates the FINAL settled state — it sees
             the state AFTER the script's dispatches commit, not the
             pre-script state (rf2-nyjoa: terminal = check the FINAL state)"
-    (rf/reg-event-db :test/set-n (fn [db [_ n]] (assoc db :n n)))
+    (rf/reg-event :test/set-n (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
     (story/reg-variant :story.nyjoa/after-script
       {:script     [[:dispatch [:test/set-n 7]]]
        :assertions [[:rf.assert/path-equals [:n] 7]]})
@@ -1030,7 +1030,7 @@
             against the epoch tape. Pinned alongside a handler-backed
             terminal assertion in the same block so the split is exercised
             (rf2-nyjoa critical guard)."
-    (rf/reg-event-db :test/seed-ok (fn [db _] (assoc db :ok? true)))
+    (rf/reg-event :test/seed-ok (fn [{:keys [db]} _] {:db (assoc db :ok? true)}))
     (story/reg-variant :story.nyjoa/mixed
       {:setup      [[:test/seed-ok]]
        :assertions [[:rf.assert/path-equals [:ok?] true]
@@ -1054,7 +1054,7 @@
   (testing "a plan-construction failure (an [:assert …] checkpoint placed
             in :setup) surfaces through the run-error projection rather
             than crashing the orchestrator"
-    (rf/reg-event-db :test/noop (fn [db _] db))
+    (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.planerr/v
       {:setup [[:dispatch [:test/noop]]
                [:assert [:rf.assert/path-equals [:x] 1]]]})
@@ -1078,7 +1078,7 @@
             :setup and lifts :required-runner to :dom/:cljs-reactive, but the
             headless runner cannot honour that boundary — so it fails closed
             (:cannot-run shape) instead of vanishing the precondition."
-    (rf/reg-event-db :test/seed-z (fn [db _] (assoc db :seeded? true)))
+    (rf/reg-event :test/seed-z (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
     (doseq [[vid bad-step] [[:story.zaiwl/wait  [:wait 100]]
                             [:story.zaiwl/click [:click "[data-test=open]"]]]]
       (story/reg-variant vid
@@ -1106,8 +1106,8 @@
             vector (coerced to [:dispatch …]) — still run cleanly through
             phase 2 (rf2-zaiwl positive control: the refusal targets ONLY
             non-dispatch steps)"
-    (rf/reg-event-db :test/seed-a (fn [db _] (assoc db :a true)))
-    (rf/reg-event-db :test/seed-b (fn [db _] (assoc db :b true)))
+    (rf/reg-event :test/seed-a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
+    (rf/reg-event :test/seed-b (fn [{:keys [db]} _] {:db (assoc db :b true)}))
     (story/reg-variant :story.zaiwl/ok
       {:setup [[:dispatch [:test/seed-a]]   ; tagged dispatch
                [:test/seed-b]]})            ; bare event vector → [:dispatch …]
@@ -1220,7 +1220,7 @@
 
 (deftest event-throwing-projects-as-assertion
   (testing "a thrown exception during :events lands in :assertions"
-    (rf/reg-event-db :test/boom
+    (rf/reg-event :test/boom
       (fn [_ _] (throw (ex-info "bang" {:why :test}))))
     (story/reg-variant :story.err/v
       {:events [[:test/boom]]})
@@ -1239,7 +1239,7 @@
             key records :rf/redacted in :error :data, NOT the raw secret; the
             :error :message survives verbatim (rf2-294yq5.5). JVM gate (the
             CLJS twin lives in error_projection_redaction_cljs_test.cljs)"
-    (rf/reg-event-db :auth/boom-jvm
+    (rf/reg-event :auth/boom-jvm
       (fn [_ _]
         (throw (ex-info "Invalid credentials"
                         {:token  "BEARER-secret-12345"
@@ -1267,7 +1267,7 @@
 (deftest exception-ex-data-non-sensitive-passes-through-jvm
   (testing "with NO marks, captured ex-data passes through unredacted —
             frame-scoped elision only redacts marked paths (rf2-294yq5.5)"
-    (rf/reg-event-db :plain/boom-jvm
+    (rf/reg-event :plain/boom-jvm
       (fn [_ _] (throw (ex-info "boom" {:detail "not-secret"}))))
     (story/reg-variant :story.err-plain-jvm/v
       {:events [[:plain/boom-jvm]]})
@@ -1284,7 +1284,7 @@
             :phase-0-setup :rf.error/exception assertion — NOT a silent
             :pass / :ready against a frame missing its declared
             preconditions (rf2-294yq5.1)"
-    (rf/reg-event-db :test/setup-boom
+    (rf/reg-event :test/setup-boom
       (fn [_ _] (throw (ex-info "setup blew up" {:why :setup}))))
     (story/reg-decorator :boom-setup
       {:kind :frame-setup
@@ -1316,7 +1316,7 @@
             old handler-exception-only capture was a false green"
     (rf/reg-cofx :test/boom-cofx
       (fn [] (throw (ex-info "cofx blew up" {:why :cofx}))))
-    (rf/reg-event-fx :test/uses-boom-cofx
+    (rf/reg-event :test/uses-boom-cofx
       {:rf.cofx/requires [:test/boom-cofx]}
       (fn [_ _] {}))
     (story/reg-variant :story.cofx-boom/v
@@ -1340,9 +1340,9 @@
     (let [boom-icpt (rf/->interceptor
                       :id :test/boom-icpt
                       :before (fn [_ctx] (throw (ex-info "icpt blew up" {:why :icpt}))))]
-      (rf/reg-event-db :test/uses-boom-icpt
+      (rf/reg-event :test/uses-boom-icpt
         {:interceptors [boom-icpt]}
-        (fn [db _] db))
+        (fn [{:keys [db]} _] {:db db}))
       (story/reg-variant :story.icpt-boom/v
         {:events [[:test/uses-boom-icpt]]})
       (let [r    (async/deref-blocking (story/run-variant :story.icpt-boom/v) 5000)
@@ -1363,8 +1363,8 @@
   (testing "two consecutive run-variant calls on the same id produce the
             SAME fresh app-db — run-variant does not reuse the prior frame
             (rf2-294yq5.3)"
-    (rf/reg-event-db :test/inc-counter
-      (fn [db _] (update db :counter (fnil inc 0))))
+    (rf/reg-event :test/inc-counter
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
     (story/reg-variant :story.fresh/v
       {:events [[:test/inc-counter]]})
     (let [r1 (async/deref-blocking (story/run-variant :story.fresh/v) 5000)
@@ -1379,8 +1379,8 @@
   (testing "a LOADER variant reruns its loaders on the second run-variant —
             the prior :ready frame is destroyed, so run-loaders! does not
             short-circuit (rf2-294yq5.3)"
-    (rf/reg-event-db :test/load-mark
-      (fn [db _] (update db :loads (fnil inc 0))))
+    (rf/reg-event :test/load-mark
+      (fn [{:keys [db]} _] {:db (update db :loads (fnil inc 0))}))
     (story/reg-variant :story.fresh-loader/v
       {:loaders [[:test/load-mark]]})
     (let [r1 (async/deref-blocking (story/run-variant :story.fresh-loader/v) 5000)

--- a/tools/story/test/re_frame/story_teardown_test.clj
+++ b/tools/story/test/re_frame/story_teardown_test.clj
@@ -102,13 +102,13 @@
   (testing ":teardown events dispatched at destroy reach the variant
             frame's event handlers"
     (let [fired (atom [])]
-      (rf/reg-event-db :feed/close-socket
-        (fn [db _] (swap! fired conj :feed/close-socket) db))
+      (rf/reg-event :feed/close-socket
+        (fn [{:keys [db]} _] (swap! fired conj :feed/close-socket) {:db db}))
       (story/reg-decorator :feed/live-subscription
         {:kind     :frame-setup
          :init     [[:feed/noop-init]]
          :teardown [[:feed/close-socket]]})
-      (rf/reg-event-db :feed/noop-init (fn [db _] db))
+      (rf/reg-event :feed/noop-init (fn [{:keys [db]} _] {:db db}))
       (story/reg-variant :story.feed/teardown-fires
         {:decorators [[:feed/live-subscription]]
          :events     []})
@@ -126,17 +126,17 @@
   (testing "within a single decorator's :teardown vector, events fire
             in declared order — symmetric with :init"
     (let [fired (atom [])]
-      (rf/reg-event-db :step/one
-        (fn [db _] (swap! fired conj :one) db))
-      (rf/reg-event-db :step/two
-        (fn [db _] (swap! fired conj :two) db))
-      (rf/reg-event-db :step/three
-        (fn [db _] (swap! fired conj :three) db))
+      (rf/reg-event :step/one
+        (fn [{:keys [db]} _] (swap! fired conj :one) {:db db}))
+      (rf/reg-event :step/two
+        (fn [{:keys [db]} _] (swap! fired conj :two) {:db db}))
+      (rf/reg-event :step/three
+        (fn [{:keys [db]} _] (swap! fired conj :three) {:db db}))
       (story/reg-decorator :multi-step-teardown
         {:kind     :frame-setup
          :init     [[:step/noop]]
          :teardown [[:step/one] [:step/two] [:step/three]]})
-      (rf/reg-event-db :step/noop (fn [db _] db))
+      (rf/reg-event :step/noop (fn [{:keys [db]} _] {:db db}))
       (story/reg-variant :story.feed/multi-step
         {:decorators [[:multi-step-teardown]]
          :events     []})
@@ -157,16 +157,16 @@
             variant-level decorator's :teardown runs BEFORE the story-
             level decorator's :teardown. Mirrors function-scope cleanup."
     (let [fired (atom [])]
-      (rf/reg-event-db :outer/cleanup
-        (fn [db _] (swap! fired conj :outer) db))
-      (rf/reg-event-db :inner/cleanup
-        (fn [db _] (swap! fired conj :inner) db))
+      (rf/reg-event :outer/cleanup
+        (fn [{:keys [db]} _] (swap! fired conj :outer) {:db db}))
+      (rf/reg-event :inner/cleanup
+        (fn [{:keys [db]} _] (swap! fired conj :inner) {:db db}))
       (story/reg-decorator :outer-dec
         {:kind :frame-setup :init [[:outer/noop]] :teardown [[:outer/cleanup]]})
       (story/reg-decorator :inner-dec
         {:kind :frame-setup :init [[:inner/noop]] :teardown [[:inner/cleanup]]})
-      (rf/reg-event-db :outer/noop (fn [db _] db))
-      (rf/reg-event-db :inner/noop (fn [db _] db))
+      (rf/reg-event :outer/noop (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :inner/noop (fn [{:keys [db]} _] {:db db}))
       (story/reg-story :story.teardown.order
         {:decorators [[:outer-dec]]})
       (story/reg-variant :story.teardown.order/v
@@ -185,16 +185,16 @@
             tear down in reverse-declaration order — the resolved
             :frame-setup vector reversed is the walk order"
     (let [fired (atom [])]
-      (rf/reg-event-db :dec-a/cleanup
-        (fn [db _] (swap! fired conj :a) db))
-      (rf/reg-event-db :dec-b/cleanup
-        (fn [db _] (swap! fired conj :b) db))
+      (rf/reg-event :dec-a/cleanup
+        (fn [{:keys [db]} _] (swap! fired conj :a) {:db db}))
+      (rf/reg-event :dec-b/cleanup
+        (fn [{:keys [db]} _] (swap! fired conj :b) {:db db}))
       (story/reg-decorator :dec-a
         {:kind :frame-setup :init [[:dec-a/noop]] :teardown [[:dec-a/cleanup]]})
       (story/reg-decorator :dec-b
         {:kind :frame-setup :init [[:dec-b/noop]] :teardown [[:dec-b/cleanup]]})
-      (rf/reg-event-db :dec-a/noop (fn [db _] db))
-      (rf/reg-event-db :dec-b/noop (fn [db _] db))
+      (rf/reg-event :dec-a/noop (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :dec-b/noop (fn [{:keys [db]} _] {:db db}))
       (story/reg-variant :story.teardown.same-level/v
         {:decorators [[:dec-a] [:dec-b]]
          :events     []})
@@ -212,11 +212,11 @@
   (testing "a teardown event that throws is caught by the runtime —
             destroy-frame! still runs. spec/002 §Loader teardown
             contract: teardown never aborts destroy-frame!"
-    (rf/reg-event-db :boom/cleanup
+    (rf/reg-event :boom/cleanup
       (fn [_ _] (throw (ex-info "teardown boom" {:why :test}))))
     (story/reg-decorator :boom-dec
       {:kind :frame-setup :init [[:boom/noop]] :teardown [[:boom/cleanup]]})
-    (rf/reg-event-db :boom/noop (fn [db _] db))
+    (rf/reg-event :boom/noop (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.teardown.boom/v
       {:decorators [[:boom-dec]]
        :events     []})
@@ -242,13 +242,13 @@
             copies it to a side-atom, so the test can inspect the record
             after destroy-frame! evicts the frame."
     (let [captured (atom nil)]
-      (rf/reg-event-db :boom/cleanup
+      (rf/reg-event :boom/cleanup
         (fn [_ _] (throw (ex-info "teardown boom" {:why :test}))))
-      (rf/reg-event-db :boom/noop (fn [db _] db))
-      (rf/reg-event-db ::probe-snapshot
-        (fn [db _]
+      (rf/reg-event :boom/noop (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event ::probe-snapshot
+        (fn [{:keys [db]} _]
           (reset! captured (:rf.story/assertions db))
-          db))
+          {:db db}))
       (story/reg-decorator :boom-dec
         {:kind :frame-setup :init [[:boom/noop]] :teardown [[:boom/cleanup]]})
       (story/reg-decorator :probe-dec
@@ -293,8 +293,8 @@
 (deftest decorator-without-teardown-is-untouched
   (testing "a :frame-setup decorator that declares no :teardown still
             tears down cleanly — the walk is a no-op for that decorator"
-    (rf/reg-event-db :seed/init
-      (fn [db _] (assoc db :seeded? true)))
+    (rf/reg-event :seed/init
+      (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
     (story/reg-decorator :seed-only
       {:kind :frame-setup :init [[:seed/init]]})
     (story/reg-variant :story.teardown.none/v
@@ -325,7 +325,7 @@
   (testing "after a play runs and the variant is destroyed, the play-runner's
             per-frame run-state is gone from every process-global atom — no
             leak (rf2-booyu)"
-    (rf/reg-event-db :rs/noop (fn [db _] db))
+    (rf/reg-event :rs/noop (fn [{:keys [db]} _] {:db db}))
     (story/reg-variant :story.runstate/v
       {:events      []
        :play-script [[:dispatch-sync [:rs/noop]]]})
@@ -387,7 +387,7 @@
                       (swap! live disj id)
                       (swap! @#'trace-tooling/listeners dissoc id)
                       nil)]
-        (rf/reg-event-db :lst/noop (fn [db _] db))
+        (rf/reg-event :lst/noop (fn [{:keys [db]} _] {:db db}))
         (story/reg-variant :story.listener/v {:events [[:lst/noop]]})
         (async/deref-blocking (story/run-variant :story.listener/v) 5000)
         (is (some play-listener-id? @live)
@@ -413,7 +413,7 @@
                       (swap! live disj id)
                       (swap! @#'trace-tooling/listeners dissoc id)
                       nil)]
-        (rf/reg-event-db :lst/noop2 (fn [db _] db))
+        (rf/reg-event :lst/noop2 (fn [{:keys [db]} _] {:db db}))
         (story/reg-variant :story.listener2/v {:events [[:lst/noop2]]})
         (async/deref-blocking (story/run-variant :story.listener2/v) 5000)
         (async/deref-blocking (story/run-variant :story.listener2/v) 5000)

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -290,7 +290,7 @@
             frame-provider wrap scoped to the variant id (rf2-zme7)"
     ;; Register a tiny view + variant + workspace. The view returns a
     ;; sentinel hiccup tag so we can find it in the rendered tree.
-    (rf/reg-event-db :rf2-zme7/init (fn [db _] (assoc db :marker 42)))
+    (rf/reg-event :rf2-zme7/init (fn [{:keys [db]} _] {:db (assoc db :marker 42)}))
     (rf/reg-sub :rf2-zme7/marker (fn [db _] (:marker db)))
     (rf/reg-view* :rf2-zme7/view
       {}

--- a/tools/story/testbeds/counter_with_stories/elision_demo.cljs
+++ b/tools/story/testbeds/counter_with_stories/elision_demo.cljs
@@ -115,7 +115,7 @@
 ;; Handler metadata is the cross-cutting escape hatch for event payloads
 ;; that cannot be represented as schema-sensitive app-db slots.
 
-(rf/reg-event-fx :auth/sign-in
+(rf/reg-event :auth/sign-in
   ;; Registration metadata — the registrar copies `:sensitive? true`
   ;; into the registry slot's meta; the runtime hoists it to the
   ;; TOP level of every trace event emitted within this handler's
@@ -140,23 +140,23 @@
                 {:email      email
                  :submitted? true})}))
 
-(rf/reg-event-db :user.avatar-pdf/set
+(rf/reg-event :user.avatar-pdf/set
   {:doc "Demo: write a synthetic large blob into the `:large?`-flagged
          schema slot. Walking app-db through `rf/elide-wire-value`
          substitutes the slot value with a `:rf.size/large-elided`
          marker, with the schema's `:hint` propagated verbatim."}
-  (fn [db [_ {:keys [bytes]}]]
-    (assoc db :user/avatar-pdf (str/join (repeat (or bytes 5000) "A")))))
+  (fn [{:keys [db]} [_ {:keys [bytes]}]]
+    {:db (assoc db :user/avatar-pdf (str/join (repeat (or bytes 5000) "A")))}))
 
-(rf/reg-event-db :user.avatar-pdf/clear
+(rf/reg-event :user.avatar-pdf/clear
   {:doc "Drop the avatar slot. Uses `dissoc` rather than `(assoc ...
          nil)` so the slot is absent from app-db rather than carrying
          a typed `nil`, matching the schema's `:string` declaration
          (Spec 010 §Optional slots: absence is the soft-pass-friendly
          shape for an optional slot)."}
-  (fn [db _] (dissoc db :user/avatar-pdf)))
+  (fn [{:keys [db]} _] {:db (dissoc db :user/avatar-pdf)}))
 
-(rf/reg-event-db :user.avatar/upload
+(rf/reg-event :user.avatar/upload
   {:doc "Demo: dispatch a 20 kB blob INLINE inside the event vector.
          The event-emit listener's `elide-wire-value` pass auto-
          detects the leaf string (over the default 16 kB threshold)
@@ -164,10 +164,10 @@
          listener receives the record. Demonstrates the runtime
          auto-detect branch of the wire walker — orthogonal to the
          schema-driven branch above."}
-  (fn [db [_ {:keys [_blob]}]]
+  (fn [{:keys [db]} [_ {:keys [_blob]}]]
     ;; We don't keep the blob; the point is the elision at the wire
     ;; boundary. Bump a counter so the UI has something to render.
-    (update db :user/uploads (fnil inc 0))))
+    {:db (update db :user/uploads (fnil inc 0))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS  (UI plumbing only — none of these flow on the wire)

--- a/tools/story/testbeds/counter_with_stories/events.cljs
+++ b/tools/story/testbeds/counter_with_stories/events.cljs
@@ -25,37 +25,37 @@
 ;; lives at `[:rf.runtime/machines :snapshots ...]` in the frame's
 ;; runtime-db partition (EP-0001 rf2-vzld77 — durable runtime-db state, not
 ;; app-db), so a `:db` (app-db) effect can never touch it.
-(rf/reg-event-fx :counter/initialise
+(rf/reg-event :counter/initialise
   (fn [{:keys [db]} [_ initial-count]]
     {:db (assoc db :count (or initial-count 0))}))
 
-(rf/reg-event-db :counter/inc
-  (fn [db _event]
-    (update db :count inc)))
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event]
+    {:db (update db :count inc)}))
 
-(rf/reg-event-db :counter/dec
-  (fn [db _event]
-    (update db :count dec)))
+(rf/reg-event :counter/dec
+  (fn [{:keys [db]} _event]
+    {:db (update db :count dec)}))
 
-(rf/reg-event-db :counter/set
-  (fn [db [_ n]]
-    (assoc db :count n)))
+(rf/reg-event :counter/set
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db :count n)}))
 
-(rf/reg-event-db :counter/throw-deterministic
-  (fn [_db _event]
+(rf/reg-event :counter/throw-deterministic
+  (fn [_cofx _event]
     (throw (ex-info "story-load deterministic event handler failure"
                     {:surface :story-load
                      :kind    :event-handler-exception}))))
 
-(rf/reg-event-db :counter/throw-loader-rejection
-  (fn [_db _event]
+(rf/reg-event :counter/throw-loader-rejection
+  (fn [_cofx _event]
     (throw (ex-info "story-load deterministic loader rejection"
                     {:surface :story-load
                      :kind    :loader-rejection}))))
 
-(rf/reg-event-db :counter/loader-never-ready?
-  (fn [db _event]
-    (assoc db :rf.story/loaders-complete? false)))
+(rf/reg-event :counter/loader-never-ready?
+  (fn [{:keys [db]} _event]
+    {:db (assoc db :rf.story/loaders-complete? false)}))
 
 ;; A user-fx so the `force-fx-stub` decorator story has something
 ;; concrete to stub. In the live app this would talk to a server;
@@ -68,7 +68,7 @@
     ;; intercepts the fx-id well before this fires.
     nil))
 
-(rf/reg-event-fx :counter/save
+(rf/reg-event :counter/save
   (fn [{:keys [db]} _event]
     {:db (assoc db :saving? true)
      :fx [[:counter/sync-to-server {:value (:count db)}]]}))
@@ -93,7 +93,7 @@
 ;; unredacted payload (redaction is a trace-consumer concern, not a
 ;; handler concern); we stash only a redacted placeholder in app-db —
 ;; the password never lives in app-db.
-(rf/reg-event-fx :counter/sign-in
+(rf/reg-event :counter/sign-in
   {:doc        "Demo sign-in handler — the password rides the event
                 vector. `:sensitive? true` tells trace consumers and
                 always-on substrates to suppress or redact these

--- a/tools/story/testbeds/login_form/events.cljs
+++ b/tools/story/testbeds/login_form/events.cljs
@@ -52,7 +52,7 @@
 ;; tutorial's claim that "you swap five variants without a single
 ;; refresh."
 
-(rf/reg-event-fx :login/flow
+(rf/reg-event :login/flow
   {:doc "Login flow machine — five-state authentication FSM."}
   (machines/make-machine-handler
     {:initial :idle

--- a/tools/template/resources/day8/re_frame2_template/_shared/clj-kondo/config.edn
+++ b/tools/template/resources/day8/re_frame2_template/_shared/clj-kondo/config.edn
@@ -3,7 +3,7 @@
 ;; Empty for now — clj-kondo picks up sensible defaults and editor
 ;; integrations (VS Code Calva, CIDER, IntelliJ Cursive) provide
 ;; on-save linting. Add project-specific lint rules below as your
-;; app grows; the re-frame2-side macros (`reg-event-db`, `reg-sub`,
+;; app grows; the re-frame2-side macros (`reg-event`, `reg-sub`,
 ;; `reg-view`, ...) are recognised by clj-kondo's built-in support
 ;; for clojure.core-style defining forms — no hook lib required for
 ;; the canonical counter shape.

--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -1,8 +1,12 @@
 (ns {{namespace}}.events
   "Event handlers — the second domino in the re-frame2 pipeline.
 
-   The handler is a pure function `(fn [db event] new-db)`. The runtime
-   applies the returned db to the frame; views fan out from there."
+   The handler is a pure function `(fn [cofx event] effects-map)` — it
+   takes the coeffects map (its `:db` is the current app-db) and returns a
+   closed effects map (`{:db new-db}`, plus `:fx` when it has side-effects).
+   The runtime applies the returned `:db` to the frame and runs the `:fx`;
+   views fan out from there. `reg-event` is the one public event-registration
+   form (EP-0018)."
   (:require [re-frame.core :as rf]
             ;; The trace-listener surface (`register-listener!`)
             ;; lives in `re-frame.trace.tooling`, NOT `re-frame.core` —
@@ -82,10 +86,10 @@
 ;; core/run via `dispatch-sync` so the first render sees the initial
 ;; value rather than a transient empty frame.
 
-(rf/reg-event-db
+(rf/reg-event
   :counter/initialise
-  (fn [_db _event]
-    {:counter/value 0}))
+  (fn [_cofx _event]
+    {:db {:counter/value 0}}))
 
 ;; --- Counter increment -----------------------------------------------------
 ;;
@@ -93,10 +97,10 @@
 ;; effects, no side-channels. Everything else (re-render, trace emission,
 ;; epoch tagging, schema validation) is the runtime's job.
 
-(rf/reg-event-db
+(rf/reg-event
   :counter/increment
-  (fn [db _event]
-    (update db :counter/value inc)))
+  (fn [{:keys [db]} _event]
+    {:db (update db :counter/value inc)}))
 
 ;; --- HTTP failure matrix (commented exemplar) ------------------------------
 ;;
@@ -130,7 +134,7 @@
 ;; **out of scope** for `:retry`; lift those into a state machine per
 ;; Spec 014 §Boundary — transport vs semantic retry.
 ;;
-#_(rf/reg-event-fx
+#_(rf/reg-event
     :counter/load
     (fn [{:keys [db]} [_ msg]]
       (cond

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -32,7 +32,7 @@ you a clean reload:
 
 1. **Namespace reload re-runs your registrations.** Reloading
    `events.cljs` / `subs.cljs` / `views.cljs` re-evaluates the
-   `reg-event-db` / `reg-sub` / `reg-view` forms at the top level, so
+   `reg-event` / `reg-sub` / `reg-view` forms at the top level, so
    each handler / sub / view re-registers in place against the new
    code. Add a new `reg-*` form and it shows up live; rename or remove
    a handler and the next reload drops the old registration.

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -676,7 +676,7 @@ sections that read top-to-bottom as the developer scans.
 │   :auth/require-login          src/auth/interceptors.cljs:42   [code]              │
 │                                                                                      │
 │ ▼ HANDLER                                                                            │
-│   reg-event-fx · src/cart/events.cljs:88                       [code]              │
+│   reg-event · src/cart/events.cljs:88                          [code]              │
 │                                                                                      │
 │ ▼ FLOWS  (3)                                                                         │
 │   ▸ :cart-total                wrote [:cart :total]   52.50                         │
@@ -1711,7 +1711,7 @@ Without the modal, large drill-ins can blow out the renderer and degrade INP. Th
 
 Per [spec/015-Data-Classification](../../../spec/015-Data-Classification.md):
 
-1. **Event handler** (`reg-event-db/fx/ctx`) — `{:sensitive [paths]}` on the registration map.
+1. **Event handler** (`reg-event`) — `{:sensitive [paths]}` on the registration map.
 2. **App-db** (per frame) — `(rf/add-marks <frame-id> {path mark, ...})` (additive merge) or `(rf/set-marks <frame-id> {path mark, ...})` (replace wholesale).
 3. **Subscription** — output marking via `{:sensitive [paths]}` or whole-output `{:sensitive? true/false}` override. Default = propagate from sensitive input paths.
 4. **Effect** (`reg-fx`) — input marking on the fx-args.

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -247,7 +247,8 @@ Section order (numbered; optional sections shown only when present):
      click-to-source link).
   2. **COEFFECTS** *(optional)* — user-injected coeffects: each id (click-to-source) + the
      value it added to context (`+ [:now] #inst…`).
-  3. **EVENT HANDLER** — the flavour (`reg-event-db` / `reg-event-fx`) as a click-to-source
+  3. **EVENT HANDLER** — the verb (`reg-event`, the one public event-registration form after
+     EP-0018; `reg-machine` for machine handlers) as a click-to-source
      link + the **syntax-highlighted handler source** in a code block + a **returned
      effects sub-block** (the t1 pre-commit observable: the pending `:db` VALUE + each
      entry of the returned `:fx` vector). Per rf2-ta0y7 (Mike 2026-05-25) the substrate
@@ -316,10 +317,10 @@ flows, and fx):
 │   │      + [:session]  {:user-id 42, :token "..."}                       │
 │   │                                                                       │
 │  ③  EVENT HANDLER ↗                                                       │
-│   │    (rf/reg-event-db :counter-inc          ← syntax-highlighted        │
-│   │      [:rf/db]                                                         │
-│   │      (fn [db _]                                                       │
-│   │        (update db :counter inc)))                                     │
+│   │    (rf/reg-event :counter-inc             ← syntax-highlighted        │
+│   │      (fn [{:keys [db]} _]                                             │
+│   │        {:db (update db :counter inc)                                  │
+│   │         :fx [[:dispatch [:title/flow [:rf/init]]]]}))                 │
 │   │    ↳ returned effects (pre-commit)                                    │
 │   │       :db   pending — see APP-DB CHANGES below for committed diff     │
 │   │       :fx   1 entry — see FX below for what ran                       │
@@ -360,7 +361,7 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 │   │    FROM: timer ↗                                                      │
 │   │                                                                       │
 │  ②  EVENT HANDLER ↗                                                       │
-│   │    (rf/reg-event-db :poll/tick …)        ← syntax-highlighted         │
+│   │    (rf/reg-event :poll/tick …)           ← syntax-highlighted         │
 │   │    ↳ returned effects (pre-commit)                                    │
 │   │       :db   pending — see APP-DB CHANGES below for committed diff     │
 │   │                                                                       │
@@ -1471,6 +1472,16 @@ from the trace stream:
 - **`:reg-event-fx`** — `:db` diff + per-fx-entry block.
 - **`:reg-machine`** — **TIME-ORDERED MACHINE CASCADE** per rf2-u69j7.
 
+> **EP-0018 note.** `:reg-event-db` / `:reg-event-fx` are INTERNAL
+> classification keywords describing the handler's OBSERVED EFFECT SHAPE
+> (`:db`-only vs `:db`+`:fx`), discovered purely from the trace stream — never
+> from the registration form. They are NOT user-facing registrar names: the
+> three public event registrars collapsed onto the one `reg-event` form
+> (EP-0018), so the HANDLER step's VERB renders `reg-event` for both event
+> flavours (`reg-machine` for machine handlers — see `handler-flavour-label`).
+> The effect-shape discrimination below still drives which body sections
+> render; it just no longer prints a retired registrar spelling.
+
 **Flavour discriminator (`handler-flavour`, rf2-eue07).** The classifier is
 a pure-data `cond` over the trace stream, machine-predicates FIRST (a machine
 handler always rides a `:rf.fx/do-fx` for its snapshot write, so `do-fx` must
@@ -2451,8 +2462,9 @@ source of truth.
 
 #### §9.1.6.1 HANDLER source affordance (rf2-ehd8v · rf2-80u5a · rf2-xjgdk · pair-debug 2026-05-26)
 
-The HANDLER step's flavour label (e.g. `reg-event-db` / `reg-event-fx`
-/ `reg-event-ctx` / `reg-machine`) IS the click-to-source affordance —
+The HANDLER step's verb label (`reg-event`, the one public event-registration
+form after EP-0018; `reg-machine` for machine handlers) IS the
+click-to-source affordance —
 the verb itself is the hyperlink, with an external-link glyph (↗)
 trailing inside it. The earlier rf2-ehd8v shape parked a separate
 `file:line + [open]` sub-header below the HANDLER header; Mike's pair-

--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -126,7 +126,7 @@ Colour and visual styling are intentionally **not specified here** — to be des
 +0.0  DISPATCH         EVENT     dispatched      [:counter-inc] from view↗       —
 +0.0  EPOCH            EPOCH     snapshotted     #42 · frame :rf/default          —
 +0.0  COEFFECT         COEFFECT  run             :now → #inst…                   0.1 ms
-+0.1  EVENT HANDLER    EVENT     handler ran     reg-event-db                    0.2 ms
++0.1  EVENT HANDLER    EVENT     handler ran     reg-event                       0.2 ms
 +0.3  FLOW             FLOW      computed        :totals → [:totals]             1.5 ms
 +1.8  EFFECT HANDLERS  DB        changed         [:counter] 1 → 2 · [:totals] 42  —
 +1.9  EFFECT HANDLERS  FX        :http-xhrio     GET /api/data (queued)           —

--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -105,14 +105,14 @@
   ;; A nil `frame-id` (the reset case) symmetrically clears the focus
   ;; slot's `:frame` — leaving it set to a stale value would re-introduce
   ;; the misalignment in the inverse direction.
-  (rf/reg-event-db :rf.xray/set-target-frame
-    (fn [db [_ frame-id]]
-      (let [target (or frame-id defaults/default-target-frame)]
+  (rf/reg-event :rf.xray/set-target-frame
+    (fn [{:keys [db]} [_ frame-id]]
+      {:db (let [target (or frame-id defaults/default-target-frame)]
         (cond-> (assoc db :epoch-history (vec (rf/epoch-history target)))
           (nil? frame-id)  (dissoc :target-frame)
           (nil? frame-id)  (update :focus (fnil dissoc {}) :frame)
           (some? frame-id) (assoc :target-frame frame-id)
-          (some? frame-id) (assoc-in [:focus :frame] frame-id)))))
+          (some? frame-id) (assoc-in [:focus :frame] frame-id)))}))
 
   ;; `:rf.xray/epoch-recorded` — dispatched from `preload/install-
   ;; epoch-listener!` whenever the framework records a new epoch on any
@@ -121,13 +121,13 @@
   ;; `:rf.trace/no-emit? true` — the dispatch must not itself emit a
   ;; trace event (the listener is part of Xray's instrumentation loop;
   ;; a self-emit would re-enter the listener).
-  (rf/reg-event-db :rf.xray/epoch-recorded
+  (rf/reg-event :rf.xray/epoch-recorded
     {:rf.trace/no-emit? true}
-    (fn [db [_ frame-id]]
-      (let [target (get db :target-frame defaults/default-target-frame)]
+    (fn [{:keys [db]} [_ frame-id]]
+      {:db (let [target (get db :target-frame defaults/default-target-frame)]
         (if (= frame-id target)
           (assoc db :epoch-history (vec (rf/epoch-history target)))
-          db))))
+          db))}))
 
   ;; `:rf.xray/sync-epoch-history` — wholesale overwrite of the
   ;; `:epoch-history` slot. Dispatched from `mount.cljs/open!` on first
@@ -162,14 +162,14 @@
   ;; auto-follow re-derives `:epoch-id` from the head cascade — that
   ;; path is unchanged; this stamp is the authoritative selection only
   ;; for history-only seeds (the standalone panel-gallery stories).
-  (rf/reg-event-db :rf.xray/sync-epoch-history
+  (rf/reg-event :rf.xray/sync-epoch-history
     {:rf.trace/no-emit? true}
-    (fn [db [_ history]]
-      (let [history    (vec history)
+    (fn [{:keys [db]} [_ history]]
+      {:db (let [history    (vec history)
             latest-id  (:epoch-id (peek history))]
         (cond-> (assoc db :epoch-history history)
           (some? latest-id) (assoc-in [:focus :epoch-id] latest-id)
-          (nil? latest-id)  (update :focus (fnil dissoc {}) :epoch-id)))))
+          (nil? latest-id)  (update :focus (fnil dissoc {}) :epoch-id)))}))
 
   ;; `:rf.xray/select-epoch` — spine shim (rf2-adve5). Writes the
   ;; spine's `[:focus :epoch-id]` slot — the single source of truth that

--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -178,9 +178,9 @@
   ;; when the user picks an epoch (rf2-uy7nz retired the `:selected-
   ;; epoch-id` mirror). Symmetric with `:rf.xray/select-dispatch-id` (in
   ;; registry.cljs post rf2-5gl5r).
-  (rf/reg-event-db :rf.xray/select-epoch
-    (fn [db [_ epoch-id]]
-      (assoc-in db [:focus :epoch-id] epoch-id)))
+  (rf/reg-event :rf.xray/select-epoch
+    (fn [{:keys [db]} [_ epoch-id]]
+      {:db (assoc-in db [:focus :epoch-id] epoch-id)}))
 
   ;; `:rf.xray/reset-to-epoch` (rf2-hga49) — the UI rewind affordance.
   ;; The tab ribbon's `Reset` button dispatches this with the OBSERVED
@@ -207,7 +207,7 @@
   ;; prior failure, and the fx re-sets the flash only when THIS attempt
   ;; also fails. The dissoc runs before the fx so a failure that fires
   ;; `:rf.xray/reset-flash-failed` synchronously still wins.
-  (rf/reg-event-fx :rf.xray/reset-to-epoch
+  (rf/reg-event :rf.xray/reset-to-epoch
     (fn [{:keys [db]} [_ frame epoch-id]]
       {:db (dissoc db :reset-flash)
        :fx [[:rf.xray.fx/restore-epoch {:frame frame :epoch-id epoch-id}]]}))
@@ -216,19 +216,19 @@
   ;; flash. Dispatched from `:rf.xray.fx/restore-epoch` when
   ;; `rf/restore-epoch!` returns false. `:rf.trace/no-emit? true` keeps
   ;; Xray's own chrome event off the trace bus it is inspecting.
-  (rf/reg-event-db :rf.xray/reset-flash-failed
+  (rf/reg-event :rf.xray/reset-flash-failed
     {:rf.trace/no-emit? true}
-    (fn [db _event]
-      (assoc db :reset-flash "Reset failed — epoch unavailable (see Trace)")))
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :reset-flash "Reset failed — epoch unavailable (see Trace)")}))
 
   ;; `:rf.xray/clear-reset-flash` (rf2-hga49) — clear the inline flash.
   ;; The steady-state clear path is `:rf.xray/reset-to-epoch` dissoc-ing
   ;; the slot on every fresh attempt (rf2-wa7tk); this event remains the
   ;; explicit imperative clear (tests + any future dismiss affordance).
   ;; `:rf.trace/no-emit? true` per the sibling rationale.
-  (rf/reg-event-db :rf.xray/clear-reset-flash
+  (rf/reg-event :rf.xray/clear-reset-flash
     {:rf.trace/no-emit? true}
-    (fn [db _event]
-      (dissoc db :reset-flash)))
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :reset-flash)}))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -289,9 +289,9 @@
                     :pill   pill})
             (assoc :edit-popup-draft draft)))}))
 
-  (rf/reg-event-db :rf.xray/close-edit-popup
-    (fn [db _event]
-      (close-popup db)))
+  (rf/reg-event :rf.xray/close-edit-popup
+    (fn [{:keys [db]} _event]
+      {:db (close-popup db)}))
 
   (rf/reg-event :rf.xray/edit-popup-set-mode
     {:rf.trace/no-emit? true}

--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -276,9 +276,9 @@
   ;; so 'click pill → edit' arrives pre-populated and 'right-click
   ;; row → add' arrives with the event-id pre-filled.
 
-  (rf/reg-event-db :rf.xray/open-edit-popup
-    (fn [db [_ {:keys [source mode idx pill] :as trigger}]]
-      (let [draft (-> (edit-popup/pill->draft (or pill {}))
+  (rf/reg-event :rf.xray/open-edit-popup
+    (fn [{:keys [db]} [_ {:keys [source mode idx pill] :as trigger}]]
+      {:db (let [draft (-> (edit-popup/pill->draft (or pill {}))
                       (assoc :mode (or mode :in)))]
         (-> db
             (assoc :edit-popup-open? true)
@@ -287,21 +287,21 @@
                     :mode   (or mode :in)
                     :idx    idx
                     :pill   pill})
-            (assoc :edit-popup-draft draft)))))
+            (assoc :edit-popup-draft draft)))}))
 
   (rf/reg-event-db :rf.xray/close-edit-popup
     (fn [db _event]
       (close-popup db)))
 
-  (rf/reg-event-db :rf.xray/edit-popup-set-mode
+  (rf/reg-event :rf.xray/edit-popup-set-mode
     {:rf.trace/no-emit? true}
-    (fn [db [_ mode]]
-      (assoc-in db [:edit-popup-draft :mode] mode)))
+    (fn [{:keys [db]} [_ mode]]
+      {:db (assoc-in db [:edit-popup-draft :mode] mode)}))
 
-  (rf/reg-event-db :rf.xray/edit-popup-set-pattern
+  (rf/reg-event :rf.xray/edit-popup-set-pattern
     {:rf.trace/no-emit? true}
-    (fn [db [_ pattern]]
-      (assoc-in db [:edit-popup-draft :pattern] (or pattern ""))))
+    (fn [{:keys [db]} [_ pattern]]
+      {:db (assoc-in db [:edit-popup-draft :pattern] (or pattern ""))}))
 
   ;; ---- events: save / delete -------------------------------------------
   ;;
@@ -310,7 +310,7 @@
   ;; persist` fx so the post-mutation slot lands in localStorage in
   ;; one place (no fx-per-handler duplication).
 
-  (rf/reg-event-fx :rf.xray/save-edit-popup
+  (rf/reg-event :rf.xray/save-edit-popup
     (fn [{:keys [db]} _event]
       (let [draft  (get db :edit-popup-draft)
             trig   (get db :edit-popup-trigger)
@@ -355,7 +355,7 @@
             {:db final-db
              :fx [[:rf.xray.filters/persist (get final-db :active-filters)]]})))))
 
-  (rf/reg-event-fx :rf.xray/delete-edit-popup
+  (rf/reg-event :rf.xray/delete-edit-popup
     (fn [{:keys [db]} _event]
       (let [trig (get db :edit-popup-trigger)
             mode (:mode trig)
@@ -391,7 +391,7 @@
   ;; `:active-filters` slot + persist fx); the mute reset routes through
   ;; its owning event via `:dispatch` so its persistence /
   ;; instrumentation stays in one place.
-  (rf/reg-event-fx :rf.xray/clear-all-filters
+  (rf/reg-event :rf.xray/clear-all-filters
     (fn [{:keys [db]} _event]
       (let [cleared {:in [] :out []}]
         {:db (assoc db :active-filters cleared)
@@ -408,16 +408,16 @@
   ;; than silently appending — the user sees what's about to land in
   ;; the OUT bucket and can cancel.
 
-  (rf/reg-event-db :rf.xray/hide-event-type
-    (fn [db [_ event-id]]
-      (let [pill {:pattern (when event-id (str event-id))}]
+  (rf/reg-event :rf.xray/hide-event-type
+    (fn [{:keys [db]} [_ event-id]]
+      {:db (let [pill {:pattern (when event-id (str event-id))}]
         (-> db
             (assoc :edit-popup-open? true)
             (assoc :edit-popup-trigger
                    {:source :context :mode :out :pill pill})
             (assoc :edit-popup-draft
                    (-> (edit-popup/pill->draft pill)
-                       (assoc :mode :out)))))))
+                       (assoc :mode :out)))))}))
 
   ;; ---- typed-predicate add events (rf2-piye4) -------------------------
   ;;
@@ -432,14 +432,14 @@
   ;; collapses to a no-op so multiple right-click → add chains don't
   ;; pile up redundant pills.
 
-  (rf/reg-event-fx :rf.xray/filter-by-machine
+  (rf/reg-event :rf.xray/filter-by-machine
     (fn [{:keys [db]} [_ machine-id]]
       (let [pill    {:kind :machine :params {:machine-id machine-id}}
             next-db (append-typed-pill db :in pill)]
         {:db next-db
          :fx [[:rf.xray.filters/persist (get next-db :active-filters)]]})))
 
-  (rf/reg-event-fx :rf.xray/filter-by-http-correlation
+  (rf/reg-event :rf.xray/filter-by-http-correlation
     (fn [{:keys [db]} [_ correlation-id]]
       (let [pill    {:kind :http-correlation
                      :params {:correlation-id correlation-id}}
@@ -447,7 +447,7 @@
         {:db next-db
          :fx [[:rf.xray.filters/persist (get next-db :active-filters)]]})))
 
-  (rf/reg-event-fx :rf.xray/filter-by-fx
+  (rf/reg-event :rf.xray/filter-by-fx
     (fn [{:keys [db]} [_ fx-id]]
       (let [pill    {:kind :fx :params {:fx-id fx-id}}
             next-db (append-typed-pill db :in pill)]
@@ -456,11 +456,11 @@
 
   ;; ---- load: hydrate from localStorage --------------------------------
 
-  (rf/reg-event-db :rf.xray/hydrate-filters
+  (rf/reg-event :rf.xray/hydrate-filters
     {:rf.trace/no-emit? true}
-    (fn [db [_ filters]]
-      (assoc db :active-filters
-                (or filters {:in [] :out []}))))
+    (fn [{:keys [db]} [_ filters]]
+      {:db (assoc db :active-filters
+                (or filters {:in [] :out []}))}))
 
   ;; NO hydrate on install (rf2-swclw). The IN/OUT pills are a TRANSIENT
   ;; exploration filter — they reset to unfiltered on every page load so

--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -625,7 +625,7 @@
   ;; epoch reads. nil clears the view scope back to its head-frame
   ;; default. Persist fx is retained (the data layer); init does not
   ;; restore it (rf2-swclw — frame is transient).
-  (rf/reg-event-fx :rf.xray/select-frame
+  (rf/reg-event :rf.xray/select-frame
     (fn [{:keys [db]} [_ frame-id]]
       {:db (if (some? frame-id)
              (assoc db :view-scope-frame frame-id)

--- a/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
@@ -416,7 +416,7 @@
   ;; shape, omitting `:db` from the return leaves Xray's app-db
   ;; untouched. The trace bus still records the dispatch so the
   ;; "click → open" trail is observable.
-  (rf/reg-event-fx :rf.xray/open-in-editor
+  (rf/reg-event :rf.xray/open-in-editor
     (fn [_ctx [_event-id payload]]
       ;; rf2-4s08ov — DX hint when no editor is effectively configured.
       ;; A host that wired only the bare preload (never called

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -293,22 +293,22 @@
           (assoc :palette-query (or text ""))
           (reset-cursor))))
 
-  (rf/reg-event-db :rf.xray/palette-cursor-up
+  (rf/reg-event :rf.xray/palette-cursor-up
     {:rf.trace/no-emit? true}
-    (fn [db _event]
-      (update db :palette-cursor #(max 0 (dec (or % 0))))))
+    (fn [{:keys [db]} _event]
+      {:db (update db :palette-cursor #(max 0 (dec (or % 0))))}))
 
-  (rf/reg-event-db :rf.xray/palette-cursor-down
+  (rf/reg-event :rf.xray/palette-cursor-down
     {:rf.trace/no-emit? true}
-    (fn [db [_ max-idx]]
-      (update db :palette-cursor
+    (fn [{:keys [db]} [_ max-idx]]
+      {:db (update db :palette-cursor
               (fn [c]
-                (min (or max-idx 0) (inc (or c 0)))))))
+                (min (or max-idx 0) (inc (or c 0)))))}))
 
-  (rf/reg-event-db :rf.xray/palette-cursor-set
+  (rf/reg-event :rf.xray/palette-cursor-set
     {:rf.trace/no-emit? true}
-    (fn [db [_ idx]]
-      (assoc db :palette-cursor (max 0 (or idx 0)))))
+    (fn [{:keys [db]} [_ idx]]
+      {:db (assoc db :palette-cursor (max 0 (or idx 0)))}))
 
   ;; ---- invoke -----------------------------------------------------------
   ;;
@@ -317,7 +317,7 @@
   ;; tuple into the appropriate Xray-side dispatch (or mount-layer
   ;; side effect) and closes the palette.
 
-  (rf/reg-event-fx :rf.xray/palette-invoke
+  (rf/reg-event :rf.xray/palette-invoke
     (fn [{:keys [db]} [_ item popout?]]
       (let [[verb & args]    (:action item)
             ;; rf2-ybjkx — record recents for `:command` source items

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -258,23 +258,23 @@
   ;; so the load cost is negligible; lazy-seed means we don't have to
   ;; thread a preload hook through every test that drives the registry.
 
-  (rf/reg-event-db :rf.xray/palette-open
-    (fn [db _event]
-      (let [seeded (if (contains? db :palette-recents)
+  (rf/reg-event :rf.xray/palette-open
+    (fn [{:keys [db]} _event]
+      {:db (let [seeded (if (contains? db :palette-recents)
                      db
                      (assoc db :palette-recents (recents/load)))]
         (-> seeded
             (assoc :palette-open? true)
             (assoc :palette-query "")
-            (reset-cursor)))))
+            (reset-cursor)))}))
 
-  (rf/reg-event-db :rf.xray/palette-close
-    (fn [db _event]
-      (close-palette db)))
+  (rf/reg-event :rf.xray/palette-close
+    (fn [{:keys [db]} _event]
+      {:db (close-palette db)}))
 
-  (rf/reg-event-db :rf.xray/palette-toggle
-    (fn [db _event]
-      (if (get db :palette-open? false)
+  (rf/reg-event :rf.xray/palette-toggle
+    (fn [{:keys [db]} _event]
+      {:db (if (get db :palette-open? false)
         (close-palette db)
         (let [seeded (if (contains? db :palette-recents)
                        db
@@ -282,16 +282,16 @@
           (-> seeded
               (assoc :palette-open? true)
               (assoc :palette-query "")
-              (reset-cursor))))))
+              (reset-cursor))))}))
 
   ;; ---- query / cursor ---------------------------------------------------
 
-  (rf/reg-event-db :rf.xray/palette-set-query
+  (rf/reg-event :rf.xray/palette-set-query
     {:rf.trace/no-emit? true}
-    (fn [db [_ text]]
-      (-> db
+    (fn [{:keys [db]} [_ text]]
+      {:db (-> db
           (assoc :palette-query (or text ""))
-          (reset-cursor))))
+          (reset-cursor))}))
 
   (rf/reg-event :rf.xray/palette-cursor-up
     {:rf.trace/no-emit? true}

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
@@ -15,13 +15,13 @@
 (defn install!
   "Install the App-DB Diff events and effects."
   []
-  (rf/reg-event-db :rf.xray/focus-slice-path
-    (fn [db [_ path]]
-      (assoc db :focused-slice-path path)))
+  (rf/reg-event :rf.xray/focus-slice-path
+    (fn [{:keys [db]} [_ path]]
+      {:db (assoc db :focused-slice-path path)}))
 
-  (rf/reg-event-db :rf.xray/clear-slice-focus
-    (fn [db _event]
-      (dissoc db :focused-slice-path)))
+  (rf/reg-event :rf.xray/clear-slice-focus
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :focused-slice-path)}))
 
   ;; ---- App-DB panel diff-mode toggle — RETIRED 2026-05-29 (rf2-vv3m6) -----
   ;;
@@ -61,7 +61,7 @@
   ;; on the inspected frame, not the Xray chrome frame the affordance
   ;; dispatches from). A nil / unregistered observed frame degrades to a
   ;; bare (current-frame-resolved) egress — still fail-closed.
-  (rf/reg-event-fx :rf.xray/copy-value-to-clipboard
+  (rf/reg-event :rf.xray/copy-value-to-clipboard
     (fn [{:keys [db]} [_ value]]
       (let [observed (or (get-in db [:focus :frame]) (get db :target-frame))
             elided   (if (and (some? observed) (some? (frame/frame observed)))
@@ -71,6 +71,6 @@
 
   ;; The path-copy variant copies ONLY the path vector (key names, no
   ;; values) so there is nothing to elide — it is not a value-egress site.
-  (rf/reg-event-fx :rf.xray/copy-path-to-clipboard
+  (rf/reg-event :rf.xray/copy-path-to-clipboard
     (fn [_ctx [_ path]]
       {:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str path)}]]})))

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
@@ -103,13 +103,13 @@
 ;; ---- events --------------------------------------------------------------
 
 (defn install-events! []
-  (rf/reg-event-db :rf.xray/open-segment-inspector
-    (fn [db [_ path]]
-      (assoc db :segment-inspector {:path (vec path)})))
+  (rf/reg-event :rf.xray/open-segment-inspector
+    (fn [{:keys [db]} [_ path]]
+      {:db (assoc db :segment-inspector {:path (vec path)})}))
 
-  (rf/reg-event-db :rf.xray/close-segment-inspector
-    (fn [db _]
-      (dissoc db :segment-inspector))))
+  (rf/reg-event :rf.xray/close-segment-inspector
+    (fn [{:keys [db]} _]
+      {:db (dissoc db :segment-inspector)})))
 
 ;; ---- styles --------------------------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_events.cljs
@@ -33,25 +33,25 @@
 
   ;; ---- popover open / close --------------------------------------------
 
-  (rf/reg-event-db :rf.xray/cancellation-cascade-open
-    (fn [db [_ focus]]
-      (-> db
+  (rf/reg-event :rf.xray/cancellation-cascade-open
+    (fn [{:keys [db]} [_ focus]]
+      {:db (-> db
           (assoc :cancellation-cascade-popover-open? true)
-          (assoc :cancellation-cascade-popover-focus focus))))
+          (assoc :cancellation-cascade-popover-focus focus))}))
 
-  (rf/reg-event-db :rf.xray/cancellation-cascade-close
-    (fn [db _event]
-      (assoc db :cancellation-cascade-popover-open? false)))
+  (rf/reg-event :rf.xray/cancellation-cascade-close
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :cancellation-cascade-popover-open? false)}))
 
   ;; ---- show-all / collapse toggle --------------------------------------
 
-  (rf/reg-event-db :rf.xray/cancellation-cascade-toggle-expand
-    (fn [db _event]
-      (update db :cancellation-cascade-expanded? not)))
+  (rf/reg-event :rf.xray/cancellation-cascade-toggle-expand
+    (fn [{:keys [db]} _event]
+      {:db (update db :cancellation-cascade-expanded? not)}))
 
-  (rf/reg-event-db :rf.xray/cancellation-cascade-set-expanded
-    (fn [db [_ expanded?]]
-      (assoc db :cancellation-cascade-expanded? (boolean expanded?))))
+  (rf/reg-event :rf.xray/cancellation-cascade-set-expanded
+    (fn [{:keys [db]} [_ expanded?]]
+      {:db (assoc db :cancellation-cascade-expanded? (boolean expanded?))}))
 
   ;; ---- focus-trace-entry: row-click jump --------------------------------
   ;;
@@ -60,7 +60,7 @@
   ;; (when the trace event was emitted during a drain); we delegate into
   ;; the legacy spine shim `:rf.xray/select-dispatch-id` so the
   ;; existing event-detail panel takes the focus pivot.
-  (rf/reg-event-fx :rf.xray/focus-trace-entry
+  (rf/reg-event :rf.xray/focus-trace-entry
     (fn [_ctx [_ {:keys [dispatch-id frame trace-id]}]]
       ;; trace-id rides through for the future per-event focus surface
       ;; (rf2-pending event-row direct focus); today the dispatch-id is

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -394,9 +394,9 @@
   runtime-db decoupled; it dispatches nothing and pins nothing."
   []
   ;; ---- mode toggle ------------------------------------------------------
-  (rf/reg-event-db :rf.xray/set-derivation-graph-mode
-    (fn [db [_ mode]]
-      (assoc db :derivation-graph-mode (if (#{:static :live} mode) mode :static))))
+  (rf/reg-event :rf.xray/set-derivation-graph-mode
+    (fn [{:keys [db]} [_ mode]]
+      {:db (assoc db :derivation-graph-mode (if (#{:static :live} mode) mode :static))}))
 
   (rf/reg-sub :rf.xray/derivation-graph-mode
     (fn [db _] (get db :derivation-graph-mode :static)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -402,10 +402,10 @@
     (fn [db _] (get db :derivation-graph-mode :static)))
 
   ;; ---- test override ----------------------------------------------------
-  (rf/reg-event-db :rf.xray/set-derivation-graph-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :derivation-graph-override)
-          (assoc db :derivation-graph-override ov))))
+  (rf/reg-event :rf.xray/set-derivation-graph-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :derivation-graph-override)
+          (assoc db :derivation-graph-override ov))}))
   (rf/reg-sub :rf.xray/derivation-graph-override
     (fn [db _] (get db :derivation-graph-override)))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -637,11 +637,25 @@
       (str "history recorded " compound " = " (pr-str recorded-config)))))
 
 (defn handler-flavour-label
-  "Human-readable label for a handler flavour keyword."
+  "Human-readable label for a handler flavour keyword — the HANDLER step's
+  verb.
+
+  EP-0018 collapsed the three public event registrars onto the ONE public
+  `reg-event` form, so the verb the panel surfaces is `reg-event` for BOTH
+  the db-only and the fx-bearing event flavours — the panel no longer names
+  the retired `reg-event-db` / `reg-event-fx` spellings. The internal
+  `:reg-event-db` / `:reg-event-fx` discriminator (read off the trace stream
+  by `projection/handler-flavour`) still drives WHICH sections the HANDLER
+  body renders (a `:db`-only diff vs a `:db` diff plus per-fx blocks) — that
+  observed effect-shape distinction is real and useful — but it is an
+  internal classification, not a user-facing registrar name.
+
+  `:reg-machine` keeps its own verb: machines are a distinct registration
+  concept (`reg-machine`), untouched by the event-registration collapse."
   [flavour]
   (case flavour
-    :reg-event-db  "reg-event-db"
-    :reg-event-fx  "reg-event-fx"
+    :reg-event-db  "reg-event"
+    :reg-event-fx  "reg-event"
     :reg-machine   "reg-machine"
     (str flavour)))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -13,8 +13,12 @@
   - no `:rf.flow/computed` events → no FLOW step
   - no side effect (no `:db` commit, no `:fx`, no other effect) →
     no SIDE EFFECTS step
-  - HANDLER step adapts to the handler's flavour:
-      reg-event-db / reg-event-fx / reg-machine
+  - HANDLER step adapts to the handler's flavour — the OBSERVED effect
+    shape, read off the trace stream (NOT the registration form):
+      :reg-event-db (db-only) / :reg-event-fx (db+fx) / :reg-machine.
+    These are internal classification keywords; EP-0018 collapsed the
+    public event registrars onto the one `reg-event` form, so the HANDLER
+    VERB the panel displays is `reg-event` (see `format/handler-flavour-label`).
 
   Per the bead body, the panel's correctness depends on a pure-data
   projection layer that runs against the epoch record's `:trace-events`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -120,18 +120,18 @@
     (fn [db _query]
       (get db :epoch-panel-expanded-rows #{})))
 
-  (rf/reg-event-db :rf.xray.epoch/toggle-row-expand
-    (fn [db [_ step-kw row-id]]
-      (let [k (vector step-kw row-id)
+  (rf/reg-event :rf.xray.epoch/toggle-row-expand
+    (fn [{:keys [db]} [_ step-kw row-id]]
+      {:db (let [k (vector step-kw row-id)
             current (get db :epoch-panel-expanded-rows #{})]
         (assoc db :epoch-panel-expanded-rows
                (if (contains? current k)
                  (disj current k)
-                 (conj current k))))))
+                 (conj current k))))}))
 
-  (rf/reg-event-db :rf.xray.epoch/clear-row-expand
-    (fn [db _event]
-      (dissoc db :epoch-panel-expanded-rows)))
+  (rf/reg-event :rf.xray.epoch/clear-row-expand
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :epoch-panel-expanded-rows)}))
 
   ;; ---- SUBSCRIPTIONS [all][changed][unchanged] filter (rf2-tzmmf) ------
   ;;
@@ -157,9 +157,9 @@
     (fn [db _query]
       (get db :epoch-panel-subs-filter-mode :changed)))
 
-  (rf/reg-event-db :rf.xray.epoch/set-subs-filter-mode
-    (fn [db [_ mode]]
-      (assoc db :epoch-panel-subs-filter-mode mode)))
+  (rf/reg-event :rf.xray.epoch/set-subs-filter-mode
+    (fn [{:keys [db]} [_ mode]]
+      {:db (assoc db :epoch-panel-subs-filter-mode mode)}))
 
   ;; ---- HANDLER :db + SUBSCRIPTIONS value rendering ---------------------
   ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -158,20 +158,20 @@
     (fn [{:keys [db]} [_ t]]
       {:db (assoc db :rings/now-ms (or t (.now js/Date)))}))
 
-  (rf/reg-event-db :rf.xray/timer-hover
-    (fn [db [_ payload]]
-      (if (nil? payload)
+  (rf/reg-event :rf.xray/timer-hover
+    (fn [{:keys [db]} [_ payload]]
+      {:db (if (nil? payload)
         (dissoc db :rings/hover)
-        (assoc db :rings/hover payload))))
+        (assoc db :rings/hover payload))}))
 
   ;; Test-only override for `now-ms` — the JVM helpers tests don't
   ;; need it (pure fn) but the CLJS test surface uses it to pin a
   ;; deterministic timestamp into the projection.
-  (rf/reg-event-db :rf.xray/set-now-ms-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray/set-now-ms-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :rings/now-ms-override)
-        (assoc db :rings/now-ms-override ov)))))
+        (assoc db :rings/now-ms-override ov))})))
 
 ;; ---- rAF tick driver ----------------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -150,13 +150,13 @@
 (defn install-events!
   "Register the rings event family. Idempotent."
   []
-  (rf/reg-event-db :rf.xray/timer-tick
+  (rf/reg-event :rf.xray/timer-tick
     ;; Per rf2-qsjda — `:rf.trace/no-emit?` keeps the rAF tick from
     ;; bombing Xray's own trace buffer 60 times per second. The tick
     ;; is an internal animation pulse, not user-visible signal.
     {:rf.trace/no-emit? true}
-    (fn [db [_ t]]
-      (assoc db :rings/now-ms (or t (.now js/Date)))))
+    (fn [{:keys [db]} [_ t]]
+      {:db (assoc db :rings/now-ms (or t (.now js/Date)))}))
 
   (rf/reg-event-db :rf.xray/timer-hover
     (fn [db [_ payload]]

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -163,7 +163,7 @@
   ;; rf2-3d987 issue #4 — toggle the per-machine chart-collapsed flag.
   ;; `mode` is :collapsed / :expanded / :toggle. Persists the post-mutation
   ;; map to localStorage so the operator's choice survives reloads.
-  (rf/reg-event-fx :rf.xray.machine-canvas/set-chart-collapsed
+  (rf/reg-event :rf.xray.machine-canvas/set-chart-collapsed
     (fn [{:keys [db]} [_ {:keys [machine-id mode]}]]
       (let [current (chart-collapsed-of db machine-id)
             next    (case mode
@@ -177,9 +177,9 @@
         {:db db'
          :rf.xray.machine-canvas/persist-chart-collapsed by-id})))
 
-  (rf/reg-event-db :rf.xray.machine-canvas/hydrate-chart-collapsed
-    (fn [db [_ by-id]]
-      (assoc-in db [slot-root :chart-collapsed-by-id] (or by-id {})))))
+  (rf/reg-event :rf.xray.machine-canvas/hydrate-chart-collapsed
+    (fn [{:keys [db]} [_ by-id]]
+      {:db (assoc-in db [slot-root :chart-collapsed-by-id] (or by-id {}))})))
 
 ;; ---- fx -----------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -689,11 +689,11 @@
             (try (vec (machines/machines))
                  (catch :default _ []))))))
 
-  (rf/reg-event-db :rf.xray/set-registered-machines-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray/set-registered-machines-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :registered-machines-override)
-        (assoc db :registered-machines-override ov))))
+        (assoc db :registered-machines-override ov))}))
 
   ;; The live snapshots map for every registered machine.
   ;;
@@ -726,11 +726,11 @@
     (fn [db _query]
       (get db :machine-snapshots-override)))
 
-  (rf/reg-event-db :rf.xray/set-machine-snapshots-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray/set-machine-snapshots-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :machine-snapshots-override)
-        (assoc db :machine-snapshots-override ov))))
+        (assoc db :machine-snapshots-override ov))}))
 
   ;; The registered-machine-definition map for every machine.
   (rf/reg-sub :rf.xray/machine-definitions-override
@@ -749,11 +749,11 @@
                           (when m [id m]))))
                 (or machines [])))))
 
-  (rf/reg-event-db :rf.xray/set-machine-definitions-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray/set-machine-definitions-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :machine-definitions-override)
-        (assoc db :machine-definitions-override ov))))
+        (assoc db :machine-definitions-override ov))}))
 
   ;; The user's per-panel machine selection (kept as a slot for the
   ;; Sim engine + the Instances-jump focus landing; the share-URL
@@ -845,17 +845,17 @@
          :event-id event-id})))
 
   ;; Test-only overrides for the focused-event composite.
-  (rf/reg-event-db :rf.xray/set-epoch-history-for-test
-    (fn [db [_ history]]
-      (if (nil? history)
+  (rf/reg-event :rf.xray/set-epoch-history-for-test
+    (fn [{:keys [db]} [_ history]]
+      {:db (if (nil? history)
         (dissoc db :epoch-history)
-        (assoc db :epoch-history (vec history)))))
+        (assoc db :epoch-history (vec history)))}))
 
-  (rf/reg-event-db :rf.xray/set-focus-epoch-id-for-test
-    (fn [db [_ epoch-id]]
-      (if (nil? epoch-id)
+  (rf/reg-event :rf.xray/set-focus-epoch-id-for-test
+    (fn [{:keys [db]} [_ epoch-id]]
+      {:db (if (nil? epoch-id)
         (update db :focus dissoc :epoch-id)
-        (update db :focus (fnil assoc {}) :epoch-id epoch-id))))
+        (update db :focus (fnil assoc {}) :epoch-id epoch-id))}))
 
   ;; ---- Machine Inspector panel events -----------------------------
 
@@ -867,9 +867,9 @@
     (fn [{:keys [db]} _event]
       {:db (dissoc db :selected-machine-id)}))
 
-  (rf/reg-event-db :rf.xray/machine-state-clicked
-    (fn [db [_ _payload]]
-      db))
+  (rf/reg-event :rf.xray/machine-state-clicked
+    (fn [{:keys [db]} [_ _payload]]
+      {:db db}))
 
   (rf/reg-event :rf.xray/machine-chart-layout-pulse
     (fn [{:keys [db]} _event]
@@ -970,11 +970,11 @@
                         frame-id (assoc-in [:focus :frame] frame-id))))
 
                   :else (recur (step i))))))]
-    (rf/reg-event-db :rf.xray/machine-focus-prev
-      (fn [db _event] (step-focus db :prev)))
+    (rf/reg-event :rf.xray/machine-focus-prev
+      (fn [{:keys [db]} _event] {:db (step-focus db :prev)}))
 
-    (rf/reg-event-db :rf.xray/machine-focus-next
-      (fn [db _event] (step-focus db :next))))
+    (rf/reg-event :rf.xray/machine-focus-next
+      (fn [{:keys [db]} _event] {:db (step-focus db :next)})))
 
   ;; ---- scrubber-position slot ----------
 
@@ -988,9 +988,9 @@
     (fn [db _query]
       (get db :machine-inspector/scrubber-position :present)))
 
-  (rf/reg-event-db :rf.xray/set-scrubber-position
-    (fn [db [_ position]]
-      (cond
+  (rf/reg-event :rf.xray/set-scrubber-position
+    (fn [{:keys [db]} [_ position]]
+      {:db (cond
         (= :present position)
         (assoc db :machine-inspector/scrubber-position :present)
 
@@ -1000,7 +1000,7 @@
         (nil? position)
         (assoc db :machine-inspector/scrubber-position :present)
 
-        :else db)))
+        :else db)}))
 
   ;; ---- Sim engine ------------------------------------------------
   ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -859,21 +859,21 @@
 
   ;; ---- Machine Inspector panel events -----------------------------
 
-  (rf/reg-event-db :rf.xray/select-machine-id
-    (fn [db [_ machine-id]]
-      (assoc db :selected-machine-id machine-id)))
+  (rf/reg-event :rf.xray/select-machine-id
+    (fn [{:keys [db]} [_ machine-id]]
+      {:db (assoc db :selected-machine-id machine-id)}))
 
-  (rf/reg-event-db :rf.xray/clear-machine-selection
-    (fn [db _event]
-      (dissoc db :selected-machine-id)))
+  (rf/reg-event :rf.xray/clear-machine-selection
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :selected-machine-id)}))
 
   (rf/reg-event-db :rf.xray/machine-state-clicked
     (fn [db [_ _payload]]
       db))
 
-  (rf/reg-event-db :rf.xray/machine-chart-layout-pulse
-    (fn [db _event]
-      (update db :machine-inspector/elk-pulse-tick (fnil inc 0))))
+  (rf/reg-event :rf.xray/machine-chart-layout-pulse
+    (fn [{:keys [db]} _event]
+      {:db (update db :machine-inspector/elk-pulse-tick (fnil inc 0))}))
 
   ;; ---- per-machine prev/next nav (rf2-y9xmf · fixed rf2-nugvv) ----
   ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_subs.cljs
@@ -56,6 +56,6 @@
   ;; panel-side concept ('focus this event'), since the panel surfaces
   ;; an event vector and the user thinks 'jump to that event' rather
   ;; than 'jump to that cascade'. Internally same write.
-  (rf/reg-event-db :rf.xray/focus-event
-    (fn [db [_ dispatch-id frame-id]]
-      (spine/focus-cascade-reducer db dispatch-id frame-id))))
+  (rf/reg-event :rf.xray/focus-event
+    (fn [{:keys [db]} [_ dispatch-id frame-id]]
+      {:db (spine/focus-cascade-reducer db dispatch-id frame-id)})))

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_events.cljs
@@ -9,11 +9,11 @@
 
 (defn install!
   []
-  (rf/reg-event-db :rf.xray/reactive-toggle-unchanged
-    (fn [db _]
-      (update db :reactive/show-unchanged? not)))
+  (rf/reg-event :rf.xray/reactive-toggle-unchanged
+    (fn [{:keys [db]} _]
+      {:db (update db :reactive/show-unchanged? not)}))
 
-  (rf/reg-event-db :rf.xray/reactive-set-unchanged
-    (fn [db [_ v?]]
-      (assoc db :reactive/show-unchanged? (boolean v?))))
+  (rf/reg-event :rf.xray/reactive-set-unchanged
+    (fn [{:keys [db]} [_ v?]]
+      {:db (assoc db :reactive/show-unchanged? (boolean v?))}))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -771,45 +771,45 @@
 
   ;; Test-only override slots ---------------------------------------------
 
-  (rf/reg-event-db :rf.xray/set-registered-resources-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :registered-resources-override)
-          (assoc db :registered-resources-override ov))))
+  (rf/reg-event :rf.xray/set-registered-resources-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :registered-resources-override)
+          (assoc db :registered-resources-override ov))}))
   (rf/reg-sub :rf.xray/registered-resources-override
     (fn [db _] (get db :registered-resources-override)))
 
-  (rf/reg-event-db :rf.xray/set-registered-scope-resolvers-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :registered-scope-resolvers-override)
-          (assoc db :registered-scope-resolvers-override ov))))
+  (rf/reg-event :rf.xray/set-registered-scope-resolvers-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :registered-scope-resolvers-override)
+          (assoc db :registered-scope-resolvers-override ov))}))
   (rf/reg-sub :rf.xray/registered-scope-resolvers-override
     (fn [db _] (get db :registered-scope-resolvers-override)))
 
-  (rf/reg-event-db :rf.xray/set-resource-entries-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :resource-entries-override)
-          (assoc db :resource-entries-override ov))))
+  (rf/reg-event :rf.xray/set-resource-entries-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-entries-override)
+          (assoc db :resource-entries-override ov))}))
   (rf/reg-sub :rf.xray/resource-entries-override
     (fn [db _] (get db :resource-entries-override)))
 
-  (rf/reg-event-db :rf.xray/set-resource-work-ledger-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :resource-work-ledger-override)
-          (assoc db :resource-work-ledger-override ov))))
+  (rf/reg-event :rf.xray/set-resource-work-ledger-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-work-ledger-override)
+          (assoc db :resource-work-ledger-override ov))}))
   (rf/reg-sub :rf.xray/resource-work-ledger-override
     (fn [db _] (get db :resource-work-ledger-override)))
 
-  (rf/reg-event-db :rf.xray/set-resource-sub-reads-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :resource-sub-reads-override)
-          (assoc db :resource-sub-reads-override ov))))
+  (rf/reg-event :rf.xray/set-resource-sub-reads-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-sub-reads-override)
+          (assoc db :resource-sub-reads-override ov))}))
   (rf/reg-sub :rf.xray/resource-sub-reads-override
     (fn [db _] (get db :resource-sub-reads-override)))
 
-  (rf/reg-event-db :rf.xray/set-resource-routing-slice-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov) (dissoc db :resource-routing-slice-override)
-          (assoc db :resource-routing-slice-override ov))))
+  (rf/reg-event :rf.xray/set-resource-routing-slice-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-routing-slice-override)
+          (assoc db :resource-routing-slice-override ov))}))
   (rf/reg-sub :rf.xray/resource-routing-slice-override
     (fn [db _] (get db :resource-routing-slice-override)))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
@@ -488,21 +488,21 @@
 
   ;; Test-only override slots --------------------------------------------
 
-  (rf/reg-event-db :rf.xray/set-registered-routes-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray/set-registered-routes-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :registered-routes-override)
-        (assoc db :registered-routes-override ov))))
+        (assoc db :registered-routes-override ov))}))
 
   (rf/reg-sub :rf.xray/registered-routes-override
     (fn [db _query]
       (get db :registered-routes-override)))
 
-  (rf/reg-event-db :rf.xray/set-current-route-slice-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray/set-current-route-slice-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :current-route-slice-override)
-        (assoc db :current-route-slice-override ov))))
+        (assoc db :current-route-slice-override ov))}))
 
   (rf/reg-sub :rf.xray/current-route-slice-override
     (fn [db _query]

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -950,19 +950,19 @@
     (fn [db _query]
       (get db :trace-expanded-row-ids #{})))
 
-  (rf/reg-event-db :rf.xray/toggle-trace-row-expand
-    (fn [db [_ row-id]]
-      (let [current (get db :trace-expanded-row-ids #{})]
+  (rf/reg-event :rf.xray/toggle-trace-row-expand
+    (fn [{:keys [db]} [_ row-id]]
+      {:db (let [current (get db :trace-expanded-row-ids #{})]
         (assoc db :trace-expanded-row-ids
                (if (contains? current row-id)
                  (disj current row-id)
-                 (conj current row-id))))))
+                 (conj current row-id))))}))
 
   ;; rf2-aqusw — the flat list lost the collapsible phase bands; the
   ;; expand set is the only per-row UI state left to clear.
-  (rf/reg-event-db :rf.xray/clear-trace-expand
-    (fn [db _event]
-      (dissoc db :trace-expanded-row-ids)))
+  (rf/reg-event :rf.xray/clear-trace-expand
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :trace-expanded-row-ids)}))
 
   ;; rf2-2moh1 — register the Dynamic Trace tab with the internal L4
   ;; tab registry. The tab keeps its `t` mnemonic + order-3 placement.

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -214,10 +214,10 @@
       (fn [db _query]
         (get db :modal-positioning :fixed)))
 
-    (rf/reg-event-db :rf.xray/set-modal-positioning
+    (rf/reg-event :rf.xray/set-modal-positioning
       {:rf.trace/no-emit? true}
-      (fn [db [_ positioning]]
-        (assoc db :modal-positioning (or positioning :fixed))))
+      (fn [{:keys [db]} [_ positioning]]
+        {:db (assoc db :modal-positioning (or positioning :fixed))}))
 
     ;; ---- Panel width (rf2-x8h9y horizontal resize handle) -------
     ;;
@@ -247,10 +247,10 @@
             (config/get-setting :general :panel-width-px)
             config/default-panel-width-px)))
 
-    (rf/reg-event-db :rf.xray/set-panel-width-px
+    (rf/reg-event :rf.xray/set-panel-width-px
       {:rf.trace/no-emit? true}
-      (fn [db [_ px]]
-        (let [viewport (or (when (exists? js/window)
+      (fn [{:keys [db]} [_ px]]
+        {:db (let [viewport (or (when (exists? js/window)
                              (.-innerWidth js/window))
                            2000)
               clamped  (config/clamp-panel-width-px px viewport)]
@@ -260,14 +260,14 @@
           ;; layout host's `flex-basis` re-evaluates this paint.
           (config/update-setting! :general :panel-width-px clamped)
           (settings-effects/apply-panel-width! clamped)
-          (assoc-in db [:settings :general :panel-width-px] clamped))))
+          (assoc-in db [:settings :general :panel-width-px] clamped))}))
 
     ;; Reset to default — bound to the resize handle's double-click.
     ;; Routes through the same write surface so persistence + DOM
     ;; cascade stay consistent. Separate event id so the palette /
     ;; key-binding affordance can wire to it without re-implementing
     ;; the clamp + persist logic.
-    (rf/reg-event-fx :rf.xray/reset-panel-width
+    (rf/reg-event :rf.xray/reset-panel-width
       {:rf.trace/no-emit? true}
       (fn [_ _event]
         {:fx [[:dispatch [:rf.xray/set-panel-width-px
@@ -299,10 +299,10 @@
             (config/get-setting :general :events-list-height-px)
             config/default-events-list-height-px)))
 
-    (rf/reg-event-db :rf.xray/set-events-list-height-px
+    (rf/reg-event :rf.xray/set-events-list-height-px
       {:rf.trace/no-emit? true}
-      (fn [db [_ px]]
-        (let [viewport (or (when (exists? js/window)
+      (fn [{:keys [db]} [_ px]]
+        {:db (let [viewport (or (when (exists? js/window)
                              (.-innerHeight js/window))
                            1000)
               clamped  (config/clamp-events-list-height-px px viewport)]
@@ -310,12 +310,12 @@
           ;; (config atom drives localStorage round-trip; app-db slot
           ;; drives reactive re-render).
           (config/update-setting! :general :events-list-height-px clamped)
-          (assoc-in db [:settings :general :events-list-height-px] clamped))))
+          (assoc-in db [:settings :general :events-list-height-px] clamped))}))
 
     ;; Reset to default — bound to the seam handle's double-click +
     ;; Enter/Space keyboard binding. Routes through the same write
     ;; surface so persistence stays consistent.
-    (rf/reg-event-fx :rf.xray/reset-events-list-height
+    (rf/reg-event :rf.xray/reset-events-list-height
       {:rf.trace/no-emit? true}
       (fn [_ _event]
         {:fx [[:dispatch [:rf.xray/set-events-list-height-px
@@ -366,7 +366,7 @@
     ;; double-click and to the Enter/Space keyboard affordance.
     ;; Routes through the same write surface so persistence stays
     ;; consistent.
-    (rf/reg-event-fx :rf.xray/reset-event-list-col-width
+    (rf/reg-event :rf.xray/reset-event-list-col-width
       {:rf.trace/no-emit? true}
       (fn [_ [_ col-id]]
         (when-let [default-px (get config/event-list-col-default-widths col-id)]
@@ -509,13 +509,13 @@
     ;; focus back to LIVE (head-tracking) per the rf2-s0s5x Phase A
     ;; semantics. Relocated from event_detail.cljs alongside the
     ;; select event above (rf2-5gl5r).
-    (rf/reg-event-db :rf.xray/clear-selected-dispatch-id
-      (fn [db _event]
-        (update db :focus (fnil assoc {})
+    (rf/reg-event :rf.xray/clear-selected-dispatch-id
+      (fn [{:keys [db]} _event]
+        {:db (update db :focus (fnil assoc {})
                 :dispatch-id nil
                 :epoch-id    nil
                 :mode        :live
-                :previewing? false)))
+                :previewing? false)}))
 
     ;; ---- L2 relative-time anchor (rf2-vbbq0 / rf2-0s2at) ----------
     ;;
@@ -640,14 +640,14 @@
       (fn [db _query]
         (get db :rf.xray.static/selected-tab static-shell/default-tab)))
 
-    (rf/reg-event-fx :rf.xray/set-mode
+    (rf/reg-event :rf.xray/set-mode
       (fn [{:keys [db]} [_ mode]]
         (let [next-mode (static-persistence/normalise-mode mode)
               next-db   (assoc db :mode next-mode)]
           {:db next-db
            :fx [[:rf.xray.static/persist-mode next-mode]]})))
 
-    (rf/reg-event-fx :rf.xray/toggle-mode
+    (rf/reg-event :rf.xray/toggle-mode
       (fn [{:keys [db]} _event]
         (let [current  (static-persistence/normalise-mode (get db :mode :dynamic))
               next-mode (if (= current :static) :dynamic :static)
@@ -680,13 +680,13 @@
     ;; same slot but threads through the popup's draft. Both surfaces
     ;; share the `:rf.xray.filters/persist` fx so every mutation
     ;; round-trips to localStorage in one place (rf2-ak4ms).
-    (rf/reg-event-fx :rf.xray/add-filter
+    (rf/reg-event :rf.xray/add-filter
       (fn [{:keys [db]} [_ mode pill]]
         (let [next-db (update-in db [:active-filters mode] (fnil conj []) pill)]
           {:db next-db
            :fx [[:rf.xray.filters/persist (get next-db :active-filters)]]})))
 
-    (rf/reg-event-fx :rf.xray/remove-filter
+    (rf/reg-event :rf.xray/remove-filter
       (fn [{:keys [db]} [_ mode idx]]
         (let [next-db
               (update-in db [:active-filters mode]
@@ -705,19 +705,19 @@
     ;; `mount/popout!` — the event/fx bridge keeps shell.cljs free of a
     ;; direct mount require (mirrors the close-shell bridge below). The
     ;; programmatic `(xray/popout!)` API remains the secondary path.
-    (rf/reg-event-db :rf.xray/open-settings
-      (fn [db _event]
+    (rf/reg-event :rf.xray/open-settings
+      (fn [{:keys [db]} _event]
         ;; Settings popup lands behind rf2-pending-settings-modal.
-        (assoc db :settings-open? true)))
+        {:db (assoc db :settings-open? true)}))
 
-    (rf/reg-event-fx :rf.xray/popout-shell
+    (rf/reg-event :rf.xray/popout-shell
       (fn [_cofx _event]
         ;; rf2-czcg5 — open the second-window pop-out via the DOM-side
         ;; effect. No db change: the pop-out is a sibling mount surface,
         ;; not a reactive flag.
         {:fx [[:rf.xray.fx/popout-shell]]}))
 
-    (rf/reg-event-fx :rf.xray/close-shell
+    (rf/reg-event :rf.xray/close-shell
       (fn [{:keys [db]} _event]
         ;; Close intent (rf2-fq491). Two outcomes, kept in lock-step:
         ;;   :db  — set the reactive `:close-requested?` flag so the
@@ -760,10 +760,10 @@
     ;; per-frame rings + Xray's frameless secondary ring (dispatched
     ;; from `trace-collector/retroactive-scrub!`). Per rf2-qsjda the
     ;; `:rf.trace/no-emit?` flag avoids re-entering the trace fan-out.
-    (rf/reg-event-db :rf.xray/clear-trace-buffer
+    (rf/reg-event :rf.xray/clear-trace-buffer
       {:rf.trace/no-emit? true}
-      (fn [db _event]
-        (dissoc db :trace-buffer)))
+      (fn [{:keys [db]} _event]
+        {:db (dissoc db :trace-buffer)}))
 
     ;; Wholesale overwrite of the mirrored slot. Dispatched from
     ;; `mount.cljs/open!` on first Ctrl+Shift+C to seed `:rf/xray`'s
@@ -772,10 +772,10 @@
     ;; opened, and from `trace-collector/refresh-trace-rings!` /
     ;; `request-mirror-sync!` on every microtask. Per rf2-qsjda
     ;; `:rf.trace/no-emit? true` for the same loop-avoidance reason.
-    (rf/reg-event-db :rf.xray/sync-trace-buffer
+    (rf/reg-event :rf.xray/sync-trace-buffer
       {:rf.trace/no-emit? true}
-      (fn [db [_ buffer]]
-        (assoc db :trace-buffer (vec buffer))))
+      (fn [{:keys [db]} [_ buffer]]
+        {:db (assoc db :trace-buffer (vec buffer))}))
 
     ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
     ;; Dispatched from `trace-collector/collect-trace!` (CLJS) under
@@ -795,11 +795,11 @@
     ;; short-circuits emission at the `emit!` / `emit-error!` /
     ;; `emit-dispatched-trace!` gates — the predecessor Xray-side
     ;; `self-emitted?` guard (rf2-nk01x) is obsolete.
-    (rf/reg-event-db :rf.xray/note-sensitive-suppressed
+    (rf/reg-event :rf.xray/note-sensitive-suppressed
       {:rf.trace/no-emit? true}
-      (fn [db [_ frame-id]]
-        (update-in db [:suppressed-counters (or frame-id :global)]
-                   (fnil inc 0))))
+      (fn [{:keys [db]} [_ frame-id]]
+        {:db (update-in db [:suppressed-counters (or frame-id :global)]
+                   (fnil inc 0))}))
 
     ;; Reset the suppressed-events counter (rf2-0vxdn). With no arg,
     ;; clears every bucket; with a `frame-id`, drops just that bucket.

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -345,10 +345,10 @@
           (or (get-in db [:settings :general :event-list-col-widths])
               (config/get-setting :general :event-list-col-widths)))))
 
-    (rf/reg-event-db :rf.xray/set-event-list-col-width
+    (rf/reg-event :rf.xray/set-event-list-col-width
       {:rf.trace/no-emit? true}
-      (fn [db [_ col-id px]]
-        (if-let [clamped (config/clamp-event-list-col-width col-id px)]
+      (fn [{:keys [db]} [_ col-id px]]
+        {:db (if-let [clamped (config/clamp-event-list-col-width col-id px)]
           (let [persisted (or (config/get-setting :general :event-list-col-widths)
                               config/event-list-col-default-widths)
                 next-map  (assoc persisted col-id clamped)]
@@ -360,7 +360,7 @@
           ;; Unknown column-id (e.g. `event-id` — flex, never sized):
           ;; no-op. Defensive — the divider views only dispatch for
           ;; the three resizable ids.
-          db)))
+          db)}))
 
     ;; Reset one column to its default — bound to a divider's
     ;; double-click and to the Enter/Space keyboard affordance.
@@ -496,14 +496,14 @@
     ;; epoch-id nil → the epoch-keyed panels strand on an empty/stale
     ;; state. The cross-frame ring is resolved via `rf/epoch-history` at
     ;; dispatch time; the re-seed is a no-op when the frame is unchanged.
-    (rf/reg-event-db :rf.xray/select-dispatch-id
-      (fn [db [_ dispatch-id frame-id]]
-        (let [db       (spine/reseed-epoch-history-for-frame
+    (rf/reg-event :rf.xray/select-dispatch-id
+      (fn [{:keys [db]} [_ dispatch-id frame-id]]
+        {:db (let [db       (spine/reseed-epoch-history-for-frame
                          db frame-id (rf/epoch-history frame-id))
               history  (get db :epoch-history [])
               epoch-id (spine/epoch-id-for-cascade history dispatch-id)
               head-id  (spine/focusable-head-id (spine/db->cascades db))]
-          (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))
+          (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))}))
 
     ;; Programmatic clear of the focused cascade. Resets the spine
     ;; focus back to LIVE (head-tracking) per the rf2-s0s5x Phase A
@@ -556,8 +556,8 @@
     ;; supersedes):
     ;; :epoch :app-db :views :trace :machines :routing
     ;; (rf2-2moh1 registry-driven; new tab requires only a reg-l4-tab! call).
-    (rf/reg-event-db :rf.xray/select-tab
-      (fn [db [_ tab-id]]
+    (rf/reg-event :rf.xray/select-tab
+      (fn [{:keys [db]} [_ tab-id]]
         ;; rf2-6tw7t — activating the Machine tab bumps a monotonic
         ;; fit-signal counter so the Machine panel's topology re-fits to
         ;; view on entry (xyflow's one-shot `:fitView` + the layout-key
@@ -568,9 +568,9 @@
         ;; boolean) guarantees a fresh value on every re-entry, including
         ;; the case where the prior selection was already `:machines`
         ;; (re-clicking the active tab still re-frames).
-        (cond-> (assoc db :selected-tab tab-id)
+        {:db (cond-> (assoc db :selected-tab tab-id)
           (= tab-id :machines)
-          (update :machine-tab-activations (fnil inc 0)))))
+          (update :machine-tab-activations (fnil inc 0)))}))
 
     ;; ---- Issues feed composite (rf2-gbz39) ------------------------
     ;;
@@ -655,9 +655,9 @@
           {:db next-db
            :fx [[:rf.xray.static/persist-mode next-mode]]})))
 
-    (rf/reg-event-db :rf.xray.static/select-tab
-      (fn [db [_ tab-id]]
-        (if (contains? (static-shell/tab-ids) tab-id)
+    (rf/reg-event :rf.xray.static/select-tab
+      (fn [{:keys [db]} [_ tab-id]]
+        {:db (if (contains? (static-shell/tab-ids) tab-id)
           ;; rf2-6tw7t — Static shares the same `:machines` tab id +
           ;; `machine-canvas/Chart`, so activating it bumps the same
           ;; fit-signal counter the Dynamic select-tab does. The Static
@@ -665,7 +665,7 @@
           (cond-> (assoc db :rf.xray.static/selected-tab tab-id)
             (= tab-id :machines)
             (update :machine-tab-activations (fnil inc 0)))
-          db)))
+          db)}))
 
     ;; The persistence fx installs idempotently — re-frame's registrar
     ;; replaces in place. Mounting here means the fx is available the
@@ -810,12 +810,12 @@
     ;;
     ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
     ;; `:rf.xray/note-sensitive-suppressed` above for the rationale).
-    (rf/reg-event-db :rf.xray/reset-suppressed-counters
+    (rf/reg-event :rf.xray/reset-suppressed-counters
       {:rf.trace/no-emit? true}
-      (fn [db [_ frame-id]]
-        (if frame-id
+      (fn [{:keys [db]} [_ frame-id]]
+        {:db (if frame-id
           (update db :suppressed-counters dissoc (or frame-id :global))
-          (dissoc db :suppressed-counters))))
+          (dissoc db :suppressed-counters))}))
 
     ;; ---- per-panel installations --------------------------------
     ;;

--- a/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
@@ -56,20 +56,20 @@
   from `registry/register-xray-handlers!` (gated by the orchestrator's
   sentinel)."
   []
-  (rf/reg-event-db :rf.xray/editor-hint-show
-    (fn [db _event]
-      (assoc db :editor-hint-open? true)))
+  (rf/reg-event :rf.xray/editor-hint-show
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :editor-hint-open? true)}))
 
-  (rf/reg-event-db :rf.xray/editor-hint-dismiss
-    (fn [db _event]
-      (assoc db :editor-hint-open? false)))
+  (rf/reg-event :rf.xray/editor-hint-dismiss
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :editor-hint-open? false)}))
 
   ;; Open the Settings popup on the General tab (where the editor
   ;; picker lives) and dismiss the toast in the same reduce. The
   ;; `:rf.xray/settings-open` handler already resets the active tab to
   ;; `:general` and seeds the settings snapshot, so opening it lands
   ;; the operator directly on the editor picker.
-  (rf/reg-event-fx :rf.xray/editor-hint-open-settings
+  (rf/reg-event :rf.xray/editor-hint-open-settings
     (fn [{:keys [db]} _event]
       {:db (assoc db :editor-hint-open? false)
        :fx [[:dispatch [:rf.xray/settings-open]]]}))

--- a/tools/xray/src/day8/re_frame2_xray/settings/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/events.cljs
@@ -55,9 +55,9 @@
   with a sentinel so re-loads do not re-install."
   []
 
-  (rf/reg-event-db :rf.xray/settings-open
-    (fn [db _event]
-      (-> db
+  (rf/reg-event :rf.xray/settings-open
+    (fn [{:keys [db]} _event]
+      {:db (-> db
           (assoc :settings-open? true)
           (assoc :settings-active-tab :general)
           ;; Lift the current atom snapshot into app-db so the
@@ -66,11 +66,11 @@
           ;; first render reads from the atom via the
           ;; `:rf.xray/setting` sub's fallback — works, but later
           ;; updates wouldn't propagate without a re-render trigger.
-          (assoc :settings (config/get-settings)))))
+          (assoc :settings (config/get-settings)))}))
 
-  (rf/reg-event-db :rf.xray/settings-close
-    (fn [db _event]
-      (assoc db :settings-open? false)))
+  (rf/reg-event :rf.xray/settings-close
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :settings-open? false)}))
 
   (rf/reg-event-db :rf.xray/settings-toggle
     (fn [db _event]
@@ -81,9 +81,9 @@
             (assoc :settings-active-tab :general)
             (assoc :settings (config/get-settings))))))
 
-  (rf/reg-event-db :rf.xray/settings-select-tab
-    (fn [db [_ tab-id]]
-      (assoc db :settings-active-tab tab-id)))
+  (rf/reg-event :rf.xray/settings-select-tab
+    (fn [{:keys [db]} [_ tab-id]]
+      {:db (assoc db :settings-active-tab tab-id)}))
 
   ;; Write a single setting. Dual-write: the atom (canonical, drives
   ;; localStorage round-trip) and app-db (drives the immediate
@@ -171,13 +171,13 @@
   ;; The button opens a nested confirmation dialog before clearing the
   ;; ring buffer; the dialog tracks its open state under
   ;; `:settings-clear-confirm-open?`.
-  (rf/reg-event-db :rf.xray/settings-confirm-clear-buffer
-    (fn [db _event]
-      (assoc db :settings-clear-confirm-open? true)))
+  (rf/reg-event :rf.xray/settings-confirm-clear-buffer
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :settings-clear-confirm-open? true)}))
 
-  (rf/reg-event-db :rf.xray/settings-cancel-clear-buffer
-    (fn [db _event]
-      (assoc db :settings-clear-confirm-open? false)))
+  (rf/reg-event :rf.xray/settings-cancel-clear-buffer
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :settings-clear-confirm-open? false)}))
 
   ;; rf2-ttnst (rf2-43koh consumer substrate) — perform the clear.
   ;; `trace-collector/retroactive-scrub!` empties the framework's
@@ -185,9 +185,9 @@
   ;; mirrored `:trace-buffer` slot, and drops the redaction counter.
   ;; We dismiss the confirm modal here; the parent Settings popup
   ;; stays open so the user lands back on the Buffer tab.
-  (rf/reg-event-db :rf.xray/settings-clear-buffer
-    (fn [db _event]
+  (rf/reg-event :rf.xray/settings-clear-buffer
+    (fn [{:keys [db]} _event]
       (try (trace-collector/retroactive-scrub!) (catch :default _ nil))
-      (assoc db :settings-clear-confirm-open? false)))
+      {:db (assoc db :settings-clear-confirm-open? false)}))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/settings/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/events.cljs
@@ -72,14 +72,14 @@
     (fn [{:keys [db]} _event]
       {:db (assoc db :settings-open? false)}))
 
-  (rf/reg-event-db :rf.xray/settings-toggle
-    (fn [db _event]
-      (if (get db :settings-open? false)
+  (rf/reg-event :rf.xray/settings-toggle
+    (fn [{:keys [db]} _event]
+      {:db (if (get db :settings-open? false)
         (assoc db :settings-open? false)
         (-> db
             (assoc :settings-open? true)
             (assoc :settings-active-tab :general)
-            (assoc :settings (config/get-settings))))))
+            (assoc :settings (config/get-settings))))}))
 
   (rf/reg-event :rf.xray/settings-select-tab
     (fn [{:keys [db]} [_ tab-id]]
@@ -95,8 +95,8 @@
   ;; After the dual-write, the matching side-effect lands so the
   ;; user sees the change immediately (text-size CSS var, theme
   ;; class, panel-position route).
-  (rf/reg-event-db :rf.xray/settings-update
-    (fn [db [_ section key value]]
+  (rf/reg-event :rf.xray/settings-update
+    (fn [{:keys [db]} [_ section key value]]
       (config/update-setting! section key value)
       (cond
         (and (= section :general) (= key :text-size))
@@ -163,9 +163,9 @@
           (effects/detach-auto-open-watcher!))
 
         :else nil)
-      (if (and (= section :theme) (nil? key))
+      {:db (if (and (= section :theme) (nil? key))
         (assoc-in db [:settings :theme] value)
-        (assoc-in db [:settings section key] value))))
+        (assoc-in db [:settings section key] value))}))
 
   ;; rf2-ttnst — Buffer tab "Clear buffer now" confirm-modal events.
   ;; The button opens a nested confirmation dialog before clearing the

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -856,32 +856,32 @@
   ;; pre-popup-seed reads fall back to the config atom via the helper
   ;; below (mirrors the `:rf.xray/show-ungrouped?` sub).
 
-  (rf/reg-event-db :rf.xray/focus-cascade
-    (fn [db [_ dispatch-id frame-id]]
+  (rf/reg-event :rf.xray/focus-cascade
+    (fn [{:keys [db]} [_ dispatch-id frame-id]]
       ;; rf2-q8hvw — re-key `:epoch-history` onto the clicked cascade's
       ;; frame BEFORE resolving its settling epoch. With the picker
       ;; untouched the L2 list spans every frame, so a non-head-frame
       ;; row's epoch lives outside the boot-frame slot; resolving against
       ;; the stale slot yields nil. No-op when the frame is unchanged.
-      (let [db             (reseed-epoch-history-for-frame
+      {:db (let [db             (reseed-epoch-history-for-frame
                              db frame-id (rf/epoch-history frame-id))
             cascades       (db->cascades db)
             show-ungrouped? (db->show-ungrouped? db)
             head-id        (focusable-head-id cascades show-ungrouped?)
             epoch-id       (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
-        (focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))
+        (focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))}))
 
-  (rf/reg-event-db :rf.xray/focus-cascade-prev
-    (fn [db _event]
-      (focus-step-reducer db (db->cascades db) (db->epoch-history db) -1
-                          (db->show-ungrouped? db))))
+  (rf/reg-event :rf.xray/focus-cascade-prev
+    (fn [{:keys [db]} _event]
+      {:db (focus-step-reducer db (db->cascades db) (db->epoch-history db) -1
+                          (db->show-ungrouped? db))}))
 
-  (rf/reg-event-db :rf.xray/focus-cascade-next
-    (fn [db _event]
-      (focus-step-reducer db (db->cascades db) (db->epoch-history db) +1
-                          (db->show-ungrouped? db))))
+  (rf/reg-event :rf.xray/focus-cascade-next
+    (fn [{:keys [db]} _event]
+      {:db (focus-step-reducer db (db->cascades db) (db->epoch-history db) +1
+                          (db->show-ungrouped? db))}))
 
-  (rf/reg-event-db :rf.xray/focus-epoch
+  (rf/reg-event :rf.xray/focus-epoch
     ;; Per rf2-5qp4g — focus the spine by epoch-id (the primary key
     ;; into the epoch ring buffer). Resolves the matching record's
     ;; settling dispatch-id via `dispatch-id-for-epoch` then defers
@@ -891,7 +891,7 @@
     ;; dispatches (the parent epoch was settled in the buffer); the
     ;; chip's click dispatches this event with the resolved
     ;; parent-epoch-id.
-    (fn [db [_ epoch-id]]
+    (fn [{:keys [db]} [_ epoch-id]]
       ;; rf2-q8hvw — if the targeted epoch's record lives in a frame
       ;; other than the slot's current `:target-frame`, re-key
       ;; `:epoch-history` onto it BEFORE resolving the settling
@@ -899,7 +899,7 @@
       ;; ring (the dispatch-id lookup walks `:epoch-history`). The frame
       ;; is read off the record in the current slot; when the slot
       ;; already holds that frame the re-seed is a no-op.
-      (let [record-frame    (:frame (some #(when (= epoch-id (:epoch-id %)) %)
+      {:db (let [record-frame    (:frame (some #(when (= epoch-id (:epoch-id %)) %)
                                           (db->epoch-history db)))
             db              (reseed-epoch-history-for-frame
                              db record-frame (rf/epoch-history record-frame))
@@ -923,27 +923,27 @@
                           :epoch-id   epoch-id
                           :mode       :retro
                           :previewing? false)
-            frame-id (assoc-in [:focus :frame] frame-id))))))
+            frame-id (assoc-in [:focus :frame] frame-id))))}))
 
-  (rf/reg-event-db :rf.xray/follow-head
-    (fn [db _event]
-      (follow-head-reducer db)))
+  (rf/reg-event :rf.xray/follow-head
+    (fn [{:keys [db]} _event]
+      {:db (follow-head-reducer db)}))
 
-  (rf/reg-event-db :rf.xray/toggle-live-pause
-    (fn [db _event]
-      (toggle-live-pause-reducer db)))
+  (rf/reg-event :rf.xray/toggle-live-pause
+    (fn [{:keys [db]} _event]
+      {:db (toggle-live-pause-reducer db)}))
 
-  (rf/reg-event-db :rf.xray/set-frame
-    (fn [db [_ frame-id]]
+  (rf/reg-event :rf.xray/set-frame
+    (fn [{:keys [db]} [_ frame-id]]
       ;; rf2-ug1r6 + rf2-thodq — re-seed `:epoch-history` from the
       ;; framework's per-frame ring at picker-change time so every
       ;; per-frame composite (App-DB Diff, Views, machine-inspector)
       ;; reads the picked frame's epochs immediately. See the reducer
       ;; docstring for the shared root cause.
-      (set-frame-reducer db frame-id (rf/epoch-history frame-id))))
+      {:db (set-frame-reducer db frame-id (rf/epoch-history frame-id))}))
 
-  (rf/reg-event-db :rf.xray/preview-cascade
-    (fn [db [_ dispatch-id]]
+  (rf/reg-event :rf.xray/preview-cascade
+    (fn [{:keys [db]} [_ dispatch-id]]
       ;; rf2-yng0y — resolve the previewed cascade's settling epoch-id
       ;; from the per-frame ring and write it in lockstep with
       ;; `:dispatch-id` so the spine's two axes never desync mid-
@@ -967,9 +967,9 @@
       ;; preview, which never commits a frame change. nil dispatch-id
       ;; (preview-clear) resolves frame to nil → epoch-id nil; the
       ;; reducer's restore-arm ignores it.
-      (let [frame-id      (:frame (cascade-by-id (db->cascades db) dispatch-id))
+      {:db (let [frame-id      (:frame (cascade-by-id (db->cascades db) dispatch-id))
             frame-history (when frame-id (rf/epoch-history frame-id))
             epoch-id      (epoch-id-for-cascade frame-history dispatch-id)]
-        (preview-cascade-reducer db dispatch-id epoch-id))))
+        (preview-cascade-reducer db dispatch-id epoch-id))}))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
@@ -629,15 +629,15 @@
   ;; outside-click / Escape / menu-item click (after the item's own
   ;; action lands).
 
-  (rf/reg-event-db :rf.xray/open-row-context-menu
+  (rf/reg-event :rf.xray/open-row-context-menu
     {:rf.trace/no-emit? true}
-    (fn [db [_ {:keys [event-id x y]}]]
-      (if event-id
+    (fn [{:keys [db]} [_ {:keys [event-id x y]}]]
+      {:db (if event-id
         (assoc db :row-context-menu
                   {:event-id event-id
                    :x        (or x 0)
                    :y        (or y 0)})
-        db)))
+        db)}))
 
   (rf/reg-event :rf.xray/close-row-context-menu
     {:rf.trace/no-emit? true}

--- a/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
@@ -587,21 +587,21 @@
   ;; lands in localStorage in one place (no fx-per-handler duplication;
   ;; mirrors the filters subsystem's pattern).
 
-  (rf/reg-event-fx :rf.xray/mute-event-id
+  (rf/reg-event :rf.xray/mute-event-id
     (fn [{:keys [db]} [_ event-id]]
       (let [next-muted (mute-event-id (get db :muted-event-ids) event-id)
             next-db    (assoc db :muted-event-ids next-muted)]
         {:db next-db
          :fx [[:rf.xray.spine-filters/persist next-muted]]})))
 
-  (rf/reg-event-fx :rf.xray/unmute-event-id
+  (rf/reg-event :rf.xray/unmute-event-id
     (fn [{:keys [db]} [_ event-id]]
       (let [next-muted (unmute-event-id (get db :muted-event-ids) event-id)
             next-db    (assoc db :muted-event-ids next-muted)]
         {:db next-db
          :fx [[:rf.xray.spine-filters/persist next-muted]]})))
 
-  (rf/reg-event-fx :rf.xray/clear-muted-event-ids
+  (rf/reg-event :rf.xray/clear-muted-event-ids
     (fn [{:keys [db]} _event]
       (let [next-muted (clear-muted (get db :muted-event-ids))
             next-db    (assoc db :muted-event-ids next-muted)]
@@ -610,15 +610,15 @@
 
   ;; ---- events: manager modal open / close -----------------------------
 
-  (rf/reg-event-db :rf.xray/open-mute-manager
+  (rf/reg-event :rf.xray/open-mute-manager
     {:rf.trace/no-emit? true}
-    (fn [db _event]
-      (assoc db :mute-manager-open? true)))
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :mute-manager-open? true)}))
 
-  (rf/reg-event-db :rf.xray/close-mute-manager
+  (rf/reg-event :rf.xray/close-mute-manager
     {:rf.trace/no-emit? true}
-    (fn [db _event]
-      (assoc db :mute-manager-open? false)))
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :mute-manager-open? false)}))
 
   ;; ---- events: row context menu open / close --------------------------
   ;;
@@ -639,17 +639,17 @@
                    :y        (or y 0)})
         db)))
 
-  (rf/reg-event-db :rf.xray/close-row-context-menu
+  (rf/reg-event :rf.xray/close-row-context-menu
     {:rf.trace/no-emit? true}
-    (fn [db _event]
-      (dissoc db :row-context-menu)))
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :row-context-menu)}))
 
   ;; ---- events: hydrate from localStorage ------------------------------
 
-  (rf/reg-event-db :rf.xray/hydrate-muted-event-ids
+  (rf/reg-event :rf.xray/hydrate-muted-event-ids
     {:rf.trace/no-emit? true}
-    (fn [db [_ muted]]
-      (assoc db :muted-event-ids (set (or muted #{})))))
+    (fn [{:keys [db]} [_ muted]]
+      {:db (assoc db :muted-event-ids (set (or muted #{})))}))
 
   ;; NO hydrate on install (rf2-swclw). The muted-event-ids set is a
   ;; TRANSIENT exploration filter — it resets to empty on every page

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -311,11 +311,11 @@
 
   ;; ---- UI state ---------------------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.flows/set-query
-    (fn [db [_ q]]
-      (if (or (nil? q) (= "" q))
+  (rf/reg-event :rf.xray.static.flows/set-query
+    (fn [{:keys [db]} [_ q]]
+      {:db (if (or (nil? q) (= "" q))
         (dissoc db :rf.xray.static.flows/query)
-        (assoc db :rf.xray.static.flows/query q))))
+        (assoc db :rf.xray.static.flows/query q))}))
 
   (rf/reg-sub :rf.xray.static.flows/query
     (fn [db _]
@@ -323,11 +323,11 @@
 
   ;; ---- test-only override ----------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.flows/set-registered-flows-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray.static.flows/set-registered-flows-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :rf.xray.static.flows/registered-flows-override)
-        (assoc db :rf.xray.static.flows/registered-flows-override ov))))
+        (assoc db :rf.xray.static.flows/registered-flows-override ov))}))
 
   (rf/reg-sub :rf.xray.static.flows/registered-flows-override
     (fn [db _]

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -256,11 +256,11 @@
 
   ;; ---- UI state ---------------------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.interceptors/set-query
-    (fn [db [_ q]]
-      (if (or (nil? q) (= "" q))
+  (rf/reg-event :rf.xray.static.interceptors/set-query
+    (fn [{:keys [db]} [_ q]]
+      {:db (if (or (nil? q) (= "" q))
         (dissoc db :rf.xray.static.interceptors/query)
-        (assoc db :rf.xray.static.interceptors/query q))))
+        (assoc db :rf.xray.static.interceptors/query q))}))
 
   (rf/reg-sub :rf.xray.static.interceptors/query
     (fn [db _]
@@ -268,11 +268,11 @@
 
   ;; ---- test-only override ----------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.interceptors/set-registry-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray.static.interceptors/set-registry-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :rf.xray.static.interceptors/registry-override)
-        (assoc db :rf.xray.static.interceptors/registry-override ov))))
+        (assoc db :rf.xray.static.interceptors/registry-override ov))}))
 
   (rf/reg-sub :rf.xray.static.interceptors/registry-override
     (fn [db _]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -171,30 +171,30 @@
 ;; ---- events -------------------------------------------------------------
 
 (defn- install-events! []
-  (rf/reg-event-fx :rf.xray.static.machines/select
+  (rf/reg-event :rf.xray.static.machines/select
     (fn [{:keys [db]} [_ machine-id]]
       (let [next-db (assoc db :rf.xray.static.machines/selected-id machine-id)]
         {:db next-db
          :fx [[:rf.xray.static.machines/persist-selection machine-id]]})))
 
-  (rf/reg-event-db :rf.xray.static.machines/set-search
-    (fn [db [_ query]]
-      (assoc db :rf.xray.static.machines/search (or query ""))))
+  (rf/reg-event :rf.xray.static.machines/set-search
+    (fn [{:keys [db]} [_ query]]
+      {:db (assoc db :rf.xray.static.machines/search (or query ""))}))
 
-  (rf/reg-event-db :rf.xray.static.machines/clear-search
-    (fn [db _event]
-      (dissoc db :rf.xray.static.machines/search)))
+  (rf/reg-event :rf.xray.static.machines/clear-search
+    (fn [{:keys [db]} _event]
+      {:db (dissoc db :rf.xray.static.machines/search)}))
 
-  (rf/reg-event-db :rf.xray.static.machines/cycle-sort
-    (fn [db _event]
-      (let [current (h/normalise-sort-key
+  (rf/reg-event :rf.xray.static.machines/cycle-sort
+    (fn [{:keys [db]} _event]
+      {:db (let [current (h/normalise-sort-key
                       (get db :rf.xray.static.machines/sort-key))
             ix      (.indexOf h/sort-keys current)
             next-ix (mod (inc ix) (count h/sort-keys))
             next-k  (nth h/sort-keys next-ix)]
-        (assoc db :rf.xray.static.machines/sort-key next-k))))
+        (assoc db :rf.xray.static.machines/sort-key next-k))}))
 
-  (rf/reg-event-fx :rf.xray.static.machines/set-sub-mode
+  (rf/reg-event :rf.xray.static.machines/set-sub-mode
     (fn [{:keys [db]} [_ machine-id sub-mode]]
       (let [normed  (h/normalise-sub-mode sub-mode)
             next-db (assoc-in db [:rf.xray.static.machines/sub-mode-by-id

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -204,27 +204,27 @@
         {:db next-db
          :fx [[:rf.xray.static.machines/persist-sub-mode by-id]]})))
 
-  (rf/reg-event-db :rf.xray.static.machines/hydrate
-    (fn [db [_ {:keys [selected-id sub-mode-by-id]}]]
-      (cond-> db
+  (rf/reg-event :rf.xray.static.machines/hydrate
+    (fn [{:keys [db]} [_ {:keys [selected-id sub-mode-by-id]}]]
+      {:db (cond-> db
         (some? selected-id)
         (assoc :rf.xray.static.machines/selected-id selected-id)
         (map? sub-mode-by-id)
-        (assoc :rf.xray.static.machines/sub-mode-by-id sub-mode-by-id))))
+        (assoc :rf.xray.static.machines/sub-mode-by-id sub-mode-by-id))}))
 
   ;; Click-on-state in the Topology mode. v1 is a no-op slot — the
   ;; metadata rail wires in a follow-on bead (per the bead's §Topology
   ;; mode 'Click state → metadata rail'). The event is registered now
   ;; so the chart's `:on-state-click` dispatch lands on a known handler
   ;; rather than emitting a `:rf.warning/no-handler` trace.
-  (rf/reg-event-db :rf.xray.static.machines/state-clicked
-    (fn [db [_ _payload]] db))
+  (rf/reg-event :rf.xray.static.machines/state-clicked
+    (fn [{:keys [db]} [_ _payload]] {:db db}))
 
   ;; Open-chart-popout — same posture: registered as a no-op slot so
   ;; the affordance has a landing handler. The pop-out window
   ;; orchestration rides the second-window UX bead.
-  (rf/reg-event-db :rf.xray.static.machines/open-chart-popout
-    (fn [db [_ _machine-id]] db))
+  (rf/reg-event :rf.xray.static.machines/open-chart-popout
+    (fn [{:keys [db]} [_ _machine-id]] {:db db}))
   nil)
 
 ;; ---- public install -----------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -198,16 +198,16 @@
   ;; definition so the event handler doesn't need to reach back through
   ;; `rf/machine-meta` (which would be re-resolved per step; sim wants
   ;; the definition pinned at start time).
-  (rf/reg-event-db :rf.xray.static.machines/sim-start
-    (fn [db [_ {:keys [machine-id definition]}]]
-      (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id]
-        (sim-h/make-sim-state machine-id definition))))
+  (rf/reg-event :rf.xray.static.machines/sim-start
+    (fn [{:keys [db]} [_ {:keys [machine-id definition]}]]
+      {:db (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id]
+        (sim-h/make-sim-state machine-id definition))}))
 
   ;; Stop sim for `machine-id`. Removes the per-machine slot so the
   ;; clone is GC'd; production registry was never touched.
-  (rf/reg-event-db :rf.xray.static.machines/sim-stop
-    (fn [db [_ {:keys [machine-id]}]]
-      (update db :rf.xray.static.machines/sim-by-machine dissoc machine-id)))
+  (rf/reg-event :rf.xray.static.machines/sim-stop
+    (fn [{:keys [db]} [_ {:keys [machine-id]}]]
+      {:db (update db :rf.xray.static.machines/sim-by-machine dissoc machine-id)}))
 
   ;; Reset sim for `machine-id` — rewind to the initial snapshot,
   ;; clear the trail, but stay in sim mode.

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -211,20 +211,20 @@
 
   ;; Reset sim for `machine-id` — rewind to the initial snapshot,
   ;; clear the trail, but stay in sim mode.
-  (rf/reg-event-db :rf.xray.static.machines/sim-reset
-    (fn [db [_ {:keys [machine-id]}]]
-      (if-let [sim (get-in db [:rf.xray.static.machines/sim-by-machine
+  (rf/reg-event :rf.xray.static.machines/sim-reset
+    (fn [{:keys [db]} [_ {:keys [machine-id]}]]
+      {:db (if-let [sim (get-in db [:rf.xray.static.machines/sim-by-machine
                                machine-id])]
         (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id]
           (sim-h/reset-sim-state sim))
-        db)))
+        db)}))
 
   ;; Step the sim — fire one event against the cloned snapshot.
   ;; `event` is a vector like `[:foo/bar {:x 1}]`. The step-and-store
   ;; body is shared with `:sim-chart-edge-clicked` via `step-and-store`.
-  (rf/reg-event-db :rf.xray.static.machines/sim-step
-    (fn [db [_ {:keys [machine-id event]}]]
-      (step-and-store db machine-id event)))
+  (rf/reg-event :rf.xray.static.machines/sim-step
+    (fn [{:keys [db]} [_ {:keys [machine-id event]}]]
+      {:db (step-and-store db machine-id event)}))
 
   ;; rf2-u422r — on-chart edge click → step. The chart's clickable edge
   ;; hands us the raw fireable event-id; coerce it to a step event vector
@@ -234,27 +234,27 @@
   ;; nil/non-keyword event-id (an inert auto edge) coerces to nil, which
   ;; `step-and-store`'s nil-`event-v` guard treats as a no-op so the
   ;; click never produces a malformed dispatch.
-  (rf/reg-event-db :rf.xray.static.machines/sim-chart-edge-clicked
-    (fn [db [_ {:keys [machine-id event-id]}]]
-      (step-and-store db machine-id (sim-h/edge-click->event event-id))))
+  (rf/reg-event :rf.xray.static.machines/sim-chart-edge-clicked
+    (fn [{:keys [db]} [_ {:keys [machine-id event-id]}]]
+      {:db (step-and-store db machine-id (sim-h/edge-click->event event-id))}))
 
   ;; Update the pending event-input text (controlled-input).
-  (rf/reg-event-db :rf.xray.static.machines/sim-set-pending-event
-    (fn [db [_ {:keys [machine-id text]}]]
-      (if (get-in db [:rf.xray.static.machines/sim-by-machine machine-id])
+  (rf/reg-event :rf.xray.static.machines/sim-set-pending-event
+    (fn [{:keys [db]} [_ {:keys [machine-id text]}]]
+      {:db (if (get-in db [:rf.xray.static.machines/sim-by-machine machine-id])
         (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id
                       :pending-event]
                   (or text ""))
-        db)))
+        db)}))
 
   ;; Update the pending payload-input text (controlled-input).
-  (rf/reg-event-db :rf.xray.static.machines/sim-set-pending-data
-    (fn [db [_ {:keys [machine-id text]}]]
-      (if (get-in db [:rf.xray.static.machines/sim-by-machine machine-id])
+  (rf/reg-event :rf.xray.static.machines/sim-set-pending-data
+    (fn [{:keys [db]} [_ {:keys [machine-id text]}]]
+      {:db (if (get-in db [:rf.xray.static.machines/sim-by-machine machine-id])
         (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id
                       :pending-data]
                   (or text ""))
-        db))))
+        db)})))
 
 ;; ---- pill (4-mode sub-strip) -------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -155,25 +155,25 @@
     (fn [db _]
       (get db :rf.xray.static.routes/sim-url)))
 
-  (rf/reg-event-db :rf.xray.static.routes/toggle-row
-    (fn [db [_ route-id]]
-      (let [expanded (or (:rf.xray.static.routes/expanded db) #{})]
+  (rf/reg-event :rf.xray.static.routes/toggle-row
+    (fn [{:keys [db]} [_ route-id]]
+      {:db (let [expanded (or (:rf.xray.static.routes/expanded db) #{})]
         (assoc db :rf.xray.static.routes/expanded
                (if (contains? expanded route-id)
                  (disj expanded route-id)
-                 (conj expanded route-id))))))
+                 (conj expanded route-id))))}))
 
   (rf/reg-sub :rf.xray.static.routes/expanded
     (fn [db _]
       (or (:rf.xray.static.routes/expanded db) #{})))
 
-  (rf/reg-event-db :rf.xray.static.routes/toggle-sim-nav
-    (fn [db [_ route-id]]
-      (let [open (or (:rf.xray.static.routes/sim-nav-open db) #{})]
+  (rf/reg-event :rf.xray.static.routes/toggle-sim-nav
+    (fn [{:keys [db]} [_ route-id]]
+      {:db (let [open (or (:rf.xray.static.routes/sim-nav-open db) #{})]
         (assoc db :rf.xray.static.routes/sim-nav-open
                (if (contains? open route-id)
                  (disj open route-id)
-                 (conj open route-id))))))
+                 (conj open route-id))))}))
 
   (rf/reg-sub :rf.xray.static.routes/sim-nav-open
     (fn [db _]
@@ -185,7 +185,7 @@
   ;; Dynamic + opens the Routing lens. No route-id is plumbed down to
   ;; the Dynamic side — the lens IS the focused-event slice; the
   ;; orientation comes from whatever event is currently focused.
-  (rf/reg-event-fx :rf.xray.static.routes/jump-to-dynamic
+  (rf/reg-event :rf.xray.static.routes/jump-to-dynamic
     (fn [_ [_ _route-id]]
       {:fx [[:dispatch [:rf.xray/set-mode :dynamic]]
             [:dispatch [:rf.xray/select-tab :routing]]]}))

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -135,21 +135,21 @@
 
   ;; ---- UI-state slots --------------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.routes/set-query
-    (fn [db [_ q]]
-      (if (or (nil? q) (= "" q))
+  (rf/reg-event :rf.xray.static.routes/set-query
+    (fn [{:keys [db]} [_ q]]
+      {:db (if (or (nil? q) (= "" q))
         (dissoc db :rf.xray.static.routes/query)
-        (assoc db :rf.xray.static.routes/query q))))
+        (assoc db :rf.xray.static.routes/query q))}))
 
   (rf/reg-sub :rf.xray.static.routes/query
     (fn [db _]
       (get db :rf.xray.static.routes/query)))
 
-  (rf/reg-event-db :rf.xray.static.routes/set-sim-url
-    (fn [db [_ url]]
-      (if (or (nil? url) (= "" url))
+  (rf/reg-event :rf.xray.static.routes/set-sim-url
+    (fn [{:keys [db]} [_ url]]
+      {:db (if (or (nil? url) (= "" url))
         (dissoc db :rf.xray.static.routes/sim-url)
-        (assoc db :rf.xray.static.routes/sim-url url))))
+        (assoc db :rf.xray.static.routes/sim-url url))}))
 
   (rf/reg-sub :rf.xray.static.routes/sim-url
     (fn [db _]

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -369,11 +369,11 @@
 
   ;; ---- UI state ---------------------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.schemas/set-query
-    (fn [db [_ q]]
-      (if (or (nil? q) (= "" q))
+  (rf/reg-event :rf.xray.static.schemas/set-query
+    (fn [{:keys [db]} [_ q]]
+      {:db (if (or (nil? q) (= "" q))
         (dissoc db :rf.xray.static.schemas/query)
-        (assoc db :rf.xray.static.schemas/query q))))
+        (assoc db :rf.xray.static.schemas/query q))}))
 
   (rf/reg-sub :rf.xray.static.schemas/query
     (fn [db _]
@@ -381,11 +381,11 @@
 
   ;; ---- test-only override ----------------------------------------------
 
-  (rf/reg-event-db :rf.xray.static.schemas/set-registry-override-for-test
-    (fn [db [_ ov]]
-      (if (nil? ov)
+  (rf/reg-event :rf.xray.static.schemas/set-registry-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
         (dissoc db :rf.xray.static.schemas/registry-override)
-        (assoc db :rf.xray.static.schemas/registry-override ov))))
+        (assoc db :rf.xray.static.schemas/registry-override ov))}))
 
   (rf/reg-sub :rf.xray.static.schemas/registry-override
     (fn [db _]

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -324,17 +324,17 @@
 (rf/reg-sub widths-slot
   (fn [db _] (get db widths-slot)))
 
-(rf/reg-event-db :rf.xray.edn-inspector/set-width
-  (fn [db [_ mount-id width-px]]
-    (if (and (string? mount-id) (number? width-px) (pos? width-px))
+(rf/reg-event :rf.xray.edn-inspector/set-width
+  (fn [{:keys [db]} [_ mount-id width-px]]
+    {:db (if (and (string? mount-id) (number? width-px) (pos? width-px))
       (assoc-in db [widths-slot mount-id] (long width-px))
-      db)))
+      db)}))
 
-(rf/reg-event-db :rf.xray.edn-inspector/clear-width
-  (fn [db [_ mount-id]]
-    (if (and (string? mount-id) (some-> db (get widths-slot) (contains? mount-id)))
+(rf/reg-event :rf.xray.edn-inspector/clear-width
+  (fn [{:keys [db]} [_ mount-id]]
+    {:db (if (and (string? mount-id) (some-> db (get widths-slot) (contains? mount-id)))
       (update db widths-slot dissoc mount-id)
-      db)))
+      db)}))
 
 ;; =========================================================================
 ;; zoom-into-node + breadcrumb navigation (rf2-h71e0; gesture reworked rf2-zl4rs)
@@ -381,37 +381,37 @@
 (rf/reg-sub zoom-slot
   (fn [db _] (get db zoom-slot)))
 
-(rf/reg-event-db :rf.xray.edn-inspector/zoom-to
+(rf/reg-event :rf.xray.edn-inspector/zoom-to
   ;; Sets the zoom path for `[panel-id mount-id]` to `path`. An empty /
   ;; nil path clears the zoom (renders the full tree).
-  (fn [db [_ panel-id mount-id path]]
-    (let [k (zoom-key panel-id mount-id)
+  (fn [{:keys [db]} [_ panel-id mount-id path]]
+    {:db (let [k (zoom-key panel-id mount-id)
           p (vec path)]
       (if (seq p)
         (assoc-in db [zoom-slot k] p)
-        (update db zoom-slot dissoc k)))))
+        (update db zoom-slot dissoc k)))}))
 
-(rf/reg-event-db :rf.xray.edn-inspector/zoom-up
+(rf/reg-event :rf.xray.edn-inspector/zoom-up
   ;; Pop one segment off the zoom path. No-op when no zoom is active.
-  (fn [db [_ panel-id mount-id]]
-    (let [k        (zoom-key panel-id mount-id)
+  (fn [{:keys [db]} [_ panel-id mount-id]]
+    {:db (let [k        (zoom-key panel-id mount-id)
           current  (get-in db [zoom-slot k])
           popped   (when (seq current) (vec (butlast current)))]
       (cond
         (nil? current)   db
         (empty? popped)  (update db zoom-slot dissoc k)
-        :else            (assoc-in db [zoom-slot k] popped)))))
+        :else            (assoc-in db [zoom-slot k] popped)))}))
 
-(rf/reg-event-db :rf.xray.edn-inspector/zoom-reset
+(rf/reg-event :rf.xray.edn-inspector/zoom-reset
   ;; Clear the zoom for a specific mount. With no args (mount-unspecified)
   ;; clear the entire slot — used by the panel-level reset affordance.
-  (fn [db [_ panel-id mount-id]]
-    (cond
+  (fn [{:keys [db]} [_ panel-id mount-id]]
+    {:db (cond
       (and panel-id mount-id)
       (update db zoom-slot dissoc (zoom-key panel-id mount-id))
 
       :else
-      (dissoc db zoom-slot))))
+      (dissoc db zoom-slot))}))
 
 (defn resolve-zoom-path
   "Pure projection — given the per-render zoom map, return the zoom

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -198,18 +198,18 @@
   click/keydown context pop doesn't leak the event to `:rf/default`
   (same fix as the App-DB segment-inspector + settings popup)."
   []
-  (rf/reg-event-db :rf.xray.edn-inspector-popup/open
-    (fn [db [_ mount-id payload]]
+  (rf/reg-event :rf.xray.edn-inspector-popup/open
+    (fn [{:keys [db]} [_ mount-id payload]]
       ;; payload shape: {:value <any> :opts <map>}
-      (-> db
+      {:db (-> db
           (update stack-slot push-entry mount-id)
-          (assoc-in [entries-slot mount-id] payload))))
+          (assoc-in [entries-slot mount-id] payload))}))
 
-  (rf/reg-event-db :rf.xray.edn-inspector-popup/close
-    (fn [db [_ mount-id]]
-      (-> db
+  (rf/reg-event :rf.xray.edn-inspector-popup/close
+    (fn [{:keys [db]} [_ mount-id]]
+      {:db (-> db
           (update stack-slot pop-entry mount-id)
-          (update entries-slot dissoc mount-id))))
+          (update entries-slot dissoc mount-id))}))
 
   (rf/reg-event-db :rf.xray.edn-inspector-popup/close-top
     ;; Esc handler — close the topmost popup only. No-op when stack
@@ -222,11 +222,11 @@
               (update entries-slot dissoc top))
           db))))
 
-  (rf/reg-event-db :rf.xray.edn-inspector-popup/close-all
-    (fn [db _]
-      (-> db
+  (rf/reg-event :rf.xray.edn-inspector-popup/close-all
+    (fn [{:keys [db]} _]
+      {:db (-> db
           (assoc stack-slot [])
-          (assoc entries-slot {})))))
+          (assoc entries-slot {}))})))
 
 (defn install!
   "Idempotent install for the popup's Xray-side registrations.

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -211,16 +211,16 @@
           (update stack-slot pop-entry mount-id)
           (update entries-slot dissoc mount-id))}))
 
-  (rf/reg-event-db :rf.xray.edn-inspector-popup/close-top
+  (rf/reg-event :rf.xray.edn-inspector-popup/close-top
     ;; Esc handler — close the topmost popup only. No-op when stack
     ;; is empty.
-    (fn [db _]
-      (let [top (top-entry (get db stack-slot))]
+    (fn [{:keys [db]} _]
+      {:db (let [top (top-entry (get db stack-slot))]
         (if top
           (-> db
               (update stack-slot pop-entry top)
               (update entries-slot dissoc top))
-          db))))
+          db))}))
 
   (rf/reg-event :rf.xray.edn-inspector-popup/close-all
     (fn [{:keys [db]} _]

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_state.cljs
@@ -46,8 +46,8 @@
 (rf/reg-sub expansion-slot
   (fn [db _] (get db expansion-slot)))
 
-(rf/reg-event-db :rf.xray.edn-inspector/toggle-node
-  (fn [db [_ panel-id mount-id path rendered-expanded?]]
+(rf/reg-event :rf.xray.edn-inspector/toggle-node
+  (fn [{:keys [db]} [_ panel-id mount-id path rendered-expanded?]]
     ;; rf2-y59tb — first click MUST invert the currently-visible state.
     ;;
     ;; The widget renders `default-expanded` paths (top-level nodes,
@@ -63,21 +63,21 @@
     ;; is stored the reducer flips from that visible state; when an
     ;; override IS stored it flips the override (idempotent given a
     ;; consistent dispatcher).
-    (let [k       (expansion-key panel-id mount-id path)
+    {:db (let [k       (expansion-key panel-id mount-id path)
           current (get-in db [expansion-slot k])
           next?   (if (contains? current :expanded?)
                     (not (boolean (:expanded? current)))
                     (not (boolean rendered-expanded?)))]
-      (assoc-in db [expansion-slot k] {:expanded? next?}))))
+      (assoc-in db [expansion-slot k] {:expanded? next?}))}))
 
-(rf/reg-event-db :rf.xray.edn-inspector/set-node
-  (fn [db [_ panel-id mount-id path expanded?]]
-    (assoc-in db [expansion-slot (expansion-key panel-id mount-id path)]
-              {:expanded? (boolean expanded?)})))
+(rf/reg-event :rf.xray.edn-inspector/set-node
+  (fn [{:keys [db]} [_ panel-id mount-id path expanded?]]
+    {:db (assoc-in db [expansion-slot (expansion-key panel-id mount-id path)]
+              {:expanded? (boolean expanded?)})}))
 
-(rf/reg-event-db :rf.xray.edn-inspector/reset-expansion
-  (fn [db _]
-    (dissoc db expansion-slot)))
+(rf/reg-event :rf.xray.edn-inspector/reset-expansion
+  (fn [{:keys [db]} _]
+    {:db (dissoc db expansion-slot)}))
 
 (defn resolve-expanded?
   "Pure projection — given the per-render expansion map, the path,

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -394,8 +394,13 @@
   highlighter. Public so tests can assert membership."
   #{"def" "defn" "defn-" "defmacro" "let" "if" "when" "when-not"
     "cond" "case" "do" "loop" "recur" "fn" "fn*" "reify"
-    "deftype" "defrecord" "ns" "require" "reg-event-db"
-    "reg-event-fx" "reg-event-ctx" "reg-sub" "reg-fx" "reg-view"
+    "deftype" "defrecord" "ns" "require" "reg-event"
+    ;; EP-0018 collapsed the three public event registrars onto `reg-event`
+    ;; (above). The retired spellings stay in the highlighter set: during the
+    ;; additive window they still resolve, and the source-text highlighter
+    ;; renders whatever the substrate captured — including legacy
+    ;; `reg-event-db` / `-fx` / `-ctx` call sites in an app under inspection.
+    "reg-event-db" "reg-event-fx" "reg-event-ctx" "reg-sub" "reg-fx" "reg-view"
     "reg-flow" "reg-machine" "dispatch" "dispatch-sync" "subscribe"
     "assoc" "assoc-in" "update" "update-in" "get" "get-in"
     "->" "->>" "some->" "some->>"})

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -242,13 +242,13 @@
     (fn [db [_ table-id left-id left-px right-id right-px]]
       (write-pair db table-id left-id left-px right-id right-px)))
 
-  (rf/reg-event-fx :rf.xray.column-widths/resize-pair-commit
+  (rf/reg-event :rf.xray.column-widths/resize-pair-commit
     {:rf.trace/no-emit? true}
     (fn [{:keys [db]} _]
       {:fx [[:rf.xray.column-widths/persist
              (get db :rf.xray/column-widths)]]}))
 
-  (rf/reg-event-fx :rf.xray.column-widths/reset
+  (rf/reg-event :rf.xray.column-widths/reset
     {:rf.trace/no-emit? true}
     (fn [{:keys [db]} [_ table-id]]
       (let [next-db (update db :rf.xray/column-widths dissoc table-id)]
@@ -262,10 +262,10 @@
   ;; source produces the same slot. `:rf.trace/no-emit?` mirrors the
   ;; other hydrate handlers (the hydrate dispatch is a load-time
   ;; orchestration step, not a user-facing event).
-  (rf/reg-event-db :rf.xray.column-widths/hydrate
+  (rf/reg-event :rf.xray.column-widths/hydrate
     {:rf.trace/no-emit? true}
-    (fn [db [_ widths]]
-      (assoc db :rf.xray/column-widths (or widths {})))))
+    (fn [{:keys [db]} [_ widths]]
+      {:db (assoc db :rf.xray/column-widths (or widths {}))})))
 
 ;; ---- hydration ----------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -237,10 +237,10 @@
   ;; pattern. `reset` keeps its single-event shape; it has no drag
   ;; cadence — one click → one mutation → one persist.
 
-  (rf/reg-event-db :rf.xray.column-widths/resize-pair-tick
+  (rf/reg-event :rf.xray.column-widths/resize-pair-tick
     {:rf.trace/no-emit? true}
-    (fn [db [_ table-id left-id left-px right-id right-px]]
-      (write-pair db table-id left-id left-px right-id right-px)))
+    (fn [{:keys [db]} [_ table-id left-id left-px right-id right-px]]
+      {:db (write-pair db table-id left-id left-px right-id right-px)}))
 
   (rf/reg-event :rf.xray.column-widths/resize-pair-commit
     {:rf.trace/no-emit? true}

--- a/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
@@ -510,7 +510,7 @@
     (frame-class/validate+extract host-frame
       {:sensitive {:app-db [[:auth :password]]}}))
   (rf/with-frame host-frame
-    (rf/reg-event-db :test/seed-host (fn [db _] (db-fn db)))
+    (rf/reg-event :test/seed-host (fn [{:keys [db]} _] {:db (db-fn db)}))
     (rf/dispatch-sync [:test/seed-host])))
 
 (defn- drive-snapshot-of-host! []
@@ -571,8 +571,8 @@
         (frame-class/validate+extract host-frame
           {:large {:app-db [[:blob :payload]]}}))
       (rf/with-frame host-frame
-        (rf/reg-event-db :test/seed-blob
-          (fn [db _] (assoc db :blob {:payload {:big "value"}})))
+        (rf/reg-event :test/seed-blob
+          (fn [{:keys [db]} _] {:db (assoc db :blob {:payload {:big "value"}})}))
         (rf/dispatch-sync [:test/seed-blob]))
       (drive-snapshot-of-host!)
       (let [payload (first @(:console sinks))]

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -89,15 +89,15 @@
   frame's app-db. Production code reaches the same shape via
   :rf.xray/epoch-recorded + the host frame's runtime mutations."
   []
-  (rf/reg-event-db :rf.xray-test/seed-history
-    (fn [db [_ records]]
-      (assoc db :epoch-history (vec records))))
-  (rf/reg-event-db :rf.xray-test/seed-target-frame-db
-    (fn [db _]
+  (rf/reg-event :rf.xray-test/seed-history
+    (fn [{:keys [db]} [_ records]]
+      {:db (assoc db :epoch-history (vec records))}))
+  (rf/reg-event :rf.xray-test/seed-target-frame-db
+    (fn [{:keys [db]} _]
       ;; This is a no-op marker — the host frame's db is the source
       ;; of truth, and we set it via replace-app-db! below. Kept so
       ;; tests can locate the seed step by name.
-      db)))
+      {:db db})))
 
 (defn- seed-host-frame!
   "Reset the host (:rf/default) frame's app-db to the supplied
@@ -118,7 +118,7 @@
   diagnostic does not fire."
   [runtime-db-value]
   (frame/reg-frame :rf/default {})
-  (rf/reg-event-fx :rf.xray-test/seed-runtime-db
+  (rf/reg-event :rf.xray-test/seed-runtime-db
     {:rf/machine? true}
     (fn [_ _] {:rf.db/runtime runtime-db-value}))
   (rf/with-frame :rf/default

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
@@ -55,7 +55,7 @@
   (frame/reg-frame :rf/xray {})
   (frame/reg-frame :rf/default {})
   ;; A one-off host event to plant a known db on the observed frame.
-  (rf/reg-event-db :test/seed-host-db (fn [_ [_ db]] db))
+  (rf/reg-event :test/seed-host-db (fn [_ [_ db]] {:db db}))
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:test/seed-host-db host-db]))
   ;; EP-0002 (rf2-bd4div) — the inspected target no longer defaults to
@@ -232,9 +232,9 @@
   (frame/reg-frame :rf/xray {})
   (frame/reg-frame :rf/default {})
   (rf/replace-app-db! :rf/default live-db)
-  (rf/reg-event-db :rf.xray-test/seed-history
-    (fn [db [_ records]]
-      (assoc db :epoch-history (vec records))))
+  (rf/reg-event :rf.xray-test/seed-history
+    (fn [{:keys [db]} [_ records]]
+      {:db (assoc db :epoch-history (vec records))}))
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray-test/seed-history history])))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
@@ -72,10 +72,10 @@
 ;; ---- handler -----------------------------------------------------------
 
 (defn- register-counter-handler! []
-  (rf/reg-event-db
+  (rf/reg-event
     :rf.tyivx/counter-inc
-    (fn [db [_ amount]]
-      (update db :counter (fnil + 0) (or amount 1)))))
+    (fn [{:keys [db]} [_ amount]]
+      {:db (update db :counter (fnil + 0) (or amount 1))})))
 
 ;; ---- end-to-end ---------------------------------------------------------
 
@@ -152,9 +152,9 @@
 
 (defn- register-flow-bearing-handler! []
   ;; :base ++ in the handler; the flow derives :derived = 2 × :base AFTER.
-  (rf/reg-event-db
+  (rf/reg-event
     :rf.tyivx/increment-flow
-    (fn [db _] (update db :base (fnil inc 0))))
+    (fn [{:keys [db]} _] {:db (update db :base (fnil inc 0))}))
   (rf/reg-flow
     {:id     :rf.tyivx/derived
      :inputs [[:base]]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -203,7 +203,7 @@
       ;; shape `projection/state-spec-path-prefix` produces:
       ;; `[:active :authenticating]` → `[:states :active :states
       ;; :authenticating]` — and reads `:source-coords` there.
-      (rf/reg-event-fx :rf2-dcsw1.view/timer-machine
+      (rf/reg-event :rf2-dcsw1.view/timer-machine
                        {:rf/machine? true
                         :rf/machine {:initial :active
                                      :states {:active
@@ -1642,7 +1642,7 @@
             extension."
     (rf/with-frame :rf/default
       (let [inline-fn (fn [_ctx] {})]
-        (rf/reg-event-fx :rf2-wwc3j.view/inline-entry
+        (rf/reg-event :rf2-wwc3j.view/inline-entry
                          {:rf/machine? true
                           :rf/machine {:initial :a
                                        :states  {:a {:entry inline-fn
@@ -1671,7 +1671,7 @@
             slot from the spec value at `[:states <s> :on <ev> :guard]`."
     (rf/with-frame :rf/default
       (let [inline-guard (fn [_ctx] true)]
-        (rf/reg-event-fx :rf2-wwc3j.view/inline-guard
+        (rf/reg-event :rf2-wwc3j.view/inline-guard
                          {:rf/machine? true
                           :rf/machine {:initial :idle
                                        :states  {:idle {:on {:submit {:target :done
@@ -1707,7 +1707,7 @@
             the defmachine-definition coord (part B-ii) DEGRADES to the
             call-site until rf2-gwj8l stamps it."
     (rf/with-frame :rf/default
-      (rf/reg-event-fx :rf2-iwy0c.view/no-source-machine
+      (rf/reg-event :rf2-iwy0c.view/no-source-machine
                        {:rf/machine? true
                         :rf/machine {:initial :idle
                                      :states  {:idle {:on {:go {:target :done}}}
@@ -1864,7 +1864,7 @@
             (the parent state-node value is too verbose to render
             verbatim)."
     (rf/with-frame :rf/default
-      (rf/reg-event-fx :rf2-wwc3j.view/timer-row
+      (rf/reg-event :rf2-wwc3j.view/timer-row
                        {:rf/machine? true
                         :rf/machine {:initial :idle
                                      :states  {:idle {:after {500 {:target :done}}}
@@ -1939,9 +1939,9 @@
             `:rf.handler/source`, the body renders it via the
             canonical `edn/code-block` widget"
     (rf/with-frame :rf/default
-      (rf/reg-event-db :rf.test.epoch.view/srctest-handler
+      (rf/reg-event :rf.test.epoch.view/srctest-handler
                        {:rf.handler/source "(reg-event-db :rf.test.epoch.view/srctest-handler\n  (fn [db _] (assoc db :ok true)))"}
-                       (fn [db _] db))
+                       (fn [{:keys [db]} _] {:db db}))
       (let [step {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-event-db
                   :event-id :rf.test.epoch.view/srctest-handler

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -70,7 +70,11 @@
                 :fx [] :machine nil}
           tree (view/render-handler-step step)
           header-text (text-of tree "rf-xray-epoch-handler-header")]
-      (is (string/includes? header-text "reg-event-db"))
+      ;; EP-0018 — the HANDLER verb is now `reg-event` for both the db-only
+      ;; and fx-bearing event flavours (the panel no longer names the retired
+      ;; `reg-event-db` / `reg-event-fx` spellings). The internal `:flavour`
+      ;; discriminator keyword (`:reg-event-db`, fed above) is unchanged.
+      (is (string/includes? header-text "reg-event"))
       ;; The body's first slot is now the source block — never a
       ;; duplicate flavour pill.
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
@@ -81,7 +85,7 @@
       (is (not (string/includes?
                  (or (text-of tree "rf-xray-epoch-handler-source-placeholder")
                      "")
-                 "reg-event-db"))
+                 "reg-event"))
           "the source-placeholder slot MUST NOT echo the flavour pill"))))
 
 ;; ---- rf2-93a7s — DISPATCH body shows the event vector ----------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -897,10 +897,10 @@
 
 ;; A test-only event that pins :focus to an :epoch-id that's not in
 ;; history — exercises the :epoch-evicted classifier path.
-(rf/reg-event-db
+(rf/reg-event
   :day8.re-frame2-xray.panels.trace-view-cljs-test/seed-evicted-focus
-  (fn [db _event]
-    (assoc db :focus {:dispatch-id 999
+  (fn [{:keys [db]} _event]
+    {:db (assoc db :focus {:dispatch-id 999
                       :epoch-id    999
                       :mode        :retro
-                      :frame       nil})))
+                      :frame       nil})}))

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/evicted_epoch_all_panels_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/evicted_epoch_all_panels_cljs_test.cljs
@@ -58,11 +58,11 @@
   ;; A tiny test-local seeder for the spine slots the composite subs read.
   ;; Stamps a RETRO pin on an epoch-id + an epoch-history ring that does
   ;; NOT contain it — the exact "scrubbed onto an evicted epoch" state.
-  (rf/reg-event-db :test/seed-evicted-pin
-    (fn [db [_ {:keys [pinned-epoch-id history]}]]
-      (-> db
+  (rf/reg-event :test/seed-evicted-pin
+    (fn [{:keys [db]} [_ {:keys [pinned-epoch-id history]}]]
+      {:db (-> db
           (assoc :epoch-history (vec history))
-          (assoc :focus {:mode :retro :epoch-id pinned-epoch-id}))))
+          (assoc :focus {:mode :retro :epoch-id pinned-epoch-id}))}))
   nil)
 
 (defn- sub-xray [query]

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/focus_epoch_id_correlation_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/focus_epoch_id_correlation_e2e_cljs_test.cljs
@@ -65,7 +65,7 @@
   nil)
 
 (defn- install-counter! []
-  (rf/reg-event-db :counter/inc (fn [db _] (update db :counter (fnil inc 0))))
+  (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
   (rf/reg-sub :counter/value (fn [db _] (:counter db))))
 
 (defn- mount-xray-with-target! [target]

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/parallel_frames_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/parallel_frames_e2e_cljs_test.cljs
@@ -82,8 +82,8 @@
   "Register counter event/sub once globally. Resolves per-dispatch via
   the `:frame` option each frame's dispatch carries."
   []
-  (rf/reg-event-db :counter/inc
-    (fn [db _ev] (update db :counter/value (fnil inc 0))))
+  (rf/reg-event :counter/inc
+    (fn [{:keys [db]} _ev] {:db (update db :counter/value (fnil inc 0))}))
   (rf/reg-sub :counter/value
     (fn [db _] (:counter/value db))))
 
@@ -202,11 +202,11 @@
   produce a `:rf.error/handler-exception` issue keyed to its own
   `:dispatch-id`."
   []
-  (rf/reg-event-db :throws/a
-    (fn [_db _ev]
+  (rf/reg-event :throws/a
+    (fn [_ _ev]
       (throw (ex-info "throw-a" {:where :a}))))
-  (rf/reg-event-db :throws/b
-    (fn [_db _ev]
+  (rf/reg-event :throws/b
+    (fn [_ _ev]
       (throw (ex-info "throw-b" {:where :b})))))
 
 (deftest rf2-1p1j4-issues-panel-scopes-to-focused-cascade

--- a/tools/xray/test/day8/re_frame2_xray/preload_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/preload_cljs_test.cljs
@@ -101,14 +101,14 @@
     (registry/register-xray-handlers!)
     ;; Register a host event under :rf/default that writes a marker
     ;; into the host's db.
-    (rf/reg-event-db :test/host-write
-      (fn [db _] (assoc db :host-touched? true)))
+    (rf/reg-event :test/host-write
+      (fn [{:keys [db]} _] {:db (assoc db :host-touched? true)}))
     ;; A Xray-side event under the :rf.xray/* prefix that writes a
     ;; marker into whatever frame is active at dispatch time. Xray's
     ;; runtime always dispatches under `with-frame :rf/xray`, so the
     ;; write lands in the Xray frame.
-    (rf/reg-event-db :rf.xray/test-write
-      (fn [db _] (assoc db :xray-touched? true)))
+    (rf/reg-event :rf.xray/test-write
+      (fn [{:keys [db]} _] {:db (assoc db :xray-touched? true)}))
 
     ;; Allocate the Xray frame (the preload doesn't create it; it's
     ;; allocated lazily on first use).

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -174,8 +174,8 @@
   (testing "with the framework's default `:rf/default` registered, the
             no-arg `get-app-db` resolves it without an explicit `:frame`
             arg"
-    (rf/reg-event-db :test/seed-db
-      (fn [_ _] {:seeded? true}))
+    (rf/reg-event :test/seed-db
+      (fn [{:keys [db]} _] {:db {:seeded? true}}))
     (rf/dispatch-sync [:test/seed-db])
     (let [result (runtime/get-app-db)]
       (is (true? (:ok? result))
@@ -185,8 +185,8 @@
 
 (deftest get-app-db-explicit-path
   (testing "the `:path` arg scopes the returned value via `get-in`"
-    (rf/reg-event-db :test/seed-db
-      (fn [_ _] {:cart {:items [:a :b :c]}}))
+    (rf/reg-event :test/seed-db
+      (fn [{:keys [db]} _] {:db {:cart {:items [:a :b :c]}}}))
     (rf/dispatch-sync [:test/seed-db])
     (let [result (runtime/get-app-db {:path [:cart :items]})]
       (is (true? (:ok? result)))
@@ -217,7 +217,7 @@
             frame id that is not in `rf/frame-ids` with a distinct
             `:no-such-frame` reason; the implicit / sole-frame path is
             unaffected (the registry still holds :rf/default)."
-    (rf/reg-event-db :test/seed-db (fn [_ _] {:seeded? true}))
+    (rf/reg-event :test/seed-db (fn [{:keys [db]} _] {:db {:seeded? true}}))
     (rf/dispatch-sync [:test/seed-db])
     (let [bogus :app/does-not-exist
           ;; The frame-scoped accessors that take an explicit `:frame`:
@@ -305,7 +305,7 @@
 ;; the machines lifecycle-fx writes); `:rf/machine? true` marks it
 ;; framework-authority so the runtime-write diagnostic does not fire.
 (defn- seed-machine-snapshot-in-runtime-db! [snapshot]
-  (rf/reg-event-fx :test/seed-machine-snapshot
+  (rf/reg-event :test/seed-machine-snapshot
     {:rf/machine? true}
     (fn [_ _]
       {:rf.db/runtime {:rf.runtime/machines {:snapshots {:auth snapshot}}}}))
@@ -450,10 +450,10 @@
             `get-trace-buffer {:origin <origin>}` isolates the
             tool-dispatched cascade (Lock #4 / I1)"
     (let [captured (atom nil)]
-      (rf/reg-event-db :test/capture-meta
-        (fn [db [_ marker]]
+      (rf/reg-event :test/capture-meta
+        (fn [{:keys [db]} [_ marker]]
           (reset! captured marker)
-          (assoc db :marker marker)))
+          {:db (assoc db :marker marker)}))
       (trace-tooling/clear-trace-buffer! :rf/default)
       ;; sync? so the dispatch completes (and its trace lands) before we read.
       (let [result (runtime/dispatch! [:test/capture-meta :ok] {:sync? true})]
@@ -478,8 +478,8 @@
   (testing "a `binding` around `dispatch!` re-tags the dispatch on the
             trace bus — this is the synchronous-extent contract
             `eval-cljs` rides (Lock #4 / I6)"
-    (rf/reg-event-db :test/origin-marker
-      (fn [db _] db))
+    (rf/reg-event :test/origin-marker
+      (fn [{:keys [db]} _] {:db db}))
     (trace-tooling/clear-trace-buffer! :rf/default)
     (binding [runtime/*current-origin* :test-rebind]
       (let [result (runtime/dispatch! [:test/origin-marker] {:sync? true})]
@@ -583,8 +583,8 @@
             without an explicit `:frame` arg (post per-frame ring
             adoption rf2-q03j7) and returns the historical flat-event
             shape via the framework's `{:flat true}` opt"
-    (rf/reg-event-db :test/just-dispatch
-      (fn [db _] (assoc db :touched? true)))
+    (rf/reg-event :test/just-dispatch
+      (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
     (rf/dispatch-sync [:test/just-dispatch])
     (let [result (runtime/get-trace-buffer)]
       (is (true? (:ok? result))
@@ -888,9 +888,9 @@
   (testing "EP-0001 rf2-jj1xer — get-app-db reads ONLY the app-db partition
             (rf/app-db-value), so a runtime-db-only commit never bleeds into
             the app-db read (partition distinction at the read boundary)"
-    (rf/reg-event-db :test/seed-app (fn [_ _] {:cart {:items [:a]}}))
+    (rf/reg-event :test/seed-app (fn [{:keys [db]} _] {:db {:cart {:items [:a]}}}))
     (rf/dispatch-sync [:test/seed-app])
-    (rf/reg-event-fx :test/seed-rt {:rf/machine? true}
+    (rf/reg-event :test/seed-rt {:rf/machine? true}
       (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:snapshots {:m {:state :on}}}}}))
     (rf/dispatch-sync [:test/seed-rt])
     (let [result (runtime/get-app-db)]
@@ -904,8 +904,8 @@
   (testing "the rerouted `get-app-db` call site still redacts a
             sensitive slot end-to-end (regression: the named egress fn
             is wired into the accessor)"
-    (rf/reg-event-db :test/seed-auth
-      (fn [_ _] {:auth {:username "ada" :password "shh"}}))
+    (rf/reg-event :test/seed-auth
+      (fn [{:keys [db]} _] {:db {:auth {:username "ada" :password "shh"}}}))
     (rf/dispatch-sync [:test/seed-auth])
     ;; Populate AFTER the whole-db reset so the declarations survive.
     (seed-sensitive-schema!)
@@ -945,8 +945,8 @@
             leaf redacts by default — the absolute :path is threaded into
             the egress walker so the [:auth :password] declaration
             matches the scoped slice (rf2-a96xq: fail-closed)"
-    (rf/reg-event-db :test/seed-auth
-      (fn [_ _] {:auth {:username "ada" :password "shh"}}))
+    (rf/reg-event :test/seed-auth
+      (fn [{:keys [db]} _] {:db {:auth {:username "ada" :password "shh"}}}))
     (rf/dispatch-sync [:test/seed-auth])
     (seed-sensitive-schema!)
     ;; Scope the read down to the sensitive leaf itself.
@@ -970,8 +970,8 @@
   (testing "a PATH-scoped get-app-db with {:include-sensitive? true}
             reveals the raw leaf — the operator opt-in still flows through
             the threaded-path egress (rf2-a96xq: opt-in gate open)"
-    (rf/reg-event-db :test/seed-auth
-      (fn [_ _] {:auth {:username "ada" :password "shh"}}))
+    (rf/reg-event :test/seed-auth
+      (fn [{:keys [db]} _] {:db {:auth {:username "ada" :password "shh"}}}))
     (rf/dispatch-sync [:test/seed-auth])
     (seed-sensitive-schema!)
     (let [result (runtime/get-app-db {:path [:auth :password]
@@ -985,8 +985,8 @@
             emits the :rf.size/large-elided marker by default, and reveals
             the raw value only on {:include-large? true} (rf2-a96xq:
             symmetric size minimisation on the scoped path)"
-    (rf/reg-event-db :test/seed-blob
-      (fn [_ _] {:blob {:payload {:big "value"}}}))
+    (rf/reg-event :test/seed-blob
+      (fn [{:keys [db]} _] {:db {:blob {:payload {:big "value"}}}}))
     (rf/dispatch-sync [:test/seed-blob])
     (seed-large-schema!)
     (let [result (runtime/get-app-db {:path [:blob :payload]})]
@@ -1022,7 +1022,7 @@
   `:db-before before` / `:db-after after`. Returns the recorded
   epoch's `:epoch-id`."
   [before after]
-  (rf/reg-event-db :test/seed-before (fn [_ _] before))
+  (rf/reg-event :test/seed-before (fn [_ _] {:db before}))
   (rf/dispatch-sync [:test/seed-before])
   (let [fid (first (rf/frame-ids))]
     (rf/replace-app-db! fid after)
@@ -1210,7 +1210,7 @@
    :tags          #{[:article "old"]}})
 
 (defn- seed-resource-entries! [entries]
-  (rf/reg-event-fx :test/seed-resources
+  (rf/reg-event :test/seed-resources
     {:rf/machine? true}
     (fn [_ _]
       {:rf.db/runtime {:rf.runtime/resources {:entries entries}}}))

--- a/tools/xray/test/day8/re_frame2_xray/sensitive_trace_loop_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/sensitive_trace_loop_cljs_test.cljs
@@ -74,9 +74,9 @@
 ;; ---- helpers ------------------------------------------------------------
 
 (defn- register-non-sensitive-event! []
-  (rf/reg-event-db :test/plain-bump
-    (fn [db [_ n]]
-      (assoc db :test/last-bump n))))
+  (rf/reg-event :test/plain-bump
+    (fn [{:keys [db]} [_ n]]
+      {:db (assoc db :test/last-bump n)})))
 
 (defn- drain-depth-exceeded?
   "True iff Xray's trace buffer contains a `:rf.error/drain-depth-

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/counter.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/counter.cljs
@@ -27,14 +27,14 @@
   `:counter/initialise` seeds the slot at `5`, `:counter/inc` and
   `:counter/dec` walk it."
   []
-  (rf/reg-event-db :counter/initialise
-    (fn [_db _event] {:counter/value 5}))
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
 
-  (rf/reg-event-db :counter/inc
-    (fn [db _event] (update db :counter/value inc)))
+  (rf/reg-event :counter/inc
+    (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))
 
-  (rf/reg-event-db :counter/dec
-    (fn [db _event] (update db :counter/value dec)))
+  (rf/reg-event :counter/dec
+    (fn [{:keys [db]} _event] {:db (update db :counter/value dec)}))
 
   (rf/reg-sub :counter/value
     (fn [db _query] (:counter/value db)))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/deliberate_throw.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/deliberate_throw.cljs
@@ -17,13 +17,13 @@
   Each entry's throw site is identical to the canonical testbed so
   the bug surface is preserved."
   []
-  (rf/reg-event-db :deliberate-throw/initialise
-    (fn [_db _ev]
-      {:click-count {:handler 0 :fx 0}}))
+  (rf/reg-event :deliberate-throw/initialise
+    (fn [{:keys [db]} _ev]
+      {:db {:click-count {:handler 0 :fx 0}}}))
 
   ;; Button A — synchronous throw in event handler
-  (rf/reg-event-db :deliberate-throw/throw-in-handler
-    (fn [_db _ev]
+  (rf/reg-event :deliberate-throw/throw-in-handler
+    (fn [_ _ev]
       (throw (ex-info "deliberate-throw / handler" {:where :handler}))))
 
   ;; Button B — throw inside fx body
@@ -31,7 +31,7 @@
     (fn [_frame-ctx _args]
       (throw (ex-info "deliberate-throw / fx" {:where :fx}))))
 
-  (rf/reg-event-fx :deliberate-throw/throw-in-fx
+  (rf/reg-event :deliberate-throw/throw-in-fx
     (fn [{:keys [db]} _ev]
       {:db (update-in db [:click-count :fx] inc)
        :fx [[:deliberate-throw/boom {}]]}))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/multi_frame.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/multi_frame.cljs
@@ -31,19 +31,19 @@
 (def frame-b   :counter/b)
 (def frame-log :log)
 
-(rf/reg-event-db ::counter-init
-  (fn [_db _ev] {:n 0}))
+(rf/reg-event ::counter-init
+  (fn [{:keys [db]} _ev] {:db {:n 0}}))
 
-(rf/reg-event-db ::log-init
-  (fn [_db _ev] {:entries []}))
+(rf/reg-event ::log-init
+  (fn [{:keys [db]} _ev] {:db {:entries []}}))
 
-(rf/reg-event-db ::inc
-  (fn [db _ev]
-    (update db :n (fnil inc 0))))
+(rf/reg-event ::inc
+  (fn [{:keys [db]} _ev]
+    {:db (update db :n (fnil inc 0))}))
 
-(rf/reg-event-db ::log-append
-  (fn [db [_ entry]]
-    (update db :entries (fnil conj []) entry)))
+(rf/reg-event ::log-append
+  (fn [{:keys [db]} [_ entry]]
+    {:db (update db :entries (fnil conj []) entry)}))
 
 (rf/reg-fx ::dispatch-to-frame
   (fn [_ctx {:keys [event frame]}]
@@ -56,7 +56,7 @@
     ;; fixture exists to probe) is identical either way.
     (rf/dispatch-sync event {:frame frame})))
 
-(rf/reg-event-fx ::cross-bump
+(rf/reg-event ::cross-bump
   (fn [{:keys [db]} _ev]
     {:db (update db :n (fnil inc 0))
      :fx [[::dispatch-to-frame {:event [::inc] :frame frame-b}]

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/non_trivial_app_db.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/host_fixtures/non_trivial_app_db.cljs
@@ -39,46 +39,46 @@
                :ui   {:sidebar-open? true}}
    :metrics   {:requests 0 :errors 0 :renders 0 :sub-runs 0 :flow-evals 0}})
 
-(rf/reg-event-db ::initialise
-  (fn [_db _ev] initial-db))
+(rf/reg-event ::initialise
+  (fn [_ _ev] {:db initial-db}))
 
-(rf/reg-event-db ::toggle-theme
-  (fn [db _ev]
-    (update-in db [:settings :theme] {:dark :light :light :dark})))
+(rf/reg-event ::toggle-theme
+  (fn [{:keys [db]} _ev]
+    {:db (update-in db [:settings :theme] {:dark :light :light :dark})}))
 
-(rf/reg-event-db ::toggle-notifications
-  (fn [db _ev]
-    (update-in db [:settings :notifications]
+(rf/reg-event ::toggle-notifications
+  (fn [{:keys [db]} _ev]
+    {:db (update-in db [:settings :notifications]
                (fn [m]
                  (-> m
                      (update :email not)
-                     (update :marketing not))))))
+                     (update :marketing not))))}))
 
-(rf/reg-event-db ::add-cart-item
-  (fn [db _ev]
-    (let [new-item {:sku "BK-099" :title "Patterns of Distributed Systems"
+(rf/reg-event ::add-cart-item
+  (fn [{:keys [db]} _ev]
+    {:db (let [new-item {:sku "BK-099" :title "Patterns of Distributed Systems"
                     :qty 1 :price {:currency :AUD :amount 55.00}}]
       (-> db
           (update-in [:cart :items] (fnil conj []) new-item)
-          (update-in [:cart :total] (fnil + 0) 55.00)))))
+          (update-in [:cart :total] (fnil + 0) 55.00)))}))
 
-(rf/reg-event-db ::bump-first-item-qty
-  (fn [db _ev]
-    (-> db
+(rf/reg-event ::bump-first-item-qty
+  (fn [{:keys [db]} _ev]
+    {:db (-> db
         (update-in [:cart :items 0 :qty] inc)
         (update-in [:cart :items 0 :price :amount] + 42.50)
-        (update-in [:cart :total] + 42.50))))
+        (update-in [:cart :total] + 42.50))}))
 
-(rf/reg-event-db ::register-new-sku
-  (fn [db _ev]
-    (update-in db [:catalog :categories :books :groups :tech :skus]
-               (fnil conj #{}) "BK-099")))
+(rf/reg-event ::register-new-sku
+  (fn [{:keys [db]} _ev]
+    {:db (update-in db [:catalog :categories :books :groups :tech :skus]
+               (fnil conj #{}) "BK-099")}))
 
-(rf/reg-event-db ::revoke-write-and-collapse-sidebar
-  (fn [db _ev]
-    (-> db
+(rf/reg-event ::revoke-write-and-collapse-sidebar
+  (fn [{:keys [db]} _ev]
+    {:db (-> db
         (update-in [:session :auth :scopes] (fnil disj #{}) :write)
-        (update-in [:session :ui :sidebar-open?] not))))
+        (update-in [:session :ui :sidebar-open?] not))}))
 
 (rf/reg-sub :settings  (fn [db _] (:settings  db)))
 (rf/reg-sub :cart      (fn [db _] (:cart      db)))

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -167,10 +167,10 @@
    :secure     {:user {:id 7}}
    :cache      {}})
 
-(rf/reg-event-db :edn-inspector/reset
+(rf/reg-event :edn-inspector/reset
   {:doc "Re-seed app-db to the matrix baseline."}
-  (fn handler-reset [_db _ev]
-    initial-db))
+  (fn handler-reset [_ _ev]
+    {:db initial-db}))
 
 ;; ============================================================================
 ;; EVENTS — the step ladder, grouped by the audit matrix
@@ -182,65 +182,65 @@
 
 ;; -- MAPS --------------------------------------------------------------------
 
-(rf/reg-event-db :edn-inspector/map-key-added
+(rf/reg-event :edn-inspector/map-key-added
   {:doc "Map: a KEY ADDED. assoc a new `:team` key under :profile — the
          App-db diff paints `+:team` (green, key-anchored)."}
-  (fn [db _] (assoc-in db [:profile :team] :platform)))
+  (fn [{:keys [db]} _] {:db (assoc-in db [:profile :team] :platform)}))
 
-(rf/reg-event-db :edn-inspector/map-key-removed
+(rf/reg-event :edn-inspector/map-key-removed
   {:doc "Map: a KEY REMOVED. dissoc `:role` from :profile — the diff paints
          a struck-through `−:role` (red, key-anchored)."}
-  (fn [db _]
-    (if (contains? (:profile db) :role)
-      (update db :profile dissoc :role)
-      (assoc-in db [:profile :role] :engineer))))
+  (fn [{:keys [db]} _]
+    {:db (if (contains? (:profile db) :role)
+           (update db :profile dissoc :role)
+           (assoc-in db [:profile :role] :engineer))}))
 
-(rf/reg-event-db :edn-inspector/map-value-changed
+(rf/reg-event :edn-inspector/map-value-changed
   {:doc "Map: a VALUE CHANGED in place. Bump :profile/name — the value-side
          `~` glyph + `← was \"…\"` annotation, key intact."}
-  (fn [db _]
-    (update-in db [:profile :name]
-               #(if (= % "Ada") "Ada Lovelace" "Ada"))))
+  (fn [{:keys [db]} _]
+    {:db (update-in db [:profile :name]
+               #(if (= % "Ada") "Ada Lovelace" "Ada"))}))
 
 ;; -- SEQUENTIALS (vector / list / set) ---------------------------------------
 
-(rf/reg-event-db :edn-inspector/seq-entry-added
+(rf/reg-event :edn-inspector/seq-entry-added
   {:doc "Sequential: ENTRY ADDED. conj a new task onto the :queue vector —
          the appended entry paints `+` green."}
-  (fn [db _]
-    (update db :queue conj (keyword (str "task-" (inc (count (:queue db))))))))
+  (fn [{:keys [db]} _]
+    {:db (update db :queue conj (keyword (str "task-" (inc (count (:queue db))))))}))
 
-(rf/reg-event-db :edn-inspector/seq-entry-removed
+(rf/reg-event :edn-inspector/seq-entry-removed
   {:doc "Sequential: ENTRY REMOVED. pop the tail off the :queue vector — the
          dropped entry renders struck-through (member-level, not a whole-key
          replace). Re-seeds when down to one so there is always a tail."}
-  (fn [db _]
-    (if (> (count (:queue db)) 1)
-      (update db :queue pop)
-      (assoc db :queue [:task-1 :task-2 :task-3]))))
+  (fn [{:keys [db]} _]
+    {:db (if (> (count (:queue db)) 1)
+           (update db :queue pop)
+           (assoc db :queue [:task-1 :task-2 :task-3]))}))
 
-(rf/reg-event-db :edn-inspector/seq-scattered-removed
+(rf/reg-event :edn-inspector/seq-scattered-removed
   {:doc "Sequential: SCATTERED / MID-VECTOR removal. Thin :lane
          `[:a :b :c :d]` → `[:a :c]` — drop :b@1 AND :d@3. The genuinely-
          removed :b and :d render struck IN PLACE; the surviving-shifted :c
          (was index 2 → now 1) must NOT be struck and carries a `(was N)`
          suffix. Toggles back to the full lane so the diff alternates."}
-  (fn [db _]
-    (if (= (:lane db) [:a :b :c :d])
-      (assoc db :lane [:a :c])
-      (assoc db :lane [:a :b :c :d]))))
+  (fn [{:keys [db]} _]
+    {:db (if (= (:lane db) [:a :b :c :d])
+           (assoc db :lane [:a :c])
+           (assoc db :lane [:a :b :c :d]))}))
 
-(rf/reg-event-db :edn-inspector/set-member-changed
+(rf/reg-event :edn-inspector/set-member-changed
   {:doc "Set: a MEMBER CHANGED (swap). Replace one member of :tags — the
          diff paints member-level `−:alpha +:delta` with the :tags KEY
          INTACT (not a 'sea of red' whole-key strike). Cycles members."}
-  (fn [db _]
-    (let [tags (:tags db)]
+  (fn [{:keys [db]} _]
+    {:db (let [tags (:tags db)]
       (assoc db :tags
              (cond
                (contains? tags :alpha) (-> tags (disj :alpha) (conj :delta))
                (contains? tags :delta) (-> tags (disj :delta) (conj :alpha))
-               :else                   #{:alpha :beta :gamma})))))
+               :else                   #{:alpha :beta :gamma})))}))
 
 ;; -- EMPTY vs REMOVAL (the subtle one) ---------------------------------------
 ;;
@@ -250,162 +250,162 @@
 ;; "remove key" step dissocs the :doomed key wholesale — a struck-through
 ;; removed KEY (the collapsed removed-ghost). The two must read DISTINCTLY.
 
-(rf/reg-event-db :edn-inspector/empty-vector
+(rf/reg-event :edn-inspector/empty-vector
   {:doc "Empty a VECTOR, key intact. `:one-vec [:only]` → `[]` — the element
          removal renders member-level inside the intact (now-empty) vector,
          NOT a whole-key `~` modify. Re-seeds when empty."}
-  (fn [db _]
-    (assoc db :one-vec (if (seq (:one-vec db)) [] [:only]))))
+  (fn [{:keys [db]} _]
+    {:db (assoc db :one-vec (if (seq (:one-vec db)) [] [:only]))}))
 
-(rf/reg-event-db :edn-inspector/empty-list
+(rf/reg-event :edn-inspector/empty-list
   {:doc "Empty a LIST, key intact. `:one-list (:only)` → `()` — member-level
          removal inside the intact list. Re-seeds."}
-  (fn [db _]
-    (assoc db :one-list (if (seq (:one-list db)) '() '(:only)))))
+  (fn [{:keys [db]} _]
+    {:db (assoc db :one-list (if (seq (:one-list db)) '() '(:only)))}))
 
-(rf/reg-event-db :edn-inspector/empty-set
+(rf/reg-event :edn-inspector/empty-set
   {:doc "Empty a SET, key intact. `:one-set #{:only}` → `#{}` — member-level
          removal inside the intact set. Re-seeds."}
-  (fn [db _]
-    (assoc db :one-set (if (seq (:one-set db)) #{} #{:only}))))
+  (fn [{:keys [db]} _]
+    {:db (assoc db :one-set (if (seq (:one-set db)) #{} #{:only}))}))
 
-(rf/reg-event-db :edn-inspector/empty-map
+(rf/reg-event :edn-inspector/empty-map
   {:doc "Empty a MAP, key intact. `:one-map {:k 1}` → `{}` — member-level
          removal inside the intact map. Re-seeds."}
-  (fn [db _]
-    (assoc db :one-map (if (seq (:one-map db)) {} {:k 1}))))
+  (fn [{:keys [db]} _]
+    {:db (assoc db :one-map (if (seq (:one-map db)) {} {:k 1}))}))
 
-(rf/reg-event-db :edn-inspector/remove-key
+(rf/reg-event :edn-inspector/remove-key
   {:doc "Remove a KEY wholesale. dissoc `:doomed` — a struck-through removed
          KEY (collapsed removed-ghost), DISTINCT from emptying a collection
          whose key stays. Re-seeds the key when gone."}
-  (fn [db _]
-    (if (contains? db :doomed)
-      (dissoc db :doomed)
-      (assoc db :doomed {:goodbye true}))))
+  (fn [{:keys [db]} _]
+    {:db (if (contains? db :doomed)
+           (dissoc db :doomed)
+           (assoc db :doomed {:goodbye true}))}))
 
 ;; -- SCALARS -----------------------------------------------------------------
 
-(rf/reg-event-db :edn-inspector/scalar-number
+(rf/reg-event :edn-inspector/scalar-number
   {:doc "Scalar: NUMBER changed in place. Increment :scalar — `~` + `← was N`."}
-  (fn [db _] (-> db (update :scalar #(if (number? %) (inc %) 5)))))
+  (fn [{:keys [db]} _] {:db (-> db (update :scalar #(if (number? %) (inc %) 5)))}))
 
-(rf/reg-event-db :edn-inspector/scalar-nil-toggle
+(rf/reg-event :edn-inspector/scalar-nil-toggle
   {:doc "Scalar: NIL ↔ VALUE. Toggle :scalar between a value and nil — both
          transitions are `:modified` leaves (nil is a real value, not absence)."}
-  (fn [db _] (-> db (update :scalar #(if (nil? %) 5 nil)))))
+  (fn [{:keys [db]} _] {:db (-> db (update :scalar #(if (nil? %) 5 nil)))}))
 
-(rf/reg-event-db :edn-inspector/scalar-type-flip
+(rf/reg-event :edn-inspector/scalar-type-flip
   {:doc "Scalar: TYPE CHANGE. Flip :scalar number↔string (`5` ↔ `\"five\"`)
          and scalar↔map — R7 renders `~` + `← was <type>` type-change suffix."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (update :scalar
                 (fn [v]
                   (cond
                     (number? v) "five"
                     (string? v) {:was :string}
-                    :else       5))))))
+                    :else       5))))}))
 
 ;; -- MULTI-ADJUST (add AND remove in one diff) -------------------------------
 
-(rf/reg-event-db :edn-inspector/map-multi-adjust
+(rf/reg-event :edn-inspector/map-multi-adjust
   {:doc "Map: ADD + REMOVE in ONE diff. Swap :flags `{:a 1 :b 2}` ↔
          `{:a 1 :c 3}` — `:b` removed AND `:c` added simultaneously, `:a`
          unchanged."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (update :flags
                 (fn [m]
-                  (if (contains? m :b) {:a 1 :c 3} {:a 1 :b 2}))))))
+                  (if (contains? m :b) {:a 1 :c 3} {:a 1 :b 2}))))}))
 
-(rf/reg-event-db :edn-inspector/vector-multi-adjust
+(rf/reg-event :edn-inspector/vector-multi-adjust
   {:doc "Vector: CHANGE + APPEND in ONE diff. Swap :slots `[1 2 3]` ↔
          `[1 9 3 4]` — index 1 modified (2→9) AND index 3 appended (4)."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (update :slots
-                (fn [v] (if (= v [1 2 3]) [1 9 3 4] [1 2 3]))))))
+                (fn [v] (if (= v [1 2 3]) [1 9 3 4] [1 2 3]))))}))
 
-(rf/reg-event-db :edn-inspector/set-multi-adjust
+(rf/reg-event :edn-inspector/set-multi-adjust
   {:doc "Set: MULTI-MEMBER swap in ONE diff. Swap :labels `#{:x :y :z}` ↔
          `#{:x :p :q}` — `:y :z` removed AND `:p :q` added, `:x` kept,
          member-level, key intact."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (update :labels
-                (fn [s] (if (contains? s :y) #{:x :p :q} #{:x :y :z}))))))
+                (fn [s] (if (contains? s :y) #{:x :p :q} #{:x :y :z}))))}))
 
 ;; -- DEEP / MIXED ------------------------------------------------------------
 
-(rf/reg-event-db :edn-inspector/deep-change
+(rf/reg-event :edn-inspector/deep-change
   {:doc "Deep: a scalar change FIVE levels deep at `[:deep :a :b :c :d]`.
          Every ancestor reads `:children` (◴ + rail); none promotes to a
          whole-key replace."}
-  (fn [db _] (-> db (update-in [:deep :a :b :c :d] (fnil inc 0)))))
+  (fn [{:keys [db]} _] {:db (-> db (update-in [:deep :a :b :c :d] (fnil inc 0)))}))
 
-(rf/reg-event-db :edn-inspector/mixed-deep-change
+(rf/reg-event :edn-inspector/mixed-deep-change
   {:doc "Mixed: a SET swap through map→map→vector→set at
          `[:mixed :a :b 0]`. Diffs member-level at the set; no ancestor
          (map or vector) is falsely promoted to a whole-key replace
          (the ancestor-non-promotion property across kinds). Cycles."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (update-in [:mixed :a :b 0]
-                   (fn [s] (if (contains? s :x) #{:y} #{:x}))))))
+                   (fn [s] (if (contains? s :x) #{:y} #{:x}))))}))
 
 ;; -- SENTINELS ---------------------------------------------------------------
 
-(rf/reg-event-db :edn-inspector/redacted
+(rf/reg-event :edn-inspector/redacted
   {:doc "Sentinel: :rf/redacted. Write the sentinel three levels deep at
          `[:secure :user :password]` — the inspector renders a `redacted`
          chip, never the raw value."}
-  (fn [db _] (-> db (assoc-in [:secure :user :password] :rf/redacted))))
+  (fn [{:keys [db]} _] {:db (-> db (assoc-in [:secure :user :password] :rf/redacted))}))
 
-(rf/reg-event-db :edn-inspector/large-elided
+(rf/reg-event :edn-inspector/large-elided
   {:doc "Sentinel: :rf.size/large-elided (Spec 015). Write the sentinel at
          `[:cache :report-42]` — routed through the size-chip renderer."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (assoc-in [:cache :report-42]
                   {:rf.size/large-elided {:source        :app-db
                                           :path          [:cache :report-42]
                                           :original-size 12480293
                                           :bytes         12480293
                                           :handle        :report/payload-42
-                                          :reason        :over-budget}}))))
+                                          :reason        :over-budget}}))}))
 
 ;; -- SHOWCASE (rendering capabilities the diff matrix doesn't exercise) ------
 
-(rf/reg-event-db :edn-inspector/large-collection
+(rf/reg-event :edn-inspector/large-collection
   {:doc "Showcase: LARGE collection → elision. Write a 50-key map at
          `[:cache :grid]` — the App-db inspector elides past its threshold +
          the body scrolls."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (assoc-in [:cache :grid]
                   (into {} (for [i (range 50)]
-                             [(keyword (str "metric-" i)) (str "value-" i)]))))))
+                             [(keyword (str "metric-" i)) (str "value-" i)]))))}))
 
-(rf/reg-event-db :edn-inspector/deeply-nested
+(rf/reg-event :edn-inspector/deeply-nested
   {:doc "Showcase: DEEP nesting → path render / collapse. Write a six-level
          nested map at `:cache/tenant` — deep nodes render `▸ {…N keys}`
          summaries past the depth ceiling."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (assoc-in [:cache :tenant]
                   {:acme {:department {:engineering {:team {:platform
                                                             {:project :xray
                                                              :status  :active
-                                                             :leads   ["Ada" "Grace"]}}}}}}))))
+                                                             :leads   ["Ada" "Grace"]}}}}}}))}))
 
-(rf/reg-event-db :edn-inspector/mixed-types
+(rf/reg-event :edn-inspector/mixed-types
   {:doc "Showcase: MIXED scalar kinds + tagged literals. Write a vector of
          every scalar kind PLUS `#uuid` + `#inst` at `:cache/scalar-mix` —
          every syntax-palette token + the default formatters' compact
          headers."}
-  (fn [db _]
-    (-> db
+  (fn [{:keys [db]} _]
+    {:db (-> db
         (assoc-in [:cache :scalar-mix]
                   [nil true false
                    42 -7 3.14159
@@ -413,7 +413,7 @@
                    :simple :ns/qualified
                    'plain-sym 'my.ns/qualified-sym
                    (random-uuid)
-                   (js/Date.)]))))
+                   (js/Date.)]))}))
 
 ;; ============================================================================
 ;; THE STEP VECTOR — code data (the single source of truth)

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -181,7 +181,7 @@
 ;; transition, then attempt the guarded close. The close fails `:may-close?`
 ;; because the flag is armed, so the door STAYS in `:open` and GUARDS RUN
 ;; shows the failed guard.
-(rf/reg-event-fx :machine-epochs/reopen-then-block
+(rf/reg-event :machine-epochs/reopen-then-block
   {:doc ":door/push (re-open) → :door/hold (arm the guard input) → :door/close.
          The :may-close? guard FAILS, so the close is blocked and the machine
          stays in :open."}
@@ -193,15 +193,15 @@
 
 ;; The acknowledgement event dispatched by :enter-alarm's :fx. A plain deck
 ;; event so the cascade has a downstream child epoch the lens links to.
-(rf/reg-event-db :machine-epochs/alarm-acknowledged
+(rf/reg-event :machine-epochs/alarm-acknowledged
   {:doc "The downstream event fired by the door's :enter-alarm action :fx —
          the child epoch under the originating dispatch-id."}
-  (fn handler-alarm-acknowledged [db _ev] db))
+  (fn handler-alarm-acknowledged [{:keys [db]} _ev] {:db db}))
 
 ;; re-start the brew (schedules a fresh :after timer) then immediately
 ;; :brew/abort, which exits :brewing BEFORE the timer fires. Exiting the
 ;; :after-bearing state cancels the in-flight timer (:reason :on-exit).
-(rf/reg-event-fx :machine-epochs/cancel-brew
+(rf/reg-event :machine-epochs/cancel-brew
   {:doc ":brew/start (re-enter :brewing, schedule the :after timer) →
          :brew/abort (exit :brewing before the timer fires). The exit cancels
          the pending timer with :reason :on-exit."}
@@ -214,7 +214,7 @@
 ;; deterministic spawn-id is resolved through `machine-paths/spawned-path`.
 ;; FAIL LOUD ON A MISS (rf2-4i0ac): an `assert` surfaces a missing slot as a
 ;; loud failure at the call site rather than a silent no-op.
-(rf/reg-event-fx :machine-epochs/finish-login
+(rf/reg-event :machine-epochs/finish-login
   {:doc "Resolve the spawned :session/login child via the machines artefact's
          spawned-path constructor, then dispatch [:succeed <token>] to drive it
          to its :final? state. The child fires :on-done (reporting the token to
@@ -244,7 +244,7 @@
 ;; answer twice more so the running score reaches the `:enough?` pass mark (3)
 ;; and the guarded `:always` chain settles `:asking` ──► `:passed` in N>0
 ;; microsteps. (The first :quiz/answer step already answered once.)
-(rf/reg-event-fx :machine-epochs/answer-to-pass
+(rf/reg-event :machine-epochs/answer-to-pass
   {:doc ":quiz/answer ×2 so the score reaches the pass mark and the guarded
          :always chain fires (microsteps > 0)."}
   (fn handler-answer-to-pass [{:keys [db]} _ev]
@@ -257,13 +257,13 @@
 ;; synchronously at reg-machine time (:rf.error/machine-history-misplaced).
 ;; The deck event swallows the throw (the step's job is to DRIVE the
 ;; rejection; the harness asserts the throw shape directly).
-(rf/reg-event-db :machine-epochs/probe-history-rejection
+(rf/reg-event :machine-epochs/probe-history-rejection
   {:doc "Attempt to register a ROOT :type :history machine and confirm the
          PLACEMENT constraint rejects it (a pseudo-state needs an owning
          compound). The throw is swallowed here so the deck does not crash;
          the harness asserts the misplaced-history rejection shape."}
-  (fn handler-probe-history [db _ev]
-    (assoc db :machine-epochs/history-rejected? (machines/history-rejected?))))
+  (fn handler-probe-history [{:keys [db]} _ev]
+    {:db (assoc db :machine-epochs/history-rejected? (machines/history-rejected?))}))
 
 ;; the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the focal
 ;; cascade, the step first POSITIONS the player deep (`:insert` → `:seek`)
@@ -279,7 +279,7 @@
    [:dispatch [machine-id [:eject]]]     ; exit :player → :tray (RECORDS history)
    [:dispatch [machine-id [:insert]]]])  ; re-enter via :hist (RESTORES — the headline)
 
-(rf/reg-event-fx :machine-epochs/history-shallow-restore
+(rf/reg-event :machine-epochs/history-shallow-restore
   {:doc "Drive :media/shallow through the eject/restore dance so the final
          :insert restores the recorded CHILD then descends its :initial chain.
          The restore cascade carries the history banner + :source :recorded
@@ -288,7 +288,7 @@
     {:db db
      :fx (history-restore-fx :media/shallow)}))
 
-(rf/reg-event-fx :machine-epochs/history-deep-restore
+(rf/reg-event :machine-epochs/history-deep-restore
   {:doc "Drive :media/deep through the eject/restore dance so the final :insert
          restores the EXACT recorded leaf [:player :playing :mid-track]. The
          restore cascade carries the history banner (DEEP) + :source :recorded
@@ -317,54 +317,54 @@
   [machine-ids]
   (mapv (fn [id] [:dispatch [id [:rf.machine/start]]]) machine-ids))
 
-(rf/reg-event-fx :machine-epochs/boot-door
+(rf/reg-event :machine-epochs/boot-door
   {:doc "Boot the door machine — its START cascade is the door frame's first
          observed epoch (the START badge demo, for free)."}
   (fn [_ _] {:fx (boot-machines-fx [:door/main])}))
 
-(rf/reg-event-fx :machine-epochs/boot-traffic
+(rf/reg-event :machine-epochs/boot-traffic
   {:doc "Boot the parallel traffic machine — both regions enter their initial
          leaves in the START cascade."}
   (fn [_ _] {:fx (boot-machines-fx [:traffic/light])}))
 
-(rf/reg-event-fx :machine-epochs/boot-quiz
+(rf/reg-event :machine-epochs/boot-quiz
   {:doc "Boot the quiz machine to :asking."}
   (fn [_ _] {:fx (boot-machines-fx [:quiz/scorer])}))
 
-(rf/reg-event-fx :machine-epochs/boot-brew
+(rf/reg-event :machine-epochs/boot-brew
   {:doc "Boot the brew machine to :idle."}
   (fn [_ _] {:fx (boot-machines-fx [:brew/machine])}))
 
-(rf/reg-event-fx :machine-epochs/boot-session
+(rf/reg-event :machine-epochs/boot-session
   {:doc "Boot the session parent machine to :idle (the child is spawned later
          by the Session: open step)."}
   (fn [_ _] {:fx (boot-machines-fx [:session/flow])}))
 
-(rf/reg-event-fx :machine-epochs/boot-fuse
+(rf/reg-event :machine-epochs/boot-fuse
   {:doc "Boot the fuse machine — its initial state :armed declares an :entry
          action :blow-fuse that THROWS, so booting fuse raises a real
          :rf.error/machine-action-exception immediately. The exception card +
          pink-wash is the headline of the fuse arc (boot-on-select, rf2-q3lfm)."}
   (fn [_ _] {:fx (boot-machines-fx [:fuse/box])}))
 
-(rf/reg-event-fx :machine-epochs/boot-hvac
+(rf/reg-event :machine-epochs/boot-hvac
   {:doc "Boot the deep-compound HVAC machine — both regions enter their deep
          initial leaves in the START cascade."}
   (fn [_ _] {:fx (boot-machines-fx [:hvac/controller])}))
 
-(rf/reg-event-fx :machine-epochs/boot-media
+(rf/reg-event :machine-epochs/boot-media
   {:doc "Boot BOTH media machines (:media/deep + :media/shallow) into the one
          media frame — the media track owns two machine-ids in one observed
          domain (rf2-q3lfm). Both start at :tray."}
   (fn [_ _] {:fx (boot-machines-fx [:media/deep :media/shallow])}))
 
-(rf/reg-event-fx :machine-epochs/boot-modal
+(rf/reg-event :machine-epochs/boot-modal
   {:doc "Boot the modal machine to :closed — the multi-event-transition machine
          whose :open ──► :closed edge is reached on THREE distinct events
          (the events-as-nodes divergence, rf2-vilpfa)."}
   (fn [_ _] {:fx (boot-machines-fx [:modal/main])}))
 
-(rf/reg-event-fx :machine-epochs/boot-gate
+(rf/reg-event :machine-epochs/boot-gate
   {:doc "Boot the gate machine to :idle — the multi-branch guarded-fork machine
          whose :gate/check forks by guard (:high / :low / :rejected) from :idle
          (the guard-fork divergence, rf2-vilpfa)."}
@@ -612,11 +612,11 @@
 ;; Seed the shell bookkeeping (:rf.runner/selected + :rf.runner/cursors).
 ;; Machine snapshots do NOT live here — each lives in its own :machine/<id>
 ;; frame. `run` dispatch-syncs this at boot before the first paint.
-(rf/reg-event-db :machine-epochs/seed
+(rf/reg-event :machine-epochs/seed
   {:doc "Seed the shell frame's runner bookkeeping (:rf.runner/selected +
          :rf.runner/cursors)."}
-  (fn handler-seed [db _ev]
-    (merge db initial-shell-db)))
+  (fn handler-seed [{:keys [db]} _ev]
+    {:db (merge db initial-shell-db)}))
 
 ;; ============================================================================
 ;; LOCAL RUNNER EVENTS — select / step / restart (machine-epochs-LOCAL)
@@ -646,7 +646,7 @@
 ;; through the host-facing focus channel (`xray-focus/focus!`), which fires
 ;; `:rf.xray/select-frame` into Xray's own `:rf/xray` frame for us — the deck
 ;; never reaches into Xray internals.
-(rf/reg-event-fx :machine-epochs/select
+(rf/reg-event :machine-epochs/select
   {:doc "Select a track: set :rf.runner/selected in the shell, lazily create +
          boot the track's :machine/<id> frame (boot-on-select), and re-point
          Xray (:rf.xray/select-frame) at that frame so every observation panel
@@ -681,7 +681,7 @@
 ;; n's machine `:event` INTO the machine frame. Two epochs: the cursor write
 ;; here (not observed) + the machine cascade in the machine frame (observed).
 ;; An out-of-range n (or an unselected/unknown track) is a no-op.
-(rf/reg-event-fx :machine-epochs/run-step
+(rf/reg-event :machine-epochs/run-step
   {:doc "Run step n of the CURRENTLY SELECTED track: write the per-track cursor
          in the shell (:rf.runner/cursors), and dispatch step n's machine
          :event into the track's :machine/<id> frame. The machine cascade is
@@ -724,7 +724,7 @@
 ;; track cursor. The :session track's spawned child is torn down by the frame
 ;; destroy (the :rf.machine/destroy cascade on frame teardown). Re-points Xray
 ;; at the freshly-reset frame so the operator sees the clean re-boot arc.
-(rf/reg-event-fx :machine-epochs/restart
+(rf/reg-event :machine-epochs/restart
   {:doc "Restart the CURRENTLY SELECTED track: RESET its :machine/<id> frame
          (clears the ring, re-arcs from boot via the frame's :on-create) and
          clear the track cursor. Re-points Xray at the reset frame. The track

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -111,10 +111,10 @@
 ;; last lifecycle events. The Xray Epoch / Trace panels are the primary
 ;; surface; the DOM strip is a standalone fall-back.
 
-(rf/reg-event-db ::initialise
+(rf/reg-event ::initialise
   {:doc "Seed app-db: no step yet, idle, no reply, empty log."}
-  (fn [_db _ev]
-    {:step nil :status :idle :reply nil :log []}))
+  (fn [{:keys [db]} _ev]
+    {:db {:step nil :status :idle :reply nil :log []}}))
 
 (defn- log-line [db line]
   (update db :log (fn [xs] (vec (take-last 8 (conj (or xs []) line))))))
@@ -123,21 +123,21 @@
 ;; Reply addressing — one handler per logical request receives the reply.
 ;; ----------------------------------------------------------------------------
 
-(rf/reg-event-db ::reply
+(rf/reg-event ::reply
   {:doc "Reply sink for the success / failure paths. Receives the reply
          payload DIRECTLY (explicit `:on-success` / `:on-failure`
          addressing per Spec 014 §Reply addressing appends the
          `{:kind …}` payload as the last arg — not wrapped in
          `:rf/reply`). Files it and narrates the lifecycle outcome
          (`:done` on success, `:error` + the failure :kind otherwise)."}
-  (fn [db [_ reply]]
-    (let [ok? (= :success (:kind reply))]
-      (-> db
-          (assoc :status (if ok? :done :error))
-          (assoc :reply reply)
-          (log-line (if ok?
-                      (str "✓ success: " (pr-str (:value reply)))
-                      (str "✗ failure: " (pr-str (get-in reply [:failure :kind])))))))))
+  (fn [{:keys [db]} [_ reply]]
+    {:db (let [ok? (= :success (:kind reply))]
+           (-> db
+               (assoc :status (if ok? :done :error))
+               (assoc :reply reply)
+               (log-line (if ok?
+                           (str "✓ success: " (pr-str (:value reply)))
+                           (str "✗ failure: " (pr-str (get-in reply [:failure :kind])))))))}))
 
 ;; ============================================================================
 ;; REQUEST IDS / URLS
@@ -224,7 +224,7 @@
                                                     :reason reason}}]))})
     nil))
 
-(rf/reg-event-fx ::fire-in-flight
+(rf/reg-event ::fire-in-flight
   {:doc "Seed an in-flight request that stays pending (deterministic).
          Populates the in-flight registry; status → :loading. The slot
          persists until the abort step (5) resolves it."}
@@ -233,7 +233,7 @@
      :fx [[:managed-http/seed-in-flight {:request-id in-flight-id}]]}))
 
 ;; (2) Success — a real Fetch against the static asset api/ok.json.
-(rf/reg-event-fx ::success
+(rf/reg-event ::success
   {:doc "Live GET against the static api/ok.json. 2xx → decoded JSON →
          reply :kind :success."}
   (fn [{:keys [db]} _ev]
@@ -246,7 +246,7 @@
 
 ;; (3) Error response — 4xx. Canned-failure-with-trace synthesises the
 ;; same reply envelope + error trace a live 404 would.
-(rf/reg-event-fx ::error-4xx
+(rf/reg-event ::error-4xx
   {:doc "Synthesised :rf.http/http-4xx (404, raw body) via the canned-
          failure-with-trace wrapper. Same reply envelope as a live 4xx."}
   (fn [{:keys [db]} _ev]
@@ -260,7 +260,7 @@
                          :body   "<html>not found</html>" :headers {}}}]]}))
 
 ;; (4) Error response — 5xx.
-(rf/reg-event-fx ::error-5xx
+(rf/reg-event ::error-5xx
   {:doc "Synthesised :rf.http/http-5xx (500, raw body)."}
   (fn [{:keys [db]} _ev]
     {:db (-> db (assoc :status :loading :reply nil) (log-line "→ request (will 500)"))
@@ -278,7 +278,7 @@
 ;; and fires its abort-fn, which dispatches the :rf.http/aborted reply and
 ;; clears the registry slot. No separate abortable slot — the one seeded
 ;; request is the one aborted.
-(rf/reg-event-fx ::abort
+(rf/reg-event ::abort
   {:doc "Abort the step-1 in-flight request (:request-id ::in-flight) via
          the live :rf.http/managed-abort fx. The handle's abort-fn
          dispatches the :rf.http/aborted reply and clears the registry
@@ -304,7 +304,7 @@
        :url      pending-url})
     nil))
 
-(rf/reg-event-fx ::concurrent-by-actor
+(rf/reg-event ::concurrent-by-actor
   {:doc "Issue TWO requests under the SAME actor-id so the actor-in-flight
          index carries both (Spec 014 §Abort on actor destroy)."}
   (fn [{:keys [db]} _ev]
@@ -326,7 +326,7 @@
     (http-managed/abort-on-actor-destroy actor-id)
     nil))
 
-(rf/reg-event-fx ::actor-teardown
+(rf/reg-event ::actor-teardown
   {:doc "Tear down actor-a: its in-flight requests outlive the actor and
          are aborted via abort-on-actor-destroy (:rf.http/aborted-on-
          actor-destroy). actor-b's slot is untouched."}
@@ -346,7 +346,7 @@
     (http-managed/clear-all-in-flight!)
     nil))
 
-(rf/reg-event-fx ::reset
+(rf/reg-event ::reset
   {:doc "Re-seed app-db (no step, idle, no reply, empty log) and clear the
          in-flight registries. Start clean."}
   (fn [_ctx _ev]

--- a/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_edn_inspector.cljs
@@ -60,9 +60,9 @@
   gallery view and the sub can share the keyword without typo drift."
   :panel-gallery.edn-inspector/fixture)
 
-(rf/reg-event-db :panel-gallery.edn-inspector/seed!
-  (fn [db [_ fixture]]
-    (assoc db fixture-slot fixture)))
+(rf/reg-event :panel-gallery.edn-inspector/seed!
+  (fn [{:keys [db]} [_ fixture]]
+    {:db (assoc db fixture-slot fixture)}))
 
 (rf/reg-sub fixture-slot
   (fn [db _] (get db fixture-slot)))

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -214,7 +214,7 @@
    :profile         nil
    :settings-dirty? false})
 
-(rf/reg-event-fx :routes-epochs/reset
+(rf/reg-event :routes-epochs/reset
   {:doc "Re-seed app-db AND navigate home. Start clean."}
   (fn handler-reset [_ _ev]
     {:db initial-db
@@ -231,7 +231,7 @@
 ;; from the dispatched routing event.
 
 ;; A reusable navigate event-fx: every navigation rung routes through here.
-(rf/reg-event-fx :routes-epochs/go
+(rf/reg-event :routes-epochs/go
   {:doc "Dispatch `:rf.route/navigate` with the supplied target / params /
          opts. The shared driver behind every navigation rung."}
   (fn handler-go [{:keys [db]} [_ target params opts]]
@@ -242,7 +242,7 @@
 ;; REDIRECT (#6) + ROUTE-DRIVEN APP-DB LOADER (#8)
 ;; ============================================================================
 
-(rf/reg-event-fx :routes-epochs/redirect-to-home
+(rf/reg-event :routes-epochs/redirect-to-home
   {:doc "Step #6's redirect — fired as `:routes-epochs/old-home`'s
          `:on-match`. Re-navigates to home so the slice lands on a
          DIFFERENT route one cascade later."}
@@ -250,7 +250,7 @@
     {:db db
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
 
-(rf/reg-event-fx :routes-epochs/load-profile
+(rf/reg-event :routes-epochs/load-profile
   {:doc "Step #8's route-driven loader — fired as
          `:routes-epochs/profile`'s `:on-match`. Reads the route params
          from the route slice and writes `:profile` into app-db (the
@@ -280,14 +280,14 @@
 (rf/reg-sub :routes-epochs/can-leave-settings?
   (fn [db _] (boolean (not (:settings-dirty? db)))))
 
-(rf/reg-event-fx :routes-epochs/enter-dirty-settings
+(rf/reg-event :routes-epochs/enter-dirty-settings
   {:doc "Step #10 — navigate INTO settings AND arm the dirty flag, so
          the `:can-leave` guard will block the next attempt to leave."}
   (fn handler-enter-dirty [{:keys [db]} _ev]
     {:db (assoc db :settings-dirty? true)
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/settings]]]}))
 
-(rf/reg-event-fx :routes-epochs/try-leave-settings
+(rf/reg-event :routes-epochs/try-leave-settings
   {:doc "Step #11 — attempt to navigate home FROM dirty settings. The
          `:can-leave` guard refuses: the slice stays on settings, the
          outcome reads `blocked`, and `:rf/pending-navigation` fills."}
@@ -304,7 +304,7 @@
 ;; button), so NAVIGATION THIS EPOCH's FROM ──► TO reverses relative to
 ;; the forward navigation that preceded it.
 
-(rf/reg-event-fx :routes-epochs/back
+(rf/reg-event :routes-epochs/back
   {:doc "Step #9 — emulate the browser Back button by handling a
          url-change back to the articles list (a popstate-style
          transition). NAVIGATION THIS EPOCH's FROM ──► TO reverses."}

--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -217,7 +217,7 @@
   `register-focus-listener!`) so each step's CHILD epoch is pinned into
   view — the 'you see the result' contract."
   [{:keys [id steps host-frame]}]
-  (rf/reg-event-fx id
+  (rf/reg-event id
     {:doc "Step driver: set app-db :step = n and dispatch step n's :event.
            The child dispatch inherits host-frame from this handler's
            envelope (the views dispatch [<this> n] {:frame host-frame}).

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -159,13 +159,13 @@
               :b-prop      "alpha"
               :diamond-root 0}})
 
-(rf/reg-event-db :standard-epochs/reset
+(rf/reg-event :standard-epochs/reset
   {:doc "Seed event — re-seed app-db and unmount both child views. Used by
          `run` (dispatch-sync on load) and by two_frame_isolation's per-frame
          :on-create. There is no on-page reset button; a reload re-seeds.
          The runner cursor `:step` re-seeds to nil here."}
-  (fn handler-reset [_db _ev]
-    initial-db))
+  (fn handler-reset [_ _ev]
+    {:db initial-db}))
 
 ;; ============================================================================
 ;; APP-DB SCHEMA (button #19)
@@ -300,14 +300,14 @@
 ;; ============================================================================
 
 ;; -- 1. plain increment ------------------------------------------------------
-(rf/reg-event-db :standard-epochs/increment
+(rf/reg-event :standard-epochs/increment
   {:doc "Step 1 — a plain event. The per-step App-db delta is the runner's
          `:step` write on the parent run-step epoch; Epoch shows THIS event
          firing with db-before / db-after (no further write)."}
-  (fn handler-increment [db _ev] db))
+  (fn handler-increment [{:keys [db]} _ev] {:db db}))
 
 ;; -- 2. increment + coeffect -------------------------------------------------
-(rf/reg-event-fx :standard-epochs/increment-cofx
+(rf/reg-event :standard-epochs/increment-cofx
   {:doc "Button 2 — declare the `:standard-epochs/now` cofx via
          `:rf.cofx/requires`. Epoch's event detail shows the coeffect
          feeding the handler (EP-0017 declared-only delivery)."
@@ -316,7 +316,7 @@
     {:db (assoc db :last-clicked now)}))
 
 ;; -- 3. increment + effect ---------------------------------------------------
-(rf/reg-event-fx :standard-epochs/increment-fx
+(rf/reg-event :standard-epochs/increment-fx
   {:doc "Button 3 — return a one-shot fx. Effects / Trace show
          `:standard-epochs/ping` fire this epoch."}
   (fn handler-increment-fx [{:keys [db]} _ev]
@@ -324,24 +324,24 @@
      :fx [[:standard-epochs/ping {:at (.getTime (js/Date.))}]]}))
 
 ;; -- 4. increment + cascade --------------------------------------------------
-(rf/reg-event-fx :standard-epochs/increment-cascade
+(rf/reg-event :standard-epochs/increment-cascade
   {:doc "Button 4 — dispatch a follow-on event. Epoch's dispatch-id tree
          shows the cascade (this event → :standard-epochs/cascade-tail)."}
   (fn handler-increment-cascade [{:keys [db]} _ev]
     {:db db
      :fx [[:dispatch [:standard-epochs/cascade-tail]]]}))
 
-(rf/reg-event-db :standard-epochs/cascade-tail
+(rf/reg-event :standard-epochs/cascade-tail
   {:doc "The follow-on event dispatched by button 4 — the second epoch in
          the cascade under one root dispatch-id."}
-  (fn handler-cascade-tail [db _ev] db))
+  (fn handler-cascade-tail [{:keys [db]} _ev] {:db db}))
 
 ;; -- 5. increment + flow -----------------------------------------------------
-(rf/reg-event-db :standard-epochs/increment-flow
+(rf/reg-event :standard-epochs/increment-flow
   {:doc "Button 5 — perturb :base so the `:standard-epochs/derived` flow
          recomputes a derived slot into app-db; App-db / Trace show it."}
-  (fn handler-increment-flow [db _ev]
-    (update db :base inc)))
+  (fn handler-increment-flow [{:keys [db]} _ev]
+    {:db (update db :base inc)}))
 
 ;; -- 6..11. Views / subscriptions — sub-driven Child A + props-driven Child B
 ;;
@@ -350,91 +350,91 @@
 ;; CAUSE — Child A re-renders ← a SUB changed (#8); Child B re-renders ←
 ;; PROPS changed (#11).
 
-(rf/reg-event-db :standard-epochs/mount-a
+(rf/reg-event :standard-epochs/mount-a
   {:doc "Button 6 — mount the SUBSCRIPTION-driven Child A (sets
          :views/a-mounted? true). On mount A subscribes its own
          L1→L2→L3 chain (:chain-root → :chain-doubled → :chain-labelled)
          PLUS the arg-keyed `[:standard-epochs/greater-than? N]` sub — so
          Views shows the node and those sub-cache entries appear."}
-  (fn handler-mount-a [db _ev]
-    (assoc-in db [:views :a-mounted?] true)))
+  (fn handler-mount-a [{:keys [db]} _ev]
+    {:db (assoc-in db [:views :a-mounted?] true)}))
 
-(rf/reg-event-db :standard-epochs/set-threshold
+(rf/reg-event :standard-epochs/set-threshold
   {:doc "Button 7 — change the sub-arg N (5 → 10). `[:standard-epochs/
          greater-than? N]` is keyed by its arg, so the new N is a NEW,
          distinct sub-cache entry alongside the old one."}
-  (fn handler-set-threshold [db [_ n]]
-    (assoc-in db [:views :threshold] n)))
+  (fn handler-set-threshold [{:keys [db]} [_ n]]
+    {:db (assoc-in db [:views :threshold] n)}))
 
-(rf/reg-event-db :standard-epochs/perturb-chain
+(rf/reg-event :standard-epochs/perturb-chain
   {:doc "Button 8 — perturb Child A's chain input (:views/chain-input).
          With A mounted, Views shows the L1 (:chain-root) → L2
          (:chain-doubled) → L3 (:chain-labelled) invalidation recompute,
          and A re-renders BECAUSE A SUB CHANGED (← :standard-epochs/chain-
          labelled), not because its props changed."}
-  (fn handler-perturb-chain [db _ev]
-    (update-in db [:views :chain-input] inc)))
+  (fn handler-perturb-chain [{:keys [db]} _ev]
+    {:db (update-in db [:views :chain-input] inc)}))
 
-(rf/reg-event-db :standard-epochs/unmount-a
+(rf/reg-event :standard-epochs/unmount-a
   {:doc "Button 9 — unmount Child A (sets :views/a-mounted? false). The
          node disappears and ALL of A's subs are disposed once the last
          reader is gone (the chain L1/L2/L3 + every [:gt? N] cache
          entry); the unmount is recorded."}
-  (fn handler-unmount-a [db _ev]
-    (assoc-in db [:views :a-mounted?] false)))
+  (fn handler-unmount-a [{:keys [db]} _ev]
+    {:db (assoc-in db [:views :a-mounted?] false)}))
 
-(rf/reg-event-db :standard-epochs/mount-b
+(rf/reg-event :standard-epochs/mount-b
   {:doc "Button 10 — mount the PROPS-driven Child B (sets
          :views/b-mounted? true). B receives a prop and subscribes
          NOTHING, so Views shows the node appear with NO new sub-cache
          entries."}
-  (fn handler-mount-b [db _ev]
-    (assoc-in db [:views :b-mounted?] true)))
+  (fn handler-mount-b [{:keys [db]} _ev]
+    {:db (assoc-in db [:views :b-mounted?] true)}))
 
-(rf/reg-event-db :standard-epochs/set-b-prop
+(rf/reg-event :standard-epochs/set-b-prop
   {:doc "Button 11 — change Child B's prop. B re-renders BECAUSE ITS
          PROPS CHANGED (no sub cause) — the foil to button 8's
          sub-driven re-render."}
-  (fn handler-set-b-prop [db _ev]
-    (update-in db [:views :b-prop]
-               {"alpha" "beta" "beta" "gamma" "gamma" "alpha"})))
+  (fn handler-set-b-prop [{:keys [db]} _ev]
+    {:db (update-in db [:views :b-prop]
+               {"alpha" "beta" "beta" "gamma" "gamma" "alpha"})}))
 
 ;; -- 12. exception in the handler → Issues: handler-exception, db rolls back -
-(rf/reg-event-db :standard-epochs/throw-handler
+(rf/reg-event :standard-epochs/throw-handler
   {:doc "Button 12 — throw in the handler. The router catches it; the
          handler's :db never commits; Issues shows
          `:rf.error/handler-exception` with the source coord."}
-  (fn handler-throw [_db _ev]
+  (fn handler-throw [_ _ev]
     (throw (ex-info "standard-epochs / handler (intentional — exercises the handler error surface)"
                     {:surface :handler-exception}))))
 
 ;; -- 13. exception in an interceptor :before → Issues: interceptor exc. ------
-(rf/reg-event-db :standard-epochs/throw-interceptor
+(rf/reg-event :standard-epochs/throw-interceptor
   {:doc "Button 13 — an interceptor throws in :before. The chain aborts on
          the way IN; Issues shows the interceptor :before exception and the
          handler never runs."
    :interceptors [throwing-interceptor]}
-  (fn handler-after-throwing-interceptor [db _ev] db))
+  (fn handler-after-throwing-interceptor [{:keys [db]} _ev] {:db db}))
 
 ;; -- 14. exception in an interceptor :after → Issues: interceptor exc. -------
-(rf/reg-event-db :standard-epochs/throw-interceptor-after
+(rf/reg-event :standard-epochs/throw-interceptor-after
   {:doc "Button 14 — an interceptor throws in :after. The foil to button
          13: the handler runs to completion (the :db is computed), THEN the
          interceptor throws on the way OUT. Issues shows the interceptor
          :after exception; per-step placement renders it under the
          interceptor's :after step, distinct from a handler exception."
    :interceptors [throwing-interceptor-after]}
-  (fn handler-before-throwing-after-interceptor [db _ev] db))
+  (fn handler-before-throwing-after-interceptor [{:keys [db]} _ev] {:db db}))
 
 ;; -- 15. exception in a coeffect supplier → Issues: cofx error ---------------
-(rf/reg-event-fx :standard-epochs/throw-cofx
+(rf/reg-event :standard-epochs/throw-cofx
   {:doc "Button 15 — a declared coeffect's supplier throws at context
          assembly. Issues shows the cofx error; the handler never runs."
    :rf.cofx/requires [:standard-epochs/throwing-cofx]}
   (fn handler-after-throwing-cofx [{:keys [db]} _ev] {:db db}))
 
 ;; -- 16. exception in an effect handler (post-commit) → Issues: fx error -----
-(rf/reg-event-fx :standard-epochs/throw-fx
+(rf/reg-event :standard-epochs/throw-fx
   {:doc "Button 16 — the :db commits, then a post-commit fx throws. Issues
          shows the fx error; post-commit fx are best-effort per the FX
          atomicity asymmetry, so the committed db survives. (The visible
@@ -444,45 +444,45 @@
      :fx [[:standard-epochs/boom {}]]}))
 
 ;; -- 17. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
-(rf/reg-event-fx :standard-epochs/slow
+(rf/reg-event :standard-epochs/slow
   {:doc "Button 17 — issue a ~600ms managed fx. Status moves :loading;
          Issues flags the slow fx; the reply lands :loaded ~600ms later."}
   (fn handler-slow [{:keys [db]} _ev]
     {:db (assoc db :slow-status :loading)
      :fx [[:standard-epochs/slow-fetch {}]]}))
 
-(rf/reg-event-db :standard-epochs/slow-done
+(rf/reg-event :standard-epochs/slow-done
   {:doc "The deferred reply from the slow fx. Lands on the originating
          frame and flips status to :loaded."}
-  (fn handler-slow-done [db _ev]
-    (assoc db :slow-status :loaded)))
+  (fn handler-slow-done [{:keys [db]} _ev]
+    {:db (assoc db :slow-status :loaded)}))
 
 ;; -- 18. schema violation, bad event args → Issues / Schema-timeline ---------
-(rf/reg-event-db :standard-epochs/bad-event-args
+(rf/reg-event :standard-epochs/bad-event-args
   {:doc "Button 18 — dispatched with a bad arg (a string where a pos-int
          is required). The handler is skipped; Issues / Schema-timeline
          shows `:rf.error/schema-validation-failure :where :event`."
    :schema [:cat [:= :standard-epochs/bad-event-args] pos-int?]}
-  (fn handler-bad-event-args [db _ev] db))
+  (fn handler-bad-event-args [{:keys [db]} _ev] {:db db}))
 
 ;; -- 19. schema violation, app-db write → Issues: app-db schema failure ------
-(rf/reg-event-db :standard-epochs/bad-app-db-write
+(rf/reg-event :standard-epochs/bad-app-db-write
   {:doc "Button 19 — write an int into [:auth :token] (the registered
          app-schema requires a string). The post-handler app-db
          validation rolls the :db back; Issues shows the app-db schema
          failure, which survives the rollback."}
-  (fn handler-bad-app-db-write [db _ev]
-    (assoc-in db [:auth :token] 42)))
+  (fn handler-bad-app-db-write [{:keys [db]} _ev]
+    {:db (assoc-in db [:auth :token] 42)}))
 
 ;; -- 20. diamond probe — bump the join-sub root once -------------------------
-(rf/reg-event-db :standard-epochs/bump-diamond
+(rf/reg-event :standard-epochs/bump-diamond
   {:doc "Button 20 — bump :views/diamond-root once. The join sub
          :standard-epochs/diamond-c (c ← a,b ← root) increments a recompute
          counter each time its compute fn runs. Press once: the counter should
          rise by 1 (clean); a rise of 2 means the diamond double-computes the
          intermediate sub. The count is shown by the diamond-display view."}
-  (fn handler-bump-diamond [db _ev]
-    (update-in db [:views :diamond-root] (fnil inc 0))))
+  (fn handler-bump-diamond [{:keys [db]} _ev]
+    {:db (update-in db [:views :diamond-root] (fnil inc 0))}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS


### PR DESCRIPTION
## What

EP-0018 slice **K (rf2-xhfxcs.11)** — propagate the one-event-registration collapse (`reg-event-db` / `reg-event-fx` / `reg-event-ctx` → one public **`reg-event`**) into `/tools`. Migrates tool-internal event registrations, the snippet labels / templates the tools emit, and the spec/doc teaching snippets to `reg-event`. Runs during the additive window — old forms still resolve, so every tool stays green.

Surface (tools/ only — disjoint from other live workers): **xray**, **story**, **story-mcp**, **mcp-conformance**, **template**.

## How

- **Call sites** migrated with the Slice-E codemod (`migration/from-re-frame-v1/codemod`) applied to explicit file lists (never whole directories — a directory arg re-serializes hundreds of unrelated files / flips line endings):
  - `reg-event-fx` → `reg-event` (pure rename — `reg-event` *is* `reg-event-fx`).
  - simple `reg-event-db` → `reg-event` with `db` → `{:keys [db]}` and body wrapped `{:db BODY}`.
  - nil-capable / multi-form `reg-event-db` (D7 flags) hand-wrapped with the same faithful `{:db BODY}` shape — every flagged site was an inline-fn tool-internal reducer that always returns a db.
  - Covered: `tools/xray/{src,test,testbeds}`, `tools/story/{src,test,testbeds}`, `tools/story-mcp/test`, `tools/mcp-conformance/test` (fn-form `re-frame.events/reg-event` for the runtime cljs-eval fixture, since a macro can't expand in eval).
  - Final codemod scan across all tool `src`/`test`/`testbeds`: **0 residual `reg-event-db` / `reg-event-fx` call sites**.
- **Snippet labels / templates the tools emit** hand-edited to teach `reg-event`:
  - **Epoch panel HANDLER verb** (`panels/epoch/format.cljc` `handler-flavour-label`): both event flavours now render the verb **`reg-event`** (was `reg-event-db` / `reg-event-fx`); `reg-machine` keeps its own verb. The internal `:reg-event-db` / `:reg-event-fx` discriminator keywords are **unchanged** — they classify the OBSERVED effect shape (`:db`-only vs `:db`+`:fx`) read off the trace stream (NOT `:event/kind`), and still drive which body sections render. View test + spec (021/018/023) updated to match.
  - **Source highlighter** (`views/edn_widget.cljs`): added `"reg-event"` to the builtin token set; kept the retired spellings so legacy source the panel displays still highlights.
  - **`template` scaffold** (`_shared/events.cljs`, `README.md`, `clj-kondo/config.edn`): the shipped counter example + prose now teach `reg-event` (`(fn [{:keys [db]} ev] {:db ...})`).
  - **story spec docs** (`spec/{001-Authoring,002-Runtime,004-Assertions,006-MCP-Surface,017-Testing-Story,API}.md`): teaching snippets + prose migrated to `reg-event`.

## xray-spec disposition

Per the standing rule (every dispatch touching `tools/xray/` updates `tools/xray/spec/*` in the same PR): **spec updated** — `021-Dynamic-Panel-Designs.md` (HANDLER verb prose, the two ASCII-mock handler snippets, an EP-0018 note clarifying that `:reg-event-db`/`:reg-event-fx` are internal effect-shape classifiers not registrar names), `018-Event-Spine.md` (HANDLER mock verb + the seven-marking-sites registrar label), `023-Trace-Panel.md` (trace-row handler verb).

## Scope decision — `:event/kind` / `:rf/db-handler` fixtures deliberately NOT migrated

The bead's scope-note anticipated rewriting tool FIXTURE DATA (`:event/kind`, `:rf/db-handler`/`:rf/fx-handler`) to `:rf/event-handler` and dropping `:event/kind`. **Premise check:** the merged state is Slice **B-add** (additive only) — `reg-event` registers under `:event/kind :fx` with the `:rf/fx-handler` wrapper *verbatim*; `:event/kind` + the per-kind wrapper ids STILL EXIST, and `:rf/event-handler` does NOT exist in the implementation yet. EP-0018 §"final-removal" places `:event/kind` removal + the single `:rf/event-handler` wrapper in the **final-removal flip slice (Z = rf2-xhfxcs.14)**, not the additive window. Rewriting fixtures (e.g. `static/interceptors/panel_cljs_test.cljs` `sample-events-with-chains`, which the interceptors panel renders + asserts `:rf/db-handler`/`:rf/fx-handler` as framework defaults) to `:rf/event-handler` now would assert against internals that don't exist → the tool would NOT stay green, violating the bead's own green requirement. These fixtures mirror live substrate internals and are left exactly as-is; their migration belongs to Z. Internal narrative comments that mention "the reg-event-fx handler" (describing the mechanism, not emitted output) are likewise left — they're not tool-emitted snippets/labels/templates.

No `rf2-` bead-ids in any shipped skill/MCP leaf.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` (canonical node CLJS — full xray+story suites ride this) | **PASS** — 7163 tests, 29536 assertions, 0 failures, 0 errors |
| `npm run test:bundle-isolation` | **PASS** — 22 entries, 40 sentinels absent, 3 budgets ok; uix/helix reagent-free ok |
| `npm run test:mcp-conformance` | **PASS** — all 6 gates green (story-mcp + re-frame2-pair-mcp e2e + wire-vocab) |
| `tools/xray` `clojure -M:test` (JVM) | **PASS** — 1196 tests, 5336 assertions, 0 failures |
| `tools/story` `clojure -M:test` (JVM) | **PASS** — 1683 tests, 6235 assertions, 0 failures |
| `tools/story-mcp` `clojure -M:test` (JVM) | **PASS** — 267 tests, 1331 assertions, 0 failures |
| `mkdocs build --strict` | **PASS** — built clean, no warnings/errors |

Branched off `origin/main`; rebased onto latest `origin/main` (clean, no conflicts; disjoint surface). Closes rf2-xhfxcs.11.
