### PR TITLE
refactor(xray): split production registration from install-test-overrides! seam (xxo3zz F3)

### DIFF
--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -36,7 +36,14 @@
             [re-frame.core :as rf]
             [re-frame.machines]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; rf2-e8330v (xxo3zz F3) — this feature-gate testbed drives the
+            ;; Xray Machine Inspector chart-render path via the test-only
+            ;; epoch-history / focus-epoch-id seeding events. Production
+            ;; `register-xray-handlers!` no longer installs those `-for-test`
+            ;; ids, so this dev testbed opts into the per-panel test-override
+            ;; seam at boot (see `run`). Dev-only; testbeds are never bundled.
+            [day8.re-frame2-xray.test-support :as xray-test-support])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ----------------------------------------------------------------------------
@@ -383,6 +390,13 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
+  ;; rf2-e8330v — install the Xray test-only override seam so the
+  ;; feature-gate scenario's synthetic-epoch injection (via
+  ;; `:rf.xray/set-epoch-history-for-test` + `:rf.xray/set-focus-epoch-
+  ;; id-for-test`) lands. The xray preload has already run
+  ;; `register-xray-handlers!`; this layers the test seam on top.
+  ;; Dev-testbed only — never ships.
+  (xray-test-support/install-test-overrides!)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — `:rf/default` is this testbed's app frame, registered
   ;; explicitly here (init! installs only the adapter). The boot dispatch

--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -89,6 +89,40 @@ NOT call `reset-for-test!`. Per-panel `install!` helpers run inside
 the same gate so panel-owned registrations inherit idempotency
 without re-doing the dance.
 
+### Production registration carries no test seams (rf2-e8330v / xxo3zz F3)
+
+`register-xray-handlers!` (and the per-panel `install!` helpers it
+calls) registers **no id ending in `-for-test`** and **no `*-override`
+reader sub**. The production data subs read their live source directly —
+they carry no `(or override …)` branch. This keeps the test-only
+override surface off the public dispatch / subscribe contract.
+
+The override seam is split out per panel as
+`<panel-ns>/install-test-overrides!`, orchestrated by the test-only
+`day8.re-frame2-xray.test-support/install-test-overrides!`. Each per-
+panel `install-test-overrides!`:
+
+1. registers the panel's `:rf.xray*/set-*-override-for-test` events +
+   companion `*-override` subs (plus the Machine Inspector's
+   `:rf.xray/set-epoch-history-for-test` /
+   `:rf.xray/set-focus-epoch-id-for-test` SEEDING events, which write
+   the real `:epoch-history` / `:focus` slots), and
+2. RE-registers the affected production data subs to layer the override
+   read on top (`(or override (real …))`) — re-frame's registrar
+   replaces in place.
+
+A test (or a feature-gate dev testbed that injects synthetic state via
+those events) opts in by calling `install-test-overrides!` AFTER
+`register-xray-handlers!`. The production-vs-seam split is asserted by
+`registry_cljs_test.cljs`:
+`production-registration-installs-no-for-test-ids` (no `-for-test`
+events, no `*-override` subs after production registration) and
+`test-seam-installs-exactly-the-override-surface` (the seam installs
+exactly the `test-override-sub-names` / `test-override-event-names`
+snapshot). The shared value-source `defn`s the production sub and the
+seam's override sub both call (e.g. `routing/registered-routes-value`)
+keep the projection logic single-sourced.
+
 ## Shared infrastructure
 
 Subscriptions and events the entire panel set composes against. These

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -448,25 +448,36 @@ No event registered here dispatches a `:rf.resource/*` event (read-only).
 
 ### Subscriptions
 
-| Sub | Inputs | Returns |
+In production registration these subs read their live source directly —
+they carry NO override input (rf2-e8330v). The test-override seam
+(`resources/install-test-overrides!`) re-registers them with the
+override input layered on top; see §Events below.
+
+| Sub | Inputs (production) | Returns |
 |---|---|---|
