### PR TITLE
fix(epoch): redact raw trigger-event args from off-box projected-record

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -894,12 +894,22 @@
 
 (defn projected-record
   "Project an `:rf/epoch-record` for off-box egress. Routes the
-  full-value payload slots (`:frame-state-before`, `:frame-state-after`,
-  `:db-before`, `:db-after`, `:trigger-event`, `:trace-events`) through
+  app-db-rooted full-value payload slots (`:frame-state-before`,
+  `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through
   `re-frame.elision/elide-wire-value` against the record's frame, with
   the off-box defaults `:include-sensitive? false` /
   `:include-large? false`. Sensitive paths land as `:rf/redacted`; large
   paths land as `:rf.size/large-elided` markers per the §Composition rule.
+
+  The `:trigger-event` slot is NOT app-db-rooted (rf2-nm611o): the
+  dispatched event vector's ARGS are registration-owned transient payloads
+  (Spec 015 §151), the same class as the `:effects` `:args` — so it fails
+  closed instead. The args are redacted while the head event-id keyword
+  (the non-payload summary, == the record's `:event-id` slot) is retained,
+  so `[:login \"topsecret\"]` egresses as `[:login :rf/redacted]`. The same
+  event-args also ride the `:rf.event/v` / `:event` tags of every
+  `:trace-events` entry; they fail closed there too. The trusted-local
+  `:include-event-args? true` opt keeps the raw args.
 
   EP-0001 (rf2-3aizt1, decision #2 + Mike ruling #14): the CANONICAL
   `:frame-state-before` / `:frame-state-after` slots egress with their
@@ -949,14 +959,17 @@
 
   The 2-arity accepts a trusted-local `opts` map —
   `{:include-sensitive? :include-large? :include-runtime-db?
-  :include-fx-args?}`, all defaulting `false`. `:include-sensitive?` /
-  `:include-large?` opt the APP-DB partition's privacy / size posture back
-  in across every payload slot; they do NOT lift the frame-state
-  `:rf.db/runtime` partition boundary, which stays `:rf/redacted` unless
-  `:include-runtime-db? true` is also passed, NOR the structured `:effects`
-  `:args` (a different keyspace), which stay `:rf/redacted` unless
-  `:include-fx-args? true` is passed (rf2-rlt3sv). The 1-arity is the safe,
-  fully-redacted off-box path."
+  :include-fx-args? :include-event-args?}`, all defaulting `false`.
+  `:include-sensitive?` / `:include-large?` opt the APP-DB partition's
+  privacy / size posture back in across every payload slot; they do NOT
+  lift the frame-state `:rf.db/runtime` partition boundary, which stays
+  `:rf/redacted` unless `:include-runtime-db? true` is also passed, NOR the
+  structured `:effects` `:args` (a different keyspace), which stay
+  `:rf/redacted` unless `:include-fx-args? true` is passed (rf2-rlt3sv),
+  NOR the `:trigger-event` / trace-event `:rf.event/v` args (another
+  keyspace), which stay redacted unless `:include-event-args? true` is
+  passed (rf2-nm611o). The 1-arity is the safe, fully-redacted off-box
+  path."
   ([record] (tool-pair/projected-record record))
   ([record opts] (tool-pair/projected-record record opts)))
 

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1142,21 +1142,78 @@
                   ev))))
           trace-events)))
 
+(def ^:private event-arg-tag-slots
+  "The trace-event tag slots that carry the DISPATCHED EVENT VECTOR
+  `[<event-id> <arg> …]` (rf2-nm611o). The same registration-owned
+  transient event args the `:trigger-event` record slot carries ride here,
+  on EVERY `:rf.event/*` op of a cascade (`:rf.event/dispatched`,
+  `:rf.event/run-start`, `:rf.event/db-pending`, `:rf.event/db-changed`,
+  `:rf.event/run-end`, …) under `:rf.event/v`, and on the `:rf.error/*`
+  handler-exception traces under the bare `:event` slot
+  (`HandlerExceptionTags`, Spec-Schemas §`:rf/error-event`). The marks
+  chokepoint (`re-frame.marks/project-event-tags`) redacts these against
+  the event's REGISTRATION marks at emit time, but UNMARKED args (a bare
+  positional secret like `[:login \"topsecret\"]`, or a map arg with no
+  declaration) are passed through raw, and the on-box ring stores the raw
+  event for `restore-epoch!` fidelity — so off-box egress must fail closed
+  here, the same posture as the `:trigger-event` record slot."
+  [:rf.event/v :event])
+
+(defn- omit-off-box-event-args
+  "Per rf2-nm611o: enforce the EP-0015 §151 registration-owned-transient
+  fail-closed rule on the dispatched-event-vector tag slots
+  (`event-arg-tag-slots`) of every trace event. For each slot present whose
+  value is the event vector `[<id> <arg> …]`, retain the head event-id
+  keyword and redact every arg to `:rf/redacted` — the SAME shape the
+  `:trigger-event` record slot egresses (see `elide-trigger-event-slot`).
+  This closes the sibling leak whereby a secret carried in the dispatched
+  event vector survives off-box inside `:trace-events` (the marks
+  chokepoint cannot prove an UNMARKED arg safe, and the on-box ring keeps
+  the raw event).
+
+  The redaction is the off-box default; the trusted-local
+  `:include-event-args? true` opt-in lifts it (the same opt that lifts the
+  `:trigger-event` redaction — one event-args keyspace, one switch).
+  Orthogonal to the app-db `:include-sensitive?` / `:include-large?`
+  opt-ins. Idempotent (a `[<id> :rf/redacted …]` re-redacts to the same
+  sentinels) and nil/non-sequential-preserving."
+  [trace-events {:keys [include-event-args?]}]
+  (if (or include-event-args? (not (sequential? trace-events)))
+    trace-events
+    (mapv (fn [ev]
+            (if-not (map? ev)
+              ev
+              (reduce (fn [ev slot]
+                        (let [tag-path [:tags slot]
+                              v        (get-in ev tag-path)]
+                          (if (and (vector? v) (seq v))
+                            (assoc-in ev tag-path
+                                      (into [(first v)]
+                                            (repeat (dec (count v)) :rf/redacted)))
+                            ev)))
+                      ev
+                      event-arg-tag-slots)))
+          trace-events)))
+
 (defn- elide-trace-events-slot
   "The `:trace-events` projection chain (rf2-ta0y7): first re-root the
   per-event `:rf.event/db` slots on the t1 / t2 trace events so the
-  sensitive / large declarations match natively, then enforce the off-box
+  sensitive / large declarations match natively, then fail closed on the
+  dispatched-event-vector args (rf2-nm611o — `:rf.event/v` / `:event`
+  carry the same registration-owned transient args as `:trigger-event`,
+  which the app-db walker cannot prove safe), then enforce the off-box
   HTTP response-body fail-closed rule (rf2-t55hxg.6 — omit unschematized
   bodies), then run the bulk frame/profile `project-egress` walk over the
   whole vector to handle the other payload-bearing tag values
-  (`:rf.event/v`, `:rf.cofx/value`, etc.) with their own per-tag paths.
-  `opts` `:include-sensitive?` / `:include-large?` opt the per-call posture
-  back in (rf2-5w06uu). Idempotent (a second pass walks already-redacted
-  scalars). Nil-preserving."
+  (`:rf.cofx/value`, etc.) with their own per-tag paths. `opts`
+  `:include-sensitive?` / `:include-large?` / `:include-event-args?` opt
+  the per-call posture back in (rf2-5w06uu / rf2-nm611o). Idempotent (a
+  second pass walks already-redacted scalars). Nil-preserving."
   [v frame-id opts]
   (when (some? v)
     (-> v
         (reroot-trace-event-db-slots frame-id opts)
+        (omit-off-box-event-args opts)
         (omit-off-box-http-bodies opts)
         (projection/project-egress (egress-opts frame-id opts)))))
 
@@ -1269,15 +1326,80 @@
     effects
     (mapv #(elide-effect-row % opts) effects)))
 
+(defn- elide-trigger-event-slot
+  "Project the `:trigger-event` slot for off-box egress (rf2-nm611o).
+
+  `:trigger-event` is the FULL dispatched event vector — `[<event-id>
+  <arg> …]` (e.g. `[:login \"topsecret\"]`, `[:auth/login {:password p}]`).
+  Per EP-0015 / Spec 015 §Registration-owned transient classification
+  (`015-Data-Classification.md` §151) the event ARGS are
+  registration-owned transient payloads, NOT frame-app-db-owned data — the
+  exact same class as the `:effects` `:args` slot (`elide-effect-row`,
+  rf2-rlt3sv, whose docstring even names `[:login pw]` dispatch vectors as
+  payload-bearing user data). They are captured verbatim from the
+  `:rf.event/v` trace tag (`capture/find-trigger-event`); they are NOT
+  routed through the marks-projection chokepoint at emit time, NOR are they
+  rooted at the frame's app-db, so the schema-path-keyed `elide-wire-value`
+  walker cannot prove any of them safe. (The prior projection routed this
+  slot through the generic `project-payload-slot`, which roots the walk at
+  the frame's app-db classification — so a secret carried positionally in
+  the event vector, e.g. `[:login \"topsecret\"]`, egressed RAW because no
+  app-db sensitive declaration matches the trigger-event path.)
+
+  A safe per-event projection cannot be proven, so off-box egress FAILS
+  CLOSED (Spec 009 §Privacy / sensitive data in traces + Security.md
+  §Off-box egress): the ARGS are redacted by default while the head
+  `<event-id>` keyword — a non-identity, non-payload field (it is the SAME
+  value the record carries in its bare `:event-id` slot, per Spec-Schemas
+  §`:rf/epoch-record`) — is retained as the event-id SUMMARY. So
+  `[:login \"topsecret\"]` egresses as `[:login :rf/redacted]`: a consumer
+  still sees WHICH event ran, never its args. Fail-closed covers BOTH
+  unmarked positional args (`[:login \"topsecret\"]`) and unmarked map args
+  (`[:auth/login {:password p}]`) — neither can be matched by the app-db
+  classification walker. The whole-vector redaction (`:rf/redacted`) is
+  reserved for a degenerate non-vector or empty slot, which the open record
+  schema admits (Spec-Schemas §`:rf/epoch-record` — consumers MUST tolerate
+  `:rf/redacted` at `:trigger-event`).
+
+  `opts` `:include-event-args? true` is the trusted-local opt-in (the
+  rf2-5w06uu / `:include-fx-args?` family) — a developer's own Xray panel
+  inspecting their own running app keeps the raw args. It is ORTHOGONAL to
+  the app-db `:include-sensitive?` / `:include-large?` opt-ins (event args
+  are a different keyspace, not app-db values), so those do NOT lift it,
+  matching the `:effects` `:args` / runtime-db boundaries.
+
+  Idempotent: a second pass over an already-projected `[<id> :rf/redacted
+  …]` re-redacts the (already-`:rf/redacted`) tail to the same sentinels.
+  Nil-preserving (a halted record may carry no `:trigger-event`)."
+  [v {:keys [include-event-args?]}]
+  (cond
+    (or include-event-args? (nil? v)) v
+    ;; The canonical shape is a non-empty event vector `[<id> <arg> …]`.
+    ;; Retain the head event-id keyword (the non-payload summary); fail
+    ;; closed on every positional / map arg in the tail.
+    (and (vector? v) (seq v))
+    (into [(first v)] (repeat (dec (count v)) :rf/redacted))
+    ;; Degenerate non-vector / empty slot (or a `:redact-fn` that already
+    ;; substituted a scalar sentinel) — redact wholesale; nothing safe to
+    ;; expose, and the open schema admits `:rf/redacted` here.
+    :else :rf/redacted))
+
 (defn projected-record
   "Project an `:rf/epoch-record` for off-box egress. Routes the
-  full-value payload slots (`:frame-state-before`, `:frame-state-after`,
-  `:db-before`, `:db-after`, `:trigger-event`, `:trace-events`) through
+  app-db-rooted full-value payload slots (`:frame-state-before`,
+  `:frame-state-after`, `:db-before`, `:db-after`, `:trace-events`) through
   `re-frame.projection/project-egress` under the
   `:rf.egress/off-box-observability` profile (EP-0015 §15 / §10) against
   the record's frame, with the off-box defaults `:include-sensitive? false`
   / `:include-large? false`. Sensitive paths land as `:rf/redacted`; large
   paths land as `:rf.size/large-elided` markers per the §Composition rule.
+
+  The `:trigger-event` slot is NOT app-db-rooted — its event ARGS are
+  registration-owned transient payloads (Spec 015 §151), the same class as
+  the `:effects` `:args` — so it fails closed instead: the args are redacted
+  by default while the head event-id keyword (the non-payload summary) is
+  retained, and the trusted-local `:include-event-args?` opt keeps them raw
+  (rf2-nm611o — see `elide-trigger-event-slot`).
 
   ## Frame/profile projection then `:redact-fn` advanced override (EP-0015 §15)
 
@@ -1304,7 +1426,8 @@
       {:include-sensitive?  <bool>   ;; reveal app-db sensitive values
        :include-large?      <bool>   ;; reveal app-db large values
        :include-runtime-db? <bool>   ;; reveal the frame-state runtime-db partition
-       :include-fx-args?    <bool>}  ;; reveal the structured `:effects` `:args`
+       :include-fx-args?    <bool>   ;; reveal the structured `:effects` `:args`
+       :include-event-args? <bool>}  ;; reveal the `:trigger-event` args (rf2-nm611o)
 
   All default `false` — the 1-arity (`(projected-record record)`) is the
   safe, fully-redacted off-box path. `:include-sensitive?` /
@@ -1343,6 +1466,15 @@
   `:rf/redacted` off-box under the `:include-fx-args? false` default (see
   `elide-effects-slot`). The value-free row metadata (`:fx-id`, `:outcome`,
   `:error-trace`) and the whole `:renders` projection pass through unchanged.
+
+  The `:trigger-event` slot is payload-bearing too (rf2-nm611o): the
+  dispatched event vector's ARGS are registration-owned transient payloads
+  (Spec 015 §151), not app-db-rooted, so the app-db classification walker
+  cannot prove them safe. It fails closed under the `:include-event-args?
+  false` default — the args are redacted while the head event-id keyword
+  (the non-payload summary, == the record's `:event-id` slot) is retained,
+  so `[:login \"topsecret\"]` egresses as `[:login :rf/redacted]` (see
+  `elide-trigger-event-slot`).
 
   The record-level bookkeeping (`:epoch-id`, `:frame`, `:committed-at`,
   `:event-id`, `:outcome`, `:halt-reason`, `:schema-digest`,
@@ -1395,8 +1527,20 @@
                        (contains? record :db-after)
                        (update :db-after      project-payload-slot frame-id opts)
 
+                       ;; rf2-nm611o: `:trigger-event` carries the dispatched
+                       ;; event vector `[<id> <arg> …]`. Its ARGS are
+                       ;; registration-owned transient payloads (Spec 015 §151),
+                       ;; NOT frame-app-db-owned data — the generic
+                       ;; `project-payload-slot` (rooted at the frame's app-db
+                       ;; classification) cannot prove them safe, so a positional
+                       ;; secret like `[:login "topsecret"]` egressed RAW. Off-box
+                       ;; egress now FAILS CLOSED: the args are redacted while the
+                       ;; head event-id keyword (the non-payload summary, == the
+                       ;; record's `:event-id` slot) is retained. The
+                       ;; trusted-local `:include-event-args? true` opt keeps the
+                       ;; raw args (the `:include-fx-args?` family).
                        (contains? record :trigger-event)
-                       (update :trigger-event project-payload-slot frame-id opts)
+                       (update :trigger-event elide-trigger-event-slot opts)
 
                        (contains? record :trace-events)
                        (update :trace-events  elide-trace-events-slot frame-id opts)
@@ -1427,8 +1571,9 @@
   snapshot, a recorder dumping the full session) can call this once
   rather than walking the raw ring and re-wrapping each record. The
   2-arity threads the trusted-local egress `opts` (rf2-5w06uu —
-  `:include-sensitive?` / `:include-large?` / `:include-runtime-db?`) to
-  every record; the 1-arity is the safe, fully-redacted off-box path."
+  `:include-sensitive?` / `:include-large?` / `:include-runtime-db?` /
+  `:include-fx-args?` / `:include-event-args?`) to every record; the
+  1-arity is the safe, fully-redacted off-box path."
   ([frame-id] (projected-history frame-id nil))
   ([frame-id opts]
    (mapv #(projected-record % opts) (state/history-for frame-id))))

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -110,10 +110,14 @@
   "Drive a deterministic, mixed cascade matrix against `frame-id`:
     - :seed — non-sensitive bookkeeping
     - :login — writes the sensitive path (secret value closed-over in the
-              handler so it never appears in the trigger-event vector;
-              the frame-declared sensitive path is the only sensitive
-              leaf the projection's wire-elision walker can match
-              against, not arbitrary positional event args)
+              handler so this fixture exercises the APP-DB classification
+              axis specifically; the frame-declared sensitive path is the
+              leaf the projection's wire-elision walker matches against.
+              The trigger-event event-args axis is exercised separately by
+              the rf2-nm611o `forwarder-trigger-event-*` tests, which drive
+              the secret IN the event vector and assert it fails closed —
+              before rf2-nm611o the walker could not match arbitrary args,
+              so this fixture kept them out; that constraint is now lifted)
     - :upload — writes the large path (large payload closed-over in the
                 handler for the same reason)
     - :inc — non-sensitive again
@@ -653,3 +657,77 @@
             "the bulk-shape large slot is an elision marker (`:rf.size/large-elided`)")
         (is (elision/marker? per-slot)
             "the per-record-shape large slot is an elision marker")))))
+
+;; ============================================================================
+;;  rf2-nm611o — :trigger-event event-args fail-closed off-box egress.
+;;
+;;  The dispatched event vector's args are registration-owned transient
+;;  payloads (Spec 015 §151), not app-db-rooted, so the app-db classification
+;;  walker cannot prove them safe. A secret carried IN the event vector (e.g.
+;;  [:login "topsecret"]) previously egressed RAW through the generic
+;;  app-db-rooted payload-slot projection. The fix fails closed: args
+;;  redacted, head event-id retained; trusted-local :include-event-args?
+;;  opts back in. (drive-mixed-ring! keeps secrets OUT of the trigger-event
+;;  on purpose — see its :login comment — so these tests drive the secret IN.)
+;; ============================================================================
+
+(deftest forwarder-trigger-event-positional-secret-fails-closed
+  (testing "rf2-nm611o — an MCP forwarder shipping a record whose dispatched
+            event vector carried a secret POSITIONALLY ([:login secret])
+            MUST NOT egress the secret. projected-record fails closed: the
+            head event-id is retained, the positional arg is :rf/redacted."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (rf/reg-event :login (fn [{:keys [db]} [_ pw]]
+                           {:db (assoc-in db [:auth :password] pw)}))
+    (let [shipped (atom [])]
+      (rf/register-epoch-listener! ::forwarder
+                                   (fn [r] (swap! shipped conj (epoch/projected-record r))))
+      (rf/dispatch-sync [:login secret-password] {:frame :test/mcp})
+      (is (pos? (count @shipped)) "the forwarder saw the cascade")
+      (is (not-any? contains-secret? @shipped)
+          "no projected record leaks the positional secret anywhere")
+      (let [proj (last @shipped)]
+        (is (= [:login :rf/redacted] (:trigger-event proj))
+            "trigger-event egresses with the head id retained, arg redacted")
+        (is (= :login (:event-id proj))
+            "the event-id summary slot is intact")))))
+
+(deftest forwarder-trigger-event-map-secret-fails-closed
+  (testing "rf2-nm611o — a secret nested in a MAP arg of the dispatched
+            event vector ([:auth/login {:password secret}]) also fails
+            closed off-box: the whole arg redacts to :rf/redacted."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (rf/reg-event :auth/login (fn [{:keys [db]} [_ {:keys [password]}]]
+                                {:db (assoc-in db [:auth :password] password)}))
+    (rf/dispatch-sync [:auth/login {:password secret-password}] {:frame :test/mcp})
+    (let [proj (epoch/projected-record (last (rf/epoch-history :test/mcp)))]
+      (is (= [:auth/login :rf/redacted] (:trigger-event proj)))
+      (is (not (contains-secret? (:trigger-event proj)))
+          "the map-arg secret is absent from the projected trigger-event"))))
+
+(deftest include-event-args-reveals-trigger-event-but-keeps-app-db-axes
+  (testing "rf2-nm611o — `{:include-event-args? true}` reveals the raw
+            trigger-event args YET is ORTHOGONAL to the app-db
+            sensitive/large axes (and vice-versa). Asking for event args
+            must not lift the app-db sensitive leaf, and asking for app-db
+            sensitive values must not lift the event args."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (rf/reg-event :login (fn [{:keys [db]} [_ pw]]
+                           {:db (assoc-in db [:auth :password] pw)}))
+    (rf/dispatch-sync [:login secret-password] {:frame :test/mcp})
+    (let [raw (last (rf/epoch-history :test/mcp))]
+      ;; include-event-args reveals the args but keeps app-db sensitive redacted.
+      (let [proj (epoch/projected-record raw {:include-event-args? true})]
+        (is (= [:login secret-password] (:trigger-event proj))
+            "`:include-event-args? true` reveals the raw trigger-event args")
+        (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
+            "the app-db sensitive leaf STAYS redacted — orthogonal axis"))
+      ;; include-sensitive reveals the app-db leaf but keeps event args redacted.
+      (let [proj (epoch/projected-record raw {:include-sensitive? true})]
+        (is (= secret-password (get-in proj [:db-after :auth :password]))
+            "`:include-sensitive? true` reveals the app-db sensitive leaf")
+        (is (= [:login :rf/redacted] (:trigger-event proj))
+            "the trigger-event args STAY redacted — event-args axis is orthogonal")))))

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -99,6 +99,18 @@
 (defn- big-string [n]
   (apply str (repeat n "X")))
 
+(defn- contains-leaf?
+  "Walk an arbitrary EDN value looking for `secret` as a leaf string (exact
+  equality or substring). Used by the rf2-nm611o trigger-event redaction
+  tests as the 'no raw secret bytes anywhere in the projected slot' check."
+  [x secret]
+  (cond
+    (string? x) (.contains ^String x ^String secret)
+    (map? x)    (or (some #(contains-leaf? % secret) (keys x))
+                    (some #(contains-leaf? % secret) (vals x)))
+    (coll? x)   (boolean (some #(contains-leaf? % secret) x))
+    :else       false))
+
 ;; ---- 1. sensitive rollup ---------------------------------------------------
 
 (deftest rollup-false-on-non-sensitive-cascade
@@ -561,29 +573,133 @@
       (is (= :rf/redacted (:args (effect-row twice :fxp/login)))
           "double-projection is idempotent at the :args slot"))))
 
-(deftest projected-record-trigger-event-projected
-  (testing ":trigger-event is walked through the projection so a
-            sensitive value carried in the dispatched event vector
-            (e.g. a password as a positional arg) does not leak via
-            the off-box surface"
+(deftest projected-record-trigger-event-positional-arg-redacted
+  (testing "rf2-nm611o: a sensitive value carried POSITIONALLY in the
+            dispatched event vector (e.g. a password as a bare positional
+            arg, [:login \"topsecret\"]) does NOT leak via the off-box
+            projection. The event ARGS are registration-owned transient
+            payloads (Spec 015 §151), not app-db-rooted, so the app-db
+            classification walker cannot match them — the projection FAILS
+            CLOSED: the head event-id keyword is retained as the summary,
+            every positional arg is redacted to :rf/redacted."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    ;; The login event payload itself is the sensitive value, but the
-    ;; frame-declared sensitive path is :auth/password, not the
-    ;; trigger-event slot. The projection still walks :trigger-event;
-    ;; whether the leaf there gets redacted depends on whether the
-    ;; walker can find a sensitive declaration matching that path.
-    ;; This test pins that the projection RAN against :trigger-event
-    ;; (the slot exists in the projected record) — what it changes
-    ;; depends on the registered declarations.
+    ;; The secret rides POSITIONALLY in the event vector — there is no
+    ;; app-db sensitive declaration that could match the trigger-event
+    ;; path (the frame-declared path is [:auth :password], rooted at
+    ;; app-db, not at the event vector). The prior projection routed this
+    ;; slot through the generic app-db-rooted walker, so the secret leaked
+    ;; raw. Fail-closed redaction is the fix.
     (rf/reg-event :login
                      (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
           projected (epoch/projected-record raw)]
+      (is (= [:login "topsecret"] (:trigger-event raw))
+          "the raw ring keeps the exact dispatched event vector")
       (is (contains? projected :trigger-event)
-          ":trigger-event slot preserved through the projection"))))
+          ":trigger-event slot preserved through the projection")
+      (is (= [:login :rf/redacted] (:trigger-event projected))
+          "off-box projection retains the head event-id keyword and
+           redacts the positional arg")
+      (is (not= "topsecret" (second (:trigger-event projected)))
+          "the secret positional arg is absent from the projected slot")
+      (is (= :login (:event-id projected))
+          "the event-id summary slot is unaffected (head keyword preserved)"))))
+
+(deftest projected-record-trigger-event-map-arg-redacted
+  (testing "rf2-nm611o: a sensitive value nested in a MAP arg of the
+            dispatched event vector ([:auth/login {:password p}]) also
+            fails closed off-box. Map args are registration-owned
+            transient payloads too — an unmarked map arg cannot be proven
+            safe by the app-db walker, so the whole arg redacts to
+            :rf/redacted (no per-key descent that could leak the value)."
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+    (rf/reg-event :auth/login
+                     (fn [{:keys [db]} [_ {:keys [password]}]]
+                       {:db (assoc-in db [:auth :password] password)}))
+    (rf/dispatch-sync [:auth/login {:password "topsecret" :email "a@b.c"}]
+                      {:frame :test/main})
+
+    (let [raw       (last-record :test/main)
+          projected (epoch/projected-record raw)]
+      (is (= [:auth/login {:password "topsecret" :email "a@b.c"}]
+             (:trigger-event raw))
+          "the raw ring keeps the exact dispatched map arg")
+      (is (= [:auth/login :rf/redacted] (:trigger-event projected))
+          "off-box projection redacts the whole map arg, head id retained")
+      (is (not (contains-leaf? (:trigger-event projected) "topsecret"))
+          "the secret is absent anywhere in the projected trigger-event"))))
+
+(deftest projected-record-trigger-event-marked-event-arg-redacted
+  (testing "rf2-nm611o: even an event whose registration DECLARES a
+            sensitive arg path ({:sensitive [[:password]]}) fails closed
+            at the trigger-event slot off-box. The marks-projection
+            chokepoint does not run over the verbatim :rf.event/v trace
+            tag (the trigger-event source), and the projector roots its
+            walk at app-db, not the event arg-map — so the conservative,
+            consistent answer is to redact the whole arg regardless of
+            registration marks. The declaration still governs OTHER
+            surfaces (schema-validation error traces, fx args derived from
+            the event); it is the trigger-event slot specifically that
+            fails closed."
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+    (rf/reg-event :auth/login
+                     {:sensitive [[:password]]}
+                     (fn [{:keys [db]} [_ {:keys [password]}]]
+                       {:db (assoc-in db [:auth :password] password)}))
+    (rf/dispatch-sync [:auth/login {:password "topsecret"}] {:frame :test/main})
+
+    (let [projected (epoch/projected-record (last-record :test/main))]
+      (is (= [:auth/login :rf/redacted] (:trigger-event projected))
+          "a marked event arg still fails closed at the trigger-event slot")
+      (is (not (contains-leaf? (:trigger-event projected) "topsecret"))
+          "the marked secret is absent from the projected trigger-event"))))
+
+(deftest projected-record-trigger-event-trusted-local-opt-in
+  (testing "rf2-nm611o: the trusted-local :include-event-args? true opt-in
+            keeps the RAW event args off-box (a developer's own Xray panel
+            inspecting their own running app). It is ORTHOGONAL to the
+            app-db :include-sensitive? / :include-large? opt-ins — those do
+            NOT lift it; only :include-event-args? does."
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
+    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+    (let [raw (last-record :test/main)]
+      (is (= [:login "topsecret"]
+             (:trigger-event (epoch/projected-record raw {:include-event-args? true})))
+          ":include-event-args? true keeps the raw event args off-box")
+      ;; Orthogonality: the app-db sensitive/large opt-ins do NOT lift the
+      ;; event-args redaction (event args are a different keyspace).
+      (is (= [:login :rf/redacted]
+             (:trigger-event (epoch/projected-record raw {:include-sensitive? true})))
+          ":include-sensitive? does NOT lift the trigger-event-args redaction")
+      (is (= [:login :rf/redacted]
+             (:trigger-event (epoch/projected-record raw {:include-large? true})))
+          ":include-large? does NOT lift the trigger-event-args redaction"))))
+
+(deftest projected-record-trigger-event-redaction-idempotent
+  (testing "rf2-nm611o: re-projecting an already-projected record leaves
+            the trigger-event args as the :rf/redacted sentinel (no drift,
+            no re-leak under double-projection — a forwarder pipeline may
+            project the same record twice)."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event :login
+                     (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
+    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+    (let [raw   (last-record :test/main)
+          once  (epoch/projected-record raw)
+          twice (epoch/projected-record once)]
+      (is (= [:login :rf/redacted] (:trigger-event once)))
+      (is (= [:login :rf/redacted] (:trigger-event twice))
+          "double-projection is idempotent at the :trigger-event slot"))))
 
 (deftest projected-record-sensitive-wins-over-large
   (testing "the wire-elision walker's composition rule (sensitive


### PR DESCRIPTION
Fixes rf2-nm611o (P1, BUG — EP-0015 privacy/data-classification correctness).

## Problem

`epoch/projected-record`, the required off-box helper for MCP/log/story epoch egress, could preserve RAW `:trigger-event` args. It routed the `:trigger-event` slot through the generic `project-payload-slot`, which roots its walk at the frame's app-db classification. Event args are **registration-owned transient payloads** (Spec 015 §151), not app-db-rooted — so a secret carried in the dispatched event vector (e.g. `[:login "topsecret"]`) egressed RAW because no app-db sensitive declaration matches the trigger-event path.

Investigation while writing the conformance test surfaced a **sibling leak**: the same event args also ride the `:rf.event/v` (and the `:rf.error/*` bare `:event`) tags of every `:trace-events` entry, leaking the secret through that slot too. The emit-time marks chokepoint (`re-frame.marks/project-event-tags`) only redacts against *registration* marks and passes UNMARKED args through raw; the on-box ring stores the raw event for `restore-epoch!` fidelity — so off-box egress must fail closed.

## Fix

Fail closed by default, consistent with the established `:effects` `:args` / runtime-db / HTTP-body egress posture:

- `elide-trigger-event-slot` replaces `project-payload-slot` for the `:trigger-event` record slot. It retains the head event-id keyword (the non-payload summary, identical to the record's separate `:event-id` slot) and redacts every arg, so `[:login "topsecret"]` egresses as `[:login :rf/redacted]`. Covers unmarked positional args AND unmarked map args; the open record schema admits `:rf/redacted` at `:trigger-event` (Spec-Schemas §`:rf/epoch-record`).
- `omit-off-box-event-args` fail-closes the `:rf.event/v` / `:event` args across every `:trace-events` entry in `elide-trace-events-slot`.
- New trusted-local `:include-event-args?` opt (the `:include-fx-args?` family) keeps the raw args; orthogonal to the app-db `:include-sensitive?` / `:include-large?` opt-ins.
- The on-box ring stays raw (restore fidelity unaffected); redaction is purely at the off-box egress boundary.

## Acceptance criteria

- (a) Default `projected-record` no longer exposes raw trigger-event args off-box.
- (b) Implementation omits/summarizes args (head event-id retained) and fails closed for unclassified args.
- (c) New regression tests for unmarked positional args, unmarked map args, marked event args, the trusted-local opt-in, idempotency, and the trace-events sibling leak.
- (d) The old privacy test (`projected-record-trigger-event-projected`) that only asserted the slot EXISTS now asserts the secret is ABSENT/redacted.

## Quality gates

Run from `implementation/epoch/` (bounded — Windows full-JVM-spine can deadlock):

- `clojure -M:test -n re-frame.epoch-privacy-test -n re-frame.epoch-mcp-egress-conformance-test` → **55 tests, 206 assertions, 0 failures, 0 errors** (the two bead-named nses).
- `clojure -M:test -n re-frame.epoch-egress-trace-events-test -n re-frame.epoch-redact-fn-projection-test` → **36 tests, 92 assertions, 0 failures**.
- `clojure -M:test` (full epoch JVM suite) → **336 tests, 1324 assertions, 0 failures, 0 errors**.

CLJS node gate not run locally: the new/updated tests are `.clj` (JVM-only); the source change is portable `.cljc` (standard `into`/`repeat`/`assoc-in`/`reduce`, identical to the sibling `omit-off-box-http-bodies`) and is fully exercised by the green JVM suite. CI-Linux covers the full `test:cljs` matrix.