### PR TITLE
test(machines): :actor-id egress-redaction coverage (rf2-sxmeqs)

### DIFF
--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -71,12 +71,21 @@
       :states      {:anon  {:on {:login :authed}}
                     :authed {}}})))
 
-(defn- machine-transition-event
+(defn- machine-transition-event*
   "Build a `:rf.machine/transition` trace event whose `:before` / `:after`
-  snapshots carry a populated `:data` (token + blob + a plain sibling)."
-  [machine-id]
+  snapshots carry a populated `:data` (token + blob + a plain sibling), with
+  the addressed id keyed under `id-key`.
+
+  `project-machine-tags` resolves marks via `(or (:actor-id tags)
+  (:machine-id tags))` (marks.cljc:1341) — every LIVE-runtime snapshot row
+  addresses the instance under `:actor-id` (transition.cljc:348/1681; the
+  PREFERRED branch production hits), reserving `:machine-id` for the
+  registered TYPE / birth signal (the FALLBACK). Parameterising `id-key`
+  lets each redaction row be proven on BOTH branches (rf2-sxmeqs — the
+  `:actor-id` branch previously had no synthesized-fixture coverage)."
+  [id-key machine-id]
   {:operation :rf.machine/transition
-   :tags      {:machine-id machine-id
+   :tags      {id-key      machine-id
                :frame      :rf/default
                :before     {:state :anon
                             :data  {:retries 0
@@ -86,6 +95,11 @@
                             :data  {:retries 1
                                     :token   "secret-jwt-after"
                                     :blob    "huge-after"}}}})
+
+(defn- machine-transition-event
+  "The `:machine-id`-keyed transition event (the FALLBACK lookup branch)."
+  [machine-id]
+  (machine-transition-event* :machine-id machine-id))
 
 ;; ---- (1) per-slot extraction + rooting under [:data …] --------------------
 
@@ -303,6 +317,170 @@
           out  (marks/project-trace-event ev)]
       (is (= "not-secret" (get-in out [:tags :data :token]))
           "no marks → :data slot verbatim"))))
