### PR TITLE
fix(reply-conformance): correct CLJS reader API in vocab test

### DIFF
--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -59,6 +59,12 @@
   Canonical contract: `spec/Managed-Effects.md` §The uniform reply
   envelope."
   (:require [clojure.test :refer [deftest is testing]]
+            ;; CLJS-only: the `:cljs` arm of `edn-roundtrip` reads EDN via
+            ;; `cljs.reader/read-string` (JVM uses core `read-string`). Without
+            ;; this require the node CLJS gate hits `Use of undeclared Var
+            ;; cljs.reader/read-string` then a runtime undefined-deref, even
+            ;; though `clojure -M:test` is green. See rf2-u99i9j.
+            #?(:cljs [cljs.reader])
             [re-frame.reply :as reply]
             [re-frame.http-reply :as http-reply]
             [re-frame.resources.reply :as rreply]


### PR DESCRIPTION
Fixes **rf2-u99i9j** (P2, BUG).

## Problem

`implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc` calls `cljs.reader/read-string` in the `:cljs` arm of its `edn-roundtrip` helper (line ~77, reached from `every-work-id-is-a-comparable-edn-tuple`), but the `ns` `:require` block never required `cljs.reader`. The JVM gate (`clojure -M:test`) stayed green because its arm uses core `read-string`, but the always-on CLJS node gate (`npm run test:cljs`, `cljs-test$` ns-regexp) hit `Use of undeclared Var cljs.reader/read-string` at compile and then a runtime `Cannot read properties of undefined (reading 'read_string')`. The advertised CLJS conformance tier was therefore broken while the JVM pass looked green.

## Fix

Add the CLJS-only `#?(:cljs [cljs.reader])` require to the namespace — matching the established convention in the analog round-trip tests (`resources_cache_key_identity_cljs_test.cljc:34`, `timer_probe_conformance_cljs_test.cljc`). One-line require addition; no assertion logic changed, so the suite still asserts the same EDN-round-trip / `=`-comparability invariant.

## Quality gates

Run in the worker worktree (Windows; full-JVM matrix scoped to avoid deadlock — CI-Linux covers the full sweep):

- **JVM** `clojure -M:test` from `implementation/reply-conformance` — **PASS**: Ran 16 tests, 287 assertions, 0 failures, 0 errors.
- **CLJS compile** (focused node-test build on `reply-vocab-conformance-cljs-test$`, temporary build reverted before commit) — **PASS**: Build completed, 90 files, 0 warnings (no undeclared-var warning).
- **CLJS run** (compiled focused node-test, exercises the `:cljs` `cljs.reader/read-string` branch incl. `every-work-id-is-a-comparable-edn-tuple`) — **PASS**: Ran 9 tests, 268 assertions, 0 failures, 0 errors.

Full `npm run test:cljs` not run locally (Windows full-JVM deadlock risk); CI-Linux covers the complete matrix.