### PR TITLE
feat(schemas): register :rf.schema/at-boundary interceptor + reconcile spec/010 (rf2-i3uxo2)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2590,6 +2590,11 @@
       ;; (`:rf.interceptor/path`) so the standard refs survive a test fixture's
       ;; `registrar/clear-all!`. Idempotent.
       (std-interceptors/register-standard-interceptors!)
+      ;; EP-0022 (rf2-i3uxo2): re-seed the framework-standard
+      ;; `:rf.schema/at-boundary` interceptor so the ref form
+      ;; `[:rf.schema/at-boundary]` resolves after a `registrar/clear-all!`.
+      ;; Idempotent.
+      (spec/register-schema-interceptors!)
       nil)))
 
 (defn init-platform

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -147,16 +147,40 @@
 ;; equality — keeps `events` decoupled from `re-frame.spec` (which depends
 ;; transitively on this ns via core re-exports).
 
+(defn- at-boundary-entry?
+  "Truthy when a single RAW chain entry attaches the `:rf.schema/at-boundary`
+  interceptor — in EITHER of the two EP-0022 chain forms:
+
+    - the BY-REF form (the canonical EP-0022 shape): a bare keyword
+      `:rf.schema/at-boundary`, or an `[:rf.schema/at-boundary arg]` 2-vector
+      (the chain stores refs UNRESOLVED, so the bare keyword reaches here);
+    - the INLINE-VALUE form (the migration boundary): an interceptor map
+      carrying `:id :rf.schema/at-boundary` (the `validate-at-boundary-interceptor`
+      Var dropped directly into the chain).
+
+  Detects by id keyword / `:id` so the check stays cycle-free against
+  `re-frame.spec`."
+  [icpt]
+  (or
+    ;; By-ref: bare keyword.
+    (= :rf.schema/at-boundary icpt)
+    ;; By-ref: `[id arg]` 2-vector.
+    (and (vector? icpt)
+         (= 2 (count icpt))
+         (= :rf.schema/at-boundary (first icpt)))
+    ;; Inline value (migration boundary).
+    (and (map? icpt)
+         (= :rf.schema/at-boundary (:id icpt)))))
+
 (defn- attaches-validate-at-boundary-interceptor?
-  "Truthy when the effective user interceptor chain contains the
-  `:rf.schema/at-boundary` interceptor. Detects by `:id` so the check
-  stays cycle-free against `re-frame.spec`."
+  "Truthy when the effective user interceptor chain attaches the
+  `:rf.schema/at-boundary` interceptor — by REF (`[:rf.schema/at-boundary]`,
+  the canonical EP-0022 form) or as an INLINE value (the migration boundary).
+  See `at-boundary-entry?`. Detects by id so the check stays cycle-free
+  against `re-frame.spec`."
   [interceptors]
   (and (sequential? interceptors)
-       (some (fn [icpt]
-               (and (map? icpt)
-                    (= :rf.schema/at-boundary (:id icpt))))
-             interceptors)))
+       (boolean (some at-boundary-entry? interceptors))))
 
 (defn- reject-at-boundary-without-schema!
   "Raise `:rf.error/at-boundary-missing-schema` (ex-info) when the

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -62,6 +62,7 @@
   the interceptor falls through as a no-op."
   (:require [re-frame.error :as error]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -244,3 +245,56 @@
                       ;; checks `:rf/skip-handler?` in its :before slot
                       ;; (see events.cljc).
                       (assoc ctx :rf/skip-handler? true))))))))))))
