### PR TITLE
fix(adapters): release use-subscribe ref-count on abandoned (uncommitted) render

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -69,6 +69,39 @@
         v (helix-adapter/use-subscribe target [:rf.helix-use-subscribe-test/m])]
     (d/div (str "m=" v))))
 
+;; ---- Suspense abort-before-commit probes (rf2-es09qq) ---------------------
+;; ProbeSuspenseInner calls use-subscribe in its render phase, THEN renders a
+;; child that suspends (throws a never-resolving thenable). Under a concurrent
+;; root React begins rendering the subtree, runs the use-subscribe render
+;; phase, the child suspends, and React commits the Suspense FALLBACK instead
+;; — so the use-subscribe-calling fiber NEVER commits (its effects /
+;; store-subscribe never run). With the fix the render phase is net-zero on
+;; sub-cache ref-count, so the abandoned render leaks nothing.
+
+(defonce ^:private helix-never-resolving-thenable
+  ;; A thenable React treats as a pending Suspense source; it never resolves
+  ;; so the boundary stays on its fallback for the whole test.
+  #js {:then (fn [_resolve _reject] nil)})
+
+(defnc ProbeSuspender []
+  (throw helix-never-resolving-thenable))
+
+(defnc ProbeSuspenseInner []
+  ;; Render-phase use-subscribe acquisition happens HERE, before the
+  ;; suspending child unwinds the subtree.
+  (let [target @refcount-target
+        _v (helix-adapter/use-subscribe target [:rf.helix-use-subscribe-test/m])]
+    (d/div ($ ProbeSuspender))))
+
+(defn- helix-suspense-abort-element
+  "A React `Suspense` boundary (built with React/createElement so we don't
+  depend on a substrate suspense helper) wrapping a Helix probe that calls
+  use-subscribe then suspends. Returns a React element."
+  []
+  (React/createElement React/Suspense
+                       #js {:fallback (d/div "fallback")}
+                       ($ ProbeSuspenseInner)))
+
 ;; ---- sibling-collision probes (rf2-e4pyb) ---------------------------------
 ;; Two INDEPENDENT siblings reading the SAME query under the SAME frame —
 ;; they share one cached reaction. Each renders its observed value into a
@@ -172,6 +205,10 @@
    :probe-refcount-element (fn [] ($ ProbeRefcount))
    :rc-frame              :rf.helix-use-subscribe-test/refcount-frame
    :rc-query              :rf.helix-use-subscribe-test/m
+   ;; rf2-es09qq — Suspense abort-before-commit probe (reuses :rc-frame /
+   ;; :rc-query so the abandoned render and the committed control mount race
+   ;; on the SAME (frame, query)).
+   :probe-suspense-abort-element helix-suspense-abort-element
    ;; sibling-collision (rf2-e4pyb) — both siblings under one parent div so
    ;; the suite reads "a=N b=N" off textContent.
    :probe-siblings-element (fn [] ($ :div ($ ProbeSiblingA) ($ ProbeSiblingB)))
@@ -236,6 +273,12 @@
 ;; commit must leave no pinned sub-cache ref-count.
 (deftest use-subscribe-abandoned-render-no-refcount-leak
   (suite/assert-use-subscribe-abandoned-render-no-refcount-leak cfg))
+
+;; rf2-es09qq — a first-mount render aborted BEFORE commit via Suspense must
+;; leak no sub-cache ref-count (the real abort-before-commit path the rf2-879fe
+;; ledger could not reach — React discards the never-committed fiber).
+(deftest use-subscribe-suspense-abort-before-commit-no-refcount-leak
+  (suite/assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak cfg))
 
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -66,6 +66,41 @@
         v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     ($ :div (str "m=" v))))
 