+
+;; ---- (2c) :actor-id PREFERRED-branch coverage (rf2-sxmeqs) ----------------
+;;
+;; Every fixture above keys the addressed id under :machine-id — the FALLBACK
+;; branch of `(or (:actor-id tags) (:machine-id tags))`. But after the
+;; :machine-id -> :actor-id rename, every LIVE snapshot/started/guard/action/
+;; cascade emit addresses the running instance under :actor-id (the PREFERRED
+;; branch production hits — transition.cljc:348/1681). These mirror the
+;; redaction rows above on the :actor-id key so the privacy-critical preferred
+;; branch is proven to redact identically. The :machine-id fallback cases above
+;; are retained (the birth signal / registered-type rows still ride it).
+
+(deftest sensitive-slot-redacted-in-egress-actor-id
+  (testing "rf2-sxmeqs — an :actor-id-keyed transition (the PREFERRED lookup
+            branch, the one production emits) redacts the :sensitive? slot in
+            :before / :after exactly like the :machine-id case"
+    (reg-auth-machine!)
+    (let [out  (marks/project-trace-event
+                 (machine-transition-event* :actor-id auth-id))
+          tags (:tags out)]
+      (is (= :rf/redacted (get-in tags [:before :data :token])))
+      (is (= :rf/redacted (get-in tags [:after :data :token])))
+      (is (= 0 (get-in tags [:before :data :retries])) "plain sibling untouched")
+      (is (= 1 (get-in tags [:after :data :retries])))
+      (is (not (.contains (pr-str out) "secret-jwt"))
+          "no raw token leaked via the :actor-id branch"))))
+
+(deftest large-slot-marked-in-egress-actor-id
+  (testing "rf2-sxmeqs — an :actor-id-keyed transition elides the :large? slot
+            to the size marker on the preferred branch"
+    (reg-auth-machine!)
+    (let [out  (marks/project-trace-event
+                 (machine-transition-event* :actor-id auth-id))
+          tags (:tags out)]
+      (is (contains? (get-in tags [:before :data :blob]) :rf.size/large-elided))
+      (is (contains? (get-in tags [:after :data :blob]) :rf.size/large-elided))
+      (is (not (.contains (pr-str out) "huge-before"))))))
+
+(deftest snapshot-slot-redacted-in-egress-actor-id
+  (testing "rf2-sxmeqs — the :snapshot slot on an :actor-id-keyed
+            :rf.machine/snapshot-updated redacts on the preferred branch"
+    (reg-auth-machine!)
+    (let [ev   {:operation :rf.machine/snapshot-updated
+                :tags      {:actor-id auth-id
+                            :frame    :rf/default
+                            :snapshot {:state :authed
+                                       :data  {:retries 2
+                                               :token   "secret-jwt-snap"
+                                               :blob    nil}}}}
+          out  (marks/project-trace-event ev)]
+      (is (= :rf/redacted (get-in out [:tags :snapshot :data :token])))
+      (is (not (.contains (pr-str out) "secret-jwt-snap"))))))
+
+(deftest started-data-slot-redacted-in-egress-actor-id
+  (testing "rf2-sxmeqs — an :actor-id-keyed :rf.machine/started redacts the
+            :sensitive? :data slot and elides the :large? slot on the preferred
+            branch (NOTE: a real :rf.machine/started BIRTH row keys the TYPE id
+            under :machine-id — the fallback case above pins that; this proves
+            the lookup itself honours :actor-id when present)"
+    (reg-auth-machine!)
+    (let [ev   {:operation :rf.machine/started
+                :tags      {:actor-id auth-id
+                            :frame    :rf/default
+                            :state    :anon
+                            :data     {:retries 0
+                                       :token   "secret-jwt-started"
+                                       :blob    "huge-started"}}}
+          out  (marks/project-trace-event ev)
+          tags (:tags out)]
+      (is (= :rf/redacted (get-in tags [:data :token])))
+      (is (contains? (get-in tags [:data :blob]) :rf.size/large-elided))
+      (is (= 0 (get-in tags [:data :retries])) "plain sibling verbatim")
+      (is (not (.contains (pr-str out) "secret-jwt-started"))))))
+
+(deftest guard-evaluated-input-data-redacted-in-egress-actor-id
+  (testing "rf2-sxmeqs — an :actor-id-keyed :rf.machine/guard-evaluated redacts
+            the :input :data sub-slot on the preferred branch"
+    (reg-auth-machine!)
+    (let [ev   {:operation :rf.machine/guard-evaluated
+                :tags      {:actor-id auth-id
+                            :frame    :rf/default
+                            :guard-id :ready?
+                            :state    :anon
+                            :outcome  :pass
+                            :input    {:data  {:retries 0
+                                               :token   "secret-jwt-guard"
+                                               :blob    "huge-guard"}
+                                       :event [:login]}}}
+          out  (marks/project-trace-event ev)
+          tags (:tags out)]
+      (is (= :rf/redacted (get-in tags [:input :data :token])))
+      (is (contains? (get-in tags [:input :data :blob]) :rf.size/large-elided))
+      (is (= [:login] (get-in tags [:input :event])) ":input :event passes through")
+      (is (not (.contains (pr-str out) "secret-jwt-guard"))))))
+
+(deftest action-ran-input-data-redacted-in-egress-actor-id
+  (testing "rf2-sxmeqs — an :actor-id-keyed :rf.machine/action-ran redacts the
+            :input :data sub-slot on the preferred branch"
+    (reg-auth-machine!)
+    (let [ev   {:operation :rf.machine/action-ran
+                :tags      {:actor-id  auth-id
+                            :frame     :rf/default
+                            :action-id :tap
+                            :phase     :transition
+                            :outcome   :ok
+                            :input     {:data  {:retries 1
+                                                :token   "secret-jwt-action"
+                                                :blob    "huge-action"}
+                                        :event [:login]}}}
+          out  (marks/project-trace-event ev)
+          tags (:tags out)]
+      (is (= :rf/redacted (get-in tags [:input :data :token])))
+      (is (contains? (get-in tags [:input :data :blob]) :rf.size/large-elided))
+      (is (not (.contains (pr-str out) "secret-jwt-action"))))))
+
+(deftest transition-cascade-data-deltas-redacted-in-egress-actor-id
+  (testing "rf2-sxmeqs — an :actor-id-keyed transition's :cascade redacts each
+            step's :data-delta on the preferred branch"
+    (reg-auth-machine!)
+    (let [ev   {:operation :rf.machine/transition
+                :tags      {:actor-id auth-id
+                            :frame    :rf/default
+                            :before   {:state :anon  :data {:retries 0 :token nil :blob nil}}
+                            :after    {:state :authed :data {:retries 1
+                                                             :token "secret-jwt-after"
+                                                             :blob "huge-after"}}
+                            :microsteps 0
+                            :cascade  [{:kind   :action
+                                        :state  []
+                                        :region nil
+                                        :action :authenticate
+                                        :data-delta {:token "secret-jwt-delta"
+                                                     :blob  "huge-delta"
+                                                     :retries 1}}
+                                       {:kind   :entry
+                                        :state  [:authed]
+                                        :region nil
+                                        :action nil
+                                        :data-delta {}}]}}
+          out     (marks/project-trace-event ev)
+          cascade (get-in out [:tags :cascade])
+          step0   (first cascade)]
+      (is (= :rf/redacted (get-in step0 [:data-delta :token])))
+      (is (contains? (get-in step0 [:data-delta :blob]) :rf.size/large-elided))
+      (is (= 1 (get-in step0 [:data-delta :retries])) "plain :data-delta key verbatim")
+      (is (= {} (get-in cascade [1 :data-delta])) "empty :data-delta unchanged")
+      (is (= :rf/redacted (get-in out [:tags :after :data :token])))
+      (is (not (.contains (pr-str out) "secret-jwt-delta")))
+      (is (not (.contains (pr-str out) "secret-jwt-after"))))))
+
+(deftest actor-id-takes-precedence-over-machine-id-in-snapshot-egress
+  (testing "rf2-sxmeqs — when a transition carries BOTH ids the lookup PREFERS
+            :actor-id: :actor-id on the marked (auth) machine redacts even
+            though :machine-id points at an UNMARKED machine (proves precedence,
+            not the fallback)"
+    (reg-auth-machine!)
+    (rf/reg-machine :rf.machine-redaction/unmarked-sibling
+      {:initial :idle :data {:n 0} :data-schema [:map [:n :int]] :states {:idle {}}})
+    (let [ev   (-> (machine-transition-event* :actor-id auth-id)
+                   (assoc-in [:tags :machine-id] :rf.machine-redaction/unmarked-sibling))
+          out  (marks/project-trace-event ev)]
+      (is (= :rf/redacted (get-in out [:tags :after :data :token]))
+          "redacted via the PREFERRED :actor-id (marked), not the :machine-id sibling")
+      (is (not (.contains (pr-str out) "secret-jwt"))))))
 
 ;; ---- (3) UNION with a manual register-marks! (Mike ruling #3) -------------
 

--- a/implementation/machines/test/re_frame/spawned_marks_lifecycle_test.clj
+++ b/implementation/machines/test/re_frame/spawned_marks_lifecycle_test.clj
@@ -200,15 +200,33 @@
             ":sensitive? slot rehydrated, snapshot-rooted")
         (is (= #{[:data :blob]} (set (:large m)))
             ":large? slot rehydrated"))
