### PR TITLE
examples: EP-0022 — migrate to reg-interceptor refs (rf2-0adhqs.4)

### DIFF
--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -498,8 +498,9 @@
   (rf/init! reagent-adapter/adapter)
   ;; Override :rf.http/managed on the default frame so all the realworld
   ;; feature HTTP calls land on the demo stub (no real backend required).
-  ;; The auth-guard interceptor (routing.cljs) is prepended to every event
-  ;; in this frame (Spec 002 §reg-frame :interceptors) — it short-circuits
+  ;; The auth-guard interceptor (registered in routing.cljs via
+  ;; `reg-interceptor` and referenced here BY ID per EP-0022) is prepended to
+  ;; every event in this frame (Spec 002 §reg-frame :interceptors) — it short-circuits
   ;; for all non-navigation events and redirects unauthenticated
   ;; `:rf.route/navigate` to `:requires-auth`-tagged routes to login (Spec
   ;; 012 §Redirects and guards). This is what makes the `:requires-auth`
@@ -533,7 +534,7 @@
   (rf/reg-frame :rf/default {:doc          "Realworld demo frame."
                              :url-bound?   true
                              :sensitive    {:app-db [[:auth :token]]}
-                             :interceptors [routing/auth-guard]
+                             :interceptors [:realworld.routing/auth-guard]
                              :fx-overrides {:rf.http/managed :realworld.demo/http-stub}})
   ;; Register the Bearer-auth interceptor at app boot. Order matters:
   ;; before :app/initialise dispatches, since session-restore will fire

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -218,9 +218,16 @@
 
     nil))
 
