### PR TITLE
test(core): EP-0022 override + at-boundary coverage gaps (48ypb6,nnpimw,iz3v0r)

### DIFF
--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -18,6 +18,7 @@
   `:interceptors` value is a loud `:rf.error/reg-event-bad-interceptors`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.events :as events]
             [re-frame.frame :as frame]
             [re-frame.interceptor :as interceptor]
             [re-frame.late-bind :as late-bind]
@@ -784,6 +785,53 @@
            (catch clojure.lang.ExceptionInfo _ nil))
       (is (nil? (registrar/lookup :event :test.i3uxo2/ref-no-side-effect))
           "no partial registry trace after the ref-form rejection"))))
+
+;; ---- rf2-48ypb6 — at-boundary-entry? detects BOTH ref forms (unit) ----------
+;;
+;; `at-boundary-entry?` (events.cljc) detects the `:rf.schema/at-boundary`
+;; attachment in two ref forms: a bare keyword `:rf.schema/at-boundary` AND an
+;; `[:rf.schema/at-boundary arg]` 2-vector. The existing registration-path
+;; tests above only exercise the BARE-KEYWORD form. This pins the predicate's
+;; 2-vector arm directly.
+;;
+;; REACHABILITY (rf2-48ypb6 verdict): the 2-vector arm is effectively VESTIGIAL
+;; through the public `reg-event` registration path. The standard
+;; `:rf.schema/at-boundary` interceptor is registered as a STATIC interceptor
+;; (no `:factory`), so an `[:rf.schema/at-boundary arg]` chain ref is rejected
+;; at `validate-refs-registered!` with `:rf.error/interceptor-factory-arity`
+;; BEFORE `reject-at-boundary-without-schema!` (which calls this predicate) ever
+;; runs — verified empirically (with AND without `:schema`). The predicate's
+;; 2-vector branch is therefore unreachable for its intended missing-schema
+;; rejection purpose via the public surface. The branch is still pinned here at
+;; the unit level (the predicate IS reachable + exercised by
+;; `attaches-validate-at-boundary-interceptor?`), and a follow-up bead tracks
+;; confirming / pruning the unreachable-via-registration 2-vector arm.
+
+(deftest at-boundary-entry?-detects-both-ref-forms
+  (testing "Per rf2-48ypb6 — the private at-boundary-entry? predicate detects the
+            `:rf.schema/at-boundary` attachment in BOTH legal ref forms."
+    (let [at-boundary-entry? @#'events/at-boundary-entry?]
+      (testing "bare-keyword ref"
+        (is (true? (boolean (at-boundary-entry? :rf.schema/at-boundary)))
+            "the bare keyword is detected"))
+
+      (testing "[id arg] 2-vector ref (the previously-untested arm)"
+        (is (true? (boolean (at-boundary-entry? [:rf.schema/at-boundary {:some :arg}])))
+            "the `[:rf.schema/at-boundary arg]` 2-vector is detected")
+        (is (true? (boolean (at-boundary-entry? [:rf.schema/at-boundary nil])))
+            "a nil arg in the 2-vector still detects (shape, not arg, drives it)"))
+
+      (testing "non-matching entries are NOT detected"
+        (is (false? (boolean (at-boundary-entry? :some/other-interceptor)))
+            "an unrelated bare keyword is not detected")
+        (is (false? (boolean (at-boundary-entry? [:some/other-interceptor {:k 1}])))
+            "an unrelated [id arg] 2-vector is not detected")
+        (is (false? (boolean (at-boundary-entry? [:rf.schema/at-boundary])))
+            "a 1-vector (wrong arity) is not detected by the 2-vector arm")
+        (is (false? (boolean (at-boundary-entry? [:rf.schema/at-boundary :a :b])))
+            "a 3-vector (wrong arity) is not detected by the 2-vector arm")
+        (is (false? (boolean (at-boundary-entry? {:id :rf.schema/at-boundary})))
+            "an inline map value is not a ref form and is not detected")))))
 
 ;; ---- rf2-3ut12 — a BARE interceptor is rejected loudly at registration ----
 ;;

--- a/implementation/core/test/re_frame/interceptor_overrides_test.clj
+++ b/implementation/core/test/re_frame/interceptor_overrides_test.clj
@@ -23,7 +23,9 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.identity :as identity]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -175,3 +177,113 @@
               [::log-a :after]]
              @log)
           "both interceptors fired in standard before/after sandwich"))))