-      ;; And a sensitive :data slot redacts again post-restore.
+      ;; And a sensitive :data slot redacts again post-restore. A spawned
+      ;; instance's live transition row addresses itself under :actor-id (the
+      ;; PREFERRED `(or (:actor-id …) (:machine-id …))` branch production hits —
+      ;; transition.cljc:348/1681), so the post-restore redaction is asserted on
+      ;; the realistic :actor-id key (rf2-sxmeqs); a parallel :machine-id row
+      ;; below pins the fallback branch resolves the SAME rehydrated marks.
+      (let [ev  {:operation :rf.machine/transition
+                 :tags      {:actor-id spawned-id
+                             :frame    :rf/default
+                             :after    {:state :authed
+                                        :data  {:retries 1
+                                                :token   "secret-jwt-restored"
+                                                :blob    nil}}}}
+            out (marks/project-trace-event ev)]
+        (is (= :rf/redacted (get-in out [:tags :after :data :token]))
+            "the rehydrated marks redact the sensitive slot post-restore (:actor-id branch)")
+        (is (not (.contains (pr-str out) "secret-jwt-restored"))))
+      ;; FALLBACK branch: the same rehydrated per-instance marks also resolve
+      ;; when the row is keyed under :machine-id (the legacy id key).
       (let [ev  {:operation :rf.machine/transition
                  :tags      {:machine-id spawned-id
                              :frame      :rf/default
                              :after      {:state :authed
                                           :data  {:retries 1
-                                                  :token   "secret-jwt-restored"
+                                                  :token   "secret-jwt-fallback"
                                                   :blob    nil}}}}
             out (marks/project-trace-event ev)]
         (is (= :rf/redacted (get-in out [:tags :after :data :token]))
-            "the rehydrated marks redact the sensitive slot post-restore")
-        (is (not (.contains (pr-str out) "secret-jwt-restored")))))))
+            "the rehydrated marks redact via the :machine-id fallback branch too")
+        (is (not (.contains (pr-str out) "secret-jwt-fallback")))))))

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -126,14 +126,22 @@
   ;; Plain machine — no marks at all.
   (marks/register-marks! :event plain-machine-id {}))
 
