### PR TITLE
docs(xray): scrub stale EP-0018/EP-0022 prose (rf2-u19hge)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1694,7 +1694,7 @@ unhandled-no-op branch is never reached and NO `:no-op` row fires: its transitio
 microsteps > 0 / an action cascade) is preserved untouched. The
 no-op row also makes the cascade's handler-flavour `:reg-machine` even when
 no action ran, so the EVENT HANDLER machine section renders the notice
-rather than collapsing to a plain `reg-event-db` handler.
+rather than collapsing to a plain `reg-event` handler.
 
 **Per-row chrome.** Each row carries:
 
@@ -2134,7 +2134,7 @@ body — cancellations are housekeeping; the chip routes to the
 `:after`-bearing state node).
 
 **Empty-state correctness** (acceptance #4 — rf2-u69j7). A vanilla
-`reg-event-db` cascade (or any non-`:reg-machine` flavour) renders
+`reg-event` cascade (or any non-`:reg-machine` flavour) renders
 the existing pipeline UNCHANGED — the cascade view is gated on
 `:flavour = :reg-machine`. The redesign is machine-specific.
 
@@ -2477,7 +2477,7 @@ the verb so the affordance is read inline with the cascade rhythm
 
 - **Source-coord read.** Pulls `(rf/handler-meta :event event-id)` for
   ALL flavours — including `:reg-machine` (rf2-ge6uj ISSUE 1). A machine
-  is registered as a `reg-event-fx` carrying `:rf/machine? true`, so its
+  is registered as an `:event` handler carrying `:rf/machine? true`, so its
   registration meta (with the top-level `reg-machine` call-site `:file` /
   `:line`) lives under the `:event` kind. There is NO `:machine`
   registrar kind (`registrar/kinds` is the closed ten `:event :sub :fx
@@ -2636,7 +2636,7 @@ available. (rf2-evgf5 / rf2-g5q8d decision.)
 Where `coord-chip` is the **icon-only** affordance (a glyph appended
 after an id), `coord-link` is the **label-as-link** companion — the
 verb / label TEXT itself is the hyperlink, with the `external-link`
-glyph appended (`reg-event-fx ↗`). Before rf2-vw5pi this shape was
+glyph appended (`reg-event ↗`). Before rf2-vw5pi this shape was
 hand-rolled ~11 times across `panels/epoch/view.cljs` (the HANDLER
 verb-link, the DISPATCH source label, the COEFFECT / FLOW verb ids,
 the machine cascade verb-link + state-path, the schema-violation
@@ -2675,7 +2675,7 @@ asserts the `dispatch [:rf.xray/open-in-editor …]` CALL appears ONLY
 in `coord_chip.cljs` + `coord_link.cljs` — a future hand-rolled button
 trips it. (The guard keys on the dispatch-CALL shape, not the bare
 keyword, so docstrings / comments naming the event — and the
-`open_in_editor.cljs` reg-event-fx receiver + static-page `<a href>`
+`open_in_editor.cljs` reg-event receiver + static-page `<a href>`
 anchor, excluded by design — do not false-positive.)
 
 #### §9.1.6.3 DISPATCH source-kind enrichment (rf2-5qp4g · consuming rf2-ejtpd)
@@ -2753,7 +2753,7 @@ contract is the closed set documented in §9.1.10.1's table.
 #### §9.1.6.4 Machine-event EVENT HANDLER orientation line (rf2-akvfe, supersedes rf2-18oe3)
 
 A re-frame2 machine **is** an event handler addressed by its id
-(`reg-machine :door/main spec` ≈ `reg-event-fx :door/main …`);
+(`reg-machine :door/main spec` ≈ `reg-event :door/main …`);
 dispatching `[:door/main [:door/close]]` routes the **inner trigger**
 `[:door/close]` through the machine's `:on` map. The raw event vector
 reads as opaque nesting — `[:machine-id [inner-trigger]]` — so the
@@ -3235,18 +3235,20 @@ name, rendered UPPERCASE (`BEFORE` / `AFTER`) as a grey chip
 jump-to-source coord rides the projection row's `:coord` slot, resolved
 from the `:rf.error/interceptor-exception` trace's `:source-coord` tag
 (threaded by the router from the throwing interceptor's map). The
-**`->interceptor` macro** (framework, rf2-siheh) captures that coord from
-`(meta &form)` — before rf2-siheh `->interceptor` was a plain fn and the
-row had no coord to render (yz57h's `handler-meta :interceptor` lookup was
-unsatisfiable: interceptors are not a registry kind). The id renders via
+**`reg-interceptor` macro** (the public interceptor-authoring form under
+EP-0022) captures that coord at the registration site; an interceptor
+registered via the plain `reg-interceptor*` fn carries no captured coord,
+so its row has nothing to render (`handler-meta :interceptor` resolves the
+registration meta — `:interceptor` is a first-class registrar kind under
+EP-0022). The id renders via
 the shared **`coord-link`**, which ALREADY emits `name ↗` — **a SINGLE
 go-to-source glyph** (rf2-rvxem FIX 1: the row formerly ALSO appended a
 standalone `coord-chip`, producing TWO `↗`; the HANDLER / COEFFECTS rows
 use `coord-link` alone, and only the plain-label SUBS / VIEWS /
 SIDE-EFFECTS rows pair a label with a `coord-chip` — the interceptor row
 had conflated the two). The id hyperlinks when a coord is present and
-degrades to plain text + no glyph when the interceptor was built via the
-`->interceptor*` fn, is a framework interceptor, or the bundle elided the
+degrades to plain text + no glyph when the interceptor was registered via the
+`reg-interceptor*` fn, is a framework interceptor, or the bundle elided the
 coord in production. rf2-oqi0c **DROPPED** the badge's "N interceptor(s)
 threw" summary verb — redundant with the per-row id + the inline card
 below; the `:INTERCEPTOR` badge stands alone (it pulls the `:accent`
@@ -3430,7 +3432,7 @@ present] + [:fx rows, in order] + [other rows]`:
   no duplication). The marker is clickable: it jumps to the App-db panel
   for the focused epoch (a `[:rf.xray/select-tab :app-db]` dispatch; the
   App-db panel reads the same shared focus). The `:db` row appears
-  whenever a `:db` commit happened, **including a plain reg-event-db that
+  whenever a `:db` commit happened, **including a plain reg-event that
   returns only `:db`** (no `:fx`); it is **ABSENT** when the handler
   returned only `:fx` / only `:rf.db/runtime` / only other / nothing, or
   THREW (no phantom `:db`, rf2-wnvid). Reconciles with rf2-4wywy: this is
@@ -3495,7 +3497,7 @@ exception-under-step rendering.
 
 **ALWAYS APPEARS.** Unlike the pre-rf2-kt6js `:fx` step (which showed
 only when an `:fx` fired), the SIDE EFFECTS step appears whenever ANY
-side effect occurred (a `:db` commit — including a bare reg-event-db —
+side effect occurred (a `:db` commit — including a bare reg-event —
 and/or a runtime-db (`:rf.db/runtime`) commit — including a runtime-ONLY
 commit — and/or `:fx` and/or other). The `:db`-commit signal is the
 framework's `:rf.event/db-changed` trace (a second one with
@@ -3510,7 +3512,7 @@ Neither is a fx-id-less
 handled!` always stamps `:rf.fx/id`, and the `:db` install path
 `re-frame.router/commit-db-effect!` routes through `:rf.event/db-changed`,
 not the fx pipeline). The pre-rf2-kt6js heuristic looked for that
-non-existent emit, so a clean reg-event-db surfaced no side-effects step
+non-existent emit, so a clean reg-event surfaced no side-effects step
 at all — the bug rf2-kt6js fixes tool-side.
 
 **Settle-first (rf2-kt6js — confirmed against the live substrate; NO

--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -62,7 +62,7 @@
 
   ;; rf2-hga49 — `restore-epoch` is a side-effecting framework call (it
   ;; rewinds an OBSERVED frame's `app-db` to a past epoch's `:db-after`),
-  ;; so it lives in an fx, not a `reg-event-db` reducer. `rf/restore-epoch!`
+  ;; so it lives in an fx, not a plain `reg-event` `:db` reducer. `rf/restore-epoch!`
   ;; returns `false` on any of the seven documented failure modes (per
   ;; Tool-Pair §Time-travel — Restore, including
   ;; `:rf.epoch/restore-non-ok-record`) leaving the frame unchanged; on

--- a/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
@@ -11,7 +11,7 @@
        presentation. The `:on-click` fires the OS scheme handler
        directly via `Location.assign` (per rf2-muvs8).
 
-    2. `:rf.xray/open-in-editor` reg-event-fx — the panel-side
+    2. `:rf.xray/open-in-editor` reg-event — the panel-side
        dispatch shape (`[:rf.xray/open-in-editor coord]` or
        `[:rf.xray/open-in-editor {:source-coord coord}]`). Panels
        render their own button/code/span affordance and dispatch this
@@ -28,7 +28,7 @@
        replay) can share the gate.
 
   Per rf2-g5q8d (P0 — the panel chip was a no-op previously). The
-  earlier wiring routed clicks to a stub `reg-event-db` that recorded
+  earlier wiring routed clicks to a stub `reg-event` that recorded
   the coord into app-db and did nothing else; this ns now owns the
   full data-driven path end-to-end.
 
@@ -363,7 +363,7 @@
 
   Registers two framework primitives:
 
-    - `:rf.xray/open-in-editor` reg-event-fx — the dispatch shape the
+    - `:rf.xray/open-in-editor` reg-event — the dispatch shape the
       four panels (trace, issues-ribbon, mcp-server, hydration-
       debugger) use when their source-coord affordance is clicked.
       The handler unwraps the payload, resolves the URI, and returns
@@ -406,7 +406,7 @@
 
   ;; ---- :rf.xray/open-in-editor ----
   ;;
-  ;; Pre-rf2-g5q8d this was a `reg-event-db` stub that recorded the
+  ;; Pre-rf2-g5q8d this was a `reg-event` stub that recorded the
   ;; coord into app-db and did nothing else; the editor never opened.
   ;; The handler now resolves the URI through the allowlist seam and
   ;; routes it to `:rf.editor/open`.

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -461,7 +461,7 @@
   coeffect stamp when no granular events exist (older runtimes / test
   fixtures). Returns an empty vec when neither surface is present, or
   when every coeffect is system-injected — the latter is the typical
-  reg-event-db case where the operator gains nothing from a `:db`
+  db-only reg-event case where the operator gains nothing from a `:db`
   presence-pill."
   [events]
   (let [granular (coeffect-rows-from-runs events)]
@@ -510,7 +510,7 @@
     ;; commit transition at the source — no transition row either) is still
     ;; a machine cascade: classify it :reg-machine so the EVENT HANDLER
     ;; machine section renders the no-op notice rather than collapsing to a
-    ;; plain reg-event-db handler.
+    ;; plain reg-event handler.
     (some #(= :rf.machine.event/unhandled-no-op (op %)) events) :reg-machine
     ;; rf2-it4vt — an EAGER `[:rf.machine/start]` kick is a PURE init
     ;; (rf2-gl588 / F‴): it runs the initial-entry cascade then STOPS,
@@ -587,7 +587,7 @@
   dropped/`:skipped` `other` key (rf2-ff9b0d). The view conditions each
   section's render on its slot being non-empty.
 
-  Returns nil when no `:rf.fx/do-fx` fired (reg-event-db with no
+  Returns nil when no `:rf.fx/do-fx` fired (a reg-event with no `:fx`
   effects, or the cascade aborted before do-fx)."
   [events]
   (when-let [do-fx (find-op events :rf.fx/do-fx)]
@@ -1259,7 +1259,7 @@
   supersedes the flat `:rf.machine/state-coords` index of rf2-npvsx).
 
   Returns an empty vec when no machine-cascade events fired (vanilla
-  reg-event-db / reg-event-fx cascades — the redesign is
+  non-machine reg-event cascades — the redesign is
   machine-specific and the empty vec drives the view's empty-state
   branch off the prior handler-step rendering unchanged)."
   [events]
@@ -1782,7 +1782,7 @@
 ;;            ledger when present. ✓ on a successful commit; ✗ when the
 ;;            post-commit app-db schema check rejected the write and the
 ;;            cascade rolled back. Shown whenever a `:db` commit was
-;;            attempted — INCLUDING a plain reg-event-db that returns only
+;;            attempted — INCLUDING a plain reg-event that returns only
 ;;            `:db` (no `:fx`); ABSENT when the handler returned only
 ;;            `:fx` / only other / nothing, or THREW (no phantom `:db`,
 ;;            rf2-wnvid). Its args slot is the DESTINATION marker
@@ -1814,7 +1814,7 @@
 ;;   rollback) — it does NOT route `:db` through the fx pipeline. The
 ;;   pre-rf2-kt6js heuristic looked for a non-existent fx-id-less
 ;;   `:rf.fx/handled`, so the `:db` row only ever appeared on the
-;;   rollback path; a clean reg-event-db showed NO side-effects step at
+;;   rollback path; a clean reg-event showed NO side-effects step at
 ;;   all. Keying off `:rf.event/db-changed` fixes the ALWAYS-APPEARS
 ;;   contract tool-side.
 ;;
@@ -1907,7 +1907,7 @@
         effect!` emits this for EVERY actual `:db` install (forward
         commit), and a second one with `:rf.trace/phase :rollback` on a
         schema-fail rollback. This is the canonical `:db`-commit signal,
-        present for a plain reg-event-db that returns only `:db`.
+        present for a plain reg-event that returns only `:db`.
     (b) A `:where :app-db` schema violation — implies a commit was
         ATTEMPTED even on the abort path.
     (c) A `:rf.event/db-noop` trace (rf2-ekq28v) — the handler returned a
@@ -1930,7 +1930,7 @@
 (defn db-effect-row
   "The synthesised `:db` row — the handler's app-db write, leading the
   flat SIDE EFFECTS ledger (rf2-kt6js synthesis · rf2-j630b ledger).
-  nil when no `:db` commit was attempted (a reg-event-fx that returned no
+  nil when no `:db` commit was attempted (a reg-event that returned no
   `:db`, or a handler that threw — no phantom `:db`, rf2-wnvid). `:status`
   is `:error` on a schema-fail rollback (so the badge / `step-status`
   paints ✗ and the attached `:where :app-db` violation carries the reason
@@ -2158,7 +2158,7 @@
   nil (step OMITTED) when NO side effect occurred — no `:db` commit, no
   runtime-db commit, no `:fx`, no other effect. ALWAYS appears when a
   `:db` commit happened (`db-commit?` keys off `:rf.event/db-changed`),
-  INCLUDING a plain reg-event-db with no `:fx`, AND when a runtime-ONLY
+  INCLUDING a plain reg-event with no `:fx`, AND when a runtime-ONLY
   commit happened (`runtime-db-commit?` keys off the partition-tagged
   `:rf.event/frame-state-changed` — Mike ruling #6: a runtime-only commit
   emits NO `:rf.event/db-changed`).
@@ -3107,10 +3107,10 @@
 ;; threw in, so the operator reads WHICH interceptor failed on WHICH side
 ;; of the chain. rf2-siheh — the jump-to-source coord rides the row's
 ;; `:coord` slot, resolved here off the `:rf.error/interceptor-exception`
-;; trace's `:source-coord` tag (captured by the `->interceptor` macro from
-;; `(meta &form)`); it degrades to plain text when no coord was captured
-;; (the `->interceptor*` fn path, framework interceptors, or a production
-;; CLJS bundle). The shared "Exception Thrown" card (rf2-wnvid) attaches
+;; trace's `:source-coord` tag (captured by the `reg-interceptor` macro at
+;; the registration site); it degrades to plain text when no coord was
+;; captured (the `reg-interceptor*` fn path, framework interceptors, or a
+;; production CLJS bundle). The shared "Exception Thrown" card (rf2-wnvid) attaches
 ;; per the standard `attach-exceptions` path.
 
 (defn interceptor-exception-rows
@@ -3125,11 +3125,11 @@
   "Resolve the throwing interceptor's definition-site `{:ns :file :line}`
   source-coord off the `:rf.error/interceptor-exception` trace event
   (rf2-siheh). The router threads it onto the trace under the `:source-
-  coord` tag (the `->interceptor` macro captured it from `(meta &form)`,
-  riding the rf2-wvsxg absolutise path). Returns nil when no coord was
-  captured — the interceptor was built via the `->interceptor*` fn or is
-  a framework interceptor (`path` / `unwrap` / cofx injector), or the
-  build is a production CLJS bundle that elided the coord. The view's
+  coord` tag (the `reg-interceptor` macro captured it at the registration
+  site, riding the rf2-wvsxg absolutise path). Returns nil when no coord was
+  captured — the interceptor was registered via the `reg-interceptor*` fn or
+  is a framework interceptor (`:rf.interceptor/path` or a cofx injector), or
+  the build is a production CLJS bundle that elided the coord. The view's
   shared `coord-chip` drops out cleanly when nil (parity with the
   EVENT HANDLER / SUBSCRIPTIONS / VIEWS rows)."
   [ev]
@@ -3144,7 +3144,7 @@
   `:rf.error/interceptor-exception` with the matching `:phase`), each
   carrying the interceptor `:interceptor-id` (== the exception row's
   `:failing-id`), the `:phase` it threw in, and (rf2-siheh) the
-  interceptor's definition-site `:coord` (when the `->interceptor` macro
+  interceptor's definition-site `:coord` (when the `reg-interceptor` macro
   captured one) so the view renders a jump-to-source chip — parity with
   the EVENT HANDLER / SUBSCRIPTIONS / VIEWS rows. The shared exception
   card attaches to this step via `attach-exceptions`.
@@ -3509,7 +3509,7 @@
       :handler        — always present; adapts to handler flavour
       :flow           — only when flows fired
       :side-effects   — when ANY side effect occurred (a :db commit —
-                        including a bare reg-event-db — and/or :fx and/or
+                        including a bare reg-event — and/or :fx and/or
                         other top-level effects); :db / :fx / other
                         sub-steps each shown only when present (rf2-kt6js)
       :subscriptions  — only when subs recomputed

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -18,7 +18,7 @@
       ├── ③ COEFFECT      :session ↗
       │      + [:session] {:user-id 42 …}
       │
-      ├── ③ HANDLER       reg-event-db ↗               0.5ms
+      ├── ③ HANDLER       reg-event ↗                  0.5ms
       │      (fn [db [_ amount]]
       │        (update db :total + amount))
       │      ↳ :db diff
@@ -2090,7 +2090,7 @@
   (when (and (keyword? machine-id) (vector? state-path) (seq state-path))
     ;; rf2-dcsw1 (iwy0c-followup) — read the registration meta under the
     ;; `:event` kind, NOT the non-existent `:machine` kind. A machine is
-    ;; registered as a `reg-event-fx` carrying `:rf/machine? true` + the
+    ;; registered as an `:event` handler carrying `:rf/machine? true` + the
     ;; stamped spec (with co-located state-node `:source-coords`, rf2-vqja2)
     ;; under `:rf/machine` (rf2-ge6uj ISSUE 2 / rf2-iwy0c part C —
     ;; `machine-block` and `handler-source-block` already read `:event`).
@@ -2590,15 +2590,15 @@
   then the interceptor name + its single open-in-editor glyph.
 
   rf2-siheh — the jump-to-source coord rides the projection row's
-  `:coord` slot (captured by the `->interceptor` macro from `(meta &form)`
-  and threaded onto the trace by the router). The name hyperlinks via
+  `:coord` slot (captured by the `reg-interceptor` macro at the registration
+  site and threaded onto the trace by the router). The name hyperlinks via
   `coord-link`, which ALREADY emits `name ↗` (one glyph) — the row no
   longer appends a redundant standalone `coord-chip` (rf2-rvxem FIX 1:
   the HANDLER / COEFFECTS rows use `coord-link` alone; only the plain-
   label SUBS / VIEWS / SIDE-EFFECTS rows pair a label with `coord-chip`,
   and the interceptor row conflated the two). `coord-link` drops cleanly
-  to plain text + no glyph when the interceptor was built via the
-  `->interceptor*` fn, is a framework interceptor, or the bundle elided
+  to plain text + no glyph when the interceptor was registered via the
+  `reg-interceptor*` fn, is a framework interceptor, or the bundle elided
   the coord in production."
   [idx {:keys [interceptor-id phase errors coord]}]
   (let [label (fmt/ns-keyword interceptor-id)]
@@ -3629,7 +3629,7 @@
   [cascade event-id]
   ;; rf2-ge6uj ISSUE 2 — read the registration meta under the `:event`
   ;; kind, NOT a (non-existent) `:machine` kind. A machine is registered
-  ;; as a `reg-event-fx` carrying `:rf/machine? true` + the stamped spec
+  ;; as an `:event` handler carrying `:rf/machine? true` + the stamped spec
   ;; under `:rf/machine` (with co-located `:guards` / `:actions` entries
   ;; carrying `:source-coords` / `:source-code`, plus reference-site
   ;; `:source-coords` co-located on each `:states`-tree map node,
@@ -3675,7 +3675,7 @@
 ;; collapsing silently.
 ;;
 ;; For machine handlers the "source" is the machine spec — read via
-;; `rf/handler-meta :event event-id` (the machine IS a `reg-event-fx`
+;; `rf/handler-meta :event event-id` (the machine IS an `:event` handler
 ;; with the spec under `:rf/machine`; rf2-iwy0c part C — the prior
 ;; `:machine` kind resolved nil). The spec renders through the same
 ;; `edn/inspect` widget every other top-level EDN map uses.
@@ -3720,7 +3720,7 @@
       line (str ":" line))))
 
 (defn- handler-verb-link
-  "Render the HANDLER step's verb (e.g. `reg-event-fx`) as a
+  "Render the HANDLER step's verb (e.g. `reg-event`) as a
   clickable hyperlink + external-link glyph when the handler's
   registered meta carries `:file` / `:line` (clicks dispatch
   `:rf.xray/open-in-editor`). Falls back to a plain coloured span
@@ -3747,7 +3747,7 @@
   [flavour event-id]
   (let [meta     (when (some? event-id)
                    ;; Machine + plain event handlers BOTH live under the
-                   ;; `:event` kind (the machine is a `reg-event-fx` with
+                   ;; `:event` kind (the machine is an `:event` handler with
                    ;; `:rf/machine? true`); the call-site coord rides the
                    ;; top-level `:file` / `:line` for both.
                    (try (rf/handler-meta :event event-id)
@@ -3908,7 +3908,7 @@
 
   Per rf2-p2zy0 (Mike pair-debug 2026-05-27) the legacy per-fx-row
   list (one `fx-entry-line` per entry) is REPLACED by two
-  decomposed sections matching how a reg-event-fx author thinks
+  decomposed sections matching how a reg-event author thinks
   about the return map:
 
     - `:fx` — the canonical `:fx` vector-of-vectors (when present)
@@ -3972,8 +3972,8 @@
 
 (defn render-handler-step
   "Render the HANDLER step (always present). Per Mike pair-debug
-  2026-05-26: the verb (reg-event-db / reg-event-fx / reg-event-ctx
-  / reg-machine flavour label) is the click-to-source hyperlink;
+  2026-05-26: the verb (reg-event / reg-machine flavour label) is
+  the click-to-source hyperlink;
   the event-id is NOT repeated in the HANDLER line because the
   DISPATCH step's header already names it.
 
@@ -4276,7 +4276,7 @@
   "Render the SIDE EFFECTS step as a FLAT per-effect ledger (rf2-j630b —
   supersedes the rf2-kt6js 3-tier `:db` / `:fx` / other sub-step
   presentation). ALWAYS present when ANY side effect occurred — including
-  a bare reg-event-db that returns only `:db` (`db-commit?` keys off
+  a bare reg-event that returns only `:db` (`db-commit?` keys off
   `:rf.event/db-changed`).
 
   The SIDE EFFECTS badge carries NO overall stage glyph (the per-stage

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -335,8 +335,8 @@
      [:div {:data-testid "rf-xray-machine-event-handler-mini-pipeline"
             :data-machine-id (str machine-id)
             :style {:padding "10px 14px"}}
-      ;; `machine-id` IS the reg-event-fx id `handler-meta` resolves
-      ;; (a machine is registered as a `reg-event-fx` carrying its spec
+      ;; `machine-id` IS the `:event` handler id `handler-meta` resolves
+      ;; (a machine is registered as an `:event` handler carrying its spec
       ;; under `:rf/machine`), so the cascade rows' guard / action
       ;; source-coords resolve identically to the Epoch panel.
       (epoch-view/machine-cascade-mini-pipeline cascade machine-id)]
@@ -826,7 +826,7 @@
   ;; sub for those events; Prev/Next moves the spine focus, which moves
   ;; the resolved focused epoch, which re-feeds BOTH this mini-pipeline
   ;; AND the chart highlights together. `:event-id` is the head record's
-  ;; machine-id — the reg-event-fx id `handler-meta` resolves so the
+  ;; machine-id — the `:event` handler id `handler-meta` resolves so the
   ;; cascade rows' guard / action source-coords resolve identically to
   ;; the Epoch panel.
   (rf/reg-sub :rf.xray/machine-focused-epoch-cascade

--- a/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_chip.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_chip.cljs
@@ -39,7 +39,7 @@
   static page). The button chip here dispatches via the trace bus so
   the click is observable as a first-class operation on the
   `:rf/xray` frame, and the URI resolution happens inside the
-  `:rf.xray/open-in-editor` reg-event-fx → `:rf.editor/open` reg-fx
+  `:rf.xray/open-in-editor` reg-event → `:rf.editor/open` reg-fx
   pipeline. Both surfaces co-exist by design (rf2-evgf5 / rf2-g5q8d
   decision)."
   (:require [day8.re-frame2-xray.panels.event.icons :as icons]

--- a/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_link.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/shared/coord_link.cljs
@@ -10,7 +10,7 @@
   - **icon-only** — a glyph appended after an id (`:counter/value ↗`).
     The canonical home is `panels/shared/coord_chip.cljs` (rf2-xjgdk).
   - **label-as-link** — the verb / label TEXT itself is the hyperlink,
-    with the `external-link` glyph appended (`reg-event-fx ↗`). Before
+    with the `external-link` glyph appended (`reg-event ↗`). Before
     rf2-vw5pi this shape was hand-rolled ~7 times across
     `panels/epoch/view.cljs` (the HANDLER verb-link, the DISPATCH
     source label, the COEFFECT / FLOW verb ids, the machine cascade
@@ -31,7 +31,7 @@
   anchor for the static page, rf2-evgf5 / rf2-g5q8d) and is excluded
   by design. `coord-link` (like `coord-chip`) dispatches via the trace
   bus so the click is observable as a first-class operation on the
-  `:rf/xray` frame; the `:rf.xray/open-in-editor` reg-event-fx →
+  `:rf/xray` frame; the `:rf.xray/open-in-editor` reg-event →
   `:rf.editor/open` reg-fx pipeline resolves the URI.
 
   See `panels/shared/coord_chip.cljs` for the icon-only sibling and

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -12,7 +12,7 @@
 
       +0.0  DISPATCH         EVENT     dispatched   [:counter-inc]      —
       +0.1  COEFFECT         COEFFECT  run          :now -> #inst      0.1 ms
-      +0.2  EVENT HANDLER    EVENT     handler ran  reg-event-db       0.2 ms
+      +0.2  EVENT HANDLER    EVENT     handler ran  reg-event          0.2 ms
       +0.3  FLOW             FLOW      computed     :totals            1.5 ms
       +1.8  EFFECT HANDLERS  DB        changed      [:counter] 1 -> 2   —
       +1.9  EFFECT HANDLERS  FX        :http-xhrio  GET /api/data       —

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -33,7 +33,7 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
             ;; Load the first-class edn-inspector widget ns so its
-            ;; top-level `reg-sub` / `reg-event-db` calls land in
+            ;; top-level `reg-sub` / `reg-event` calls land in
             ;; the registrar at orchestrator-load time. The widget
             ;; owns `:rf.xray.edn-inspector/*` events/subs and is the
             ;; SINGLE source of truth for browse + diff + mini

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -805,7 +805,7 @@
   `:rf.xray/show-ungrouped?` sub in `settings/subs.cljs`.
 
   Public (rf2-nugvv) so cross-panel spine-shim events that need to
-  resolve the composed focus inside a `reg-event-db` handler — e.g.
+  resolve the composed focus inside a `reg-event` handler — e.g.
   the Machine Inspector's per-machine prev/next nav — can pass the
   same opt-in into `compose-focus` / `focus-cascade-reducer` rather
   than re-deriving it."

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -36,7 +36,7 @@
   interceptor that appears on many chains shows up once with the count
   of chains it appears on. A REFERENCE entry contributes its referenced
   id (a `[id arg]` ref contributes the head keyword); an inline value
-  with no `:id` (rare — `->interceptor` requires one) falls under
+  with no `:id` (rare — `reg-interceptor` requires one) falls under
   `::unnamed`. Reference rows are enriched by resolving the authored ref
   through `(rf/handler-meta :interceptor id)` — the `:interceptor`
   registrar kind reg-interceptor populates (EP-0022) — so the catalogue

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -43,7 +43,7 @@
 
       (mini   v)    ;; one-liner (no expansion, no diff)
 
-      (code-block {:source \"(reg-event-db :foo …)\"
+      (code-block {:source \"(reg-event :foo …)\"
                    :lang   :clojure})
 
   ## Posture
@@ -373,7 +373,7 @@
   cool-blue) in BOTH the light and dark theme. Keywords and builtins
   resolve to DIFFERENT hues — keyword on `:syntax-keyword` (red family,
   per Figma), builtin on `:accent` (the chrome blue, reading as
-  macro-call emphasis) — so a `:foo` keyword and a `reg-event-db`
+  macro-call emphasis) — so a `:foo` keyword and a `reg-event`
   builtin no longer paint identically against a real editor.
 
   The fallthrough is `:text-primary`, matching a real editor where
@@ -396,10 +396,11 @@
     "cond" "case" "do" "loop" "recur" "fn" "fn*" "reify"
     "deftype" "defrecord" "ns" "require" "reg-event"
     ;; EP-0018 collapsed the three public event registrars onto `reg-event`
-    ;; (above). The retired spellings stay in the highlighter set: during the
-    ;; additive window they still resolve, and the source-text highlighter
-    ;; renders whatever the substrate captured — including legacy
-    ;; `reg-event-db` / `-fx` / `-ctx` call sites in an app under inspection.
+    ;; (above); calling a retired name is now a hard error. The retired
+    ;; spellings nonetheless stay in the highlighter set because the
+    ;; source-text highlighter renders whatever source the substrate captured
+    ;; — including legacy `reg-event-db` / `-fx` / `-ctx` call sites in a v1
+    ;; or pre-migration app under inspection.
     "reg-event-db" "reg-event-fx" "reg-event-ctx" "reg-sub" "reg-fx" "reg-view"
     "reg-flow" "reg-machine" "dispatch" "dispatch-sync" "subscribe"
     "assoc" "assoc-in" "update" "update-in" "get" "get-in"


### PR DESCRIPTION
Implements **rf2-u19hge**. Scrubs xray docs/spec/source PROSE for stale pre-EP-0018/EP-0022 language, aligning every comment, docstring, and example to the shipped end-state. **No xray behavior or panel-structure change — prose/spec-text only.**

## What changed (prose only)

**EP-0018 (one event registrar):**
- User-facing event-registrar prose now uses `reg-event` — scrubbed bare `reg-event-db` / `reg-event-fx` / `reg-event-ctx` spellings in HANDLER + trace ASCII-art examples, docstrings, and comments across `open_in_editor.cljs`, `epoch.cljs`, `registry.cljs`, `spine.cljs`, `panels/trace.cljs`, `panels/epoch/{view.cljs,projection.cljc}`, `panels/shared/{coord_chip,coord_link}.cljs`, `views/edn_widget.cljs`, and `spec/021-Dynamic-Panel-Designs.md`.
- Machine prose now says a machine is registered as an `:event` handler carrying `:rf/machine? true` (not a `reg-event-fx`) — `machine_inspector.cljs`, `panels/epoch/view.cljs`, `spec/021`.
- The stale "additive window" comment in the `edn_widget` highlighter was corrected: calling a retired name is now a hard error; the highlighter retains the legacy spellings only to render v1/pre-migration source under inspection.

**EP-0022 (registered interceptors):**
- Interceptor coord-capture prose now references the `reg-interceptor` macro (capture at the registration site) and the `reg-interceptor*` fn (no-coord path), replacing the removed-public `->interceptor` macro references — `panels/epoch/{projection.cljc,view.cljs}`, `spec/021`.
- Dropped the stale "standard `unwrap`" reference; the standard framework interceptor surface is `:rf.interceptor/path` (plus cofx injectors).
- `static/interceptors/panel.cljs`: an inline value's `:id` requirement now attributed to `reg-interceptor`; `:interceptor` is a first-class registrar kind under EP-0022.

## Preserved (intentional internals — NOT touched)
- The INTERNAL effect-shape classifier keywords `:reg-event-db` / `:reg-event-fx` (read off the trace stream by `projection/handler-flavour`, mapped to the `reg-event` label by `format/handler-flavour-label`) are unchanged, including the explanatory note in `format.cljc` that exists so reviewers don't remove them by mistake.
- The `clojure-builtins` highlighter SET in `edn_widget.cljs` (behavioral, test-covered) is unchanged.

## xray-spec disposition
`tools/xray/spec/021-Dynamic-Panel-Designs.md` was updated in the same PR (per the standing xray-spec-current rule): bare-prose registrar spellings → `reg-event`; the machine-registration gloss → `:event` handler; the interceptor coord-capture passage rewritten to the EP-0022 `reg-interceptor` / `reg-interceptor*` model. The §9.1.5 keyword-classifier list + its EP-0018 note are preserved.

## Quality gates
- `clojure -M:test` (xray artefact): 1196 tests, 5336 assertions, 0 failures/0 errors
- `npm run test:cljs` (node runtime): 7239 tests, 29754 assertions, 0 failures/0 errors
- `npm run test:bundle-isolation`: PASS (22 artefact entries; 40 internal sentinels absent; uix/helix/reagent-free OK)
- `mkdocs build --strict`: built clean (no warnings/errors)