### PR TITLE
docs(skills): reconcile EP-0018/0022 + epoch-restore prose

### DIFF
--- a/skills/re-frame2-pair/STATUS.md
+++ b/skills/re-frame2-pair/STATUS.md
@@ -66,9 +66,9 @@ Four colon-separated segments, where `<ns>` and `<handler-id>` derive from the r
 
 ## What's genuinely verified
 
-- `re-frame.core` exposes the Tool-Pair surfaces this skill consumes — `register-listener!`, `register-epoch-listener!`, `epoch-history`, `restore-epoch`, `replace-app-db!`, `configure`, `registrations`, `handler-meta`, `frame-ids`, `frame-meta`, `app-db-value`, `snapshot-of`, `sub-cache`, `machines`, `machine-meta`, `app-schemas` — confirmed in `implementation/core/src/re_frame/core.cljc`. The `trace-buffer` reader lives in `re-frame.trace.tooling` (re-exported on `rf/` JVM-side only); CLJS callers use the `re-frame.trace.tooling` ns directly.
+- `re-frame.core` exposes the Tool-Pair surfaces this skill consumes — `register-listener!`, `register-epoch-listener!`, `epoch-history`, `restore-epoch!` (core-API name carries the bang; the MCP tool that calls it is named `restore-epoch`), `replace-app-db!`, `configure`, `registrations`, `handler-meta`, `frame-ids`, `frame-meta`, `app-db-value`, `snapshot-of`, `sub-cache`, `machines`, `machine-meta`, `app-schemas` — confirmed in `implementation/core/src/re_frame/core.cljc`. The `trace-buffer` reader lives in `re-frame.trace.tooling` (re-exported on `rf/` JVM-side only); CLJS callers use the `re-frame.trace.tooling` ns directly.
 - Epoch records carry the documented `:rf/epoch-record` shape (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, `:trace-events`, `:sub-runs`, `:renders`, `:effects`).
-- `restore-epoch` implements the **seven** documented failure modes per Tool-Pair §Time-travel.
+- `restore-epoch!` implements the **seven** documented failure modes per Tool-Pair §Time-travel.
 - shadow-cljs nREPL accepts JVM `(shadow.cljs.devtools.api/cljs-eval ...)` calls (well-known).
 
 Everything else is structurally correct per the Tool-Pair Spec but not exhaustively runtime-verified.

--- a/skills/re-frame2-pair/spec/design.md
+++ b/skills/re-frame2-pair/spec/design.md
@@ -81,7 +81,7 @@ When the user mentions a button / view / panel / "the thing I clicked", the AI r
 
 ### L12 — Surface restore limits
 
-Before any time-travel experiment, the AI walks the cascade's effects and tells the user which effects already fired and cannot be reversed. `restore-epoch` is first-class but it rewinds `app-db`, not external side effects (HTTP requests already dispatched, navigation that already happened, etc.).
+Before any time-travel experiment, the AI walks the cascade's effects and tells the user which effects already fired and cannot be reversed. `rf/restore-epoch!` (the MCP tool exposes it as `restore-epoch`) is first-class but it rewinds the frame's WHOLE frame-state — both app-db AND runtime-db, from `:frame-state-after` via `replace-frame-state!` — not external side effects (HTTP requests already dispatched, navigation that already happened, etc.).
 
 ## 4. Audience and scope
 

--- a/skills/re-frame2-pair/spec/inputs.md
+++ b/skills/re-frame2-pair/spec/inputs.md
@@ -23,7 +23,7 @@ The skill is one of the principal downstream consumers of these surfaces.
 
 For verifying that the public surface in `spec/Tool-Pair.md` is wired up in the reference impl:
 
-- `implementation/core/src/re_frame/core.cljc` — the public single-import API; `register-listener!`, `register-epoch-listener!`, `epoch-history`, `restore-epoch`, `frame-ids`, `frame-meta`, `app-schemas`, `handler-meta`, `configure`. (`trace-buffer` lives in `re-frame.trace.tooling`; `core.cljc` re-exports it on `rf/` JVM-side only.)
+- `implementation/core/src/re_frame/core.cljc` — the public single-import API; `register-listener!`, `register-epoch-listener!`, `epoch-history`, `restore-epoch!` (the core-API name carries the bang — the MCP tool that calls it is named `restore-epoch`), `frame-ids`, `frame-meta`, `app-schemas`, `handler-meta`, `configure`. (`trace-buffer` lives in `re-frame.trace.tooling`; `core.cljc` re-exports it on `rf/` JVM-side only.)
 - `implementation/core/src/re_frame/trace.cljc` — the trace stream's internals; what op-types are emitted, how `:op-type :error` filtering works.
 - `implementation/core/src/re_frame/epoch.cljc` — the per-frame epoch ring; what fields a `:rf/epoch-record` carries; the structured `:sub-runs` / `:renders` / `:effects` projections.
 - `implementation/core/src/re_frame/frame.cljc` — frame lifecycle; `:rf/default` registration; per-frame router queues.

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -52,7 +52,7 @@ Anchor on that, then note the deliberate divergences.
 |---|---|---|
 | Action log (the left-rail list of dispatched actions) | The **L2 event spine** — one row per dispatched event, live-tailing | Each row is an *epoch* (a full six-domino cascade), not a single reducer call — far richer than an action entry |
 | Inspecting one action's state diff | The **Epoch** tab (hero) — the focused dispatch's numbered cascade, DISPATCH → COEFFECTS → HANDLER → FLOWS → SIDE EFFECTS → SUBSCRIPTIONS → VIEWS | Redux shows action + state diff; the Epoch cascade shows the *whole causal chain* (cofx, interceptors, fx, flows, sub recompute, re-render), not just before/after state |