-(defn- machine-action-exception-event
+(defn- machine-action-exception-event*
   "Build a realistic `:rf.error/machine-action-exception` trace envelope
-  (the shape `trace/build-event` produces) carrying `machine-id` and the
-  sentinel-bearing `:exception-data`."
-  [machine-id]
+  (the shape `trace/build-event` produces) carrying the sentinel-bearing
+  `:exception-data`, with the addressed id keyed under `id-key`.
+
+  `project-machine-error-tags` resolves the schema lookup via
+  `(or (:actor-id tags) (:machine-id tags))` (rf2-yyvtk5): a LIVE actor's
+  exception row addresses the throwing instance under `:actor-id` (the
+  preferred branch every production emit site now hits —
+  registration.cljc:99), while `:machine-id` is the legacy fallback. We
+  parameterise `id-key` so BOTH branches of that `or` are exercised
+  (rf2-sxmeqs — the `:actor-id` branch had zero coverage)."
+  [id-key machine-id]
   {:operation :rf.error/machine-action-exception
    :op-type   :error
-   :tags      {:machine-id        machine-id
+   :tags      {id-key             machine-id
                :action-id         :do/thing
                :state-path        [:running]
                :event             [machine-id [:tick]]
@@ -141,6 +149,12 @@
                :exception-data    {:user-token sentinel :doc-id [sentinel]}
                :reason            "Machine action threw."
                :recovery          :no-recovery}})
+
+(defn- machine-action-exception-event
+  "The legacy `:machine-id`-keyed envelope (the `:machine-id` FALLBACK
+  branch of the `(or (:actor-id …) (:machine-id …))` lookup)."
+  [machine-id]
+  (machine-action-exception-event* :machine-id machine-id))
 
 (deftest machine-exception-data-redacted-for-sensitive-machine
   (testing "rf2-zsm03 — a sensitive machine's :exception-data is elided to
@@ -183,6 +197,64 @@
       (is (not (contains? tags :sensitive?)) "no :sensitive? stamp"))))
 
 ;; ---------------------------------------------------------------------------
