### PR TITLE
fix(ssr-ring): keep protocol chunks out of body + realm-route error/redirect render

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -91,7 +91,8 @@
 
     - Async Ring handler (3-arity) — synchronous-only in v1;
       extension is additive."
-  (:require [re-frame.ssr :as ssr]
+  (:require [re-frame.frame :as frame]
+            [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.cookie :as cookie]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
@@ -399,11 +400,27 @@
         (if short-circuit
           short-circuit
           (try
-            (let [resp (ssr/get-response frame-id)]
-              (if (some? (:redirect resp))
-                ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
-                (pipeline/ssr-response->ring-response resp nil)
-                (pipeline/build-full-response frame-id resp opts)))
+            ;; rf2-nu5w48 / EP-0013 §Realm Conformance: bind the request
+            ;; frame's OWN realm around the accumulator read + the redirect
+            ;; short-circuit so the per-frame response side channel is
+            ;; addressed by the `(realm, frame)` slot (`frame/frame-address`),
+            ;; not the default realm's bare-id slot. `ssr/get-response` reads
+            ;; the realm's accumulated status/headers/cookies/redirect, and the
+            ;; redirect materialiser ships THAT realm's response. The non-error
+            ;; render branch (`build-full-response*`) re-establishes the realm
+            ;; binding around its own render walk (rf2-bzw8gd); the error path
+            ;; binds it inside `project-render-throw->ring-response`. Both
+            ;; no-op for a default-realm frame (byte-identical single-realm
+            ;; path). The redirect branch does no view resolution, so it only
+            ;; needs `call-with-realm` (the side-channel addressing dimension);
+            ;; the registrar is bound by the branches that resolve views.
+            (frame/call-with-realm (frame/frame-realm frame-id)
+              (fn []
+                (let [resp (ssr/get-response frame-id)]
+                  (if (some? (:redirect resp))
+                    ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
+                    (pipeline/ssr-response->ring-response resp nil)
+                    (pipeline/build-full-response frame-id resp opts)))))
             (catch Throwable t
               ;; rf2-ljjh0 — `safe-on-error` contains a throwing
               ;; caller `:on-error`: a bug in the caller's transport-

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -470,17 +470,41 @@
 
   When projection returns nil (e.g. no server frame) the locked
   generic-500 public-error is substituted so the wire still carries a
-  well-formed fail-closed body."
+  well-formed fail-closed body.
+
+  rf2-nu5w48 / EP-0013 §Realm Conformance: the WHOLE error-projection +
+  error-body render path is bound to the request frame's OWN realm
+  (`call-with-realm` + `call-with-frame-realm-registrar`), mirroring the
+  happy-path `build-full-response*` realm binding (rf2-bzw8gd):
+
+    - `call-with-realm` binds `*current-realm*` so the per-frame side
+      channels this path touches (`project-render-exception!` stamps the
+      response accumulator, `peek-response` reads it) address the
+      `(realm, frame)` slot via `frame/frame-address` — a non-default-realm
+      frame's error status/headers/cookies are read from ITS slot, not the
+      default realm's bare-id slot;
+    - `call-with-frame-realm-registrar` binds the realm's registrar so a
+      caller `:error-view` REGISTERED IN THE REALM resolves through the
+      owning realm's registrar (`resolve-error-body`'s `[error-view
+      public-error]` view lookup), not the process-global default's.
+
+  Both no-op for a default-realm frame (byte-identical single-realm path).
+  The frame record is resolved ONCE for the registrar binding."
   [frame-id ^Throwable t opts]
-  (let [public-error  (ssr/project-render-exception! frame-id t)
-        resp*         (ssr/peek-response frame-id)
-        public-error* (or public-error
-                          {:status 500 :code :internal-error
-                           :message "Something went wrong"
-                           :retryable? false})
-        body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
-        content-type  (:content-type opts)]
-    (ssr-response->ring-response resp* body-html content-type)))
+  (frame/call-with-realm (frame/frame-realm frame-id)
+    (fn []
+      (frame/call-with-frame-realm-registrar
+        (frame/frame frame-id)
+        (fn []
+          (let [public-error  (ssr/project-render-exception! frame-id t)
+                resp*         (ssr/peek-response frame-id)
+                public-error* (or public-error
+                                  {:status 500 :code :internal-error
+                                   :message "Something went wrong"
+                                   :retryable? false})
+                body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
+                content-type  (:content-type opts)]
+            (ssr-response->ring-response resp* body-html content-type)))))))
 
 (defn build-full-response
   "Render the caller's `:root-view` against `frame-id`, build the

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -114,13 +114,23 @@
          ">")))
 
 (defn default-streaming-suffix
-  "The shell suffix flushed after the final-payload chunk. Closes the
-  app-div, emits the bootstrap script tag (if any), the body-end raw
-  HTML, and the document close."
+  "The shell suffix flushed after the final-payload chunk. Emits the
+  bootstrap script tag (if any), the body-end raw HTML, and the document
+  close.
+
+  rf2-z9dduj — the app root (`</div>`) is NO LONGER closed here. It is
+  closed at the END of the shell chunk (immediately after the shell HTML,
+  see `run-streaming-writer!`), so the resolved templates, hydration-delta
+  scripts, and the final `__rf_payload` script all stream OUTSIDE `#app`
+  per Spec 011 §Chunk-ordering contract (chunk 1 is
+  `…<div id=\"app\"><shell-html/></div>`). The suffix is therefore purely
+  the bootstrap `<script>` + the raw `:body-end` + the document close —
+  all of which already belonged outside `#app`, mirroring the non-streaming
+  `default-html-shell` (which emits the payload script + bootstrap + body-end
+  after `</div>`)."
   [{:keys [body-end script-src]
     :or   {script-src "/main.js"}}]
-  (str "</div>"
-       (when script-src
+  (str (when script-src
          ;; rf2-7x0qk — `:script-src` is an attribute-value position;
          ;; escape through `html/escape-attr` (same split as the non-
          ;; streaming `default-html-shell`). `:body-end` stays raw
@@ -351,14 +361,32 @@
                              ;; marker when false (a true no-op was the
                              ;; bug). Same hash the final payload carries.
                              :render-hash (when emit-hash? doc-hash)})]
-      ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks).
-      ;; rf2-l1qgjw — stamp the phase before each write so the catch arm
-      ;; names the in-flight chunk. `:shell-prefix` is already the initial
-      ;; volatile value, set explicitly here for symmetry/readability.
+      ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks) +
+      ;; the app-root close. rf2-l1qgjw — stamp the phase before each write
+      ;; so the catch arm names the in-flight chunk. `:shell-prefix` is
+      ;; already the initial volatile value, set explicitly here for
+      ;; symmetry/readability.
       (vreset! phase [:shell-prefix nil])
       (write-chunk! out (default-streaming-prefix head-html shell-opts))
