### PR TITLE
fix(core): dispose-realm! removes owned frames from addressability

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -2098,6 +2098,51 @@
           (destroy-frame! id)
           (reg-frame id config))))))
 
+;; ---- realm disposal — destroy the frames the realm owns -------------------
+;;
+;; EP-0013 realm-lifecycle correctness (rf2-yueuvi). Disposing a realm MUST end
+;; the LIFECYCLE of the frames it owns, not just drop the realm's registry entry
+;; — the realm owns the frame registry + their disposal state (Spec
+;; Runtime-Subsystems §What a realm owns). `re-frame.realm/dispose-realm!` tore
+;; down the realm's adapter + host-transient state and dissoc'd the realm, but
+;; left every owned frame RECORD alive in `frames`: a post-dispose
+;; `(frame [realm-id frame-id])` (and `realm/realm-frames`) still resolved the
+;; stale frame, and recreating the same realm id + the same frame id hit
+;; `reg-frame`'s re-registration branch and PRESERVED the disposed realm's
+;; app-db / sub-cache / router runtime state instead of creating a fresh frame.
+;;
+;; This helper runs the FULL `destroy-frame!` recipe (the same teardown a normal
+;; frame destroy runs — :on-destroy, machine cascade, sub-cache + projection
+;; disposal, the host-transient + cleanup hooks, the registry dissoc) for every
+;; frame the realm owns, so disposal releases the same resources a per-frame
+;; destroy does. It runs BEFORE the realm's own host-transient inventory is
+;; cleared so each frame's `tear-down-frame-host-transient!` step can still walk
+;; the realm's live inventory. `re-frame.realm` reaches this through the
+;; `:frame/destroy-realm-frames!` late-bind hook (a static `realm` → `frame`
+;; require would cycle — frame requires realm for the record's default realm-id).
+
+(defn destroy-realm-frames!
+  "Destroy every frame OWNED by realm `rid` — the realm-disposal counterpart of
+  `destroy-frame!` (rf2-yueuvi). Resolves the realm's owned frame ids from the
+  realm-membership view (`frames-by-realm`), then runs the full `destroy-frame!`
+  recipe for each under `*current-realm*` bound to `rid` (via `call-with-realm`)
+  so a non-default-realm frame is found under its `[realm-id frame-id]` address.
+  After this every owned frame's record is gone from `frames`, so post-dispose
+  `(frame rid id)` and `realm/realm-frames` no longer expose it, and recreating
+  the realm + frame id starts fresh (no preserved app-db/sub-cache/router state).
+  A realm owning no frames is a no-op. INTERNAL — the `:frame/destroy-realm-frames!`
+  hook `re-frame.realm/dispose-realm!` calls."
+  [rid]
+  ;; Snapshot the owned ids BEFORE destroying any (destroy-frame! mutates
+  ;; `frames`, and so the derived membership view, mid-walk).
+  (let [owned (get (frames-by-realm) rid #{})]
+    (call-with-realm rid
+      (fn []
+        (doseq [fid owned]
+          (destroy-frame! fid))))))
+
+(late-bind/set-fn! :frame/destroy-realm-frames! destroy-realm-frames!)
+
 ;; ---- :rf/default — TEST-ONLY fixture helper -------------------------------
 ;;
 ;; Per Spec 002 §`:rf/default` is an ordinary id (EP-0002): `:rf/default`

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -994,6 +994,10 @@
     :producer-ns 're-frame.frame
     :design-bead "rf2-gkddyq"
     :description "EP-0013 D1 realm-owned frame-registry view. Returns `realm-id → #{frame-id …}` over the live (non-destroyed) frames, grouped by each frame record's `:realm` slot. `re-frame.realm/realm-frames` consults it to answer the realm-owned membership query — `re-frame.frame` requires `re-frame.realm` for the frame record's default realm-id, so the back-read is late-bound to avoid a require cycle. Membership is DERIVED from `re-frame.frame/frames` (single source of truth; no separately-stored set), so the `(reset! frame/frames {})` test fixtures reset it for free."}
+   {:key         :frame/destroy-realm-frames!
+    :producer-ns 're-frame.frame
+    :design-bead "rf2-yueuvi"
+    :description "EP-0013 realm-disposal counterpart of `:realm/frames-by-realm`. Destroys every frame OWNED by a realm — runs the full per-frame `destroy-frame!` recipe for each owned frame id (resolved from `frames-by-realm`, under `*current-realm*` bound to the realm so a non-default-realm frame is found by its `[realm-id frame-id]` address). `re-frame.realm/dispose-realm!` calls it FIRST (before its adapter + host-transient teardown) so disposing a realm ends its frames' lifecycle rather than leaving stale records addressable; routed late-bound because a static `realm` → `frame` require would cycle (`frame` requires `realm` for the record's default realm-id). No-op when the realm owns no frames."}
    {:key         :app-value/project
     :producer-ns 're-frame.app-value
     :design-bead "rf2-yozjzo"

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -777,34 +777,63 @@
 
   Per EP-0013 §Realm Conformance disposing a realm MUST release the operational
   resources the realm owns, not merely drop the registry entry (a bare `dissoc`
-  would ORPHAN the seated adapter + the host-transient subsystems). The teardown
+  would ORPHAN the seated adapter + the host-transient subsystems AND leave every
+  frame the realm OWNS still addressable — rf2-kq0yfb / rf2-yueuvi). The teardown
   walks the realm-owned seams, in order:
 
-    1. ADAPTER — run the seated adapter's own `:dispose-adapter!` fn (read
+    1. FRAMES — destroy every frame the realm OWNS (rf2-yueuvi). The realm owns
+       the frame registry + their lifecycle/disposal state (Runtime-Subsystems
+       §What a realm owns), so disposing the realm MUST end those frames'
+       lifecycle, not leave stale records addressable. Routed through the
+       `:frame/destroy-realm-frames!` late-bind hook (a static `realm` → `frame`
+       require would cycle), which runs the full per-frame `destroy-frame!`
+       recipe for each owned frame. Runs FIRST — before the realm's adapter +
+       host-transient state is torn down — so each frame's own teardown can still
+       walk the realm's LIVE host-transient inventory and reach the seated
+       adapter. No-op when the frame ns is not loaded or the realm owns no frames.
+    2. ADAPTER — run the seated adapter's own `:dispose-adapter!` fn (read
        directly off the realm's `:adapter` slot, so this leaf ns needs no
        `substrate.adapter` require), then clear the slot + set the disposed
        breadcrumb via `dispose-realm-adapter!`. Mirrors
        `substrate.adapter/dispose-adapter!` for the default realm.
-    2. HOST-TRANSIENT — walk the realm's host-transient inventory, running each
+    3. HOST-TRANSIENT — walk the realm's host-transient inventory, running each
        descriptor's `:teardown` token (the realm-dispose cleanup hook), then
        drop the inventory via `clear-host-transient!`.
-    3. REGISTRY — `dissoc` the realm so its program + own registrar are no
+    4. REGISTRY — `dissoc` the realm so its program + own registrar are no
        longer reachable.
 
-  The teardown runs only for a CONSTRUCTED realm; for the default realm (and
-  nil) the whole call is a no-op — the default realm's adapter/host-transient
-  lifecycle is owned by `substrate.adapter` + the per-subsystem reset hooks, and
-  the realm itself is never disposed."
+  The teardown runs only for a CONSTRUCTED realm that is STILL registered; for
+  the default realm (and nil) the whole call is a no-op — the default realm's
+  adapter/host-transient lifecycle is owned by `substrate.adapter` + the
+  per-subsystem reset hooks, and the realm itself is never disposed.
+
+  IDEMPOTENT (rf2-yueuvi): disposing an ALREADY-disposed (or never-constructed)
+  realm is a clean no-op rather than a throw — once the registry entry is gone
+  the realm owns no live frames / adapter / host-transient inventory to release,
+  and the realm-owned mutation seams (`clear-host-transient!` →
+  `update-realm!`) FAIL CLOSED on an unknown id. A defensive double-dispose
+  (e.g. a `finally` after a body that already disposed) must not raise."
   [realm-or-id]
   (let [rid (realm-id realm-or-id)]
-    (when-not (= rid default-realm-id)
-      ;; (1) adapter: run the seated adapter's own teardown, then clear the slot.
+    (when (and (not (= rid default-realm-id))
+               ;; Idempotency guard: only tear down a realm that is STILL
+               ;; registered. A second dispose (or a never-constructed id) finds
+               ;; nothing to release and no-ops cleanly, rather than driving the
+               ;; fail-closed realm-owned mutation seams (rf2-yueuvi).
+               (contains? @realms rid))
+      ;; (1) frames: end the lifecycle of every frame the realm OWNS so no stale
+      ;; frame record stays addressable after disposal (rf2-yueuvi). FIRST, so
+      ;; each frame's destroy can still reach the realm's live adapter +
+      ;; host-transient inventory (torn down in steps 2-3 below).
+      (when-let [destroy-realm-frames! (late-bind/get-fn :frame/destroy-realm-frames!)]
+        (destroy-realm-frames! rid))
+      ;; (2) adapter: run the seated adapter's own teardown, then clear the slot.
       (when-let [adapter (realm-adapter rid)]
         (when-let [f (:dispose-adapter! adapter)]
           (f))
         (dispose-realm-adapter! rid))
-      ;; (2) host-transient: walk the inventory's teardown tokens, then drop it.
+      ;; (3) host-transient: walk the inventory's teardown tokens, then drop it.
       (dispose-realm-host-transient! rid)
-      ;; (3) registry: drop the realm so its registrar + program are unreachable.
+      ;; (4) registry: drop the realm so its registrar + program are unreachable.
       (swap! realms dissoc rid)))
   nil)

--- a/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
@@ -557,6 +557,97 @@
           (rf/dispose-realm! :live/a)
           (rf/dispose-realm! :live/b))))))
 
