### PR TITLE
fix(story): legacy share hydrator respects URL-state validation

### DIFF
--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -245,6 +245,20 @@ Share semantics:
   reproducibility status and surfaces the drift banner instead of being
   installed as an orphan live arg `args/resolve-args` would merge into the
   recipient's effective state (a partial artifact masquerading as full);
+- mount URL hydration runs in TWO passes with a SINGLE authoritative owner
+  per slot (rf2-ovb1en — `re-frame.story.ui.shell/hydrate-url-state!`):
+  pass 1 (`url-state/hydrate-from-url!`) is the sole VALIDATING owner of
+  selection, substrate, and every chrome slot (an unregistered `substrate=`
+  degrades to `:reagent`; an unregistered variant degrades to no selection);
+  pass 2 (`share/hydrate-from-url!`) is the sole owner of the focused
+  variant's cell-overrides slice — it applies the `drop-stale-overrides`
+  drift filter pass 1 cannot run (pass 1 is pure, with no registrar access)
+  and writes the filtered slice authoritatively (installing it, or CLEARING
+  it when every parsed override is stale), plus the drift hint. Pass 2 READS
+  — never rewrites — pass 1's validated selection / substrate, so the second
+  pass can never undo the first pass's validation (the bug rf2-ovb1en fixed:
+  pass 2 had reparsed the raw `substrate=` unvalidated and resurrected a
+  stale value, and left an all-stale override slice live);
 - a shared link restores VIEW STATE (it lands the recipient on the cell);
   it does not replay a run — that is the recorder's `:play-script` export;
 - the reproducibility status is computed (purely) by

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -32,11 +32,14 @@
   - `hydrate-from-url!` — fold the share-URL `?overrides=` slot into
     the shell state on mount, including any drift the URL carries
     against the live registry (variant args renamed / removed). The
-    rest of the share-URL surface (workspace, mode-tab, viewport,
-    background, tag-filter, substrate) is hydrated by
-    `re-frame.story.ui.url-state` — that ns owns chrome-state slots;
-    this one owns the per-variant cell-overrides slot and the
-    accompanying drift hint.
+    rest of the share-URL surface (selection, workspace, mode-tab,
+    viewport, background, tag-filter, substrate) is hydrated AND
+    VALIDATED by `re-frame.story.ui.url-state` — that ns is the single
+    authoritative owner of those slots; this pass reads (never rewrites)
+    the selection it set and owns only the focused-variant cell-overrides
+    slice + the accompanying drift hint (rf2-ovb1en — a prior version
+    reparsed `substrate=` here without validation and resurrected a stale
+    value `url-state` had already normalised to `:reagent`).
 
   - `share-import-hint` / `dismiss-share-import-hint!` — non-blocking
     banner the canvas splices over a variant when a hydrated URL
@@ -79,7 +82,13 @@
 
 ;; ---- helpers -------------------------------------------------------------
 
