### PR TITLE
fix(template): generated scratch.cljs REPL examples run under a frame

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
+++ b/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
@@ -3,32 +3,53 @@
 
    Connect your editor (Calva, CIDER, Cursive) to the shadow-cljs
    nREPL after `npx shadow-cljs watch app`, then evaluate the
-   `(comment …)` forms below. Each call hits the same registrar /
-   frame the live UI is using — dispatches you fire here mutate the
-   app-db you see on screen."
+   `(comment …)` forms below.
+
+   EP-0002 (Spec 002 §Frame target resolution): the runtime never
+   synthesises a frame from absence — there is NO `:rf/default` floor.
+   A bare `rf/dispatch` / `rf/subscribe` evaluated at the REPL with no
+   established scope raises `:rf.error/no-frame-context`. So every
+   example below names a frame explicitly: the live-app forms pin
+   `:rf/default` (the id `core.cljs` registers for this app) with
+   `rf/with-frame`; the throw-away experiment makes its own frame with
+   `rf/with-new-frame`."
   (:require [re-frame.core :as rf]))
 
 (comment
-  ;; Fire the counter event a few times and watch the on-screen value
-  ;; tick up.
-  (rf/dispatch [:counter/increment])
-  (rf/dispatch [:counter/increment])
-
-  ;; Obtain the subscription ref for the default frame. `subscribe`
-  ;; returns a reactive ref — deref it (`@…`) to read the current
-  ;; value, as the `with-frame` block below does.
-  (rf/subscribe [:counter/value])
-
-  ;; Run a scratch experiment against a throw-away frame — leaves
-  ;; the live :rf/default frame untouched.
+  ;; --- Drive the live app -------------------------------------------------
   ;;
-  ;; `with-frame` takes a keyword frame-id and binds `*current-frame*`
-  ;; to it for the duration of the body. (For an eval-bind-run-destroy
-  ;; throwaway frame, reach for the sibling macro `with-new-frame`,
-  ;; which takes `[sym expr]` and destroys the bound frame on exit —
-  ;; see Spec 002 §with-frame.)
-  (rf/with-frame :scratch
-    (rf/dispatch-sync [:counter/initialise])
+  ;; `core.cljs` registers `:rf/default` as this app's frame and renders the
+  ;; UI under `(rf/frame-provider {:frame :rf/default} …)`. At the REPL no
+  ;; lexical scope is in effect, so pin `:rf/default` with `with-frame` — the
+  ;; body then resolves to the SAME frame the on-screen UI uses. Dispatches
+  ;; you fire here mutate the app-db you see on screen; the deref reads the
+  ;; live value back.
+  (rf/with-frame :rf/default
+    ;; Fire the counter event a few times and watch the on-screen value
+    ;; tick up.
+    (rf/dispatch [:counter/increment])
+    (rf/dispatch [:counter/increment])
+
+    ;; `subscribe` returns a reactive ref — deref it (`@…`) to read the
+    ;; current value.
+    @(rf/subscribe [:counter/value]))
+
+  ;; A single one-off form can name the frame inline instead of opening a
+  ;; `with-frame` block — `dispatch` takes a `:frame` opt and `subscribe`
+  ;; takes a leading frame-id:
+  (rf/dispatch [:counter/increment] {:frame :rf/default})
+  @(rf/subscribe :rf/default [:counter/value])
+
+  ;; --- Experiment in a throw-away frame -----------------------------------
+  ;;
+  ;; `with-new-frame` is the eval-bind-run-destroy form: it evaluates the
+  ;; expr (here `make-frame`), binds the new frame-id to the symbol, runs
+  ;; the body under that frame's scope, then destroys the frame on exit
+  ;; (success or exception) — the live `:rf/default` frame is untouched.
+  ;; `:on-create` seeds the fresh frame's app-db before the body runs.
+  ;; (Use `with-frame <keyword>` to PIN an EXISTING frame, as above; use
+  ;; `with-new-frame [sym expr]` to CREATE one — see Spec 002 §with-frame.)
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/initialise]})]
     (rf/dispatch-sync [:counter/increment])
     @(rf/subscribe [:counter/value]))
   )

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -56,6 +56,21 @@ the emitted test file up out of the box, and `dev/scratch.cljs` +
 `(user/refresh)` entry) are reachable from `clojure -M:shadow` and
 shadow's nREPL without further classpath plumbing.
 
