### PR TITLE
fix(ssr): carry frame realm-id through SSR per-frame state + rehydration

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -518,6 +518,31 @@
   (when-let [f (frame id)]
     (or (:realm f) realm/default-realm-id)))
 
+(defn frame-address
+  "Resolve the (realm, frame) ADDRESS key for `frame-id` — the key a per-frame
+  SIDE-CHANNEL (SSR request / response / error-trace / head snapshot, …) keys
+  its entries by, so the SAME frame id in two realms addresses two distinct
+  entries (EP-0013, Spec 002 §Frames reference realms). The realm dimension is:
+
+    1. the CARRIED realm (`*current-realm*`) when bound — it covers a whole
+       dispatch drain AND a frame's destroy teardown (the router binds it via
+       `call-with-realm` around both), which is exactly when a side-channel is
+       written / cleared; OR
+    2. the frame's own `:realm` reference (`frame-realm`) as the read-time
+       fallback for a side-channel READ issued outside a drain (a host adapter
+       reading the resolved response after the drain settles) while the frame
+       record still exists.
+
+  Collapses to the bare `frame-id` keyword for the default realm (nil carried
+  realm AND a default-realm / unknown / already-marked-destroyed frame) via
+  `frame-key`, so every single-realm side-channel is byte-identical to the
+  pre-realm bare-id keying — the default-realm round-trip is preserved with no
+  realm key. DERIVED from the carried address, never ambient synthesis
+  (EP-0002 carried-invariant). INTERNAL — the addressing seam the SSR
+  side-channels share."
+  [frame-id]
+  (frame-key (or *current-realm* (frame-realm frame-id)) frame-id))
+
 ;; ---- realm-routed resolution — the (realm, frame) address binding ----------
 ;;
 ;; EP-0013 staging step 4 (rf2-a15n62): a frame REFERENCES its realm, and the

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -35,6 +35,7 @@
   no fixed `\"Internal error\"` fallback string ever reaches a client
   (rf2-kzvwq)."
   (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.headers :as headers]
@@ -334,7 +335,21 @@
         ;; frame's route registry). One push/pop per request.
         explicit-head (:head opts)
         {:keys [hash-str body-html head-html html-attrs body-attrs]}
-        (rf/with-frame frame-id
+        ;; rf2-bzw8gd / EP-0013 §Realm Conformance: route the render walk's
+        ;; registered-view + head/route registry lookups through the request
+        ;; frame's OWN realm registrar, so a non-default-realm frame renders
+        ;; its realm's views/heads — not the process-global default's. The
+        ;; binding is established ONCE per request (covers resolve-root-view,
+        ;; render-to-string's `:view` lookups, and resolve-head's `:head` /
+        ;; `:route` lookups); a default-realm frame binds nothing (the
+        ;; byte-identical single-realm path). `with-frame` only binds
+        ;; `*current-frame*` (core_reg_view_macro.cljc), not the realm
+        ;; registrar — so the realm registrar is bound here, at the host
+        ;; adapter that holds the frame.
+        (frame/call-with-frame-realm-registrar
+         (frame/frame frame-id)
+         (fn []
+          (rf/with-frame frame-id
           (let [hiccup    (lifecycle/resolve-root-view root-view)
                 ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's
                 ;; :head (or default-head fallback). The head fragment
@@ -374,7 +389,7 @@
                              :render-hash (when emit-hash? hash-str)})]
             (assoc head-bag
                    :hash-str  hash-str
-                   :body-html body-html)))
+                   :body-html body-html)))))
         ;; app-db-value / runtime-db-value read the named frame explicitly; no
         ;; with-frame needed. Kept outside the block so the explicit frame-id
         ;; read is visible — pulling the snapshot AFTER the render walk is

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -47,6 +47,7 @@
   (`:replace-app-db`) when it lands."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.html-helpers :as html]
@@ -220,7 +221,14 @@
   ;; deferral is a separate axis — blocking ROUTE resources still settle before
   ;; the shell, exactly as in the non-streaming path.
   (ssr/drain-blocking-resources! frame-id opts)