-(defn- current-url-params
+(defn current-url-params
+  "Parse `window.location.search` into a `URLSearchParams` for the
+  share-overrides hydration seam. Returns nil when window is unavailable
+  or no search params are present. Public (like
+  `url-state/parse-current-url`) so the shell-level hydration regression
+  test (rf2-ovb1en) can drive the real `hydrate-from-url!` under the node
+  runner, where `window.location` is read-only."
   []
   (when (exists? js/window)
     (let [search (some-> js/window .-location .-search)]
@@ -119,59 +128,85 @@
       (into (into arg-keys argtype-ks) schema-ks))))
 
 (defn hydrate-from-url!
-  "Hydrate the share-URL-owned shell state from `window.location.search`.
+  "Second-pass URL hydration: own the focused-variant cell-overrides
+  contract + the share-import drift hint. Runs AFTER
+  `re-frame.story.ui.url-state/hydrate-from-url!` at shell mount.
 
-  Toolbar modes hydrate in `re-frame.story.ui.toolbar`; this function
-  owns the rest of the share URL contract: focused variant, per-variant
-  cell overrides, and substrate. Invalid/stale variant ids are ignored
-  so old URLs degrade to the shell empty state instead of crashing.
+  rf2-ovb1en — this pass is deliberately NARROW. `url-state` is the
+  single authoritative owner of every URL-owned slot it writes —
+  selection (`variant` / `workspace`), substrate, viewport, background,
+  tag-filter, modes — and it VALIDATES each against the live registry
+  (an unregistered `substrate=ghost` degrades to `:reagent`; an
+  unregistered variant degrades to no selection). This pass must NOT
+  reparse and rewrite any of those slots from the raw URL: doing so
+  reverted `url-state`'s validation (a stale `substrate=ghost` was
+  normalised to `:reagent` by the first pass, then resurrected to
+  `:ghost` by an unvalidated reparse here). So substrate + selection are
+  read ONLY — this pass reads the variant `url-state` already focused and
+  speaks solely for that variant's cell-overrides slice and its hint.
+
+  What this pass uniquely adds over `url-state` (which installs the raw
+  parsed overrides under `[:cell-overrides variant-id]`) is the
+  declared-key DRIFT filter `url-state` cannot run (it is pure, with no
+  registrar access): `drop-stale-overrides` drops every parsed override
+  whose arg-key the focused variant no longer DECLARES (args refactored /
+  renamed / removed) so they are REPORTED, not merged as orphan live
+  args. This pass is therefore the AUTHORITATIVE owner of the
+  focused-variant cell-overrides slice on mount: it writes the
+  declared-filtered slice when non-empty and CLEARS the slot otherwise —
+  so an all-stale `overrides=` set (which `drop-stale-overrides` collapses
+  to nil) does NOT leave the unfiltered slice `url-state` installed.
 
   Surfaces the count of dropped overrides (rf2-9jthx) under
-  `[:rf.story/share-import-hint variant-id]` so the shell can render
-  a non-blocking hint when a recorded URL has drifted (variant args
-  refactored, removed, renamed). Returns nothing — side-effect only.
-  Pure helper exposed via `share/parse-overrides-param*` so tests can
-  assert per-axis without touching the ratom.
+  `[:rf.story/share-import-hint variant-id]` so the shell can render a
+  non-blocking hint when a recorded URL has drifted. Returns nothing —
+  side-effect only.
 
   rf2-76l69l — drift is detected at TWO stages: `parse-overrides-param*`
   drops UNPARSEABLE entries, then `share/drop-stale-overrides` drops every
-  parsed override whose arg-key the selected variant no longer DECLARES
-  (renamed / removed args — `declared-arg-keys`). Both classes land in
-  `:dropped` and feed the share-import hint, so a stale override is
-  reported (reproducibility downgraded) instead of silently installed as
-  an orphan live arg."
+  parsed override whose arg-key the focused variant no longer DECLARES.
+  Both classes land in `:dropped` and feed the share-import hint, so a
+  stale override is reported (reproducibility downgraded) instead of
+  silently installed as an orphan live arg."
   []
   (when-let [params (current-url-params)]
-    (let [variant-id (share/parse-keyword-token (.get params "variant"))
+    ;; rf2-ovb1en: read the variant `url-state` already focused (its swap
+    ;; ran first) rather than re-deriving it from the raw URL — guarantees
+    ;; this pass operates on `url-state`'s authoritative, validated
+    ;; selection and can never diverge from it.
+    (let [variant-id (:selected-variant @state/shell-state-atom)
           valid?     (and variant-id (registrar/registered? :variant variant-id))
           parsed0    (share/parse-overrides-param* (.get params "overrides"))
-          ;; Second stage: drop overrides for args the selected variant no
+          ;; Second stage: drop overrides for args the focused variant no
           ;; longer declares (renamed / removed) so they are REPORTED, not
           ;; merged as orphan live args. Only meaningful for a valid variant
-          ;; (its declared-key contract); an invalid variant installs nothing
-          ;; anyway. `declared-arg-keys` returns nil → keep-all degrade.
+          ;; (its declared-key contract). `declared-arg-keys` returns nil →
+          ;; keep-all degrade.
           parsed     (if valid?
                        (share/drop-stale-overrides parsed0
                                                    (declared-arg-keys variant-id))
                        parsed0)
           overrides  (:overrides parsed)
-          dropped    (:dropped parsed)
-          substrate  (share/parse-substrate-param (.get params "substrate"))]
-      (state/swap-state!
-        (fn [s]
-          (let [s' (if valid?
-                     (cond-> (-> s
-                                 (state/select-variant variant-id)
-                                 (state/select-workspace nil))
-                       (seq overrides)
-                       (assoc-in [:cell-overrides variant-id] overrides)
-                       (seq dropped)
-                       (assoc-in [:rf.story/share-import-hint variant-id]
-                                 {:dropped-count (count dropped)
-                                  :dropped       (vec dropped)}))
-                     s)]
-            (cond-> s'
-              substrate (assoc :substrate substrate))))))))
+          dropped    (:dropped parsed)]
+      (when valid?
+        (state/swap-state!
+          (fn [s]
+            (cond-> s
+              ;; AUTHORITATIVE owner of the focused variant's overrides slice:
+              ;; install the declared-filtered slice when non-empty, else CLEAR
+              ;; it — so an all-stale `overrides=` (collapsed to nil by
+              ;; `drop-stale-overrides`) drops the unfiltered slice `url-state`
+              ;; installed rather than leaving stale args live (rf2-ovb1en).
+              (seq overrides)
+              (assoc-in [:cell-overrides variant-id] overrides)
+
+              (not (seq overrides))
+              (update :cell-overrides dissoc variant-id)
+
+              (seq dropped)
+              (assoc-in [:rf.story/share-import-hint variant-id]
+                        {:dropped-count (count dropped)
+                         :dropped       (vec dropped)}))))))))
 
 (defn dismiss-share-import-hint!
   "Clear the share-import hint for `variant-id` (rf2-9jthx). Called

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -525,17 +525,28 @@
       (url-state/apply-parsed-to-state state parsed validators))))
 
 (defn- hydrate-url-state!
-  "One-shot URL → shell-state hydration on mount. Also folds the
-  `share/parse-overrides-param*` dropped-entries hint for the focused
-  variant (rf2-9jthx parity) and selects the variant through the
-  existing `share/hydrate-from-url!` cell-overrides path so the
-  selection-watcher's preallocate-frame branch fires.
+  "One-shot URL → shell-state hydration on mount, in two passes with a
+  CLEAR single-owner split (rf2-ovb1en):
 
-  Order:
-    1. `url-state/hydrate-from-url!` writes selection / mode-tab /
-       modes / viewport / background / tag-filter / substrate.
-    2. `share/hydrate-from-url!` adds cell-overrides + the
-       share-import hint (idempotent; selection is already set)."
+    1. `url-state/hydrate-from-url!` is the AUTHORITATIVE owner of every
+       URL-owned slot it writes — selection (variant / workspace),
+       mode-tab, modes, viewport, background, tag-filter, substrate — and
+       VALIDATES each against the live registry (a stale `substrate=ghost`
+       degrades to `:reagent`; an unregistered variant degrades to no
+       selection). It also installs the raw parsed cell-overrides under
+       `[:cell-overrides variant-id]`.
+    2. `share/hydrate-from-url!` is the AUTHORITATIVE owner of the
+       focused-variant cell-overrides slice on mount: it applies the
+       declared-key DRIFT filter `url-state` cannot run (renamed / removed
+       args), writing the filtered slice (or CLEARING it when all overrides
+       are stale) and recording the share-import drift hint (rf2-9jthx).
+       It reads — never rewrites — `url-state`'s validated selection and
+       substrate, so the second pass can never undo the first pass's
+       validation (the bug rf2-ovb1en fixed).
+
+  The selection-watcher's preallocate-frame branch fires on pass 1's swap
+  (it sets `:selected-variant`), so deep-linked variants still preallocate
+  without pass 2 re-selecting."
   []
   (url-state/hydrate-from-url! state/shell-state-atom (url-state-apply-fn))
   (share/hydrate-from-url!))