+      ;; rf2-z9dduj — CLOSE the app root (`</div>`) at the END of the shell
+      ;; chunk, immediately after the shell HTML and BEFORE any resolved
+      ;; template / hydration-delta / final `__rf_payload` chunk. Spec 011
+      ;; §Chunk-ordering contract pins chunk 1 as
+      ;; `…<div id="app"><shell-html/></div>` — the app root is CLOSED in the
+      ;; shell chunk, and the resolved chunks + final payload + bootstrap +
+      ;; body-end stream OUTSIDE it (chunks 2..N). The non-streaming
+      ;; `default-html-shell` already closes `</div>` right after the body and
+      ;; emits the payload script outside `#app`; the streaming path used to
+      ;; leave the close in `default-streaming-suffix` AFTER the protocol
+      ;; chunks, so resolved templates + the `__rf_payload` script landed
+      ;; INSIDE the application root — control/protocol nodes in the DOM a
+      ;; client renderer/hydrator owns, risking a hydration mismatch /
+      ;; replacement (Spec 011 §998-1001). The close is appended to the same
+      ;; `:shell-html` write (one flush) so a write throw is still attributed
+      ;; to the `:shell-html` phase, and the suffix is now purely the bootstrap
+      ;; script + body-end + `</body></html>`.
       (vreset! phase [:shell-html nil])
