### PR TITLE
docs(core): EP-0022 interceptor comment/docstring accuracy (rf2-0adhqs.11)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -167,8 +167,10 @@
   validation: every interceptor REFERENCE in `chain` must name a registered
   interceptor. A reference to an absent id throws
   `:rf.error/unregistered-interceptor` at registration so typos die before
-  dispatch. INLINE values (the additive window) and the appended framework
-  handler-wrapper are skipped. Resolution is deferred to chain assembly (the
+  dispatch. Only refs are checked here; the appended framework handler-wrapper
+  (the one inline value a chain carries since the reference-only flip) is
+  skipped — any other inline value has already been rejected by
+  `validate-meta-interceptors!`. Resolution is deferred to chain assembly (the
   router) so hot-reloaded descriptors are picked up on the next dispatch."
   [chain]
   (doseq [entry chain]

--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -213,8 +213,9 @@
 ;; The reserved slot a resolved chain entry carries so its AUTHORED reference
 ;; survives resolution — `:interceptor-overrides` exact-reference matching
 ;; (EP-0022 Slice C) keys on this. A bare-keyword ref stamps the keyword; an
-;; `[id arg]` ref stamps the full vector. Inline interceptor values (additive
-;; window) carry NO authored ref, so they match overrides by `:id` only.
+;; `[id arg]` ref stamps the full vector. An entry without an authored ref
+;; (the framework default-wrapper, which is the only inline value a chain
+;; carries since the reference-only flip) matches overrides by `:id` only.
 
 (def authored-ref-key
   "The reserved key under which a resolved chain entry carries its AUTHORED
@@ -244,8 +245,8 @@
   §`:interceptor-overrides` exact-reference matching:
 
     - a bare KEYWORD key matches when it equals the entry's AUTHORED ref (a
-      bare-keyword ref) OR the entry's `:id` (covers inline values + the
-      `:id` the resolver stamps);
+      bare-keyword ref) OR the entry's `:id` (the `:id` the resolver stamps —
+      so a bare-keyword key can match a `[id arg]`-resolved entry by its id);
     - an `[id arg]` VECTOR key matches ONLY the entry whose AUTHORED ref is
       `ref=` to that exact `[id arg]` vector — so `{[:rf.interceptor/path
       [:cart]] nil}` removes only that exact reference and leaves a sibling

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -27,11 +27,15 @@
   path argument is `:rf.error/path-interceptor-bad-path`.
 
   This standard interceptor is DISTINCT from the legacy `path` fn / the
-  `rf/path` value constructor (the additive-window inline shape): the
-  standard interceptor is the canonical `:factory` consumer and is the
-  carrier of the rule-4 identity-fast-path; the legacy `path` fn stays for
-  the inline-value window (its `:after` only short-circuits the no-`:db`
-  case, not the unchanged-slice case)."
+  `rf/path` value constructor: the standard interceptor is the canonical
+  `:factory` consumer and is the carrier of the rule-4 identity-fast-path.
+  Since the EP-0022 reference-only flip (rf2-0adhqs.9) chains carry refs
+  only, the `path` fn's value is no longer a legal inline chain entry —
+  it is the underlying value builder the `:rf.interceptor/path` factory
+  consumes, and may still be registered at the `reg-interceptor` boundary
+  and referenced by id. (The legacy `path` value's own `:after` only
+  short-circuits the no-`:db` case, not the unchanged-slice case — which is
+  why the standard interceptor, not the legacy value, carries rule 4.)"
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.trace :as trace]))
@@ -105,7 +109,7 @@
 ;; the frame-commit `identical?` no-op (rf2-ekq28v) is preserved.
 ;;
 ;; This is DISTINCT from the legacy `path` fn above. The legacy fn (the
-;; additive-window `rf/path` inline value) only short-circuits the no-`:db`
+;; `rf/path` value builder) only short-circuits the no-`:db`
 ;; case; it still does `(assoc-in original-db path slice)` when a `:db` effect
 ;; is present, allocating a fresh top-level map even for an unchanged slice —
 ;; which defeats the commit no-op. The standard interceptor knows BOTH the


### PR DESCRIPTION
## What

EP-0022 wave-end comment/docstring accuracy pass (rf2-0adhqs.11, part 2). The reference-only flip (rf2-0adhqs.9) closed the additive window where interceptor chains could carry both references and inline values. Several **source-level comments/docstrings** still framed the legacy `path` value and the additive window as live. The public facade docstrings in `core.cljc` (`path`, `unwrap-interceptor`, `validate-at-boundary-interceptor`) were already corrected during the flip; this PR brings the internal-namespace comments/docstrings into line.

### Changes (comments/docstrings only — no behavior change)

- **`std_interceptors.cljc`** — ns docstring + the inline path comment: dropped the "additive-window / inline-value window" framing. The `rf/path` value is no longer a legal inline chain entry; it is the underlying value builder the `:rf.interceptor/path` factory consumes (registerable at the `reg-interceptor` boundary + referenced by id).
- **`interceptor_registry.cljc`** — the override-matching section comment + `override-key-matches?` docstring: the only inline value a chain carries since the flip is the framework default-wrapper; the bare-keyword `:id`-fallback arm covers a resolver-stamped id (so a bare-keyword key can match an `[id arg]`-resolved entry), not application inline values.
- **`events.cljc`** — `validate-refs-registered!` docstring: any non-default inline value is already rejected by `validate-meta-interceptors!` before this fn runs; only refs are checked here and only the framework wrapper is skipped.

The diff is 19 insertions / 12 deletions across three files, all inside docstrings / `;;` comments — no code lines changed.

## Quality gates

- **`api-manifest --check`**: PASS — `spec/api-manifest.edn in sync (505 public vars)`. No public-surface drift (edits touch only internal/private docstrings + ns comments; no public facade var).
- **JVM namespace load**: PASS — `re-frame.events`, `re-frame.interceptor-registry`, `re-frame.std-interceptors` all `require` cleanly (docstrings/comments parse; reader unaffected).
- **`npm run test:cljs`**: unaffected by construction — the change is comments/docstrings only, inert to the compiler. (Not executed here: node_modules absent in the fresh worktree; the change cannot alter test behavior. The JVM load + api-manifest check exercise the same source.)
- **`mkdocs --strict`**: not applicable — these are internal-namespace docstrings/`;;` comments; mkdocs builds from `docs/` + spec, not from source docstrings.

Companion to the part-1 testing-coverage assessment (8 `[EP-0022][coverage-gap]` beads filed under rf2-0adhqs).