+**`dev/scratch.cljs` runs under a frame (EP-0002).** The runtime has no
+implicit `:rf/default` floor — a bare `rf/dispatch` / `rf/subscribe`
+evaluated at the REPL with no established scope raises
+`:rf.error/no-frame-context` (Spec 002 §Frame target resolution). Every
+frame-scoped REPL example the scaffold emits must therefore name a frame:
+the live-app forms pin `:rf/default` (the id `core.cljs` registers and
+renders under) with `rf/with-frame`, or carry an explicit frame inline
+(`{:frame :rf/default}` opts for `dispatch` / `dispatch-sync`, the
+2-arity `(rf/subscribe :rf/default [query])` for `subscribe`); the
+throw-away experiment creates its own frame with `rf/with-new-frame`
+(eval-bind-run-destroy) so the live frame is untouched. The emission test
+(`template_emission_test.clj` §scratch.cljs frame-context audit) rejects
+any frame-scoped scratch call that is neither inside a frame-scope form
+nor carries an explicit frame target.
+
 The UIx and Helix variants follow the same shape; only `core.cljs`,
 `views.cljs`, `deps.edn`, and the substrate-adapter coord change.
 See [001-Substrate-Variants.md](001-Substrate-Variants.md) §What

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -479,6 +479,136 @@
                    "keyword argument is a compile-time error; use "
                    "`with-frame` to pin to an existing frame-id.")))))))
 
