### PR TITLE
fix(examples): strict 7GUIs numeric parsing + adapter ten-fn docstring

### DIFF
--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -97,6 +97,24 @@
 ;;
 ;; Tiny S-expression flavor: '=(+ A1 (* B2 3))'. Pure functions, JVM-runnable.
 
+(def num-re
+  "Full-string numeric grammar: optional sign, integer and/or fractional
+   part, optional exponent. Anchored end-to-end so lax prefixes like
+   \"1abc\" or \"1.2.3\" are rejected — `js/parseFloat` would otherwise
+   silently accept their leading numeric run (\"1abc\" → 1), letting an
+   invalid token/literal evaluate as a number instead of surfacing a
+   parse error / staying text."
+  #"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
+
+(defn parse-num
+  "Strict numeric parse: returns the number iff `s` (trimmed) is wholly
+   numeric, else nil."
+  [s]
+  (let [trimmed (str/trim s)]
+    (when (re-matches num-re trimmed)
+      (let [n (js/parseFloat trimmed)]
+        (when-not (js/isNaN n) n)))))
+
 (defn tokenise [s]
   ;; Splits a formula body into tokens. Whitespace-separated; '(' and ')'
   ;; split out as their own tokens.
@@ -121,9 +139,9 @@
                                        (recur (conj acc child) rest-toks))))
         ")" (throw (ex-info "Unexpected )" {}))
         ;; Atom: number, cell ref, or operator symbol.
-        (let [num (js/parseFloat t)]
+        (let [num (parse-num t)]
           (cond
-            (not (js/isNaN num))           [num                             more]
+            (some? num)                    [num                             more]
             (re-matches cell-re t)         [{:cell t}                       more]
             (#{"+" "-" "*" "/"} t)         [(symbol t)                      more]
             :else                          (throw (ex-info "Bad atom" {:token t}))))))))
@@ -183,8 +201,8 @@
       (cond
         (= ast :error/parse) :error/parse
         formula?             (evaluate-ast ast cells (conj visited id))
-        :else                (let [n (js/parseFloat raw)]
-                               (if (js/isNaN n) raw n)))
+        :else                (let [n (parse-num raw)]
+                               (if (some? n) n raw)))
       0)))                                       ;; empty cells are 0
 
 ;; ============================================================================

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -61,9 +61,16 @@
   (fn handler-temp-initialise [{:keys [db]} _]
     {:db (assoc db :temp {:celsius 0.0 :input-source :celsius :typing "0"})}))
 
+(def num-re
+  "Full-string numeric grammar: optional sign, integer and/or fractional
+   part, optional exponent. Anchored end-to-end so lax prefixes like
+   \"1abc\" or \"1.2.3\" are rejected — `js/parseFloat` would otherwise
+   silently accept their leading numeric run (\"1abc\" → 1)."
+  #"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
+
 (defn parse-num [s]
   (let [trimmed (str/trim s)]
-    (when-not (str/blank? trimmed)
+    (when (re-matches num-re trimmed)
       (let [n (js/parseFloat trimmed)]
         (when-not (js/isNaN n) n)))))
 

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -2,7 +2,7 @@
   "The reactive substrate adapter contract. Per Spec 006.
 
   The runtime is substrate-agnostic; every host-specific reactivity concern
-  goes through these 9 functions. The CLJS reference ships four adapter
+  goes through these ten functions. The CLJS reference ships four adapter
   artefacts: Reagent (browser), UIx (browser), Helix (browser), and
   plain-atom (JVM / SSR / headless).
 
@@ -299,7 +299,7 @@
   the hook is false (chain fallback) and the atom-marker arm decides.
 
   The hook lives in the late-bind table (not the adapter spec map) so the
-  9-fn adapter contract shape is preserved."
+  ten-fn adapter contract shape is preserved."
   [container]
   (let [hook (late-bind/get-fn :adapter/derived-container?)]
     (or (boolean (and hook (hook container)))


### PR DESCRIPTION
Two small disjoint fixes (rf2-dlv84w P3 + rf2-8l156v P3, both authoritative).

## rf2-dlv84w — examples/reagent: 7GUIs numeric parsers accept invalid prefixes

The reagent 7GUIs **temperature** and **cells** examples used `js/parseFloat`
directly, which accepts invalid numeric prefixes (`parseFloat("1abc")` → `1`,
`parseFloat("1.2.3")` → `1.2`). Invalid input could become numeric durable
state — temperature would update the other field from `"1abc"`, and spreadsheet
tokens/literals could evaluate as numbers instead of surfacing parse/text errors.

Fix: full-string anchored numeric validation (`num-re` + a `parse-num` helper)
before parsing, in both examples (idiomatic — events/subs/app-db unchanged in
shape):
- **temperature** (`seven_guis/temperature/core.cljs`): `parse-num` gates
  `parseFloat` on a whole-string match → invalid input yields `nil` (empty),
  not a truncated number.
- **cells** (`seven_guis/cells/core.cljs`): the formula-atom parser and the
  literal-cell evaluator both route through strict `parse-num`. Invalid atoms
  fall through to `"Bad atom"` (`#PARSE`); invalid literals stay text (so
  text-in-arithmetic surfaces `#TYPE`) instead of evaluating numerically.

**Note on acceptance criteria:** the bead asks to "add tests for `1abc`,
`1.2.3`, …". Per the standing rule, examples are **test-free** (no `*.spec.cjs`
under `examples/`); real regression coverage lives in substrate contract tests /
framework gates, not the examples tree. No tests were added under `examples/`.
The fix itself is what closes the correctness gap.

## rf2-8l156v — adapter.cljc docstring: "9-fn" → "ten-fn"

`implementation/core/src/re_frame/substrate/adapter.cljc` referred to the
"9-fn adapter contract" (line 302, and the matching ns-docstring line 5).
Spec 006 was reconciled to the **ten-fn** contract (6 required + 3 optional +
1 lifecycle, per the Normative contract table and the `adapter.cljc:9-17`
enumeration, which already lists all ten). Both prose references updated to
ten-fn for consistency. Docstring-only.

## Quality gates

- `npx shadow-cljs compile :examples/temperature :examples/cells` → both builds
  completed, **0 warnings**. (Both transitively `:require` `re-frame.core` →
  `re-frame.substrate.adapter`, so the touched `.cljc` ns compiled clean as
  part of these builds.)
- Docstring change is low-risk; CI covers the full matrix.