### PR TITLE
fix(schemas): fail-closed redaction on recordable-cofx schema validation failure

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -488,25 +488,54 @@
   recordable value failed the registration's `:schema`) and throw. ALWAYS-ON
   — fires in production too: a causal-token contract validation (an
   out-of-contract durable value is corrupt state). Per Spec 002
-  §Satisfaction + Spec 009 §Error catalogue."
-  [cofx-id value explanation failing-id frame-id]
-  (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-    (dispatch-on-error! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)))
-  (trace/emit-error! :rf.error/cofx-value-invalid
-                     (cond-> {:rf.cofx/id        cofx-id
-                              :failing-id        failing-id
-                              :rf.trace/event-id failing-id
-                              :value             value
-                              :recovery          :no-recovery}
-                       (some? explanation) (assoc :explain explanation)
-                       frame-id             (assoc :frame frame-id)))
-  (throw (ex-info ":rf.error/cofx-value-invalid"
-                  {:rf.error/id :rf.error/cofx-value-invalid
-                   :rf.cofx/id  cofx-id
-                   :failing-id  failing-id
-                   :value       value
-                   :explain     explanation
-                   :recovery    :no-recovery})))
+  §Satisfaction + Spec 009 §Error catalogue.
+
+  Per rf2-hdi6wr (EP-0015 / EP-0017) — a recordable value validated against a
+  `:schema` that marks any slot `{:sensitive? true}` MUST NOT surface the raw
+  secret off-box. Both the emitted trace tags AND the thrown `ex-info`'s
+  `ex-data` carry the value-bearing slots (`:value` / `:explain`), and BOTH
+  egress (the trace to every listener → MCP / log / story; the throw's ex-data
+  is public error data). Route them through THE shared schema-aware redaction
+  seam (`:schemas/redact-validation-tags`, the same one the boundary
+  interceptor / machine-`:data` / sub-override / flow-output emit sites use):
+  when the `schema` declares any `:sensitive?` slot the value-bearing slots
+  scrub to `:rf/redacted` and `:sensitive? true` is stamped; otherwise the
+  slots ride verbatim. FAILS CLOSED — a recordable-value failure with a
+  sensitive schema redacts on every off-box surface. The hook is nil only
+  when the schemas artefact is absent — but this fn is reached only AFTER the
+  schemas-owned validator ran (a `:schema` was declared + a validator was
+  registered), so the hook is bound whenever a sensitive failure can fire; the
+  `(when redact-fn …)` guard is belt-and-braces (no schemas artefact ⇒ no
+  schema to redact against)."
+  [cofx-id value explanation schema failing-id frame-id]
+  (let [redact-fn (late-bind/get-fn-cached :schemas/redact-validation-tags)
+        ;; The off-box slots shared by the trace and the throw's ex-data.
+        ;; Redaction scrubs `:value` / `:explain` and stamps `:sensitive?`
+        ;; when `schema` declares any `:sensitive?` slot.
+        leak-slots (cond-> {:value value}
+                     (some? explanation) (assoc :explain explanation))
+        redacted   (if (and redact-fn (some? schema))
+                     (redact-fn schema leak-slots)
+                     leak-slots)]
+    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
+      (dispatch-on-error! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)))
+    (trace/emit-error! :rf.error/cofx-value-invalid
+                       (cond-> {:rf.cofx/id        cofx-id
+                                :failing-id        failing-id
+                                :rf.trace/event-id failing-id
+                                :value             (:value redacted)
+                                :recovery          :no-recovery}
+                         (contains? redacted :explain) (assoc :explain (:explain redacted))
+                         (:sensitive? redacted)        (assoc :sensitive? true)
+                         frame-id                      (assoc :frame frame-id)))
+    (throw (ex-info ":rf.error/cofx-value-invalid"
+                    (cond-> {:rf.error/id :rf.error/cofx-value-invalid
+                             :rf.cofx/id  cofx-id
+                             :failing-id  failing-id
+                             :value       (:value redacted)
+                             :explain     (:explain redacted)
+                             :recovery    :no-recovery}
+                      (:sensitive? redacted) (assoc :sensitive? true))))))
 
 (defn- validate-recordable-value!
   "Validate a recordable `value` for `cofx-id` against its registration's
@@ -538,7 +567,10 @@
                   explanation (when explain-fn
                                 (try (explain-fn schema value)
                                      (catch #?(:clj Throwable :cljs :default) _ nil)))]
-              (emit-cofx-value-invalid! cofx-id value explanation failing-id frame-id))))))
+              ;; Pass `schema` so the emit redacts the value-bearing slots
+              ;; (trace tags AND thrown ex-data) when the schema marks any
+              ;; slot `:sensitive?` — fail-closed off-box (rf2-hdi6wr).
+              (emit-cofx-value-invalid! cofx-id value explanation schema failing-id frame-id))))))
     value))
 
 ;; ---- structural-EDN check of GENERATED recordable values ------------------

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -121,18 +121,24 @@
 ;; `:rf.error/schema-validation-failure` trace it emitted.
 ;; ---------------------------------------------------------------------------
 