+;; --- scratch.cljs frame-context audit (rf2-f37lul) -------------------------
+;;
+;; EP-0002 removed the implicit `:rf/default` floor: a frame-scoped call
+;; (`dispatch` / `dispatch-sync` / `subscribe`) evaluated with no
+;; established scope raises `:rf.error/no-frame-context`
+;; (implementation/core/src/re_frame/core.cljc §current-frame-id). The
+;; emitted dev/scratch.cljs is executable generated code — its REPL
+;; on-ramp must NOT ship forms that throw on first eval.
+;;
+;; `assert-scratch-with-frame-shape!` above checks the first-arg shape of
+;; the `with-frame` / `with-new-frame` forms, but a bare `(rf/dispatch
+;; [:counter/increment])` sitting OUTSIDE any frame-scope form, with no
+;; `:frame` opt, still passes that audit while being frameless. This audit
+;; closes that gap: every frame-scoped call in scratch.cljs must EITHER
+;;   (a) sit lexically inside a `with-frame` / `with-new-frame` body (which
+;;       pins / creates a frame for the duration), OR
+;;   (b) carry an explicit frame target inline:
+;;         - `dispatch` / `dispatch-sync`: a `:frame` key in the opts map
+;;           (the trailing map arg), e.g.
+;;           `(rf/dispatch [:e] {:frame :rf/default})`.
+;;         - `subscribe`: the 2-arity `(rf/subscribe <frame-id> [query])`
+;;           form, whose first arg is a keyword/symbol frame-id rather
+;;           than the query vector.
+
+(def ^:private frame-scoped-call-names
+  "Bare names (alias-stripped) of the frame-scoped REPL ops scratch.cljs
+  may use. Each requires a resolvable frame at eval time (EP-0002)."
+  #{"dispatch" "dispatch-sync" "subscribe"})
+
+(defn- frame-scope-form?
+  "True when `form` opens a frame scope for its body —
+  `(with-frame …)` or `(with-new-frame …)` (alias-qualified or bare)."
+  [form]
+  (or (with-frame-call? form) (with-new-frame-call? form)))
+
+(defn- frame-scoped-call?
+  "True when `form` is `(<rf-or-alias>/dispatch …)` / `…/dispatch-sync` /
+  `…/subscribe` — a call whose target frame must resolve at eval time."
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (contains? frame-scoped-call-names (name (first form)))))
+
+(defn- dispatch-has-explicit-frame?
+  "True when a `dispatch` / `dispatch-sync` call carries `:frame` in its
+  trailing opts map — `(rf/dispatch [:e] {:frame :rf/default})`."
+  [form]
+  (let [opts (last form)]
+    (and (> (count form) 2)
+         (map? opts)
+         (contains? opts :frame))))
+
+(defn- subscribe-has-explicit-frame?
+  "True when a `subscribe` call uses the 2-arity `(rf/subscribe <frame-id>
+  [query])` form — its first arg is a keyword/symbol frame-id, not the
+  query vector."
+  [form]
+  (let [first-arg (second form)]
+    (and (= 3 (count form))
+         (or (keyword? first-arg) (symbol? first-arg)))))
+
+(defn- call-carries-explicit-frame?
+  "Does this frame-scoped call name its frame inline (so it does not need a
+  surrounding `with-frame` / `with-new-frame` scope)?"
+  [form]
+  (case (name (first form))
+    ("dispatch" "dispatch-sync") (dispatch-has-explicit-frame? form)
+    "subscribe"                  (subscribe-has-explicit-frame? form)
+    false))
+
+(defn- frameless-scoped-calls
+  "Walk `forms` top-down. Track whether we are lexically inside a
+  `with-frame` / `with-new-frame` body. Return every frame-scoped call
+  that is NEITHER inside a frame scope NOR carries an explicit inline
+  frame target — i.e. the calls that would throw `:rf.error/no-frame-
+  context` on first eval."
+  [forms]
+  (let [acc (volatile! [])]
+    (letfn [(walk-form [form scoped?]
+              (cond
+                (frame-scope-form? form)
+                ;; Inside a frame scope: walk the body with scoped? = true.
+                ;; (The scope head — frame-id / [sym expr] — is still walked
+                ;; so a nested call there is checked under the outer scope.)
+                (doseq [child (rest form)]
+                  (walk-form child true))
+
+                (frame-scoped-call? form)
+                (do
+                  (when (and (not scoped?)
+                             (not (call-carries-explicit-frame? form)))
+                    (vswap! acc conj form))
+                  ;; Still descend into args (a nested subscribe in opts, etc.).
+                  (doseq [child (rest form)]
+                    (walk-form child scoped?)))
+
+                (seq? form)
+                (doseq [child form] (walk-form child scoped?))
+
+                (vector? form)
+                (doseq [child form] (walk-form child scoped?))
+
+                (map? form)
+                (doseq [child (concat (keys form) (vals form))]
+                  (walk-form child scoped?))
+
+                :else nil))]
+      (doseq [form forms] (walk-form form false)))
+    @acc))
+
+(defn- assert-scratch-frame-context!
+  "Reject any frameless frame-scoped REPL call in the emitted scratch.cljs
+  (rf2-f37lul). Complements the first-arg shape audit above."
+  [substrate ^java.io.File root]
+  (let [scratch (io/file root "dev/scratch.cljs")]
+    (is (.isFile scratch)
+        (str "dev/scratch.cljs emitted for " substrate))
+    (let [forms     (read-cljs-forms scratch)
+          frameless (frameless-scoped-calls forms)]
+      (is (empty? frameless)
+          (str "scratch.cljs (" substrate ") has frame-scoped REPL "
+               "call(s) with no resolvable frame: "
+               (pr-str (mapv #(take 2 %) frameless)) ". EP-0002 removed "
+               "the :rf/default floor — such a call throws "
+               ":rf.error/no-frame-context on first eval. Put it inside a "
+               "(with-frame :rf/default …) / (with-new-frame [f …] …) body, "
+               "or give it an explicit frame: {:frame :rf/default} opts for "
+               "dispatch / dispatch-sync, or the 2-arity "
+               "(subscribe <frame-id> [query]) form for subscribe.")))))
+
 ;; --- Xray layout-host contract audit (rf2-29zmf) ---------------------------
 ;;
 ;; The scaffold ships an Xray layout host in the emitted
@@ -618,6 +748,7 @@
       (let [proj (run-template! tmp "acme/my-app" substrate)]
         (assert-events-test-shape! substrate proj)
         (assert-scratch-with-frame-shape! substrate proj)
+        (assert-scratch-frame-context! substrate proj)
         (assert-xray-host-contract! substrate proj)
         (assert-no-stale-xray-wording! substrate proj)
         (doseq [rel ["test/acme/my_app/events_test.cljs"


### PR DESCRIPTION
@
Fixes **rf2-f37lul** (P2, BUG).

## Problem
EP-0002 removed the implicit `:rf/default` frame floor, so the generated `dev/scratch.cljs` REPL on-ramp shipped frameless executable code:
- Bare `rf/dispatch [:counter/increment]` / `rf/subscribe [:counter/value]` at the REPL hit no scope → throw `:rf.error/no-frame-context` on first eval.
- The throw-away example used `(rf/with-frame :scratch …)`, pinning an uncreated frame (`with-frame` only pins an existing frame; it never creates one).

## Fix
- **Live-app examples** pin `:rf/default` — the id `core.cljs` registers and renders under (`rf/frame-provider {:frame :rf/default}`) — via `rf/with-frame`. Added an inline-frame variant showing the `{:frame :rf/default}` dispatch opt and the 2-arity `(rf/subscribe :rf/default [query])` form.
- **Throw-away example** now uses `rf/with-new-frame [f (rf/make-frame {:on-create [:counter/initialise]})]` (eval-bind-run-destroy) against a fresh frame, leaving `:rf/default` untouched.
- **New emission audit** `assert-scratch-frame-context!` walks the emitted `scratch.cljs` and rejects any frame-scoped call (`dispatch` / `dispatch-sync` / `subscribe`) that is neither lexically inside a `with-frame` / `with-new-frame` body nor carries an explicit inline frame target. Complements the existing first-arg shape audit. Verified it fails on a frameless scratch and passes on the fixed one.
- **Spec** `tools/template/spec/002-Generated-Shape.md` documents the frame-context contract on the emitted scratch on-ramp.

## Quality gates
- `clojure -M:test` in `tools/template/` — **39 tests, 450 assertions, 0 failures, 0 errors** (was 435 assertions; the new per-substrate audit adds them). Guard verified to fail-red on a deliberately frameless scratch, then green on the fix.
- Generated the template once (`clojure -Tnew create … :name acme/my-app`) and confirmed the emitted `dev/scratch.cljs` is frame-correct: `{{namespace}}` → `acme.my-app`, all live forms pin `:rf/default`, throw-away uses `with-new-frame` + `make-frame`, no frameless frame-scoped call remains.
- `mkdocs build --strict` — not run; no `docs/` files changed (spec edit is under `tools/template/spec/`).
@