### PR TITLE
docs(EP): scrub stale flip-is-next-step prose in accepted EP-0018 (rf2-kz995t)

### DIFF
--- a/docs/EP/EP-0018-one-event-registration.md
+++ b/docs/EP/EP-0018-one-event-registration.md
@@ -29,8 +29,9 @@ Type: standards-track
 > `(fn [cofx event])` handler only; **D5** defer any static db-only metadata
 > signal; **D6** sequence behind EP-0017 slice A; **D7** the migration codemod
 > rewrites faithfully and *flags* nil-capable handlers. The design surface is
-> settled; the formal `proposal → accepted` flip and action epic are the next
-> governance step.
+> settled and the `proposal → accepted` flip is recorded (2026-06-14, Mike); the
+> action epic that lands the changes in the normative spec is the next governance
+> step.
 
 ## Abstract
 
@@ -497,5 +498,6 @@ Adopt the one-surface event model — `(rf/reg-event id ?metadata handler)` with
 `handler := (coeffects, event) -> effect-map-or-nil` — removing public
 `reg-event-db` / `reg-event-fx` and demoting `reg-event-ctx`, sequenced behind
 EP-0017 slice A, with the codemod and a mandatory corpus sweep. All seven design
-decisions are ruled (above); the next governance step is the
-`proposal → accepted` flip and the action epic.
+decisions are ruled (above) and the `proposal → accepted` flip is recorded
+(2026-06-14, Mike); the next governance step is the action epic that lands the
+changes in the normative spec.


### PR DESCRIPTION
## Summary

EP-0018 is now `Status: accepted` (:3) with an accepted-flip banner (:6-10) recording the `proposal → accepted` flip (2026-06-14, Mike). Two carried-over sentences still called that flip "the next governance step", contradicting the accepted (and fully-implemented) status:

- **Proposal banner (~:32)** — "the formal `proposal → accepted` flip and action epic are the next governance step" → now "the `proposal → accepted` flip is recorded (2026-06-14, Mike); the action epic that lands the changes in the normative spec is the next governance step."
- **Recommendation (~:501)** — "the next governance step is the `proposal → accepted` flip and the action epic" → now "the `proposal → accepted` flip is recorded (2026-06-14, Mike); the next governance step is the action epic that lands the changes in the normative spec."

Both now match the canonical accepted-flip banner framing. Verified no other lingering "flip is next step / pending" contradictions remain (the surviving "build is pending" / "Normative home after acceptance" phrases are accurate for accepted-but-not-yet-built status). Trivial doc scrub, surface limited to this one file.

Fixes rf2-kz995t (verified PR-review finding from #4212).

## Quality gates

- `mkdocs build --strict` — PASS (exit 0; INFO-only, pre-existing, unrelated to this change)
- `scripts/check_doc_slugs.py` — PASS (exit 0)
- `scripts/check_readme_links.py` — PASS (exit 0)
- `scripts/check_ep_status_sync.py` — PASS (exit 0)