-| Time-travel / "jump to state" replay | The **inspect · `Reset`-rewind** chrome | **Passive by default** — picking an epoch rebases the panels but does NOT move `app-db`; moving the live app is the explicit `Reset` button (`restore-epoch` to the focused epoch's `:db-after`). Redux's slider *replays dispatches* into the store; Xray inverts that. |
+| Time-travel / "jump to state" replay | The **inspect · `Reset`-rewind** chrome | **Passive by default** — picking an epoch rebases the panels but does NOT move the live frame; moving the live app is the explicit `Reset` button (`restore-epoch!` reinstalls the focused epoch's WHOLE frame-state — both app-db AND runtime-db — via `replace-frame-state!`, not the `:db-after` projection alone). Redux's slider *replays dispatches* into the store; Xray inverts that. |
 | State tree inspector | The **app-db** tab — sectioned, lazy-tree, inline diff annotations | Sectioned by reserved area (machines, routes, system-ids…) with downstream-subs hover, not a raw single tree |
 | React DevTools Profiler "why did this render?" | The **Views** tab — render-cause chips (`← :sub-id` vs `← props`) on every re-render leaf | Built into the same panel and tied to the epoch, not a separate profiler tab |
 | *(no Redux equivalent)* | **Static mode** — event-INDEPENDENT browse of what's *registered* (machines / routes / schemas / flows / interceptors) | Redux has no "what's registered?" surface; this is the registry-catalogue half Xray adds |
@@ -204,10 +204,12 @@ than the one-liner.
  until you pick a historical event or pause (**RETRO**); `Space`
  pauses/resumes, `L` snaps back. (chrome.md §LIVE vs RETRO spine.)
 - **Time-travel: passive inspect vs explicit rewind.** Picking an epoch is
- *passive INSPECTION* — panels rebase, `app-db` does NOT move; live rewind
- is the *separate, explicit* **`Reset` button** on the L3 ribbon
- (`restore-epoch` to the focused epoch's `:db-after`). No wired `r`/`R`/`*`
- keys — those are spec-future only. (chrome.md §Time-travel.)
+ *passive INSPECTION* — panels rebase, the live frame does NOT move; live
+ rewind is the *separate, explicit* **`Reset` button** on the L3 ribbon
+ (`restore-epoch!` reinstalls the focused epoch's WHOLE frame-state — both
+ app-db AND runtime-db — via `replace-frame-state!`, not the `:db-after`
+ projection alone). No wired `r`/`R`/`*` keys — those are spec-future only.
+ (chrome.md §Time-travel.)
 - **Filter pills.** The L1.5 events ribbon carries IN / OUT pills, a mute
  set, an `N hidden by filters` count, and `Clear Filters`; transient,
  reset on load. (chrome.md §Filter pills.)

--- a/skills/re-frame2-xray/evals/README.md
+++ b/skills/re-frame2-xray/evals/README.md
@@ -54,7 +54,7 @@ prompts whose answer drifts fastest as the Xray UI moves:
 | 8 | `panel-route-machine-canvas` | yes | Full topology → Static Machines tab, not the event-driven Dynamic Machine tab; no standalone Machines-Canvas tab. |
 | 11 | `panel-route-schema` | yes | Schema violations → Epoch inline + L2 pink-wash; registry → Static Schemas; no Issues tab, no Dynamic Schemas tab. |
 | 12 | `panel-route-hydration` | yes | No standalone Hydration tab; mismatches → Epoch inline + issues-ribbon signal. |
-| 21 | `chrome-rewind` | yes | Passive inspect (app-db unmoved) vs explicit `Reset` button (restore-epoch); `r`/`R`/`*` are NOT wired. |
+| 21 | `chrome-rewind` | yes | Passive inspect (live frame unmoved) vs explicit `Reset` button (`restore-epoch!` reinstalls the whole frame-state — both app-db and runtime-db — not just `:db-after`); `r`/`R`/`*` are NOT wired. |
 | 23 | `chrome-palette` | yes | Palette source kinds + representative command verbs; `Cmd/Ctrl+K` is wired (not struck). |
 | 24 | `launch-overlay` | yes | `open-overlay!` is the supported FALLBACK for no-layout-host; floats above `document.body`; not the primary path. |
 | 26 | `config-init-vs-settings` | yes | Settings popup wins over the `init!` boot default; merge order `defaults < configure! < Settings`; density is NOT a popup control. |

--- a/skills/re-frame2-xray/evals/evals.json
+++ b/skills/re-frame2-xray/evals/evals.json
@@ -99,10 +99,10 @@
  "name": "chrome-rewind",
  "should_trigger": true,
  "prompt": "How do I go back in time in Xray — scrub through history and rewind to an earlier epoch?",
- "expected_output": "The agent distinguishes passive INSPECTION (picking an epoch in the L2 list / the ribbon nav rebases the panels but does NOT move the live app-db) from explicit REWIND (the `Reset` button on the L3 tab-bar ribbon, which calls restore-epoch to roll the live app-db to the focused epoch's :db-after). It does NOT teach r / R / * as wired rewind/re-dispatch/pin keys (those are spec-future only).",
+ "expected_output": "The agent distinguishes passive INSPECTION (picking an epoch in the L2 list / the ribbon nav rebases the panels but does NOT move the live frame) from explicit REWIND (the `Reset` button on the L3 tab-bar ribbon, which calls restore-epoch! to reinstall the focused epoch's WHOLE frame-state — both app-db AND runtime-db — from :frame-state-after via replace-frame-state!, not the :db-after projection alone). It does NOT teach r / R / * as wired rewind/re-dispatch/pin keys (those are spec-future only).",
  "expectations": [
- "The output explains that scrubbing / picking an epoch is passive inspection — panels rebase but the live app-db does NOT move.",
- "The output names the explicit `Reset` button (L3 tab-bar ribbon) as the live rewind (restore-epoch to the focused epoch's :db-after).",
+ "The output explains that scrubbing / picking an epoch is passive inspection — panels rebase but the live frame does NOT move.",
+ "The output names the explicit `Reset` button (L3 tab-bar ribbon) as the live rewind (restore-epoch! reinstalls the focused epoch's whole frame-state — both app-db and runtime-db — not just :db-after).",
  "The output does NOT present r / R / * as wired rewind / re-dispatch / pin keys (it may note they are spec-future / not yet wired)."
  ]
  },

--- a/skills/re-frame2-xray/references/chrome.md
+++ b/skills/re-frame2-xray/references/chrome.md
@@ -24,13 +24,16 @@ pulses while live. Spec
 
 The ribbon `[◀ ▶ ⏭]` nav cluster + the L2 list walk history **without
 disturbing the live app** — picking an epoch is *passive INSPECTION*
-(panels rebase; `app-db` does NOT move). Rewind is the *separate, explicit*
-**`Reset` button** on the far-right of the L3 tab-bar ribbon:
+(panels rebase; the live frame does NOT move). Rewind is the *separate,
+explicit* **`Reset` button** on the far-right of the L3 tab-bar ribbon:
 it dispatches `:rf.xray/reset-to-epoch` against the *observed* app frame +
-the focused epoch, rewinding that frame's live `app-db` to the epoch's
-`:db-after` via `(rf/restore-epoch! …)` — disabled when no epoch is focused;
-on the rare framework failure (epoch aged out) it shows a brief inline
-flash, never a modal.
+the focused epoch, reinstalling that frame's WHOLE frame-state — both app-db
+AND runtime-db — from the epoch's `:frame-state-after` via
+`(rf/restore-epoch! …)` (which installs atomically through
+`replace-frame-state!`, not the `:db-after` projection alone, so machine
+snapshots / the route slice / elision declarations / SSR metadata revive
+alongside app-db) — disabled when no epoch is focused; on the rare framework
+failure (epoch aged out) it shows a brief inline flash, never a modal.
 
 This passive-inspect-by-default / rewind-opt-in posture is the load-bearing
 inversion from re-frame-10x v1 (the lineage fact lives once in

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -75,10 +75,12 @@ own lens. Cross-epoch signals belong on L2 badges, never inside L4.
 ### Inspection vs Rewind
 
 Clicking an L2 row is **INSPECTION** — L4 panels rebind to that epoch's
-captured snapshots; app-db is NOT rolled back. Rewind is a separate,
+captured snapshots; the live frame is NOT rolled back. Rewind is a separate,
 explicit affordance — the **`Reset` button** on the far-right of the L3
-tab-bar ribbon, which rewinds the observed frame's live
-`app-db` to the focused epoch's `:db-after` (`002-Time-Travel.md`).
+tab-bar ribbon, which reinstalls the observed frame's WHOLE frame-state —
+both app-db AND runtime-db — from the focused epoch's `:frame-state-after`
+via `restore-epoch!` / `replace-frame-state!`, not the `:db-after`
+projection alone (`002-Time-Travel.md`).
 
 ## Panel-by-panel (Dynamic mode)
 


### PR DESCRIPTION
Fixes three skill-prose beads (surface = `skills/` only; prose/docstring/eval-fixture, no behavior change).

## rf2-6kdk0h (P2 BUG) — M-26 restore prose naming reg-event-db
**Already shipped on origin/main** (commit `2ee0895d4` "align migration + non-migration skills with EP-0018/0022 shipped"). Verified against current state:
- `auto-call-site-rewrites.md:169` already names `reg-event` ("restore via a one-shot `reg-event` dispatched synchronously"); the snippet at :189-198 returns `{:db v}` under the one registration form.
- All remaining `reg-event-db/fx/ctx` mentions in the file (lines 282, 325, 388-418) are clearly M-73 migration-INPUT / v1-source "before" examples, not v2 targets.

No edits required.

## rf2-uudxtj (P2) — migration mirror EP-0017/0018/0022 reconciliation
**Already shipped on origin/main** (same commit + `041399d2f`, `f43e9c713`). Verified:
- `http-fx-to-managed-http.md` + `async-flow-to-machines.md`: add-on rationale already says the add-on "fails to compile" (not the false "every surface incl reg-event-fx is preserved"). v2-target examples use `reg-event`/`reg-machine`; the cited `reg-event-fx`/`reg-event-db` lines are v1-SOURCE migrate-from examples (correct to keep).
- `breaking-changes.md:193` states the carve-out correctly (`reg-event-db/fx/ctx` NOT preserved → collapse to `reg-event` per M-73).
- Interceptor guidance (`guided-interceptors-subs.md`, `breaking-changes.md` M-59 + preserved-list): already on the EP-0022 ref model (`reg-interceptor` + `[:rf.interceptor/path …]` refs; `unwrap`/`->interceptor` flagged internal/pre-rename-only).

No edits required.

## rf2-05gnnt (P2 BUG) — epoch-restore whole-frame-state contract
Stragglers still taught restore as an app-db / `:db-after` rewind. Aligned to the contract in `skills/shared/tool-pair-surfaces.md` and `core.cljc` (`restore-epoch!` reinstalls the WHOLE frame-state `:frame-state-after` — both app-db AND runtime-db — atomically via `replace-frame-state!`; passive inspection leaves the live frame untouched):

- `skills/re-frame2-xray/SKILL.md:55,209` — Reset rewind prose → whole frame-state.
- `skills/re-frame2-xray/references/chrome.md:30-31` — rewind prose → whole frame-state.
- `skills/re-frame2-xray/references/panels.md:78-81` — same straggler (Inspection-vs-Rewind) → whole frame-state.
- `skills/re-frame2-xray/evals/evals.json` (chrome-rewind expected_output + expectations) + `evals/README.md:57` — expected answer → whole frame-state.
- `skills/re-frame2-pair/spec/design.md:84` — restore-limits prose → whole frame-state; distinguishes MCP tool `restore-epoch` from core `rf/restore-epoch!`.
- `skills/re-frame2-pair/spec/inputs.md:26` + `STATUS.md:69` — core-API inventory now lists `restore-epoch!` (bang); annotated to distinguish the MCP tool name `restore-epoch`. STATUS.md:71 failure-modes line aligned to `restore-epoch!`.

MCP-tool-name references (`restore-epoch` no bang) deliberately left unchanged — that is the correct tool name and the mcp-drift guard pins it.

No `rf2-` bead IDs introduced into skill prose (drift-check).

## Quality gates
- `check_skill_eval_docs.py` — PASS
- `check_skill_eval_packaging.py` — PASS
- `check_skill_mcp_drift.py` — PASS
- `check_skill_pair_authoring_drift.py` — PASS
- `check_skill_re_frame2_drift.py` — PASS
- `check_skill_redirect_anchors.py` — PASS
- `check_skill_migration_cites.py` — PASS
- `check_skill_migration_contract_drift.py` — PASS
- `check_skill_package_refs.py` — PASS
- `check_skill_setup_counter_drift.py` — PASS
- `check_skill_implementor_order.py` — PASS
- `check_skill_implementor_partition_drift.py` — PASS
- `check_doc_slugs.py` — PASS
- `check_readme_links.py` — PASS
- `python -m mkdocs build --strict` — PASS (no warnings-as-errors)
- `evals.json` — valid JSON
- No `re-frame2-pair/tests/prompts/*` fixtures touched → `bb` prompts test not required.