-| `:rf.xray/registered-resources` | `:rf.xray/trace-buffer`, override | `(rf/registrations :resource)` — the static registry map. |
-| `:rf.xray/registered-scope-resolvers` | `:rf.xray/trace-buffer`, override | `(rf/registrations :resource-scope)` — the static named-scope-resolver registry map (rf2-hls77w, EP-0016 D3). |
-| `:rf.xray/resource-entries` | `:rf.xray/target-frame-runtime-db`, override | the live cache entries map at `[:rf.runtime/resources :entries]`. |
-| `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db`, override | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
-| `:rf.xray/resource-sub-reads` | override | observed live subscription reads backing the scope-mismatch lint (empty by default). |
-| `:rf.xray/resource-routing-slice` | `:rf.xray/target-frame-runtime-db`, override | the live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. |
+| `:rf.xray/registered-resources` | `:rf.xray/trace-buffer` | `(rf/registrations :resource)` — the static registry map. |
+| `:rf.xray/registered-scope-resolvers` | `:rf.xray/trace-buffer` | `(rf/registrations :resource-scope)` — the static named-scope-resolver registry map (rf2-hls77w, EP-0016 D3). |
+| `:rf.xray/resource-entries` | `:rf.xray/target-frame-runtime-db` | the live cache entries map at `[:rf.runtime/resources :entries]`. |
+| `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db` | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
+| `:rf.xray/resource-sub-reads` | (none) | observed live subscription reads backing the scope-mismatch lint (empty by default). |
+| `:rf.xray/resource-routing-slice` | `:rf.xray/target-frame-runtime-db` | the live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. |
 | `:rf.xray/resources-tab-data` | the six above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :scope-resolvers :instances :work :live-work :stale-races :stale-tally :route-graph :timeline :invalidations :scope-resolutions :mutation-invalidations :continuations :cache-growth :audit}`. Its `:scope-resolvers` is the projected named-scope-resolver registry (id + declared inputs + whole-db cost flag, paths summarized, NO resolved value); `:scope-resolutions` is the `:rf.resource/scope-resolved` resolution timeline (resolver id + resolved scope summarized + fail-closed nil evidence — EP-0016 D3); `:mutation-invalidations` is the descriptor-level invalidation evidence off the mutation settlement traces (per-descriptor resolved scope + fail-closed `:unresolved` + Rider-1 `:populate-exempt` — EP-0016 D2); `:continuations` is the `:rf.mutation/replied` call-site `:reply-to` dispatch evidence (EP-0016 D1). `:route-graph` joins the static route plan against the live instance/work rows + routing slice. The `:live-work` / `:stale-races` / `:stale-tally` slots are the UNIFORM reply-envelope reads (see below). |
 
-### Events (test-only override hooks)
+### Events (test-only override seam — rf2-e8330v / xxo3zz F3)
+
+These are **NOT** installed by `register-xray-handlers!`. They live behind
+`resources/install-test-overrides!` (orchestrated by `test-support/
+install-test-overrides!`), which a test opts into AFTER
+`register-xray-handlers!`. The seam also re-registers the six production
+subs above with their `*-override` input layered on top. Production code
+paths never dispatch these; `nil` clears the override.
 
 `:rf.xray/set-registered-resources-override-for-test`,
 `:rf.xray/set-registered-scope-resolvers-override-for-test`,
 `:rf.xray/set-resource-entries-override-for-test`,
 `:rf.xray/set-resource-work-ledger-override-for-test`,
 `:rf.xray/set-resource-sub-reads-override-for-test`,
-`:rf.xray/set-resource-routing-slice-override-for-test` — production code
-paths MUST NOT dispatch these; `nil` clears the override.
+`:rf.xray/set-resource-routing-slice-override-for-test`.
 
 ### Uniform reply-envelope reads (`:live-work` / `:stale-races`)
 

--- a/tools/xray/spec/025-Derivation-Graph-Panel.md
+++ b/tools/xray/spec/025-Derivation-Graph-Panel.md
@@ -236,10 +236,16 @@ read-only (assembling the graph dispatches nothing and pins nothing):
 |---|---|---|
 | `:rf.xray/derivation-graph-mode` | sub | `:static` \| `:live` toggle (default `:static`) |
 | `:rf.xray/set-derivation-graph-mode` | event | set the mode toggle |
-| `:rf.xray/derivation-graph-override` | sub | test-only graph override |
-| `:rf.xray/set-derivation-graph-override-for-test` | event | set the override |
-| `:rf.xray/derivation-graph` | sub | the assembled `DerivationGraph` (static / live, over `xray-contributors`) |
+| `:rf.xray/derivation-graph` | sub | the assembled `DerivationGraph` (static / live, over `xray-contributors`) — production registration reads the live source directly, no override branch |
 | `:rf.xray/derivation-graph-tab-data` | sub | the view-facing composite (on-box summaries + family grouping + summary header) |
+
+The test-only graph override (`:rf.xray/derivation-graph-override` sub +
+`:rf.xray/set-derivation-graph-override-for-test` event) is **NOT**
+installed by `register-xray-handlers!` (rf2-e8330v / xxo3zz F3). It lives
+behind `derivation-graph/install-test-overrides!` (orchestrated by
+`test-support/install-test-overrides!`), which a test opts into AFTER
+production registration; the seam also re-registers `:rf.xray/derivation-
+graph` with the override input layered on top.
 
 ## Read-only
 
@@ -272,13 +278,15 @@ the enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
   idempotent under double-projection.
 - **`derivation_graph_consumer_cljs_test.cljs`** (node) — the **behavioral
   consumer** test (rf2-4wtllq): registers the panel handlers via
-  `derivation-graph/install!` + `registry/register-xray-handlers!`, then
+  `registry/register-xray-handlers!` + `test-support/install-test-overrides!`
+  (the override seam, rf2-e8330v), then
   asserts the `:rf.xray/derivation-graph` subscription actually calls the
   shared composer path — static mode returns a graph the composer produced
   (`:mode :static`, real node/edge counts, by-family grouping, edge roles
   through `:rf.xray/derivation-graph-tab-data`); switching to `:live` +
   setting `:rf.xray/target-frame` makes it call `live-derivation-graph` with
-  the observed `:frame`; the test override still bypasses the composer; and a
+  the observed `:frame`; the test override (installed by the seam) still
+  bypasses the composer; and a
   node carrying the reserved EP-0013 relocation coordinates (`:realm/id`,
   `:app/id`, `:module/id`) survives tab-data summarization unchanged. This
   closes the seam the helper/registry/redaction tests leave: that Xray's

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -367,6 +367,21 @@
                h/families)
               [^{:key "edges"} (edges-section edges)])))]))
 
+;; ---- production value source ---------------------------------------------
+;;
+;; The raw assembled graph the production data sub reads. Shared with the
+;; test-override seam (`install-test-overrides!` below) so the override
+;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+
+(defn- derivation-graph-value
+  "The assembled `DerivationGraph` for `mode` over `target-frame`:
+  `live-derivation-graph` in `:live` mode, else the static
+  `derivation-graph` over `xray-contributors`."
+  [mode target-frame]
+  (if (= :live mode)
+    (dgraph/live-derivation-graph target-frame xray-contributors)
+    (dgraph/derivation-graph xray-contributors)))
+
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
@@ -401,25 +416,18 @@
   (rf/reg-sub :rf.xray/derivation-graph-mode
     (fn [db _] (get db :derivation-graph-mode :static)))
 
-  ;; ---- test override ----------------------------------------------------
-  (rf/reg-event :rf.xray/set-derivation-graph-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :derivation-graph-override)
-          (assoc db :derivation-graph-override ov))}))
-  (rf/reg-sub :rf.xray/derivation-graph-override
-    (fn [db _] (get db :derivation-graph-override)))
+  ;; The test-only override seam (`:rf.xray/set-derivation-graph-
+  ;; override-for-test` + the `*-override` sub) is NOT installed here —
+  ;; production registration carries no `-for-test` ids. Tests opt into
+  ;; it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
 
   ;; ---- assembled graph --------------------------------------------------
   (rf/reg-sub :rf.xray/derivation-graph
     :<- [:rf.xray/trace-buffer]
     :<- [:rf.xray/derivation-graph-mode]
     :<- [:rf.xray/target-frame]
-    :<- [:rf.xray/derivation-graph-override]
-    (fn [[_buffer mode target-frame override] _]
-      (cond
-        (some? override) override
-        (= :live mode)   (dgraph/live-derivation-graph target-frame xray-contributors)
-        :else            (dgraph/derivation-graph xray-contributors))))
+    (fn [[_buffer mode target-frame] _]
+      (derivation-graph-value mode target-frame)))
 
   ;; ---- view-facing composite -------------------------------------------
   (rf/reg-sub :rf.xray/derivation-graph-tab-data
@@ -443,4 +451,32 @@
      :order 8
      :panel Panel})
 
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Derivation-Graph panel's test-only override seam — the
+  `:rf.xray/set-derivation-graph-override-for-test` event + the
+  `*-override` sub, then RE-register the production `:rf.xray/derivation-
+  graph` sub to layer the override read on top. Tests opt in by calling
+  this AFTER `register-xray-handlers!` (typically via `test-support/
+  install-test-overrides!`). **Test-only — never call from production.**"
+  []
+  (rf/reg-event :rf.xray/set-derivation-graph-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :derivation-graph-override)
+          (assoc db :derivation-graph-override ov))}))
+  (rf/reg-sub :rf.xray/derivation-graph-override
+    (fn [db _] (get db :derivation-graph-override)))
+
+  (rf/reg-sub :rf.xray/derivation-graph
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/derivation-graph-mode]
+    :<- [:rf.xray/target-frame]
+    :<- [:rf.xray/derivation-graph-override]
+    (fn [[_buffer mode target-frame override] _]
+      (if (some? override)
+        override
+        (derivation-graph-value mode target-frame))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -109,12 +109,13 @@
   ;; `:rings/now-ms` slot; every consumer (ring-fraction / tooltip)
   ;; re-fires on the standard reactive path.
   ;;
-  ;; Tests pin a deterministic `now-ms` via the override slot so
-  ;; ring-fraction calcs don't drift between assertion + capture.
+  ;; Tests pin a deterministic `now-ms` via the override slot — the
+  ;; override read lives behind `install-test-overrides!` (rf2-e8330v),
+  ;; so production registration carries no `-for-test` ids and the
+  ;; production sub reads the live tick slot directly.
   (rf/reg-sub :rf.xray/now-ms
     (fn [db _query]
-      (or (get db :rings/now-ms-override)
-          (get db :rings/now-ms))))
+      (get db :rings/now-ms)))
 
   ;; ---- active-timers-for-focused-machine ------------------------------
   ;;
@@ -162,16 +163,30 @@
     (fn [{:keys [db]} [_ payload]]
       {:db (if (nil? payload)
         (dissoc db :rings/hover)
-        (assoc db :rings/hover payload))}))
+        (assoc db :rings/hover payload))})))
 
-  ;; Test-only override for `now-ms` — the JVM helpers tests don't
-  ;; need it (pure fn) but the CLJS test surface uses it to pin a
-  ;; deterministic timestamp into the projection.
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) -------------------
+
+(defn install-test-overrides!
+  "Install the after-rings test-only override seam — the
+  `:rf.xray/set-now-ms-override-for-test` event, then RE-register
+  `:rf.xray/now-ms` to read the override slot ahead of the live tick.
+  Tests opt in by calling this AFTER `register-xray-handlers!`
+  (typically via `test-support/install-test-overrides!`). The JVM
+  helpers tests don't need it (pure fn); the CLJS test surface uses it
+  to pin a deterministic timestamp into the projection. **Test-only —
+  never call from production.**"
+  []
   (rf/reg-event :rf.xray/set-now-ms-override-for-test
     (fn [{:keys [db]} [_ ov]]
       {:db (if (nil? ov)
         (dissoc db :rings/now-ms-override)
-        (assoc db :rings/now-ms-override ov))})))
+        (assoc db :rings/now-ms-override ov))}))
+  (rf/reg-sub :rf.xray/now-ms
+    (fn [db _query]
+      (or (get db :rings/now-ms-override)
+          (get db :rings/now-ms))))
+  nil)
 
 ;; ---- rAF tick driver ----------------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -652,6 +652,38 @@
        :else
        (blank-state))]))
 
+;; ---- production value sources --------------------------------------------
+;;
+;; The raw values the production data subs read. Shared with the
+;; test-override seam (`install-test-overrides!` below) so each override
+;; branch lives in ONE place (the seam), not duplicated across the
+;; production and test surfaces (rf2-e8330v).
+
+(defn- registered-machines-value
+  "Registered-machine vector (reads `(rf/machines)`)."
+  []
+  (try (vec (machines/machines))
+       (catch :default _ [])))
+
+(defn- machine-snapshots-value
+  "The egress-redacted live snapshots map off the target frame's
+  runtime-db (`[:rf.runtime/machines :snapshots]`)."
+  [target-runtime-db]
+  (when (map? target-runtime-db)
+    (let [snapshots (get-in target-runtime-db
+                            [:rf.runtime/machines :snapshots] {})]
+      (redact-live-snapshots snapshots))))
+
+(defn- machine-definitions-value
+  "The `{machine-id meta}` definition map for `machines`."
+  [machines]
+  (into {}
+        (keep (fn [id]
+                (let [m (try (machines/machine-meta id)
+                             (catch :default _ nil))]
+                  (when m [id m]))))
+        (or machines [])))
+
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
@@ -681,19 +713,13 @@
   ;; rendering — `snapshot-drill-in` hard-wires that posture and this
   ;; install no longer registers the sub/event/slot trio.
 
-  ;; Registered-machine vector (reads `(rf/machines)`).
+  ;; Registered-machine vector (reads `(rf/machines)`). The test-only
+  ;; override seam (`:rf.xray/set-registered-machines-override-for-test`
+  ;; + the `*-override` read) lives behind `install-test-overrides!`
+  ;; (rf2-e8330v) — production registration carries no `-for-test` ids.
   (rf/reg-sub :rf.xray/registered-machines
-    (fn [db _query]
-      (let [ov (get db :registered-machines-override)]
-        (or ov
-            (try (vec (machines/machines))
-                 (catch :default _ []))))))
-
-  (rf/reg-event :rf.xray/set-registered-machines-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :registered-machines-override)
-        (assoc db :registered-machines-override ov))}))
+    (fn [_db _query]
+      (registered-machines-value)))
 
   ;; The live snapshots map for every registered machine.
   ;;
@@ -717,43 +743,16 @@
   (rf/reg-sub :rf.xray/machine-snapshots
     :<- [:rf.xray/target-frame-runtime-db]
     (fn [target-runtime-db _query]
-      (when (map? target-runtime-db)
-        (let [snapshots (get-in target-runtime-db
-                                [:rf.runtime/machines :snapshots] {})]
-          (redact-live-snapshots snapshots)))))
+      (machine-snapshots-value target-runtime-db)))
 
-  (rf/reg-sub :rf.xray/machine-snapshots-override
-    (fn [db _query]
-      (get db :machine-snapshots-override)))
-
-  (rf/reg-event :rf.xray/set-machine-snapshots-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :machine-snapshots-override)
-        (assoc db :machine-snapshots-override ov))}))
-
-  ;; The registered-machine-definition map for every machine.
-  (rf/reg-sub :rf.xray/machine-definitions-override
-    (fn [db _query]
-      (get db :machine-definitions-override)))
-
+  ;; The registered-machine-definition map for every machine. The
+  ;; machine-snapshots / machine-definitions test-only override seams
+  ;; live behind `install-test-overrides!` (rf2-e8330v) — production
+  ;; registration carries no `-for-test` ids and no override branches.
   (rf/reg-sub :rf.xray/machine-definitions
     :<- [:rf.xray/registered-machines]
-    :<- [:rf.xray/machine-definitions-override]
-    (fn [[machines override] _query]
-      (or override
-          (into {}
-                (keep (fn [id]
-                        (let [m (try (machines/machine-meta id)
-                                     (catch :default _ nil))]
-                          (when m [id m]))))
-                (or machines [])))))
-
-  (rf/reg-event :rf.xray/set-machine-definitions-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :machine-definitions-override)
-        (assoc db :machine-definitions-override ov))}))
+    (fn [machines _query]
+      (machine-definitions-value machines)))
 
   ;; The user's per-panel machine selection (kept as a slot for the
   ;; Sim engine + the Instances-jump focus landing; the share-URL
@@ -772,16 +771,14 @@
   (rf/reg-sub :rf.xray/machine-inspector-data
     :<- [:rf.xray/registered-machines]
     :<- [:rf.xray/machine-snapshots]
-    :<- [:rf.xray/machine-snapshots-override]
     :<- [:rf.xray/machine-definitions]
     :<- [:rf.xray/trace-buffer]
     :<- [:rf.xray/selected-machine-id]
     :<- [:rf.xray/target-frame]
-    (fn [[machines live-snapshots snapshots-override definitions buffer selected-id target-frame]
+    (fn [[machines live-snapshots definitions buffer selected-id target-frame]
          _query]
-      (let [snapshots (or snapshots-override live-snapshots {})]
-        (h/project-data
-          machines snapshots definitions buffer selected-id target-frame))))
+      (h/project-data
+        machines (or live-snapshots {}) definitions buffer selected-id target-frame)))
 
   ;; ---- focused-event lens composite (rf2-a9cke) ------------------
 
@@ -844,18 +841,10 @@
          :cascade  (epoch-proj/machine-cascade-rows (or events []))
          :event-id event-id})))
 
-  ;; Test-only overrides for the focused-event composite.
-  (rf/reg-event :rf.xray/set-epoch-history-for-test
-    (fn [{:keys [db]} [_ history]]
-      {:db (if (nil? history)
-        (dissoc db :epoch-history)
-        (assoc db :epoch-history (vec history)))}))
-
-  (rf/reg-event :rf.xray/set-focus-epoch-id-for-test
-    (fn [{:keys [db]} [_ epoch-id]]
-      {:db (if (nil? epoch-id)
-        (update db :focus dissoc :epoch-id)
-        (update db :focus (fnil assoc {}) :epoch-id epoch-id))}))
+  ;; Test-only seeding events for the focused-event composite
+  ;; (`:rf.xray/set-epoch-history-for-test`, `:rf.xray/set-focus-epoch-
+  ;; id-for-test`) live behind `install-test-overrides!` (rf2-e8330v) —
+  ;; production registration carries no `-for-test` ids.
 
   ;; ---- Machine Inspector panel events -----------------------------
 
@@ -1033,3 +1022,88 @@
      :modes #{:dynamic}
      :order 4
      :panel Panel}))
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Machine Inspector panel's test-only override seam:
+
+    - `:rf.xray/set-registered-machines-override-for-test`,
+      `:rf.xray/set-machine-snapshots-override-for-test`,
+      `:rf.xray/set-machine-definitions-override-for-test` — override
+      events + companion `*-override` subs, with the production
+      `:rf.xray/registered-machines` / `:rf.xray/machine-snapshots` /
+      `:rf.xray/machine-definitions` / `:rf.xray/machine-inspector-data`
+      subs RE-registered to layer the override read on top.
+    - `:rf.xray/set-epoch-history-for-test`,
+      `:rf.xray/set-focus-epoch-id-for-test` — pure SEEDING events that
+      write the real `:epoch-history` / `:focus` slots (no override sub).
+
+  Tests opt in by calling this AFTER `register-xray-handlers!`
+  (typically via `test-support/install-test-overrides!`). **Test-only —
+  never call from production.**"
+  []
+  ;; Registered machines.
+  (rf/reg-event :rf.xray/set-registered-machines-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :registered-machines-override)
+        (assoc db :registered-machines-override ov))}))
+  (rf/reg-sub :rf.xray/registered-machines
+    (fn [db _query]
+      (or (get db :registered-machines-override)
+          (registered-machines-value))))
+
+  ;; Live snapshots.
+  (rf/reg-sub :rf.xray/machine-snapshots-override
+    (fn [db _query]
+      (get db :machine-snapshots-override)))
+  (rf/reg-event :rf.xray/set-machine-snapshots-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :machine-snapshots-override)
+        (assoc db :machine-snapshots-override ov))}))
+
+  ;; Definitions.
+  (rf/reg-sub :rf.xray/machine-definitions-override
+    (fn [db _query]
+      (get db :machine-definitions-override)))
+  (rf/reg-sub :rf.xray/machine-definitions
+    :<- [:rf.xray/registered-machines]
+    :<- [:rf.xray/machine-definitions-override]
+    (fn [[machines override] _query]
+      (or override (machine-definitions-value machines))))
+  (rf/reg-event :rf.xray/set-machine-definitions-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :machine-definitions-override)
+        (assoc db :machine-definitions-override ov))}))
+
+  ;; The per-panel composite — re-register so the snapshots-override
+  ;; flips the projection (same shape the Static Machines surface uses).
+  (rf/reg-sub :rf.xray/machine-inspector-data
+    :<- [:rf.xray/registered-machines]
+    :<- [:rf.xray/machine-snapshots]
+    :<- [:rf.xray/machine-snapshots-override]
+    :<- [:rf.xray/machine-definitions]
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/selected-machine-id]
+    :<- [:rf.xray/target-frame]
+    (fn [[machines live-snapshots snapshots-override definitions buffer selected-id target-frame]
+         _query]
+      (let [snapshots (or snapshots-override live-snapshots {})]
+        (h/project-data
+          machines snapshots definitions buffer selected-id target-frame))))
+
+  ;; Focused-event composite seeding events (write the real slots).
+  (rf/reg-event :rf.xray/set-epoch-history-for-test
+    (fn [{:keys [db]} [_ history]]
+      {:db (if (nil? history)
+        (dissoc db :epoch-history)
+        (assoc db :epoch-history (vec history)))}))
+  (rf/reg-event :rf.xray/set-focus-epoch-id-for-test
+    (fn [{:keys [db]} [_ epoch-id]]
+      {:db (if (nil? epoch-id)
+        (update db :focus dissoc :epoch-id)
+        (update db :focus (fnil assoc {}) :epoch-id epoch-id))}))
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -733,6 +733,31 @@
         (cache-growth-section cache-growth)
         (audit-section audit)])]))
 
+;; ---- production value sources --------------------------------------------
+;;
+;; The raw values the production data subs read. Shared with the
+;; test-override seam (`install-test-overrides!` below) so each override
+;; branch — `(or override (real …))` — lives in ONE place (the seam),
+;; not duplicated across production and test surfaces (rf2-e8330v).
+
+(defn- registered-resources-value []
+  (rf/registrations :resource))
+
+(defn- registered-scope-resolvers-value []
+  (rf/registrations :resource-scope))
+
+(defn- resource-entries-value [target-runtime-db]
+  (when (map? target-runtime-db)
+    (get-in target-runtime-db h/entries-rel-path)))
+
+(defn- resource-work-ledger-value [target-runtime-db]
+  (when (map? target-runtime-db)
+    (get target-runtime-db h/work-ledger-key)))
+
+(defn- resource-routing-slice-value [target-runtime-db]
+  (when (map? target-runtime-db)
+    (get target-runtime-db h/routing-key)))
+
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
@@ -765,107 +790,56 @@
       slice (per-resource freshness rollup, the active route flagged
       `:current?` with its live `:blocking-live` wait points).
 
+  The test-only override seam (six `:rf.xray/set-*-override-for-test`
+  events + companion `*-override` subs) is NOT installed here —
+  production registration carries no `-for-test` ids. Tests opt into it
+  via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
+
   Read-only: NO event registered here dispatches a `:rf.resource/*`
   event — inspection never becomes an owner (Spec 016)."
   []
-
-  ;; Test-only override slots ---------------------------------------------
-
-  (rf/reg-event :rf.xray/set-registered-resources-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :registered-resources-override)
-          (assoc db :registered-resources-override ov))}))
-  (rf/reg-sub :rf.xray/registered-resources-override
-    (fn [db _] (get db :registered-resources-override)))
-
-  (rf/reg-event :rf.xray/set-registered-scope-resolvers-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :registered-scope-resolvers-override)
-          (assoc db :registered-scope-resolvers-override ov))}))
-  (rf/reg-sub :rf.xray/registered-scope-resolvers-override
-    (fn [db _] (get db :registered-scope-resolvers-override)))
-
-  (rf/reg-event :rf.xray/set-resource-entries-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :resource-entries-override)
-          (assoc db :resource-entries-override ov))}))
-  (rf/reg-sub :rf.xray/resource-entries-override
-    (fn [db _] (get db :resource-entries-override)))
-
-  (rf/reg-event :rf.xray/set-resource-work-ledger-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :resource-work-ledger-override)
-          (assoc db :resource-work-ledger-override ov))}))
-  (rf/reg-sub :rf.xray/resource-work-ledger-override
-    (fn [db _] (get db :resource-work-ledger-override)))
-
-  (rf/reg-event :rf.xray/set-resource-sub-reads-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :resource-sub-reads-override)
-          (assoc db :resource-sub-reads-override ov))}))
-  (rf/reg-sub :rf.xray/resource-sub-reads-override
-    (fn [db _] (get db :resource-sub-reads-override)))
-
-  (rf/reg-event :rf.xray/set-resource-routing-slice-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov) (dissoc db :resource-routing-slice-override)
-          (assoc db :resource-routing-slice-override ov))}))
-  (rf/reg-sub :rf.xray/resource-routing-slice-override
-    (fn [db _] (get db :resource-routing-slice-override)))
 
   ;; Production data subs --------------------------------------------------
 
   (rf/reg-sub :rf.xray/registered-resources
     :<- [:rf.xray/trace-buffer]
-    :<- [:rf.xray/registered-resources-override]
-    (fn [[_buffer override] _]
-      (or override (rf/registrations :resource))))
+    (fn [_buffer _]
+      (registered-resources-value)))
 
   ;; Named resource-scope resolvers (rf2-hls77w, EP-0016 D3 / Spec 016
   ;; §Named resource-scope resolvers). The static `:resource-scope` registry
-  ;; read decoupled, exactly like `:registered-resources` above. Test
-  ;; override slot below.
+  ;; read decoupled, exactly like `:registered-resources` above.
   (rf/reg-sub :rf.xray/registered-scope-resolvers
     :<- [:rf.xray/trace-buffer]
-    :<- [:rf.xray/registered-scope-resolvers-override]
-    (fn [[_buffer override] _]
-      (or override (rf/registrations :resource-scope))))
+    (fn [_buffer _]
+      (registered-scope-resolvers-value)))
 
   (rf/reg-sub :rf.xray/resource-entries
     :<- [:rf.xray/target-frame-runtime-db]
-    :<- [:rf.xray/resource-entries-override]
-    (fn [[target-runtime-db override] _]
-      (cond
-        (some? override)         override
-        (map? target-runtime-db) (get-in target-runtime-db h/entries-rel-path)
-        :else                    nil)))
+    (fn [target-runtime-db _]
+      (resource-entries-value target-runtime-db)))
 
   (rf/reg-sub :rf.xray/resource-work-ledger
     :<- [:rf.xray/target-frame-runtime-db]
-    :<- [:rf.xray/resource-work-ledger-override]
-    (fn [[target-runtime-db override] _]
-      (cond
-        (some? override)         override
-        (map? target-runtime-db) (get target-runtime-db h/work-ledger-key)
-        :else                    nil)))
+    (fn [target-runtime-db _]
+      (resource-work-ledger-value target-runtime-db)))
 
   (rf/reg-sub :rf.xray/resource-sub-reads
-    :<- [:rf.xray/resource-sub-reads-override]
-    (fn [override _] (or override [])))
+    (fn [_db _]
+      ;; Empty by default; the host/runtime never populates app-db with
+      ;; observed sub-reads, so the production value is the empty vector.
+      ;; The test seam supplies fixtures via the override slot.
+      []))
 
   ;; The routing-runtime slice backing the LIVE route/resource graph
   ;; (rf2-m5u3gt). Reads `[:rf.runtime/routing]` off the target frame's
   ;; runtime-db (decoupled, like the Routing tab's current-route sub) and
   ;; surfaces the live `:current` route slice (carrying `:route-id` + `:nav-token`)
-  ;; + the per-nav-token unsettled-blocking set. Test override slot.
+  ;; + the per-nav-token unsettled-blocking set.
   (rf/reg-sub :rf.xray/resource-routing-slice
     :<- [:rf.xray/target-frame-runtime-db]
-    :<- [:rf.xray/resource-routing-slice-override]
-    (fn [[target-runtime-db override] _]
-      (cond
-        (some? override)         override
-        (map? target-runtime-db) (get target-runtime-db h/routing-key)
-        :else                    nil)))
+    (fn [target-runtime-db _]
+      (resource-routing-slice-value target-runtime-db)))
 
   ;; View-facing composite -------------------------------------------------
 
@@ -956,4 +930,93 @@
      :order 7
      :panel Panel})
 
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Resources panel's test-only override seam — the six
+  `:rf.xray/set-*-override-for-test` events + companion `*-override`
+  subs, then RE-register the production data subs to layer each override
+  read on top (`(or override (real …))`). Tests opt in by calling this
+  AFTER `register-xray-handlers!` (typically via
+  `test-support/install-test-overrides!`). **Test-only — never call
+  from production.**"
+  []
+  (rf/reg-event :rf.xray/set-registered-resources-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :registered-resources-override)
+          (assoc db :registered-resources-override ov))}))
+  (rf/reg-sub :rf.xray/registered-resources-override
+    (fn [db _] (get db :registered-resources-override)))
+
+  (rf/reg-event :rf.xray/set-registered-scope-resolvers-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :registered-scope-resolvers-override)
+          (assoc db :registered-scope-resolvers-override ov))}))
+  (rf/reg-sub :rf.xray/registered-scope-resolvers-override
+    (fn [db _] (get db :registered-scope-resolvers-override)))
+
+  (rf/reg-event :rf.xray/set-resource-entries-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-entries-override)
+          (assoc db :resource-entries-override ov))}))
+  (rf/reg-sub :rf.xray/resource-entries-override
+    (fn [db _] (get db :resource-entries-override)))
+
+  (rf/reg-event :rf.xray/set-resource-work-ledger-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-work-ledger-override)
+          (assoc db :resource-work-ledger-override ov))}))
+  (rf/reg-sub :rf.xray/resource-work-ledger-override
+    (fn [db _] (get db :resource-work-ledger-override)))
+
+  (rf/reg-event :rf.xray/set-resource-sub-reads-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-sub-reads-override)
+          (assoc db :resource-sub-reads-override ov))}))
+  (rf/reg-sub :rf.xray/resource-sub-reads-override
+    (fn [db _] (get db :resource-sub-reads-override)))
+
+  (rf/reg-event :rf.xray/set-resource-routing-slice-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov) (dissoc db :resource-routing-slice-override)
+          (assoc db :resource-routing-slice-override ov))}))
+  (rf/reg-sub :rf.xray/resource-routing-slice-override
+    (fn [db _] (get db :resource-routing-slice-override)))
+
+  ;; Override-aware re-registration of the production data subs.
+  (rf/reg-sub :rf.xray/registered-resources
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/registered-resources-override]
+    (fn [[_buffer override] _]
+      (or override (registered-resources-value))))
+
+  (rf/reg-sub :rf.xray/registered-scope-resolvers
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/registered-scope-resolvers-override]
+    (fn [[_buffer override] _]
+      (or override (registered-scope-resolvers-value))))
+
+  (rf/reg-sub :rf.xray/resource-entries
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/resource-entries-override]
+    (fn [[target-runtime-db override] _]
+      (if (some? override) override (resource-entries-value target-runtime-db))))
+
+  (rf/reg-sub :rf.xray/resource-work-ledger
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/resource-work-ledger-override]
+    (fn [[target-runtime-db override] _]
+      (if (some? override) override (resource-work-ledger-value target-runtime-db))))
+
+  (rf/reg-sub :rf.xray/resource-sub-reads
+    :<- [:rf.xray/resource-sub-reads-override]
+    (fn [override _] (or override [])))
+
+  (rf/reg-sub :rf.xray/resource-routing-slice
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/resource-routing-slice-override]
+    (fn [[target-runtime-db override] _]
+      (if (some? override) override (resource-routing-slice-value target-runtime-db))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
@@ -458,6 +458,27 @@
                              :current    current})
         (route-table-section topology)])]))
 
+;; ---- production value sources --------------------------------------------
+;;
+;; The raw values the production data subs read. Shared with the
+;; test-override seam (`install-test-overrides!` below) so the override
+;; branch — `(or override (real …))` — lives in ONE place (the seam),
+;; not duplicated across production and test surfaces (rf2-e8330v).
+
+(defn- registered-routes-value
+  "The flat `{<route-id> <meta>}` map sourced from `(rf/registrations
+  :route)`."
+  []
+  (rf/registrations :route))
+
+(defn- current-route-slice-value
+  "The live route slice off the target frame's runtime-db
+  (`[:rf.runtime/routing :current]`; EP-0001 rf2-vzld77 — runtime-db
+  state, not app-db)."
+  [target-runtime-db]
+  (when (map? target-runtime-db)
+    (get-in target-runtime-db [:rf.runtime/routing :current])))
+
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
@@ -474,9 +495,12 @@
     - `:rf.xray/routing-tab-data` — view-facing topology-plus-overlay
       composite (focused-epoch scoped). Carries `:silent?`, `:topology`,
       `:activity`, `:from-id`, `:to-id`, `:navigated?`, `:current`.
-    - `:rf.xray/set-registered-routes-override-for-test`,
-      `:rf.xray/set-current-route-slice-override-for-test` —
-      test-only override hooks.
+
+  The test-only override seam (`:rf.xray/set-registered-routes-override-
+  for-test`, `:rf.xray/set-current-route-slice-override-for-test` + the
+  companion `*-override` subs) is NOT installed here — production
+  registration carries no `-for-test` ids. Tests opt into it via
+  `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
 
   The browse / search / Simulate-URL slots (`:rf.xray.routing/
   query`, `:rf.xray.routing/sim-url`, `:rf.xray.routing/expanded`,
@@ -486,46 +510,17 @@
   `static/routes/panel/install!`)."
   []
 
-  ;; Test-only override slots --------------------------------------------
-
-  (rf/reg-event :rf.xray/set-registered-routes-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :registered-routes-override)
-        (assoc db :registered-routes-override ov))}))
-
-  (rf/reg-sub :rf.xray/registered-routes-override
-    (fn [db _query]
-      (get db :registered-routes-override)))
-
-  (rf/reg-event :rf.xray/set-current-route-slice-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :current-route-slice-override)
-        (assoc db :current-route-slice-override ov))}))
-
-  (rf/reg-sub :rf.xray/current-route-slice-override
-    (fn [db _query]
-      (get db :current-route-slice-override)))
-
   ;; Production data subs -------------------------------------------------
 
   (rf/reg-sub :rf.xray/registered-routes
     :<- [:rf.xray/trace-buffer]
-    :<- [:rf.xray/registered-routes-override]
-    (fn [[_buffer override] _query]
-      (or override (rf/registrations :route))))
+    (fn [_buffer _query]
+      (registered-routes-value)))
 
   (rf/reg-sub :rf.xray/current-route-slice
     :<- [:rf.xray/target-frame-runtime-db]
-    :<- [:rf.xray/current-route-slice-override]
-    (fn [[target-runtime-db override] _query]
-      (cond
-        (some? override)        override
-        ;; EP-0001 (rf2-vzld77): the route slice is durable runtime-db state
-        ;; at `[:rf.runtime/routing :current]`, no longer in app-db.
-        (map? target-runtime-db) (get-in target-runtime-db [:rf.runtime/routing :current])
-        :else                   nil)))
+    (fn [target-runtime-db _query]
+      (current-route-slice-value target-runtime-db)))
 
   ;; View-facing composite (topology-plus-overlay shape, rf2-3kjlo) -------
 
@@ -559,4 +554,49 @@
      :order 6
      :panel Panel})
 
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Routing panel's test-only override seam. Registers the
+  `:rf.xray/set-*-override-for-test` events + companion `*-override`
+  subs, then RE-registers the production data subs to layer the override
+  read on top (`(or override (real …))`). Tests opt in by calling this
+  AFTER `register-xray-handlers!` (typically via
+  `test-support/install-test-overrides!`). **Test-only — never call
+  from production.**"
+  []
+  (rf/reg-event :rf.xray/set-registered-routes-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :registered-routes-override)
+        (assoc db :registered-routes-override ov))}))
+  (rf/reg-sub :rf.xray/registered-routes-override
+    (fn [db _query]
+      (get db :registered-routes-override)))
+
+  (rf/reg-event :rf.xray/set-current-route-slice-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :current-route-slice-override)
+        (assoc db :current-route-slice-override ov))}))
+  (rf/reg-sub :rf.xray/current-route-slice-override
+    (fn [db _query]
+      (get db :current-route-slice-override)))
+
+  ;; Override-aware re-registration of the production data subs.
+  (rf/reg-sub :rf.xray/registered-routes
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/registered-routes-override]
+    (fn [[_buffer override] _query]
+      (or override (registered-routes-value))))
+
+  (rf/reg-sub :rf.xray/current-route-slice
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/current-route-slice-override]
+    (fn [[target-runtime-db override] _query]
+      (if (some? override)
+        override
+        (current-route-slice-value target-runtime-db))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -288,6 +288,19 @@
                   ^{:key (str (:frame row) "/" (:flow-id row))}
                   [flow-row row])))])]))
 
+;; ---- production value source ---------------------------------------------
+;;
+;; The raw value the production data sub reads. Shared with the
+;; test-override seam (`install-test-overrides!` below) so the override
+;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+
+(defn- registered-flows-value
+  "The registered flows regrouped into the per-frame
+  `{frame-id {flow-id flow-map}}` shape from `(rf/registrations :flow)`."
+  []
+  (try (registrations->by-frame (rf/registrations :flow))
+       (catch :default _ {})))
+
 ;; ---- registrations -------------------------------------------------------
 
 (defn install!
@@ -321,17 +334,10 @@
     (fn [db _]
       (get db :rf.xray.static.flows/query)))
 
-  ;; ---- test-only override ----------------------------------------------
-
-  (rf/reg-event :rf.xray.static.flows/set-registered-flows-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :rf.xray.static.flows/registered-flows-override)
-        (assoc db :rf.xray.static.flows/registered-flows-override ov))}))
-
-  (rf/reg-sub :rf.xray.static.flows/registered-flows-override
-    (fn [db _]
-      (get db :rf.xray.static.flows/registered-flows-override)))
+  ;; The test-only override seam (`:rf.xray.static.flows/set-registered-
+  ;; flows-override-for-test` + the `*-override` sub) is NOT installed
+  ;; here — production registration carries no `-for-test` ids. Tests opt
+  ;; into it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
 
   ;; ---- production data sub ---------------------------------------------
 
@@ -346,11 +352,8 @@
   ;; subscribe re-render.
   (rf/reg-sub :rf.xray.static.flows/registered-flows
     :<- [:rf.xray/trace-buffer]
-    :<- [:rf.xray.static.flows/registered-flows-override]
-    (fn [[_buffer override] _query]
-      (or override
-          (try (registrations->by-frame (rf/registrations :flow))
-               (catch :default _ {})))))
+    (fn [_buffer _query]
+      (registered-flows-value)))
 
   ;; ---- view-facing composite -------------------------------------------
 
@@ -384,4 +387,30 @@
      :order 3
      :panel Panel})
 
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Static Flows panel's test-only override seam — the
+  `:rf.xray.static.flows/set-registered-flows-override-for-test` event +
+  the `*-override` sub, then RE-register the production
+  `:rf.xray.static.flows/registered-flows` sub to layer the override read
+  on top. Tests opt in via `test-support/install-test-overrides!` AFTER
+  `register-xray-handlers!`. **Test-only — never call from production.**"
+  []
+  (rf/reg-event :rf.xray.static.flows/set-registered-flows-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :rf.xray.static.flows/registered-flows-override)
+        (assoc db :rf.xray.static.flows/registered-flows-override ov))}))
+  (rf/reg-sub :rf.xray.static.flows/registered-flows-override
+    (fn [db _]
+      (get db :rf.xray.static.flows/registered-flows-override)))
+
+  (rf/reg-sub :rf.xray.static.flows/registered-flows
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray.static.flows/registered-flows-override]
+    (fn [[_buffer override] _query]
+      (or override (registered-flows-value))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -363,6 +363,19 @@
                   ^{:key (pr-str (:id row))}
                   [interceptor-row row])))])]))
 
+;; ---- production value source ---------------------------------------------
+;;
+;; The raw value the production data sub reads. Shared with the
+;; test-override seam (`install-test-overrides!` below) so the override
+;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+
+(defn- registry-value
+  "The event-chain registry off the public `(rf/registrations :event)`
+  surface — each entry carries its interceptor chain."
+  []
+  (try (rf/registrations :event)
+       (catch :default _ {})))
+
 ;; ---- registrations -------------------------------------------------------
 
 (defn install!
@@ -391,27 +404,17 @@
     (fn [db _]
       (get db :rf.xray.static.interceptors/query)))
 
-  ;; ---- test-only override ----------------------------------------------
-
-  (rf/reg-event :rf.xray.static.interceptors/set-registry-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :rf.xray.static.interceptors/registry-override)
-        (assoc db :rf.xray.static.interceptors/registry-override ov))}))
-
-  (rf/reg-sub :rf.xray.static.interceptors/registry-override
-    (fn [db _]
-      (get db :rf.xray.static.interceptors/registry-override)))
+  ;; The test-only override seam (`:rf.xray.static.interceptors/set-
+  ;; registry-override-for-test` + the `*-override` sub) is NOT installed
+  ;; here — production registration carries no `-for-test` ids. Tests opt
+  ;; into it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
 
   ;; ---- production data sub ---------------------------------------------
 
   (rf/reg-sub :rf.xray.static.interceptors/registry
     :<- [:rf.xray/trace-buffer]
-    :<- [:rf.xray.static.interceptors/registry-override]
-    (fn [[_buffer override] _query]
-      (or override
-          (try (rf/registrations :event)
-               (catch :default _ {})))))
+    (fn [_buffer _query]
+      (registry-value)))
 
   ;; ---- view-facing composite -------------------------------------------
 
@@ -431,4 +434,30 @@
      :order 4
      :panel Panel})
 
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Static Interceptors panel's test-only override seam — the
+  `:rf.xray.static.interceptors/set-registry-override-for-test` event +
+  the `*-override` sub, then RE-register the production
+  `:rf.xray.static.interceptors/registry` sub to layer the override read
+  on top. Tests opt in via `test-support/install-test-overrides!` AFTER
+  `register-xray-handlers!`. **Test-only — never call from production.**"
+  []
+  (rf/reg-event :rf.xray.static.interceptors/set-registry-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :rf.xray.static.interceptors/registry-override)
+        (assoc db :rf.xray.static.interceptors/registry-override ov))}))
+  (rf/reg-sub :rf.xray.static.interceptors/registry-override
+    (fn [db _]
+      (get db :rf.xray.static.interceptors/registry-override)))
+
+  (rf/reg-sub :rf.xray.static.interceptors/registry
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray.static.interceptors/registry-override]
+    (fn [[_buffer override] _query]
+      (or override (registry-value))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -141,30 +141,25 @@
   ;; existing :rf.xray/registered-machines + machine-definitions +
   ;; machine-snapshots subs registered by panels.machine-inspector
   ;; (install order is purely cosmetic — re-frame resolves :<- lazily).
-  ;; The `:rf.xray/machine-snapshots-override` test-seam composes on
-  ;; top of the live snapshots — same shape the Dynamic Machine
-  ;; Inspector's composite uses, so the override flips both surfaces.
+  ;; The `:rf.xray/machine-snapshots-override` test-seam composes on top
+  ;; of the live snapshots in `install-test-overrides!` (rf2-e8330v) —
+  ;; production registration carries no override branch.
   (rf/reg-sub :rf.xray.static.machines/rows
     :<- [:rf.xray/registered-machines]
     :<- [:rf.xray/machine-definitions]
     :<- [:rf.xray/machine-snapshots]
-    :<- [:rf.xray/machine-snapshots-override]
-    (fn [[machines definitions live-snapshots snapshots-override] _query]
-      (h/project-rows machines definitions
-                      (or snapshots-override live-snapshots {}))))
+    (fn [[machines definitions live-snapshots] _query]
+      (h/project-rows machines definitions (or live-snapshots {}))))
 
   (rf/reg-sub :rf.xray.static.machines/data
     :<- [:rf.xray/registered-machines]
     :<- [:rf.xray/machine-definitions]
     :<- [:rf.xray/machine-snapshots]
-    :<- [:rf.xray/machine-snapshots-override]
     :<- [:rf.xray.static.machines/search]
     :<- [:rf.xray.static.machines/sort-key]
     :<- [:rf.xray.static.machines/selected-id]
-    (fn [[machines definitions live-snapshots snapshots-override
-          query sort-key selected-id] _query]
-      (h/project-browse-list machines definitions
-                             (or snapshots-override live-snapshots {})
+    (fn [[machines definitions live-snapshots query sort-key selected-id] _query]
+      (h/project-browse-list machines definitions (or live-snapshots {})
                              query sort-key selected-id)))
   nil)
 
@@ -258,4 +253,40 @@
      :modes #{:static}
      :order 0
      :panel panel})
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Re-register the Static Machines browse-list subs to layer the
+  `:rf.xray/machine-snapshots-override` test-seam on top of the live
+  snapshots — same shape the Dynamic Machine Inspector's composite uses,
+  so the override flips both surfaces. The override event + `*-override`
+  sub themselves are owned by `panels.machine-inspector/install-test-
+  overrides!`; this only re-points the two static-machines composites.
+  Tests opt in via `test-support/install-test-overrides!` AFTER
+  `register-xray-handlers!`. **Test-only — never call from production.**"
+  []
+  (rf/reg-sub :rf.xray.static.machines/rows
+    :<- [:rf.xray/registered-machines]
+    :<- [:rf.xray/machine-definitions]
+    :<- [:rf.xray/machine-snapshots]
+    :<- [:rf.xray/machine-snapshots-override]
+    (fn [[machines definitions live-snapshots snapshots-override] _query]
+      (h/project-rows machines definitions
+                      (or snapshots-override live-snapshots {}))))
+
+  (rf/reg-sub :rf.xray.static.machines/data
+    :<- [:rf.xray/registered-machines]
+    :<- [:rf.xray/machine-definitions]
+    :<- [:rf.xray/machine-snapshots]
+    :<- [:rf.xray/machine-snapshots-override]
+    :<- [:rf.xray.static.machines/search]
+    :<- [:rf.xray.static.machines/sort-key]
+    :<- [:rf.xray.static.machines/selected-id]
+    (fn [[machines definitions live-snapshots snapshots-override
+          query sort-key selected-id] _query]
+      (h/project-browse-list machines definitions
+                             (or snapshots-override live-snapshots {})
+                             query sort-key selected-id)))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -346,6 +346,27 @@
     {}
     (rf/frame-ids)))
 
+;; ---- production value source ---------------------------------------------
+;;
+;; The raw value the production data sub reads. Shared with the
+;; test-override seam (`install-test-overrides!` below) so the override
+;; branch lives in ONE place (the seam), not duplicated (rf2-e8330v).
+
+(defn- registry-value
+  "The three input registries assembled from public surfaces: app-db
+  schemas via the `re-frame.schemas` façade, event / sub specs via
+  `(rf/registrations <kind>)`."
+  []
+  {:schemas-by-frame
+   (try (read-app-schemas-by-frame)
+        (catch :default _ {}))
+   :events
+   (try (rf/registrations :event)
+        (catch :default _ {}))
+   :subs
+   (try (rf/registrations :sub)
+        (catch :default _ {}))})
+
 ;; ---- registrations -------------------------------------------------------
 
 (defn install!
@@ -379,17 +400,10 @@
     (fn [db _]
       (get db :rf.xray.static.schemas/query)))
 
-  ;; ---- test-only override ----------------------------------------------
-
-  (rf/reg-event :rf.xray.static.schemas/set-registry-override-for-test
-    (fn [{:keys [db]} [_ ov]]
-      {:db (if (nil? ov)
-        (dissoc db :rf.xray.static.schemas/registry-override)
-        (assoc db :rf.xray.static.schemas/registry-override ov))}))
-
-  (rf/reg-sub :rf.xray.static.schemas/registry-override
-    (fn [db _]
-      (get db :rf.xray.static.schemas/registry-override)))
+  ;; The test-only override seam (`:rf.xray.static.schemas/set-registry-
+  ;; override-for-test` + the `*-override` sub) is NOT installed here —
+  ;; production registration carries no `-for-test` ids. Tests opt into
+  ;; it via `install-test-overrides!` (rf2-e8330v / xxo3zz F3).
 
   ;; ---- production data sub ---------------------------------------------
 
@@ -402,18 +416,8 @@
   ;; subs ride.
   (rf/reg-sub :rf.xray.static.schemas/registry
     :<- [:rf.xray/trace-buffer]
-    :<- [:rf.xray.static.schemas/registry-override]
-    (fn [[_buffer override] _query]
-      (or override
-          {:schemas-by-frame
-           (try (read-app-schemas-by-frame)
-                (catch :default _ {}))
-           :events
-           (try (rf/registrations :event)
-                (catch :default _ {}))
-           :subs
-           (try (rf/registrations :sub)
-                (catch :default _ {}))})))
+    (fn [_buffer _query]
+      (registry-value)))
 
   ;; ---- view-facing composite -------------------------------------------
 
@@ -440,4 +444,30 @@
      :order 2
      :panel Panel})
 
+  nil)
+
+;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
+
+(defn install-test-overrides!
+  "Install the Static Schemas panel's test-only override seam — the
+  `:rf.xray.static.schemas/set-registry-override-for-test` event + the
+  `*-override` sub, then RE-register the production
+  `:rf.xray.static.schemas/registry` sub to layer the override read on
+  top. Tests opt in via `test-support/install-test-overrides!` AFTER
+  `register-xray-handlers!`. **Test-only — never call from production.**"
+  []
+  (rf/reg-event :rf.xray.static.schemas/set-registry-override-for-test
+    (fn [{:keys [db]} [_ ov]]
+      {:db (if (nil? ov)
+        (dissoc db :rf.xray.static.schemas/registry-override)
+        (assoc db :rf.xray.static.schemas/registry-override ov))}))
+  (rf/reg-sub :rf.xray.static.schemas/registry-override
+    (fn [db _]
+      (get db :rf.xray.static.schemas/registry-override)))
+
+  (rf/reg-sub :rf.xray.static.schemas/registry
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray.static.schemas/registry-override]
+    (fn [[_buffer override] _query]
+      (or override (registry-value))))
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -37,7 +37,19 @@
   (:require [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            ;; rf2-e8330v (xxo3zz F3) — per-panel test-override seams.
+            ;; Production registration installs NO `-for-test` ids; tests
+            ;; opt into the override surface via `install-test-overrides!`.
+            [day8.re-frame2-xray.panels.derivation-graph :as derivation-graph]
+            [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
+            [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-xray.panels.resources :as resources]
+            [day8.re-frame2-xray.panels.routing :as routing]
+            [day8.re-frame2-xray.static.flows.panel :as static-flows-panel]
+            [day8.re-frame2-xray.static.interceptors.panel :as static-interceptors-panel]
+            [day8.re-frame2-xray.static.machines.panel :as static-machines-panel]
+            [day8.re-frame2-xray.static.schemas.panel :as static-schemas-panel]))
 
 (defn reset-sentinels!
   "Reset ONLY the install + registry idempotency sentinels, in
@@ -79,4 +91,37 @@
   []
   (reset-all!)
   (config/reset-settings!)
+  nil)
+
+;; ---- test-only override seam orchestrator (rf2-e8330v / xxo3zz F3) -------
+
+(defn install-test-overrides!
+  "Install EVERY panel's test-only override seam in one call.
+
+  Production `register-xray-handlers!` installs NO ids ending in
+  `-for-test` and no `(or override …)` branches in the data subs — the
+  override seam is split out per panel (xxo3zz F3 / rf2-e8330v). A test
+  that drives panel data via the `:rf.xray/set-*-override-for-test`
+  events (or the machine-inspector `set-epoch-history-for-test` /
+  `set-focus-epoch-id-for-test` seeding events) calls this AFTER
+  `register-xray-handlers!` to:
+
+    1. register the `:rf.xray/set-*-override-for-test` events + companion
+       `*-override` subs, and
+    2. RE-register the affected production data subs to layer the
+       override read on top (`(or override (real …))`).
+
+  Idempotent (re-frame's registrar replaces in place). Order-independent
+  — re-frame resolves `:<-` chains lazily. **Test-only — never call from
+  production code.** Returns nil."
+  []
+  (routing/install-test-overrides!)
+  (resources/install-test-overrides!)
+  (derivation-graph/install-test-overrides!)
+  (after-rings/install-test-overrides!)
+  (machine-inspector/install-test-overrides!)
+  (static-machines-panel/install-test-overrides!)
+  (static-flows-panel/install-test-overrides!)
+  (static-interceptors-panel/install-test-overrides!)
+  (static-schemas-panel/install-test-overrides!)
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_consumer_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_consumer_cljs_test.cljs
@@ -69,6 +69,7 @@
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; A one-shot read of an `:rf.xray/*` sub, in the :rf/xray frame (where the

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
@@ -47,6 +47,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 (defn- override-machines! [machines]
@@ -98,8 +99,15 @@
     (is (some? (registrar/handler :sub :rf.xray/now-ms)))
     (is (some? (registrar/handler :sub :rf.xray/timer-hover)))
     (is (some? (registrar/handler :event :rf.xray/timer-tick)))
-    (is (some? (registrar/handler :event :rf.xray/timer-hover)))
-    (is (some? (registrar/handler :event :rf.xray/set-now-ms-override-for-test)))))
+    (is (some? (registrar/handler :event :rf.xray/timer-hover))))
+  (testing "rf2-e8330v — the test-only now-ms override is NOT installed by
+            production registration; the test seam installs it"
+    (registry/register-xray-handlers!)
+    (is (nil? (registrar/handler :event :rf.xray/set-now-ms-override-for-test))
+        "production registration installs no -for-test ids")
+    (xray-test-support/install-test-overrides!)
+    (is (some? (registrar/handler :event :rf.xray/set-now-ms-override-for-test))
+        "install-test-overrides! installs the now-ms override event")))
 
 ;; ---- (2) active-timers composite ---------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -60,6 +60,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 (defn- override-machines! [machines]
@@ -93,7 +94,6 @@
     (is (some? (registrar/handler :sub :rf.xray/registered-machines)))
     (is (some? (registrar/handler :sub :rf.xray/machine-snapshots)))
     (is (some? (registrar/handler :sub :rf.xray/machine-definitions)))
-    (is (some? (registrar/handler :sub :rf.xray/machine-definitions-override)))
     (is (some? (registrar/handler :sub :rf.xray/selected-machine-id)))
     (is (some? (registrar/handler :sub :rf.xray/machine-inspector-data)))
     (is (some? (registrar/handler
@@ -104,17 +104,31 @@
     (is (some? (registrar/handler :event :rf.xray/machine-state-clicked)))
     (is (some? (registrar/handler :event :rf.xray/machine-focus-prev)))
     (is (some? (registrar/handler :event :rf.xray/machine-focus-next)))
-    (is (some? (registrar/handler :event :rf.xray/set-scrubber-position)))
+    (is (some? (registrar/handler :event :rf.xray/set-scrubber-position))))
+  (testing "rf2-e8330v — production registration installs NO -for-test ids
+            and no *-override subs; the test seam installs them"
+    (registry/register-xray-handlers!)
+    (is (nil? (registrar/handler :sub :rf.xray/machine-definitions-override)))
+    (is (nil? (registrar/handler :sub :rf.xray/machine-snapshots-override)))
+    (is (nil? (registrar/handler
+                :event :rf.xray/set-registered-machines-override-for-test)))
+    (is (nil? (registrar/handler
+                :event :rf.xray/set-machine-snapshots-override-for-test)))
+    (is (nil? (registrar/handler
+                :event :rf.xray/set-machine-definitions-override-for-test)))
+    (is (nil? (registrar/handler :event :rf.xray/set-epoch-history-for-test)))
+    (is (nil? (registrar/handler :event :rf.xray/set-focus-epoch-id-for-test)))
+    (xray-test-support/install-test-overrides!)
+    (is (some? (registrar/handler :sub :rf.xray/machine-definitions-override)))
+    (is (some? (registrar/handler :sub :rf.xray/machine-snapshots-override)))
     (is (some? (registrar/handler
                  :event :rf.xray/set-registered-machines-override-for-test)))
     (is (some? (registrar/handler
                  :event :rf.xray/set-machine-snapshots-override-for-test)))
     (is (some? (registrar/handler
                  :event :rf.xray/set-machine-definitions-override-for-test)))
-    (is (some? (registrar/handler
-                 :event :rf.xray/set-epoch-history-for-test)))
-    (is (some? (registrar/handler
-                 :event :rf.xray/set-focus-epoch-id-for-test)))))
+    (is (some? (registrar/handler :event :rf.xray/set-epoch-history-for-test)))
+    (is (some? (registrar/handler :event :rf.xray/set-focus-epoch-id-for-test)))))
 
 (deftest composite-defaults-to-empty-when-no-override
   (testing "with an empty machines override the composite returns the

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -72,6 +72,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- fixtures: registry + entries + ledger ------------------------------
@@ -114,29 +115,50 @@
 ;; ---- (1) registry wiring ------------------------------------------------
 
 (deftest registry-installs-resources-subs
-  (testing "register-xray-handlers! installs the resources tab subs + overrides"
+  (testing "register-xray-handlers! installs the resources tab production subs"
     (registry/register-xray-handlers!)
     (doseq [s [:rf.xray/registered-resources
-               :rf.xray/registered-resources-override
                :rf.xray/registered-scope-resolvers
-               :rf.xray/registered-scope-resolvers-override
                :rf.xray/resource-entries
-               :rf.xray/resource-entries-override
                :rf.xray/resource-work-ledger
-               :rf.xray/resource-work-ledger-override
                :rf.xray/resource-sub-reads
-               :rf.xray/resource-sub-reads-override
                :rf.xray/resource-routing-slice
-               :rf.xray/resource-routing-slice-override
                :rf.xray/resources-tab-data]]
-      (is (some? (registrar/handler :sub s)) (str s " sub registered")))
+      (is (some? (registrar/handler :sub s)) (str s " sub registered"))))
+  (testing "rf2-e8330v — production registration installs NO -for-test ids
+            nor *-override subs; install-test-overrides! installs them"
+    (registry/register-xray-handlers!)
+    (doseq [s [:rf.xray/registered-resources-override
+               :rf.xray/registered-scope-resolvers-override
+               :rf.xray/resource-entries-override
+               :rf.xray/resource-work-ledger-override
+               :rf.xray/resource-sub-reads-override
+               :rf.xray/resource-routing-slice-override]]
+      (is (nil? (registrar/handler :sub s))
+          (str s " override sub NOT installed by production registration")))
     (doseq [e [:rf.xray/set-registered-resources-override-for-test
                :rf.xray/set-registered-scope-resolvers-override-for-test
                :rf.xray/set-resource-entries-override-for-test
                :rf.xray/set-resource-work-ledger-override-for-test
                :rf.xray/set-resource-sub-reads-override-for-test
                :rf.xray/set-resource-routing-slice-override-for-test]]
-      (is (some? (registrar/handler :event e)) (str e " event registered")))))
+      (is (nil? (registrar/handler :event e))
+          (str e " NOT installed by production registration")))
+    (xray-test-support/install-test-overrides!)
+    (doseq [s [:rf.xray/registered-resources-override
+               :rf.xray/registered-scope-resolvers-override
+               :rf.xray/resource-entries-override
+               :rf.xray/resource-work-ledger-override
+               :rf.xray/resource-sub-reads-override
+               :rf.xray/resource-routing-slice-override]]
+      (is (some? (registrar/handler :sub s)) (str s " override sub registered by seam")))
+    (doseq [e [:rf.xray/set-registered-resources-override-for-test
+               :rf.xray/set-registered-scope-resolvers-override-for-test
+               :rf.xray/set-resource-entries-override-for-test
+               :rf.xray/set-resource-work-ledger-override-for-test
+               :rf.xray/set-resource-sub-reads-override-for-test
+               :rf.xray/set-resource-routing-slice-override-for-test]]
+      (is (some? (registrar/handler :event e)) (str e " event registered by seam")))))
 
 (deftest read-only-no-resource-events
   (testing "Spec 016 — the Xray registry surface carries NO :rf.resource/*
@@ -146,6 +168,7 @@
             the read-only contract is checked against the Xray-owned
             registry surface (every event Xray registers is :rf.xray*/)."
     (registry/register-xray-handlers!)
