### PR TITLE
fix(examples): helix login schema validation + scripts runner asset

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -71,8 +71,20 @@
 
 ;; Outer event-vector schema for the :auth.login/flow machine handler —
 ;; see examples/reagent/login for the full rationale. The :submit
-;; sub-event is validated against `Credentials`; framework-internal
-;; sub-events (:dismiss, :success, :failure) admit :any.
+;; sub-event is validated STRICTLY against `Credentials`; framework-internal
+;; sub-events (:dismiss, :success, :failure) admit a framework-controlled
+;; tail.
+;;
+;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
+;; the nested sub-event vector as a SINGLE element, so the branch must match
+;; that one element AS a vector. A `:cat` branch would apply sequence-regex
+;; semantics and — paired with a permissive `[:vector :any]` fallback —
+;; silently re-admit a `:submit` whose `Credentials` failed (the original
+;; bug: malformed submit payloads passed the `:where :event` boundary). With
+;; the strict `:tuple` and no `[:vector :any]` escape hatch, a short-password
+;; or bad-email submit is rejected at the boundary BEFORE the machine
+;; transitions or issues the login HTTP effect (Spec 010 §Validation order
+;; step 1, recovery `:no-recovery`).
 ;;
 ;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
 ;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
@@ -86,8 +98,9 @@
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
-    [:cat [:= :auth.login/submit] Credentials]
-    [:vector :any]]
+    [:tuple [:= :auth.login/submit] Credentials]
+    [:cat [:enum :auth.login/dismiss :auth.login/success :auth.login/failure]
+     [:* :any]]]
    [:? :any]])
 
 ;; The machine's `:data-schema` validates the machine's `:data` slot ONLY —

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -131,12 +131,22 @@
 
 ;; Outer event-vector schema for the :auth.login/flow machine handler.
 ;; The login form is the canonical user-facing boundary, so we validate
-;; the :submit payload against `Credentials`. Other sub-events
+;; the :submit payload STRICTLY against `Credentials`. Other sub-events
 ;; (:dismiss, :success, :failure) are dispatched internally by the
-;; machine — their inner shape is framework-controlled, so we admit
-;; them as :any. Per Spec 010 §Validation order step 1: a malformed
-;; event vector is rejected at the boundary; the handler is NOT
+;; machine — their inner shape is framework-controlled, so we admit a
+;; framework-controlled tail. Per Spec 010 §Validation order step 1: a
+;; malformed event vector is rejected at the boundary; the handler is NOT
 ;; invoked (recovery: :no-recovery).
+;;
+;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
+;; the nested sub-event vector as a SINGLE element, so the branch must match
+;; that one element AS a vector. A `:cat` branch would apply sequence-regex
+;; semantics and — paired with a permissive `[:vector :any]` fallback —
+;; silently re-admit a `:submit` whose `Credentials` failed (the original
+;; bug: malformed submit payloads passed the `:where :event` boundary). With
+;; the strict `:tuple` and no `[:vector :any]` escape hatch, a short-password
+;; or bad-email submit is rejected at the boundary BEFORE the machine
+;; transitions or issues the login HTTP effect.
 ;;
 ;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
 ;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
@@ -150,8 +160,9 @@
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
-    [:cat [:= :auth.login/submit] Credentials]
-    [:vector :any]]
+    [:tuple [:= :auth.login/submit] Credentials]
+    [:cat [:enum :auth.login/dismiss :auth.login/success :auth.login/failure]
+     [:* :any]]]
    [:? :any]])
 
 ;; The login flow's runtime state lives in the machine snapshot at

--- a/examples/scripts/examples-staging.cjs
+++ b/examples/scripts/examples-staging.cjs
@@ -61,6 +61,85 @@ function stageShared(outDir) {
 }
 
 // ---------------------------------------------------------------------------