-(defn- capture-failure
-  "Run `f` (which is expected to drive ONE validation failure emit) with a
-  trace listener attached; return the first `:rf.error/schema-validation-failure`
-  trace event (or nil if none fired)."
-  [f]
+(defn- capture-op
+  "Run `f` (which is expected to drive ONE error emit) with a trace listener
+  attached; return the first trace event whose `:operation` is `op` (or nil if
+  none fired)."
+  [op f]
   (let [traces (atom [])
         kw     (keyword "rf2-o69h5" (name (gensym "listen")))]
     (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
     (try (f) (finally (trace-tooling/unregister-listener! kw)))
     #?(:clj (schemas/clear-sensitive-paths-cache!))
-    (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                   @traces))))
+    (first (filter #(= op (:operation %)) @traces))))
+
+(defn- capture-failure
+  "Run `f` (which is expected to drive ONE validation failure emit) with a
+  trace listener attached; return the first `:rf.error/schema-validation-failure`
+  trace event (or nil if none fired)."
+  [f]
+  (capture-op :rf.error/schema-validation-failure f))
 
 (defn- assert-no-leak
   "Core invariant assertion for one captured failure trace: it fired, it is
@@ -446,6 +452,95 @@
               ":where :flow-output — drove the real flow-output emit site")
           (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
           (is (= :rf/redacted (-> trace :tags :explain)) ":explain redacted"))))))
