### PR TITLE
chore(skills): vestigial review — pair/improver/implementor

### DIFF
--- a/skills/re-frame2-improver/references/schemaless-events.md
+++ b/skills/re-frame2-improver/references/schemaless-events.md
@@ -17,7 +17,7 @@ Greppable signals — flag when **any** of these match AND no production gate is
 - A `reg-event` handler bound to `:*/loaded`, `:*/received`, `:*/decoded`, `:*/synced`, `:*/rehydrated`, `:*/restored` whose return `:db` writes `(assoc db :foo/bar payload)` where `payload` originated outside the application's own dispatches.
 - Events that take an unstructured second arg — `(fn [{:keys [db]} [_ data]] {:db (assoc db :remote data)})` — where `data` is the raw boundary payload.
 - Handlers that read `js/window.location.search`, `js/localStorage`, `js/sessionStorage`, `js/postMessage`, or `IndexedDB` results in their bodies (often via fx) and write the result to `app-db`.
-- New handlers introduced in a feature whose `app-db` writes use paths absent from `(re-frame.schemas/app-schemas)` (the `app-schemas` query lives on `re-frame.schemas` — no longer re-exported from `re-frame.core`, per rf2-wad2fl).
+- New handlers introduced in a feature whose `app-db` writes use paths absent from `(re-frame.schemas/app-schemas)` (the `app-schemas` query lives on `re-frame.schemas` — no longer re-exported from `re-frame.core`).
 
 Detection logic (apply for each candidate handler):
 

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -227,7 +227,7 @@ mcp__re-frame2-pair__tail-build {wait-ms: 5000, probe: "(some/probe-form)"}
 `probe` is a CLJS form chosen to change when the edited code reloads. Good probes for re-frame2:
 
 - After editing a `reg-*` handler: `(re-frame2-pair.runtime/registrar-handler-ref :event <id>)` — compares a hash over `handler-meta`. The underlying `(rf/handler-meta :event :foo)` `:line` / `:column` / `:handler-fn` change after re-registration; capture the meta map's hash before the edit, compare after.
-- After editing a `reg-machine`: same shape against `:event` (machines register under `:event` per Spec 005); `(re-frame.machines/machine-meta :auth)` is the equivalent direct read (`machine-meta` lives on `re-frame.machines` — no longer re-exported from `re-frame.core`, per rf2-wad2fl).
+- After editing a `reg-machine`: same shape against `:event` (machines register under `:event` per Spec 005); `(re-frame.machines/machine-meta :auth)` is the equivalent direct read (`machine-meta` lives on `re-frame.machines` — no longer re-exported from `re-frame.core`).
 - After editing a view or helper: pick a CLJS form that derefs the view's namespace var (e.g. `(some-ns/my-view)` or `(meta #'some-ns/my-view)`).
 - If you don't know a good probe, omit `probe` and the tool falls back to a 300ms timer; the result includes `:soft? true` so you know it's timer-based.
 


### PR DESCRIPTION
Actions the three AUTHORITATIVE vestigial-review beads — rf2-5m6m4w (`skills/re-frame2-pair`), rf2-2y38mm (`skills/re-frame2-improver`), rf2-40ftl7 (`skills/re-frame2-implementor`). Each subtree was reviewed for vestigial content (dead/outdated/superseded guidance, removed-API references, stale EP spellings, broken cross-refs) and verified against shipped reality.

## Per-subtree findings

**`skills/re-frame2-pair`** — one vestige fixed.
- `references/ops.md` — stripped the internal bead-id provenance tag (`per rf2-wad2fl`) from the `machine-meta` namespace-relocation note. The guidance is correct (`machine-meta` lives on `re-frame.machines`, no longer re-exported from `re-frame.core`); only the bead-id citation was vestigial.
- Everything else current: SKILL.md/references describe the two-partition frame (EP-0001), no-default-frame (EP-0002), realms (EP-0013), `:rf.error/legacy-runtime-root`, one `reg-event`, and whole-frame-state epoch restore (`restore-epoch` reinstalls both partitions via `replace-frame-state!`, `:db-after` as the app-db projection) — all aligned to shipped reality. `app-db-reset!` / `restore-epoch` / `replace-app-db` surfaces accurate. The `../../SKILL-REDIRECT.md` cross-ref resolves to repo root (verified). Bead-ids in `preload/runtime.cljs`, `tests/`, and `scripts/ops.clj` are source/test code provenance, not user-facing prose (the no-bead-ids rule scans SKILL.md/README.md/references only); the one bead-id in `spec/inputs.md` is in a `spec/` meta-doc, which L7 explicitly permits — left in place.

**`skills/re-frame2-improver`** — one vestige fixed.
- `references/schemaless-events.md` — stripped the same `per rf2-wad2fl` provenance tag from the `app-schemas` namespace-relocation note (guidance correct; tag vestigial).
- All six anti-pattern leaves current: one `reg-event` (EP-0018), `:rf.cofx/requires` + recordable/ambient cofx fork (EP-0010/EP-0017), `inject-cofx` removed, `:rf/time-ms`, tags/`reg-machine`. No removed-API usages, no stale EP spellings.

**`skills/re-frame2-implementor`** — reviewed clean, no edits.
- SKILL.md + 8 reference leaves + spec meta-docs verified current: EP-0011 (uniform reply envelope), EP-0012 (path algebra + CEDN-1), EP-0013 (realms — correctly distinguished from "EP 013 Flows"), EP-0014 (derivation/process algebra), EP-0015 (frame-owned egress; `add-marks`/`set-marks`/`redact-interceptor`/`declare-sensitive-*` removed), EP-0016, EP-0017 (`inject-cofx` removed, `:dispatched-at` retired), EP-0018 (one `reg-event`). All EP spellings valid; cross-ref targets resolve. No bead-ids in user-facing leaves.

No non-skills changes required; nothing outside the three target subtrees was touched.

## Quality gates
- `python scripts/check_skill_pair_authoring_drift.py` — pass
- `python scripts/check_skill_implementor_partition_drift.py` (incl. Rule 5 no-bead-ids scan) — pass
- `python scripts/check_skill_implementor_order.py` — pass
- `python scripts/check_skill_re_frame2_drift.py` — pass
- `python scripts/check_skill_mcp_drift.py` — pass
- `python scripts/check_readme_inventories.py` — pass
- `python scripts/check_doc_slugs.py` — pass
- `python scripts/check_readme_links.py` — pass
- `mkdocs build --strict` — not run (no `docs/` changes; edits are `skills/` only)