### PR TITLE
fix(mcp-conformance): pair classification ratchet enforces the invariant

### DIFF
--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -16,6 +16,7 @@
     "test:runner-watchdog": "node --test test/runner-watchdog.test.cjs",
     "test:runner-cleanup": "node --test test/runner-cleanup.test.cjs",
     "test:call-coverage-ratchet": "node --test test/call-coverage-ratchet.test.cjs",
+    "test:classification-ratchet": "node --test test/classification-ratchet.test.cjs",
     "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
     "test:port-file-escape": "node --test test/port-file-escape.test.cjs",
     "test": "node scripts/test-all.cjs"

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -68,6 +68,10 @@ const TESTS = [
     argv: ['--test', 'test/call-coverage-ratchet.test.cjs'],
   },
   {
+    name: 'classification ratchet unit tests — read/destructive + open-world partition (rf2-yi451 / rf2-ppk6hy)',
+    argv: ['--test', 'test/classification-ratchet.test.cjs'],
+  },
+  {
     name: 're-frame2-pair-mcp end-to-end',
     argv: ['test/end-to-end-re-frame2-pair.cjs'],
   },

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -530,14 +530,19 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
 //                      openWorldHint; pinning `neither` catches a
 //                      side-effecting tool that wrongly gained
 //                      readOnlyHint, masking its effect)
-//   - `closed-world`  — tools whose descriptor MUST carry
-//                       `openWorldHint:false` (inline / no-runtime-reach
-//                       tools, e.g. get-re-frame2-pair-instructions). All
-//                       OTHER tools are not pinned on openWorldHint here
-//                       — the read-only/destructive axis is the trust-
-//                       classification a flipped-hint regression breaks;
-//                       the openWorld axis is the per-server `allowOpenWorld`
-//                       dimension `assertDescriptorShape` already handles.
+//   - `closed-world`  — the EXHAUSTIVE open-world partition (rf2-ppk6hy):
+//                       tools listed here MUST carry `openWorldHint:false`
+//                       (inline / no-runtime-reach tools, e.g.
+//                       get-re-frame2-pair-instructions); EVERY tool NOT
+//                       listed MUST carry `openWorldHint:true` (it reaches
+//                       the live browser / nREPL — an external process).
+//                       Both sides are pinned. Asserting only the `false`
+//                       side left a hole: a read-only/destructive tool that
+//                       reaches the runtime could drop `openWorldHint:true`
+//                       (or set it false) and still ship green, mislabelling
+//                       a live-reaching tool as contained and weakening the
+//                       MCP client trust/confirmation boundary. Pinning the
+//                       complement turns that regression RED.
 //
 // Also pins, per descriptor, that the `max-tokens` property carries a
 // NON-EMPTY `description` (the budget-hint prose — TOKEN-BUDGETS.md
@@ -624,15 +629,44 @@ function assertClassificationRatchet(tools, expected) {
       );
     }
 