+;; ---------------------------------------------------------------------------
+;; (9b) dispose-realm! ends the LIFECYCLE of the frames the realm OWNS
+;;      (EP-0013 realm-lifecycle correctness, rf2-yueuvi)
+;; ---------------------------------------------------------------------------
+;;
+;; A realm OWNS the frame registry + their lifecycle/disposal state
+;; (Runtime-Subsystems §What a realm owns). Before rf2-yueuvi, `dispose-realm!`
+;; tore down the realm's adapter + host-transient state and dropped the realm
+;; entry, but left every owned frame RECORD alive in `frame/frames`: a
+;; post-dispose `(frame [realm-id frame-id])` (and `realm/realm-frames`) still
+;; resolved the stale frame, and recreating the same realm id + the same frame
+;; id hit `reg-frame`'s re-registration branch and PRESERVED the disposed
+;; realm's app-db / sub-cache / router runtime state. These pin the fix: an
+;; owned frame is unaddressable after disposal, a SIBLING realm's same-id frame
+;; is untouched, and a same-id realm+frame recreation starts fresh.
+
+(deftest dispose-realm-removes-owned-frames-from-addressability
+  (testing "rf2-yueuvi: dispose-realm! destroys the frames the realm OWNS, so
+            post-dispose neither (frame realm-id id) nor realm/realm-frames
+            exposes them — while a SIBLING realm's same-id frame is untouched"
+    (let [ra (rf/realm {:id :disp/a})
+          rb (rf/realm {:id :disp/b})
+          app-for (fn [tag]
+                    (rf/app {:id :disp/app :modules
+                             [(rf/module
+                                {:id :m
+                                 :frames {:disp/f {:doc "shared id"}}
+                                 :events {:disp/set {:handler (fn [{:keys [db]} _] {:db (assoc db :who tag)})}}})]}))]
+      (try
+        (rf/install! ra (app-for :a))
+        (rf/install! rb (app-for :b))
+        ;; Both realms own a live :disp/f frame, addressable by their address.
+        (is (some? (frame/frame :disp/a :disp/f)) "realm a's frame is live pre-dispose")
+        (is (some? (frame/frame :disp/b :disp/f)) "realm b's frame is live pre-dispose")
+        (is (contains? (realm/realm-frames :disp/a) :disp/f) "realm a owns :disp/f")
+        (is (contains? (realm/realm-frames :disp/b) :disp/f) "realm b owns :disp/f")
+        ;; Dispose realm a ONLY.
+        (rf/dispose-realm! :disp/a)
+        ;; realm a's frame is no longer addressable — fail-closed, not a stale
+        ;; resolve of a dead frame.
+        (is (nil? (frame/frame :disp/a :disp/f))
+            "after dispose-realm! :disp/a, (frame :disp/a :disp/f) is nil")
+        (is (not (contains? (realm/realm-frames :disp/a) :disp/f))
+            "realm a's owned frame is gone from realm/realm-frames")
+        (is (= #{} (realm/realm-frames :disp/a))
+            "realm a owns no frames after disposal")
+        ;; The SIBLING realm b's same-id frame is untouched — still live + owned.
+        (is (some? (frame/frame :disp/b :disp/f))
+            "sibling realm b's :disp/f frame survives realm a's disposal")
+        (is (contains? (realm/realm-frames :disp/b) :disp/f)
+            "realm b still owns :disp/f")
+        (finally
+          (rf/dispose-realm! :disp/a)
+          (rf/dispose-realm! :disp/b))))))
+
+(deftest recreating-disposed-realm-and-frame-starts-fresh
+  (testing "rf2-yueuvi: after dispose-realm!, recreating the same realm id and
+            installing the same frame id creates a FRESH frame with no preserved
+            app-db state from the disposed realm (not a re-registration that
+            keeps the dead realm's runtime state)"
+    (let [app-with (fn [seed]
+                     (rf/app {:id :recr/app :modules
+                              [(rf/module
+                                 {:id :m
+                                  :frames {:recr/f {:doc "x"}}
+                                  :events {:recr/seed {:handler (fn [{:keys [db]} _]
+                                                                  {:db (assoc db :seed seed)})}}})]}))]
+      (try
+        ;; First incarnation: install, then write state into the frame's app-db.
+        (let [r1 (rf/realm {:id :recr/r})]
+          (rf/install! r1 (app-with :first))
+          (rf/dispatch-sync [:recr/seed] {:realm :recr/r :frame :recr/f})
+          (is (= :first (frame/call-with-realm :recr/r
+                          (fn [] (:seed (frame/frame-app-db-value :recr/f)))))
+              "the first incarnation's handler wrote :seed :first"))
+        ;; Dispose the realm — this MUST end the frame's lifecycle.
+        (rf/dispose-realm! :recr/r)
+        (is (nil? (frame/frame :recr/r :recr/f))
+            "the disposed realm's frame is unaddressable")
+        ;; Recreate the SAME realm id + install the SAME frame id WITHOUT
+        ;; re-running the seed event: a fresh frame must start with EMPTY app-db,
+        ;; NOT the disposed realm's preserved {:seed :first}.
+        (let [r2 (rf/realm {:id :recr/r})]
+          (rf/install! r2 (app-with :second))
+          (is (nil? (frame/call-with-realm :recr/r
+                      (fn [] (:seed (frame/frame-app-db-value :recr/f)))))
+              "the recreated frame starts FRESH — no preserved :seed from the
+               disposed realm (a re-registration would have kept :first)"))
+        (finally
+          (rf/dispose-realm! :recr/r))))))
+
 (deftest child-dispatch-and-fx-preserve-the-realm
   (testing "EP-0013 step 4 (rf2-a15n62): a child dispatch emitted from a handler's
             :fx [[:dispatch …]] STAYS in the parent's realm — the child resolves


### PR DESCRIPTION
## Summary

Fixes **rf2-yueuvi** (P2 BUG, EP-0013 realm-lifecycle correctness).

`dispose-realm!` left the frames a realm OWNED still addressable. A realm owns the frame registry + its frames' lifecycle/disposal state (Runtime-Subsystems §What a realm owns), but `dispose-realm!` tore down only the realm's adapter + host-transient state and dropped the registry entry — every owned frame RECORD stayed alive in `frame/frames`. Consequences:

- A post-dispose `(frame realm-id frame-id)` (and `realm/realm-frames`) still resolved the stale, dead frame instead of failing closed.
- Recreating the same realm id + the same frame id hit `reg-frame`'s re-registration branch and PRESERVED the disposed realm's app-db / sub-cache / router runtime state instead of creating a fresh realm-owned frame.

## Fix

- **`frame/destroy-realm-frames!`** (new) — runs the full per-frame `destroy-frame!` recipe for every frame the realm owns, under `*current-realm*` bound to the realm so non-default-realm frames resolve by their `[realm-id frame-id]` address. Published as the `:frame/destroy-realm-frames!` late-bind hook (a static `realm` → `frame` require would cycle).
- **`realm/dispose-realm!`** — now calls `destroy-realm-frames!` FIRST (before the adapter + host-transient teardown) so each frame's own teardown can still reach the realm's live adapter + host-transient inventory.
- **Idempotency** — `dispose-realm!` now runs teardown only when the realm is still registered, so a defensive double-dispose (or never-constructed id) no-ops cleanly instead of driving the fail-closed realm-owned mutation seams (`clear-host-transient!` → `update-realm!`) to throw.
- **Late-bind directory** — registered the new `:frame/destroy-realm-frames!` hook in `re-frame.late-bind.directory/hooks` (next to its sibling `:realm/frames-by-realm`). The `late-bind-drift-test` gate enforces every published `set-fn!` key is documented; the original change published the hook without the directory entry, which broke the full JVM core suite (see Quality gates).

## Regression tests (`realm_conformance_cljs_test`)

- `dispose-realm-removes-owned-frames-from-addressability` — after disposing one realm, its owned frames are unaddressable via `frame/frame` and gone from `realm/realm-frames`, while a SIBLING realm's same-id frame is untouched.
- `recreating-disposed-realm-and-frame-starts-fresh` — recreating the same realm id + frame id starts with empty app-db (no preserved state from the disposed realm).

## Quality gates

The **full** core JVM suite now passes (the original PR bounded to a realm/frame/app-value subset, which is why the unrelated `late-bind-drift-test` failure slipped through CI's full `clojure -M:test`).

| Gate | Result |
|---|---|
| **Full core JVM suite** — `clojure -M:test` from `implementation/core/` (NOT a bounded subset) | **1523 tests, 6731 assertions, 0 failures, 0 errors** |

The directory fix touches `directory.cljc` (a `.cljc` shared with CLJS); it is plain data with no platform-specific behaviour, so CI-Linux's CLJS matrix (`npm run test:cljs`) covers it.