-      (write-chunk! out shell-html)
+      (write-chunk! out (str shell-html "</div>"))
       ;; Chunks 2..N+1 — one per continuation, FIFO over registration.
       ;;
       ;; rf2-sgvn6 / rf2-b1v8v — drain a GROWABLE FIFO worklist, not a
@@ -664,7 +692,25 @@
         (if short-circuit
           short-circuit
           (try
-            (let [resp (ssr/get-response frame-id)]
+            ;; rf2-nu5w48 / EP-0013 §Realm Conformance: bind the request
+            ;; frame's OWN realm around the request-thread body so every
+            ;; per-frame side channel it reads — the early `ssr/get-response`
+            ;; drain read, the post-shell `ssr/get-response` re-read, and the
+            ;; response materialisation on BOTH redirect short-circuits — is
+            ;; addressed by the `(realm, frame)` slot (`frame/frame-address`),
+            ;; not the default realm's bare-id slot. `render-streaming-shell!`
+            ;; re-establishes the realm registrar around its OWN render walk
+            ;; (rf2-bzw8gd) and captures `:realm-id` for the daemon writer to
+            ;; carry across the thread boundary; the shell-render error path
+            ;; binds it inside `project-render-throw->ring-response`
+            ;; (rf2-nu5w48). This request-thread binding closes the redirect +
+            ;; accumulator-read gaps the render-walk binding did not cover.
+            ;; No-op for a default-realm frame (byte-identical single-realm
+            ;; path); it does NOT cross into the spawned writer thread (which
+            ;; carries its realm via `:realm-id`).
+            (frame/call-with-realm (frame/frame-realm frame-id)
+             (fn []
+              (let [resp (ssr/get-response frame-id)]
               (if (some? (:redirect resp))
                 ;; Redirect short-circuits the stream — no chunked body,
                 ;; so the writer thread (whose `finally` normally tears
@@ -867,7 +913,7 @@
                               ^String (str "rf2-ssr-streaming-" (name frame-id)))
                             (.setDaemon true)
                             (.start))
-                          (assoc resp-map :body pipe-in))))))))
+                          (assoc resp-map :body pipe-in)))))))))) ;; close let/if + (fn []) + call-with-realm (rf2-nu5w48)
             (catch Throwable t
               ;; get-response throw, redirect-materialise throw, OR (per
               ;; rf2-z5azc) a head-materialisation throw raised BEFORE the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/realm_routing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/realm_routing_test.clj
@@ -1,0 +1,251 @@
+(ns re-frame.ssr.ring.realm-routing-test
+  "rf2-nu5w48 / EP-0013 §Realm Conformance — the ssr-ring ERROR-body render
+  path and the STREAMING continuation render (re-established on the daemon
+  writer thread) route registered-view lookups through the request frame's
+  OWN realm registrar.
+
+  Follow-up to rf2-bzw8gd (#4294), which keyed the SSR side channels by the
+  (realm, frame) address and bound the realm registrar around the NON-error
+  render walk (`build-full-response*` / `render-streaming-shell!`). Two gaps
+  remained, closed here:
+
+    1. The error-body render path (`pipeline/project-render-throw->ring-
+       response` → `resolve-error-body`) did not bind the frame's realm, so a
+       caller `:error-view` registered IN the realm resolved against the
+       process-global default registrar (a miss → the host default template).
+
+    2. The streaming daemon writer re-establishes the realm around its
+       continuation render via the carried `:realm-id`, but no JVM regression
+       drove a non-default-realm frame's continuation END-TO-END across the
+       thread boundary. This ns proves the realm view resolves on the writer
+       thread.
+
+  The unit-level side-channel + head/route isolation is covered by
+  `re-frame.ssr-realm-address-test` (implementation/ssr/test); this ns covers
+  the ssr-ring error + cross-thread streaming render paths.
+
+  Realm setup mirrors `re-frame.ssr-realm-address-test`: a constructed realm
+  carrying the SSR adapter (`:adapter ssr/adapter`) plus its OWN registrar,
+  with the per-request server frame + the realm-only views registered under
+  the realm's `*current-realm*` / `*registrar*` scope. The realm-routing only
+  activates when `*current-realm*` is ambiently bound around the request (the
+  router / host-adapter pattern — `frame/call-with-realm`), which is how the
+  bzw8gd side-channel writes are also driven."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.realm :as realm]
+            [re-frame.registrar :as registrar]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]
+            [re-frame.ssr.ring.pipeline :as pipeline]
+            [re-frame.ssr.ring.streaming :as streaming]
+            [re-frame.ssr.ring.test-support :as ts])
+  (:import [java.io OutputStream]))
+
+(use-fixtures :each ts/reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; Realm scaffolding
+;; ---------------------------------------------------------------------------
+
+(defn- with-realm-registrar
+  "Run `thunk` with BOTH the realm dimension bound: `*current-realm*` to
+  `rid` (so frame-registry + side-channel addressing resolve the realm's
+  frame) AND `registrar/*registrar*` to the realm's OWN registrar (so
+  reg-frame / reg-view* SEAT into — and view lookups RESOLVE from — the
+  realm's table). Mirrors how `app-value/install!` seats a realm's program
+  and how the SSR render path resolves one."
+  [rid thunk]
+  (binding [frame/*current-realm*    rid
+            registrar/*registrar*    (realm/registrar (realm/realm rid))]
+    (thunk)))
+
+;; ===========================================================================
+;; (1) ERROR-body render path routes through the frame's realm registrar
+;; ===========================================================================
+
+(deftest error-view-resolves-the-frames-own-realm-registration
+  (testing "rf2-nu5w48: project-render-throw->ring-response renders a caller
+            :error-view REGISTERED IN THE REALM through the realm's OWN
+            registrar (not the process-global default). A view by the same id
+            registered in the default realm would be the WRONG one — the test
+            registers the error view ONLY in the realm, so a default-registrar
+            lookup misses and the realm-routed lookup is what makes it
+            resolve."
+    (let [rid :nu5w48/err-realm
+          fid :nu5w48/err-frame]
+      (rf/realm {:id rid :adapter ssr/adapter})
+      (try
+        ;; Seat a per-request SERVER frame + the realm-only error view into
+        ;; the realm's registrar, under the realm scope.
+        (with-realm-registrar rid
+          (fn []
+            (rf/reg-frame fid {:platform :server :doc "realm per-request frame"})
+            ;; The error view lives ONLY in this realm's registrar. Its markup
+            ;; is a realm-unique signature so a default-realm miss is visible.
+            (rf/reg-view* :nu5w48/error-page
+              (fn [{:keys [status code message]}]
+                [:div.realm-error
+                 [:h1 "REALM ERROR PAGE"]
+                 [:p.code (name code)]
+                 [:p.status (str status)]
+                 [:p.msg message]]))))
+        (let [t    (ex-info "internal-render-boom" {})
+              opts {:error-view  :nu5w48/error-page
+                    :content-type "text/html; charset=utf-8"}
+              ;; Drive the error-body path UNDER the realm scope (the host /
+              ;; router binds `*current-realm*` around the request; the
+              ;; in-fn binding of the realm REGISTRAR is what rf2-nu5w48 adds).
+              response (frame/call-with-realm rid
+                         (fn [] (pipeline/project-render-throw->ring-response fid t opts)))
+              body     (:body response)]
+          (is (= 500 (:status response))
+              "the projector's fail-closed status rides the response")
+          (is (str/includes? body "REALM ERROR PAGE")
+              "rf2-nu5w48: the realm-registered :error-view resolved through the
+               frame's OWN realm registrar (a default-registrar lookup would
+               miss it and fall back to the host default template)")
+          (is (str/includes? body "class=\"realm-error\"")
+              "the realm error view's own markup reached the wire")
+          (is (not (str/includes? body "internal-render-boom"))
+              "rf2-kzvwq: the throwable message never reaches the wire"))
+        (finally
+          (rf/dispose-realm! rid))))))
+
+(deftest default-realm-error-view-still-resolves-byte-identically
+  (testing "rf2-nu5w48: the realm binding is a no-op for a default-realm
+            frame — a default-realm :error-view still resolves (the
+            single-realm path is unchanged)."
+    (rf/reg-event :nu5w48/init-ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :nu5w48/broken-default (fn [] (throw (ex-info "boom" {}))))
+    (rf/reg-view* :nu5w48/default-error-page
+      (fn [{:keys [message]}]
+        [:div.default-error [:h1 "DEFAULT ERROR PAGE"] [:p message]]))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create  [:nu5w48/init-ok]
+                      :root-view  [:nu5w48/broken-default]
+                      :error-view :nu5w48/default-error-page
+                      :payload    :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/broken" :request-method :get})
+          body     (:body response)]
+      (is (= 500 (:status response)))
+      (is (str/includes? body "DEFAULT ERROR PAGE")
+          "a default-realm error view resolves unchanged (binding no-ops)"))))
+
+;; ===========================================================================
+;; (2) STREAMING continuation render re-establishes the realm on the daemon
+;;     writer thread — cross-thread realm isolation, end to end.
+;; ===========================================================================
+
+(defn- collecting-output-stream
+  "An OutputStream that accumulates every written byte into `sb` (decoded as
+  UTF-8 on close-time read via `str`). Used to capture the streamed wire
+  bytes the writer pumps on the daemon thread."
+  ^OutputStream [^StringBuilder sb]
+  (proxy [OutputStream] []
+    (write
+      ([b]
+       (if (bytes? b)
+         (.append sb (String. ^bytes b java.nio.charset.StandardCharsets/UTF_8))
+         (.append sb (char (int b))))
+       nil)
+      ([b off len]
+       (.append sb (String. ^bytes b (int off) (int len)
+                            java.nio.charset.StandardCharsets/UTF_8))
+       nil))
+    (flush [] nil)
+    (close [] nil)))
+
+(deftest streaming-continuation-resolves-realm-view-on-daemon-thread
+  (testing "rf2-nu5w48: a non-default-realm frame's streaming render captures
+            the realm-id on the request thread (`render-streaming-shell!`),
+            and the writer re-establishes that realm on a FRESH thread so the
+            suspense-boundary continuation resolves the realm's REGISTERED
+            view. The boundary body view is registered ONLY in the realm's
+            registrar — a default-registrar lookup on the writer thread would
+            miss it; the realm-id carry + call-with-realm/call-with-frame-
+            realm-registrar binding is what resolves it cross-thread."
+    (let [rid :nu5w48/stream-realm
+          fid :nu5w48/stream-frame]
+      (rf/realm {:id rid :adapter ssr/adapter})
+      (try
+        (with-realm-registrar rid
+          (fn []
+            (rf/reg-frame fid {:platform :server :doc "realm streaming frame"})
+            ;; The deferred subtree's view — REALM-ONLY. Its body is a
+            ;; realm-unique signature string.
+            (rf/reg-view* :nu5w48/realm-section
+              (fn [] [:div.realm-deferred "REALM-DEFERRED-CONTENT"]))
+            ;; A root carrying a suspense boundary around the realm-only view.
+            (rf/reg-view* :nu5w48/stream-root
+              (fn []
+                [:main
+                 [:h1 "Realm streaming"]
+                 [:rf/suspense-boundary
+                  {:id :nu5w48/boundary :fallback [:p "loading…"]}
+                  [:nu5w48/realm-section]]]))))
+        (let [opts {:on-create nil
+                    :root-view [:nu5w48/stream-root]
+                    :emit-hash? true
+                    :payload :rf.ssr.payload/whole-app-db}
+              ;; Render the shell on THIS thread UNDER the realm scope — exactly
+              ;; as the request thread does (router binds *current-realm*). This
+              ;; captures :realm-id into the rendered map for the writer thread.
+              rendered (frame/call-with-realm rid
+                         (fn [] (#'streaming/render-streaming-shell! fid opts)))]
+          (is (= rid (:realm-id rendered))
+              "render-streaming-shell! captured the frame's non-default realm-id
+               for the daemon writer to re-establish across the thread boundary")
+          (is (seq (:continuations rendered))
+              "the realm suspense boundary registered a continuation")
+          ;; Drive the writer on a FRESH thread with NO ambient realm binding —
+          ;; the daemon thread must re-establish the realm from the carried
+          ;; :realm-id alone. A non-realm-routed writer would resolve
+          ;; :nu5w48/realm-section against the default registrar (a miss) and
+          ;; emit an unresolved/blank subtree.
+          (let [sb     (StringBuilder.)
+                out    (collecting-output-stream sb)
+                writer (Thread.
+                         ^Runnable
+                         (fn []
+                           ;; Assert there is NO ambient realm on this thread —
+                           ;; the writer must rely solely on the carried id.
+                           (assert (nil? frame/*current-realm*))
+                           (@#'streaming/run-streaming-writer! out fid rendered opts)))]
+            (.start writer)
+            (.join writer 10000)
+            (is (not (.isAlive writer)) "the writer thread completed")
+            (let [body (str sb)]
+              (is (str/includes? body "Realm streaming")
+                  "the shell streamed")
+              (is (str/includes? body "REALM-DEFERRED-CONTENT")
+                  "rf2-nu5w48: the daemon-thread continuation resolved the
+                   REALM-registered view (cross-thread realm re-establishment
+                   via the carried :realm-id) — a default-registrar lookup on
+                   the writer thread would have missed it")
+              (is (str/includes? body "data-rf2-suspense-resolved=\"1\"")
+                  "the continuation chunk streamed resolved (not the fallback)")
+              ;; The boundary did NOT fail (the view resolved cleanly).
+              (is (not (str/includes? body "data-rf2-suspense-failed=\"1\""))
+                  "the realm continuation resolved cleanly — NOT a failed
+                   fallback re-emit (which a missed realm lookup could cause)")
+              (is (str/includes? body "__rf_payload")
+                  "the final payload chunk streamed")
+              ;; rf2-z9dduj cross-check on the realm path: #app closes before
+              ;; the resolved chunk + payload here too.
+              (let [idx-close    (str/index-of body "</div>")
+                    idx-resolved (str/index-of body "data-rf2-suspense-resolved=\"1\"")
+                    idx-payload  (str/index-of body "__rf_payload")]
+                (is (and idx-close idx-resolved (< idx-close idx-resolved))
+                    "the app root closes before the realm resolved chunk")
+                (is (and idx-close idx-payload (< idx-close idx-payload))
+                    "the app root closes before the final payload")))
+            ;; Tear the realm frame down under its realm scope (the daemon
+            ;; thread had none) so the test leaves no per-frame record behind.
+            (frame/call-with-realm rid
+              (fn [] (lifecycle/destroy-frame-quietly! fid)))))
+        (finally
+          (rf/dispose-realm! rid))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -95,6 +95,101 @@
       (is (< idx-resolved idx-payload) "resolved chunks emitted before final payload")
       (is (< idx-payload idx-close) "final payload before body close"))))
 
+;; ===========================================================================
+;; rf2-z9dduj — the streaming shell closes the app root (`</div>`) at the END
+;; of the shell chunk, BEFORE the resolved templates, hydration-delta scripts,
+;; and the final `__rf_payload`. Pre-fix the close lived in
+;; `default-streaming-suffix`, AFTER every protocol chunk — so resolved
+;; templates + the `__rf_payload` script landed INSIDE the application root,
+;; leaking streaming control/protocol nodes into the DOM `#app` a client
+;; renderer/hydrator owns (hydration-mismatch / replacement risk). Spec 011
+;; §Chunk-ordering contract pins chunk 1 as `…<div id="app"><shell-html/></div>`
+;; and the non-streaming `default-html-shell` already closes `</div>` before the
+;; payload script.
+;; ===========================================================================
+
+(deftest stream-handler-closes-app-root-before-protocol-chunks
+  (testing "rf2-z9dduj: the app-root `</div>` is emitted at the END of the
+            shell chunk — BEFORE the first resolved template AND before the
+            final `__rf_payload` — so the resolved templates, delta scripts,
+            and payload all stream OUTSIDE `#app` (Spec 011 §998-1001). The
+            `:test/root` shell has NO inner `<div>`, so the only `</div>` in
+            the wire is the app-root close."
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init]
+                      :root-view [:test/root]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          body     (drain-stream (:body response))
+          idx-app-open  (str/index-of body "<div id=\"app\"")
+          ;; The app-root close: `:test/root` emits no nested <div>, so the
+          ;; first (and only) `</div>` IS the app-root close.
+          idx-app-close (str/index-of body "</div>")
+          idx-resolved  (str/index-of body "data-rf2-suspense-resolved=\"1\"")
+          idx-payload   (str/index-of body "__rf_payload")
+          idx-comments  (str/index-of body "First!")]
+      (is (= 200 (:status response)))
+      (is (some? idx-app-open) "the #app root div opened")
+      (is (some? idx-app-close) "an app-root close exists")
+      (is (some? idx-resolved) "a resolved subtree chunk streamed")
+      (is (some? idx-payload) "the final payload chunk streamed")
+      ;; THE PINS — the app-root close precedes the protocol chunks.
+      (is (< idx-app-open idx-app-close)
+          "the `</div>` comes after the `<div id=\"app\"` open")
+      (is (< idx-app-close idx-resolved)
+          "rf2-z9dduj: the app root closes BEFORE the first resolved template
+           — resolved chunks stream OUTSIDE #app, not nested inside it")
+      (is (< idx-app-close idx-payload)
+          "rf2-z9dduj: the app root closes BEFORE the final __rf_payload —
+           the payload script streams OUTSIDE #app (matching the non-streaming
+           shell, which closes </div> before the payload script)")
+      ;; The resolved comment body is itself a child of the resolved
+      ;; <template>, which is OUTSIDE #app — so it too lands after the close.
+      (is (< idx-app-close idx-comments)
+          "the resolved subtree body streams after the app-root close")
+      ;; Defense-in-depth: NO `__rf_payload` appears between the #app open and
+      ;; its close (i.e. the payload is not nested in the app root).
+      (let [app-inner (subs body idx-app-open idx-app-close)]
+        (is (not (str/includes? app-inner "__rf_payload"))
+            "no __rf_payload script nested inside #app")
+        (is (not (str/includes? app-inner "data-rf2-suspense-resolved"))
+            "no resolved-template protocol node nested inside #app")))))
+
+(deftest stream-handler-suffix-no-longer-emits-app-close
+  (testing "rf2-z9dduj: `default-streaming-suffix` no longer carries the
+            app-root `</div>` (it moved to the shell chunk). The suffix is now
+            purely the bootstrap script + body-end + document close."
+    (let [suffix (ssr-ring/default-streaming-suffix {:script-src "/main.js"})]
+      (is (not (str/includes? suffix "</div>"))
+          "the suffix no longer closes the app root")
+      (is (str/includes? suffix "</body></html>")
+          "the suffix still closes the document")
+      (is (str/includes? suffix "<script src=\"/main.js\">")
+          "the suffix still emits the bootstrap script"))))
+
+(deftest stream-handler-no-boundary-closes-app-root-before-payload
+  (testing "rf2-z9dduj: the degenerate (no-suspense) path also closes #app
+            before the final __rf_payload — the wire shape collapses to
+            shell-prefix + shell-html + `</div>` + payload + suffix."
+    (rf/reg-view ^{:rf/id :test/static-only} static-only []
+      [:main [:h1 "Static"]])
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init]
+                      :root-view [:test/static-only]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          body     (drain-stream (:body response))
+          idx-close   (str/index-of body "</div>")
+          idx-payload (str/index-of body "__rf_payload")]
+      (is (some? idx-close) "the app root closed")
+      (is (some? idx-payload) "the payload streamed")
+      (is (< idx-close idx-payload)
+          "rf2-z9dduj: even with zero continuations, #app closes before the
+           __rf_payload script")
+      (let [app-inner (subs body (str/index-of body "<div id=\"app\"") idx-close)]
+        (is (not (str/includes? app-inner "__rf_payload"))
+            "the payload is not nested inside #app on the degenerate path")))))
+
 (deftest stream-handler-multiple-boundaries-FIFO
   (testing "Multiple boundaries emit resolved chunks in document-order FIFO"
     (rf/reg-view ^{:rf/id :test/multi-root} multi-root-view []


### PR DESCRIPTION
Fixes two AUTHORITATIVE P2 ssr-ring beads. Surface is `implementation/ssr-ring/` only (src + test); no core/ssr touch needed (reused existing realm APIs).

## rf2-z9dduj — streaming response left protocol chunks inside `#app`

The streaming writer closed the app root (`</div>`) in `default-streaming-suffix`, **after** the resolved templates / hydration-delta scripts / final `__rf_payload` — so those protocol/control nodes landed **inside** the application root a client renderer/hydrator owns (hydration-mismatch / replacement risk), disagreeing with Spec 011 §Chunk-ordering contract and the non-streaming `default-html-shell`.

Fix: the writer now appends `</div>` to the shell-HTML chunk (one flush, still attributed to the `:shell-html` writer phase), and `default-streaming-suffix` no longer carries the close. Chunk 1 is now `…<div id="app"><shell-html/></div>`; resolved chunks + payload + bootstrap + body-end stream outside `#app`, exactly as the non-streaming shell does.

Regression (`ring_streaming_test`): the app-root `</div>` precedes the first resolved template AND `__rf_payload`; no `__rf_payload`/resolved-template nested inside `#app` (incl. the degenerate no-suspense path); the suffix no longer emits `</div>`.

## rf2-nu5w48 — realm-route the error-body + redirect render paths + cross-thread streaming regression

Follow-up to rf2-bzw8gd (#4294), which realm-bound the non-error render walk. Two gaps closed:

1. **Error-body path** — `pipeline/project-render-throw->ring-response` now binds the request frame's realm (`call-with-realm` + `call-with-frame-realm-registrar`), so a non-default-realm `:error-view` resolves through the realm's own registrar (`resolve-error-body`) and the error side-channel reads (`project-render-exception!` / `peek-response`) address the `(realm, frame)` slot. **Redirect short-circuit** — the non-streaming `ssr-handler` and streaming `stream-handler` bind the frame's realm around the accumulator read + both redirect branches, so the redirect/response reads address the realm slot.
2. **Streaming cross-thread test** — the daemon writer already re-establishes the realm via the carried `:realm-id` (bzw8gd); this PR adds the missing JVM regression that drives a non-default-realm frame's streaming render end-to-end and asserts the daemon-thread continuation resolves the realm's registered view. Negative-control (forcing `realm-id`→`nil` on the writer) confirmed the test goes red — the boundary then renders an unresolved `<realm-section>` element. Plus an error-view realm-routing test and a default-realm no-op pin.

All realm-binding changes no-op for default-realm frames (byte-identical single-realm path); `(frame-realm fid)` is evaluated under the host's ambient realm scope (the router/host pattern, as the bzw8gd side-channel writes are also driven).

## Quality gates

- `implementation/ssr-ring` JVM suite: **162 tests / 732 assertions, 0 failures** (includes the new rf2-z9dduj + rf2-nu5w48 regressions).
- `implementation/ssr` JVM suite: **343 tests / 1373 assertions, 0 failures** (realm-address + projector paths unaffected).
- Negative-control verified: the streaming realm test fails without the cross-thread realm re-establishment.
- `npm run test:cljs`: not run locally — all changes are JVM-only `.clj` files the CLJS gate does not compile (ssr-ring is JVM-only), and this fresh worktree has no `node_modules`. Deferred to CI-Linux.