+;; SITE 1 — :actor-id PREFERRED branch (rf2-sxmeqs).
+;;
+;; Every production emit of :rf.error/machine-action-exception addresses the
+;; throwing LIVE actor instance under :actor-id (registration.cljc:99); the
+;; schema lookup `(or (:actor-id tags) (:machine-id tags))` (marks.cljc:1419)
+;; PREFERS that branch. The fixtures above only exercise the :machine-id
+;; FALLBACK; these mirror them on the :actor-id key so the privacy-critical
+;; preferred branch is proven to redact identically.
+;; ---------------------------------------------------------------------------
+
+(deftest machine-exception-data-redacted-for-sensitive-actor
+  (testing "rf2-sxmeqs — an :actor-id-keyed sensitive-machine exception (the
+            PREFERRED lookup branch, the one production emits) has its
+            :exception-data elided to :rf/redacted at the egress chokepoint,
+            :sensitive? stamped, and the sentinel never survives"
+    (declare-machine-marks!)
+    (let [out  (marks/project-trace-event
+                 (machine-action-exception-event* :actor-id sensitive-machine-id))
+          tags (:tags out)]
+      (is (= :rf/redacted (:exception-data tags)) ":exception-data redacted")
+      (is (true? (:sensitive? tags)) ":sensitive? stamped on the tags")
+      (is (not (contains-sentinel? out))
+          (str "the sentinel leaked into the :actor-id-keyed exception trace: "
+               (pr-str tags)))
+      ;; The :actor-id structural slot survives — consumers locate the failure.
+      (is (= sensitive-machine-id (:actor-id tags)) ":actor-id kept")
+      (is (= :do/thing (:action-id tags)) ":action-id kept")
+      (is (= "boom" (:exception-message tags)) ":exception-message kept"))))
+
+(deftest machine-exception-data-verbatim-for-plain-actor
+  (testing "rf2-sxmeqs — an :actor-id-keyed machine with NO :sensitive mark
+            rides :exception-data verbatim on the preferred branch (the seam
+            is precise, not a blanket scrub)"
+    (declare-machine-marks!)
+    (let [out  (marks/project-trace-event
+                 (machine-action-exception-event* :actor-id plain-machine-id))
+          tags (:tags out)]
+      (is (map? (:exception-data tags)) ":exception-data NOT redacted")
+      (is (not (contains? tags :sensitive?))
+          "no :sensitive? stamp when the machine declares nothing sensitive"))))
+
+(deftest actor-id-takes-precedence-over-machine-id
+  (testing "rf2-sxmeqs — when BOTH keys are present the schema lookup PREFERS
+            :actor-id: an :actor-id pointing at the SENSITIVE machine redacts
+            even though :machine-id points at the PLAIN one (proves the
+            `(or (:actor-id …) (:machine-id …))` precedence, not the fallback)"
+    (declare-machine-marks!)
+    (let [ev   (-> (machine-action-exception-event* :actor-id sensitive-machine-id)
+                   (assoc-in [:tags :machine-id] plain-machine-id))
+          out  (marks/project-trace-event ev)
+          tags (:tags out)]
+      (is (= :rf/redacted (:exception-data tags))
+          ":exception-data redacted via the PREFERRED :actor-id (sensitive)")
+      (is (true? (:sensitive? tags)) ":sensitive? stamped from the :actor-id machine")
+      (is (not (contains-sentinel? out))
+          "the sentinel never survives when :actor-id wins the lookup"))))
+
+;; ---------------------------------------------------------------------------
 ;; SITE 1 PROPERTY — across arbitrary collection/map nestings of the
 ;; sentinel inside :exception-data, a sensitive machine NEVER egresses it.
 ;; ---------------------------------------------------------------------------
@@ -208,23 +280,27 @@
       ((gen-ex-data (inc depth)) rng1))))
 
 (deftest sensitive-machine-redacts-ex-data-at-arbitrary-nesting
-  (testing "rf2-zsm03 — across arbitrary nestings of the sentinel inside
-            :exception-data, a sensitive machine elides the WHOLE slot and
-            stamps :sensitive?; the sentinel never survives"
+  (testing "rf2-zsm03 / rf2-sxmeqs — across arbitrary nestings of the sentinel
+            inside :exception-data, a sensitive machine elides the WHOLE slot
+            and stamps :sensitive?; the sentinel never survives. Run over BOTH
+            id-keys so the preferred :actor-id branch (production) AND the
+            :machine-id fallback both get property coverage."
     (declare-machine-marks!)
-    (let [result (gen/for-all
-                   gen-nested-ex-data 120 41
-                   (fn [ex-data]
-                     (let [ev   (assoc-in (machine-action-exception-event
-                                            sensitive-machine-id)
-                                          [:tags :exception-data] ex-data)
-                           out  (marks/project-trace-event ev)]
-                       (and (= :rf/redacted (-> out :tags :exception-data))
-                            (true? (-> out :tags :sensitive?))
-                            (not (contains-sentinel? out))))))]
-      (is (nil? result)
-          (str "a sensitive machine leaked :exception-data for a generated "
-               "nesting: " (pr-str (when result (dissoc result :threw))))))))
+    (doseq [id-key [:actor-id :machine-id]]
+      (let [result (gen/for-all
+                     gen-nested-ex-data 120 41
+                     (fn [ex-data]
+                       (let [ev   (assoc-in (machine-action-exception-event*
+                                              id-key sensitive-machine-id)
+                                            [:tags :exception-data] ex-data)
+                             out  (marks/project-trace-event ev)]
+                         (and (= :rf/redacted (-> out :tags :exception-data))
+                              (true? (-> out :tags :sensitive?))
+                              (not (contains-sentinel? out))))))]
+        (is (nil? result)
+            (str "a sensitive machine leaked :exception-data for a generated "
+                 "nesting under " id-key ": "
+                 (pr-str (when result (dissoc result :threw)))))))))
 
 ;; ===========================================================================
 ;; SITE 2 — :rf.route/navigate :error