-    // 2. openWorld posture for the closed-world (no-runtime-reach) tools.
-    // These ship static / inline content; openWorldHint MUST be false so
-    // a host doesn't treat them as reaching an external world.
-    if (closedWorld.has(t.name) && a.openWorldHint !== false) {
-      throw new Error(
-        'tool ' + t.name + ' is pinned closed-world (inline / no runtime ' +
-          'reach) but the live descriptor has openWorldHint=' +
-          JSON.stringify(a.openWorldHint) + ' (MUST be false). rf2-yi451.',
-      );
+    // 2. openWorld posture — BOTH sides of the partition (rf2-ppk6hy).
+    // The fixture's `closed-world` list IS the exhaustive partition: a
+    // tool is closed-world (no runtime reach) OR open-world (reaches the
+    // live browser/nREPL — an external process). Asserting only the
+    // `false` side left a hole — a read-only/destructive tool that
+    // reaches the runtime could DROP `openWorldHint:true` (or set it
+    // false) and still ship GREEN, mislabelling a live-reaching tool as
+    // contained and weakening the MCP client trust/confirmation boundary.
+    // Pin both sides so the complement can't regress.
+    if (closedWorld.has(t.name)) {
+      // 2a. Closed-world (inline / no runtime reach) — these ship static /
+      // inline / server-local content; openWorldHint MUST be false so a
+      // host doesn't treat them as reaching an external world.
+      if (a.openWorldHint !== false) {
+        throw new Error(
+          'tool ' + t.name + ' is pinned closed-world (inline / no runtime ' +
+            'reach) but the live descriptor has openWorldHint=' +
+            JSON.stringify(a.openWorldHint) + ' (MUST be false). rf2-yi451.',
+        );
+      }
+    } else {
+      // 2b. Open-world (every NON-closed tool reaches the live browser /
+      // nREPL — an external process) — openWorldHint MUST be true so a
+      // host applies the appropriate confirmation ceremony instead of
+      // treating the call as contained on-box. A missing or false hint on
+      // a live-reaching tool is the exact false-green this side closes
+      // (rf2-ppk6hy).
+      if (a.openWorldHint !== true) {
+        throw new Error(
+          'tool ' + t.name + ' is open-world (reaches the live browser / ' +
+            'nREPL — not in the fixture `closed-world` list) but the live ' +
+            'descriptor has openWorldHint=' + JSON.stringify(a.openWorldHint) +
+            ' (MUST be true). A live-reaching tool mislabelled as contained ' +
+            'weakens the MCP client trust/confirmation boundary — the ' +
+            'false-green this side exists to turn RED (rf2-ppk6hy). Got ' +
+            'annotations: ' + JSON.stringify(a),
+        );
+      }
     }
 
     // 3. Budget-hint PROSE — the `max-tokens` property must carry a

--- a/tools/mcp-conformance/test/classification-ratchet.test.cjs
+++ b/tools/mcp-conformance/test/classification-ratchet.test.cjs
@@ -1,0 +1,151 @@
+// Unit test for the per-tool annotation CLASSIFICATION ratchet
+// (rf2-yi451; open-world complement closed in rf2-ppk6hy).
+//
+// `assertClassificationRatchet` is itself a conformance gate — it is the
+// teeth that turn a per-tool annotation regression (a flipped read-only /
+// destructive hint, an emptied budget-hint, or — the gap this file pins —
+// a live-reaching tool that drops `openWorldHint:true`) RED. A gate with
+// no test is a gate that can silently lose its teeth, so this pins its
+// contract directly, in-process, with no child / no MCP server (it is a
+// pure data assertion). Uses Node's built-in `node:test` — same
+// zero-dependency posture as the sibling runner tests
+// (call-coverage-ratchet.test.cjs).
+//
+// The end-to-end harnesses (`end-to-end-story.cjs` /
+// `end-to-end-re-frame2-pair.cjs`) exercise the GREEN path live (every
+// advertised tool's real wire descriptor). This test pins the RED paths
+// the green runs never hit — in particular the rf2-ppk6hy open-world hole:
+// before the fix the ratchet asserted only the `closed-world` (false) side
+// of the openWorld partition, so a read-only or destructive tool that
+// reaches the live browser / nREPL could drop (or false) `openWorldHint`
+// and still ship GREEN, mislabelling a live-reaching tool as contained.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { assertClassificationRatchet } = require('./_runner.cjs');
+
+// A minimal, server-agnostic fixture mirroring the real fixture shape:
+// `classifications` (one row per tool) + `closed-world` (the exhaustive
+// open-world partition — listed ⇒ openWorldHint MUST be false; not
+// listed ⇒ openWorldHint MUST be true).
+const FIXTURE = {
+  classifications: {
+    'read-live': 'read-only', // open-world (reaches the runtime)
+    'write-live': 'destructive', // open-world (reaches the runtime)
+    'pin-live': 'neither', // open-world (reaches the runtime)
+    'read-inline': 'read-only', // closed-world (inline / no reach)
+  },
+  'closed-world': ['read-inline'],
+};
+
+// A non-empty `max-tokens` budget-hint description is required on every
+// tool by the same ratchet (assertion 3); supply it so the openWorld /
+// posture assertions are what actually decides each case.
+function mt() {
+  return {
+    inputSchema: {
+      type: 'object',
+      properties: {
+        'max-tokens': { description: 'per-call cap override' },
+      },
+    },
+  };
+}
+
+function tool(name, annotations) {
+  return { name, annotations, ...mt() };
+}
+
+// A fully-legitimate live tool-set: open-world tools carry
+// openWorldHint:true, the closed-world tool carries openWorldHint:false,
+// and every read-only/destructive/neither posture matches.
+function greenTools() {
+  return [
+    tool('read-live', { readOnlyHint: true, openWorldHint: true }),
+    tool('write-live', { destructiveHint: true, openWorldHint: true }),
+    tool('pin-live', { openWorldHint: true }),
+    tool('read-inline', { readOnlyHint: true, openWorldHint: false }),
+  ];
+}
+
+test('GREEN: the legitimate open/closed partition ⇒ no throw', () => {
+  assert.doesNotThrow(() =>
+    assertClassificationRatchet(greenTools(), FIXTURE),
+  );
+});
+
+// --- rf2-ppk6hy: the open-world complement (the regression this fix adds) ---
+
+test('RED: a read-only live tool that DROPS openWorldHint ⇒ throws + names it', () => {
+  const tools = greenTools();
+  // read-live reaches the runtime but the descriptor forgot openWorldHint.
+  tools[0].annotations = { readOnlyHint: true };
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /read-live is open-world[\s\S]*MUST be true[\s\S]*rf2-ppk6hy/,
+  );
+});
+
+test('RED: a read-only live tool with openWorldHint:false ⇒ throws (mislabelled contained)', () => {
+  const tools = greenTools();
+  tools[0].annotations = { readOnlyHint: true, openWorldHint: false };
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /read-live is open-world[\s\S]*MUST be true/,
+  );
+});
+
+test('RED: a DESTRUCTIVE live tool that drops openWorldHint ⇒ throws (the trust-boundary case)', () => {
+  const tools = greenTools();
+  // write-live is destructive AND reaches the runtime; dropping the
+  // open-world hint without this complement would ship GREEN pre-fix.
+  tools[1].annotations = { destructiveHint: true };
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /write-live is open-world[\s\S]*MUST be true/,
+  );
+});
+
+test('RED: a `neither` live tool that drops openWorldHint ⇒ throws', () => {
+  const tools = greenTools();
+  tools[2].annotations = {}; // pin-live: no hints at all
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /pin-live is open-world[\s\S]*MUST be true/,
+  );
+});
+
+// --- the closed-world (false) side still holds (rf2-yi451) ---
+
+test('RED: a closed-world tool that flips openWorldHint:true ⇒ throws', () => {
+  const tools = greenTools();
+  // read-inline ships inline content; it must NOT claim open-world reach.
+  tools[3].annotations = { readOnlyHint: true, openWorldHint: true };
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /read-inline is pinned closed-world[\s\S]*MUST be false/,
+  );
+});
+
+test('RED: a closed-world tool that drops openWorldHint ⇒ throws', () => {
+  const tools = greenTools();
+  tools[3].annotations = { readOnlyHint: true }; // missing openWorldHint
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /read-inline is pinned closed-world[\s\S]*MUST be false/,
+  );
+});
+
+// --- the read-only / destructive posture axis still holds (rf2-yi451) ---
+
+test('RED: a destructive tool re-labelled read-only ⇒ throws', () => {
+  const tools = greenTools();
+  // write-live keeps openWorldHint:true (so it clears the open-world side)
+  // but is mislabelled read-only — the posture axis must still trip.
+  tools[1].annotations = { readOnlyHint: true, openWorldHint: true };
+  assert.throws(
+    () => assertClassificationRatchet(tools, FIXTURE),
+    /write-live classification regressed[\s\S]*pins `destructive`/,
+  );
+});