+
+;; ---- :rf.schema/at-boundary registration (EP-0022, rf2-i3uxo2) ------------
+;;
+;; Per EP-0022 chain grammar + API.md §`validate-at-boundary-interceptor`:
+;; a public `:interceptors` chain carries REFERENCES, not inline values.
+;; A handler opts into boundary validation by referencing the registered
+;; `:rf.schema/at-boundary` interceptor by id — `{:interceptors [:rf.schema/at-boundary]}`
+;; — NOT by dropping the `validate-at-boundary-interceptor` Var into the
+;; chain. The Var stays the registration-boundary INPUT (the value this ns
+;; registers); the chain references the registered interceptor.
+;;
+;; For the bare-keyword ref `[:rf.schema/at-boundary]` to resolve at chain
+;; assembly (rather than failing `:rf.error/unregistered-interceptor`), the
+;; interceptor must live under the `:interceptor` registrar kind. We register
+;; it as a STATIC descriptor (`{:before …}`) — boundary validation runs
+;; entirely in the `:before` slot. The descriptor reuses the SAME `:before`
+;; fn as the `validate-at-boundary-interceptor` value Var, so the inline-value
+;; (migration boundary) form and the by-ref form share one implementation.
+;;
+;; Mirrors `re-frame.std-interceptors/register-standard-interceptors!`: called
+;; at namespace load so standalone require'rs (no `init!`) get the ref, AND
+;; re-seeded from `re-frame.core/init!` so the ref survives a test fixture's
+;; `registrar/clear-all!` (which wipes the `:interceptor` kind).
+
+(defn register-schema-interceptors!
+  "Register the framework-standard `:rf.schema/at-boundary` interceptor into
+  the active registrar so the EP-0022 ref form `[:rf.schema/at-boundary]`
+  resolves at chain assembly (Spec 010 §Production builds + rf2-i3uxo2).
+
+  Registered as a STATIC descriptor reusing the same `:before` slot as the
+  `validate-at-boundary-interceptor` value Var — the inline-value (migration
+  boundary) and by-ref forms therefore run identical boundary validation.
+
+  Idempotent — called at namespace load AND from `re-frame.core/init!` so the
+  ref survives a test fixture's `registrar/clear-all!` (which wipes the
+  `:interceptor` kind along with everything else). Mirrors how
+  `re-frame.std-interceptors/register-standard-interceptors!` re-seeds the
+  standard `:rf.interceptor/path` interceptor."
+  []
+  (icpt-reg/reg-interceptor*
+    :rf.schema/at-boundary
+    {:doc "Framework-standard production-boundary schema-validation interceptor
+          (Spec 010 §Production builds). Referenced as `[:rf.schema/at-boundary]`
+          from an event's metadata `:interceptors`; forces the handler's own
+          `:schema` check at the boundary even in production builds where
+          dev-time validation is elided. Registration without `:schema` is
+          rejected at reg time (`:rf.error/at-boundary-missing-schema`)."}
+    {:before (:before validate-at-boundary-interceptor)})
+  nil)
+
+;; Register at namespace load so standalone require'rs (no `init!`) get the
+;; ref; `init!` re-registers (idempotent) for the post-clear-all! test path.
+(register-schema-interceptors!)

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -660,6 +660,63 @@
              {:doc "no boundary, no schema"}
              (fn [_ _] {}))))))
 