+
+;; ---- rf2-nnpimw — per-FRAME value-rejection (the per-call arm is covered above) --
+;;
+;; `override-replacement` (router.cljc) rejects an inline interceptor VALUE
+;; replacement (non-ref, non-nil) with `:rf.error/interceptor-override-invalid`
+;; — value-valued overrides retired (EP-0022). The per-call arm is pinned by
+;; `value-valued-override-replacement-rejected` above; the per-FRAME override
+;; path runs the SAME `override-replacement`, but the per-frame value-rejection
+;; arm was not pinned. This pins it.
+
+(deftest per-frame-value-valued-override-replacement-rejected
+  (testing "an inline interceptor VALUE as a per-FRAME override replacement is rejected
+            (value-valued overrides retired — same as the per-call arm)"
+    (let [log (atom [])]
+      (reg-logger! log ::log-pf)
+      (rf/reg-frame :test/bad-frame-override
+        {:interceptor-overrides
+         {::log-pf (interceptor/->interceptor*
+                     :id ::pf-inline :before identity)}})
+      (rf/reg-event :test/run
+        {:interceptors [::log-pf]}
+        (fn [{:keys [db]} _] {:db db}))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/interceptor-override-invalid"
+            (rf/dispatch-sync [:test/run] {:frame :test/bad-frame-override}))
+          "the per-frame value-valued replacement is rejected at chain assembly"))))
+
+;; ---- rf2-nnpimw — override-key-matches? direct unit (all arms) ---------------
+;;
+;; `override-key-matches?` (interceptor_registry.cljc) keys an
+;; `:interceptor-overrides` map entry against a resolved chain entry per Spec
+;; 002 §`:interceptor-overrides` exact-reference matching. The override walk
+;; exercises it indirectly; this pins every arm directly. The entry carries its
+;; AUTHORED ref under `icpt-reg/authored-ref-key` (`:rf/interceptor-ref`).
+
+(deftest override-key-matches?-all-arms
+  (let [K icpt-reg/authored-ref-key]
+    (testing "Per rf2-nnpimw — override-key-matches? for every documented arm"
+
+      (testing "bare-keyword key"
+        (is (true? (icpt-reg/override-key-matches? :my/ic {:id :my/ic K :my/ic}))
+            "matches a bare-keyword AUTHORED ref")
+        (is (true? (icpt-reg/override-key-matches? :my/ic {:id :my/ic}))
+            "matches the entry :id when there is no authored ref (inline / resolver-stamped)")
+        (is (true? (icpt-reg/override-key-matches? :my/ic {:id :my/ic K [:my/ic [:cart]]}))
+            "matches the :id even when the authored ref is a vector (factory-built)")
+        (is (false? (icpt-reg/override-key-matches? :my/ic {:id :other K :other}))
+            "does not match a different id / authored ref"))
+
+      (testing "[id arg] 2-vector key"
+        (is (true? (icpt-reg/override-key-matches? [:my/ic [:cart]]
+                                                   {:id :my/ic K [:my/ic [:cart]]}))
+            "matches the entry whose authored ref is ref= to the exact [id arg]")
+        (is (false? (icpt-reg/override-key-matches? [:my/ic [:cart]]
+                                                    {:id :my/ic K [:my/ic [:cart :items]]}))
+            "does NOT match a sibling [id arg] with a different arg")
+        (is (true? (icpt-reg/override-key-matches? [:my/ic {:a 1 :z 2}]
+                                                   {:id :my/ic K [:my/ic {:z 2 :a 1}]}))
+            "matches canonically — key-reordered map args are ref=")
+        (is (false? (icpt-reg/override-key-matches? [:my/ic [:cart]] {:id :my/ic}))
+            "does NOT match an entry with no authored ref (a vector key needs one)"))
+
+      (testing ":else arm — a structurally-invalid key never matches"
+        (is (false? (icpt-reg/override-key-matches? "not-a-ref" {:id :my/ic}))
+            "a non-keyword non-2-vector key falls through to false")
+        (is (false? (icpt-reg/override-key-matches? [:my/ic :a :b] {:id :my/ic}))
+            "a 3-vector key is not an [id arg] ref and falls through to false")))))
+
+;; ---- rf2-iz3v0r — ref= canonical-bytes fallback + fail-soft catch (unit) -----
+;;
+;; `ref=` (interceptor_registry.cljc) has two undertested arms: (1) the
+;; canonical-bytes fallback (via `identity/identical-identity?`) that makes two
+;; arg spellings differing only in map-key order match — exercised end-to-end by
+;; the override walk but not pinned at the unit level; (2) the fail-soft catch
+;; that returns false (not throws) when canonicalization throws on a non-EDN
+;; arg.
+
+(deftest ref=-fast-structural-and-canonical-fallback
+  (testing "Per rf2-iz3v0r — the fast `=` path and the canonical-bytes fallback"
+    (testing "fast structural `=` short-circuit"
+      (is (true? (icpt-reg/ref= :my/ic :my/ic))
+          "two identical bare-keyword refs are =")
+      (is (true? (icpt-reg/ref= [:my/ic [:cart]] [:my/ic [:cart]]))
+          "two identical [id arg] vectors are ="))
+
+    (testing "canonical-bytes fallback — map-key order is irrelevant"
+      (is (true? (icpt-reg/ref= [:my/ic {:a 1 :z 2}] [:my/ic {:z 2 :a 1}]))
+          "two [id arg] refs differing ONLY in map-key order are ref= via canonical bytes"))
+
+    (testing "genuinely different args are NOT equal"
+      (is (false? (icpt-reg/ref= [:my/ic {:a 1}] [:my/ic {:a 2}]))
+          "different arg values are not ref=")
+      (is (false? (icpt-reg/ref= :my/ic :other/ic))
+          "different bare keywords are not ref="))))
+
+(deftest ref=-fail-soft-on-non-edn-arg
+  (testing "Per rf2-iz3v0r — when canonicalization throws on a non-EDN arg,
+            ref= fail-softs to false rather than letting the throw escape the
+            override walk."
+    (let [f1 (fn [] :a)
+          f2 (fn [] :b)]
+      ;; Sanity: the raw canonical-identity check DOES throw on a function arg
+      ;; (an unsupported host value), so the catch arm is genuinely exercised.
+      (is (thrown? clojure.lang.ExceptionInfo
+            (identity/identical-identity? f1 f2))
+          "identical-identity? throws on a non-EDN (function) arg")
+      ;; ref= must NOT propagate that throw — it fail-softs to false.
+      (is (false? (icpt-reg/ref= [:my/ic f1] [:my/ic f2]))
+          "ref= returns false (fail-soft) rather than propagating the canonicalization throw"))))


