### PR TITLE
fix(mcp-base): marker-text? requires exact marker key, not prefix

### DIFF
--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -36,13 +36,15 @@ A zero / nil / absent count omits its slot entirely (the "omit when zero" MUST).
 
 ### `marker-prefixes` — vector of prefix strings
 
-Rendered-text prefixes of the wire-bounded `:rf.mcp/*` replacement envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH the flat and the namespaced-map print forms (see §Print-form parity below) so the detector works regardless of host or `*print-namespace-maps*`.
+Rendered-text prefixes of the wire-bounded `:rf.mcp/*` replacement envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH the flat and the namespaced-map print forms (see §Print-form parity below) so the detector works regardless of host or `*print-namespace-maps*`. The leading token must MATCH a marker key exactly — not merely begin with one (see `marker-text?` and §Exact-key match below).
 
 ### `marker-text? text` — predicate
 
 Is `text` (the rendered EDN text of a response's first content slot) a wire-bounded `:rf.mcp/*` marker envelope?
 
-Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers — the two envelopes the cache + cap steps emit themselves. The consumer reads its own platform's content text (`:text` from a Clojure map, `j/get :text` from a JS object) and passes the string here; this fn owns only the prefix-match logic, shared across hosts.
+Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers — the two envelopes the cache + cap steps emit themselves. The consumer reads its own platform's content text (`:text` from a Clojure map, `j/get :text` from a JS object) and passes the string here; this fn owns only the leading-token match logic, shared across hosts.
+
+Matches the EXACT marker key, not merely a prefix of it (see §Exact-key match below): a lookalike leading key such as `:rf.mcp/overflowed` or `:rf.mcp/cache-hit-extra` is NOT a marker.
 
 Nil-safe: a nil / non-string `text` is not a marker.
 
@@ -52,12 +54,18 @@ The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are replacement results
 
 ## Print-form parity
 
-Substring-match on the rendered text is the cheap detector — the marker map's namespaced key is the first key of the outer map, so a `starts-with?` on the trimmed text is fast and tight. The detector matches BOTH print forms the single-key namespaced marker map can take:
+Leading-token match on the rendered text is the cheap detector — the marker map's namespaced key is the first key of the outer map, so a tight match on the trimmed text's leading token is fast. The detector matches BOTH print forms the single-key namespaced marker map can take:
 
 - the flat form `{:rf.mcp/overflow …` (the form CLJS `pr-str` emits and the form JVM emits with `*print-namespace-maps*` false), and
 - the namespaced-map shorthand `#:rf.mcp{:overflow …` (the form JVM `pr-str` emits by default for a single-namespace map).
 
-Matching both keeps the detector host- and print-setting-agnostic. A false positive would require an agent-supplied payload that ALSO renders with `:rf.mcp/cache-hit` / `:rf.mcp/overflow` as its leading top-level key — not a realistic shape for any tool's result.
+Matching both keeps the detector host- and print-setting-agnostic.
+
+## Exact-key match (rf2-3xd9i9)
+
+The detector matches the marker key EXACTLY — not merely as a prefix. After the leading marker-key text matches, the very next character must be an EDN token TERMINATOR (whitespace, `,`, or a map/vector/list/string delimiter) — proving the marker key ended exactly there and was not merely a prefix of a longer key. EDN keyword/symbol constituents (alphanumerics plus `* + ! - _ ' ? < > = . / : # & %`) immediately after the prefix mean the leading key is a LOOKALIKE, not the marker.
+
+This closes a correctness hole a bare `starts-with?` left open: a lookalike leading key whose name begins with a marker key — e.g. `:rf.mcp/overflowed` or `:rf.mcp/cache-hit-extra` — was wrongly classified as an already-bounded marker, so an over-budget payload whose first key merely started with `:rf.mcp/overflow` would bypass cap enforcement. The two real markers always carry a non-empty map value, so the terminator (the space `pr-str` writes before the value) is always present — the exact-match check preserves their short-circuit while rejecting the lookalikes.
 
 ## Indicator-field parity
 

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -66,7 +66,7 @@
     (pos? (or elided  0)) (assoc vocab/elided-large-key      elided)))
 
 ;; ---------------------------------------------------------------------------
-;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi).
+;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi, rf2-3xd9i9).
 ;;
 ;; The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are
 ;; replacement results the cache + cap boundary steps emit themselves.
@@ -74,18 +74,28 @@
 ;; work and a cache check on a hit-marker would hash the marker, not
 ;; the original payload.
 ;;
-;; Substring-match on the rendered text is the cheap detector — the
+;; Leading-token match on the rendered text is the cheap detector — the
 ;; marker map's namespaced key is the first key of the outer map, so a