+;; ---- rf2-i3uxo2 — missing-schema detection fires for the BY-REF form too --
+;;
+;; Per EP-0022 + API.md §`validate-at-boundary-interceptor` a public
+;; `:interceptors` chain carries REFS, not inline values: the canonical
+;; opt-in is `{:interceptors [:rf.schema/at-boundary]}` (a bare-keyword ref),
+;; not the inline `validate-at-boundary-interceptor` Var. The chain stores
+;; refs UNRESOLVED, so the missing-schema detection (`register-event!` →
+;; `reject-at-boundary-without-schema!`) sees the RAW bare keyword, not a map.
+;; rf2-i3uxo2 extends the detection so it fires for BOTH the by-ref form and
+;; the legacy inline-value form. The interceptor itself is registered by
+;; `re-frame.spec/register-schema-interceptors!` (re-seeded by `rf/init!`,
+;; which the fixture calls AFTER `clear-all!`), so the ref resolves at
+;; registration's `validate-refs-registered!` step BEFORE the missing-schema
+;; check runs — i.e. an unregistered-interceptor error does NOT pre-empt it.
+
+(deftest at-boundary-ref-form-resolves-at-registration
+  (testing "Per rf2-i3uxo2 — the bare-keyword ref `[:rf.schema/at-boundary]`
+            resolves at chain assembly (the interceptor is registered, re-seeded
+            by init!). A handler carrying the ref AND a `:schema` registers
+            cleanly — no :rf.error/unregistered-interceptor, no missing-schema."
+    (is (= :test.i3uxo2/ref-ok
+           (rf/reg-event :test.i3uxo2/ref-ok
+             {:schema [:cat [:= :test.i3uxo2/ref-ok] :int]
+              :interceptors [:rf.schema/at-boundary]}
+             (fn [_ _] {})))
+        "by-ref form with :schema registers and returns the id")))
+
+(deftest at-boundary-ref-form-without-schema-rejected-at-registration
+  (testing "Per rf2-i3uxo2 — the missing-schema detection fires for the BY-REF
+            form (bare keyword) exactly as it does for the inline value: a
+            handler that references `:rf.schema/at-boundary` but declares no
+            `:schema` raises :rf.error/at-boundary-missing-schema at reg time."
+    (testing "bare-keyword ref, no :schema"
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/at-boundary-missing-schema"
+            (rf/reg-event :test.i3uxo2/ref-no-schema
+              {:interceptors [:rf.schema/at-boundary]}
+              (fn [_ _] {})))))
+
+    (testing "ex-data carries the same actionable slots as the inline form"
+      (let [data (try (rf/reg-event :test.i3uxo2/ref-probe
+                        {:interceptors [:rf.schema/at-boundary]}
+                        (fn [_ _] {}))
+                      (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= :rf.error/at-boundary-missing-schema (:rf.error/id data)))
+        (is (= :test.i3uxo2/ref-probe (:id data)))
+        (is (re-find #":rf\.schema/at-boundary" (:reason data)))))
+
+    (testing "rejection happens BEFORE the registry slot is written (ref form)"
+      (try (rf/reg-event :test.i3uxo2/ref-no-side-effect
+             {:interceptors [:rf.schema/at-boundary]}
+             (fn [_ _] {}))
+           (catch clojure.lang.ExceptionInfo _ nil))
+      (is (nil? (registrar/lookup :event :test.i3uxo2/ref-no-side-effect))
+          "no partial registry trace after the ref-form rejection"))))
+
 ;; ---- rf2-3ut12 — a BARE interceptor is rejected loudly at registration ----
 ;;
 ;; Field-confirmed via the rf8 migration: `reg-event` requires the

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -142,6 +142,47 @@
       (is (true? (:rf/skip-handler? bad-ctx))
           "MALFORMED event in prod: :rf/skip-handler? set true — handler is skipped"))))
 
