### PR TITLE
fix(story-mcp): validate decorator kind + per-tool arg schemas + error-shape unknown args

### DIFF
--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -70,6 +70,37 @@ before the bounded allowlists run.** Concretely:
   contract; it no longer depends on the client validating. The
   `:rf.error` id on the structured slot is
   `:rf.story-mcp/unknown-arguments`.
+
+  **Two-level enforcement (rf2-an95jj).** The global allowlist
+  (`protocol/arg-keys`) is the UNION of every tool's argument keys, so it
+  only rejects keys no tool reads. A key valid for ANOTHER tool — `:body`
+  (register-variant), `:write-back` (record-as-variant) — survives
+  normalisation as a keyword entry and would be silently ignored by the
+  selected handler. The dispatcher therefore runs a SECOND, per-tool
+  check (`wire-pipeline/tool-invalid-arg-keys`) AFTER global
+  normalisation: a globally-known key the SELECTED tool does not advertise
+  in its `inputSchema` properties is diagnosed with the same
+  `:rf.story-mcp/unknown-arguments` envelope. This is the descriptor-level
+  `additionalProperties false` backstop at PER-TOOL granularity. Two
+  cross-cutting knobs handled at the wire boundary rather than by a
+  handler are tolerated on every tool regardless of advertisement
+  (`wire-pipeline/wire-managed-arg-keys`): `:max-tokens` (injected on
+  every descriptor anyway) and `:dedup` (advertised only on dedup-eligible
+  tools but documented as silently ignored elsewhere — the dispatcher
+  gates dedup on `:dedup-eligible?`, not on the arg's presence). No-intern
+  holds: a per-tool-invalid key is already an interned keyword (it passed
+  the global allowlist), so reporting it mints nothing.
+
+  **Bounded error envelopes (rf2-p0eiq3).** Both the global and per-tool
+  unknown-argument diagnostics — and the invalid-`:max-tokens` rejection —
+  ride the SAME wire-boundary token cap (`mcp-base.cap/apply-cap`) that
+  bounds every normal tool response (see
+  [`Principles.md`](Principles.md) §Tight token budget). A caller can
+  otherwise pack many long unknown keys inside the 4 MB frame cap and
+  receive an UNCAPPED diagnostic echoing them all back, violating the
+  response-cap contract. The invalid-`:max-tokens` envelope falls back to
+  the convention default cap (the caller's own cap was malformed, so it
+  can't be honoured), but is still bounded.
 - Genuinely data-bearing nested maps keep string keys at ingress and are
   routed through each surface's own **bounded** keyword policy:
   - `:cell-overrides` KEYS are resolved through `safe-keyword` against

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -193,6 +193,17 @@ plus pagination metadata when active. Per-kind slots: `:has-wrap?`
 (hiccup, never the closure itself); `:init` + `:app-db-patch`
 (frame-setup); `:fx-id` + `:response` (fx-override).
 
+The `:kind` filter is an **enum** — a SUPPLIED value outside
+`{"hiccup" "frame-setup" "fx-override"}` returns an `isError: true`
+diagnostic (`:rf.error :rf.story-mcp/unknown-decorator-kind`), NOT a
+silent widen to the full catalogue (rf2-cdavyf). Resolving a typo
+(`"hicup"`) to `nil` and treating `nil` as no-filter used to return
+EVERY decorator, hiding the caller's mistake behind a successful-looking
+result. An ABSENT `:kind` (the slot was never sent) is the legitimate
+no-filter path; only a present-but-unrecognised value rejects. The
+unrecognised string never mints a fresh JVM keyword (it short-circuits
+through `safe-keyword`).
+
 When a `:kind` filter is applied, the cursor's fingerprint is over
 the filtered id-set — so a kind-filter change between pages reads
 as a stale cursor (different fingerprint).

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -198,23 +198,45 @@
   - `:kind` (string, optional) — narrow to one decorator kind. One
     of `\"hiccup\"`, `\"frame-setup\"`, `\"fx-override\"`. Resolved
     through `args/safe-keyword` against the bounded `decorator-kinds`
-    set (rf2-lqjbk); unrecognised values are treated as no filter.
+    set (rf2-lqjbk) — no-intern: an unrecognised string never mints a
+    fresh JVM keyword.
+
+  rf2-cdavyf: a SUPPLIED `:kind` outside the bounded enum is an
+  agent-recoverable error, NOT a silent widen to the full catalogue.
+  The enum is advertised as a filter; resolving a typo (`\"hicup\"`) to
+  `nil` and then treating `nil` as no-filter returned EVERY decorator —
+  hiding the caller's mistake behind a successful-looking full result.
+  An absent `:kind` (the slot was never sent) is still the legitimate
+  no-filter path; only a PRESENT-but-unrecognised value rejects.
 
   rf2-76sf6: pagination via `:limit` / `:cursor`. The filtered+sorted
   entry vec is paged; the cursor's fingerprint is over the FILTERED
   id-set so a kind-filter change between pages reads as a stale
   cursor (different sig)."
   [args]
-  (let [kind-filter (some-> (:kind args) (args/safe-keyword decorator-kinds))
-        decorators  (story/registrations :decorator)
-        filtered    (cond->> decorators
-                      kind-filter (into {} (filter (fn [[_ body]]
-                                                     (= kind-filter (:kind body))))))
-        sorted      (sort-by (comp str key) filtered)
-        all-ids     (keys filtered)
-        entries     (mapv (fn [[did body]] (decorator-summary did body)) sorted)]
-    (cursor/paged-result entries all-ids args "list-decorators"
-                         (fn [page] {:decorators page}))))
+  (let [raw-kind    (:kind args)
+        kind-filter (some-> raw-kind (args/safe-keyword decorator-kinds))]
+    ;; rf2-cdavyf — a present-but-unrecognised `:kind` is rejected rather
+    ;; than widened to all. `(some? raw-kind)` distinguishes "no filter
+    ;; requested" (absent slot ⇒ `raw-kind` nil) from "filter requested
+    ;; with a bad value" (`raw-kind` present but `safe-keyword` ⇒ nil).
+    (if (and (some? raw-kind) (nil? kind-filter))
+      (result/error-result
+       (str "Unknown decorator kind: " (pr-str raw-kind)
+            ". Allowed: " (pr-str (mapv name (sort decorator-kinds)))
+            ". (The :kind filter is an enum; fix the value or drop the key for the full catalogue.)")
+       {:rf.error :rf.story-mcp/unknown-decorator-kind
+        :kind     raw-kind
+        :allowed  (mapv name (sort decorator-kinds))})
+      (let [decorators (story/registrations :decorator)
+            filtered   (cond->> decorators
+                         kind-filter (into {} (filter (fn [[_ body]]
+                                                        (= kind-filter (:kind body))))))
+            sorted     (sort-by (comp str key) filtered)
+            all-ids    (keys filtered)
+            entries    (mapv (fn [[did body]] (decorator-summary did body)) sorted)]
+        (cursor/paged-result entries all-ids args "list-decorators"
+                             (fn [page] {:decorators page}))))))
 
 (def canonical-assertion-docs
   "Per spec/007 line 304 + IMPL-SPEC §3.5 the seven dispatched canonical

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
@@ -76,6 +76,7 @@
   on dedup-eligible tools' input schema via `schemas/with-dedup`."
   (:require [re-frame.mcp-base.args :as args]
             [re-frame.mcp-base.cap :as base-cap]
+            [re-frame.mcp-base.overflow :as overflow]
             [re-frame.story-mcp.protocol :as proto]
             [re-frame.story-mcp.tools.dedup :as dedup]
             [re-frame.story-mcp.tools.registry :as registry]
@@ -177,15 +178,26 @@
 
 (defn- unknown-arg-error
   "Build the tool-level `isError: true` diagnostic for unknown top-level
-  argument keys (rf2-ovmc5e). `unknown` is the vec of RAW key STRINGS the
-  caller sent outside the allowlist (recorded as metadata by
-  `protocol/normalize-frame`); `t` is the tool descriptor. The result
-  names the unknown keys, the tool, and that tool's allowed key set — so a
-  non-schema-validating host or hand-rolled agent gets agent-recoverable
-  feedback that its intended control knob was ignored rather than a
-  successful-looking call that silently defaulted. The server is the
-  authoritative backstop for the advertised `additionalProperties false`
-  contract; it no longer depends on the client validating."
+  argument keys (rf2-ovmc5e / rf2-an95jj). `unknown` is the vec of RAW key
+  STRINGS the caller sent outside the tool's allowed set; `t` is the tool
+  descriptor. The result names the unknown keys, the tool, and that tool's
+  allowed key set — so a non-schema-validating host or hand-rolled agent
+  gets agent-recoverable feedback that its intended control knob was
+  ignored rather than a successful-looking call that silently defaulted.
+  The server is the authoritative backstop for the advertised
+  `additionalProperties false` contract; it no longer depends on the
+  client validating.
+
+  Two call sites feed this builder, differing only in WHERE the unknown
+  keys came from:
+
+  - rf2-ovmc5e — keys outside the GLOBAL `protocol/arg-keys` allowlist
+    (raw strings dropped + recorded as metadata at frame normalisation).
+  - rf2-an95jj — keys inside the global allowlist (so they survived
+    normalisation as keyword ENTRIES) but outside THIS tool's advertised
+    `inputSchema` properties (e.g. `:body` on `get-variant`,
+    `:write-back` on `run-variant`). Reported as their `name`-stringified
+    form so the diagnostic shape matches the global-unknown case."
   [tool-name t unknown]
   (let [allowed (tool-allowed-arg-keys t)]
     (result/error-result
@@ -197,6 +209,79 @@
       :tool        tool-name
       :unknown     unknown
       :allowed     allowed})))
+
+(def ^:private wire-managed-arg-keys
+  "Cross-cutting argument keys CONSUMED at the wire boundary
+  (`invoke-tool`) rather than by a tool handler — so the per-tool schema
+  check (rf2-an95jj) must tolerate them on EVERY tool even when a given
+  tool's descriptor doesn't advertise them.
+
+  - `:max-tokens` is injected on every tool (`schemas/with-max-tokens`),
+    so it is always in the advertised set; listed here only for symmetry
+    with the dispatcher's read.
+  - `:dedup` is advertised ONLY on the three dedup-eligible tools
+    (`schemas/with-dedup`), but is DOCUMENTED as silently ignored on
+    ineligible tools (`schemas/with-dedup` docstring — the dispatcher
+    gates dedup on `:dedup-eligible?`, not on the arg's presence). A
+    caller leaving `:dedup` at its default on a non-eligible tool is a
+    benign no-op, not a typo'd control knob — so it must NOT trip the
+    per-tool unknown-argument diagnostic."
+  #{:max-tokens :dedup})
+
+(defn- tool-invalid-arg-keys
+  "rf2-an95jj — the keyword arg keys in `args` that are GLOBALLY known
+  (they survived `protocol/normalize-frame` as keyword entries against
+  `protocol/arg-keys`) but are NOT valid for the SELECTED tool `t`: not
+  in the tool's advertised `inputSchema` properties AND not a
+  wire-managed cross-cutting knob (`wire-managed-arg-keys`). Returns the
+  offending keys `name`-stringified + sorted (matching the global-unknown
+  diagnostic shape); empty when every key is tool-valid.
+
+  This is the server-side backstop for each descriptor's
+  `additionalProperties false` contract at the PER-TOOL granularity: the
+  global normalisation only rejects keys outside the UNION of every
+  tool's args, so a key valid for ANOTHER tool (`:body`, `:write-back`,
+  `:dedup` on a non-eligible tool) used to survive and be silently
+  ignored. No-intern is preserved — every key here is already an interned
+  keyword (it passed the global allowlist), so `name` mints nothing."
+  [t args]
+  (let [advertised (set (-> t :inputSchema :properties keys))]
+    (->> (keys args)
+         (remove advertised)
+         (remove wire-managed-arg-keys)
+         (map name)
+         sort
+         vec)))
+
+(defn- cap-error
+  "rf2-p0eiq3 — route a pre-dispatch error envelope through the SAME
+  wire-boundary token cap (`base-cap/apply-cap`) that bounds every normal
+  tool response. Per `spec/Principles.md §Tight token budget`, EVERY MCP
+  tool response is bounded, error results included — but the
+  pre-dispatch rejection branches (`unknown-arg-error`, the
+  invalid-`:max-tokens` rejection, the per-tool unknown-argument
+  diagnostic) used to return directly, BEFORE the cap. A caller can pack
+  many long unknown keys inside the 4 MB frame cap and receive an
+  UNCAPPED diagnostic echoing them all back — violating the response-cap
+  contract. Capping these envelopes closes that.
+
+  `cap` is the resolved per-call cap (the output of `base-cap/max-tokens`):
+  an integer ceiling, `nil` (caller disabled the cap with `:max-tokens 0`),
+  OR — for the invalid-`:max-tokens` branch — a
+  `{:rf.mcp/invalid-arg {...}}` REJECTION marker. A rejection marker is
+  NOT a usable cap (feeding it to `apply-cap` would crash the gate), so we
+  fall back to the convention default (`overflow/default-max-tokens`) —
+  the malformed cap can't be honoured, but the error envelope must still
+  be bounded. A genuine `nil` (cap disabled) is preserved: a caller who
+  explicitly opted out of the cap opted out for errors too."
+  [tool-name cap err-result]
+  (let [effective-cap (if (base-cap/invalid-arg? cap)
+                        overflow/default-max-tokens
+                        cap)]
+    (base-cap/apply-cap result-io err-result
+                        {:tool tool-name
+                         :cap  effective-cap
+                         :hint (get overflow-hints tool-name)})))
 
 (defn invoke-tool
   "Invoke `tool-name` with `arguments` (a map of keyword-keyed args).
@@ -243,7 +328,13 @@
           ;; `protocol/normalize-frame` (never interned, never a map
           ;; entry). A non-empty set means the agent typo'd a control
           ;; knob; we diagnose before dispatch rather than silently drop.
-          unknown (get (meta args) proto/unknown-arg-keys-meta)]
+          unknown (get (meta args) proto/unknown-arg-keys-meta)
+          ;; rf2-an95jj — keys that ARE in the global allowlist (so they
+          ;; survived normalisation as keyword entries) but are NOT valid
+          ;; for THIS tool (e.g. `:body` on `get-variant`). The global
+          ;; check above only catches keys outside the UNION of every
+          ;; tool's args; this is the per-tool backstop.
+          tool-invalid (tool-invalid-arg-keys t args)]
       (cond
         (base-cap/invalid-arg? cap)
         ;; rf2-5rdit — a negative `:max-tokens` resolves to a
@@ -253,7 +344,9 @@
         ;; where the bad cap over-trips `apply-cap`'s `over-cap?` and
         ;; every response is replaced by the overflow marker. The handler
         ;; is never dispatched; the malformed cap never reaches the gate.
-        (result/error-result (result/pr-edn cap) cap)
+        ;; rf2-p0eiq3 — the rejection envelope rides the response cap too
+        ;; (via the default cap, since the caller's cap was malformed).
+        (cap-error tool-name cap (result/error-result (result/pr-edn cap) cap))
 
         ;; rf2-ovmc5e — an unknown top-level argument key is an
         ;; agent-recoverable diagnostic, not a silent drop. The handler is
@@ -261,9 +354,22 @@
         ;; tool, and that tool's allowed key set so the model can retry
         ;; with the corrected arg name. (The no-intern invariant holds —
         ;; the unknown keys arrive as strings via metadata and are never
-        ;; keywordised.)
+        ;; keywordised.) rf2-p0eiq3 — the diagnostic rides the response
+        ;; cap so a caller packing many long unknown keys can't bypass
+        ;; the budget with an uncapped echo.
         (seq unknown)
-        (unknown-arg-error tool-name t unknown)
+        (cap-error tool-name cap (unknown-arg-error tool-name t unknown))
+
+        ;; rf2-an95jj — a globally-known but tool-invalid argument key is
+        ;; the per-tool backstop for each descriptor's
+        ;; `additionalProperties false` contract. A key valid for ANOTHER
+        ;; tool (`:body`, `:write-back`, `:dedup` on a non-eligible tool)
+        ;; would otherwise survive global normalisation and be silently
+        ;; ignored by the selected handler. Diagnose it with the same
+        ;; `:rf.story-mcp/unknown-arguments` shape before dispatch, capped
+        ;; per rf2-p0eiq3.
+        (seq tool-invalid)
+        (cap-error tool-name cap (unknown-arg-error tool-name t tool-invalid))
 
         :else
         (let [;; Dedup runs only on tools that opt in via `:dedup-eligible?`

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -4123,13 +4123,38 @@
       (is (nil? (find-kw nil name-str))
           "rf2-lqjbk: unknown tag id MUST NOT intern"))))
 
-(deftest list-decorators-unknown-kind-falls-through
-  (testing ":kind filter with an unrecognised value rejects WITHOUT interning"
-    (let [name-str (str "rf2-lqjbk-kind-" (System/nanoTime))
-          r        (invoke "list-decorators" {:kind name-str})]
-      (is (success? r) "the no-filter fallback still returns the registered decorators")
+(deftest list-decorators-unknown-kind-rejects
+  ;; rf2-cdavyf — a SUPPLIED `:kind` outside the bounded enum is an
+  ;; agent-recoverable error, NOT a silent widen to the full catalogue.
+  ;; (Pre-fix the typo resolved to nil and was treated as no filter,
+  ;; returning EVERY decorator — hiding the caller's mistake behind a
+  ;; successful-looking full result.) The no-intern invariant (rf2-lqjbk)
+  ;; still holds: the unrecognised kind string never mints a fresh keyword.
+  (testing ":kind filter with an unrecognised value REJECTS WITHOUT interning (rf2-cdavyf)"
+    (let [name-str (str "rf2-cdavyf-kind-" (System/nanoTime))
+          r        (invoke "list-decorators" {:kind name-str})
+          s        (:structuredContent r)]
+      (is (error? r) "an unrecognised :kind surfaces an isError diagnostic, not a full catalogue")
+      (is (= :rf.story-mcp/unknown-decorator-kind (:rf.error s))
+          "the structured error carries the unknown-decorator-kind id")
+      (is (= name-str (:kind s)) "echoes the bad kind value")
+      (is (= ["frame-setup" "fx-override" "hiccup"] (:allowed s))
+          "lists the bounded enum so the agent can correct")
+      (is (re-find #"(?i)unknown decorator kind" (-> r :content first :text)))
       (is (nil? (find-kw nil name-str))
-          "rf2-lqjbk: unknown kind name MUST NOT intern"))))
+          "rf2-cdavyf / rf2-lqjbk: unknown kind name MUST NOT intern"))))
+
+(deftest list-decorators-known-kind-and-absent-kind-still-work
+  ;; rf2-cdavyf — the reject path is PRESENT-but-unrecognised only. An
+  ;; absent `:kind` (no filter requested) and a valid `:kind` both still
+  ;; succeed.
+  (testing "absent :kind returns the full catalogue; a valid :kind filters (rf2-cdavyf)"
+    (let [no-filter (invoke "list-decorators" {})
+          valid     (invoke "list-decorators" {:kind "hiccup"})]
+      (is (success? no-filter) "absent :kind is the legitimate no-filter path")
+      (is (vector? (-> no-filter :structuredContent :decorators)))
+      (is (success? valid) "a recognised :kind filters rather than rejecting")
+      (is (vector? (-> valid :structuredContent :decorators))))))
 
 (deftest run-variant-unknown-substrate-does-not-intern
   (testing "run-variant :substrate with an unknown value is dropped WITHOUT interning"
@@ -4325,12 +4350,17 @@
 
 (deftest ingress-legitimate-wire-keys-still-dispatch
   (testing "known JSON wire arg keys still normalise + dispatch correctly (rf2-3luf3)"
-    ;; variant-id + max-tokens + include-sensitive are read by get-variant /
-    ;; the wire-pipeline; all must survive the no-intern normalisation.
+    ;; variant-id + max-tokens are read by get-variant / the wire-pipeline;
+    ;; both must survive the no-intern normalisation. (rf2-an95jj —
+    ;; `:include-sensitive` is deliberately NOT exercised here: get-variant
+    ;; surfaces no value-bearing slot, so it does not advertise that knob,
+    ;; and the per-tool schema check now rejects it for this tool. The
+    ;; `:include-sensitive` no-intern path is covered on the tools that DO
+    ;; advertise it — preview-variant / run-variant / read-failures etc.)
     (let [frame  (str "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\","
                       "\"params\":{\"name\":\"get-variant\","
                       "\"arguments\":{\"variant-id\":\"story.button/primary\","
-                      "\"max-tokens\":4000,\"include-sensitive\":false}}}\n")
+                      "\"max-tokens\":4000}}}\n")
           frames (run-frames! frame)
           result (-> frames first :result)]
       (is (= 5 (:id (first frames))))
@@ -4449,6 +4479,149 @@
           "no dropped keys ⇒ no unknown-arg metadata")
       (let [r (wire-pipeline/invoke-tool "run-variant" arg-map)]
         (is (success? r) "an all-recognised call dispatches the handler normally")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-an95jj — per-tool argument-schema enforcement AFTER the global
+;; no-intern normalisation.
+;;
+;; `protocol/normalize-frame` only drops keys outside the UNION of every
+;; tool's argument keys (`protocol/arg-keys`). A key valid for ANOTHER
+;; tool — `:body` (register-variant), `:write-back` (record-as-variant),
+;; `:dedup` on a non-eligible tool — therefore SURVIVES normalisation as a
+;; keyword entry and used to be silently ignored by the selected handler.
+;; The per-tool check (`tool-invalid-arg-keys`) is the descriptor-level
+;; `additionalProperties false` backstop: it rejects globally-known keys
+;; the SELECTED tool doesn't advertise, with the same
+;; `:rf.story-mcp/unknown-arguments` shape as the global-unknown diagnostic.
+;; ---------------------------------------------------------------------------
+
+(deftest invoke-tool-rejects-tool-invalid-but-globally-known-arg
+  ;; rf2-an95jj acceptance — `get-variant` with `:body`. `:body` is a real
+  ;; key (register-variant advertises it) so it survives the global
+  ;; allowlist as a keyword entry; but get-variant does NOT advertise it.
+  (testing "a globally-known but tool-invalid arg (`:body` on get-variant) rejects (rf2-an95jj)"
+    (let [r (wire-pipeline/invoke-tool "get-variant"
+                                       {:variant-id "story.button/primary" :body "x"})
+          s (:structuredContent r)]
+      (is (error? r) "tool-invalid arg ⇒ isError result, not a silent ignore + success")
+      (is (= :rf.story-mcp/unknown-arguments (:rf.error s))
+          "uses the unknown-arguments diagnostic shape")
+      (is (= "get-variant" (:tool s)) "names the tool")
+      (is (= ["body"] (:unknown s)) "names the tool-invalid key")
+      (is (contains? (set (:allowed s)) "variant-id")
+          "lists the tool's advertised arg-key set")
+      (is (not (contains? (set (:allowed s)) "body"))
+          "the tool's allowed set does NOT include the rejected key"))))
+
+(deftest invoke-tool-rejects-write-back-on-run-variant
+  ;; rf2-an95jj acceptance — `run-variant` with `:write-back`. `:write-back`
+  ;; is advertised by record-as-variant; run-variant does not advertise it.
+  (testing "`:write-back` on run-variant rejects (globally-known, tool-invalid) (rf2-an95jj)"
+    (let [r (wire-pipeline/invoke-tool "run-variant"
+                                       {:variant-id "story.button/primary"
+                                        :write-back true})
+          s (:structuredContent r)]
+      (is (error? r))
+      (is (= :rf.story-mcp/unknown-arguments (:rf.error s)))
+      (is (= "run-variant" (:tool s)))
+      (is (= ["write-back"] (:unknown s))))))
+
+(deftest invoke-tool-tolerates-dedup-on-non-eligible-tool
+  ;; rf2-an95jj — `:dedup` is advertised only on the three dedup-eligible
+  ;; tools but is DOCUMENTED as silently ignored elsewhere (it is a
+  ;; wire-managed knob the dispatcher gates on `:dedup-eligible?`). So a
+  ;; `:dedup` on a non-eligible tool must NOT trip the per-tool diagnostic
+  ;; — otherwise the test-helper default (`{:dedup false}` on every call)
+  ;; would break every non-eligible-tool test.
+  (testing "`:dedup` on a non-eligible tool is tolerated, not rejected (rf2-an95jj)"
+    (let [r (wire-pipeline/invoke-tool "get-variant"
+                                       {:variant-id "story.button/primary" :dedup false})]
+      (is (success? r) "a wire-managed knob on a non-advertising tool dispatches normally"))))
+
+(deftest invoke-tool-tolerates-include-sensitive-on-advertising-tool
+  ;; rf2-an95jj — `:include-sensitive` on a tool that DOES advertise it
+  ;; (read-failures) is tool-valid and must dispatch (the slot lives in the
+  ;; descriptor's properties regardless of the operator gate).
+  (testing "`:include-sensitive` on a tool that advertises it dispatches (rf2-an95jj)"
+    (let [r (wire-pipeline/invoke-tool "read-failures"
+                                       {:variant-id "story.button/primary"
+                                        :include-sensitive false})]
+      (is (success? r) "an advertised value-knob is tool-valid and dispatches"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-p0eiq3 — pre-dispatch error envelopes ride the response cap.
+;;
+;; `spec/Principles.md §Tight token budget` bounds EVERY tool response,
+;; errors included. The pre-dispatch rejection branches (unknown-arg,
+;; invalid-`:max-tokens`, per-tool unknown-arg) used to return BEFORE the
+;; cap — so a caller packing many long unknown keys inside the 4 MB frame
+;; cap received an uncapped diagnostic echoing them all back. The cap now
+;; applies to those envelopes too.
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-arg-error-rides-the-response-cap
+  ;; rf2-p0eiq3 — many large unknown keys produce an overflow marker under
+  ;; a small cap rather than an uncapped echo. The unknown keys ride as
+  ;; metadata (no-intern), so we build the frame through normalise-frame.
+  (testing "an unknown-argument diagnostic overflows under a small cap (rf2-p0eiq3)"
+    (let [big-keys (apply str
+                          (for [i (range 200)]
+                            (str "\"unknown-key-" i "-"
+                                 (apply str (repeat 80 \x))
+                                 "\":1,")))
+          frame    (str "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"tools/call\","
+                        "\"params\":{\"name\":\"get-variant\","
+                        "\"arguments\":{" big-keys
+                        "\"variant-id\":\"story.button/primary\"}}}")
+          arg-map  (-> (proto/normalize-frame (proto/parse-json frame))
+                       :params :arguments)
+          ;; sanity: the unknown keys WERE recorded as metadata
+          _        (is (seq (get (meta arg-map) proto/unknown-arg-keys-meta))
+                       "the many unknown keys are recorded for the diagnostic")
+          capped   (wire-pipeline/invoke-tool "get-variant"
+                                              (with-meta (assoc arg-map :max-tokens 5)
+                                                (meta arg-map)))]
+      (is (overflow-marker? capped)
+          "the uncapped echo of many long unknown keys is replaced by the overflow marker")
+      (is (= "get-variant" (get-in capped [:structuredContent vocab/overflow-key :tool]))
+          "the overflow marker names the tool"))))
+
+(deftest invalid-max-tokens-error-is-bounded
+  ;; rf2-p0eiq3 — the invalid-`:max-tokens` rejection envelope is small and
+  ;; bespoke, but it must still ride the cap path (default cap, since the
+  ;; caller's cap was malformed). It is well under the default, so it
+  ;; passes through intact — proving the cap path is exercised without
+  ;; tripping, and the rejection shape is preserved (rf2-5rdit).
+  (testing "the invalid-max-tokens rejection is routed through the cap and preserved (rf2-p0eiq3)"
+    (let [r    (wire-pipeline/invoke-tool "list-tags" {:max-tokens -1})
+          body (get-in r [:structuredContent vocab/invalid-arg-key])]
+      (is (true? (:isError r)))
+      (is (not (overflow-marker? r)) "a tiny rejection is under the default cap")
+      (is (= :max-tokens (:arg body)) "the rejection shape survives the cap path")
+      (is (= -1 (:value body))))))
+
+(deftest tool-invalid-arg-error-rides-the-response-cap
+  ;; rf2-p0eiq3 + rf2-an95jj — the per-tool unknown-arg diagnostic is
+  ;; capped too. The diagnostic echoes the offending key names + the tool's
+  ;; allowed set; throwing every globally-known key get-variant does NOT
+  ;; advertise (~18 of them) makes that echo exceed a 1-token cap, so the
+  ;; per-tool diagnostic must overflow rather than return uncapped.
+  (testing "a per-tool unknown-arg diagnostic overflows under a tiny cap (rf2-p0eiq3)"
+    (let [tool-invalid {:story-id "x" :new-variant-id "x" :extends "x"
+                        :substrate "x" :active-modes ["x"] :cell-overrides {}
+                        :base-url "x" :body "x" :doc "x" :alias "x"
+                        :tags ["x"] :kind "x" :write-back true
+                        :duration-ms 1 :timeout-ms 1}
+          r (wire-pipeline/invoke-tool "get-variant"
+                                       (assoc tool-invalid
+                                              :variant-id "story.button/primary"
+                                              :max-tokens 1))]
+      ;; All those keys are globally-known (in `protocol/arg-keys`) but
+      ;; tool-invalid for get-variant, so they survive normalisation and
+      ;; the per-tool check diagnoses them.
+      (is (overflow-marker? r)
+          "the capped per-tool diagnostic replaces the uncapped echo — proving it rides the cap path")
+      (is (= "get-variant" (get-in r [:structuredContent vocab/overflow-key :tool]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cap accounting includes :structuredContent size (rf2-mzndx)


### PR DESCRIPTION
-