### PR DESCRIPTION
Closes the EP-0022 interceptor-override + at-boundary test-coverage gaps found in review **rf2-0adhqs.11**. Test-only — no `src/` changes.

## Gaps covered

### rf2-48ypb6 — at-boundary `[id arg]` 2-vector detection
- New unit `at-boundary-entry?-detects-both-ref-forms` (events_test.clj) pins the private predicate for BOTH ref forms: bare keyword AND the previously-untested `[:rf.schema/at-boundary arg]` 2-vector (plus negative arms: wrong arity, inline map, unrelated id).
- **Reachability verdict: the 2-vector arm is VESTIGIAL via the public `reg-event` registration path.** The standard `:rf.schema/at-boundary` interceptor is registered as a STATIC interceptor (no `:factory`), so an `[:rf.schema/at-boundary arg]` chain ref is rejected at `validate-refs-registered!` with `:rf.error/interceptor-factory-arity` BEFORE `reject-at-boundary-without-schema!` (which calls the predicate) ever runs — verified empirically (throws with AND without `:schema`). The predicate itself IS reachable (via `attaches-validate-at-boundary-interceptor?`) so it is unit-pinned here rather than forced through the dead registration path.
- **rf2-48ypb6 left OPEN** per the bead's instruction; follow-up **rf2-48ypb6.1** filed (reparented under it) to confirm/prune the unreachable-via-registration 2-vector branch.

### rf2-nnpimw — per-frame value-rejection + direct override-key-matches?
- New `per-frame-value-valued-override-replacement-rejected` — pins the per-FRAME `override-replacement` value-rejection arm (the per-call arm was already covered).
- New `override-key-matches?-all-arms` — direct unit covering every documented arm: bare-kw key (vs authored kw / vs `:id` / vs vec-authored+matching-`:id` / non-match), `[id arg]` key (vs matching / sibling-arg / key-reordered-canonical / no-authored-ref), and the `:else` arm (string key, 3-vector key).

### rf2-iz3v0r — ref= canonical-bytes fallback + fail-soft catch
- New `ref=-fast-structural-and-canonical-fallback` — pins the fast `=` short-circuit and the canonical-bytes fallback (two `[id arg]` refs differing only in map-key order are `ref=`; genuinely-different args are not).
- New `ref=-fail-soft-on-non-edn-arg` — pins the fail-soft catch: a non-EDN (function) arg makes `identical-identity?` throw (asserted), and `ref=` returns `false` rather than propagating the throw.

## Quality gates
- Bounded core JVM (target nses): `clojure -M:test -n re-frame.events-test -n re-frame.interceptor-overrides-test` → **35 tests, 191 assertions, 0 failures, 0 errors**.
- Adjacent end-to-end ns: `clojure -M:test -n re-frame.interceptor-runtime-complete-cljs-test` → **17 tests, 25 assertions, 0 failures, 0 errors**.
- Full CLJS gate: `npm run test:cljs` → **7232 tests, 29725 assertions, 0 failures, 0 errors**.