### PR TITLE
fix(examples/reagent): frame-scoped schema registration + recordable-cofx nondeterminism

### DIFF
--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -140,6 +140,28 @@
   (rf/reg-app-schema [:new-todo] NewTodoSlice))
 
 ;; ============================================================================
+;; RECORDABLE COEFFECTS  (EP-0017)
+;; ============================================================================
+;;
+;; A submitted todo's `:id` is written into durable machine runtime-data
+;; (`:data :items`) and used as a React `:key` / join handle. Per EP-0010 a
+;; durable id must be a FOLDED FACT, never an ambient `(random-uuid)` read at
+;; the write site (a fresh-event-stream replay would mint a different id and the
+;; snapshot/keys would not reproduce). The EP-0017 authoring surface for an
+;; app-owned generator is a RECORDABLE `reg-cofx`: the generator runs at
+;; context-assembly, the minted value is recorded onto the causal token, and
+;; replay re-presents it verbatim (mint-policy `:strict` re-feeds the recorded
+;; value instead of re-minting). `:new-todo/submit` DECLARES it via
+;; `:rf.cofx/requires` and reads it flat from the coeffects map — the handler
+;; stays pure and replayable. A uuid is valid EDN (`#uuid`), so it is a legal
+;; recordable value; the generator runs in slice B and the minted uuid is
+;; recorded onto the token (matching the `gen-todos` seed-data id type).
+(rf/reg-cofx :new-todo/todo-id
+  {:recordable? true
+   :doc "Replayable fresh id for a newly-submitted todo (EP-0017)."}
+  (fn [] (random-uuid)))
+
+;; ============================================================================
 ;; FX  (test-friendly stubs)
 ;; ============================================================================
 ;;
@@ -420,10 +442,14 @@
          region lands in :incorrect). If valid → append to the
          machine's :data items via :fetch-succeeded, clear the draft,
          and broadcast :submit-valid (the :form region lands in
-         :correct)."}
+         :correct)."
+   ;; EP-0017: the new todo's durable id is FOLDED from a recordable
+   ;; coeffect, never read ambiently at the write site (see the
+   ;; `:new-todo/todo-id` reg-cofx above) — replay re-presents it.
+   :rf.cofx/requires [:new-todo/todo-id]}
   ;; EP-0001 (rf2-vzld77): the machine snapshot is durable runtime-db state —
   ;; read it from the `:rf.db/runtime` coeffect.