@@ -864,13 +875,16 @@
          (backgrounds-switcher/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
-         ;; rf2-o4u18: hydrate the URL-state slots (workspace + mode-tab +
-         ;; viewport + background + tag-filter + variant / modes /
-         ;; substrate) BEFORE the per-variant overrides — the URL-state
-         ;; engine sets the focused selection, then share/hydrate-from-url!
-         ;; folds in cell-overrides + the share-import hint (rf2-9jthx).
-         ;; Selection runs through the same shell-state-atom swap path
-         ;; the user's click would take, so the selection-watcher's
+         ;; rf2-o4u18 / rf2-ovb1en: hydrate the URL-state slots (workspace +
+         ;; mode-tab + viewport + background + tag-filter + variant / modes /
+         ;; substrate) — `url-state/hydrate-from-url!` is the authoritative,
+         ;; VALIDATING owner of all of them and sets the focused selection.
+         ;; `share/hydrate-from-url!` then owns ONLY the focused-variant
+         ;; cell-overrides slice (declared-key drift filter + share-import
+         ;; hint, rf2-9jthx); it reads — never rewrites — the validated
+         ;; selection / substrate, so the second pass can't undo the first
+         ;; pass's validation. Selection runs through the same shell-state-atom
+         ;; swap path the user's click would take, so the selection-watcher's
          ;; preallocate-frame branch fires for deep-linked variants.
          (hydrate-url-state!)
          ;; rf2-o4u18: subscribe to popstate so the back-button restores

--- a/tools/story/test/re_frame/story/panels_e2e/share_url_state_hydration_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/share_url_state_hydration_e2e_cljs_test.cljs
@@ -1,0 +1,168 @@
+(ns re-frame.story.panels-e2e.share-url-state-hydration-e2e-cljs-test
+  "Regression coverage for the full shell URL-hydration sequence
+  (rf2-ovb1en).
+
+  Shell mount runs TWO URL-hydration passes, in this order
+  (`re-frame.story.ui.shell/hydrate-url-state!`):
+
+      1. url-state/hydrate-from-url!  ← authoritative + VALIDATING owner of
+                                         selection / substrate / chrome slots
+      2. share/hydrate-from-url!     ← owns ONLY the focused-variant
+                                         cell-overrides slice + drift hint
+
+  The bug: pass 2 used to reparse the RAW `substrate=` without registry
+  validation and write it unconditionally, RESURRECTING a stale value pass
+  1 had already normalised to `:reagent` (`substrate=ghost-substrate` →
+  `:reagent` by pass 1 → `:ghost-substrate` again by pass 2). It also wrote
+  cell-overrides only when `(seq overrides)`, so an all-stale `overrides=`
+  set (which `drop-stale-overrides` collapses to nil) left the UNFILTERED
+  slice pass 1 had installed live as orphan args.
+
+  This ns drives the real two-pass sequence against the live registry +
+  the production `url-state` validators, with the URL parse seam stubbed
+  (jsdom `window.location` is read-only under the node runner — the
+  parsers themselves are covered by `url-state-cljs-test` /
+  `story-share-test`). It asserts the END state after BOTH passes:
+
+  - an unregistered `substrate=` ends as `:reagent` (pass 2 cannot revive it);
+  - an all-stale `overrides=` leaves NO `[:cell-overrides variant-id]` slice
+    and still records the dropped-override drift hint;
+  - a valid `substrate=` + valid `overrides=` still hydrate (no regression)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.multi-substrate :as multi-substrate]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.ui.share :as share]
+            [re-frame.story.ui.url-state :as url-state]
+            [re-frame.story.share :as share-codec]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- production validators (mirror shell's private `url-state-apply-fn`) --
+;;
+;; `shell/url-state-apply-fn` is a defn- closing over the live registrar +
+;; substrate registry. We reconstruct the same validator map here so the
+;; test exercises url-state's REAL validation path (the part that degrades a
+;; stale `substrate=` to `:reagent`) rather than a no-validator stand-in.
+
+(defn- production-apply-fn []
+  (let [validators {:variant?   (fn [vid]
+                                  (or (nil? vid)
+                                      (registrar/registered? :variant vid)))
+                    :substrate? (fn [s]
+                                  (or (nil? s)
+                                      (contains? (multi-substrate/registered-substrates) s)))}]
+    (fn [state parsed]
+      (url-state/apply-parsed-to-state state parsed validators))))
+
+;; ---- drive the real two-pass shell hydration sequence -------------------
+
+(defn- hydrate-from-url-params!
+  "Run the full shell URL-hydration sequence (both passes, in shell order)
+  against a `{param-name → string}` URL getter map, with the parse seam
+  stubbed so it runs under the node runner. `getter` keys are the wire
+  param names (\"variant\", \"substrate\", \"overrides\", ...)."
+  [getter]
+  (let [usp (js/URLSearchParams.
+              (clj->js (into {} (filter (comp some? val) getter))))]
+    (with-redefs [;; pass 1 source: url-state parses window.location.search
+                  url-state/parse-current-url (constantly (share-codec/parse-params getter))
+                  ;; pass 2 source: share reads window.location.search
+                  share/current-url-params    (constantly usp)]
+      ;; Pass 1 — the authoritative, validating owner.
+      (url-state/hydrate-from-url! ui-state/shell-state-atom (production-apply-fn))
+      ;; Pass 2 — the cell-overrides slice + drift hint owner.
+      (share/hydrate-from-url!))))
+
+;; A variant whose declared arg surface is exactly #{:label}. An
+;; `overrides=` entry for any OTHER key is stale (the variant no longer
+;; declares it) and must be dropped + reported by pass 2.
+(defn- register-variant! []
+  (story/reg-story :story.sample {:doc "Parent for the share-hydration e2e."})
+  (story/reg-variant :story.sample/card
+    {:doc      "A card variant declaring a single :label arg."
+     :argtypes {:label {:type :string}}
+     :args     {:label "Hello"}}))
+
+;; Register a second substrate so a non-default valid `substrate=` round-trips.
+(defn- register-substrates! []
+  (multi-substrate/register-substrate! :reagent (fn [_ _ _] [:div]))
+  (multi-substrate/register-substrate! :uix     (fn [_ _ _] [:div])))
+
+;; =========================================================================
+;; (1) unregistered substrate= ends :reagent after the COMPLETE sequence
+;; =========================================================================
+
+(deftest unregistered-substrate-ends-reagent-after-full-hydration
+  (testing "rf2-ovb1en — `substrate=ghost-substrate` is normalised to
+            :reagent by pass 1 and pass 2 (share) MUST NOT resurrect the
+            raw stale value. The end state after BOTH passes is :reagent."
+    (e2e/with-story-and-xray-frames
+      {:register-stories (fn [] (register-variant!) (register-substrates!))}
+      (fn []
+        ;; Seed a stale in-memory substrate so a no-op would leave it dirty.
+        (swap! ui-state/shell-state-atom assoc :substrate :uix)
+        (hydrate-from-url-params!
+          {"variant"   "story.sample/card"
+           "substrate" "ghost-substrate"})
+        (is (= :reagent (:substrate (ui-state/get-state)))
+            "unregistered substrate= degrades to :reagent — pass 2 cannot
+             revive the stale value it once reparsed without validation")
+        (is (= :story.sample/card (:selected-variant (ui-state/get-state)))
+            "the registered variant is still focused")))))
+
+;; =========================================================================
+;; (2) all-stale overrides= leaves NO slice + records the drift hint
+;; =========================================================================
+
+(deftest all-stale-overrides-clears-slice-and-records-hint
+  (testing "rf2-ovb1en — an `overrides=` set whose keys the variant no
+            longer declares collapses to nil under `drop-stale-overrides`;
+            the end state has NO [:cell-overrides variant-id] slice (pass 1's
+            unfiltered install is cleared by pass 2) AND the share-import
+            drift hint records the dropped overrides."
+    (e2e/with-story-and-xray-frames
+      {:register-stories (fn [] (register-variant!) (register-substrates!))}
+      (fn []
+        ;; `:gone` + `:also-gone` are NOT in the variant's declared #{:label}.
+        (hydrate-from-url-params!
+          {"variant"   "story.sample/card"
+           "overrides" (pr-str {:gone 1 :also-gone 2})})
+        (let [s (ui-state/get-state)]
+          (is (= :story.sample/card (:selected-variant s)))
+          (is (nil? (get-in s [:cell-overrides :story.sample/card]))
+              "all-stale overrides leave NO live slice — pass 2 clears the
+               unfiltered slice pass 1 installed")
+          (is (= 2 (get-in s [:rf.story/share-import-hint
+                              :story.sample/card :dropped-count]))
+              "both stale overrides are reported in the drift hint"))))))
+
+;; =========================================================================
+;; (3) valid substrate= + valid overrides= still hydrate (no regression)
+;; =========================================================================
+
+(deftest valid-substrate-and-overrides-still-hydrate
+  (testing "rf2-ovb1en — a registered non-default substrate= and a declared
+            overrides= entry still hydrate after the complete sequence; the
+            fix narrows pass 2, it does not break the happy path."
+    (e2e/with-story-and-xray-frames
+      {:register-stories (fn [] (register-variant!) (register-substrates!))}
+      (fn []
+        (hydrate-from-url-params!
+          {"variant"   "story.sample/card"
+           "substrate" "uix"
+           "overrides" (pr-str {:label "Shared"})})
+        (let [s (ui-state/get-state)]
+          (is (= :uix (:substrate s))
+              "a registered non-default substrate is kept (pass 1 validates,
+               pass 2 leaves it alone)")
+          (is (= :story.sample/card (:selected-variant s)))
+          (is (= {:label "Shared"} (get-in s [:cell-overrides :story.sample/card]))
+              "a declared override hydrates into the focused variant's slice")
+          (is (nil? (get-in s [:rf.story/share-import-hint :story.sample/card]))
+              "no drift hint when nothing was dropped"))))))


### PR DESCRIPTION
Fixes rf2-ovb1en (P2 BUG).

## Problem

Shell mount runs two URL-hydration passes (`re-frame.story.ui.shell/hydrate-url-state!`):

1. `url-state/hydrate-from-url!` — the VALIDATING owner of selection / substrate / chrome slots (a stale `substrate=ghost-substrate` degrades to `:reagent`; an unregistered variant degrades to no selection).
2. `share/hydrate-from-url!` — the legacy second pass.

The second pass reparsed the raw `substrate=` param WITHOUT registry validation and wrote it unconditionally, RESURRECTING the value pass 1 had already normalised (`substrate=ghost-substrate` → `:reagent` by pass 1 → `:ghost-substrate` again by pass 2). It also wrote cell-overrides only when `(seq overrides)`, so an all-stale `overrides=` set (which `drop-stale-overrides` collapses to nil) left the UNFILTERED slice pass 1 installed live as orphan args.

## Fix

Narrow the second pass to a clear single-owner-per-slot split:

- **`url-state` is the sole validating owner of substrate + selection.** The share pass no longer reparses or writes either; it reads the variant `url-state` already focused, so it can never diverge from or undo the validated selection.
- **The share pass is the authoritative owner of the focused variant's cell-overrides slice on mount** (it applies the declared-key drift filter `url-state` cannot run, being pure): it installs the filtered slice when non-empty and CLEARS the slot otherwise — so an all-stale `overrides=` drops the slice rather than leaving stale args live, while still recording the share-import drift hint.

Spec: documented the two-pass single-owner discipline in `tools/story/spec/022-Story-UI-Docs-And-Share.md` (the existing 022 contract already named `url-state` as the validating owner of substrate + cell-overrides hydration; this fix aligns the implementation to it and pins the mount-time ownership split).

## Test

New shell-level regression test `tools/story/test/re_frame/story/panels_e2e/share_url_state_hydration_e2e_cljs_test.cljs` drives the REAL two-pass sequence against the live registry + the production `url-state` validators:

- unregistered `substrate=` ends `:reagent` after the complete sequence (pass 2 cannot revive it);
- all-stale `overrides=` leaves NO `[:cell-overrides variant-id]` slice and still records the dropped-override drift hint;
- valid `substrate=` + valid `overrides=` still hydrate (no regression).

Verified load-bearing: with the pre-fix code restored, exactly the substrate + all-stale tests FAIL; with the fix, all pass.

## Quality gates

- `clojure -M:test` in `tools/story/` — **PASS** (1683 tests, 6235 assertions, 0 failures, 0 errors).
- `npm run test:cljs` (node-test build, exercises the new CLJS regression test) — **PASS** (7254 tests, 29710 assertions, 0 failures, 0 errors).
- `mkdocs build --strict` — not run (no `docs/` change; `tools/story/spec/` is not in `mkdocs.yml`).