-;; `starts-with?` on the trimmed text is fast and tight. We match BOTH
-;; print forms the single-key namespaced marker map can take: the flat
-;; form `{:rf.mcp/overflow ...` (the form CLJS `pr-str` emits and the
-;; form JVM emits with `*print-namespace-maps*` false) and the
+;; tight match on the trimmed text's leading token is fast. We match
+;; BOTH print forms the single-key namespaced marker map can take: the
+;; flat form `{:rf.mcp/overflow ...` (the form CLJS `pr-str` emits and
+;; the form JVM emits with `*print-namespace-maps*` false) and the
 ;; namespaced-map shorthand `#:rf.mcp{:overflow ...` (the form JVM
 ;; `pr-str` emits by default for a single-namespace map). Matching both
-;; keeps the detector host- and print-setting-agnostic. A false
-;; positive would require an agent-supplied payload that ALSO renders
-;; with `:rf.mcp/cache-hit` / `:rf.mcp/overflow` as its leading top-
-;; level key — not a realistic shape for any tool's result.
+;; keeps the detector host- and print-setting-agnostic.
+;;
+;; EXACT key, not a prefix (rf2-3xd9i9). A bare `starts-with?` on the
+;; marker key would wrongly classify a LOOKALIKE first key whose name
+;; merely begins with a marker key — e.g. `:rf.mcp/overflowed` or
+;; `:rf.mcp/cache-hit-extra`. That is a correctness hole: an over-budget
+;; payload whose leading key starts with `:rf.mcp/overflow` would be
+;; treated as an already-bounded marker and bypass cap enforcement. So
+;; after the prefix matches we require the very next character to be an
+;; EDN token TERMINATOR (whitespace or a delimiter), proving the marker
+;; key ended exactly there and was not merely a prefix of a longer key.
+;; The two real markers always carry a non-empty map value, so the
+;; terminator (the space `pr-str` writes before the value) is always
+;; present — the exact-match check preserves their short-circuit.
 ;; ---------------------------------------------------------------------------
 
 (defn- marker-key-prefixes
@@ -108,10 +118,39 @@
   envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH
   the flat and the namespaced-map print forms (see the comment block
   above) so the detector works regardless of host or
-  `*print-namespace-maps*`. A response whose text starts with one of
-  these is a boundary-step marker that later boundary steps must NOT
-  re-walk."
+  `*print-namespace-maps*`. A response whose leading token IS one of
+  these keys (not merely starts-with — see `marker-text?`) is a
+  boundary-step marker that later boundary steps must NOT re-walk."
   (into [] (mapcat marker-key-prefixes) [vocab/cache-hit-key vocab/overflow-key]))
