### PR TITLE
fix(scripts): path-policy rejects symlink escapes + arm reagent-slim smoke in CI

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -329,6 +329,29 @@ else
         cljs_browser=true
         cljs_prod=true
         ;;
+      implementation/scripts/serve-and-run-reagent-slim-smoke.cjs|implementation/scripts/_reagent-slim-smoke-policy.test.cjs)
+        # rf2-5v0dg7 — false-green fix, mirroring the xray-feature-gate
+        # launcher case below. serve-and-run-reagent-slim-smoke.cjs IS the
+        # executable orchestration for `npm run test:reagent-slim:smoke`,
+        # the command the cljs-reagent-slim-bundle-isolation PR job now runs
+        # (.github/workflows/test.yml). A break in this launcher (compile,
+        # staging, port resolution, ownership-token readiness, the browser
+        # drive) can break the slim client-runtime smoke gate — yet the
+        # generic implementation/scripts/* case below routes only to the
+        # always-on JS/CLJS surfaces and NEVER to reagent_slim_bundle, so a
+        # PR editing this launcher (or its policy test) could break the very
+        # gate it drives while avoiding it (a false-green hole). Fire
+        # reagent_slim_bundle so editing the launcher runs the gate it
+        # orchestrates. The remaining static-script surfaces this file shares
+        # with the generic case (cljs_node_test / cljs_browser / cljs_prod /
+        # bundle_isolation) stay armed too — this case widens coverage, it
+        # does not narrow it.
+        cljs_node_test=true
+        cljs_browser=true
+        cljs_prod=true
+        bundle_isolation=true
+        reagent_slim_bundle=true
+        ;;
       implementation/scripts/serve-and-run-xray-feature-gate.cjs)
         # rf2-rcepku — false-green fix, mirroring rf2-y9o5e3 for the
         # examples/scripts launchers. This launcher IS the executable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1678,6 +1678,14 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.reagent_slim_bundle == 'true'
     runs-on: ubuntu-latest
+    # rf2-e6enf — job-level backstop to the step-level Playwright cap below.
+    # Without it the job inherits GitHub's 360-min default, so any wedged step
+    # (the observed `--with-deps` apt/dpkg-lock hang on #4309) leaves this job
+    # — and the required `all-required-passed` aggregator that `needs:` it —
+    # open-ended pending, blocking the merge. 20 min gives a cold-Maven-cache
+    # run generous headroom while making any genuine hang a fast, re-runnable
+    # FAILURE. Mirrors the mcp-conformance-re-frame2-pair job cap.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: implementation
@@ -1749,7 +1757,34 @@ jobs:
       # itself, could ship green. This step actually executes the gate for
       # reagent_slim_bundle surface changes (which now also fire on edits to
       # the runner + its policy test — report-changed-surfaces.sh).
+
+      # rf2-f79t8 — cache the Playwright browser binary (see cljs-browser).
+      # Every other PR Playwright job carries this cache step ahead of the
+      # install; rf2-5v0dg7 armed the smoke without it, so this job
+      # re-downloaded Chromium (~120 MB) on every run. Keyed on the locked
+      # Playwright version (package-lock.json); a bump busts it.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      # rf2-e6enf — cap the `--with-deps` Playwright install. `--with-deps`
+      # runs `sudo apt-get install` for Chromium's system libraries; on a GHA
+      # runner that occasionally blocks indefinitely on the dpkg/apt lock held
+      # by the background `unattended-upgrades` job. rf2-5v0dg7 added this step
+      # with NO step timeout, so when the lock wedged the slim job sat
+      # in_progress forever — never reporting a conclusion — which left the
+      # required `all-required-passed` aggregator (it `needs:` this job)
+      # perpetually pending and blocked the merge (observed on #4309). A
+      # healthy install is ~20s; 5 min covers a slow apt + cold (cache-miss)
+      # download while turning the lock-wait into a re-runnable FAILURE
+      # instead of an open-ended block. Mirrors the identical step-level cap
+      # on the hermetic re-frame2-pair-mcp Playwright install.
       - name: Install Playwright (Chromium + system deps)
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
 
       - name: Run Reagent Slim client-runtime browser smoke

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1674,7 +1674,7 @@ jobs:
           retention-days: 14
 
   cljs-reagent-slim-bundle-isolation:
-    name: CLJS Reagent Slim bundle isolation (adapter-owned, rf2-2ppcv)
+    name: CLJS Reagent Slim bundle isolation + client-runtime smoke (adapter-owned, rf2-2ppcv + rf2-5v0dg7)
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.reagent_slim_bundle == 'true'
     runs-on: ubuntu-latest
@@ -1738,6 +1738,22 @@ jobs:
       # the fixture (rf2-vyl0vt).
       - name: Verify Reagent Slim bundle isolates stock Reagent + react-dom/server
         run: npm run test:reagent-slim:bundle-isolation
+
+      # rf2-5v0dg7 — ARM the reagent-slim CLIENT-RUNTIME browser smoke in PR
+      # CI. The dedicated, adapter-owned slim smoke runner
+      # (serve-and-run-reagent-slim-smoke.cjs) compiles the slim testbed,
+      # serves it, and drives the mount/inject/click path in headless
+      # Chromium. Previously only `test:script-policy` proved the npm script
+      # EXISTS and this job ran ONLY bundle-isolation — so a regression in
+      # the adapter-owned mount/injection/click path, or in the smoke runner
+      # itself, could ship green. This step actually executes the gate for
+      # reagent_slim_bundle surface changes (which now also fire on edits to
+      # the runner + its policy test — report-changed-surfaces.sh).
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Reagent Slim client-runtime browser smoke
+        run: npm run test:reagent-slim:smoke
 
   # ---------------------------------------------------------------------------
   # Per-tool CI jobs (rf2-qq70f).

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -413,6 +413,43 @@ test('an UNRELATED implementation/scripts/* file does NOT fire story_xray_browse
   );
 });
 