+;; ---- EP-0022 by-ref chain form (rf2-i3uxo2) ------------------------------
+;;
+;; Per EP-0022 + API.md §`validate-at-boundary-interceptor`: a public
+;; `:interceptors` chain carries interceptor REFERENCES, not inline values.
+;; The canonical opt-in is `{:interceptors [:rf.schema/at-boundary]}` (a
+;; bare-keyword ref) — NOT the inline `rf/validate-at-boundary-interceptor`
+;; Var. rf2-i3uxo2 registers `:rf.schema/at-boundary` under the `:interceptor`
+;; registrar kind (re-seeded by the fixture's `rf/init!`), so the bare-keyword
+;; ref resolves at chain assembly and runs the SAME boundary validation as the
+;; inline value. These two tests are the by-ref counterparts of
+;; `boundary-skips-handler-on-invalid-event-in-prod` /
+;; `boundary-passes-valid-event-through-in-prod` above.
+
+(deftest boundary-ref-form-skips-handler-on-invalid-event-in-prod
+  (testing "Per rf2-i3uxo2 — the EP-0022 by-ref chain form
+            `{:interceptors [:rf.schema/at-boundary]}` resolves at chain
+            assembly and runs boundary validation. Under `:advanced` +
+            `goog.DEBUG=false`, a malformed event causes the handler to be
+            SKIPPED — identical behaviour to the inline-value form."
+    (let [calls (atom 0)]
+      (rf/reg-event :api/strict-ref
+        {:schema [:cat [:= :api/strict-ref] :int]
+         :interceptors [:rf.schema/at-boundary]}   ;; EP-0022 ref by id
+        (fn [_ _] (swap! calls inc) {}))
+      (rf/dispatch-sync [:api/strict-ref "not-an-int"])
+      (is (= 0 @calls)
+          "by-ref boundary interceptor resolved and skipped the handler on a malformed payload"))))
+
+(deftest boundary-ref-form-passes-valid-event-through-in-prod
+  (testing "Per rf2-i3uxo2 — the by-ref form passes a VALID event through
+            the boundary unchanged; the handler runs exactly once. Confirms
+            the resolved ref is a live boundary interceptor, not a no-op."
+    (let [calls (atom 0)]
+      (rf/reg-event :api/strict-ref
+        {:schema [:cat [:= :api/strict-ref] :int]
+         :interceptors [:rf.schema/at-boundary]}
+        (fn [_ _] (swap! calls inc) {}))
+      (rf/dispatch-sync [:api/strict-ref 42])
+      (is (= 1 @calls)
+          "valid payload — by-ref boundary passed through, handler ran once"))))
+
 (deftest boundary-noop-when-validator-is-nil-in-prod
   (testing "Per Spec 010 §Non-Malli validators (rf2-froe): even under
             `:advanced` + `goog.DEBUG=false`, setting the validator to

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -201,14 +201,16 @@ Validation is **elided** by default — schemas remain registered (so tooling ca
 
 For users who want production validation at *system boundaries* — typically incoming events from untrusted sources (HTTP responses, websocket messages, postMessage) — re-frame2 ships a `:rf.schema/at-boundary` interceptor that the user adds to specific event handlers. Boundary validation runs even when global validation is elided.
 
+Per EP-0022 a public `:interceptors` chain carries interceptor **references**, not inline values — so reference the framework-registered boundary interceptor by id (`:rf.schema/at-boundary`):
+
 ```clojure
 (rf/reg-event :api/response-received
   {:schema ApiResponseSchema
-   :interceptors [rf/validate-at-boundary-interceptor]}
+   :interceptors [:rf.schema/at-boundary]}   ;; ref by id (EP-0022) — not the inline Var value
   (fn [m] ...))
 ```
 
-The interceptor is exposed as a value at both `re-frame.core/validate-at-boundary-interceptor` (for users who already alias `re-frame.core` as `rf`) and `re-frame.spec/validate-at-boundary-interceptor` (the namespace name is preserved as a v2 alias — the historical `:spec` segment of the segment-name no longer matches the canonical `schema` vocabulary, but the ns rename is deferred to avoid churn; reach the interceptor through `re-frame.core/validate-at-boundary-interceptor` going forward). Both refer to the same value; pick whichever fits the surrounding code's import style.
+The interceptor is **registered** under the `:interceptor` registrar kind (id `:rf.schema/at-boundary`), so the bare-keyword ref resolves at chain assembly. The `validate-at-boundary-interceptor` **value Var** is the registration-boundary *input* (the value the framework registers), not a chain entry — do not drop it into the chain; reference the registered id instead. The Var is exposed at both `re-frame.core/validate-at-boundary-interceptor` (for users who already alias `re-frame.core` as `rf`) and `re-frame.spec/validate-at-boundary-interceptor` (the namespace name is preserved as a v2 alias — the historical `:spec` segment of the segment-name no longer matches the canonical `schema` vocabulary, but the ns rename is deferred to avoid churn). Both refer to the same value.
 
 **Relationship to the handler's `:schema`.** `:rf.schema/at-boundary` re-uses the handler's existing `:schema` — it does **not** introduce a parallel schema. The interceptor's only job is to **force** validation against `:schema` regardless of the global elision flag. Concretely:
 

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -916,7 +916,7 @@ Routing has two co-equal URL-change events. Popstate and the initial sync (above
 
 (rf/reg-event :webhook/handle
   {:schema [:cat [:= :webhook/handle] IncomingWebhookPayload]
-   :interceptors [rf/validate-at-boundary-interceptor]}                   ;; rejects payload at boundary if invalid
+   :interceptors [:rf.schema/at-boundary]}                   ;; ref by id (EP-0022) — rejects payload at boundary if invalid
   ...)
 ```
 
@@ -925,7 +925,7 @@ Routing has two co-equal URL-change events. Popstate and the initial sync (above
 - **Open by default.** Don't add `:closed true` unless the data crosses a process boundary.
 - **Don't model object hierarchies.** A schema describes the *shape* of an open map. There are no classes.
 - **Schemas grow additively.** Once a schema ships, you can add new optional keys; you cannot remove or rename existing keys without bumping a version (Spec-ulation).
-- **Validation runs in dev, elides in prod** by default. Use the `:rf.schema/at-boundary` interceptor (Var `rf/validate-at-boundary-interceptor`) for runtime validation in prod at system boundaries.
+- **Validation runs in dev, elides in prod** by default. Reference the `:rf.schema/at-boundary` interceptor by id (`{:interceptors [:rf.schema/at-boundary]}`, EP-0022 ref form — the `rf/validate-at-boundary-interceptor` Var is the registration-boundary input, not a chain entry) for runtime validation in prod at system boundaries.
 
 **AI-first checklist:**
 


### PR DESCRIPTION
## What

EP-0022 chain grammar + `API.md:547` say a public `:interceptors` chain carries interceptor **references** — reference `:rf.schema/at-boundary` by id. But the merged runtime never `reg-interceptor`-registered it (only `:rf.interceptor/path` was registered, in `std_interceptors`). `re-frame.spec` built `:rf.schema/at-boundary` only as an `->interceptor*` VALUE Var. So a bare-keyword ref `[:rf.schema/at-boundary]` failed chain assembly (and registration-time `validate-refs-registered!`) with `:rf.error/unregistered-interceptor`.

The skills/guide just migrated to the ref form (correct intent, ahead of the runtime). This makes it real.

## Changes

- **`re-frame.spec`** — registers `:rf.schema/at-boundary` under the `:interceptor` registrar kind as a STATIC descriptor (`{:before …}`) reusing the SAME `:before` slot as the `validate-at-boundary-interceptor` value Var, via a new `register-schema-interceptors!` hook. Called at namespace load AND re-seeded from `core/init!` — mirroring `std_interceptors/register-standard-interceptors!` — so the ref survives a test fixture's `registrar/clear-all!`. The inline-value (migration boundary) and by-ref forms therefore run one identical implementation.
- **`events.cljc`** — extends the registration-time `:rf.error/at-boundary-missing-schema` detection so it fires for BOTH the by-ref form (bare keyword / `[id arg]` 2-vector) and the inline-value form. The chain is stored UNRESOLVED, so the detection must recognise the raw keyword, not only an inline map (detection stays by-id, cycle-free against `re-frame.spec`).
- **`spec/010-Schemas.md`** + **`spec/Construction-Prompts.md`** — reconcile the stale inline-value teaching to the ref form `[:rf.schema/at-boundary]`, matching `API.md:547` (the Var is the registration-boundary input, not a chain entry).

No public-export change (the Var was already exported; the registered id is not a new Var) — `api-manifest --check` confirms in-sync.

## Tests (adversarial)

- `events_test.clj` — by-ref form with `:schema` registers cleanly (ref resolves, no unregistered-interceptor); by-ref form WITHOUT `:schema` raises `:rf.error/at-boundary-missing-schema` at reg time with full ex-data; rejection leaves no partial registry trace. Inline-value tests unchanged + still green.
- `schemas_boundary_prod_test.cljs` (`:advanced` + `goog.DEBUG=false` prod build) — by-ref `[:rf.schema/at-boundary]` skips the handler on a malformed payload and passes a valid one through, proving the resolved ref is a live boundary interceptor.

## Quality gates

- `clojure -M:test -n re-frame.events-test` (core, bounded) — **24 tests / 148 assertions, 0 failures**
- `clojure -M:test -n re-frame.interceptor-test -n re-frame.interceptor-overrides-test -n re-frame.reg-interceptor-cljs-test` — **36 tests / 136 assertions, 0 failures**
- `clojure -M:test` (schemas JVM) — **295 tests / 18764 assertions, 0 failures**
- `npm run test:cljs` — **7227 tests / 29708 assertions, 0 failures**
- `npm run test:browser-schemas-boundary-prod` — **7 tests / 9 assertions, 0 failures** (includes the 2 new by-ref prod tests)
- `npm run test:elision` — **PASS (42/42 absent in prod, 42/42 present in control)**
- `mkdocs build --strict` — **built, 0 warnings/errors**
- `api-manifest --check` — **OK, 505 public vars in sync**

Closes rf2-i3uxo2.