### PR DESCRIPTION
## What the ratchet missed

`assertClassificationRatchet` (`tools/mcp-conformance/test/_runner.cjs`) asserted `openWorldHint:false` only for the tools listed in the fixture's `closed-world` array. It **never asserted the complement** — that every NON-closed pair tool carries `openWorldHint:true` — even though the fixture `_doc` explicitly states "every posture additionally requires `openWorldHint:true` ... EXCEPT the closed-world tools".

Consequence: a read-only or destructive pair tool that reaches the live browser / nREPL could **drop** (or set false) `openWorldHint` and still ship GREEN, because `readOnlyHint`/`destructiveHint` already satisfied the posture + shape checks and the openWorld axis was only half-pinned. That lets a live-reaching tool be mislabelled as contained on-box, weakening the MCP-client trust/confirmation boundary (rf2-ppk6hy).

## The fix

The fixture's `closed-world` list is now treated as the **exhaustive open-world partition**:

- listed in `closed-world` ⇒ `openWorldHint` MUST be `false` (inline / no-runtime-reach), as before;
- **NOT listed ⇒ `openWorldHint` MUST be `true`** (reaches the live browser / nREPL — an external process).

Both sides now turn the ratchet RED on regression. The fix is fixture-driven (no new list to maintain) and works for both servers: the pair fixture is mostly open-world, the story fixture is mostly closed-world — both partition correctly.

## The test

New `tools/mcp-conformance/test/classification-ratchet.test.cjs` — a pure in-process data assertion using `node:test`, mirroring the sibling `call-coverage-ratchet.test.cjs`. It proves the missed case is now caught:

- RED: a read-only / destructive / `neither` live tool that **drops or falses** `openWorldHint` ⇒ throws (the rf2-ppk6hy hole).
- RED: the closed-world `false` side still holds (flip-to-true / dropped ⇒ throws).
- RED: the read/destructive posture axis still holds.
- GREEN: the legitimate open/closed partition passes.

Wired into `scripts/test-all.cjs` (the authoritative conformance inventory) and a `test:classification-ratchet` npm script.

## Quality gates

`npm run test:mcp-conformance` (from `implementation/`) — **ALL MCP-CONFORMANCE GATES GREEN**. All 6 gates pass, including:
- the new `classification ratchet unit tests` row (8/8 pass);
- `re-frame2-pair-mcp end-to-end` and `story-mcp end-to-end` — the LIVE wire descriptors against the real fixtures clear the new open-world complement (GREEN path intact for both servers);
- wire-vocab: 72 tests / 762 assertions, 0 failures.

Closes rf2-ppk6hy.