+// Per-example static assets (rf2-cq6va5).
+//
+// `index.html` + `_shared` are the assets EVERY standalone example shares. A
+// handful of examples additionally reference per-example static assets via flat
+// (output-root-relative) hrefs / fetch URLs that the clean-stage boundary would
+// otherwise drop:
+//
+//   - TodoMVC's `index.html` links `base.css` + `index.css` flat — the OFFICIAL
+//     TodoMVC CSS packages, pinned in implementation/package.json and fetched
+//     into node_modules/ by `npm install` (NOT vendored in-repo). Without them
+//     the page renders unstyled.
+//   - managed-http-counter `fetch`es `api/inc.json` on its success path — the
+//     fixture lives colocated under the example source's `api/` folder. Without
+//     it the success path 404s and the example exercises only its failure
+//     branch.
+//   - The RealWorld variants fall a nil/blank avatar back to `default-avatar.svg`
+//     served from the app asset root (realworld_shared.avatar). The asset lives
+//     colocated in each RealWorld source folder. Without it every fallback
+//     avatar is a broken image.
+//
+// Each asset declares WHERE its source lives (`:src` = colocated under the
+// example's source folder, the default; `:node-modules` = under
+// implementation/node_modules) and the destination name under the output dir.
+// Keyed by shadow-cljs build id (the colon-stripped coord, as listStandalone-
+// Examples() returns). An example with no entry stages only index.html +
+// _shared (the common case).
+const PER_EXAMPLE_ASSETS = {
+  'examples/todomvc': [
+    { from: 'node-modules', src: 'todomvc-common/base.css', dest: 'base.css' },
+    { from: 'node-modules', src: 'todomvc-app-css/index.css', dest: 'index.css' },
+  ],
+  'examples/managed-http-counter': [
+    { from: 'src', src: path.join('api', 'inc.json'), dest: path.join('api', 'inc.json') },
+  ],
+  'examples/realworld': [
+    { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg' },
+  ],
+  'examples/realworld-resources': [
+    { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg' },
+  ],
+};
+
+const NODE_MODULES_ROOT = path.join(IMPL_ROOT, 'node_modules');
+
+// Resolve an asset spec's absolute SOURCE path. `:src` assets live under the
+// example's own source folder (`entry.srcDir`); `:node-modules` assets live
+// under implementation/node_modules.
+function assetSourcePath(entry, asset) {
+  const root = asset.from === 'node-modules' ? NODE_MODULES_ROOT : entry.srcDir;
+  return path.join(root, asset.src);
+}
+
+// Stage each declared per-example static asset into the output dir, FAIL-LOUD
+// on a missing source: the runner advertises these builds as runnable, so a
+// silently-absent asset (an unstyled TodoMVC, a 404ing success path, a broken
+// avatar) is a correctness bug, not a no-op. node_modules assets carry an
+// `npm install` hint because they are fetched, not vendored. No-op for an
+// example with no declared assets.
+function stagePerExampleAssets(entry) {
+  const assets = PER_EXAMPLE_ASSETS[entry.build];
+  if (!assets) return;
+  for (const asset of assets) {
+    const srcPath = assetSourcePath(entry, asset);
+    if (!fs.existsSync(srcPath)) {
+      const hint =
+        asset.from === 'node-modules'
+          ? ` Run \`npm install\` in ${IMPL_ROOT} to fetch it.`
+          : '';
+      throw new Error(
+        `stageExample: required asset for '${entry.build}' is missing: ${srcPath}.${hint}`,
+      );
+    }
+    const destPath = path.join(entry.outDir, asset.dest);
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(srcPath, destPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Clean-stage boundary (rf2-bf4vdy).
 //
 // The examples + Story browser harnesses all serve the SHARED
@@ -122,14 +201,15 @@ function cleanStageDirs(dirs, outRoot, { io = fs } = {}) {
   return cleaned;
 }
 
-// Stage one example's hand-written index.html + the _shared tree into its
-// output dir. Creates the output dir if the build hasn't emitted into it yet
-// (so the dev runner can stage before the first watch compile lands). Throws
-// with the offending path when the HTML source is missing.
+// Stage one example's hand-written index.html + the _shared tree + any declared
+// per-example static assets into its output dir. Creates the output dir if the
+// build hasn't emitted into it yet (so the dev runner can stage before the first
+// watch compile lands). Throws with the offending path when the HTML source —
+// or any declared per-example asset — is missing (fail-loud, rf2-cq6va5).
 //
-// `entry` shape: { build, outDir, htmlSrc } — as produced by
+// `entry` shape: { build, outDir, htmlSrc, srcDir } — as produced by
 // listStandaloneExamples() (and compatible with the orchestrator's EXAMPLES
-// entries, which also carry outDir + htmlSrc).
+// entries, which also carry outDir + htmlSrc + srcDir).
 function stageExample(entry) {
   if (!fs.existsSync(entry.htmlSrc)) {
     throw new Error(`HTML source missing: ${entry.htmlSrc}`);
@@ -137,6 +217,7 @@ function stageExample(entry) {
   fs.mkdirSync(entry.outDir, { recursive: true });
   fs.copyFileSync(entry.htmlSrc, path.join(entry.outDir, 'index.html'));
   stageShared(entry.outDir);
+  stagePerExampleAssets(entry);
 }
 
 // ---------------------------------------------------------------------------
@@ -282,8 +363,11 @@ module.exports = {
   IMPL_ROOT,
   EXAMPLES_ROOT,
   SHARED_SRC,
+  NODE_MODULES_ROOT,
+  PER_EXAMPLE_ASSETS,
   copyDirRecursive,
   stageShared,
+  stagePerExampleAssets,
   stageExample,
   isStrictlyUnder,
   cleanStageDirs,

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -47,8 +47,20 @@
 
 ;; Outer event-vector schema for the :auth.login/flow machine handler —
 ;; see examples/reagent/login for the full rationale. The :submit
-;; sub-event is validated against `Credentials`; framework-internal
-;; sub-events (:dismiss, :success, :failure) admit :any.
+;; sub-event is validated STRICTLY against `Credentials`; framework-internal
+;; sub-events (:dismiss, :success, :failure) admit a framework-controlled
+;; tail.
+;;
+;; The :submit branch is a `:tuple` (NOT `:cat`): the outer `:cat` consumes
+;; the nested sub-event vector as a SINGLE element, so the branch must match
+;; that one element AS a vector. A `:cat` branch would apply sequence-regex
+;; semantics and — paired with a permissive `[:vector :any]` fallback —
+;; silently re-admit a `:submit` whose `Credentials` failed (the original
+;; bug: malformed submit payloads passed the `:where :event` boundary). With
+;; the strict `:tuple` and no `[:vector :any]` escape hatch, a short-password
+;; or bad-email submit is rejected at the boundary BEFORE the machine
+;; transitions or issues the login HTTP effect (Spec 010 §Validation order
+;; step 1, recovery `:no-recovery`).
 ;;
 ;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
 ;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
@@ -62,8 +74,9 @@
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
-    [:cat [:= :auth.login/submit] Credentials]
-    [:vector :any]]
+    [:tuple [:= :auth.login/submit] Credentials]
+    [:cat [:enum :auth.login/dismiss :auth.login/success :auth.login/failure]
+     [:* :any]]]
    [:? :any]])
 
 ;; The machine's `:data-schema` validates the machine's `:data` slot ONLY —

--- a/implementation/machines/test/re_frame/machine_schema_arity_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_arity_test.clj
@@ -90,11 +90,37 @@
 
 (def ^:private AuthLoginEvent
   "Outer event-vector schema: `:submit` carries Credentials; framework-internal
-  sub-events admit :any; the trailing `[:? :any]` admits a managed-HTTP reply."
+  sub-events admit :any; the trailing `[:? :any]` admits a managed-HTTP reply.
+
+  NOTE this fixture is intentionally PERMISSIVE: tests (1)+(2) below dispatch
+  ad-hoc inner sub-events (`[:noop]`, `[:auth.login/break]`) to exercise the
+  registration-arity + redaction machinery, so the fixture must admit them. The
+  login examples' SHIPPED schema is STRICTER (no `[:vector :any]` fallback) —
+  that corrected shape and its malformed-submit rejection are pinned separately
+  by `login-example-event-schema-rejects-malformed-submit` below (rf2-thhp91)."
   [:cat [:= :auth.login/flow]
    [:or
     [:cat [:= :auth.login/submit] Credentials]
     [:vector :any]]
+   [:? :any]])
+
+;; The login examples' SHIPPED outer-event schema (rf2-thhp91). This is the
+;; corrected shape now registered on the :auth.login/flow machine in all three
+;; login examples (examples/reagent/login, examples/uix/login_uix,
+;; examples/helix/login_helix). Kept here as the executable spec of that shape
+;; so its malformed-submit rejection is a real regression gate (the examples
+;; tree is test-free, so the schema contract is pinned in the framework suite).
+(def ^:private LoginExampleEvent
+  [:cat [:= :auth.login/flow]
+   [:or
+    ;; STRICT :submit branch — a :tuple (NOT :cat): the outer :cat consumes the
+    ;; nested sub-event vector as a SINGLE element, so the branch matches that
+    ;; one element AS a vector. No permissive [:vector :any] fallback.
+    [:tuple [:= :auth.login/submit] Credentials]
+    ;; Framework-internal sub-events: an enumerated head + a framework-controlled
+    ;; tail (the reply payload rides the OUTER trailing [:? :any]).
+    [:cat [:enum :auth.login/dismiss :auth.login/success :auth.login/failure]
+     [:* :any]]]
    [:? :any]])
 
 (def ^:private AuthLoginData
@@ -215,6 +241,68 @@
         [flow-id [:auth.login/submit {:email "a@b.com" :password "longenough"}]])
       (is (= :submitting (mtest/machine-state flow-id))
           "a well-formed event vector passes the :schema boundary and transitions"))))
+
+;; ---- (3b) the login examples' SHIPPED event schema rejects malformed submit -
+;;
+;; Regression gate for rf2-thhp91: the login examples (reagent / uix / helix)
+;; previously registered `AuthLoginEvent` with a permissive `[:vector :any]`
+;; fallback that re-admitted a `:submit` whose Credentials failed, so a
+;; malformed submit (short password / bad email) passed the `:where :event`
+;; boundary and drove the transition + login HTTP effect. This pins the
+;; corrected `LoginExampleEvent` shape end-to-end: malformed submit is rejected
+;; at the boundary and does NOT transition; valid submit + the framework reply
+;; sub-events still pass. The examples tree is test-free, so this is where the
+;; shipped schema's contract is enforced.
+
+(deftest login-example-event-schema-rejects-malformed-submit
+  (testing "the login examples' shipped LoginExampleEvent rejects a malformed
+            :submit at the :where :event boundary (no machine transition, no
+            login HTTP effect), while a valid submit + framework reply events
+            still pass"
+    (machines/reg-machine* flow-id
+      {:initial     :idle
+       :data        {:attempts 0 :token nil :error nil}
+       :data-schema AuthLoginData
+       :actions     {:clear (fn [_] {:data {:error nil}})}
+       :states      {:idle       {:on {:auth.login/submit {:target :submitting
+                                                           :action :clear}}}
+                     :submitting {:on {:auth.login/success {:target :authed}
+                                       :auth.login/failure {:target :error-shown}}}
+                     :authed       {}
+                     :error-shown  {}}}
+      {:schema LoginExampleEvent})
+    ;; (a) short password — rejected at the boundary; the machine stays :idle.
+    (let [traces (collect-event-traces!
+                   #(rf/dispatch-sync
+                      [flow-id [:auth.login/submit {:email "a@b.com" :password "short"}]]))]
+      (is (<= 1 (count traces))
+          "a :where :event boundary trace fired for the malformed short-password submit")
+      (is (not= :submitting (mtest/machine-state flow-id))
+          "the malformed submit did NOT transition the machine (no login effect issued)"))
+    ;; (b) bad email — also rejected; never reaches :submitting (the rejected
+    ;; submits never reached the handler, so the machine is still un-bootstrapped
+    ;; / never transitioned — the no-transition claim, not a specific state).
+    (let [traces (collect-event-traces!
+                   #(rf/dispatch-sync
+                      [flow-id [:auth.login/submit {:email "noat" :password "longenough"}]]))]
+      (is (<= 1 (count traces))
+          "a :where :event boundary trace fired for the bad-email submit")
+      (is (not= :submitting (mtest/machine-state flow-id))
+          "the bad-email submit did NOT transition the machine"))
+    ;; (c) valid submit passes the boundary and transitions to :submitting.
+    (rf/dispatch-sync
+      [flow-id [:auth.login/submit {:email "a@b.com" :password "longenough"}]])
+    (is (= :submitting (mtest/machine-state flow-id))
+        "a well-formed submit passes the boundary and transitions")
+    ;; (d) the framework reply event (success + trailing payload) still passes —
+    ;; the corrected schema must not reject the managed-HTTP reply addressing.
+    (let [traces (collect-event-traces!
+                   #(rf/dispatch-sync
+                      [flow-id [:auth.login/success] {:kind :ok :value {:token "t"}}]))]
+      (is (zero? (count traces))
+          "the framework success-reply event passes the boundary (no validation failure)")
+      (is (= :authed (mtest/machine-state flow-id))
+          "the reply event drove the transition to :authed"))))
 
 ;; ---- (4) fail-loud guard on the bare unstamped-with-schema direct path -----
 

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -34,6 +34,9 @@ const {
   isStrictlyUnder,
   cleanStageDirs,
   stageExample,
+  stagePerExampleAssets,
+  PER_EXAMPLE_ASSETS,
+  EXAMPLES_ROOT,
 } = require('../../examples/scripts/examples-staging.cjs');
 
 let failed = 0;