### PR DESCRIPTION
## Summary

After the `:machine-id` → `:actor-id` rename, the privacy-redaction readers `project-machine-tags` / `project-machine-error-tags` (`implementation/core/src/re_frame/marks.cljc:1341`, `:1419`) resolve marks via `(or (:actor-id tags) (:machine-id tags))`. The `:actor-id` branch is now the one every production emit site hits (`registration.cljc:99`, `transition.cljc:348/1681`), but every egress-redaction fixture keyed the addressed id under the OLD `:machine-id` key — so only the FALLBACK branch was exercised; the privacy-critical preferred `:actor-id` branch had zero coverage (rf2-sxmeqs, verified PR-review finding on #4208; not a regression).

This adds `:actor-id`-keyed coverage mirroring the existing `:machine-id` fixtures, asserting redaction applies identically on the preferred branch. The `:machine-id` fallback cases are retained.

## Rows covered (added `:actor-id` coverage)

**SITE 1 — `:rf.error/machine-action-exception` `:exception-data`** (`error_slot_egress_security_cljs_test.cljc`, reader `project-machine-error-tags`):
- `machine-exception-data-redacted-for-sensitive-actor` — preferred branch redacts to `:rf/redacted`, stamps `:sensitive?`
- `machine-exception-data-verbatim-for-plain-actor` — precise (no over-redaction) on the preferred branch
- `actor-id-takes-precedence-over-machine-id` — both keys present → `:actor-id` wins the `or`
- nesting property now runs over **both** id-keys

**machine `:data` snapshot/started/guard/action/cascade slots** (`machine_data_schema_redaction_test.clj`, reader `project-machine-tags`):
- `:actor-id` variants for: `sensitive-slot` / `large-slot` (before/after), `snapshot-slot`, `started-data-slot`, `guard-evaluated-input-data`, `action-ran-input-data`, `transition-cascade-data-deltas`
- `actor-id-takes-precedence-over-machine-id-in-snapshot-egress` — `:actor-id` (marked) wins over `:machine-id` (unmarked sibling)

**spawned-instance post-restore redaction** (`spawned_marks_lifecycle_test.clj`):
- post-restore redaction now asserted on the realistic `:actor-id` key (a spawned instance addresses itself under `:actor-id`); added a `:machine-id` fallback row proving the same rehydrated marks resolve on both branches

## Quality gates

- `clojure -M:test` (machines: `machine-data-schema-redaction-test` + `spawned-marks-lifecycle-test`): **31 tests, 112 assertions, 0 failures, 0 errors** ✅
- `clojure -M:test` (core, marks readers): **1475 tests, 6587 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs` (canonical CLJS node-runtime gate — authoritative for these egress surfaces): **7175 tests, 29594 assertions, 0 failures, 0 errors** ✅
- Security artefact JVM `clojure -M:test` shows 4 pre-existing SITE-2 (`navigate`/`route-url`) failures **unrelated to this change** — confirmed identical on pristine `origin/main` baseline (route-url throw does not fire under that artefact's ad-hoc JVM `:test` alias; the surface is green under the canonical `npm run test:cljs` run above). My SITE-1 `:actor-id` tests all pass.

Test files only; no src touched.

Closes rf2-sxmeqs.