### PR TITLE
docs(spec): 002-Frames — EP-0022 :interceptor kind + slice-3 fixes

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -349,7 +349,7 @@ frame-state  (one signal: {:rf.db/app <app-db> :rf.db/runtime <runtime-db>})
    └── runtime-db = (reaction (:rf.db/runtime @frame-state)) ; layer-1 input for framework subs
 ```
 
-This is **pattern contract**, not just one acceptable representation (it resolves EP-0001 Open Issues 3 + 7 — Mike ruling #3). Ports MAY differ only if they preserve the projection-equality semantics below; the reference impl commits to the single container. The full substrate realisation lives in [006 §Frame-state container and partition projections](006-ReactiveSubstrate.md#frame-state-container-and-partition-projections).
+This is **pattern contract**, not just one acceptable representation (it resolves EP-0001 Open Issues 3 + 7 — Mike ruling #3). Ports MAY differ only if they preserve the projection-equality semantics below; the reference impl commits to the single container. The full substrate realisation **and the normative projection-equality pattern-contract** are owned by [006 §Frame-state container and partition projections](006-ReactiveSubstrate.md#frame-state-container-and-partition-projections); the prose here states the split at the frame contract.
 
 The model buys partition-aware sub-cache invalidation **for free** from existing reaction-deref equality (Mike ruling #7 — no explicit dirty flags unless an adapter needs them):
 
@@ -414,6 +414,25 @@ then `(rf/reg-event :session/reset (fn [_ _] {:db {:session/status :anonymous}})
 ```
 
 No preservation code is needed; the handler cannot touch runtime-db through `:db`.
+
+#### The `:db` commit / no-op return family
+
+The closed effects map is the only return; there is no db-only return shape. The app-db commit semantics of every return follow one table — stated here for the effect-map contract, enforced at the commit step (§Run-to-completion below):
+
+| Handler return | App-db effect |
+|---|---|
+| `nil` | no-op (nothing committed) |
+| `{}` | no-op |
+| `{:db <new>}` (new ≠ current) | commit `<new>` as app-db |
+| `{:db db}` (the unchanged db) | **no-op** — `identical?` short-circuit, no container write |
+| `{:db nil}` | **coerced to `{:db {}}`** — app-db is always a map, never nil (+ a dev-mode `:rf.warning/db-nil-coerced` diagnostic; `{:db {}}` is the clean deliberate clear) |
+
+Two rows are correctness contracts apps may rely on:
+
+- **The `identical?` commit no-op.** When a `:db` effect carries the *same object* the frame already holds (`identical?`, not merely `=`), the commit step skips the physical container write entirely — no `:rf.event/db-changed` signal, and the projection reactions do not propagate. This is what keeps the common `{:db (if cond (assoc db …) db)}` shape cheap: the `else` arm returns the same object and costs nothing. Deeper change-detection stays value equality (`=`) — a different-object-but-equal-value commit still writes, and downstream `=`-memoisation collapses it; the cheap fast-path is reference identity. This same no-op is the optimization the standard `path` interceptor's Rule 4 preserves (§The standard path interceptor) and the partition-projection equality model (§One physical container, two projection reactions) buys for free.
+- **The `{:db nil}` → `{:db {}}` coercion.** App-db is always a map, never nil. A `:db nil` effect is coerced to `{}` at the `:db` effect → app-db commit boundary so the partition layer never sees a nil app-db. The coercion is usually masking a bug (a handler accidentally computed `nil`), so it emits the dev-mode diagnostic above; a deliberate clear should be the explicit `{:db {}}`.
+
+These commit semantics apply to **every** event — they are independent of the registration-surface collapse (per [EP-0018 §Commit / no-op family](../docs/EP/EP-0018-one-event-registration.md)).
 
 #### Write authority is by convention
 
@@ -778,7 +797,7 @@ The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe t
  :frame        :todo                   ;; resolved frame keyword
  :fx-overrides {:my-app/http stub-fn}  ;; per-dispatch fx replacements (master's dispatch-with)
  :trace-id     "..."                   ;; tooling/agent fields
- :source       :ui                     ;; trigger kind — the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui :frame-init :machine-spawn :machine-action :always :after-timer :fx-dispatch :fx-dispatch-later :http :repl :ssr-hydration :test :unknown :other`); defaults to `:unknown` per [rf2-hxj0d](https://github.com/day8/re-frame2/issues/rf2-hxj0d) (previously `:ui`); substrate-internal dispatch sites stamp the matching value (`:after-timer`, `:machine-spawn`, `:machine-action`, `:fx-dispatch`, `:fx-dispatch-later`) per [rf2-ejtpd](https://github.com/day8/re-frame2/issues/rf2-ejtpd) + [rf2-c3990](https://github.com/day8/re-frame2/issues/rf2-c3990)
+ :source       :ui                     ;; trigger kind — the canonical closed enum lives on `:rf/dispatch-envelope`'s `:source` row in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (the single source of the value set); defaults to `:unknown` (previously `:ui`); substrate-internal dispatch sites stamp the matching value (`:after-timer`, `:machine-spawn`, `:machine-action`, `:fx-dispatch`, `:fx-dispatch-later`). See [§Dispatch origin tagging](#dispatch-origin-tagging) below for the `:source` vs `:origin` distinction and the full inventory.
  :origin       :pair                   ;; actor identity — open vocabulary, defaults to `:app`; e.g. `:pair`, `:claude`, `:story`, `:test`
  :rf.cofx      {:rf/time-ms 1781078400123} ;; recordable coeffects (flat, fact-name→value) — see §Recordable coeffects
  ;; :rf.realm/id :rf.realm/default     ;; the owning realm — STAMPED only for a NON-default realm (absent = default)
@@ -1508,7 +1527,7 @@ Under run-to-completion, a dispatched event runs synchronously *before* the orig
 
 ### `:fx` ordering and atomicity guarantees
 
-When an `event-fx` handler returns `{:db <new-db> :fx [[a 1] [b 2] [c 3]]}`, the runtime processes the effect map under four locked rules. Apps may rely on them; conformant implementations must produce them.
+When an event handler returns `{:db <new-db> :fx [[a 1] [b 2] [c 3]]}`, the runtime processes the effect map under four locked rules. Apps may rely on them; conformant implementations must produce them.
 
 1. **`:db` is the first side effect (when present).** The snapshot transitions atomically in one step before any `:fx` entry is processed. No external observer ever sees a half-written `app-db`.
 2. **`:fx` entries are processed in source order.** `[a 1]` runs before `[b 2]` runs before `[c 3]`. The order in which the handler wrote the entries is the order in which they reach `do-fx`.
@@ -1692,6 +1711,15 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
       ;;    changed-partition tag(s). `contains?` is the WHOLE guard: a
       ;;    pre-install throw leaves no partition effect, so this is a no-op
       ;;    and the event aborts with both partitions unchanged.
+      ;;    `commit-frame-transition!` applies the §The `:db` commit / no-op
+      ;;    return family rules at this boundary: a `:db` effect carrying the
+      ;;    CURRENT object unchanged (`identical?`, not merely `=`) skips the
+      ;;    physical container write (the commit no-op short-circuit) — no
+      ;;    `:rf.event/db-changed`, no projection propagation; a `{:db nil}`
+      ;;    effect is coerced to `{:db {}}` (app-db is always a map) with a
+      ;;    dev-mode `:rf.warning/db-nil-coerced` diagnostic. Deeper
+      ;;    change-detection is value equality (`=`); the cheap fast-path is
+      ;;    reference identity.
       (when (or (contains? effects :db) (contains? effects :rf.db/runtime))
         (substrate/commit-frame-transition!                ;; one atomic frame-state install
           (:frame-state frame)
@@ -2225,7 +2253,7 @@ re-frame2 commits to a queryable public registrar for every kind of registered e
 
 | Query | Returns | JVM-runnable? |
 |---|---|---|
-| `(rf/registrations kind)` | Map of id → metadata for every handler of the given kind. The kind keyword set is canonicalised in [001 §The query API](001-Registration.md#the-query-api): `:event` (every `reg-event` handler), `:sub`, `:fx`, `:cofx`, `:view`, `:frame`, `:route`. Machines themselves register under `:event` (per [005](005-StateMachines.md)) — filter by `:rf/machine?` metadata to enumerate them. Machine guards and actions are **machine-scoped** (declared in each machine's `:guards` / `:actions` map) — there is no `:machine-guard` / `:machine-action` registry kind. App-db schemas are **not** a registrar kind either (rf2-cq1ak) — introspect via `schemas/app-schemas` / `schemas/app-schema-meta-at`. | Yes |
+| `(rf/registrations kind)` | Map of id → metadata for every handler of the given kind. The kind keyword set is canonicalised in [001 §The query API](001-Registration.md#the-query-api): `:event` (every `reg-event` handler), `:sub`, `:fx`, `:cofx`, `:interceptor` (every `reg-interceptor` handler — per [EP-0022](../docs/EP/EP-0022-registered-interceptors.md)), `:view`, `:frame`, `:route`. Machines themselves register under `:event` (per [005](005-StateMachines.md)) — filter by `:rf/machine?` metadata to enumerate them. Machine guards and actions are **machine-scoped** (declared in each machine's `:guards` / `:actions` map) — there is no `:machine-guard` / `:machine-action` registry kind. App-db schemas are **not** a registrar kind either (rf2-cq1ak) — introspect via `schemas/app-schemas` / `schemas/app-schema-meta-at`. | Yes |
 | `(rf/registrations kind pred-fn)` | Same, filtered by `pred-fn` applied to each metadata map. | Yes |
 | `(rf/handler-meta kind id)` | Metadata for a single handler (config, source coords, doc, spec, etc.). | Yes |
 | `(rf/frame-ids)` | Seq of all registered frame keywords. | Yes |
@@ -2246,7 +2274,7 @@ The metadata maps returned by `handler-meta` and `frame-meta` follow a documente
 
 - **Per-frame app-db inspection** — covered by `app-db-value` above.
 - **Trace per frame.** Each frame owns its own cascade-keyed trace ring. Trace events emitted inside an in-flight cascade route to the frame whose router / reactive substrate / view wrapper is running — they never cross into sibling frames. Each frame's ring is sized independently via `:rf.trace/cascades-retained` (default 50; per-frame override on `reg-frame`); `(rf/trace-buffer frame-id)` reads cascade bundles from that frame's ring; cross-frame consumers (pair tools, multi-frame story sessions) merge by `:dispatch-id` across rings. Frameless emits stream live to listeners only and bypass every ring. See [Spec 009 §Per-frame trace rings](009-Instrumentation.md#per-frame-trace-rings-cascade-keyed-dev-only) for the full contract.
-- **Hot-reload notifications.** `reg-frame`/`reg-event-*`/etc. re-registration fires notifications on a re-frame-internal pub/sub that tools can listen to and refresh their state. Per the B4 ruling, hot-reload re-emits are deduplicated by shape — unchanged re-registrations do not fire a trace event; only shape changes (handler-fn identity or metadata content) emit. The dedup table is process-scoped and dev-only.
+- **Hot-reload notifications.** `reg-frame`/`reg-event`/etc. re-registration fires notifications on a re-frame-internal pub/sub that tools can listen to and refresh their state. Per the B4 ruling, hot-reload re-emits are deduplicated by shape — unchanged re-registrations do not fire a trace event; only shape changes (handler-fn identity or metadata content) emit. The dedup table is process-scoped and dev-only.
 
 ## Story-tool foundation hooks — see Spec 007
 

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -84,7 +84,7 @@ frame-state  (the physical reactive container — make-state-container holds
    └── runtime-db = (make-derived-value [frame-state] #(:rf.db/runtime %))  ; layer-1 input for framework subs
 ```
 
-This is **pattern contract**, not merely one acceptable representation (Mike ruling #3 — it commits EP-0001 Open Issues 3 + 7). A conformant adapter MAY use a different internal arrangement **only if** it preserves the projection-equality semantics below; the reference adapter commits to the single container + two `make-derived-value` projections.
+This is **pattern contract**, not merely one acceptable representation (Mike ruling #3 — it commits EP-0001 Open Issues 3 + 7). A conformant adapter MAY use a different internal arrangement **only if** it preserves the projection-equality semantics below; the reference adapter commits to the single container + two `make-derived-value` projections. **This section owns the projection-equality pattern-contract** (the substrate realisation and the per-partition propagation rules); [002 §One physical container, two projection reactions](002-Frames.md#one-physical-container-two-projection-reactions) states the two-partition split at the frame contract and defers the substrate mechanism here.
 
 **Partition-aware invalidation falls out of `make-derived-value`'s memoised equality — no new machinery** (Mike ruling #7, no explicit dirty flags unless an adapter needs them). `make-derived-value` recomputes its `compute-fn` when its source changes but propagates only when the *result* changes (per [§`(make-derived-value …)`](#make-derived-value-source-containers-compute-fn--container) — the memoised-container contract):
 
@@ -186,7 +186,7 @@ Returns a derived container whose value is computed from one or more source cont
 
 The returned container supports `read-container`; `replace-container!` is **not** supported on derived containers. A derived value is computed from its sources — there is no slot to write into — so writing to one is a programmer error. The core's `replace-container!` choke point (the single point every frame app-db write flows through, sibling to the nil-container guard in [§`read-container` and `replace-container!`](#read-container-container--value-and-replace-container-container-new-value--nil)) detects the derived container, emits a `:rf.error/derived-container-replaced` trace (so error-listeners observe it), and throws the canonical thrown-error `ex-info` carrying `:rf.error/id :rf.error/derived-container-replaced` (per [009 §The thrown-error shape](009-Instrumentation.md#the-thrown-error-shape--the-rferrorid-ex-data-contract)); the underlying adapter `replace-container!` is not invoked. `subscribe-container` works as on a base container.
 
-Detecting a derived container is the **adapter's** responsibility, because no single host protocol separates the two shapes across every substrate: a Reagent `Reaction` reifies the host atom marker protocol (`clojure.lang.IAtom`) exactly as a base `r/atom` does, even though it is read-only. An adapter MAY therefore publish an optional `:adapter/derived-container?` late-bind hook (a 1-arg predicate); the choke point consults it first. The hook lives in the late-bind table rather than the adapter spec map so the 9-fn adapter contract shape is unchanged. The reference Reagent and reagent-slim adapters publish one keyed on the substrate's own disposal protocol (a `Reaction` is disposable; a base `r/atom` / `RAtom` is not). When no adapter publishes the hook, the choke point falls back to an atom-marker heuristic — a base container satisfies the host atom marker protocol (`clojure.lang.IAtom` on the JVM, `cljs.core/IAtom` on CLJS) while the adapter's derived value (an `IDeref`-only reify, or an `IDeref`+`IWatchable`+disposal reify) does not. Note the marker is `IAtom`, not `ISwap`/`IReset`: a ClojureScript `cljs.core/Atom` implements `IAtom` but not `ISwap`/`IReset` (`swap!` / `reset!` fast-path on the concrete `Atom` type), so only `IAtom` reliably marks a base atom on both hosts. That fall-back is sound for the plain-atom, test-react, UIx, and Helix reference adapters, whose derived values are not atom-shaped; it is the Reagent family alone that publishes the hook.
+Detecting a derived container is the **adapter's** responsibility, because no single host protocol separates the two shapes across every substrate: a Reagent `Reaction` reifies the host atom marker protocol (`clojure.lang.IAtom`) exactly as a base `r/atom` does, even though it is read-only. An adapter MAY therefore publish an optional `:adapter/derived-container?` late-bind hook (a 1-arg predicate); the choke point consults it first. The hook lives in the late-bind table rather than the adapter spec map so the ten-fn adapter contract shape (six required + three optional + one lifecycle, per §Normative contract) is unchanged. The reference Reagent and reagent-slim adapters publish one keyed on the substrate's own disposal protocol (a `Reaction` is disposable; a base `r/atom` / `RAtom` is not). When no adapter publishes the hook, the choke point falls back to an atom-marker heuristic — a base container satisfies the host atom marker protocol (`clojure.lang.IAtom` on the JVM, `cljs.core/IAtom` on CLJS) while the adapter's derived value (an `IDeref`-only reify, or an `IDeref`+`IWatchable`+disposal reify) does not. Note the marker is `IAtom`, not `ISwap`/`IReset`: a ClojureScript `cljs.core/Atom` implements `IAtom` but not `ISwap`/`IReset` (`swap!` / `reset!` fast-path on the concrete `Atom` type), so only `IAtom` reliably marks a base atom on both hosts. That fall-back is sound for the plain-atom, test-react, UIx, and Helix reference adapters, whose derived values are not atom-shaped; it is the Reagent family alone that publishes the hook.
 
 The derived container's caching responsibility is **adapter discretion**: an adapter MAY memoise the derived value (and is encouraged to where the host primitive makes it cheap — Reagent's `Reaction` does this for free), or MAY recompute on every `read-container` and rely on the **per-frame sub-cache** ([§Subscription cache — contract and operational semantics](#subscription-cache--contract-and-operational-semantics)) to enforce the `=`-equality invariant across recomputes. Either shape is conformant. What is NOT conformant: a derived container whose recompute fires for an input that did not change by `=` and whose downstream propagation does not collapse on `=`-equal new values — that would break the cascade rule in [§Invalidation algorithm](#invalidation-algorithm).
 
@@ -812,7 +812,7 @@ A related case is `subscribe` itself naming an unregistered sub-id — most ofte
 
 ## CLJS reference: Reagent as default adapter
 
-The CLJS reference ships **two** adapters across **two Maven artefacts**: the plain-atom (JVM/headless) adapter ships in the core artefact (`day8/re-frame2`); the Reagent adapter ships in its own sibling artefact (`day8/re-frame2-reagent`). Both implement the closed nine-fn contract above; the runtime picks per platform. UIx and Helix adapters ship as further sibling artefacts as they land. Per [Conventions §Adapter shipping convention](Conventions.md#adapter-shipping-convention) and rf2-0hxm.
+The CLJS reference ships **two** adapters across **two Maven artefacts**: the plain-atom (JVM/headless) adapter ships in the core artefact (`day8/re-frame2`); the Reagent adapter ships in its own sibling artefact (`day8/re-frame2-reagent`). Both implement the closed ten-fn contract above; the runtime picks per platform. UIx and Helix adapters ship as further sibling artefacts as they land. Per [Conventions §Adapter shipping convention](Conventions.md#adapter-shipping-convention) and rf2-0hxm.
 
 This section is the **bridging pseudocode** for both. For each contract function, the pseudocode shows which Reagent (or, on the JVM, plain-Clojure) primitive realises it. An AI implementing the CLJS reference can lift this directly; non-CLJS implementors read it as one worked example of the contract.
 
@@ -1077,7 +1077,7 @@ Both impls share the dynamic-var tier (`re-frame.frame/*current-frame*`, set by 
 
 ### Plain-atom adapter (JVM, SSR, headless)
 
-The **plain-atom adapter** is the same nine-fn contract realised against `clojure.core/atom` instead of Reagent. It is what runs on the JVM (per [000 §C2. Cross-platform: JVM interop preserved](000-Vision.md#c2-cross-platform-jvm-interop-preserved)) and what SSR and headless tests use ([§SSR-specific behaviour](#ssr-specific-behaviour), [008-Testing](008-Testing.md)).
+The **plain-atom adapter** is the same ten-fn contract realised against `clojure.core/atom` instead of Reagent. It is what runs on the JVM (per [000 §C2. Cross-platform: JVM interop preserved](000-Vision.md#c2-cross-platform-jvm-interop-preserved)) and what SSR and headless tests use ([§SSR-specific behaviour](#ssr-specific-behaviour), [008-Testing](008-Testing.md)).
 
 How it differs from the Reagent adapter:
 
@@ -1175,11 +1175,11 @@ A mixed-substrate app — say a build that imports both `re-frame.adapter.reagen
 
 `install-adapter!` is called once per process by `init!`'s implementation. Subsequent calls without an intervening `dispose-adapter!` raise `:rf.error/adapter-already-installed` ([§Single adapter per process](#single-adapter-per-process)).
 
-The CLJS adapter namespaces (Reagent, UIx, Helix) and the SSR namespace each export their `adapter` Var; the contract surface is the same nine-fn map (see [§The adapter API contract](#the-adapter-api-contract) above). The plain-atom adapter in `re-frame.substrate.plain-atom` is reachable on both JVM and CLJS — useful for headless tests on either platform.
+The CLJS adapter namespaces (Reagent, UIx, Helix) and the SSR namespace each export their `adapter` Var; the contract surface is the same ten-fn map (see [§The adapter API contract](#the-adapter-api-contract) above). The plain-atom adapter in `re-frame.substrate.plain-atom` is reachable on both JVM and CLJS — useful for headless tests on either platform.
 
 ## CLJS reference: UIx as alternative substrate
 
-The UIx adapter ships in `day8/re-frame2-uix` and implements the same nine-fn contract as the Reagent adapter — same observable behaviour for events, subs, effects; different rendering substrate for views.
+The UIx adapter ships in `day8/re-frame2-uix` and implements the same ten-fn contract as the Reagent adapter — same observable behaviour for events, subs, effects; different rendering substrate for views.
 
 Per the locked decisions (2026-05-09) are:
 
@@ -1203,7 +1203,7 @@ Every other adapter primitive (read, replace, subscribe-container, dispose) is s
 
 ## CLJS reference: Helix as alternative substrate
 
-The Helix adapter ships in `day8/re-frame2-helix` and implements the same nine-fn contract as the Reagent and UIx adapters — same observable behaviour for events, subs, effects; different rendering substrate for views. Helix occupies the *minimal-React-wrapper* niche: it is structurally similar to UIx (React + hooks; no reactive-atom primitive) but ships a smaller surface and does not auto-instrument hooks.
+The Helix adapter ships in `day8/re-frame2-helix` and implements the same ten-fn contract as the Reagent and UIx adapters — same observable behaviour for events, subs, effects; different rendering substrate for views. Helix occupies the *minimal-React-wrapper* niche: it is structurally similar to UIx (React + hooks; no reactive-atom primitive) but ships a smaller surface and does not auto-instrument hooks.
 
 Per the locked decisions (2026-05-10) transfer one-for-one from — the React + hooks substrate model is the same:
 
@@ -1228,7 +1228,7 @@ Every other adapter primitive (read, replace, subscribe-container, dispose) is s
 
 ## Cross-substrate affordance summary
 
-The nine-fn substrate contract is identical across adapters, but the three **view-author-facing** surfaces — *read a subscription*, *scope a frame to a subtree*, *flush pending renders in a test* — differ per substrate because each rides its host's idiom (Reagent's reactive deref vs the React-hooks model). A dev moving between substrates needs the one-glance map; this table is it. It documents the surfaces **after** the rf2-z7hfp restructure, in which each React-shaped adapter's `frame-provider` is a **native substrate component** (UIx `defui`, Helix `defnc`) rather than a re-exported plain fn handed to `$`.
+The ten-fn substrate contract is identical across adapters, but the three **view-author-facing** surfaces — *read a subscription*, *scope a frame to a subtree*, *flush pending renders in a test* — differ per substrate because each rides its host's idiom (Reagent's reactive deref vs the React-hooks model). A dev moving between substrates needs the one-glance map; this table is it. It documents the surfaces **after** the rf2-z7hfp restructure, in which each React-shaped adapter's `frame-provider` is a **native substrate component** (UIx `defui`, Helix `defnc`) rather than a re-exported plain fn handed to `$`.
 
 | Affordance | Reagent (`day8/re-frame2-reagent`) | UIx (`day8/re-frame2-uix`) | Helix (`day8/re-frame2-helix`) |
 |---|---|---|---|


### PR DESCRIPTION
Actions two AUTHORITATIVE beads against `spec/002-Frames.md` (+ `spec/006-ReactiveSubstrate.md`, named by w49y1w). Sole toucher of 002/006 this wave.

## rf2-sd76ub — spec-align (EP-0022 / EP-0018)

- **002**: add `:interceptor` (every `reg-interceptor` handler — per EP-0022) to the `(rf/registrations kind)` keyword set in the query-API table — it omitted the kind even though the section intro lists interceptors. Inserted after `:cofx`, matching 001's canonical Registry-model order.
- **002**: scrub EP-0018 term residue — `reg-event-*` glob → `reg-event` (hot-reload notifications bullet); `event-fx` handler name → `event` (the `:fx` ordering section). The single remaining `reg-event-db`/`reg-event-fx`/`reg-event-ctx` mention (the EP-0018 contract prose naming the *retired* forms as retired) is correct and left intact.

## rf2-w49y1w — slice-3 Frames/Reactive review

- **HIGH (002)**: the commit no-op contract had no spec home in the 002 body. Added a new **§The `:db` commit / no-op return family** subsection to the effect-map contract (the `nil` / `{}` / `{:db <new>}` / `{:db db}` identical?-no-op / `{:db nil}`→`{:db {}}` coercion table, mirroring EP-0018 §4a and the shipped `frame.cljc commit-frame-transition!` + `router.cljc` nil-coercion), and cited it at the commit step (drain step 2). The `identical?` no-op and the nil-coercion are stated as the correctness contracts they are — aligned to shipped reality, not weakened.
- **MED (006)**: reconciled the adapter-contract count — 006:105 said "ten entries" but :189/:815/:1080 (and three more spots) said "nine-fn". The authoritative Normative-contract table (6 required + 3 optional + 1 lifecycle = 10) + the impl header (`adapter.cljc:10-17`, all ten fns) confirm **ten**. Updated all seven 006 restatements to `ten-fn`.
- **MED (002+006)**: designated **006** the owner of the projection-equality pattern-contract; 002 now defers the substrate mechanism to 006 explicitly (the Ownership.md row is filed as a follow-up — Ownership.md is out of scope / hot-zone).
- **LOW (002)**: replaced a stale inline `:source` enum (14 values, missing `:router`/`:tool`/`:websocket`) in the dispatch-envelope code block with a citation to the canonical Spec-Schemas `:rf/dispatch-envelope` enum + a pointer to §Dispatch origin tagging (which already restates the correct 17-value list).

## Out of scope — follow-ups filed

- **rf2-v2qo4q** (P3): Derivations.md duplicated 3rd-member ordinal (735+771) + Resources/Routes first-process collision (HIGH; Derivations.md out of scope).
- **rf2-ewmh63** (P3): Ownership.md:31 effect-map closed set stale (`:db`+`:fx` → `#{:db :fx :rf.db/runtime}`) + add the projection-equality owner row (MED; Ownership.md hot-zone, out of scope).
- **rf2-8l156v** (P3): adapter.cljc:302 docstring still says "9-fn" — should be ten-fn to match the 006 reconcile (impl file out of scope).
- **rf2-c60kv3** (P3): the `snapshot-of` query-table row (002:2237) says "app-db" but 002's own prose places machine snapshots in runtime-db — sd76ub flagged this ADJACENT/out-of-4-EP-scope, "confirm with 005 owner before editing". Left as a genuine open decision per the bead.

## Decisions left

- The `snapshot-of` resolution semantics (rf2-c60kv3) — a genuine open contract question (resolve against runtime-db / app-db / whole frame-state?), deferred to the 005 owner per sd76ub's instruction. Not weakened or guessed.

## Quality gates

- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `python scripts/check_readme_links.py` — PASS (exit 0)
- `python -m mkdocs build --strict` (reproduced staging: `rm -rf docs/spec && cp -r spec docs/spec`) — PASS (exit 0; only pre-existing INFO lines from untouched files)