### PR TITLE
tools(story): EP-0022 — migrate remaining interceptors to reg-interceptor refs (rf2-0adhqs.13)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -161,8 +161,7 @@ Required normalized plan shape:
  :world {:frame {:preset optional-keyword
                  :on-create [event-vector ...]
                  :fx-overrides {fx-id override-ref-or-data}
-                 :interceptor-overrides {...}
-                 :interceptors [...]}
+                 :interceptor-overrides {interceptor-id override-ref}}
          :args {...}
          :argtypes {...}                  ; control metadata; schema-derived where possible
          :view-args-schema optional-schema ; explicit view input contract copied from view :rf/props
@@ -356,6 +355,36 @@ on the variant/fragment body, normalized to
 compiler **lowers into `:fx-overrides`**. `:decorators` is reserved for
 view wrapping (theme/provider/chrome). This makes the conflict model
 (§Merge rules) target the surface authors actually type.
+
+### The interceptor-override surface
+
+Authors override interceptors through a **first-class
+`:interceptor-overrides`** map on the variant/fragment body, normalized to
+`[:world :frame :interceptor-overrides]`. It is the interceptor analog of
+`:fx-overrides`: a `{interceptor-id → override}` map keyed by **the exact
+interceptor id**, resolved per-key under the strict-conflict ladder
+(§Merge rules / §Conflict resolution).
+
+Per EP-0022 (registered interceptors), re-frame2 interceptor chains carry
+**serializable references only** — an event/frame chain names interceptors
+by id (`{:interceptors [:rf/redact-interceptor :app/unwrap]}`), and an
+inline interceptor value in a chain is rejected loud at registration with
+`:rf.error/inline-interceptor-removed`. An interceptor is authored once
+with `reg-interceptor` and referenced by its id everywhere; `->interceptor`
+is the internal constructor, not an authoring surface. Story inherits this
+model directly:
+
+- a story plan never carries an **inline interceptor chain** — there is no
+  `:interceptors [...]` plan slot. The only story interceptor surface is
+  `:interceptor-overrides`, keyed by interceptor id;
+- an `:interceptor-overrides` key matches the registered interceptor by
+  **exact id** (the same id the chain references). The override value is
+  the swapped descriptor/ref the runner installs under that id for the
+  duration of the variant;
+- because keys are ids (not values), the strict-conflict composition
+  (§Variant-owned-wins) resolves per id deterministically — two fragments
+  overriding the same interceptor id while the variant is silent is a hard
+  conflict, exactly as for `:fx-overrides`.
 
 ### The network surface
 
@@ -2196,7 +2225,7 @@ installs canonical vocabulary), and MUST fold the existing
   reserved structural tag (`:rf/map` / `:rf/set` / `:rf/vec` / `:rf/seq`), so
   `{}` ≠ `[]` ≠ `#{}` and `{:k 1}` ≠ `[:k 1]` canonically (rf2-lvrqa);
 - **fold functions to the `:rf/opaque-fn` sentinel** so a hashed slice
-  carrying a fn (a `:fx-overrides` / `:interceptors` plan slot, an app-db
+  carrying a fn (a `:fx-overrides` plan slot, an app-db
   closure-as-value, an effect `:args` callback) hashes DETERMINISTICALLY
   across processes rather than embedding the fn's object identity via
   `pr-str` (rf2-4gwja) — the deliberate trade-off is that two values

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -432,7 +432,7 @@
 (def opaque-fn
   "Stable opaque sentinel a function value canonicalises to (rf2-4gwja).
   Replaces the per-process object-identity `pr-str` of a raw fn so any
-  hashed slice carrying a fn (a `:fx-overrides` / `:interceptors` plan slot,
+  hashed slice carrying a fn (a `:fx-overrides` plan slot,
   an app-db closure-as-value, an effect `:args` callback) hashes
   DETERMINISTICALLY across processes. The deliberate trade-off: two values
   differing ONLY in fn identity hash EQUAL — determinism, not fn

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -301,8 +301,7 @@
     ;; so identity-stable-across-builds == identity-stable-across-processes.
     (let [build-plan (fn []
                        {:story/id :story.fn/v
-                        :world {:frame {:fx-overrides {:rf.http/managed (fn [_] :stub)}
-                                        :interceptors [(fn [ctx] ctx)]}}
+                        :world {:frame {:fx-overrides {:rf.http/managed (fn [_] :stub)}}}
                         :script [[:dispatch [:go]]]
                         :expect {:checks []}})
           h1 (fp/plan-hash (build-plan))


### PR DESCRIPTION
## Summary

EP-0022 (registered interceptors) propagated to `/examples` (rf2-0adhqs.4) and `/skills` (rf2-0adhqs.5) but not to `/tools` — there was no `[prop-tools]` slice. The refs-only flip (rf2-0adhqs.9: chains carry serializable refs only; inline interceptor values throw `:rf.error/inline-interceptor-removed`) is landed framework-wide, so `tools/story`'s stale inline-interceptor surfaces needed reconciling.

`bd show rf2-0adhqs.13` is authoritative.

## What changed

The story plan's only interceptor surface is `:interceptor-overrides` — a `{interceptor-id → override}` map keyed by exact id, **already EP-0022-correct** (by-reference at the plan level, no inline chain). The vestigial `:interceptors [...]` chain slot was never consumed by the apply path; post-EP-0022 it misrepresented the model (an inline chain slot cannot exist).

- **`spec/017-Testing-Story.md`**
  - drop the vestigial `:interceptors [...]` frame slot from the normalized plan shape; show `:interceptor-overrides {interceptor-id override-ref}`.
  - add a **§The interceptor-override surface** section teaching the EP-0022 by-ref chain model (`{:interceptors [:rf/redact-interceptor :app/unwrap]}`, `reg-interceptor` authoring, `->interceptor` internal, inline rejected loud) + the exact-ref `:interceptor-overrides` matching and its strict-conflict per-id composition.
  - fix the fingerprint fold docstring's stale `:interceptors` plan-slot example.
- **`src/re_frame/story/fingerprint.cljc`** — fix the `opaque-fn` docstring's stale `:interceptors` plan-slot example (`:fx-overrides` is the canonical fn-bearing plan slice).
- **`test/re_frame/story_fingerprint_test.clj`** — remove the inline `:interceptors [(fn …)]` slice from `fn-valued-slot-hashes-deterministically`. The inline-fn `:fx-overrides` in the same hashed frame slice already exercises the fn-determinism path; the removed slot was a non-schema slice implying an inline interceptor chain (EP-0022-illegal).

## Already-correct (verified, unchanged)

- `story_recorder_test.clj` / `story_runtime_test.clj` already use the shipped form: `reg-interceptor*` + by-id chains (`{:interceptors [:rf/redact-interceptor]}`, `{:interceptors [:test/boom-icpt]}`).
- `->interceptor` is used in `story_runtime_test.clj` only as the internal value-constructor, building a value that is then registered with `reg-interceptor*` and referenced by id — the EP-0022-correct pattern.
- No stale `reg-event-db`/`-fx`/`-ctx` call sites (all hits are docstring/comment mentions of re-frame's API names). No inline `rf/path` interceptor; `:rf/path` hits are the elision path keyword.

## Quality gates

- story artefact `clojure -M:test` — **1683 tests / 6235 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **7239 tests / 29754 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` — **PASS**
- `mkdocs build --strict` — **OK** (built in 15.3s, no warnings/errors)
- story-mcp untouched → mcp-conformance N/A; `story:build` N/A (spec/test/docstring-only edits)