+
+;; An EDN keyword/symbol constituent: alphanumerics plus the punctuation
+;; a keyword name/namespace may legally contain (`* + ! - _ ' ? < > = .
+;; / : # & %`). A 1-char string that matches this regex CONTINUES the
+;; marker key (⇒ lookalike); anything else (whitespace, `,`, or a
+;; map/vector/list/string delimiter) TERMINATES it. Single regex keeps
+;; the check identical across CLJ and CLJS (no host char-arithmetic).
+(def ^:private key-constituent-re #"[A-Za-z0-9*+!_'?<>=./:#&%-]")
+
+(defn- key-terminator?
+  "Is the 1-char string `ch` a character that cannot continue an EDN
+  keyword/symbol token — i.e. a valid terminator immediately following a
+  marker key in rendered text (rf2-3xd9i9)? `nil` (end-of-string) does
+  NOT count: a complete marker map always has a value after the key, so
+  a key flush against EOS is a truncated / lookalike form, not a real
+  marker."
+  [ch]
+  (boolean (and ch (not (re-matches key-constituent-re ch)))))
+
+(defn- exact-marker-prefix?
+  "Does `text` begin with marker `prefix` AND end the marker key exactly
+  there — i.e. the character at index `(count prefix)` is a token
+  terminator (rf2-3xd9i9)? This rejects lookalike first keys like
+  `:rf.mcp/overflowed` whose name merely starts with a marker key."
+  [text prefix]
+  (let [plen (count prefix)]
+    (and (str/starts-with? text prefix)
+         (key-terminator? (when (> (count text) plen)
+                            (subs text plen (inc plen)))))))
 
 (defn marker-text?
   "Is `text` (the rendered EDN text of a response's first content slot)
@@ -121,10 +160,18 @@
   the two envelopes the cache + cap steps emit themselves. The
   consumer reads its own platform's content text (`:text` from a
   Clojure map, `j/get :text` from a JS object) and passes the string
-  here; this fn owns only the prefix-match logic, shared across hosts.
+  here; this fn owns only the leading-token match logic, shared across
+  hosts.
+
+  Matches the EXACT marker key, not merely a prefix of it (rf2-3xd9i9):
+  a lookalike leading key such as `:rf.mcp/overflowed` or
+  `:rf.mcp/cache-hit-extra` is NOT a marker. The match requires the
+  marker key to be terminated by an EDN token terminator (the space
+  `pr-str` writes before the marker's value), so an over-budget payload
+  whose first key merely starts with a marker key still gets capped.
 
   Nil-safe: a nil / non-string `text` is not a marker."
   [text]
   (boolean
     (and (string? text)
-         (some #(str/starts-with? text %) marker-prefixes))))
+         (some #(exact-marker-prefix? text %) marker-prefixes))))

--- a/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
@@ -105,3 +105,37 @@
   (testing "flat form (CLJS / *print-namespace-maps* false)"
     (is (true? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}}")))
     (is (true? (envelope/marker-text? "{:rf.mcp/cache-hit {:tool \"x\"}}")))))
+
+(deftest marker-text?-requires-exact-marker-key-not-prefix
+  ;; rf2-3xd9i9 regression: the detector matched on `starts-with?` of the
+  ;; marker-key PREFIX, so a LOOKALIKE leading key whose name merely
+  ;; begins with a real marker key (`:rf.mcp/overflowed`,
+  ;; `:rf.mcp/cache-hit-extra`) was wrongly classified as an already-
+  ;; bounded marker — letting an over-budget payload bypass cap
+  ;; enforcement. The fix requires the marker key to END exactly at the
+  ;; prefix (terminated by an EDN token terminator), so a strict
+  ;; prefix-superset key is NOT a marker.
+  (testing "strict prefix-superset of a marker key ⇒ NOT a marker (flat form)"
+    (is (false? (envelope/marker-text? "{:rf.mcp/overflowed {:x 1}}"))
+        "':rf.mcp/overflowed' merely starts with ':rf.mcp/overflow'")
+    (is (false? (envelope/marker-text? "{:rf.mcp/cache-hit-extra {:x 1}}"))
+        "':rf.mcp/cache-hit-extra' merely starts with ':rf.mcp/cache-hit'")
+    ;; A real payload over budget whose first key is a lookalike: the
+    ;; exact realistic cap-bypass shape the bead calls out.
+    (is (false? (envelope/marker-text?
+                  (pr-str (array-map :rf.mcp/overflowed {:limit :reached :token-count 9000}))))))
+  (testing "strict prefix-superset of a marker key ⇒ NOT a marker (namespaced-map form)"
+    (is (false? (envelope/marker-text? "#:rf.mcp{:overflowed {:x 1}}")))
+    (is (false? (envelope/marker-text? "#:rf.mcp{:cache-hit-extra {:x 1}}"))))
+  (testing "the EXACT marker key still matches (both print forms)"
+    (is (true? (envelope/marker-text? "{:rf.mcp/overflow {:x 1}}")))
+    (is (true? (envelope/marker-text? "{:rf.mcp/cache-hit {:x 1}}")))
+    (is (true? (envelope/marker-text? "#:rf.mcp{:overflow {:x 1}}")))
+    (is (true? (envelope/marker-text? "#:rf.mcp{:cache-hit {:x 1}}")))
+    ;; Round-trip through pr-str under both *print-namespace-maps* settings.
+    (is (true? (envelope/marker-text?
+                 (binding [*print-namespace-maps* false]
+                   (pr-str {vocab/overflow-key {:limit :reached}})))))
+    (is (true? (envelope/marker-text?
+                 (binding [*print-namespace-maps* true]
+                   (pr-str {vocab/cache-hit-key {:tool "x"}})))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
@@ -319,6 +319,27 @@
     (is (contains? edn :rf.mcp/overflow)
         "non-marker payload over budget is still capped")))
 
+(deftest apply-cap-caps-over-budget-lookalike-marker-key
+  ;; rf2-3xd9i9 regression: the marker detector used to match on the
+  ;; marker-key PREFIX, so an over-budget payload whose LEADING key merely
+  ;; STARTS WITH a marker key — e.g. `:rf.mcp/overflowed` — was wrongly
+  ;; treated as an already-bounded marker and short-circuited PAST the cap
+  ;; walk, shipping the raw over-budget body. With the exact-key fix the
+  ;; lookalike is NOT a marker, so apply-cap still walks it and replaces
+  ;; the over-budget body with the real `:rf.mcp/overflow` marker.
+  (let [big   (apply str (repeat 8000 "x"))
+        ;; Single-key map ⇒ pr-str renders `:rf.mcp/overflowed` as the
+        ;; leading top-level key, the precise cap-bypass shape.
+        r     (ok-text-result {:rf.mcp/overflowed {:huge big}})
+        out   (cap/apply-cap r {:tool "snapshot" :cap 500})
+        edn   (read-edn out)]
+    (is (contains? edn :rf.mcp/overflow)
+        "over-budget lookalike-keyed payload MUST be capped, not short-circuited")
+    (is (not (contains? edn :rf.mcp/overflowed))
+        "the raw over-budget lookalike body must NOT ride the wire")
+    (is (<= (cap/sum-text-tokens out) 500)
+        "the overflow replacement itself stays under cap")))
+
 ;; ---------------------------------------------------------------------------
 ;; cap-message — per-notification wire-cap for a single serialised EDN
 ;; message string (rf2-wz66k7).


### PR DESCRIPTION
Fixes rf2-3xd9i9 — marker-text? required exact marker-key match (not prefix). Worker committed + ran gates before the session-limit cutoff; salvaged by the mayor.

## Quality gates
mcp-base test alias + mcp-conformance (worker-run pre-cutoff).