### PR TITLE
fix(flows): roll back flow-output-declaration refresh on aborted flow event

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -496,39 +496,54 @@
   (let [flow-map (get (registry/flows-snapshot) frame-id)]
     (if-not (seq flow-map)
       db
-      (let [_ (do
-                ;; rf2-ihfz9o: refresh each flow's output data-classification
-                ;; declarations BEFORE the flow walk so a propagated (input-
-                ;; inherited) sensitive mark is in the frame's elision registry
-                ;; when the t2 `:rf.event/db-pending-post-flow` trace and the
-                ;; `:rf.flow/computed` `:result` slot project (Spec 015:568).
-                ;; This is the MARK-MUTATION-aware refresh flows need — a flow
-                ;; does not recompute on a mark-only `add-marks` / `set-marks` /
-                ;; schema change, so without a drain-time refresh a sensitive
-                ;; mark added AFTER reg-flow would never reach the flow output.
-                ;; Topo-ordered inside the helper so a flow reading an upstream
-                ;; flow's `:path` inherits the upstream's refreshed mark.
-                ;;
-                ;; NOT gated on `interop/debug-enabled?`: the elision
-                ;; declaration registry feeds production-survivor OFF-BOX egress
-                ;; (the epoch projection `:epoch/projected-record` ships records
-                ;; off-box even under `:advanced`), so the privacy mark must
-                ;; exist regardless of dev/prod. The cost is bounded — a pure-
-                ;; data topo-fold plus two map reads, with NO runtime-db write
-                ;; on the steady state (the helper compares first and writes
-                ;; only when the resolved declarations actually changed). It
-                ;; touches ONLY the runtime-db elision registry, never app-db,
-                ;; so it cannot perturb the cascade value or app-db subs.
-                (registry/refresh-flow-output-declarations! frame-id))
-            ordered (topo/topo-sort flow-map)
+      (let [ordered (topo/topo-sort flow-map)
             ;; Snapshot ONLY the draining frame's dirty-check container so a
             ;; flow throw can roll back the frame's own advances — the event
             ;; aborts, so prior flows' `last-inputs` advances must NOT
             ;; survive (their outputs were never installed). Scoped to
             ;; `frame-id` (rf2-94ol5) so a concurrently-draining sibling
             ;; frame is structurally untouched. Restored in the catch below.
-            last-inputs-before (registry/frame-last-inputs-snapshot frame-id)]
+            last-inputs-before (registry/frame-last-inputs-snapshot frame-id)
+            ;; rf2-gdzv6o: snapshot the frame's flow output-declaration elision
+            ;; slots BEFORE the refresh below mutates them. The refresh writes
+            ;; runtime-db IMMEDIATELY (`swap-elision-slot!`), but a flow throw
+            ;; is a PRE-INSTALL throw that aborts the WHOLE event — so the
+            ;; refresh's runtime-db write must be rolled back too, or app-db
+            ;; rolls back while runtime-db elision declarations survive,
+            ;; violating the all-or-nothing two-partition contract (Spec
+            ;; 013:284,288 — a pre-install flow throw leaves BOTH partitions
+            ;; unchanged). Frame-scoped (rf2-94ol5); restored in the catch.
+            decls-before       (registry/flow-output-declarations-snapshot frame-id)]
+        ;; rf2-ihfz9o: refresh each flow's output data-classification
+        ;; declarations BEFORE the flow walk so a propagated (input-
+        ;; inherited) sensitive mark is in the frame's elision registry
+        ;; when the t2 `:rf.event/db-pending-post-flow` trace and the
+        ;; `:rf.flow/computed` `:result` slot project (Spec 015:568).
+        ;; This is the MARK-MUTATION-aware refresh flows need — a flow
+        ;; does not recompute on a mark-only `add-marks` / `set-marks` /
+        ;; schema change, so without a drain-time refresh a sensitive
+        ;; mark added AFTER reg-flow would never reach the flow output.
+        ;; Topo-ordered inside the helper so a flow reading an upstream
+        ;; flow's `:path` inherits the upstream's refreshed mark.
+        ;;
+        ;; NOT gated on `interop/debug-enabled?`: the elision
+        ;; declaration registry feeds production-survivor OFF-BOX egress
+        ;; (the epoch projection `:epoch/projected-record` ships records
+        ;; off-box even under `:advanced`), so the privacy mark must
+        ;; exist regardless of dev/prod. The cost is bounded — a pure-
+        ;; data topo-fold plus two map reads, with NO runtime-db write
+        ;; on the steady state (the helper compares first and writes
+        ;; only when the resolved declarations actually changed). It
+        ;; touches ONLY the runtime-db elision registry, never app-db,
+        ;; so it cannot perturb the cascade value or app-db subs.
+        ;;
+        ;; rf2-gdzv6o: this write is INSIDE the `try` so the catch arm can
+        ;; roll it back. It is staged-before-walk for the trace/projection
+        ;; reasons above, but a downstream flow throw must unwind it — the
+        ;; refresh is part of the event's two-partition transaction, not a
+        ;; commit-before-the-walk side effect.
         (try
+          (registry/refresh-flow-output-declarations! frame-id)
           ;; The drain threads ONLY the transformed APP-DB `db` — the loop is
           ;; a pure left-fold over the topo-ordered flows. `runtime-db` is the
           ;; pending runtime-db partition, read-only for the WHOLE pass: flow
@@ -554,9 +569,16 @@
             ;; router; here we restore THIS frame's pre-drain `last-inputs`
             ;; (its own container only — rf2-94ol5) so every flow on this
             ;; frame re-attempts next drain while sibling frames are
-            ;; untouched. The throw (carrying `:rf.flow/failed-id` from
-            ;; `evaluate-flow!`) propagates unchanged for router attribution.
+            ;; untouched. rf2-gdzv6o: ALSO restore the frame's flow output-
+            ;; declaration elision slots — the pre-walk
+            ;; `refresh-flow-output-declarations!` wrote runtime-db directly,
+            ;; and a pre-install flow throw must leave runtime-db (not just
+            ;; app-db) EXACTLY unchanged (Spec 013:284,288). Both restores are
+            ;; frame-scoped (rf2-94ol5): sibling frames untouched. The throw
+            ;; (carrying `:rf.flow/failed-id` from `evaluate-flow!`) propagates
+            ;; unchanged for router attribution.
             (registry/reset-frame-last-inputs-to! frame-id last-inputs-before)
+            (registry/restore-flow-output-declarations! frame-id decls-before)
             (throw e)))))))
 
 ;; ---- late-bind hook registration ----------------------------------------

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -797,6 +797,53 @@
                       reg
                       ordered))))))))
 