@@ -281,6 +284,110 @@ it('serve-example.cjs calls cleanStageDirs on the selected outDir BEFORE stageEx
   const stageAt = src.indexOf('stageExample(entry)');
   assert.ok(cleanAt !== -1 && stageAt !== -1, 'both the clean call and the stage call must be present');
   assert.ok(cleanAt < stageAt, 'the clean must precede the stage so no stale file survives into the served dir');
+});
+
+// ---- per-example static assets (rf2-cq6va5) ------------------------------
+//
+// The clean-stage boundary recreates the selected output dir EMPTY, so any
+// per-example static asset an example references via a flat (output-root-
+// relative) href / fetch URL must be re-staged each run or it 404s after a
+// clean. `stageExample` now stages index.html + _shared + the declared
+// per-example assets; these tests prove the declared assets land after a clean
+// stage and that a missing source fails LOUD (not a silent skip that ships an
+// unstyled / 404ing / broken-image page).
+
+it('PER_EXAMPLE_ASSETS declares the documented per-example assets (rf2-cq6va5)', () => {
+  // TodoMVC's official CSS (from node_modules), managed-http-counter's success
+  // fixture, and both RealWorld variants' fallback avatar.
+  assert.deepStrictEqual(
+    PER_EXAMPLE_ASSETS['examples/todomvc'].map((a) => a.dest).sort(),
+    ['base.css', 'index.css'],
+    'TodoMVC must stage base.css + index.css',
+  );
+  assert.ok(
+    PER_EXAMPLE_ASSETS['examples/todomvc'].every((a) => a.from === 'node-modules'),
+    'TodoMVC CSS is fetched into node_modules, not vendored',
+  );
+  assert.ok(
+    PER_EXAMPLE_ASSETS['examples/managed-http-counter'].some((a) =>
+      /inc\.json$/.test(a.dest),
+    ),
+    'managed-http-counter must stage its api/inc.json success fixture',
+  );
+  for (const build of ['examples/realworld', 'examples/realworld-resources']) {
+    assert.ok(
+      PER_EXAMPLE_ASSETS[build].some((a) => a.dest === 'default-avatar.svg'),
+      `${build} must stage default-avatar.svg`,
+    );
+  }
+});
+
+it('stageExample stages a colocated per-example asset after a clean stage (rf2-cq6va5)', () => {
+  // managed-http-counter: its api/inc.json lives colocated in the source folder
+  // and must land under outDir/api/inc.json after a clean stage. Drive the real
+  // manifest against the real repo source through the real clean-then-stage
+  // sequence serve-example performs.
+  const srcDir = path.join(EXAMPLES_ROOT, 'reagent', 'managed_http_counter');
+  const htmlSrc = path.join(srcDir, 'index.html');
+  assert.ok(fs.existsSync(htmlSrc), `fixture precondition: ${htmlSrc} must exist in-repo`);
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-asset-'));
+  try {
+    const outRoot = path.join(tmpRoot, 'out', 'examples');
+    const sel = path.join(outRoot, 'managed-http-counter');
+    const entry = { build: 'examples/managed-http-counter', outDir: sel, htmlSrc, srcDir };
+
+    cleanStageDirs([entry.outDir], outRoot);
+    stageExample(entry);
+
+    const staged = path.join(sel, 'api', 'inc.json');
+    assert.ok(fs.existsSync(staged), `the success fixture must be staged at ${staged}`);
+    assert.strictEqual(
+      fs.readFileSync(staged, 'utf8'),
+      fs.readFileSync(path.join(srcDir, 'api', 'inc.json'), 'utf8'),
+      'the staged fixture must be a faithful copy of the source',
+    );
+    // The RealWorld avatar pattern is the same colocated-:src shape — exercise
+    // it too so both RealWorld variants are covered.
+    const rwSrc = path.join(EXAMPLES_ROOT, 'reagent', 'realworld');
+    const rwEntry = {
+      build: 'examples/realworld',
+      outDir: path.join(outRoot, 'realworld'),
+      htmlSrc: path.join(rwSrc, 'index.html'),
+      srcDir: rwSrc,
+    };
+    cleanStageDirs([rwEntry.outDir], outRoot);
+    stageExample(rwEntry);
+    assert.ok(
+      fs.existsSync(path.join(rwEntry.outDir, 'default-avatar.svg')),
+      'the RealWorld fallback avatar must be staged',
+    );
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+it('stagePerExampleAssets FAILS LOUD on a missing declared asset source (rf2-cq6va5)', () => {
+  // Point a manifest-declared build at a srcDir that lacks the asset — staging
+  // must throw with the offending path, never silently ship a broken page.
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-asset-miss-'));
+  try {
+    const emptySrc = path.join(tmpRoot, 'src');
+    fs.mkdirSync(emptySrc, { recursive: true });
+    const entry = {
+      build: 'examples/realworld', // declares default-avatar.svg as a :src asset
+      outDir: path.join(tmpRoot, 'out'),
+      srcDir: emptySrc,
+    };
+    fs.mkdirSync(entry.outDir, { recursive: true });
+    assert.throws(
+      () => stagePerExampleAssets(entry),
+      /required asset for 'examples\/realworld' is missing/,
+      'a missing per-example asset source must fail loud',
+    );
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
 });
 
 // A no-op io for the guard-refusal tests: they must throw BEFORE any fs call,


### PR DESCRIPTION
Fixes two P3 examples bugs (rf2-thhp91 + rf2-cq6va5).

## rf2-thhp91 — helix login AuthLoginEvent accepts malformed submit payloads

The login examples' `AuthLoginEvent` outer-event schema carried a broad `[:vector :any]` fallback that, paired with the `:cat` sequence-regex semantics on the `:submit` branch, silently re-admitted a `:submit` whose `Credentials` failed. A malformed submit (short password / bad email) therefore passed the `:where :event` boundary and drove the machine transition + login HTTP effect.

Fix: a strict `:tuple` `:submit` branch (the outer `:cat` consumes the nested sub-event vector as a SINGLE element, so the branch matches it AS a vector) plus an enumerated framework-internal branch (`:dismiss` / `:success` / `:failure` + framework-controlled tail), with NO `[:vector :any]` escape hatch. The trailing `[:? :any]` reply slot is preserved.

Applied identically across all three sibling login examples (`examples/reagent/login`, `examples/uix/login_uix`, `examples/helix/login_helix`) to preserve the load-bearing cross-substrate parity shape.

The examples tree is test-free, so the shipped shape's contract is pinned by a new regression test in the machines suite (`login-example-event-schema-rejects-malformed-submit`) that drives the corrected `LoginExampleEvent` end-to-end through the `:where :event` boundary: malformed submit rejected (no transition, no login effect); valid submit + framework reply events still pass.

## rf2-cq6va5 — dev example runner omits required per-example static assets

`stageExample` (the dev runner's single staging source of truth) copied only `index.html` + `_shared` after the clean-stage boundary recreates the output dir empty, dropping per-example static assets several standalone examples reference via flat (output-root-relative) hrefs / fetch URLs:

- TodoMVC's official `base.css` + `index.css` (pinned in package.json, fetched into node_modules, not vendored)
- managed-http-counter's `api/inc.json` success fixture (colocated in the source folder)
- the RealWorld variants' `default-avatar.svg` fallback (colocated in each source folder)

Fix: a declarative per-build asset manifest (`PER_EXAMPLE_ASSETS`) + `stagePerExampleAssets`, wired into `stageExample`, that stages each declared asset from its source (colocated `:src` folder or `node_modules`) and FAILS LOUD with the offending path on a missing source (so a silently-absent asset can't ship an unstyled / 404ing / broken-image page). Covered by new asset-staging tests under `implementation/scripts/`.

## Quality gates

- `npm run test:script-policy` (incl. `_examples-staging.test.cjs` with 3 new asset-staging tests) — all passed
- `clojure -M:test -n re-frame.machine-schema-arity-test` (machines suite, incl. the new regression test) — 9 tests, 27 assertions, 0 failures
- `shadow-cljs compile examples/login-helix examples/login examples/login-uix` — 0 warnings
- `shadow-cljs compile examples/todomvc examples/managed-http-counter` — 0 warnings
- End-to-end staging verification: clean-stage of todomvc / managed-http-counter / realworld / realworld-resources confirmed to land base.css+index.css / api/inc.json / default-avatar.svg respectively
- Did NOT add any tests under examples/ (test-free policy preserved); new tests live in the machines suite + implementation/scripts/