+// rf2-5v0dg7 — reagent-slim CLIENT-RUNTIME smoke routing. The
+// serve-and-run-reagent-slim-smoke.cjs launcher IS the executable
+// orchestration for `npm run test:reagent-slim:smoke`, the command the
+// cljs-reagent-slim-bundle-isolation PR job now runs. Editing it (or its
+// policy test) must fire the reagent_slim_bundle gate it drives — else a PR
+// can break the launcher while avoiding the very smoke gate it orchestrates
+// (the generic implementation/scripts/* case never fires reagent_slim_bundle).
+
+test('implementation/scripts/serve-and-run-reagent-slim-smoke.cjs fires reagent_slim_bundle (rf2-5v0dg7)', () => {
+  const result = classify('implementation/scripts/serve-and-run-reagent-slim-smoke.cjs');
+  assert.equal(
+    result.reagent_slim_bundle,
+    'true',
+    'editing the slim smoke launcher must run the reagent-slim gate it drives',
+  );
+});
+
+test('implementation/scripts/_reagent-slim-smoke-policy.test.cjs fires reagent_slim_bundle (rf2-5v0dg7)', () => {
+  const result = classify('implementation/scripts/_reagent-slim-smoke-policy.test.cjs');
+  assert.equal(result.reagent_slim_bundle, 'true');
+});
+
+test('implementation/scripts/serve-and-run-reagent-slim-smoke.cjs still arms the generic static-script gates (regression) (rf2-5v0dg7)', () => {
+  const result = classify('implementation/scripts/serve-and-run-reagent-slim-smoke.cjs');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.cljs_prod, 'true');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
+test('the reagent-slim adapter/testbed surface fires reagent_slim_bundle (canonical trigger) (rf2-5v0dg7)', () => {
+  // The smoke testbed lives under implementation/adapters/reagent-slim/; a
+  // change there must arm the slim gate (now incl. the smoke) directly.
+  const result = classify('implementation/adapters/reagent-slim/testbed/smoke.cjs');
+  assert.equal(result.reagent_slim_bundle, 'true');
+});
+
 test('implementation/package.json still arms cljs_node_test (regression — it defines node deps) (rf2-6yuzo4)', () => {
   const result = classify('implementation/package.json');
   assert.equal(result.cljs_node_test, 'true');

--- a/implementation/scripts/_path-policy.cjs
+++ b/implementation/scripts/_path-policy.cjs
@@ -38,6 +38,7 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 
 const IMPL_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
@@ -72,27 +73,80 @@ function isInside(candidate, root) {
   return true;
 }
 
+// Resolve symlinks/junctions on an absolute path WITHOUT requiring the
+// full path to exist (rf2-l9upzf). A lexical `path.resolve` alone lets a
+// symlink/junction under an allowed root point outside the approved
+// boundary while still passing the lexical prefix check — the writing
+// scripts then follow the link and escape. To close this, walk up to the
+// deepest existing ancestor, `fs.realpathSync` THAT (collapsing every
+// symlink/junction in the existing prefix, including parent-directory
+// links), then re-append the still-nonexistent tail lexically. The tail
+// cannot itself be a symlink (it does not exist), so no escape hides
+// there; any link in the path that DOES exist is canonicalised.
+//
+// Cross-platform: `fs.realpathSync` resolves POSIX symlinks AND Windows
+// junctions/symlinks; we never assume a separator or drive shape — paths
+// are split with `path.dirname` / `path.basename` and rejoined with
+// `path.join`, so the same code runs on win32, darwin, and linux.
+function realpathExistingPrefix(abs) {
+  let existing = abs;
+  const tail = [];
+  // Walk up until we hit a path that exists (or the filesystem root).
+  // `path.dirname` of a root returns the root itself, so the loop is
+  // bounded.
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) {
+      // Reached the root and nothing exists — nothing to canonicalise.
+      return abs;
+    }
+    tail.unshift(path.basename(existing));
+    existing = parent;
+  }
+  let realExisting;
+  try {
+    realExisting = fs.realpathSync(existing);
+  } catch (_) {
+    // realpath can fail on a broken link / permission edge — fall back to
+    // the lexical absolute path (fail-closed: the lexical check still
+    // applies, we just couldn't canonicalise further).
+    return abs;
+  }
+  return tail.length === 0 ? realExisting : path.join(realExisting, ...tail);
+}
+
 function enforcePolicy(label, candidate, opts) {
   if (candidate == null || candidate === '') {
     throw new Error(`${label}: empty path`);
   }
-  const abs = path.resolve(candidate);
+  // The path the caller intends to read/write — returned on approval so
+  // callers see the path they passed (lexically normalised), not a
+  // surprise canonical rewrite.
+  const lexicalAbs = path.resolve(candidate);
+  // CONTAINMENT CHECK runs on REALPATHS (rf2-l9upzf): collapse any
+  // existing symlink/junction in BOTH the candidate and the allowed
+  // roots before comparing, so a link that resolves outside an approved
+  // root is rejected even though its lexical path looked inside. Roots
+  // are canonicalised too so a legitimate in-root path under a symlinked
+  // checkout (e.g. macOS /tmp -> /private/tmp) still matches.
+  const realCandidate = realpathExistingPrefix(lexicalAbs);
   const allowed = (opts && opts.allowedRoots) || [DEFAULT_OUT_ROOT];
-  for (const root of allowed) {
-    if (isInside(abs, root)) {
-      return abs;
+  const realAllowed = allowed.map((r) => realpathExistingPrefix(path.resolve(r)));
+  for (const root of realAllowed) {
+    if (isInside(realCandidate, root)) {
+      return lexicalAbs;
     }
   }
   if (isOptInEnabled()) {
     console.warn(
-      `${label}: '${abs}' is outside the approved roots, but ` +
+      `${label}: '${lexicalAbs}' is outside the approved roots, but ` +
         `${OPT_IN_VAR}=1 — proceeding. ` +
         `Approved roots: ${allowed.map((r) => `'${r}'`).join(', ')}.`,
     );
-    return abs;
+    return lexicalAbs;
   }
   throw new Error(
-    `${label}: refusing to use '${abs}' — path is outside the approved ` +
+    `${label}: refusing to use '${lexicalAbs}' — path is outside the approved ` +
       `roots (${allowed.map((r) => `'${r}'`).join(', ')}). ` +
       `To allow out-of-tree paths (downstream-consumer use), set ` +
       `${OPT_IN_VAR}=1 in the environment. Per rf2-o38lb security audit.`,

--- a/implementation/scripts/_path-policy.test.cjs
+++ b/implementation/scripts/_path-policy.test.cjs
@@ -10,6 +10,8 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 const assert = require('assert');
 const {
   enforcePolicy,
@@ -90,6 +92,140 @@ it('rejects path-traversal attempts', () => {
       }),
     /outside the approved roots/,
   );
+});
+
+// ---- symlink / junction escape (rf2-l9upzf) ------------------------------
+//
+// A symlink/junction UNDER an allowed root whose target resolves OUTSIDE
+// the approved boundary must be REJECTED — the lexical prefix check alone
+// (path.relative) would wrongly accept it, letting the writing scripts
+// follow the link and escape. A legitimate in-root symlink (target stays
+// inside the allowed root) must still PASS.
+//
+// Cross-platform: dir symlinks need Developer Mode / admin on Windows;
+// when creation isn't permitted we SKIP (not fail) the symlink cases so
+// the suite stays green on a locked-down Windows runner while still
+// asserting on POSIX (and Windows with the privilege). The escape-
+// rejection logic itself is OS-agnostic (it relies on fs.realpathSync,
+// which resolves both POSIX symlinks and Windows junctions/symlinks).
+
+// Create a fresh scratch sandbox: an "allowed root" dir, an "outside"
+// dir well clear of it, and a per-run temp parent so concurrent test
+// runs never collide.
+function makeSandbox() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-pathpolicy-'));
+  const allowedRoot = path.join(base, 'allowed-root');
+  const outside = path.join(base, 'outside-the-boundary');
+  fs.mkdirSync(allowedRoot, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  // realpath the allowed root so the policy's canonicalisation of the
+  // root (which also realpaths, e.g. macOS /var -> /private/var) lines up
+  // with what the test passes in.
+  return { base, allowedRoot: fs.realpathSync(allowedRoot), outside: fs.realpathSync(outside) };
+}
+
+// Try to create a directory symlink; on Windows fall back to a junction.
+// Returns true on success, false if the platform refused (no privilege).
+function trySymlinkDir(target, linkPath) {
+  try {
+    fs.symlinkSync(target, linkPath, 'dir');
+    return true;
+  } catch (_) {
+    if (process.platform === 'win32') {
+      try {
+        fs.symlinkSync(target, linkPath, 'junction');
+        return true;
+      } catch (_) {
+        return false;
+      }
+    }
+    return false;
+  }
+}
+
+it('REJECTS a symlink/junction under an allowed root that targets outside it', () => {
+  const { base, allowedRoot, outside } = makeSandbox();
+  try {
+    // allowed-root/escape-link  ->  ../outside-the-boundary (out of root)
+    const link = path.join(allowedRoot, 'escape-link');
+    if (!trySymlinkDir(outside, link)) {
+      console.log('        (skipped: symlink/junction creation not permitted on this host)');
+      return;
+    }
+    // Lexically `link` is INSIDE allowedRoot, but it resolves OUTSIDE.
+    // The policy must reject it (and reject a child path written through
+    // it, the actual escape vector the writing scripts hit).
+    assert.throws(
+      () => enforcePolicy('BROWSER_TEST_ROOT', link, { allowedRoots: [allowedRoot] }),
+      /outside the approved roots/,
+      'a symlink under the allowed root pointing outside was wrongly accepted',
+    );
+    assert.throws(
+      () =>
+        enforcePolicy('STORY_BUILD_INDEX_HTML', path.join(link, 'index.html'), {
+          allowedRoots: [allowedRoot],
+        }),
+      /outside the approved roots/,
+      'a path written THROUGH an escaping symlink was wrongly accepted',
+    );
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+it('ACCEPTS a symlink under an allowed root whose target stays inside it', () => {
+  const { base, allowedRoot } = makeSandbox();
+  try {
+    const realInner = path.join(allowedRoot, 'real-inner');
+    fs.mkdirSync(realInner, { recursive: true });
+    const link = path.join(allowedRoot, 'inner-link'); // -> allowed-root/real-inner
+    if (!trySymlinkDir(realInner, link)) {
+      console.log('        (skipped: symlink/junction creation not permitted on this host)');
+      return;
+    }
+    // The link resolves to a path still INSIDE the allowed root, so a
+    // legitimate in-root override must still pass.
+    const result = enforcePolicy('STORY_BUILD_OUTPUT_DIR', link, {
+      allowedRoots: [allowedRoot],
+    });
+    assert.strictEqual(result, path.resolve(link));
+    // And a not-yet-created child written under the in-root link passes
+    // too (nonexistent-final-path handling: existing parent realpaths
+    // inside the root).
+    const child = path.join(link, 'index.html');
+    const childResult = enforcePolicy('STORY_BUILD_INDEX_HTML', child, {
+      allowedRoots: [allowedRoot],
+    });
+    assert.strictEqual(childResult, path.resolve(child));
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+it('REJECTS via a PARENT-directory symlink that escapes the allowed root', () => {
+  const { base, allowedRoot, outside } = makeSandbox();
+  try {
+    // allowed-root/escape-dir -> outside ; then probe a DEEPER child whose
+    // intermediate (escape-dir) is the escaping link. Exercises that the
+    // policy canonicalises parent-directory links, not just the final
+    // component.
+    const parentLink = path.join(allowedRoot, 'escape-dir');
+    if (!trySymlinkDir(outside, parentLink)) {
+      console.log('        (skipped: symlink/junction creation not permitted on this host)');
+      return;
+    }
+    const deepChild = path.join(parentLink, 'nested', 'manifest.json');
+    assert.throws(
+      () =>
+        enforcePolicy('STORY_BUILD_OUTPUT_DIR', deepChild, {
+          allowedRoots: [allowedRoot],
+        }),
+      /outside the approved roots/,
+      'a path under a parent-directory symlink that escapes was wrongly accepted',
+    );
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
 });
 
 it('rejects empty path', () => {

--- a/implementation/scripts/_reagent-slim-smoke-policy.test.cjs
+++ b/implementation/scripts/_reagent-slim-smoke-policy.test.cjs
@@ -52,6 +52,13 @@ const RUNNER = path.join(IMPL_ROOT, 'scripts', 'serve-and-run-reagent-slim-smoke
 const SHADOW_EDN = path.join(IMPL_ROOT, 'shadow-cljs.edn');
 const PKG_JSON = path.join(IMPL_ROOT, 'package.json');
 const EXAMPLES_FILTER = path.join(REPO_ROOT, 'examples', 'scripts', 'examples-filter.cjs');
+const WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'test.yml');
+const CHANGED_SURFACES = path.join(
+  REPO_ROOT,
+  '.github',
+  'scripts',
+  'report-changed-surfaces.sh',
+);
 
 let failed = 0;
 function it(label, fn) {
@@ -198,6 +205,65 @@ it('`test:script-policy` runs THIS policy test', () => {
     /_reagent-slim-smoke-policy\.test\.cjs/.test(s),
     'test:script-policy does not run _reagent-slim-smoke-policy.test.cjs — ' +
       'the slim smoke wiring is unguarded',
+  );
+});
+
+// ---- 5b) PR CI ACTUALLY RUNS the smoke gate (rf2-5v0dg7) ------------------
+// Teeth beyond "the npm script exists": the workflow must EXECUTE it, and a
+// reagent-slim surface change must ARM the job that runs it. Without these,
+// the smoke can silently stop running in PR CI (the exact rf2-5v0dg7 bug).
+
+const WORKFLOW_SRC = fs.existsSync(WORKFLOW) ? read(WORKFLOW) : '';
+const CHANGED_SURFACES_SRC = fs.existsSync(CHANGED_SURFACES) ? read(CHANGED_SURFACES) : '';
+
+it('PR CI workflow EXECUTES `npm run test:reagent-slim:smoke`', () => {
+  assert.ok(WORKFLOW_SRC, `missing workflow: ${WORKFLOW}`);
+  assert.ok(
+    /npm run test:reagent-slim:smoke/.test(WORKFLOW_SRC),
+    '.github/workflows/test.yml never runs `npm run test:reagent-slim:smoke` — ' +
+      'the slim client-runtime smoke is UNARMED in PR CI (it exists as an npm ' +
+      'script but no job executes it).',
+  );
+});
+
+it('the slim smoke runs in a reagent_slim_bundle-gated job', () => {
+  // The job that runs the smoke must be guarded by the reagent_slim_bundle
+  // surface so it fires for reagent-slim adapter/testbed/runner changes
+  // (and is skipped, not absent, on unrelated PRs). The smoke step lives in
+  // the cljs-reagent-slim-bundle-isolation job, whose `if:` is gated on
+  // detect_changed_surfaces.outputs.reagent_slim_bundle.
+  assert.ok(
+    /reagent_slim_bundle == 'true'/.test(WORKFLOW_SRC),
+    'no job in test.yml is gated on reagent_slim_bundle — the smoke gate ' +
+      'cannot be armed by reagent-slim surface detection',
+  );
+});
+
+it('changed-surface detection ARMS reagent_slim_bundle for the smoke RUNNER', () => {
+  // The smoke runner under implementation/scripts/ must route to
+  // reagent_slim_bundle; otherwise editing the runner (or its policy test)
+  // falls into the generic implementation/scripts/* case that never fires
+  // the gate — a false-green hole (mirrors the xray-feature-gate launcher
+  // case). Assert a dedicated case names the runner AND sets the surface.
+  assert.ok(CHANGED_SURFACES_SRC, `missing changed-surfaces script: ${CHANGED_SURFACES}`);
+  assert.ok(
+    /serve-and-run-reagent-slim-smoke\.cjs/.test(CHANGED_SURFACES_SRC),
+    'report-changed-surfaces.sh has no case naming ' +
+      'serve-and-run-reagent-slim-smoke.cjs — editing the smoke runner would ' +
+      'not arm the slim smoke gate (false-green hole)',
+  );
+  // The runner case must set reagent_slim_bundle=true. Extract the case
+  // block (from the case-pattern line naming the runner to its closing
+  // `;;`) and confirm the surface is armed within THAT block — robust to
+  // however long the explanatory comment grows.
+  const idx = CHANGED_SURFACES_SRC.indexOf('serve-and-run-reagent-slim-smoke.cjs');
+  const end = CHANGED_SURFACES_SRC.indexOf(';;', idx);
+  assert.ok(end > idx, 'could not find the end (`;;`) of the slim smoke runner case');
+  const caseBlock = CHANGED_SURFACES_SRC.slice(idx, end);
+  assert.ok(
+    /reagent_slim_bundle=true/.test(caseBlock),
+    'the serve-and-run-reagent-slim-smoke.cjs case does not set ' +
+      'reagent_slim_bundle=true',
   );
 });
 


### PR DESCRIPTION
Fixes two `implementation/scripts/` bugs (both AUTHORITATIVE).

## rf2-l9upzf — path-policy accepts symlink escapes (security)

The path-policy validator checked allowed-root containment **lexically** (`path.resolve` + `path.relative`), so a symlink/junction **under** an allowed root whose target resolved **outside** the approved boundary passed the prefix check — the writing scripts (`serve-and-run-browser-tests.cjs`, `story-build.cjs`) then followed the link and wrote outside the boundary, contradicting `spec/Security.md` (symlink escapes must fail fast).

**Fix:** `enforcePolicy` now canonicalises both the candidate and the allowed roots via `fs.realpathSync` **before** the containment check, collapsing every existing symlink/junction (including parent-directory links).
- Nonexistent final paths handled safely: realpath the deepest existing ancestor, re-append the lexical tail (which cannot itself be a link).
- Fail-closed on realpath errors (falls back to the lexical check).
- Returns the lexical path on approval, so callers see the path they passed (no surprise canonical rewrite); existing in-root tests unaffected.
- **Cross-platform:** relies on `fs.realpathSync` (POSIX symlinks + Windows junctions/symlinks); never assumes a separator or drive shape.

**Regression tests** (`_path-policy.test.cjs`): escaping-link REJECTED (final component + parent-directory component); legitimate in-root link + nonexistent in-root child ACCEPTED; skips gracefully when the host forbids symlink/junction creation (locked-down Windows).

## rf2-5v0dg7 — reagent-slim client-runtime smoke not armed in PR CI

The slim smoke runner (`serve-and-run-reagent-slim-smoke.cjs` / `test:reagent-slim:smoke`) existed and was documented, but PR CI only proved the npm script existed and ran bundle-isolation — **no job executed the smoke**, so mount/inject/click regressions could ship green.

**Fix (surgical):**
- Armed it in the existing `cljs-reagent-slim-bundle-isolation` job (already gated on `reagent_slim_bundle`, already in the required aggregator): added a Playwright-install step + `npm run test:reagent-slim:smoke`. **Hot-zone touch:** `.github/workflows/test.yml` — sole toucher, two added steps + a job-name tweak.
- `report-changed-surfaces.sh` (hot-zone): added a dedicated case routing the smoke runner + its policy test to `reagent_slim_bundle` (mirrors the `serve-and-run-xray-feature-gate.cjs` false-green-fix precedent).
- Policy tests now assert the workflow **EXECUTES** the smoke and that changed-surface detection **arms** it — not merely that `package.json` contains the script.

## Follow-up — stuck required check fix (Playwright install hang)

The first push armed the slim smoke with a `npx playwright install --with-deps chromium` step that had **no step timeout and no Playwright browser cache**. On the PR's own CI run that step wedged on the GHA runner's dpkg/apt lock (held by `unattended-upgrades`) and never completed, so the `cljs-reagent-slim-bundle-isolation` job sat `in_progress` indefinitely. Because the **required** check is the `all-required-passed` aggregator (`if: always()`, `needs:` every job — the only required contexts on `main` are *All required checks passed* / *Lint required* / *Docs required*), and it `needs:` this job, the aggregator never ran → no required check ever reported → the PR could not merge. This is the exact rf2-e6enf failure mode the rest of the workflow already guards against.

NB the original root-cause hypothesis (job conditionally **skipped** → required check hangs) did not apply: surface detection arms `reagent_slim_bundle=true` for this PR's own file list (via both `mark_all` and the `implementation/scripts/*` case), so the `if:` was true and the job **ran** — it then **hung**, it was not skipped. The aggregator already treats a legitimate skip as acceptable.

**Fix (`.github/workflows/test.yml`, sole toucher):**
- Added the missing **"Cache Playwright browser binary"** step ahead of the install (every other PR Playwright job carries it; rf2-f79t8).
- Capped the `--with-deps` install at **`timeout-minutes: 5`** (the rf2-e6enf step-level precedent on the hermetic re-frame2-pair-mcp install) so an apt-lock wedge becomes a re-runnable FAILURE, not an open-ended block.
- Added a **job-level `timeout-minutes: 20`** backstop (mirrors `mcp-conformance-re-frame2-pair`) so any wedged step reports a conclusion and the required aggregator can never zombie again.

## Quality gates

Run locally in the worktree (all green):
- `node scripts/_path-policy.test.cjs` — PASS (incl. 3 new symlink/junction escape cases; real symlinks created on this host)
- `node scripts/_reagent-slim-smoke-policy.test.cjs` — PASS (18/18; incl. workflow-execution + changed-surface-arming assertions — still green after the timeout/cache additions)
- `node scripts/_changed-surfaces.test.cjs` — 78 PASS
- `npm run test:script-policy` — exit 0 (full suite)
- `npm run test:reagent-slim:smoke` — `Ran 1 reagent-slim client-runtime smoke. 0 failures.` (exit 0)
- `npm run test:reagent-slim:bundle-isolation` — PASS (4 contracts, 21 sentinels)
- `bash -n report-changed-surfaces.sh` — OK; Python `yaml.safe_load` of `test.yml` — OK (41 jobs; slim job `timeout-minutes: 20`, install step `timeout-minutes: 5`, new cache step present)
- Surface detection reproduced on this PR's own file list → `reagent_slim_bundle=true` (the slim job runs, and now reliably reports a conclusion)

No AI attribution. No `.beads/issues.jsonl` touched.