-  (fn handler-new-todo-submit [{:keys [db] rt :rf.db/runtime} _]
+  (fn handler-new-todo-submit [{:keys [db] rt :rf.db/runtime new-id :new-todo/todo-id} _]
     (let [draft  (get-in db [:new-todo :draft])
           errors (validate-new-todo draft)
           items  (get-in rt [:rf.runtime/machines :snapshots :ui/nine-states :data :items])]
@@ -438,7 +464,7 @@
         ;; items: bump through :loading → :resolving so the :always-cascade
         ;; re-picks the cardinality bucket against the new count.
         (let [new-items (conj (vec items)
-                              {:id     (random-uuid)
+                              {:id     new-id
                                :title  (:title draft)
                                :done?  false})]
           {:db (-> db

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -29,8 +29,25 @@
 (defn comment-path [slug]
   (str (article-path slug) "/comments"))
 
-(defn temp-comment-id []
-  (str "temp-" (random-uuid)))
+;; ============================================================================
+;; RECORDABLE COEFFECTS  (EP-0017)
+;; ============================================================================
+;;
+;; The optimistic temp-id is written into durable app-db (the optimistic card is
+;; conj'd into `[:comments :data]`) AND used as a join key — it correlates the
+;; optimistic card with its eventual save (`:comment-form/submit-success`) or
+;; rollback (`:comment-form/submit-error`). Per EP-0010 a value that is written
+;; durably OR used as a join key MUST be folded from a recordable coeffect, not
+;; read ambiently at the write site — otherwise replay mints a different id and
+;; the correlation no longer matches. The EP-0017 authoring surface is a
+;; RECORDABLE `reg-cofx`: the generator runs at context-assembly, the minted id
+;; is recorded onto the causal token, and replay re-presents it verbatim.
+;; `:comment-form/submit` DECLARES it via `:rf.cofx/requires` and reads it flat
+;; from the coeffects map — the handler stays pure and replayable.
+(rf/reg-cofx :realworld/temp-comment-id
+  {:recordable? true
+   :doc "Replayable optimistic temp-id for a newly-posted comment (EP-0017)."}
+  (fn [] (str "temp-" (random-uuid))))
 
 ;; ============================================================================
 ;; INITIALISATION
@@ -151,14 +168,16 @@
   {:doc "Optimistically post a new comment. NO retry — the user clicked
          once. The temp-id correlates the optimistic UI card with the
          eventual save / rollback (Spec 014 - explicit on-success/on-failure
-         where the partial event vector pre-populates correlation args)."
-   :rf.http/decode-schemas [schema/CommentResponse]}
-  (fn [{:keys [db] rt :rf.db/runtime} _]
+         where the partial event vector pre-populates correlation args). The
+         temp-id is FOLDED from a recordable coeffect (EP-0017 — see the
+         `:realworld/temp-comment-id` reg-cofx above), never minted ambiently."
+   :rf.http/decode-schemas [schema/CommentResponse]
+   :rf.cofx/requires [:realworld/temp-comment-id]}
+  (fn [{:keys [db] rt :rf.db/runtime temp-id :realworld/temp-comment-id} _]
     (let [slug      (get-in rt [:rf.runtime/routing :current :params :slug])
           draft     (get-in db [:comment-form :draft])
           body      (str/trim (or (:body draft) ""))
           user      (get-in db [:auth :user])
-          temp-id   (temp-comment-id)
           temp-card {:id        temp-id
                      :createdAt "pending"
                      :updatedAt "pending"

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -45,7 +45,7 @@
             [re-frame.adapter.reagent :as reagent-adapter]
             [clojure.set]
             [clojure.string :as str])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 (def cols
   "Number of spreadsheet columns (A..Z)."
@@ -84,7 +84,12 @@
    [:selected-id [:maybe :string]]
    [:editing-id  [:maybe :string]]])
 
-(rf/reg-app-schema [:cells] CellsState)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
+;; schema binds to the app frame whose commits it validates.
+(with-frame :rf/default
+  (rf/reg-app-schema [:cells] CellsState))
 
 ;; ============================================================================
 ;; PARSER + EVALUATOR

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -29,7 +29,7 @@
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -61,7 +61,12 @@
    [:undo      [:vector :any]]                  ;; stack of prior :circles values
    [:redo      [:vector :any]]])
 
-(rf/reg-app-schema [:drawer] DrawerState)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
+;; schema binds to the app frame whose commits it validates.
+(with-frame :rf/default
+  (rf/reg-app-schema [:drawer] DrawerState))
 
 ;; ============================================================================
 ;; UNDO INTERCEPTOR

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -26,39 +26,56 @@
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; SCHEMA
 ;; ============================================================================
 
+;; EP-0010 (Causal World Inputs): a person's `:id` is written into durable
+;; app-db (`[:crud :people]`) and used as the selection / React `:key`, so it
+;; must be a function of prior frame-state — never an ambient `(random-uuid)` at
+;; the durable-write site (an event-stream replay would mint different ids). The
+;; id is an internal handle, so we mint it deterministically as a monotonic
+;; `:int` from a db-held `:next-id` counter — the todomvc `allocate-next-id`
+;; idiom, matching sibling 7GUIs `circle_drawer` — rather than a uuid.
 (def Person
   [:map
-   [:id      :uuid]
+   [:id      :int]
    [:name    :string]
    [:surname :string]])
 
 (def CrudState
   [:map
    [:people       [:vector Person]]
+   [:next-id      :int]                      ;; deterministic id allocator (EP-0010)
    [:filter-text  :string]
-   [:selected-id  [:maybe :uuid]]
+   [:selected-id  [:maybe :int]]
    [:draft        [:map
                    [:name    :string]
                    [:surname :string]]]])
 
-(rf/reg-app-schema [:crud] CrudState)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
+;; schema binds to the app frame whose commits it validates.
+(with-frame :rf/default
+  (rf/reg-app-schema [:crud] CrudState))
 
 ;; ============================================================================
 ;; EVENTS
 ;; ============================================================================
 
 (rf/reg-event :crud/initialise
-  {:doc "Seed the list with the 7GUIs reference data."}
+  {:doc "Seed the list with the 7GUIs reference data. Ids are deterministic
+         monotonic ints (EP-0010) so a fresh-event-stream replay reproduces
+         the same durable people. `:next-id` is the allocator for subsequent
+         Create."}
   (fn handler-crud-initialise [{:keys [db]} _]
-    {:db (assoc db :crud {:people      [{:id (random-uuid) :name "Hans"  :surname "Emil"}
-                                   {:id (random-uuid) :name "Max"   :surname "Mustermann"}
-                                   {:id (random-uuid) :name "Roman" :surname "Tisch"}]
+    {:db (assoc db :crud {:people      [{:id 1 :name "Hans"  :surname "Emil"}
+                                   {:id 2 :name "Max"   :surname "Mustermann"}
+                                   {:id 3 :name "Roman" :surname "Tisch"}]
+                     :next-id     4
                      :filter-text ""
                      :selected-id nil
                      :draft       {:name "" :surname ""}})}))
@@ -70,7 +87,7 @@
 
 (rf/reg-event :crud/select
   {:doc "User clicked a list entry. Populates the draft from the selected person."
-   :schema [:cat [:= :crud/select] :uuid]}
+   :schema [:cat [:= :crud/select] :int]}
   (fn handler-crud-select [{:keys [db]} [_ id]]
     {:db (let [people (get-in db [:crud :people])
           person (first (filter #(= id (:id %)) people))]
@@ -87,12 +104,17 @@
     {:db (assoc-in db [:crud :draft :surname] s)}))
 
 (rf/reg-event :crud/create
-  {:doc "Add a new person from the draft. Selects the new entry."}
+  {:doc "Add a new person from the draft. Selects the new entry. The id is
+         minted deterministically from the db-held `:next-id` counter (EP-0010
+         causal world inputs — a durable id must be a function of prior
+         frame-state, not an ambient `(random-uuid)` read), then the counter is
+         bumped."}
   (fn handler-crud-create [{:keys [db]} _]
-    {:db (let [new-id (random-uuid)
+    {:db (let [new-id (get-in db [:crud :next-id])
           {:keys [name surname]} (get-in db [:crud :draft])]
       (-> db
           (update-in [:crud :people] conj {:id new-id :name name :surname surname})
+          (assoc-in  [:crud :next-id] (inc new-id))
           (assoc-in  [:crud :selected-id] new-id)))}))
 
 (rf/reg-event :crud/update
@@ -171,7 +193,7 @@
       [:select.list {:size      6
                      :data-testid "crud-list"
                      :value     (or selected-id "")
-                     :on-change #(dispatch [:crud/select (uuid (.. % -target -value))])}
+                     :on-change #(dispatch [:crud/select (js/parseInt (.. % -target -value) 10)])}
        (for [{:keys [id name surname]} people]
          ^{:key id}
          [:option {:value id} (str surname ", " name)])]

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -28,7 +28,7 @@
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -42,7 +42,12 @@
    [:start-text  :string]                    ;; raw text the user typed; we don't parse until validation
    [:return-text :string]])
 
-(rf/reg-app-schema [:flight] FlightState)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
+;; schema binds to the app frame whose commits it validates.
+(with-frame :rf/default
+  (rf/reg-app-schema [:flight] FlightState))
 
 ;; ============================================================================
 ;; EVENTS

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -27,7 +27,7 @@
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -45,7 +45,12 @@
    [:input-source [:enum :celsius :fahrenheit]]
    [:typing       :string]])              ;; the literal text the user is typing
 
-(rf/reg-app-schema [:temp] TempState)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
+;; schema binds to the app frame whose commits it validates.
+(with-frame :rf/default
+  (rf/reg-app-schema [:temp] TempState))
 
 ;; ============================================================================
 ;; EVENTS

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -28,7 +28,7 @@
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 (def tick-ms
   "Wall-clock delay between successive timer ticks. Kebab-case per the
@@ -47,7 +47,12 @@
    [:tick-active? :boolean]             ;; whether a tick is in flight
    [:tick-gen :int]])                   ;; generation token; bumped on Reset to retire stale ticks
 
-(rf/reg-app-schema [:timer] TimerState)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame app-frame`), so name it explicitly so the
+;; schema binds to the app frame whose commits it validates.
+(with-frame :rf/default
+  (rf/reg-app-schema [:timer] TimerState))
 
 ;; ============================================================================
 ;; EVENTS

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -80,12 +80,30 @@
 ;; ============================================================================
 ;; SCHEMA
 ;; ============================================================================
-
-(rf/reg-app-schema [:articles]
-  [:vector [:map
-            [:id    :string]
-            [:title :string]
-            [:body  :string]]])
+;;
+;; EP-0002 (rf2-5q7um6): `reg-app-schema` is context-required frame-local and
+;; raises `:rf.error/no-frame-context` under no frame scope — so a bare ns-load
+;; registration is wrong, and (rf2-9wc2ed) a naive `with-frame :rf/default`
+;; would bind the schema to the client frame ONLY, leaving the per-request
+;; SERVER frames (where the SSR commits actually validate) unschema'd. SSR has
+;; TWO frame families: the per-request server frame (gensym, in
+;; `handle-request`) and the FIXED client hydration frame (`app-frame` →
+;; `:rf/default`, in `run`). The schema is the same contract for both, so we
+;; hold it as a value and register it explicitly against EACH frame at its
+;; entry point (server: per request; client: at boot) with the `{:frame …}`
+;; override. Holding it as a def also keeps ns-load side-effect-free — the
+;; entry namespace loads without any ambient frame fixture.
+;; `[:maybe …]` because the slice is ABSENT (nil) until `:articles/loaded`
+;; commits — the per-request server frame's `:rf/server-init` commits an
+;; articles-free db first (it only kicks off the managed-HTTP fetch), and the
+;; client frame starts empty before hydration. A bare `[:vector …]` would reject
+;; that legitimate intermediate `nil` and roll the commit back (rf2-9wc2ed: the
+;; bug was masked precisely because validation never ran on these frames).
+(def ArticlesSchema
+  [:maybe [:vector [:map
+                    [:id    :string]
+                    [:title :string]
+                    [:body  :string]]]])
 
 ;; ============================================================================
 ;; FX
@@ -242,6 +260,15 @@
    (defn handle-request [request]
      (let [fid (keyword "rf.frame" (str (gensym "f")))
            _   (ssr/set-request! fid request)
+           ;; Register the app schema AGAINST THIS per-request server frame
+           ;; (rf2-9wc2ed) BEFORE `:on-create` fires `:rf/server-init` — the
+           ;; per-request frame is where the server-side `:articles` commit
+           ;; actually validates, so the schema must bind here, not only on the
+           ;; client frame. `reg-frame` runs the `:on-create` cascade
+           ;; synchronously before returning, so the schema must be in place
+           ;; first; we register it under the gensym `fid` and only then create
+           ;; the frame.
+           _   (rf/reg-app-schema [:articles] ArticlesSchema {:frame fid})
            f   (rf/reg-frame fid
                  {:doc       "ssr-example per-request frame"
                   :platform  :server
@@ -394,6 +421,13 @@
      ;; fxs fire (Spec 011 §The :rf/hydrate event).
      (rf/reg-frame app-frame {:doc      "ssr-example client app-frame"
                               :platform :client})
+     ;; Register the app schema AGAINST THE FIXED CLIENT FRAME (rf2-9wc2ed) so
+     ;; the hydrated `:articles` commit + every post-hydration interactive
+     ;; commit validate on the client too — the symmetric counterpart of the
+     ;; per-request registration in `handle-request`. `{:frame app-frame}` is
+     ;; the explicit override; `reg-app-schema` is a no-op-safe re-registration
+     ;; on hot-reload.
+     (rf/reg-app-schema [:articles] ArticlesSchema {:frame app-frame})
      ;; `ssr/hydrate!` is the framework client-boot helper (Spec 011
      ;; §Client-side hydration boot helper). It READs the `__rf_payload`
      ;; script, dispatch-syncs `[:rf/hydrate payload]` to install the

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -31,9 +31,25 @@
 ;; ============================================================================
 ;; SCHEMA
 ;; ============================================================================
-
-(rf/reg-app-schema [:cards]
-  [:map-of :keyword [:map [:title :string] [:value [:maybe :int]]]])
+;;
+;; EP-0002 (rf2-5q7um6): `reg-app-schema` is context-required frame-local and
+;; raises `:rf.error/no-frame-context` under no frame scope — so a bare ns-load
+;; registration is wrong, and (rf2-9wc2ed) a naive `with-frame :rf/default`
+;; would bind the schema to the client frame ONLY, leaving the per-request
+;; SERVER frame (where the SSR commits actually validate) unschema'd. Streaming
+;; SSR has TWO frame families: the per-request server frame (gensym, in
+;; `handle-request`) and the FIXED client hydration frame (`app-frame` →
+;; `:rf/default`, in `run`). The schema is the same contract for both, so we
+;; hold it as a value and register it explicitly against EACH frame at its
+;; entry point with the `{:frame …}` override. Holding it as a def also keeps
+;; ns-load side-effect-free — the entry namespace loads without any ambient
+;; frame fixture.
+;; `[:maybe …]` because the slice is ABSENT (nil) until `:rf/server-init`
+;; seeds it on the server / the client hydrates it — a bare `[:map-of …]` would
+;; reject the legitimate pre-seed `nil` and roll the commit back. (The bug was
+;; masked because validation never actually ran on these frames — rf2-9wc2ed.)
+(def CardsSchema
+  [:maybe [:map-of :keyword [:map [:title :string] [:value [:maybe :int]]]]])
 
 ;; ============================================================================
 ;; EVENTS
@@ -121,6 +137,13 @@
      streaming adapter would emit in order."
      [_request]
      (let [fid (keyword "rf.frame" (str (gensym "")))
+           ;; Register the app schema AGAINST THIS per-request server frame
+           ;; (rf2-9wc2ed) BEFORE `:on-create` fires `:rf/server-init` — the
+           ;; per-request frame is where the server-side `:cards` commit
+           ;; actually validates, so the schema must bind here. `reg-frame` runs
+           ;; the `:on-create` cascade synchronously before returning, so the
+           ;; schema must be in place first; register under `fid`, then create.
+           _   (rf/reg-app-schema [:cards] CardsSchema {:frame fid})
            _   (rf/reg-frame fid {:doc "ssr-streaming-example frame"
                                   :platform :server
                                   :on-create [:rf/server-init]})
@@ -248,6 +271,12 @@
      ;; makes the hydrate compatibility-check fxs fire.
      (rf/reg-frame app-frame {:doc      "ssr-streaming-example client app-frame"
                               :platform :client})
+     ;; Register the app schema AGAINST THE FIXED CLIENT FRAME (rf2-9wc2ed) so
+     ;; the progressively-merged + finally-hydrated `:cards` commits validate on
+     ;; the client too — the symmetric counterpart of the per-request
+     ;; registration in `handle-request`. `{:frame app-frame}` is the explicit
+     ;; override; re-registration is a no-op-safe on hot-reload.
+     (rf/reg-app-schema [:cards] CardsSchema {:frame app-frame})
      ;; Install the client-side streaming runtime BEFORE the first render
      ;; so it catches resolved-subtree chunks as they arrive (and sweeps
      ;; any already present). It swaps fallbacks + merges per-subtree


### PR DESCRIPTION
Fixes two `examples/reagent/` correctness bugs (both AUTHORITATIVE).

## rf2-9wc2ed (P1) — schema registrations run under no/wrong frame

`reg-app-schema` is context-required frame-local (EP-0002): a bare ns-load call raises `:rf.error/no-frame-context`, and the masking only came from a test fixture pinning `:rf/default`.

- **seven_guis singletons** (temperature, flight_booker, crud, timer, circle_drawer, cells): wrap the ns-load `reg-app-schema` in `(with-frame :rf/default ...)` so the schema binds to the app frame whose commits it validates. Matches the already-fixed `nine_states` / `boot` / `websocket` idiom.
- **SSR (ssr, ssr_streaming)**: SSR has TWO frame families — the per-request server frame (gensym, in `handle-request`) and the fixed client hydration frame (`:rf/default`, in `run`). The schema is now held as a value (`def`) and registered explicitly against **each** frame at its entry point via the `{:frame ...}` override (server: per request, before `:on-create` fires; client: at boot). ns-load is now side-effect free, so the entry namespaces load without any ambient frame fixture. The schemas became `[:maybe ...]` to admit the legitimate pre-load `nil` state — a bare schema rolled the `:rf/server-init` commit back once validation *actually* ran on the per-request frame (the bug was masked precisely because validation never ran there).

## rf2-wbgb74 (P2) — durable handlers mint random ids outside causality

A value written durably OR used as a join key must be folded from a recordable coeffect, never read ambiently at the write site (EP-0010 / EP-0017).

- **crud**: person `:id` switched from ambient `(random-uuid)` to a deterministic monotonic `:int` from a db-held `:next-id` counter, matching sibling `circle_drawer`. Select handler + event `:schema` updated to `:int`.
- **nine_states `:new-todo/submit`** and **realworld `:comment-form/submit`**: the durable / join-key id is folded from a recordable `reg-cofx` (EP-0017), declared via `:rf.cofx/requires` and read flat from the coeffects map. The generator runs at context-assembly under the default `:live` mint policy, the minted value is recorded onto the causal token, and replay (`:strict`) re-presents it verbatim — the handlers stay pure and replayable.

Follow-up (framework test tree, outside the examples-only surface): **rf2-i6p308** tracks the regression tests the acceptance criteria asked for (ns-load-without-ambient-fixture, explicit per-request SSR schema assertion, recordable-cofx replay-stability). Examples stay test-free (rf2-8cevm).

## Quality gates

- `shadow-cljs compile` of all 10 affected example builds (`:examples/{temperature,flight-booker,timer,crud,circle-drawer,cells,nine-states,realworld,ssr,ssr-streaming}`) — **all green, 0 warnings**.
- `re-frame.examples-test` (JVM, `clojure -M:test`) — **13 tests / 59 assertions, 0 failures / 0 errors**. Exercises the per-request SSR schema validation (server-init → managed-HTTP → render), per-request frame teardown (success + throw), and client hydration (hash stash / match / divergent / malformed-payload) for both SSR examples.
- `npm run test:cljs` not run (changes are example-source only; substrate contract behaviour unchanged — CI covers the full matrix).