-  (rf/with-frame frame-id
+  ;; rf2-bzw8gd / EP-0013 §Realm Conformance: route the shell render walk's
+  ;; registered-view + head/route lookups through the request frame's OWN realm
+  ;; registrar (streaming counterpart of the non-streaming `build-full-response*`
+  ;; binding). A default-realm frame binds nothing (byte-identical path).
+  (frame/call-with-frame-realm-registrar
+   (frame/frame frame-id)
+   (fn []
+   (rf/with-frame frame-id
     (let [hiccup     (lifecycle/resolve-root-view root-view)
           head-bag   (if (:head opts)
                        {:head-html (:head opts) :html-attrs nil :body-attrs nil}
@@ -240,7 +248,12 @@
        :body-attrs    body-attrs
        :doc-hash      doc-hash
        :shell-html    shell-html
-       :continuations continuations})))
+       :continuations continuations
+       ;; rf2-bzw8gd: capture the frame's realm-id on the REQUEST thread (where
+       ;; `*current-realm*` is bound) so the daemon writer thread — which has no
+       ;; carried realm — can re-establish it around the continuation render
+       ;; walk. nil ⇒ default realm (byte-identical path).
+       :realm-id      (frame/frame-realm frame-id)})))))
 
 ;; ---- chunk writer (daemon thread, AFTER the head commits) ---------------
 ;;
@@ -328,7 +341,7 @@
           ;; request thread by `render-streaming-shell!`. `:hiccup` stays in
           ;; the `rendered` map for diagnostics but is not destructured here.
           {:keys [head-html html-attrs body-attrs
-                  doc-hash shell-html continuations]} rendered
+                  doc-hash shell-html continuations realm-id]} rendered
           shell-opts (merge opts
                             {:html-attrs  html-attrs
                              :body-attrs  body-attrs
@@ -361,7 +374,21 @@
       (loop [queue (into clojure.lang.PersistentQueue/EMPTY continuations)]
         (when-let [entry (peek queue)]
           (let [{:keys [id html delta failed? continuations]}
-                (rf/with-frame frame-id (streaming/render-continuation frame-id entry))
+                ;; rf2-bzw8gd: re-establish the frame's realm on this DAEMON
+                ;; thread (the request thread's `*current-realm*` does not cross
+                ;; the thread boundary) so `render-continuation`'s frame lookups +
+                ;; registered-view resolution route through the owning realm.
+                ;; `call-with-realm` binds `*current-realm*` so `(frame frame-id)`
+                ;; resolves the non-default realm's frame record;
+                ;; `call-with-frame-realm-registrar` then binds that realm's
+                ;; registrar. Both no-op for the default realm (byte-identical).
+                (frame/call-with-realm realm-id
+                  (fn []
+                    (frame/call-with-frame-realm-registrar
+                      (frame/frame frame-id)
+                      (fn []
+                        (rf/with-frame frame-id
+                          (streaming/render-continuation frame-id entry))))))
                 tmpl-fn (if failed?
                           streaming/failed-template
                           streaming/resolved-template)]

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -166,8 +166,12 @@
 (defonce pending-error-traces (atom {}))
 
 (defn- buffer-error-trace!
+  ;; Keyed by the (realm, frame) ADDRESS (rf2-bzw8gd) so two server frames
+  ;; sharing an id in different realms buffer independent error traces —
+  ;; `frame-address` collapses to the bare `frame-id` for the default realm.
   [frame-id trace-event]
-  (swap! pending-error-traces update frame-id (fnil conj []) trace-event))
+  (swap! pending-error-traces update (frame/frame-address frame-id)
+         (fnil conj []) trace-event))
 
 (defn- consume-pending-traces!
   "Atomically pull and clear the pending error traces for frame-id.
@@ -191,8 +195,9 @@
   next drain). No trace is dropped either way. `swap-vals!` is available
   on both the JVM (Clojure ≥1.9) and ClojureScript."
   [frame-id]
-  (let [[old _new] (swap-vals! pending-error-traces dissoc frame-id)]
-    (get old frame-id [])))
+  (let [addr       (frame/frame-address frame-id)
+        [old _new] (swap-vals! pending-error-traces dissoc addr)]
+    (get old addr [])))
 
 (defn apply-error-projection!
   "Project an error trace event via the active projector for frame-id
@@ -481,6 +486,8 @@
 
 (defn clear-pending-error-traces!
   "Drop frame-id's entry from the pending-error-traces buffer.
-  Called from `re-frame.ssr.request/on-frame-destroyed!`."
+  Called from `re-frame.ssr.request/on-frame-destroyed!`. Keyed by the
+  (realm, frame) ADDRESS (rf2-bzw8gd) so clearing one realm's frame leaves
+  another realm's same-id buffered traces intact."
   [frame-id]
-  (swap! pending-error-traces dissoc frame-id))
+  (swap! pending-error-traces dissoc (frame/frame-address frame-id)))

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -42,27 +42,34 @@
   (atom {}))
 
 (defn- record-fragment!
-  "Stash the just-produced head-model under (frame-id, head-id) so
-  `head-snapshot` reflects the most recent render-head output."
+  "Stash the just-produced head-model under ((realm, frame) address, head-id)
+  so `head-snapshot` reflects the most recent render-head output. Keyed by the
+  frame ADDRESS (rf2-bzw8gd) so the same frame id in two realms records
+  independent head snapshots — `frame-address` collapses to the bare
+  `frame-id` for the default realm (byte-identical single-realm path)."
   [frame-id head-id head-model]
   (when frame-id
-    (swap! head-snapshots assoc-in [frame-id head-id] head-model))
+    (swap! head-snapshots assoc-in [(frame/frame-address frame-id) head-id]
+           head-model))
   head-model)
 
 (defn head-snapshot
   "Read the per-frame `{head-id → last-produced head-model}` snapshot.
   Useful for tests and introspection. Returns `{}` for a frame that has
   never seen a `render-head` call (or whose snapshot has been cleared
-  via the per-request frame teardown hook)."
+  via the per-request frame teardown hook). Keyed by the (realm, frame)
+  ADDRESS (rf2-bzw8gd)."
   [frame-id]