+;; ---- flow output-declaration snapshot / rollback (rf2-gdzv6o) -------------
+;;
+;; `refresh-flow-output-declarations!` writes the frame's runtime-db elision
+;; registry IMMEDIATELY (via `swap-elision-slot!`), BEFORE the flow walk in
+;; `re-frame.flows/run-flows-on-db` runs. A flow throw is a PRE-INSTALL throw
+;; that aborts the WHOLE event (Spec 013 §Failure semantics), so the pending
+;; `:db` effect and the draining frame's `last-inputs` advances are discarded
+;; — but the refresh's runtime-db write would SURVIVE, leaving the elision
+;; declarations out of sync with the committed (rolled-back) frame state and
+;; violating the all-or-nothing two-partition contract (Spec 013:284,288 —
+;; a pre-install flow throw must leave BOTH app-db and runtime-db unchanged).
+;;
+;; These two helpers let the drain snapshot the frame's flow output-declaration
+;; slots BEFORE the refresh and restore them EXACTLY on a throw — the precise
+;; mirror of the `frame-last-inputs-snapshot` / `reset-frame-last-inputs-to!`
+;; pair this same walk already uses for the dirty-check rollback. Frame-scoped:
+;; both name `frame-id` and touch only that frame's runtime-db elision slot, so
+;; a concurrently-draining sibling frame is structurally untouched (rf2-94ol5).
+
+(defn ^:no-doc flow-output-declarations-snapshot
+  "Snapshot `frame-id`'s flow-touchable elision declaration sub-maps — the
+  two slots `refresh-flow-output-declarations!` (and `fold-flow-declarations`)
+  ever mutate: `:sensitive-declarations` and `:declarations`. Returned as a
+  plain map suitable for `restore-flow-output-declarations!`. The drain-start
+  snapshot for the rf2-gdzv6o throw-path rollback."
+  [frame-id]
+  {:sensitive-declarations (elision/sensitive-declarations frame-id)
+   :declarations           (elision/declarations frame-id)})
+
+(defn ^:no-doc restore-flow-output-declarations!
+  "Restore `frame-id`'s flow output-declaration slots to `prior` (a snapshot
+  from `flow-output-declarations-snapshot`), rolling back any mark-mutation
+  refresh that landed before an aborted flow walk. Writes the two declaration
+  sub-maps back EXACTLY through `swap-elision-slot!` (pruning an emptied slot
+  the same way `fold-flow-declarations` does), leaving any other elision-slot
+  keys the refresh never touches unchanged. Frame-scoped (rf2-94ol5)."
+  [frame-id prior]
+  (let [prior-s (:sensitive-declarations prior)
+        prior-l (:declarations prior)]
+    (elision/swap-elision-slot! frame-id
+      (fn [reg]
+        (cond-> (or reg {})
+          (seq prior-s)    (assoc :sensitive-declarations prior-s)
+          (empty? prior-s) (dissoc :sensitive-declarations)
+          (seq prior-l)    (assoc :declarations prior-l)
+          (empty? prior-l) (dissoc :declarations))))))
+
 (defn- clear-flow-output-marks!
   "Drop `flow-id`'s `:source :flow` declarations from `frame-id`'s elision
   registry. Called on `clear-flow` (`registry.cljc` §clear-flow) so a

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -859,6 +859,128 @@
       (is (= 2 @b-calls)
           ":B re-fired — its last-inputs was never advanced (it threw)"))))
 