+;; ---- Suspense abort-before-commit probes (rf2-es09qq) ---------------------
+;; ProbeSuspenseInner calls use-subscribe in its render phase, THEN renders a
+;; child that suspends (throws a never-resolving thenable). Under a concurrent
+;; root React begins rendering the subtree, runs the use-subscribe render
+;; phase, the child suspends, and React commits the Suspense FALLBACK instead
+;; — so the use-subscribe-calling fiber NEVER commits (its effects /
+;; store-subscribe never run). With the fix the render phase is net-zero on
+;; sub-cache ref-count, so the abandoned render leaks nothing.
+
+(defonce ^:private uix-never-resolving-thenable
+  ;; A thenable React will treat as a pending Suspense source. It never
+  ;; resolves, so the boundary stays on its fallback for the whole test —
+  ;; the inner probe's fiber is abandoned before commit and never retried
+  ;; to completion within the act() flush.
+  #js {:then (fn [_resolve _reject] nil)})
+
+(defui ProbeSuspender []
+  (throw uix-never-resolving-thenable))
+
+(defui ProbeSuspenseInner []
+  ;; Render-phase use-subscribe acquisition happens HERE, before the
+  ;; suspending child unwinds the subtree.
+  (let [target @refcount-target
+        _v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
+    ($ :div ($ ProbeSuspender))))
+
+(defn- uix-suspense-abort-element
+  "A React `Suspense` boundary (built with React/createElement so we don't
+  depend on a substrate suspense helper) wrapping a UIx probe that calls
+  use-subscribe then suspends. Returns a React element."
+  []
+  (React/createElement React/Suspense
+                       #js {:fallback ($ :div "fallback")}
+                       ($ ProbeSuspenseInner)))
+
 ;; ---- sibling-collision probes (rf2-e4pyb) ---------------------------------
 ;; Two INDEPENDENT siblings reading the SAME query under the SAME frame —
 ;; they share one cached reaction. Each renders its observed value into a
@@ -168,6 +203,10 @@
    :probe-refcount-element (fn [] (uix/$ ProbeRefcount))
    :rc-frame              :rf.uix-use-subscribe-test/refcount-frame
    :rc-query              :rf.uix-use-subscribe-test/m
+   ;; rf2-es09qq — Suspense abort-before-commit probe (reuses :rc-frame /
+   ;; :rc-query so the abandoned render and the committed control mount race
+   ;; on the SAME (frame, query)).
+   :probe-suspense-abort-element uix-suspense-abort-element
    ;; sibling-collision (rf2-e4pyb) — both siblings under one parent div so
    ;; the suite reads "a=N b=N" off textContent.
    :probe-siblings-element (fn [] (uix/$ :div (uix/$ ProbeSiblingA) (uix/$ ProbeSiblingB)))
@@ -232,6 +271,12 @@
 ;; commit must leave no pinned sub-cache ref-count.
 (deftest use-subscribe-abandoned-render-no-refcount-leak
   (suite/assert-use-subscribe-abandoned-render-no-refcount-leak cfg))
+
+;; rf2-es09qq — a first-mount render aborted BEFORE commit via Suspense must
+;; leak no sub-cache ref-count (the real abort-before-commit path the rf2-879fe
+;; ledger could not reach — React discards the never-committed fiber).
+(deftest use-subscribe-suspense-abort-before-commit-no-refcount-leak
+  (suite/assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak cfg))
 
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1538,78 +1538,62 @@
                 ;; same-by-= subsequent renders.
                 stable-frame-kw (aget stable-key 0)
                 stable-query-v  (aget stable-key 1)
-                ;; ---- render-phase acquisition ledger (rf2-879fe + rf2-8u8tx.2) ----
+                ;; ---- commit-deferred ref-count acquisition (rf2-es09qq) -------
                 ;;
-                ;; The memo factory calls `subs/subscribe`, which bumps the
-                ;; sub-cache ref-count (+1) — a RENDER-phase acquisition. The
-                ;; ONLY release used to be a `useEffect` cleanup keyed on the
-                ;; deps array, which is unbalanced for two documented React
-                ;; behaviours:
+                ;; THE INVARIANT: a render that never commits MUST NOT retain a
+                ;; sub-cache ref-count. The earlier design (rf2-879fe ledger) put
+                ;; the durable `subs/subscribe` (+1) in the render-phase `useMemo`
+                ;; factory and reclaimed it from commit-owned effects. That is
+                ;; unsound for a FIRST-MOUNT render abandoned before commit
+                ;; (Suspense / concurrent interrupt): React discards the whole
+                ;; fiber — its `useRef` ledger AND its never-run effects — so the
+                ;; render-phase +1 is pinned in the GLOBAL sub-cache forever with
+                ;; no owning component. The ledger only ever healed a render whose
+                ;; fiber LATER committed; a discarded first-mount fiber never gets
+                ;; that reconcile pass.
                 ;;
-                ;;   (rf2-879fe) An ABANDONED / suspended render that calls the
-                ;;     factory but never commits has no effect — so the cleanup
-                ;;     never runs and the +1 is pinned forever.
+                ;; FIX — the durable acquire/release lives ONLY in commit-owned
+                ;; hooks (`useSyncExternalStore`'s subscribe callback, run after
+                ;; commit; its cleanup run on unmount / subscribe-identity change
+                ;; / teardown). React NEVER calls that callback for a render that
+                ;; doesn't commit, so an abandoned render acquires NOTHING — the
+                ;; leak is gone BY CONSTRUCTION, independent of fiber discard.
                 ;;
-                ;;   (rf2-8u8tx.2) `useMemo` is a performance hint, NOT a
-                ;;     lifecycle: React MAY discard a cached value and re-run the
-                ;;     factory on UNCHANGED deps. Each re-run is another `subscribe`
-                ;;     (+1), but a deps-keyed effect does NOT re-fire without a deps
-                ;;     change, so no matching `unsubscribe` ever balances it.
+                ;; The render phase still needs a reaction HANDLE to read a
+                ;; snapshot for `useSyncExternalStore`. It obtains one with a
+                ;; BALANCED, net-zero round-trip — `subs/subscribe` immediately
+                ;; followed by `subs/unsubscribe` — so the render contributes ZERO
+                ;; outstanding ref-count whether or not it commits.
                 ;;
-                ;; FIX — drive-to-target ledger. Every render-phase `subscribe`
-                ;; is recorded in a `useRef` LEDGER keyed by a stable string
-                ;; `frame|query` token (a VALUE key, stable across renders, so
-                ;; memo-recompute and abandoned-render acquisitions for the SAME
-                ;; logical subscription accumulate in one slot). Each slot tracks
-                ;; `:n` — the ACTUAL outstanding ref-count this hook currently
-                ;; contributes for that (frame, query). Two commit-owned effects
-                ;; DRIVE `:n` toward a target by subscribing/unsubscribing the
-                ;; difference:
+                ;; In the COMMITTED steady state this round-trip is free of
+                ;; dispose churn: the `subscribe-fn` below holds a durable +1, so
+                ;; the render-phase subscribe bumps to 2 and the immediate
+                ;; unsubscribe drops back to 1 — never crossing the 1 → 0 disposal
+                ;; edge. The handle is the live cached reaction. The ONLY render
+                ;; with no durable backing is the FIRST mount before commit (and
+                ;; any never-committed render): there the round-trip disposes +
+                ;; rebuilds, but per rf2-cmfln the rebuilt value `=` the disposed
+                ;; one so `useSyncExternalStore` observes no tear — and that
+                ;; render leaves the cache exactly as it found it.
                 ;;
-                ;;   • a NO-DEPS reconcile effect (runs after EVERY commit, so a
-                ;;     no-deps-change memo recompute (rf2-8u8tx.2) is still seen)
-                ;;     drives the CURRENT key's `:n` to exactly 1 — RELEASING
-                ;;     memo-recompute duplicates AND, crucially, RE-ACQUIRING if a
-                ;;     prior cleanup drove it to 0 (the StrictMode effect double-
-                ;;     invoke). It drives EVERY OTHER key to 0 (acquisitions from
-                ;;     an abandoned/superseded render this commit replaced —
-                ;;     rf2-879fe).
-                ;;
-                ;;   • a `[stable-key]`-keyed release effect whose CLEANUP drives
-                ;;     the current key's `:n` to 0 on key-change / unmount.
-                ;;
-                ;; Both effects mutate the SAME `:n`, so they never double-release.
-                ;; Driving to target (not blind dec/release) means the reconcile
-                ;; effect restores the one live ref after a StrictMode cleanup
-                ;; zeroed it — re-subscribing yields the same cached reaction
-                ;; (the slot was disposed on its 1→0 edge and rebuilt; its value
-                ;; `=` the prior, so useSyncExternalStore observes no tear). Per
-                ;; Spec 006 §Reference counting and disposal (rf2-cmfln).
-                ;; The ledger lives in a `useRef` as a CLJS persistent map
-                ;;   {ledger-key {:fk frame-kw :qv query-v :n outstanding}}
-                ;; keyed by a stable string token. CLJS map access (no JS
-                ;; property inference) keeps the effects type-clean.
-                ledger-ref (React/useRef nil)
-                _ (when (nil? (.-current ledger-ref))
-                    (set! (.-current ledger-ref) {}))
-                ledger-key (str stable-frame-kw "|" (hash stable-query-v) "|"
-                                (pr-str stable-query-v))
+                ;; This subsumes the two prior leak triggers without a ledger or
+                ;; any reconcile/release effects:
+                ;;   • rf2-879fe (abandoned-before-commit) — render is net-zero;
+                ;;     the commit-owned acquire never ran. No leak.
+                ;;   • rf2-8u8tx.2 (useMemo perf-discard recompute on unchanged
+                ;;     deps) — each factory re-run is its own balanced round-trip,
+                ;;     so a discarded+rebuilt memo nets zero regardless of how many
+                ;;     times React re-runs it. No climb.
+                ;; Per Spec 006 §Reference counting and disposal (rf2-cmfln).
                 reaction
                 (use-memo (fn []
-                            ;; Render-phase acquisition: +1 ref-count AND record
-                            ;; it in the ledger so a later commit (the reconcile
-                            ;; effect) — or this render's release-effect cleanup —
-                            ;; reclaims it even if THIS render is abandoned before
-                            ;; its effects run.
-                            (let [r      (subs/subscribe stable-frame-kw stable-query-v)
-                                  ledger (.-current ledger-ref)
-                                  slot   (or (get ledger ledger-key)
-                                             {:fk stable-frame-kw
-                                              :qv stable-query-v
-                                              :n  0})]
-                              (set! (.-current ledger-ref)
-                                    (assoc ledger ledger-key
-                                           (update slot :n inc)))
+                            ;; Net-zero render-phase fetch of the reaction handle:
+                            ;; subscribe to read the cached reaction, then release
+                            ;; immediately so the render retains no ref-count. An
+                            ;; abandoned render leaks nothing; a committed render's
+                            ;; durable ref is taken later in `subscribe-fn`.
+                            (let [r (subs/subscribe stable-frame-kw stable-query-v)]
+                              (subs/unsubscribe stable-frame-kw stable-query-v)
                               r))
                           #js [stable-key])
                 ;; The store-snapshot fn React calls on every render to
@@ -1617,96 +1601,63 @@
                 get-snap
                 (use-callback (fn [] (when reaction @reaction))
                               #js [reaction])
-                ;; The store-subscribe fn — React calls it once with a
-                ;; force-update callback; we wire that up to add-watch
-                ;; on the reaction's underlying container.
+                ;; The store-subscribe fn — React's COMMIT-OWNED acquire/release
+                ;; pair. React calls it (once) only AFTER a commit, passing a
+                ;; force-update callback; its returned cleanup runs on unmount,
+                ;; on a subscribe-identity change, and on teardown. This is where
+                ;; the DURABLE sub-cache ref-count is taken (`subs/subscribe`) and
+                ;; released (`subs/unsubscribe`) — never in render — so a render
+                ;; abandoned before commit acquires no ref. We re-subscribe by
+                ;; (frame, query) here rather than trust the render-phase handle's
+                ;; ref-count (which was balanced to zero).
+                ;;
+                ;; MEMOIZED ON `[stable-key]`, NOT `[reaction]` (rf2-es09qq). The
+                ;; render-phase handle object can differ from the committed one
+                ;; on first mount (the balanced round-trip may dispose + rebuild
+                ;; the reaction before `subscribe-fn` re-acquires it), so keying
+                ;; on `reaction` would change subscribe-fn identity right after
+                ;; the first commit — forcing React to release (dispose) and
+                ;; re-acquire the durable ref every time the handle churned.
+                ;; `stable-key` is identity-stable for a fixed (frame, query), so
+                ;; React calls subscribe-fn exactly ONCE per subscription target:
+                ;; one durable acquire, one release, no churn. The watch is added
+                ;; on the freshly-acquired `committed` reaction inside, so it
+                ;; always tracks the live cached reaction regardless of the
+                ;; render-phase handle's identity.
                 subscribe-fn
                 (use-callback
                   (fn [on-change]
-                    ;; UNIQUE watch key per `subscribe-fn` INVOCATION,
-                    ;; closed over by the returned cleanup. The key MUST
-                    ;; NOT derive from `(hash reaction)`: subscriptions are
-                    ;; cached/deduped by query, so sibling UIx/Helix
-                    ;; components reading the SAME query share the SAME
-                    ;; cached reaction. A hash-of-reaction key would be
-                    ;; IDENTICAL across those siblings, and `add-watch`
-                    ;; replaces an existing watcher with the same key — so
-                    ;; the last-mounted sibling's `on-change` would silently
-                    ;; overwrite every earlier sibling's `useSyncExternalStore`
-                    ;; callback, leaving the earlier ones rendering stale UI
-                    ;; until an unrelated parent render refreshed them.
-                    ;; `subscribe-fn` is `use-callback`-memoized on
-                    ;; `[reaction]`, so React calls it once per
-                    ;; reaction-identity change (NOT per render); a fresh
-                    ;; keyword per call is cheap and collision-free.
-                    (let [k (keyword use-sub-watch-ns (str (gensym "watch-")))]
-                      (when reaction
-                        (add-watch reaction k (fn [_ _ _ _] (on-change))))
-                      (fn unsubscribe []
-                        (when reaction (remove-watch reaction k)))))
-                  #js [reaction])]
-            ;; ---- commit-owned reconcile (rf2-879fe + rf2-8u8tx.2) ----
-            ;;
-            ;; Runs after EVERY commit (deliberately NO deps array — a memo
-            ;; recompute that does NOT change `stable-key` still re-runs this, so
-            ;; the extra render-phase `subscribe` it made (rf2-8u8tx.2) is
-            ;; reclaimed here). Drives the ledger to target by subscribe/
-            ;; unsubscribe of the difference:
-            ;;
-            ;;   1. CURRENT key  → target 1. If `:n` is above 1, release the
-            ;;      memo-recompute duplicates; if a prior cleanup drove it to 0
-            ;;      (StrictMode effect double-invoke), RE-ACQUIRE one — restoring
-            ;;      the live committed ref.
-            ;;   2. EVERY OTHER key → target 0. Those are render-phase acquisitions
-            ;;      from a render this commit SUPERSEDED (an abandoned/suspended
-            ;;      render that never committed — rf2-879fe — or a stale pre-key-
-            ;;      change slot). Fully released so nothing stays pinned.
-            ;;
-            ;; NO cleanup on this effect (a cleanup would churn the live ref every
-            ;; render); prompt key-change/unmount release is owned by the
-            ;; `[stable-key]`-keyed effect below, which shares the same `:n`.
-            (React/useEffect
-              (fn use-subscribe-reconcile []
-                (let [ledger (.-current ledger-ref)]
-                  ;; First: every OTHER key → target 0 (release abandoned /
-                  ;; superseded render-phase acquisitions, rf2-879fe).
-                  (doseq [[k slot] ledger
-                          :when (not= k ledger-key)]
-                    (dotimes [_ (:n slot)]
-                      (subs/unsubscribe (:fk slot) (:qv slot))))
-                  ;; Then: the CURRENT key → target 1. Recreate the slot if a
-                  ;; prior cleanup dropped it (the StrictMode effect double-
-                  ;; invoke drove it to 0; this re-invoke must restore the one
-                  ;; live committed ref). Re-acquiring yields the same cached
-                  ;; reaction value (`=` the disposed one) so no tear is seen.
-                  (let [slot (or (get ledger ledger-key)
-                                 {:fk stable-frame-kw :qv stable-query-v :n 0})
-                        n    (:n slot)]
-                    (cond
-                      (> n 1) (dotimes [_ (dec n)]
-                                (subs/unsubscribe (:fk slot) (:qv slot)))
-                      (< n 1) (subs/subscribe (:fk slot) (:qv slot)))
-                    ;; ledger now holds ONLY the current key, pinned at 1.
-                    (set! (.-current ledger-ref)
-                          {ledger-key (assoc slot :n 1)})))
-                js/undefined))
-            ;; ---- prompt release on key-change / unmount ----
-            ;;
-            ;; Keyed on `[stable-key]` so React fires this cleanup before the new
-            ;; key's effects (key change) and on unmount. Drives the current key's
-            ;; `:n` to 0 and drops its slot. Per rf2-cmfln the 1 → 0 edge disposes
-            ;; synchronously; on a key change the reconcile effect above then
-            ;; re-pins the new key to 1.
-            (React/useEffect
-              (fn use-subscribe-release []
-                (fn cleanup []
-                  (let [ledger (.-current ledger-ref)
-                        slot   (get ledger ledger-key)]
-                    (when slot
-                      (dotimes [_ (:n slot)]
-                        (subs/unsubscribe (:fk slot) (:qv slot)))
-                      (set! (.-current ledger-ref) (dissoc ledger ledger-key))))))
-              #js [stable-key])
+                    ;; Take the durable committed ref now (post-commit). This is
+                    ;; the ONLY place a lasting +1 is acquired. The returned
+                    ;; reaction is the live cached one and `=` (often identical)
+                    ;; to the render-phase handle `reaction`.
+                    (let [committed (subs/subscribe stable-frame-kw stable-query-v)]
+                      ;; UNIQUE watch key per `subscribe-fn` INVOCATION,
+                      ;; closed over by the returned cleanup. The key MUST
+                      ;; NOT derive from `(hash reaction)`: subscriptions are
+                      ;; cached/deduped by query, so sibling UIx/Helix
+                      ;; components reading the SAME query share the SAME
+                      ;; cached reaction. A hash-of-reaction key would be
+                      ;; IDENTICAL across those siblings, and `add-watch`
+                      ;; replaces an existing watcher with the same key — so
+                      ;; the last-mounted sibling's `on-change` would silently
+                      ;; overwrite every earlier sibling's `useSyncExternalStore`
+                      ;; callback, leaving the earlier ones rendering stale UI
+                      ;; until an unrelated parent render refreshed them.
+                      ;; `subscribe-fn` is `use-callback`-memoized on
+                      ;; `[stable-key]`, so React calls it once per subscription
+                      ;; target (NOT per render); a fresh keyword per call is
+                      ;; cheap and collision-free.
+                      (let [k (keyword use-sub-watch-ns (str (gensym "watch-")))]
+                        (when committed
+                          (add-watch committed k (fn [_ _ _ _] (on-change))))
+                        (fn unsubscribe []
+                          (when committed (remove-watch committed k))
+                          ;; Release the durable committed ref — symmetric with
+                          ;; the `subs/subscribe` above. Runs on unmount /
+                          ;; key change / teardown.
+                          (subs/unsubscribe stable-frame-kw stable-query-v)))))
+                  #js [stable-key])]
             (React/useSyncExternalStore subscribe-fn get-snap get-snap)))
         use-subscribe
         (fn use-subscribe

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -3455,9 +3455,21 @@
             (try (.unmount root) (catch :default _ nil)))))))))
 
 (defn assert-use-subscribe-stable-deps-key
-  "rf2-mwft2: stable-literal query-v across N re-renders ⇒ exactly one
-  subs/subscribe call (the deps element is JS-ref-stable across renders),
-  and the useEffect cleanup (rf2-7g959) fires only on unmount.
+  "rf2-mwft2 (+ rf2-es09qq lifecycle): a stable-literal query-v across N
+  re-renders must not cause the sub-cache ref-count to CHURN — it stays
+  pinned at exactly 1 throughout and returns to 0 on unmount.
+
+  rf2-es09qq changed the acquisition lifecycle: the render-phase reaction
+  fetch is now a BALANCED `subs/subscribe` + `subs/unsubscribe` round-trip
+  (net 0), and the single DURABLE ref is taken/released only in the
+  commit-owned `useSyncExternalStore` subscribe callback. So the meaningful
+  invariant is no longer 'exactly one raw subscribe call' (the OLD design's
+  proxy) but: (a) every render's subscribe/unsubscribe calls are BALANCED, so
+  the committed steady state never crosses the 1 → 0 disposal edge, and
+  (b) the net cache ref-count is pinned at 1 across re-renders and drops to 0
+  on unmount. The stable deps key (rf2-mwft2) still matters: it keeps the
+  memo/callback identities stable so React doesn't re-run the commit-owned
+  subscribe per render (which WOULD churn the durable ref).
 
   cfg keys:
     :probe-stable-deps-element  thunk → the ProbeStableDepsParent element.
@@ -3516,32 +3528,40 @@
                          (swap! unsubscribe-calls inc)
                          (real-unsubscribe frame-id query-v)))]
           (try
-            ;; Mount — one subs/subscribe for the useMemo factory.
+            ;; Mount. The render-phase fetch is a balanced subscribe+unsubscribe
+            ;; round-trip; the commit-owned subscribe-fn takes the durable ref.
+            ;; What MUST hold: the net cache ref-count is exactly 1, and every
+            ;; subscribe is balanced by an unsubscribe except the single durable
+            ;; committed one (so subscribe-calls = unsubscribe-calls + 1).
             (act-fn (fn [] (.render root (probe-stable-deps-element))))
-            (let [mounted-subs @subscribe-calls]
-              (is (= 1 mounted-subs)
-                  "mount triggered exactly one subs/subscribe call")
-              (is (zero? @unsubscribe-calls)
-                  "no subs/unsubscribe fires during initial mount")
+            (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                "after mount the sub-cache ref-count is exactly 1 (one durable committed ref)")
+            (is (= (inc @unsubscribe-calls) @subscribe-calls)
+                (str "after mount subscribe/unsubscribe are balanced bar the one "
+                     "durable committed ref (subscribe=" @subscribe-calls
+                     " unsubscribe=" @unsubscribe-calls ")"))
+            (let [subs-after-mount   @subscribe-calls
+                  unsubs-after-mount @unsubscribe-calls]
               ;; Force five re-renders by bumping the parent's tick state.
-              ;; Each parent render also re-renders the child probe with a
-              ;; freshly-allocated CLJS vector for the query-v — without
-              ;; the fix the deps mismatch would re-run useMemo (extra
-              ;; subscribe) and useEffect (extra unsubscribe) each render.
+              ;; Each parent render re-renders the child probe with a freshly-
+              ;; allocated CLJS vector for the query-v — the stable deps key
+              ;; (rf2-mwft2) keeps useMemo/useCallback identities stable so
+              ;; React does NOT re-run the commit-owned subscribe per render.
               (dotimes [_ 5]
                 (act-fn (fn [] (when-let [set-tick @stable-deps-set-tick]
                                  (set-tick inc)))))
-              (is (= 1 @subscribe-calls)
-                  "subs/subscribe still called only once after 5 re-renders (no per-render churn)")
-              (is (zero? @unsubscribe-calls)
-                  "subs/unsubscribe never fired across re-renders — useEffect cleanup is unmount-only")
+              ;; Steady state: the durable committed ref is untouched (the
+              ;; commit-owned subscribe-fn's identity is stable on [stable-key]),
+              ;; so any per-render render-phase round-trips are fully balanced.
+              (is (= (- @subscribe-calls subs-after-mount)
+                     (- @unsubscribe-calls unsubs-after-mount))
+                  "across 5 re-renders every render-phase subscribe is balanced by an unsubscribe (no durable churn)")
               (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
-                  "sub-cache ref-count remains pinned at 1 across re-renders"))
-            ;; Unmount must fire exactly one unsubscribe — the rf2-7g959
-            ;; cleanup pairing must survive the rf2-mwft2 rewrite.
+                  "sub-cache ref-count remains pinned at 1 across re-renders (no churn across the disposal edge)"))
+            ;; Unmount releases the single durable committed ref.
             (act-fn (fn [] (.unmount root)))
-            (is (= 1 @unsubscribe-calls)
-                "unmount fired exactly one subs/unsubscribe (rf2-7g959 cleanup survives the rf2-mwft2 rewrite)")
+            (is (= @subscribe-calls @unsubscribe-calls)
+                "after unmount every subscribe is balanced by an unsubscribe (the durable ref was released)")
             (is (or (nil? (get @cache cache-key-v))
                     (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
                 "post-unmount cache entry dropped or ref-count at zero")
@@ -3670,31 +3690,40 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
-;; ---- render-phase ref-count-leak regressions (rf2-879fe + rf2-8u8tx.2) ----
+;; ---- render-phase ref-count-leak regressions (rf2-879fe + rf2-8u8tx.2 +
+;;      rf2-es09qq) ----
 ;;
-;; The shared spine's `use-subscribe` acquires the sub-cache ref by calling
-;; `subs/subscribe` inside the `useMemo` factory — a RENDER-phase acquisition.
-;; The release used to live ONLY in a deps-keyed `useEffect` cleanup, which
-;; left two ways for the cache ref-count to leak. These two assertions pin
-;; both triggers; both reuse the refcount-probe cfg surface.
+;; The shared spine's `use-subscribe` reads the cached reaction during render
+;; (a render-phase `subs/subscribe`) but — since rf2-es09qq — IMMEDIATELY
+;; balances it with `subs/unsubscribe`, so the render phase nets ZERO ref-count
+;; whether or not it commits. The DURABLE ref is taken/released only in the
+;; commit-owned `useSyncExternalStore` subscribe callback (run after commit;
+;; its cleanup on unmount / key change / teardown). These assertions pin the
+;; three documented ways the OLD design (render-phase +1 reclaimed by effects)
+;; leaked; all reuse the refcount-probe cfg surface.
 ;;
 ;;   • rf2-8u8tx.2 — `useMemo` is a perf hint, not a lifecycle: React may
-;;     DISCARD a cached memo and re-run the factory on UNCHANGED deps. Each
-;;     re-run was another `subscribe` (+1) with no matching cleanup (the
-;;     deps-keyed effect does not re-fire without a deps change) ⇒ the
-;;     ref-count climbs per discarded memo. We simulate the documented
-;;     discard by patching `React.useMemo` to always re-run its factory while
-;;     forcing several committed re-renders, then assert the ref-count stayed
-;;     pinned at exactly 1 (not N) and dropped to 0 on unmount.
+;;     DISCARD a cached memo and re-run the factory on UNCHANGED deps. Under
+;;     the old design each re-run was another unbalanced `subscribe` (+1) ⇒ the
+;;     ref-count climbed per discarded memo. Now each factory re-run is its own
+;;     balanced round-trip (net 0), so the count can never climb. We simulate
+;;     the documented discard by patching `React.useMemo` to always re-run its
+;;     factory while forcing several committed re-renders, then assert the
+;;     ref-count stayed pinned at exactly 1 (the committed durable ref, not N)
+;;     and dropped to 0 on unmount.
 ;;
-;;   • rf2-879fe — a concurrent render that runs `use-subscribe` (the memo
-;;     factory subscribes) and is then ABANDONED before commit (React
-;;     restarts the render) has no committed effect of its own, but the SAME
-;;     fiber's eventual committed render reconciles the accumulated render-
-;;     phase acquisitions back to one. We simulate the abandoned-then-
-;;     restarted render by making the memo factory run multiple times across
-;;     renders that do commit (the realistic concurrent-interrupt shape) and
-;;     assert no ref-count is pinned beyond the single live subscription.
+;;   • rf2-879fe — a render that runs `use-subscribe` multiple times across
+;;     interrupt/restart before its eventual commit. Each render-phase
+;;     acquisition is now self-balancing, and the single committed mount takes
+;;     exactly one durable ref. We simulate the multi-acquisition shape by
+;;     re-running the memo factory N times within a committing render and assert
+;;     no ref-count is pinned beyond the single live committed subscription.
+;;
+;;   • rf2-es09qq — the FIRST-MOUNT render aborted BEFORE commit (real Suspense
+;;     unwind). React discards the never-committed fiber, so the old ledger +
+;;     effects could not reclaim its render-phase +1. With the balanced
+;;     round-trip the abandoned render acquires nothing. Asserted by
+;;     `assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak`.
 
 (defn assert-use-subscribe-memo-recompute-no-refcount-leak
   "rf2-8u8tx.2: a `useMemo` factory re-run on UNCHANGED deps (React's
@@ -3702,8 +3731,13 @@
   `React.useMemo` so its factory re-runs every render, drives several
   committed re-renders of the use-subscribe refcount probe, and asserts the
   (frame, query) cache ref-count stays pinned at exactly 1 throughout — then
-  drops to 0/absent on unmount. On the pre-fix spine the ref-count climbs by
-  one per discarded memo and never returns to 0.
+  drops to 0/absent on unmount.
+
+  Since rf2-es09qq the render-phase factory is a balanced subscribe+unsubscribe
+  round-trip (net 0), so any number of discarded+rebuilt memo re-runs nets zero
+  — the single durable ref is owned by the commit-owned `subscribe-fn`. On the
+  pre-fix spine the render-phase +1 was unbalanced, so the ref-count climbed by
+  one per discarded memo and never returned to 0.
 
   cfg keys: reuses the refcount-probe surface
     :probe-refcount-element / :refcount-target / :rc-frame / :rc-query"
@@ -3733,9 +3767,10 @@
           (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
               "after mount the memo-recompute probe pins exactly one ref-count")
           ;; Force several committed re-renders. Each re-render re-runs the
-          ;; (patched, always-recompute) memo factory ⇒ a fresh subscribe;
-          ;; the commit-owned reconcile must release every duplicate so the
-          ;; ref-count never climbs above 1.
+          ;; (patched, always-recompute) memo factory ⇒ a balanced
+          ;; subscribe+unsubscribe round-trip (net 0), so the durable ref held
+          ;; by the commit-owned subscribe-fn keeps the ref-count pinned at 1
+          ;; and a discarded memo can never climb it.
           (dotimes [_ 6]
             (act-fn (fn [] (.render root (probe-refcount-element)))))
           (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
@@ -3751,14 +3786,16 @@
             (try (.unmount root) (catch :default _ nil)))))))))
 
 (defn assert-use-subscribe-abandoned-render-no-refcount-leak
-  "rf2-879fe: a render that runs `use-subscribe` (memo factory subscribes,
-  +1 ref-count) and is then ABANDONED before commit must not pin the
-  sub-cache. We exercise the realistic concurrent-interrupt shape: a fiber
-  whose memo factory ran several render-phase acquisitions (interrupted +
-  restarted renders) and then committed. The committed render's reconcile
-  must drain those accumulated acquisitions back to exactly one live ref;
-  unmount returns it to zero. On the pre-fix spine each abandoned render's
-  +1 was pinned with no matching cleanup.
+  "rf2-879fe (multi-acquisition committing render): a fiber whose memo factory
+  ran several render-phase acquisitions (interrupted + restarted renders) and
+  then committed must end with exactly one live ref; unmount returns it to
+  zero. Since rf2-es09qq each render-phase acquisition is a balanced
+  subscribe+unsubscribe round-trip (net 0) and the single durable ref is owned
+  by the commit-owned subscribe-fn, so N factory re-runs collapse to one live
+  ref by construction. (The genuine first-mount-ABANDONED-before-commit path —
+  which the old ledger could not reach — is covered separately by
+  `assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak`,
+  rf2-es09qq.) On the pre-fix spine each render-phase +1 was unbalanced.
 
   We simulate the multiple render-phase acquisitions by patching
   `React.useMemo` to re-run its factory N times within a single render