-  (get @head-snapshots frame-id {}))
+  (get @head-snapshots (frame/frame-address frame-id) {}))
 
 (defn on-frame-destroyed!
   "Clear the head-snapshot entry for `frame-id`. Wired into the
   `:ssr/on-frame-destroyed` late-bind hook chain so per-request frames
-  release their head bookkeeping on destroy. Idempotent."
+  release their head bookkeeping on destroy. Idempotent. Keyed by the
+  (realm, frame) ADDRESS (rf2-bzw8gd) so clearing one realm's frame leaves
+  another realm's same-id head snapshot intact."
   [frame-id]
-  (swap! head-snapshots dissoc frame-id)
+  (swap! head-snapshots dissoc (frame/frame-address frame-id))
   nil)
 
 ;; ---- reg-head -------------------------------------------------------------
@@ -149,7 +156,14 @@
         route    (if (contains? opts :route)
                    (:route opts)
                    (frame-route frame))
-        head-reg (registrar/lookup :head head-id)]
+        ;; Resolve the `:head` registration through the carried frame's OWN
+        ;; realm registrar (rf2-bzw8gd / EP-0013 §Realm Conformance) — a
+        ;; non-default-realm frame's head is registered in that realm's table,
+        ;; not the process-global default. `call-with-frame-realm-registrar`
+        ;; binds nothing for a default-realm frame (byte-identical path).
+        head-reg (frame/call-with-frame-realm-registrar
+                   (frame/frame frame)
+                   (fn [] (registrar/lookup :head head-id)))]
     (when-not head-reg
       (throw (ex-info ":rf.error/no-such-head"
                       {:rf.error/id :rf.error/no-such-head
@@ -204,10 +218,18 @@
   key under the `:route` kind. If the runtime ever introduces an
   indirection between the slice id and the registry key (route aliases,
   versioned routes, ...), this fn breaks and must learn the new mapping
-  (audit rf2-asmj1 H6 / cluster rf2-sljs1)."
-  [route]
+  (audit rf2-asmj1 H6 / cluster rf2-sljs1).
+
+  Resolves the `:route` registration through the carried `frame-id`'s OWN
+  realm registrar (rf2-bzw8gd / EP-0013 §Realm Conformance) — a
+  non-default-realm frame's route metadata is registered in that realm's
+  table. `call-with-frame-realm-registrar` binds nothing for a default-realm
+  frame (byte-identical path)."
+  [frame-id route]
   (when-let [route-id (:route-id route)]
-    (when-let [route-meta (registrar/lookup :route route-id)]
+    (when-let [route-meta (frame/call-with-frame-realm-registrar
+                            (frame/frame frame-id)
+                            (fn [] (registrar/lookup :route route-id)))]
       (:head route-meta))))
 
 (defn active-head
@@ -232,7 +254,7 @@
                    frame-id :rf.ssr/active-head
                    {:where 'rf/active-head})
         route    (frame-route frame-id)
-        head-id  (route-head-id route)]
+        head-id  (route-head-id frame-id route)]
     (if head-id
       ;; The route declares an id but it may not be registered — surface
       ;; that as :rf.error/no-such-head per Spec 011, but only when the

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -69,7 +69,10 @@
 
   Returns `frame-id`."
   [frame-id request]
-  (swap! request-slots assoc frame-id request)
+  ;; Key by the (realm, frame) ADDRESS (EP-0013, rf2-bzw8gd) so the same frame
+  ;; id in two realms does not collide — `frame-address` collapses to the bare
+  ;; `frame-id` for the default realm (byte-identical single-realm path).
+  (swap! request-slots assoc (frame/frame-address frame-id) request)
   frame-id)
 
 (defn get-request
@@ -82,7 +85,7 @@
   Public read surface — host adapters and tools may inspect the active
   request via this fn."
   [frame-id]
-  (get @request-slots frame-id))
+  (get @request-slots (frame/frame-address frame-id)))
 
 (defn clear-request!
   "Clear the per-frame request slot. Host adapters call this after
@@ -91,7 +94,7 @@
 
   Returns `frame-id`."
   [frame-id]
-  (swap! request-slots dissoc frame-id)
+  (swap! request-slots dissoc (frame/frame-address frame-id))
   frame-id)
 
 ;; ---- per-request frame teardown (rf2-fcj33) -------------------------------

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -58,6 +58,7 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
+            [re-frame.frame :as frame]
             [re-frame.ssr.http-validation :as http-validation]
             [re-frame.trace :as trace])
   #?(:clj (:import [java.net URI URISyntaxException])))
@@ -341,25 +342,31 @@
 (defn swap-response!
   "Mutate the response accumulator slot for `frame-id` with `f`. Returns
   the post-swap response map. The substrate is a side-channel atom keyed
-  on frame-id (rf2-jbcmt) — O(small-map) swap, no app-db ping-pong."
+  on the (realm, frame) ADDRESS (rf2-jbcmt; addressed by realm per
+  rf2-bzw8gd) — O(small-map) swap, no app-db ping-pong. `frame-address`
+  collapses to the bare `frame-id` for the default realm, so two server
+  frames sharing an id in different realms accumulate independent responses."
   [frame-id f]
-  (let [next-resp (-> (swap! response-slots
-                             update frame-id #(f (ensure-response %)))
-                      (get frame-id))]
+  (let [addr      (frame/frame-address frame-id)
+        next-resp (-> (swap! response-slots
+                             update addr #(f (ensure-response %)))
+                      (get addr))]
     next-resp))
 
 (defn response-of
   "Read the current response accumulator (with defaults applied)."
   [frame-id]
-  (ensure-response (get @response-slots frame-id)))
+  (ensure-response (get @response-slots (frame/frame-address frame-id))))
 
 (defn clear-response!
   "Drop `frame-id`'s response slot. Called from
   `re-frame.ssr.request/on-frame-destroyed!` via the
   `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33). Idempotent —
-  tolerates a frame-id with no slot."
+  tolerates a frame-id with no slot. Keyed by the (realm, frame) ADDRESS
+  (rf2-bzw8gd) so clearing one realm's frame leaves another realm's
+  same-id response slot intact."
   [frame-id]
-  (swap! response-slots dissoc frame-id)
+  (swap! response-slots dissoc (frame/frame-address frame-id))
   frame-id)
 
 ;; ---- header helpers ------------------------------------------------------

--- a/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
@@ -1,0 +1,257 @@
+(ns re-frame.ssr-realm-address-test
+  "rf2-bzw8gd / EP-0013 §Realm Conformance: SSR per-frame state (the request /
+  response / error-trace / head-snapshot side channels) and the SSR head/route
+  registry lookups must carry the frame's REALM, so the SAME frame id in two
+  different realms round-trips through SSR with its realm intact and never mixes
+  state or registrations across realms.
+
+  Spec 002 §Frames reference realms makes the same frame id legal in two realms
+  (frame ids are unique WITHIN a realm). Before this bead the SSR side channels
+  keyed on the bare frame id, so two live server frames sharing an id in
+  different realms would mix request data, response status/headers/cookies,
+  pending error projections, and head snapshots; and the head/route lookups read
+  the default realm's registrations instead of the request frame's realm-owned
+  ones.
+
+  The fix keys every side channel by the (realm, frame) ADDRESS
+  (`re-frame.frame/frame-address`, which collapses to the bare frame id for the
+  default realm — so the single-realm round-trip is byte-identical and carries
+  NO realm key) and routes the head/route lookups through the carried frame's
+  own realm registrar.
+
+  These tests are the round-trip + isolation proofs the bead asked for:
+    * a realm-stamped frame's request / response / error-trace / head state
+      round-trips through serialize→read with its realm intact;
+    * a default-realm frame stays clean (bare-id key, no realm key);
+    * the same frame id in two realms isolates every side channel;
+    * teardown of a frame in one realm leaves the other realm's same-id state
+      intact;
+    * `render-head` / `active-head` resolve the carried frame's realm-owned
+      head / route registrations."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.realm :as realm]
+            [re-frame.registrar :as registrar]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.error-listener :as error-listener]
+            [re-frame.ssr.head :as head]
+            [re-frame.ssr.head.registry :as head-registry]
+            [re-frame.ssr.request :as request]
+            [re-frame.ssr.response :as response]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; A module that installs the SAME frame id into whichever realm it is installed
+;; against, so two realms can carry a frame by the same id (the bead's central
+;; "same frame id in two realms" shape). `:shared/frame` mirrors the bead's
+;; `:shared/frame` example.
+(defn- shared-app [tag]
+  (rf/app {:id :addr/app
+           :modules
+           [(rf/module
+              {:id     :m
+               :frames {:shared/frame {:doc "shared id across realms"}}
+               :events {:addr/touch
+                        {:handler (fn [{:keys [db]} _] {:db (assoc db :who tag)})}}})]}))
+
+;; ---- default-realm round-trip stays clean (bare-id key, no realm key) -------
+
+(deftest default-realm-frame-keys-by-bare-id
+  (testing "a default-realm SSR frame's side-channel slots key by the BARE frame
+            id (no realm key) — the round-trip is byte-identical to the pre-realm
+            keying"
+    (let [f (rf/make-frame {:platform :server :doc "default-realm SSR frame"})]
+      ;; frame-address collapses to the bare id for the default realm.
+      (is (= f (frame/frame-address f))
+          "frame-address of a default-realm frame is the bare frame id")
+      (ssr/set-request! f {:uri "/default"})
+      (response/swap-response! f (fn [r] (assoc r :status 201)))
+      ;; The slot atoms are keyed by the bare frame id — no [realm id] vector.
+      (is (contains? @request/request-slots f)
+          "the request slot is keyed by the bare frame id")
+      (is (contains? @response/response-slots f)
+          "the response slot is keyed by the bare frame id")
+      (is (= {:uri "/default"} (ssr/get-request f))
+          "the request round-trips")
+      (is (= 201 (:status (response/response-of f)))
+          "the response round-trips"))))
+
+;; ---- two realms, same frame id: request slot isolation ----------------------
+
+(deftest request-slots-isolate-by-realm
+  (testing "the same frame id in two realms carries INDEPENDENT request data —
+            and round-trips through set-request!→get-request with its realm"
+    (let [ra (rf/realm {:id :addr/a})
+          rb (rf/realm {:id :addr/b})]
+      (try
+        (rf/install! ra (shared-app :a))
+        (rf/install! rb (shared-app :b))
+        ;; The side-channel ops run UNDER the frame's realm scope, exactly as the
+        ;; router binds `*current-realm*` around a real drain.
+        (frame/call-with-realm :addr/a
+          (fn [] (ssr/set-request! :shared/frame {:uri "/a" :realm :a})))
+        (frame/call-with-realm :addr/b
+          (fn [] (ssr/set-request! :shared/frame {:uri "/b" :realm :b})))
+
+        (is (= {:uri "/a" :realm :a}
+               (frame/call-with-realm :addr/a
+                 (fn [] (ssr/get-request :shared/frame))))
+            "realm a's frame reads realm a's request — its realm round-trips")
+        (is (= {:uri "/b" :realm :b}
+               (frame/call-with-realm :addr/b
+                 (fn [] (ssr/get-request :shared/frame))))
+            "realm b's frame reads realm b's request — no leak from a")
+        ;; The slots are keyed by the full (realm, frame) address.
+        (is (contains? @request/request-slots [:addr/a :shared/frame])
+            "realm a's slot is keyed by the [realm frame] address")
+        (is (contains? @request/request-slots [:addr/b :shared/frame])
+            "realm b's slot is keyed by the [realm frame] address")
+        (finally
+          (rf/dispose-realm! :addr/a)
+          (rf/dispose-realm! :addr/b))))))
+
+;; ---- two realms, same frame id: response slot isolation + teardown ----------
+
+(deftest response-slots-isolate-and-teardown-is-realm-scoped
+  (testing "the same frame id in two realms accumulates INDEPENDENT responses,
+            and tearing down one realm's frame leaves the other realm's same-id
+            response intact"
+    (let [ra (rf/realm {:id :addr/a})
+          rb (rf/realm {:id :addr/b})]
+      (try
+        (rf/install! ra (shared-app :a))
+        (rf/install! rb (shared-app :b))
+        (frame/call-with-realm :addr/a
+          (fn [] (response/swap-response! :shared/frame (fn [r] (assoc r :status 418)))))
+        (frame/call-with-realm :addr/b
+          (fn [] (response/swap-response! :shared/frame (fn [r] (assoc r :status 503)))))
+
+        (is (= 418 (frame/call-with-realm :addr/a
+                     (fn [] (:status (response/response-of :shared/frame)))))
+            "realm a's response status is its own")
+        (is (= 503 (frame/call-with-realm :addr/b
+                     (fn [] (:status (response/response-of :shared/frame)))))
+            "realm b's response status is its own — no cross-realm mix")
+
+        ;; Teardown of realm a's frame must NOT clear realm b's same-id response.
+        (frame/call-with-realm :addr/a
+          (fn [] (response/clear-response! :shared/frame)))
+        (is (not (contains? @response/response-slots [:addr/a :shared/frame]))
+            "realm a's response slot was cleared")
+        (is (contains? @response/response-slots [:addr/b :shared/frame])
+            "realm b's response slot survives realm a's teardown")
+        (is (= 503 (frame/call-with-realm :addr/b
+                     (fn [] (:status (response/response-of :shared/frame)))))
+            "realm b's response is untouched by realm a's teardown")
+        (finally
+          (rf/dispose-realm! :addr/a)
+          (rf/dispose-realm! :addr/b))))))
+
+;; ---- two realms, same frame id: error-trace buffer isolation ----------------
+;;
+;; The error-trace buffer is framework-private; exercise it through the same
+;; (realm, frame) addressing the runtime uses. `buffer-error-trace!` is private,
+;; so drive the public clear seam + the address directly to prove the keying.
+
+(deftest pending-error-traces-isolate-by-realm
+  (testing "the pending-error-traces buffer keys by the (realm, frame) address —
+            clearing one realm's frame leaves the other realm's buffered traces"
+    (let [ra (rf/realm {:id :addr/a})
+          rb (rf/realm {:id :addr/b})]
+      (try
+        (rf/install! ra (shared-app :a))
+        (rf/install! rb (shared-app :b))
+        ;; Seed each realm's buffer directly at its address (mirrors what the
+        ;; always-on error listener does under the realm-bound drain).
+        (swap! error-listener/pending-error-traces
+               assoc [:addr/a :shared/frame] [{:operation :rf.error/a}])
+        (swap! error-listener/pending-error-traces
+               assoc [:addr/b :shared/frame] [{:operation :rf.error/b}])
+
+        ;; Clear realm a's frame via the public teardown seam, under realm a.
+        (frame/call-with-realm :addr/a
+          (fn [] (error-listener/clear-pending-error-traces! :shared/frame)))
+
+        (is (not (contains? @error-listener/pending-error-traces
+                            [:addr/a :shared/frame]))
+            "realm a's error-trace buffer was cleared")
+        (is (contains? @error-listener/pending-error-traces
+                       [:addr/b :shared/frame])
+            "realm b's error-trace buffer survives realm a's teardown")
+        (finally
+          (rf/dispose-realm! :addr/a)
+          (rf/dispose-realm! :addr/b))))))
+
+;; ---- two realms, same frame id: head-snapshot isolation ---------------------
+
+(defn- reg-head-in-realm!
+  "Register a `:head` producer under `head-id` into the realm's OWN registrar.
+  `:head` is a step-8-DEFERRED kind that `install!` does not seat — it is
+  registered through `reg-head` sugar — so bind the realm's registrar around the
+  call (mirrors how `app-value/install!` binds `*registrar*` to seat a realm's
+  program, and how the SSR render path binds it to RESOLVE one)."
+  [rid head-id head-fn]
+  (binding [registrar/*registrar* (realm/registrar (realm/realm rid))]
+    (head/reg-head head-id {:doc "realm-scoped head"} head-fn)))
+
+(deftest head-snapshots-isolate-by-realm
+  (testing "render-head records the produced head-model under the (realm, frame)
+            address, so the same frame id in two realms keeps independent head
+            snapshots — and resolves each realm's OWN head registration"
+    (let [ra (rf/realm {:id :addr/a})
+          rb (rf/realm {:id :addr/b})]
+      (try
+        ;; install! seats the frame (a wired kind) into each realm.
+        (rf/install! ra (shared-app :a))
+        (rf/install! rb (shared-app :b))
+        ;; Each realm registers a DIFFERENT head fn under the SAME head id into
+        ;; its OWN registrar — proves the render-head lookup is realm-scoped.
+        (reg-head-in-realm! :addr/a :addr/title (fn [_db _route] {:title "realm-a"}))
+        (reg-head-in-realm! :addr/b :addr/title (fn [_db _route] {:title "realm-b"}))
+
+        (let [model-a (frame/call-with-realm :addr/a
+                        (fn [] (head/render-head :addr/title :shared/frame)))
+              model-b (frame/call-with-realm :addr/b
+                        (fn [] (head/render-head :addr/title :shared/frame)))]
+          (is (= {:title "realm-a"} model-a)
+              "realm a resolved realm a's OWN head registration")
+          (is (= {:title "realm-b"} model-b)
+              "realm b resolved realm b's OWN head registration — no default-realm leak"))
+
+        ;; Each realm's snapshot is keyed by its address and holds its own model.
+        (is (= {:addr/title {:title "realm-a"}}
+               (frame/call-with-realm :addr/a
+                 (fn [] (head/head-snapshot :shared/frame))))
+            "realm a's head snapshot is its own")
+        (is (= {:addr/title {:title "realm-b"}}
+               (frame/call-with-realm :addr/b
+                 (fn [] (head/head-snapshot :shared/frame))))
+            "realm b's head snapshot is its own — independent of realm a")
+        (is (contains? @head-registry/head-snapshots [:addr/a :shared/frame])
+            "realm a's snapshot keys by the [realm frame] address")
+        (is (contains? @head-registry/head-snapshots [:addr/b :shared/frame])
+            "realm b's snapshot keys by the [realm frame] address")
+        (finally
+          (rf/dispose-realm! :addr/a)
+          (rf/dispose-realm! :addr/b))))))
+
+;; ---- frame-address resolution semantics ------------------------------------
+
+(deftest frame-address-resolves-carried-then-frame-realm
+  (testing "frame-address keys a non-default-realm frame by [realm frame] under
+            the carried realm, and a default-realm frame by the bare id"
+    (let [ra (rf/realm {:id :addr/a})]
+      (try
+        (rf/install! ra (shared-app :a))
+        ;; Under the carried realm: the [realm frame] address.
+        (is (= [:addr/a :shared/frame]
+               (frame/call-with-realm :addr/a
+                 (fn [] (frame/frame-address :shared/frame))))
+            "the carried realm produces the [realm frame] address")
+        ;; The default-realm frame from the fixture keys by the bare id.
+        (is (= :rf/default (frame/frame-address :rf/default))
+            "a default-realm frame keys by its bare id (no realm key)")
+        (finally
+          (rf/dispose-realm! :addr/a))))))


### PR DESCRIPTION
Fixes **rf2-bzw8gd** (P1, BUG — EP-0013 realm correctness).

## Problem

EP-0013 makes the same frame id legal in different realms and routes resolution through the owning frame's realm (`:rf.realm/id` rides beside `:rf.frame/id`; frames key by `(realm, frame-id)`). But the SSR per-frame side channels keyed only on the bare frame id, so two live server frames sharing an id in different realms could mix request data, response status/headers/cookies, pending error projections, and head snapshots between realms. The SSR head/route registry lookups also read the default realm's registrations instead of the request frame's realm-owned ones.

## Fix

Key every SSR side channel by the **(realm, frame) ADDRESS**, and route the head/route + body/streaming view lookups through the carried frame's **own realm registrar** — both governed by the default-realm absent-key rule (absence of `:rf.realm/id` = the default realm), so a single-realm SSR frame keys by the bare id with no realm key and round-trips byte-identical (mirrors how tools/story stamped the realm in rf2-0io9uq).

- **core/frame.cljc** (surgical): add `frame-address` — the (realm, frame) side-channel key seam. Resolves the realm from the CARRIED `*current-realm*` (bound by the router around a drain AND a frame's destroy teardown), else the frame's own `:realm` (read-time fallback), and collapses to the bare frame id for the default realm via `frame-key`. Derived from the carried address, never ambient synthesis (EP-0002).
- **ssr/request, ssr/response, ssr/error-listener, ssr/head/registry**: key `request-slots` / `response-slots` / `pending-error-traces` / `head-snapshots` by `frame/frame-address`, so set/get/swap/clear and the per-request teardown isolate by realm.
- **ssr/head/registry**: resolve `:head` + `:route` registrations through the carried frame's realm registrar (`call-with-frame-realm-registrar`).
- **ssr-ring/pipeline + streaming**: bind the request frame's realm registrar around the render walk so registered-view + head/route lookups resolve in the frame's realm; the streaming daemon writer re-establishes the realm on its thread (carried via `:realm-id` from the request thread).

Default-realm behaviour is preserved everywhere: `frame-address` collapses to the bare id and the realm-registrar binders no-op (byte-identical single-realm path).

## Regression test

New JVM test `implementation/ssr/test/re_frame/ssr_realm_address_test.clj` (6 tests, 24 assertions):
- a default-realm frame stays clean — bare-id key, no realm key, request + response round-trip;
- the same frame id in two realms isolates request, response, error-trace, and head-snapshot state;
- teardown of one realm's frame leaves the other realm's same-id state intact;
- `render-head` resolves each realm's OWN head registration;
- `frame-address` resolves `[realm frame]` under the carried realm and the bare id for the default realm.

## Follow-up

rf2-nu5w48 (P2): realm-route the ssr-ring error-body + redirect render paths and add an ssr-ring streaming continuation realm-isolation end-to-end test (the cross-thread streaming path).

## Quality gates

Bounded to the affected surface (Windows full-JVM can deadlock; scoped per dispatch brief):
- ssr JVM suite (`clojure -M:test`): **343 tests, 1373 assertions, 0 failures, 0 errors** (includes the 6 new tests).
- ssr-ring JVM suite: **156 tests, 698 assertions, 0 failures, 0 errors**.
- core JVM suite (validates the `frame-address` core addition): **1521 tests, 6716 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: NOT run — this fresh worktree has no `node_modules` (shadow-cljs absent) and `npm install` + full CLJS compile is time-risky on Windows full-JVM. The `.cljc` edits are reader-conditional-clean and `frame-address` uses only CLJS-safe primitives (`frame-key`/`frame-realm`/`*current-realm*`); CI-Linux covers the full CLJS matrix.