+
+(deftest recordable-cofx-schema-failure-production-path-redacts-sensitive
+  (testing "rf2-hdi6wr — :rf.error/cofx-value-invalid PRODUCTION PATH: a
+            recordable reg-cofx whose declared `:schema` marks a slot
+            `{:sensitive? true}`, SUPPLIED/replayed a sentinel-bearing value
+            that FAILS that schema, drives the real dispatch-sync recordable-
+            value validation (re-frame.cofx/validate-recordable-value! ->
+            emit-cofx-value-invalid!). BOTH the emitted trace AND the thrown
+            ex-data are off-box egress; pre-fix both carried the raw secret in
+            `:value` and Malli `:explain`. Asserts the sentinel appears NOWHERE
+            in either, `:value`/`:explain` are `:rf/redacted`, and `:sensitive?`
+            is stamped. Reverting cofx.cljc's `(redact-fn schema …)` wiring on
+            this emit makes this RED."
+    (with-runtime*
+      (fn []
+        ;; A recordable cofx whose schema marks `:token` sensitive. The
+        ;; supplied value carries the sentinel at that slot but as a VECTOR
+        ;; where a :string is required, so it fails the schema.
+        (rf/reg-cofx :cofx/recordable-secret
+          {:recordable? true
+           :schema      [:map [:token {:sensitive? true} :string]]}
+          (fn [] {:token "ignored-supplied-wins"}))
+        (rf/reg-event :cofx/uses-recordable-secret
+          {:rf.cofx/requires [:cofx/recordable-secret]}
+          (fn [_ _] {}))
+        (let [thrown (atom nil)
+              ;; Supply the failing value on the token (the replay / supplied
+              ;; path); dispatch-sync throws the hard error. The cofx
+              ;; recordable-value path emits :rf.error/cofx-value-invalid
+              ;; (NOT :rf.error/schema-validation-failure), so capture that op.
+              trace  (capture-op
+                       :rf.error/cofx-value-invalid
+                       (fn []
+                         (try
+                           (rf/dispatch-sync
+                             [:cofx/uses-recordable-secret]
+                             {:rf.cofx {:cofx/recordable-secret
+                                        {:token [sentinel]}}})
+                           (catch #?(:clj clojure.lang.ExceptionInfo
+                                     :cljs cljs.core/ExceptionInfo) e
+                             (reset! thrown e)))))]
+          ;; (a) The off-box TRACE redacts.
+          (is (some? trace)
+              ":rf.error/cofx-value-invalid trace fired")
+          (when trace
+            (is (true? (:sensitive? trace)) "trace top-level :sensitive? stamp")
+            (is (= :rf/redacted (-> trace :tags :value)) "trace :value redacted")
+            (is (= :rf/redacted (-> trace :tags :explain)) "trace :explain redacted")
+            (is (not (contains-sentinel? trace))
+                (str "the sentinel leaked into the cofx-value-invalid trace: "
+                     (pr-str (:tags trace)))))
+          ;; (b) The thrown ex-data (public error data) redacts too.
+          (is (some? @thrown) "dispatch threw cofx-value-invalid")
+          (when-let [d (some-> @thrown ex-data)]
+            (is (= :rf.error/cofx-value-invalid (:rf.error/id d))
+                "the throw carries :rf.error/cofx-value-invalid")
+            (is (true? (:sensitive? d)) "ex-data :sensitive? stamp")
+            (is (= :rf/redacted (:value d)) "ex-data :value redacted")
+            (is (= :rf/redacted (:explain d)) "ex-data :explain redacted")
+            (is (not (contains-sentinel? d))
+                (str "the sentinel leaked into the cofx-value-invalid ex-data: "
+                     (pr-str d)))))))))
+
+(deftest valid-recordable-cofx-schema-path-unaffected
+  (testing "rf2-hdi6wr (c) — a recordable reg-cofx whose value CONFORMS to its
+            `:sensitive?`-bearing schema runs clean: no cofx-value-invalid
+            trace, no throw, the value is delivered to the handler verbatim.
+            The redaction wiring must not perturb the valid path."
+    (with-runtime*
+      (fn []
+        (let [seen (atom ::unset)]
+          (rf/reg-cofx :cofx/recordable-ok
+            {:recordable? true
+             :schema      [:map [:token {:sensitive? true} :string]]}
+            (fn [] {:token "generated-default"}))
+          (rf/reg-event :cofx/uses-recordable-ok
+            {:rf.cofx/requires [:cofx/recordable-ok]}
+            (fn [{:keys [cofx/recordable-ok]} _]
+              (reset! seen recordable-ok) {}))
+          (let [trace (capture-op
+                        :rf.error/cofx-value-invalid
+                        (fn []
+                          (rf/dispatch-sync
+                            [:cofx/uses-recordable-ok]
+                            {:rf.cofx {:cofx/recordable-ok {:token "ok-value"}}})))]
+            (is (nil? trace)
+                "a conforming recordable value emits NO cofx-value-invalid trace")
+            (is (= {:token "ok-value"} @seen)
+                "the conforming value is delivered to the handler verbatim")))))))
 
 #?(:cljs
    (deftest sub-override-production-path-redacts-sensitive


### PR DESCRIPTION
## Summary

Fixes **rf2-hdi6wr** (P1, BUG — EP-0015 / EP-0017 privacy correctness).

A recordable cofx value (supplied/replayed or generated) that fails its registration's `:schema` was emitted and thrown carrying the **raw** value and Malli `:explain`, bypassing the schemas redaction hook. A schema marking a slot `{:sensitive? true}` therefore **leaked the secret off-box** on two surfaces:

- the `:rf.error/cofx-value-invalid` **trace** (→ every listener → MCP / log / story egress), and
- the thrown `ex-info`'s **`ex-data`** (public error data).

This is the cofx parallel of the just-fixed epoch trigger-event leak (rf2-nm611o) — fail-OPEN where it must fail-CLOSED.

## Leak path

- `implementation/core/src/re_frame/cofx.cljc` — `emit-cofx-value-invalid!` built the trace tags and the thrown `ex-data` with raw `:value` + raw `:explain`, never routing through `:schemas/redact-validation-tags`. Reached from `validate-recordable-value!` for both the SUPPLIED/replayed path (`deliver-declared-cofx`, the `contains? (:rf.cofx acc) id` branch) and the GENERATED path (`run-generator` write-back).

## Fix (surgical core touch)

`emit-cofx-value-invalid!` now threads the registration `:schema` and routes the value-bearing slots (`:value` / `:explain`) — for **both** the trace tags **and** the thrown ex-data — through the shared `:schemas/redact-validation-tags` seam (the same redactor the boundary interceptor / machine-`:data` / sub-override / flow-output emit sites already use). When the schema declares any `:sensitive?` slot the slots scrub to `:rf/redacted` and `:sensitive? true` is stamped; non-sensitive schemas ride verbatim. The only core change is the arity of the private emit fn + its single caller.

## Regression test

Added to the security redaction-invariant tier (`implementation/security/test/.../validation_redaction_invariant_security_cljs_test.cljc`), which carries the real schemas+Malli validator + the per-kind privacy corpus:

- **`recordable-cofx-schema-failure-production-path-redacts-sensitive`** — a recordable `reg-cofx` with a `{:sensitive? true}` schema, supplied a sentinel-bearing failing value, drives the real `dispatch-sync` recordable-value validation; asserts the sentinel is **absent** from both the trace and the thrown ex-data, `:value`/`:explain` are `:rf/redacted`, and `:sensitive?` is stamped.
- **`valid-recordable-cofx-schema-path-unaffected`** — a conforming value emits no failure trace, no throw, and is delivered verbatim (acceptance (c)).

**Verify-by-revert:** disabling the redaction wiring makes the new test go RED — the sentinel surfaces unredacted in `:value` and Malli `:explain` (confirmed locally, then restored).

## Quality gates

Bounded to the affected surfaces (Windows full-JVM shadow can deadlock; `node_modules`/shadow-cljs not installed in this checkout — `npm run test:cljs` deferred to CI-Linux, which covers the full CLJS matrix; the new tests are `.cljc` and the JVM arm is green here):

| Gate | Result |
| --- | --- |
| `clojure -M:test` — `security` (full suite) | **0 failures, 0 errors** (68 tests / 511 assertions) |
| `clojure -M:test` — `schemas` (full suite) | **0 failures, 0 errors** (295 tests / 18764 assertions) |
| `clojure -M:test -n re-frame.cofx-cljs-test` (core, arity change) | **0 failures, 0 errors** (46 tests / 163 assertions) |
| Verify-by-revert (disable redaction → expect RED) | **RED as expected** (sentinel leaks; restored) |

`npm run test:cljs` (node-runtime CLJS matrix): not run locally (shadow-cljs not installed); covered by CI-Linux.