+;; ---------------------------------------------------------------------------
+;; 7c-bis. Failed-flow rolls back the output-declaration refresh — two-
+;; partition atomicity (rf2-gdzv6o).
+;;
+;; `run-flows-on-db` refreshes each flow's `:source :flow` output elision
+;; declarations BEFORE the flow walk (rf2-ihfz9o), writing the frame's
+;; runtime-db elision registry IMMEDIATELY via `swap-elision-slot!`. A flow
+;; throw is a PRE-INSTALL throw: the event aborts wholesale, app-db rolls
+;; back and the dirty-check rolls back — but pre-fix the refresh's runtime-db
+;; write SURVIVED, leaving the elision declarations ahead of the committed
+;; (rolled-back) frame state. Spec 013:284,288 requires a pre-install flow
+;; throw to leave BOTH partitions unchanged. This deftest pins that the
+;; runtime-db elision declarations are EXACTLY unchanged after a throw, in
+;; lock-step with app-db.
+;;
+;; Construction: register `:downstream` FIRST (reads `[:secret]`, NO explicit
+;; classification key) so its reg-flow-time write is suppressed — at that
+;; point no sensitive declaration overlaps its inputs. THEN register
+;; `:upstream`, which force-marks its output `[:secret]` sensitive
+;; (`:rf.egress/output-sensitivity :rf.egress/sensitive`). reg-flow only
+;; (re)derives the flow being registered, so `:downstream`'s propagated
+;; sensitive declaration on `[:derived]` materialises ONLY via the topo-
+;; ordered drain-time refresh. `:downstream` then throws, so that drain's
+;; refresh (which newly added `[:derived]`) must roll back.
+;; ---------------------------------------------------------------------------
+
+(deftest failed-flow-rolls-back-output-declaration-refresh
+  (testing "on a flow throw, the pre-walk output-declaration refresh is rolled back: runtime-db elision AND app-db are both exactly unchanged"
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 5}}))
+    ;; :downstream reads [:secret] with NO explicit mark, registered BEFORE
+    ;; [:secret] is sensitive → no reg-flow-time write; its propagated
+    ;; sensitive [:derived] declaration appears only at DRAIN time. It throws,
+    ;; aborting the event.
+    (rf/reg-flow {:id     :downstream
+                  :inputs [[:secret]]
+                  :output (fn [_] (throw (ex-info "boom" {:why :test})))
+                  :path   [:derived]})
+    ;; :upstream force-marks [:secret] sensitive (explicit → reg-flow-time
+    ;; write of [:secret] only; does NOT re-derive :downstream).
+    (rf/reg-flow {:id     :upstream
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:secret]
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
+
+    ;; Capture BOTH partitions' relevant state immediately before the
+    ;; throwing event: app-db AND the frame's elision declaration sub-maps.
+    (let [db-before        (rf/app-db-value :rf/default)
+          sens-before      (elision/sensitive-declarations :rf/default)
+          large-before     (elision/declarations :rf/default)]
+      ;; Sanity: the propagated [:derived] declaration is NOT present yet —
+      ;; it would only be added by the drain-time refresh of the throwing
+      ;; event. (:upstream's [:secret] IS present from its reg-flow-time write.)
+      (is (not (contains? sens-before [:derived]))
+          "[:derived] not yet a sensitive declaration before the event (propagation is drain-time)")
+      (is (contains? sens-before [:secret])
+          "[:secret] is already a sensitive declaration from :upstream's reg-flow-time write (sanity)")
+
+      ;; Dispatch the event whose drain throws in :downstream.
+      (rf/dispatch-sync [:seed])
+
+      ;; Atomicity — app-db unchanged (the existing contract; control here).
+      (is (= db-before (rf/app-db-value :rf/default))
+          "app-db EXACTLY unchanged after the flow throw (no install)")
+      (is (not (contains? (rf/app-db-value :rf/default) :secret))
+          ":secret absent — :upstream's flow write did not land")
+      (is (not (contains? (rf/app-db-value :rf/default) :derived))
+          ":derived absent — :downstream never wrote (it threw)")
+
+      ;; The fix — runtime-db elision declarations EXACTLY unchanged: the
+      ;; pre-walk refresh that propagated the sensitive mark onto [:derived]
+      ;; was rolled back along with the aborted event.
+      (is (= sens-before (elision/sensitive-declarations :rf/default))
+          "sensitive declarations EXACTLY unchanged after the flow throw — refresh rolled back")
+      (is (= large-before (elision/declarations :rf/default))
+          "large declarations EXACTLY unchanged after the flow throw")
+      (is (not (contains? (elision/sensitive-declarations :rf/default) [:derived]))
+          "[:derived] is NOT a stray surviving sensitive declaration — the refresh's runtime-db write rolled back (rf2-gdzv6o)"))))
+
+(deftest successful-flow-refresh-still-marks-output
+  (testing "negative control: a SUCCESSFUL drain still installs the propagated output declaration (refresh not over-rolled)"
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 5}}))
+    ;; :downstream reads [:secret], registered BEFORE [:secret] is sensitive →
+    ;; its propagated [:derived] mark materialises only at drain time. It
+    ;; SUCCEEDS this time.
+    (rf/reg-flow {:id     :downstream
+                  :inputs [[:secret]]
+                  :output (fn [secret] (str "derived-from-" secret))
+                  :path   [:derived]})
+    (rf/reg-flow {:id     :upstream
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:secret]
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
+    (is (not (contains? (elision/sensitive-declarations :rf/default) [:derived]))
+        "[:derived] not yet declared before the event (sanity)")
+    (rf/dispatch-sync [:seed])
+    ;; The successful drain commits — the propagated declaration must survive.
+    (is (contains? (elision/sensitive-declarations :rf/default) [:derived])
+        "[:derived] IS a sensitive declaration after a SUCCESSFUL drain — the propagated mark installed (refresh commits with the event)")
+    (is (= 10 (:secret (rf/app-db-value :rf/default)))
+        ":secret flow output landed (sanity)")
+    (is (= "derived-from-10" (:derived (rf/app-db-value :rf/default)))
+        ":derived flow output landed (sanity)")))
+
+(deftest mark-only-refresh-after-reg-flow-still-works
+  (testing "rf2-gdzv6o acceptance (c): a mark-only refresh on a SUCCESSFUL drain after reg-flow still installs the declaration"
+    ;; This exercises the refresh's mark-mutation purpose directly: a flow
+    ;; with an explicit sensitive output mark whose declaration is (re)derived
+    ;; on the drain. With no throw, the refresh's write commits normally.
+    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 3}}))
+    (rf/reg-flow {:id     :marked
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:token]
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
+    (rf/dispatch-sync [:seed])
+    (is (contains? (elision/sensitive-declarations :rf/default) [:token])
+        "[:token] sensitive declaration present after a clean drain — mark-only refresh path intact")
+    (is (= 6 (:token (rf/app-db-value :rf/default)))
+        ":token flow output landed (sanity)")))
+
 (deftest failed-flow-app-db-unchanged-across-multiple-failing-drains
   (testing "across multiple failing drains, NOTHING lands — app-db stays unchanged (no partial commit)"
     (rf/reg-event :n!   (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))


### PR DESCRIPTION
## Problem (rf2-gdzv6o, P1 BUG)

`run-flows-on-db` refreshes each flow's `:source :flow` output elision declarations BEFORE the flow walk (rf2-ihfz9o), writing the frame's runtime-db elision registry **immediately** via `swap-elision-slot!`. A flow throw is a PRE-INSTALL throw that aborts the whole event: app-db and the draining frame's `last-inputs` roll back, but the refresh's runtime-db write **survived** — leaving the elision declarations ahead of the committed (rolled-back) frame state and violating the all-or-nothing two-partition event contract (Spec 013:284,288 require a pre-install flow throw to leave BOTH app-db and runtime-db unchanged).

This left trace / off-box egress classification out of sync with committed frame state: a flow throw could still add flow-sourced sensitive/large elision declarations for uncommitted output paths.

## Fix

Snapshot the frame's two flow-touchable elision declaration sub-maps (`:sensitive-declarations`, `:declarations`) before the refresh, and restore them on the throw path — the exact mirror of the existing `last-inputs` snapshot/restore in the same function. The pre-walk refresh now runs inside the `try` so the catch can unwind it. Frame-scoped (rf2-94ol5): a concurrently-draining sibling frame is structurally untouched.

**Kept entirely inside `implementation/flows/`** — no core elision/frame change. The transactional "route through the pending runtime-db effect" alternative does not fit the existing machinery cleanly: the refresh write is buried inside the flows walk and `pending-runtime-db` is explicitly read-only for the pass; routing it back out would force a multi-value return contract change across the late-bind boundary and a core router touch. The snapshot/restore is the blessed pattern this same function already uses for the dirty-check rollback, and is the minimal correct fix.

## Tests (NEW regression coverage)

- `failed-flow-rolls-back-output-declaration-refresh` — after a flow throw, **app-db AND runtime-db elision declarations are both EXACTLY unchanged** from pre-event values (the propagated `[:derived]` sensitive declaration the throwing drain's refresh added must NOT survive). Verified to FAIL without the fix (the stray `[:derived]` declaration survives) and pass with it.
- `successful-flow-refresh-still-marks-output` — negative control: a successful drain still installs the propagated declaration (refresh not over-rolled).
- `mark-only-refresh-after-reg-flow-still-works` — acceptance criterion (c): a successful mark-only refresh after `reg-flow` still works.

Existing throw tests (`flows_trace_test:760,830`) covered app-db + `last-inputs` only; these add the runtime-db elision partition.

## Quality gates

Run from this worktree:

- **Flows JVM full suite** (`clojure -M:test` in `implementation/flows`): **205 tests / 4844 assertions, 0 failures, 0 errors.**
- **CLJS node-test** (`npm run test:cljs` — cross-artefact `:node-test`): **7240 tests / 29757 assertions, 0 failures, 0 errors.**
- Bug-reproduction check: temporarily disabling the restore call makes the new regression test fail with the stray surviving `[:derived]` declaration; restoring it makes all green.

CI-Linux covers the remainder of the full JVM matrix.