-(def auth-guard
-  {:id     :realworld.routing/auth-guard
-   :before (fn auth-guard-before [ctx]
+;; EP-0022: the guard is a REGISTERED interceptor referenced BY ID
+;; (`:realworld.routing/auth-guard`) from the demo frame's `:interceptors`
+;; chain in core.cljs — not an inline value. `reg-interceptor` is a top-level
+;; load-time registration; core.cljs requires this ns, so the descriptor is
+;; registered before `reg-frame` resolves the reference.
+(rf/reg-interceptor :realworld.routing/auth-guard
+  {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
+         unauthenticated users away from `:requires-auth`-tagged routes to
+         login, stashing the intended target for post-login bounce-back."}
+  {:before (fn auth-guard-before [ctx]
              (if-let [{:keys [id params]} (resolve-nav-target
                                             (get-in ctx [:coeffects :event]))]
                (let [route-meta  (rf/handler-meta :route id)

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -180,9 +180,10 @@
 ;; login / register / the public reads (logged-out) are unaffected.
 
 ;; Public (not `defn-`) so a headless fixture can wire it into a test frame
-;; and assert the decoration — mirroring how the sibling's `routing/auth-guard`
-;; is referenced from `re-frame.realworld-resources-cljs-test`. The example
-;; tree stays test-free (rf2-8cevm); the visibility is the only concession.
+;; and assert the decoration — the sibling's route guard takes the other route
+;; now: it is a `reg-interceptor` descriptor referenced BY ID
+;; (`:realworld-resources.routing/auth-guard`, EP-0022) rather than a var. The
+;; example tree stays test-free (rf2-8cevm); the visibility is the only concession.
 (defn bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))
                       :auth :token)]
@@ -224,7 +225,9 @@
 (defn run []
   (rf/init! reagent-adapter/adapter)
   ;; EP-0002: the frame is established explicitly, owns the browser URL
-  ;; (`:url-bound? true`), and prepends the auth-guard interceptor + routes
+  ;; (`:url-bound? true`), and prepends the auth-guard interceptor — registered
+  ;; in routing.cljs via `reg-interceptor` and referenced here BY ID per
+  ;; EP-0022 — + routes
   ;; the demo `:rf.http/managed` through the in-process backend stub so reads
   ;; (resources) and writes (mutations) run without a network.
   ;; EP-0015 (frame-owned egress policy): the JWT is a durable, frame-wide
@@ -245,7 +248,7 @@
     {:doc          "RealWorld-on-resources demo frame."
      :url-bound?   true
      :sensitive    {:app-db [[:auth :token]]}
-     :interceptors [routing/auth-guard]
+     :interceptors [:realworld-resources.routing/auth-guard]
      :fx-overrides {:rf.http/managed :realworld-resources.demo/http-stub}})
   ;; Register the Bearer-auth interceptor at app boot, BEFORE :app/initialise
   ;; dispatches — session-restore fires an authenticated `GET /user` as soon as

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -219,9 +219,16 @@
                                   {:id route-id :params (or params {})})
     nil))
 
-(def auth-guard
-  {:id     :realworld-resources.routing/auth-guard
-   :before (fn auth-guard-before [ctx]
+;; EP-0022: the guard is a REGISTERED interceptor referenced BY ID
+;; (`:realworld-resources.routing/auth-guard`) from the demo frame's
+;; `:interceptors` chain in core.cljs — not an inline value. `reg-interceptor`
+;; is a top-level load-time registration; core.cljs requires this ns, so the
+;; descriptor is registered before `reg-frame` resolves the reference.
+(rf/reg-interceptor :realworld-resources.routing/auth-guard
+  {:doc "Route-level auth guard (Spec 012 §Redirects and guards): redirect
+         unauthenticated users away from `:requires-auth`-tagged routes to
+         login, stashing the intended target for post-login bounce-back."}
+  {:before (fn auth-guard-before [ctx]
              (if-let [{:keys [id params]} (resolve-nav-target (get-in ctx [:coeffects :event]))]
                (let [route-meta  (rf/handler-meta :route id)
                      needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -68,13 +68,16 @@
 ;; ============================================================================
 ;;
 ;; Captures :circles before the handler runs; pushes the prior value onto :undo
-;; and clears :redo. Events tagged as undoable use this interceptor in their
-;; :interceptors list. Continuous events (slider drag) opt out by not using it,
-;; only the *commit* event uses it.
+;; and clears :redo. Events tagged as undoable reference this interceptor BY ID
+;; (`:undoable`) in their :interceptors list (EP-0022 — interceptors are
+;; registered descriptors referenced by keyword, not inline values). Continuous
+;; events (slider drag) opt out by not referencing it; only the *commit* event
+;; uses it.
 
-(def undoable
-  {:id    :undoable
-   :before (fn before [ctx]
+(rf/reg-interceptor :undoable
+  {:doc "Snapshot :circles before an undoable handler runs; push the prior
+         value onto :undo and clear :redo when the handler changed it."}
+  {:before (fn before [ctx]
              ;; snapshot taken from coeffects (the pre-handler db).
              (let [db   (get-in ctx [:coeffects :db])
                    prior (get-in db [:drawer :circles])]
@@ -106,7 +109,7 @@
          not an ambient `(random-uuid)` read), then the counter is bumped. The
          counter is NOT in the undoable `:circles` snapshot, so it advances
          monotonically across undo/redo and never re-mints a live id."
-   :interceptors [undoable]}
+   :interceptors [:undoable]}
   (fn handler-drawer-add-circle [{:keys [db]} [_ x y]]
     {:db (let [id (get-in db [:drawer :next-id])]
       (-> db
@@ -135,7 +138,7 @@
          was untouched while the slider moved, so the undoable
          interceptor's prior-snapshot is exactly the pre-dialog state —
          the whole edit collapses into a single undo step."
-   :interceptors [undoable]}
+   :interceptors [:undoable]}
   (fn handler-drawer-close-dialog [{:keys [db]} _]
     {:db (let [{:keys [circle-id draft-radius]} (get-in db [:drawer :dialog])]
       (-> db

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -30,7 +30,10 @@
             [re-frame.views]
             [re-frame.http-test-support]
             [realworld.core]
-            [realworld.routing :as routing]
+            ;; Loaded for its ns-load side effects: registers the routes +
+            ;; the `:realworld.routing/auth-guard` interceptor (EP-0022) the
+            ;; auth-guard tests reference by id.
+            [realworld.routing]
             [realworld.ssr :as ssr])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
@@ -724,13 +727,14 @@
     (is (= :rf.route/not-found (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))))
 
 (defn- auth-guard-test []
-  ;; The auth-guard is a plain interceptor (Spec 012 §Redirects and
+  ;; The auth-guard is a registered interceptor (Spec 012 §Redirects and
   ;; guards) wired into the demo frame via `reg-frame :interceptors`
-  ;; (core.cljs). Configure the test frame with the same interceptor so
-  ;; the guard is exercised end-to-end.
+  ;; (core.cljs) BY ID (EP-0022). Configure the test frame with the same
+  ;; id-reference so the guard is exercised end-to-end. Its descriptor is
+  ;; registered at `realworld.routing` ns-load (required below).
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
-                                 :interceptors [routing/auth-guard]})]
+                                 :interceptors [:realworld.routing/auth-guard]})]
     ;; Unauthenticated: navigating to a :requires-auth route
     ;; (:realworld.user/settings) is redirected to :realworld.auth/login.
     (rf/dispatch-sync [:rf.route/navigate :realworld.user/settings {}] {:frame f})
@@ -774,7 +778,7 @@
   ;; --- direct-URL / reload / popstate (`:rf.route/handle-url-change`) ---
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
-                                 :interceptors [routing/auth-guard]})]
+                                 :interceptors [:realworld.routing/auth-guard]})]
     ;; Logged-out direct URL (or reload) to a :requires-auth route.
     (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
     (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
@@ -800,7 +804,7 @@
   ;; --- anchor click (`:rf/url-requested`) ---
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
-                                 :interceptors [routing/auth-guard]})]
+                                 :interceptors [:realworld.routing/auth-guard]})]
     ;; An anchor whose href targets a :requires-auth route. The
     ;; framework `rf/route-link` dispatches `:rf/url-requested` with the
     ;; resolved url + :to route-id.
@@ -829,7 +833,7 @@
   ;; --- authenticated: every entry point now PASSES through ---
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
-                                 :interceptors [routing/auth-guard]})]
+                                 :interceptors [:realworld.routing/auth-guard]})]
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
     ;; direct-URL / reload to a guarded route proceeds when logged in.
     (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})


### PR DESCRIPTION
EP-0022 propagation slice 4 — examples/ tree.

Migrate the inline interceptor values in event/frame `:interceptors` chains across the examples to `reg-interceptor` registrations + by-id references. The interceptor runtime (reg-interceptor + by-reference chains + standard `:rf.interceptor/path` + overrides) is fully merged + additive — inline values still work — so each example builds and behaves identically. This is reference-only-flip readiness.

## Sites migrated

- **`examples/reagent/realworld/routing.cljs`** — `(def auth-guard {:id :realworld.routing/auth-guard …})` inline value → `(rf/reg-interceptor :realworld.routing/auth-guard {:doc …} {:before …})`; referenced by id from the demo frame's `:interceptors` in `core.cljs:537`.
- **`examples/reagent/realworld_resources/routing.cljs`** — `(def auth-guard {:id :realworld-resources.routing/auth-guard …})` → `reg-interceptor`; referenced by id from `core.cljs:250`.
- **`examples/reagent/seven_guis/circle_drawer/core.cljs`** — `(def undoable {:id :undoable …})` → `(rf/reg-interceptor :undoable …)`; the two undoable events (`:drawer/add-circle`, `:drawer/close-dialog`) reference `:undoable` by id.
- **`implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`** — co-located example test (lives in the adapter test tree per the test-free-examples policy, rf2-8cevm). Its 4 auth-guard test frames reference the guard by id; `realworld.routing` is required for its registration side effects.

No `rf/path` / `rf/after` inline interceptors exist in examples/. Examples stay test-free (no `*.spec.cjs`).

## Quality gates

- `npm run test:cljs` — PASS (7227 tests, 29708 assertions; 0 failures, 0 errors)
- `npm run test:elision` — PASS (production 42/42 absent; control 42/42 present)
- `npm run test:examples` — PASS (3 adapter example specs, 0 failures)
- `shadow-cljs compile examples/realworld examples/realworld-resources examples/circle-drawer` — PASS (0 warnings each)
- `mkdocs build --strict` — PASS (no docs touched; INFO-level relative-link notes only)