+    (xray-test-support/install-test-overrides!)
     ;; The panel's install! must register every event under the :rf.xray*/
     ;; isolation prefix and NONE under :rf.resource/* — the structural
     ;; guarantee that inspection never dispatches a resource event.

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -107,6 +107,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- fixture builders ---------------------------------------------------
@@ -142,18 +143,26 @@
     (registry/register-xray-handlers!)
     (is (some? (registrar/handler :sub :rf.xray/registered-routes))
         ":rf.xray/registered-routes sub registered (shared with Static)")
-    (is (some? (registrar/handler :sub :rf.xray/registered-routes-override))
-        "test-only override sub registered")
     (is (some? (registrar/handler :sub :rf.xray/current-route-slice))
         ":rf.xray/current-route-slice sub registered")
-    (is (some? (registrar/handler :sub :rf.xray/current-route-slice-override))
-        "test-only override sub registered")
     (is (some? (registrar/handler :sub :rf.xray/routing-tab-data))
-        "view-facing topology-plus-overlay composite sub registered")
+        "view-facing topology-plus-overlay composite sub registered"))
+  (testing "rf2-e8330v — production registration installs NO -for-test ids
+            nor *-override subs; install-test-overrides! installs them"
+    (registry/register-xray-handlers!)
+    (is (nil? (registrar/handler :sub :rf.xray/registered-routes-override)))
+    (is (nil? (registrar/handler :sub :rf.xray/current-route-slice-override)))
+    (is (nil? (registrar/handler :event :rf.xray/set-registered-routes-override-for-test)))
+    (is (nil? (registrar/handler :event :rf.xray/set-current-route-slice-override-for-test)))
+    (xray-test-support/install-test-overrides!)
+    (is (some? (registrar/handler :sub :rf.xray/registered-routes-override))
+        "test-only override sub registered by seam")
+    (is (some? (registrar/handler :sub :rf.xray/current-route-slice-override))
+        "test-only override sub registered by seam")
     (is (some? (registrar/handler :event :rf.xray/set-registered-routes-override-for-test))
-        "test-only override event registered")
+        "test-only override event registered by seam")
     (is (some? (registrar/handler :event :rf.xray/set-current-route-slice-override-for-test))
-        "test-only override event registered"))
+        "test-only override event registered by seam"))
   (testing "rf2-o5f5f.3 — browse + search + Simulate-URL slots NO LONGER live
             under :rf.xray.routing/* (promoted to :rf.xray.static.routes/*)"
     (registry/register-xray-handlers!)

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -64,6 +64,7 @@
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.self-noise :as self-noise]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -86,10 +87,12 @@
 ;; ---- helpers ------------------------------------------------------------
 
 (defn- setup-xray-frame!
-  "The canonical per-test boot: register handlers, allocate the
-  :rf/xray frame, return."
+  "The canonical per-test boot: register handlers, install the test-only
+  override seam (rf2-e8330v — production registration installs no
+  `-for-test` ids), allocate the :rf/xray frame, return."
   []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- focus ↔ registry single-source-of-truth cross-check ----------------
@@ -246,7 +249,6 @@
    ;; (pure rows, no filtering — spec/021 §8.2).
    :rf.xray/issues-ribbon
    :rf.xray/machine-definitions
-   :rf.xray/machine-definitions-override
    :rf.xray/machine-inspector-data
    ;; rf2-3d987 issue #4 — chart-collapsed slot per machine, persisted
    ;; to localStorage. Lets the operator hide the chart so the snapshot
@@ -269,7 +271,6 @@
    ;; (sibling bead rf2-r4nao re-hosts it under Static).
    :rf.xray/machine-scrubber-position
    :rf.xray/machine-snapshots
-   :rf.xray/machine-snapshots-override
    ;; rf2-uyp86 — managed-fx wire-boundary diff composite.
    :rf.xray/managed-fx-for-focused-event
    ;; rf2-7hwwe — `:after` ring tick driver wall-clock surface + hover slot.
@@ -291,38 +292,32 @@
    :rf.xray/palette-recents
    :rf.xray/palette-results
    :rf.xray/registered-machines
-   ;; rf2-nrbs9 — Routes tab (7th L3 tab) sub family.
+   ;; rf2-nrbs9 — Routes tab (7th L3 tab) sub family. (The `*-override`
+   ;; subs split out behind `install-test-overrides!` — rf2-e8330v.)
    :rf.xray/registered-routes
-   :rf.xray/registered-routes-override
    :rf.xray/current-route-slice
-   :rf.xray/current-route-slice-override
    :rf.xray/routing-tab-data
    ;; Spec 016 §Xray and AI tooling — Resources tab (8th L3 tab) sub
    ;; family. The static registry + the live runtime-db cache/ledger
    ;; slices + the view-facing composite + the scope-mismatch-lint
-   ;; sub-reads slot, each with a test-only override.
+   ;; sub-reads slot. (The per-kind `*-override` subs split out behind
+   ;; `install-test-overrides!` — rf2-e8330v.)
    :rf.xray/registered-resources
-   :rf.xray/registered-resources-override
-   ;; rf2-hls77w (EP-0016 D3) — named resource-scope resolver registry +
-   ;; its test-only override (the third resources kind).
+   ;; rf2-hls77w (EP-0016 D3) — named resource-scope resolver registry
+   ;; (the third resources kind).
    :rf.xray/registered-scope-resolvers
-   :rf.xray/registered-scope-resolvers-override
    :rf.xray/resource-entries
-   :rf.xray/resource-entries-override
    :rf.xray/resource-work-ledger
-   :rf.xray/resource-work-ledger-override
    :rf.xray/resource-sub-reads
-   :rf.xray/resource-sub-reads-override
    ;; rf2-m5u3gt — the live route/resource graph reads the routing slice.
    :rf.xray/resource-routing-slice
-   :rf.xray/resource-routing-slice-override
    :rf.xray/resources-tab-data
    ;; rf2-9ett2d (EP-0014 prop-3) — Derivation-Graph tab subs: the
    ;; assembled `re-frame.derivation.graph` view (static/live), the mode
-   ;; toggle slot, the test override, and the view-facing composite.
+   ;; toggle slot, and the view-facing composite. (The `*-override` sub
+   ;; split out behind `install-test-overrides!` — rf2-e8330v.)
    :rf.xray/derivation-graph
    :rf.xray/derivation-graph-mode
-   :rf.xray/derivation-graph-override
    :rf.xray/derivation-graph-tab-data
    ;; rf2-wtg9z4 — Module-view tab (EP-0013 disposition 6): the projected
    ;; (realm, frame) address space (`rf/realm-ids` × `rf/frame-realm`).
@@ -342,23 +337,24 @@
    :rf.xray.static.routes/tab-data
    ;; rf2-o5f5f.4 — Static Schemas sub-tab subs (browse-all over the
    ;; app-db schemas storage + the registrar's `:event` / `:sub`
-   ;; `:spec` slots + view-facing composite + test seam).
+   ;; `:spec` slots + view-facing composite). The `*-override` sub split
+   ;; out behind `install-test-overrides!` (rf2-e8330v).
    :rf.xray.static.schemas/query
    :rf.xray.static.schemas/registry
-   :rf.xray.static.schemas/registry-override
    :rf.xray.static.schemas/tab-data
    ;; rf2-uhsqb — Static Flows sub-tab subs (browse-all over the live
-   ;; `re-frame.flows.registry/flows` atom + view-facing composite +
-   ;; test seam).
+   ;; `re-frame.flows.registry/flows` atom + view-facing composite). The
+   ;; `*-override` sub split out behind `install-test-overrides!`
+   ;; (rf2-e8330v).
    :rf.xray.static.flows/query
    :rf.xray.static.flows/registered-flows
-   :rf.xray.static.flows/registered-flows-override
    :rf.xray.static.flows/tab-data
    ;; rf2-o5f5f.6 — Static Interceptors sub-tab subs (pure-browse over
-   ;; the interceptors surfaced through registered events).
+   ;; the interceptors surfaced through registered events). The
+   ;; `*-override` sub split out behind `install-test-overrides!`
+   ;; (rf2-e8330v).
    :rf.xray.static.interceptors/query
    :rf.xray.static.interceptors/registry
-   :rf.xray.static.interceptors/registry-override
    :rf.xray.static.interceptors/tab-data
    ;; rf2-hga49 — tab-ribbon Reset rewind affordance: the transient
    ;; inline failure-flash slot the ribbon reads.
@@ -692,28 +688,10 @@
    :rf.xray.static.machines/set-sub-mode
    :rf.xray.static.machines/state-clicked
    :rf.xray/set-frame
-   :rf.xray/set-machine-definitions-override-for-test
-   :rf.xray/set-machine-snapshots-override-for-test
-   ;; rf2-nrbs9 — Routes tab test-only override events.
-   :rf.xray/set-current-route-slice-override-for-test
-   :rf.xray/set-registered-routes-override-for-test
-   ;; Spec 016 §Xray and AI tooling — Resources tab test-only override
-   ;; events (registry / entries / work-ledger / sub-reads). The panel
-   ;; registers NO :rf.resource/* event — it is read-only (observing
-   ;; pins no resource).
-   :rf.xray/set-registered-resources-override-for-test
-   ;; rf2-hls77w (EP-0016 D3) — named resource-scope resolver registry
-   ;; override (the third resources kind).
-   :rf.xray/set-registered-scope-resolvers-override-for-test
-   :rf.xray/set-resource-entries-override-for-test
-   :rf.xray/set-resource-work-ledger-override-for-test
-   :rf.xray/set-resource-sub-reads-override-for-test
-   ;; rf2-m5u3gt — live route/resource graph routing-slice override.
-   :rf.xray/set-resource-routing-slice-override-for-test
-   ;; rf2-9ett2d (EP-0014 prop-3) — Derivation-Graph tab events: the
-   ;; static/live mode toggle + the test-only graph override.
+   ;; rf2-9ett2d (EP-0014 prop-3) — Derivation-Graph tab mode toggle.
+   ;; (The `set-*-override-for-test` events across every panel split out
+   ;; behind `install-test-overrides!` — rf2-e8330v.)
    :rf.xray/set-derivation-graph-mode
-   :rf.xray/set-derivation-graph-override-for-test
    ;; rf2-o5f5f.3 — Static Routes UI-state events (search input,
    ;; Simulate-URL input, expand-row toggle, hermetic Simulate-nav
    ;; toggle, cross-link to Dynamic Routing). Promoted from the
@@ -726,14 +704,10 @@
    :rf.xray.static.routes/jump-to-dynamic
    ;; rf2-o5f5f.4 — Static Schemas sub-tab events.
    :rf.xray.static.schemas/set-query
-   :rf.xray.static.schemas/set-registry-override-for-test
    ;; rf2-uhsqb — Static Flows sub-tab events.
    :rf.xray.static.flows/set-query
-   :rf.xray.static.flows/set-registered-flows-override-for-test
-   ;; rf2-o5f5f.6 — Static Interceptors sub-tab events (search slot,
-   ;; test seam).
+   ;; rf2-o5f5f.6 — Static Interceptors sub-tab events (search slot).
    :rf.xray.static.interceptors/set-query
-   :rf.xray.static.interceptors/set-registry-override-for-test
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.xray/set-modal-positioning
    ;; rf2-6ni62 — L2 event-list column-divider live update event.
@@ -742,12 +716,6 @@
    :rf.xray/set-panel-width-px
    ;; rf2-t2dsh — L2/L3 seam-handle live update event.
    :rf.xray/set-events-list-height-px
-   ;; rf2-7hwwe — `:after` countdown rings now-ms override (test-only).
-   :rf.xray/set-now-ms-override-for-test
-   :rf.xray/set-registered-machines-override-for-test
-   ;; rf2-a9cke — focused-event lens test overrides (Machine Inspector).
-   :rf.xray/set-epoch-history-for-test
-   :rf.xray/set-focus-epoch-id-for-test
    ;; rf2-y9xmf — scrubber-position slot reducer (UI is gone; the
    ;; `:after`-rings overlay reads the slot this event writes. The
    ;; share-URL surface that also round-tripped it was removed in
@@ -885,6 +853,56 @@
    ;; Xray-specific.
    :rf.editor/open))
 
+;; ---- test-only override seam snapshot (rf2-e8330v / xxo3zz F3) ----------
+;;
+;; Production `register-xray-handlers!` installs NONE of these — the
+;; override seam is split out per panel and installed via
+;; `xray-test-support/install-test-overrides!`. The snapshot tests above
+;; (`registry-snapshot-matches-expected-set`) assert production carries
+;; no `-for-test` ids; the seam-snapshot test below asserts the seam
+;; installs exactly this set.
+
+(def ^:private test-override-sub-names
+  "Every `*-override` sub the per-panel test seam re-registers."
+  (sorted-set
+   :rf.xray/registered-routes-override
+   :rf.xray/current-route-slice-override
+   :rf.xray/registered-resources-override
+   :rf.xray/registered-scope-resolvers-override
+   :rf.xray/resource-entries-override
+   :rf.xray/resource-work-ledger-override
+   :rf.xray/resource-sub-reads-override
+   :rf.xray/resource-routing-slice-override
+   :rf.xray/derivation-graph-override
+   :rf.xray/machine-snapshots-override
+   :rf.xray/machine-definitions-override
+   :rf.xray.static.schemas/registry-override
+   :rf.xray.static.flows/registered-flows-override
+   :rf.xray.static.interceptors/registry-override))
+
+(def ^:private test-override-event-names
+  "Every `set-*-override-for-test` / `*-for-test` seeding event the
+  per-panel test seam installs."
+  (sorted-set
+   :rf.xray/set-registered-routes-override-for-test
+   :rf.xray/set-current-route-slice-override-for-test
+   :rf.xray/set-registered-resources-override-for-test
+   :rf.xray/set-registered-scope-resolvers-override-for-test
+   :rf.xray/set-resource-entries-override-for-test
+   :rf.xray/set-resource-work-ledger-override-for-test
+   :rf.xray/set-resource-sub-reads-override-for-test
+   :rf.xray/set-resource-routing-slice-override-for-test
+   :rf.xray/set-derivation-graph-override-for-test
+   :rf.xray/set-now-ms-override-for-test
+   :rf.xray/set-registered-machines-override-for-test
+   :rf.xray/set-machine-snapshots-override-for-test
+   :rf.xray/set-machine-definitions-override-for-test
+   :rf.xray/set-epoch-history-for-test
+   :rf.xray/set-focus-epoch-id-for-test
+   :rf.xray.static.schemas/set-registry-override-for-test
+   :rf.xray.static.flows/set-registered-flows-override-for-test
+   :rf.xray.static.interceptors/set-registry-override-for-test))
+
 ;; ---- (1) smoke: every registered name resolves -------------------------
 
 (deftest registry-installs-every-sub
@@ -969,6 +987,33 @@
           "Event registry drift — diff names the added/removed :rf.xray/* event-ids")
       (is (= all-fx-names actual-fxs)
           "Fx registry drift — diff names the added/removed :rf.xray/* fx-ids"))))
+
+(deftest production-registration-installs-no-for-test-ids
+  (testing "rf2-e8330v (xxo3zz F3) — register-xray-handlers! installs NO id
+            ending in -for-test, and none of the `*-override` reader subs"
+    (registry/register-xray-handlers!)
+    (let [actual-events (->> (registrar/registrations :event) keys (filter xray-id?))
+          actual-subs   (->> (registrar/registrations :sub) keys (filter xray-id?))
+          for-test      (filter #(re-find #"-for-test$" (name %)) actual-events)
+          override-subs (filter #(re-find #"-override$" (name %)) actual-subs)]
+      (is (empty? for-test)
+          (str "production registration leaked -for-test events: " for-test))
+      (is (empty? override-subs)
+          (str "production registration leaked *-override subs: " override-subs)))))
+
+(deftest test-seam-installs-exactly-the-override-surface
+  (testing "rf2-e8330v — install-test-overrides! installs exactly the
+            test-override sub + event snapshot on top of production"
+    (registry/register-xray-handlers!)
+    (xray-test-support/install-test-overrides!)
+    (let [actual-events     (->> (registrar/registrations :event) keys (filter xray-id?) set)
+          actual-subs       (->> (registrar/registrations :sub) keys (filter xray-id?) set)
+          seam-events       (set (filter #(re-find #"-for-test$" (name %)) actual-events))
+          seam-override-subs (set (filter #(re-find #"-override$" (name %)) actual-subs))]
+      (is (= test-override-event-names seam-events)
+          "test-override event drift — diff names the added/removed -for-test ids")
+      (is (= test-override-sub-names seam-override-subs)
+          "test-override sub drift — diff names the added/removed *-override subs"))))
 
 (deftest registry-is-idempotent
   (testing "calling register-xray-handlers! twice is a no-op (same handler instance)"

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -78,6 +78,7 @@
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- fixture data -------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
@@ -54,6 +54,7 @@
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- fixture data -------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
@@ -69,6 +69,7 @@
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 (defn- frame-sub [q]

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -102,6 +102,7 @@
 
 (defn- xray-setup! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 (defn- frame-sub [q]

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
@@ -59,6 +59,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- hiccup walker -------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -99,6 +99,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- fixture data -------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_nav_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_nav_cljs_test.cljs
@@ -65,6 +65,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 (def routes

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_url_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_url_cljs_test.cljs
@@ -72,6 +72,7 @@
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 (def cart-routes

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
@@ -61,6 +61,7 @@
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {}))
 
 ;; ---- fixture data -------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/e2e_multi_frame.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/e2e_multi_frame.cljs
@@ -108,6 +108,10 @@
   []
   (xray-test-support/reset-sentinels!)
   (registry/register-xray-handlers!)
+  ;; rf2-e8330v (xxo3zz F3) — production registration installs no
+  ;; `-for-test` ids; opt the e2e surface into the per-panel override +
+  ;; seeding seam the harness's tests drive.
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {})
   ;; Seed app-db slots so subs that depend on `:epoch-history` /
   ;; `:target-frame` / `:trace-buffer` resolve to the canonical

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/sub_reactivity.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/sub_reactivity.cljs
@@ -124,6 +124,11 @@
   `reseed-epoch-history-for-frame` same-target no-op contract)."
   []
   (registry/register-xray-handlers!)
+  ;; rf2-e8330v (xxo3zz F3) — production registration installs no
+  ;; `-for-test` ids; opt the test surface into the per-panel override +
+  ;; seeding seam (`set-epoch-history-for-test`, the `*-override` events,
+  ;; etc.) the reactivity helpers drive.
+  (xray-test-support/install-test-overrides!)
   (frame/reg-frame :rf/xray {})
   (frame/reg-frame :rf/default {})
   (rf/with-frame :rf/xray


### PR DESCRIPTION
## What

Carves out rf2-xxo3zz **finding 3** (rf2-e8330v): production Xray registration was installing ~test-only override event handlers (ids ending `-override-for-test` / `-for-test`) across 9 panels, and the production data subs carried `(or override …)` branches + companion `*-override` reader subs. These test seams leaked onto the public dispatch/subscribe surface (inert in production, but a clarity/best-practice problem).

This splits the override surface out of production registration:

- **Production** (`register-xray-handlers!` + per-panel `install!`) now registers **no `-for-test` id and no `*-override` sub**; the production data subs read their live source directly (no override branch).
- **Test seam**: each panel exposes `install-test-overrides!`, orchestrated by the test-only `test-support/install-test-overrides!`. Each seam (1) registers the `set-*-override-for-test` events + `*-override` subs (plus the Machine Inspector `set-epoch-history-for-test` / `set-focus-epoch-id-for-test` seeding events), and (2) re-registers the affected production subs with the override read layered on top. Shared private `*-value` fns keep the projection logic single-sourced — no duplication between production and seam.

Panels touched: routing · resources · derivation-graph · machine-after-rings · machine-inspector · static.machines · static.flows · static.interceptors · static.schemas.

## Acceptance (xxo3zz F3)

- (a) normal Xray registration registers **no** ids ending `-for-test` — asserted by new `registry_cljs_test/production-registration-installs-no-for-test-ids` (no `-for-test` events, no `*-override` subs after production registration).
- (b) production subs no longer carry override branches — the override read moved entirely behind the seam.
- (c) existing tests explicitly install the seam (`install-test-overrides!` after `register-xray-handlers!`) and still pass; the registry catalogue snapshot was trimmed to production-only ids, with a new `test-seam-installs-exactly-the-override-surface` snapshot guarding the seam.

The deep-machine feature-gate testbed (which injects synthetic epochs via the seeding events against a live runtime) installs the seam at boot so its injection still lands.

## Spec

`tools/xray/spec/014-Registry-Catalogue.md` Idempotency section gains a normative "Production registration carries no test seams" subsection; `024-Resources-Panel.md` + `025-Derivation-Graph-Panel.md` registry tables reflect the seam split. (`docs/` untouched → no mkdocs build needed; xray spec is not in `mkdocs.yml`.)

## Quality gates

- `clojure -M:test` in `tools/xray/` (JVM/CLJC) — **1196 tests, 5336 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (CLJS node-test, the real regression gate for the `.cljs` test edits) — **7242 tests, 29656 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` (nightly-full sweep, browser) — **15 scenarios, 0 failures, 13 matrix rows covered**.
- `mkdocs build --strict` — not run (no `docs/` files touched).