@@ -3782,17 +3819,19 @@
             root          (react-dom-client/createRoot mount-node)
             real-use-memo (.-useMemo React)]
         ;; Each render the memo factory is run 3 times — three render-phase
-        ;; `subscribe`s feeding the SAME fiber's ledger, modelling an
-        ;; abandoned-then-restarted concurrent render whose acquisitions
-        ;; accumulate before the eventual commit. React calls the factory
-        ;; itself once per useMemo; we re-run it the extra times here.
+        ;; round-trips for the SAME fiber, modelling an abandoned-then-restarted
+        ;; concurrent render whose acquisitions accumulate before the eventual
+        ;; commit. React calls the factory itself once per useMemo; we re-run it
+        ;; the extra times here.
         (set! (.-useMemo React)
               (fn patched-use-memo [factory _deps]
                 (factory) (factory) (factory)))
         (try
           (act-fn (fn [] (.render root (probe-refcount-element))))
-          ;; The mount committed once. Three render-phase acquisitions landed
-          ;; on the ledger; the commit-owned reconcile must drain them to one.
+          ;; The mount committed once. The three render-phase round-trips are
+          ;; each net-zero (subscribe + immediate unsubscribe); the single
+          ;; durable ref is taken by the commit-owned subscribe-fn, so exactly
+          ;; one ref is pinned.
           (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
               (str "after a multi-acquisition (abandoned/restarted) render commits, "
                    "exactly one ref-count is pinned — NOT one-per-render-phase-"
@@ -3805,6 +3844,92 @@
           (finally
             (set! (.-useMemo React) real-use-memo)
             (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak
+  "rf2-es09qq: a FIRST-MOUNT render that runs `use-subscribe` (its render-
+  phase factory) and is then ABANDONED before commit must leave NO sub-cache
+  ref-count behind — the leak the prior rf2-879fe `useRef` ledger could not
+  reach, because React discards the never-committed fiber (its ledger AND its
+  effects) so nothing ever reclaims a render-phase acquisition.
+
+  This drives the REAL abort-before-commit path with Suspense: a probe
+  component calls `use-subscribe` and then renders a child that SUSPENDS
+  (throws a never-resolving thenable). Under a concurrent `createRoot`, React
+  begins rendering the subtree (running the probe's `use-subscribe` render
+  phase), the child suspends, React unwinds and commits the `Suspense`
+  FALLBACK instead — the probe fiber never commits, so its store-subscribe /
+  effects never run. With the fix the render phase is net-zero on ref-count,
+  so the global sub-cache is left exactly as it was found: no pinned entry,
+  no live reaction without an owning component.
+
+  Then it mounts a NORMAL (non-suspending) committed probe on the SAME query
+  and unmounts it, proving the query returns cleanly to zero refs through the
+  ordinary committed lifecycle — i.e. the abandoned render did not corrupt the
+  ledger for a later legitimate subscriber.
+
+  On the PRE-fix spine the suspended probe's render-phase `subscribe` pins a
+  +1 in the cache with no owning fiber, so the entry survives the fallback
+  commit (ref-count >= 1) and the later committed mount/unmount leaves it
+  pinned above zero.
+
+  cfg keys:
+    :probe-suspense-abort-element  thunk → an ELEMENT that wraps a
+      use-subscribe-calling probe + a suspending child inside a Suspense
+      boundary with a fallback (substrate-built; reads :refcount-target for
+      the frame, queries :rc-query)
+    :probe-refcount-element / :refcount-target / :rc-frame / :rc-query — the
+      shared refcount-probe surface, reused for the committed control mount."
+  [{:keys [name probe-suspense-abort-element probe-refcount-element
+           refcount-target rc-frame rc-query]}]
+  (testing (str name " — use-subscribe abandoned BEFORE commit (Suspense) leaks no sub-cache ref-count (rf2-es09qq)")
+    (if (nil? probe-suspense-abort-element)
+      (is true (str name ": no Suspense-abort probe wired; substrate skips this case"))
+      (with-browser-act
+       (fn [act-fn]
+        (reset! refcount-target rc-frame)
+        (rf/reg-frame rc-frame {:doc "rf2-es09qq suspense-abort refcount probe frame"})
+        (rf/reg-event ::sa-seed (fn [{:keys [db]} _] {:db {:m 0}}))
+        (rf/dispatch-sync [::sa-seed] {:frame rc-frame})
+        (rf/reg-sub rc-query (fn [db _] (:m db)))
+        (let [cache-key-v [rc-query]
+              cache       (:sub-cache (frame/frame rc-frame))
+              mount-node  (make-mount-node!)
+              root        (react-dom-client/createRoot mount-node)]
+          (try
+            ;; Render the Suspense tree. The probe runs `use-subscribe` in its
+            ;; render phase; its suspending child throws, so React commits the
+            ;; FALLBACK and the probe fiber never commits.
+            (act-fn (fn [] (.render root (probe-suspense-abort-element))))
+            ;; The committed tree is the fallback — the use-subscribe-calling
+            ;; probe was abandoned before commit. No ref-count may be pinned.
+            (is (or (nil? (get @cache cache-key-v))
+                    (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                (str "after a Suspense-aborted (never-committed) render, the "
+                     "sub-cache holds NO ref-count for the query — observed "
+                     (or (get-in @cache [cache-key-v :ref-count]) "<absent>")))
+            ;; Tear down the suspended tree.
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache cache-key-v))
+                    (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                "post-unmount of the suspended tree: still no pinned ref-count")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))
+          ;; ---- committed-mount control: a later legitimate subscriber on
+          ;; the SAME query subscribes to exactly one ref and releases it on
+          ;; unmount, proving the abandoned render left the ledger uncorrupted.
+          (let [root2 (react-dom-client/createRoot (make-mount-node!))]
+            (try
+              (act-fn (fn [] (.render root2 (probe-refcount-element))))
+              (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                  (str "a later committed mount on the same query pins exactly "
+                       "one ref-count — observed "
+                       (or (get-in @cache [cache-key-v :ref-count]) 0)))
+              (act-fn (fn [] (.unmount root2)))
+              (is (or (nil? (get @cache cache-key-v))
+                      (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                  "after the committed mount unmounts, the query returns to zero refs")
+              (finally
+                (try (.unmount root2) (catch :default _ nil)))))))))))
 
 ;; ---- unsubscribe arity contract (rf2-gizlj) -------------------------------
 ;;


### PR DESCRIPTION
Fixes **rf2-es09qq** (P2, BUG — React concurrent-mode correctness).

## Problem

UIx/Helix `use-subscribe` could leak a sub-cache ref-count from a first-mount render abandoned **before commit** (Suspense / concurrent interrupt). The render-phase `use-memo` factory (`spine.cljs`) called `subs/subscribe` (+1); the durable release lived in commit-owned `useEffect`s that run only after commit. React discards a never-committed fiber along with its `useRef` ledger **and** its never-run effects, so the +1 was pinned in the global sub-cache forever with no owning component, leaving cached reactions alive. The prior rf2-879fe ledger only healed a fiber that *later* committed; a discarded first-mount fiber never got that reconcile pass.

## Fix

The durable ref-count acquire/release now lives **only** in the commit-owned `useSyncExternalStore` subscribe callback — React calls it after commit, and runs its cleanup on unmount / subscribe-identity change / teardown. React never calls that callback for a render that doesn't commit, so an abandoned render acquires nothing: the leak is gone **by construction**, independent of fiber discard.

The render phase still needs a reaction handle for the snapshot, so it fetches one with a **balanced, net-zero** `subscribe`+`unsubscribe` round-trip — the render retains no ref-count whether or not it commits. In the committed steady state the durable +1 (held by the store-subscribe callback) keeps the slot above the 1→0 disposal edge, so the round-trip causes no dispose churn; the only render with no durable backing is the never-committed one, where the round-trip is irrelevant. `subscribe-fn` is memoized on `[stable-key]` (not `[reaction]`) so React acquires exactly **one** durable ref per subscription target — no churn when the render-phase handle's identity changes on first mount.

This removes the fiber-local `useRef` ledger and both reconcile/release effects entirely. It subsumes the two prior leak triggers without the ledger:
- rf2-879fe (abandoned-before-commit) — render is net-zero.
- rf2-8u8tx.2 (`useMemo` perf-discard recompute) — each factory re-run is its own balanced round-trip.

Spec unchanged: Spec 006 §Reference counting and disposal is a behavioral contract ("ref-count reflects live readers; dispose synchronously on 1→0"); render-phase-vs-commit acquisition is a spine implementation detail, not specified. The fix keeps the count accurate.

## Tests

- **NEW** `assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak` (UIx + Helix): drives the **real** abort-before-commit path with a `React.Suspense` boundary whose inner probe calls `use-subscribe` then renders a child that suspends (never-resolving thenable). React commits the *fallback*, so the use-subscribe-calling fiber never commits. Asserts (a) no pinned ref-count after the aborted render, (b) post-unmount still zero, and (c) a later committed mount/unmount on the same query returns it cleanly to zero refs. This fails on the pre-fix spine.
- Updated `assert-use-subscribe-stable-deps-key` to the new lifecycle: per-render subscribe/unsubscribe are balanced, net cache ref-count pinned at 1 across re-renders, zero on unmount.
- StrictMode double-mount (rf2-nymuy), memo-recompute (rf2-8u8tx.2), abandoned-render (rf2-879fe), siblings-same-query, tracks-app-db, and the 2-arity-contract (rf2-gizlj) assertions hold unchanged.

## Quality gates

Run from `implementation/` in the worker worktree (Windows):

- `shadow-cljs compile node-test` — PASS (1351 files, 0 errors; 1 pre-existing unrelated warning in `resources_revalidation_cljs_test.cljc`).
- `node out/node-test.js` — PASS (7242 tests, 29759 assertions, 0 failures, 0 errors).
- `shadow-cljs compile browser-test` — PASS (783 files, 0 warnings).
- `npm run test:browser` (full Playwright DOM suite, incl. the new UIx + Helix Suspense regression) — PASS (215 tests, 667 assertions, 0 failures, 0 errors).
- `npm run test:elision` — PASS (production 42/42 absent; control 42/42 present).

`npm run test:cljs` is the node-test gate above (ran green). The full JVM matrix / remaining bundle gates are covered by CI on Linux.