### PR TITLE
test(core): frame-scoped ns-load + SSR per-request validation + recordable-cofx replay regressions

### DIFF
--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -117,16 +117,64 @@
   back-ticked category as the first cell content."
   #"^\|\s*`(:rf\.[^`]+)`\s*\|\s*`?:[^|`]+`?\s*\|([^|]*)\|")
 
+(def ^:private catalogue-heading-re
+  "The canonical `### Error event catalogue` section heading — the one
+  five-column table (`:operation | :op-type | Channel | …`) that IS the
+  single source of truth. Anchored to the bare heading text so it does
+  NOT match the later `### Error event catalogue (single source of
+  truth)` prose subsection under §Resolved decisions (which carries no
+  table)."
+  #"^###\s+Error event catalogue\s*$")
+
+(def ^:private section-heading-re
+  "Any `#`/`##`/`###`-level heading — the boundary that ends the
+  catalogue section. The catalogue table is followed by the
+  `#### History-error tag layering` subsection (a `####`, which does NOT
+  terminate the section — its rows are part of the catalogue's tag
+  prose, carrying no table rows) and then the sibling `### Schemas`
+  heading, which DOES terminate it."
+  #"^#{1,3}\s+\S")
+
+(defn- catalogue-section-lines
+  "The lines of `spec/009-Instrumentation.md` that belong to the
+  canonical `### Error event catalogue` section — from the catalogue
+  heading (exclusive) to the next sibling-or-higher heading (exclusive).
+
+  Why scope to the section (rf2-i6p308): `catalogue-row-re` is anchored
+  at `^|` so it only matches genuine table rows, but the doc carries a
+  SECOND, differently-shaped table — the `#### Per-`:operation` quick
+  reference` (a 3-column `:operation | :op-type | One-line meaning`
+  table, NO Channel column). A single-category quick-ref row matches the
+  regex too, and its `One-line meaning` cell parses as the `Channel` —
+  an out-of-set value that fails every channel invariant. (Multi-
+  category slash-joined quick-ref rows escape the regex; single-category
+  ones don't — 17 of them, exactly the categories that surfaced.) Adding
+  that quick-ref table introduced the breakage independently of any test
+  change; the durable fix is to parse ONLY the canonical catalogue
+  section so a future second `:rf.*` table elsewhere in the doc can't
+  pollute the parse either. The blank/typo'd-channel invariant
+  (rf2-9fvp25) is unaffected: a malformed cell WITHIN the catalogue
+  section still parses as a row and fails."
+  [lines]
+  (->> lines
+       (drop-while #(not (re-find catalogue-heading-re %)))
+       (drop 1)                                     ;; the heading line itself
+       (take-while #(not (re-find section-heading-re %)))))
+
 (defn- parse-catalogue
   "Parse the Spec 009 error-event catalogue into a vector of
   `{:category <kw> :channel <string>}` maps, in table order. The
   `:channel` is the TRIMMED third-column cell — possibly the empty
   string when the cell is blank — so the blank/invalid-channel
   invariant is testable directly (rf2-9fvp25) rather than relying on a
-  row-count floor. Reads the markdown fresh each call (cheap; one file)."
+  row-count floor. Scoped to the canonical `### Error event catalogue`
+  section so the doc's other `:rf.*` tables (e.g. the quick-reference
+  table) don't pollute the parse (rf2-i6p308). Reads the markdown fresh
+  each call (cheap; one file)."
   []
   (->> (slurp spec-009-file)
        (str/split-lines)
+       (catalogue-section-lines)
        (keep (fn [line]
                (when-let [[_ cat-str chan] (re-find catalogue-row-re line)]
                  {:category (keyword (subs cat-str 1)) ;; drop leading ':'

--- a/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
@@ -1,0 +1,257 @@
+(ns re-frame.example-frame-scoping-cljs-test
+  "Framework-tree regressions carved out of rf2-9wc2ed / rf2-wbgb74
+  (rf2-i6p308). These belong in the framework test tree, NOT under
+  examples/ (examples stay test-free per rf2-8cevm), because they require
+  the example ENTRY namespaces — which are `.cljs`-only (Reagent-coupled
+  `reg-view`) and so cannot load on the JVM. They run under the
+  consolidated `:node-test` CLJS build (`../examples/reagent` is on its
+  source-paths) — the only runtime where these examples' ns-load + their
+  durable handlers actually execute.
+
+  Two contracts are pinned here:
+
+  1. NS-LOAD FRAME-SCOPING (rf2-9wc2ed). `reg-app-schema` is EP-0002
+     context-required frame-local: a bare ns-load call under no established
+     scope raises `:rf.error/no-frame-context`. The seven_guis singletons +
+     nine_states fixed this by wrapping their ns-load registration in
+     `(with-frame :rf/default …)` so the schema binds to the app frame whose
+     commits it validates. This test runs with the fixture's ambient
+     `:rf/default` pin REMOVED (`:ambient-frame nil`) — the pin that MASKED
+     the bug by silently supplying a frame to a bare call (cf rf2-lo28u: a
+     fixture pin routing around the gap is a false-green). With the pin
+     removed it asserts BOTH halves: (a) each example's ns-load schema landed
+     on `:rf/default` (proving the fix's explicit frame fired — these survive
+     in the per-frame schema snapshot because the example ns loaded at THIS
+     test ns's require), AND (b) a bare `reg-app-schema` under this same
+     no-ambient scope DOES raise `:rf.error/no-frame-context` (proving the
+     guard is live exactly here — so had the example used a bare ns-load
+     call, its load at require time would have thrown and aborted the whole
+     `:node-test` bundle).
+
+  3. RECORDABLE-COFX REPLAY-STABILITY (rf2-wbgb74 / EP-0017). A durable id
+     (nine_states' new-todo `:id`; realworld's optimistic comment temp-id)
+     must be FOLDED from a recordable `reg-cofx`, never read ambiently at the
+     write site — otherwise replay mints a different id and the snapshot /
+     join-key no longer reproduces (EP-0010 §Restore, Replay, And
+     Hydration). This test dispatches `:new-todo/submit` and
+     `:comment-form/submit` TWICE with the SAME recorded `:rf.cofx` token +
+     `:rf.cofx/mint-policy :strict` (which re-feeds the recorded value
+     verbatim and never re-mints) and asserts the durable id is the token's
+     id on BOTH runs (identical across runs). Mirrors
+     `world_inputs_test/supplied-uuid-replay-stable-where-ambient-would-diverge`,
+     but executed against the EXAMPLES' OWN handlers — so a drift back to a
+     write-site `(random-uuid)` (the rf2-wbgb74 bug) fails loud here.
+
+  (Regression 2 — the SSR per-request schema validation assertion — lives in
+  `re-frame.examples-test` (JVM), where the `.cljc` SSR example's
+  `handle-request` runs.)"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; The affected example ENTRY namespaces. Requiring them here is
+            ;; load-bearing twice over: (1) it fires their ns-load
+            ;; `reg-app-schema` / `reg-cofx` / `reg-machine` / `reg-event`
+            ;; forms (against the live registrar, captured into this ns's
+            ;; fixture baseline), and (2) had any of these reverted to a bare
+            ;; ns-load `reg-app-schema`, the require below would throw
+            ;; `:rf.error/no-frame-context` and abort the whole `:node-test`
+            ;; bundle — the strongest possible regression.
+            [nine-states.core]
+            [seven-guis.temperature.core]
+            [seven-guis.flight-booker.core]
+            [seven-guis.crud.core]
+            [seven-guis.timer.core]
+            [seven-guis.circle-drawer.core]
+            [seven-guis.cells.core]
+            [realworld.comments]))
+
+;; The fixture's ambient `:rf/default` pin is REMOVED (`:ambient-frame nil`)
+;; and `:clear-app-schemas?` is OMITTED so the example ns-load schemas
+;; registered on `:rf/default` stay live through the test body. This is the
+;; precise configuration the rf2-9wc2ed regression needs:
+;;   - no ambient pin → a bare `reg-app-schema` would raise (the bug's
+;;     failure mode is observable, not masked);
+;;   - schemas retained → the example's explicit-frame registration is
+;;     readable, proving the fix fired.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+;; ============================================================================
+;; 1. NS-LOAD FRAME-SCOPING  (rf2-9wc2ed)
+;; ============================================================================
+
+;; (entry-ns . app-schema-path) pairs the fix bound to `:rf/default` at
+;; ns-load via `(with-frame :rf/default (reg-app-schema path …))`.
+(def ^:private example-app-schema-paths
+  {"nine-states.core"               [:new-todo]
+   "seven-guis.temperature.core"    [:temp]
+   "seven-guis.flight-booker.core"  [:flight]
+   "seven-guis.crud.core"           [:crud]
+   "seven-guis.timer.core"          [:timer]
+   "seven-guis.circle-drawer.core"  [:drawer]
+   "seven-guis.cells.core"          [:cells]})
+
+;; Snapshot, AT THIS NS'S LOAD (the moment the example `:require`s above have
+;; finished firing their ns-load `(with-frame :rf/default (reg-app-schema …))`
+;; forms), where each example's app-schema landed — BEFORE any `:each`
+;; fixture runs and churns the per-frame schema side-table (rf2-cq1ak: that
+;; table is per-frame state outside the registrar; sibling test nses snapshot/
+;; restore it around their own bodies and can leave it cleared between runs).
+;; This freeze captures the ground truth — "did the example ns-load register
+;; against `:rf/default`?" — at the only point it is reliably observable: the
+;; load itself. NB the deftest is what makes this assertion; this toplevel
+;; merely records the evidence the way the example produced it.
+(def ^:private example-app-schema-snapshot-at-load
+  (into {}
+        (map (fn [[ns-name path]]
+               [ns-name {:on-default
+                         (schemas/app-schema-at path {:frame :rf/default})
+                         :on-unrelated
+                         (schemas/app-schema-at path {:frame :test/never-registered})}]))
+        example-app-schema-paths))
+
+(deftest example-ns-load-schemas-bound-to-rf-default-not-an-ambient-pin
+  (testing "rf2-9wc2ed — every affected example's ns-load `reg-app-schema`
+            landed on `:rf/default` (its explicit-frame registration fired,
+            captured at THIS ns's load), NOT on some ambient pin and NOT
+            frameless. With seven_guis + nine_states having loaded at require
+            time under NO `with-frame` fixture (the fixture below is `:each`,
+            so it runs only around test bodies), a reverted bare ns-load
+            `reg-app-schema` would have raised `:rf.error/no-frame-context`
+            during those requires and aborted the whole `:node-test` bundle —
+            so reaching this assertion at all already proves the loads were
+            frame-scoped; the snapshot pins WHICH frame they targeted"
+    (doseq [[ns-name path] example-app-schema-paths]
+      (let [{:keys [on-default on-unrelated]}
+            (get example-app-schema-snapshot-at-load ns-name)]
+        (is (some? on-default)
+            (str ns-name " registered its app-schema " (pr-str path)
+                 " against :rf/default at ns-load (the with-frame fix fired)"))
+        ;; And it did NOT bleed onto an unrelated frame — :rf/default
+        ;; specifically is where the example's commits validate.
+        (is (nil? on-unrelated)
+            (str ns-name "'s schema is frame-SCOPED — absent on an unrelated frame"))))))
+
+(deftest bare-reg-app-schema-without-scope-raises-no-frame-context
+  (testing "rf2-9wc2ed (load-bearing guard) — under THIS test's no-ambient
+            scope a bare `reg-app-schema` (no frame, no `:frame` opt — exactly
+            what a reverted ns-load registration would do) raises
+            `:rf.error/no-frame-context`. This proves the guard the examples'
+            `with-frame` wrappers exist to satisfy is LIVE right here — so a
+            reverted bare ns-load call would have thrown at this ns's require
+            and aborted the bundle, never reaching a green assertion"
+    (is (nil? (frame/current-frame))
+        "precondition: no ambient frame (the pin is removed)")
+    (let [ex (try
+               (rf/reg-app-schema [:regression/bare] [:map])
+               nil
+               (catch :default e e))]
+      (is (some? ex)
+          "a bare frameless reg-app-schema throws (it does not silently
+           default to a synthesised :rf/default)")
+      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data ex)))
+          "the throw is the EP-0002 no-frame-context error — the exact
+           failure mode the examples' explicit-frame ns-load registration
+           avoids")
+      ;; The bad call must NOT have landed an entry anywhere.
+      (is (nil? (schemas/app-schema-at [:regression/bare] {:frame :rf/default}))
+          "the rejected registration left no entry on :rf/default"))))
+
+;; ============================================================================
+;; 3. RECORDABLE-COFX REPLAY-STABILITY  (rf2-wbgb74 / EP-0017)
+;; ============================================================================
+
+;; nine_states — the new todo's durable `:id` is folded from the
+;; `:new-todo/todo-id` recordable cofx, written into the machine's `:data
+;; :items` (durable runtime-db state) and used as a React `:key`.
+
+(defn- run-new-todo-submit!
+  "Boot a fresh nine-states frame (machine spawned via `:initialise`), seed a
+  valid draft, then dispatch `:new-todo/submit` with `recorded` as the
+  `:rf.cofx` token under `:rf.cofx/mint-policy :strict`. Returns the durable
+  item id the handler folded in."
+  [recorded]
+  (let [f (rf/make-frame {:doc          "nine-states replay frame"
+                          :fx-overrides {:rf.http/managed
+                                         :nine-states.http/managed-demo}})]
+    ;; `:initialise` seeds the form slice + resets/spawns the :ui/nine-states
+    ;; machine snapshot into runtime-db (the submit reads its :data :items).
+    (rf/dispatch-sync [:nine-states.app/initialise] {:frame f})
+    ;; A title >= 3 chars passes `validate-new-todo`, so the handler takes the
+    ;; valid branch that folds the recordable id into a new item.
+    (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
+    (rf/dispatch-sync [:new-todo/submit]
+                      {:frame               f
+                       :rf.cofx             recorded
+                       :rf.cofx/mint-policy :strict})
+    ;; Read the durable item id back off the machine snapshot.
+    (let [items (rf/compute-sub [:todos/items] (rf/frame-state-value f))]
+      (-> items first :id))))
+
+(deftest nine-states-new-todo-id-is-replay-stable-under-recorded-cofx
+  (testing "rf2-wbgb74 / EP-0017 — re-running `:new-todo/submit` with the SAME
+            recorded `:new-todo/todo-id` token (+ mint-policy :strict)
+            reproduces the SAME durable item id; an ambient write-site
+            `(random-uuid)` would have diverged run-to-run"
+    (let [token #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"
+          recorded {:new-todo/todo-id token}
+          id-1 (run-new-todo-submit! recorded)
+          id-2 (run-new-todo-submit! recorded)]
+      (is (= token id-1)
+          "run 1 folded the TOKEN's id into the durable item (not a fresh
+           ambient draw)")
+      (is (= token id-2)
+          "run 2 re-presented the SAME recorded id verbatim under :strict")
+      (is (= id-1 id-2)
+          "two runs of the same token produce IDENTICAL durable ids —
+           replay-stable (the EP-0017 contract)"))))
+
+;; realworld — the optimistic comment temp-id is folded from the
+;; `:realworld/temp-comment-id` recordable cofx, conj'd into `[:comments
+;; :data]` (durable app-db) and used as the correlation join key onto the
+;; eventual save / rollback.
+
+(defn- run-comment-form-submit!
+  "Boot a fresh realworld frame, seed a non-blank comment draft + a stub auth
+  user, then dispatch `:comment-form/submit` with `recorded` as the
+  `:rf.cofx` token under `:rf.cofx/mint-policy :strict`. The managed-HTTP fx
+  the success path fires is stubbed to a no-op so no backend is needed.
+  Returns the durable optimistic card id the handler folded in."
+  [recorded]
+  (let [f (rf/make-frame {:doc "realworld replay frame"})]
+    ;; Stub the managed-HTTP fx so the optimistic-post fx fires harmlessly
+    ;; (the durable write under test is the temp card conj'd into
+    ;; [:comments :data]; the request itself is irrelevant here).
+    (rf/reg-fx :realworld-replay/noop-http (fn [_ _] nil))
+    ;; Seed a non-blank draft + a user so the handler takes the valid branch.
+    (rf/dispatch-sync [:comment-form/edit-field :body "Great article!"]
+                      {:frame f})
+    (rf/with-fx-overrides {:rf.http/managed :realworld-replay/noop-http}
+      (rf/dispatch-sync [:comment-form/submit]
+                        {:frame               f
+                         :rf.cofx             recorded
+                         :rf.cofx/mint-policy :strict}))
+    (-> (rf/app-db-value f) :comments :data first :id)))
+
+(deftest realworld-comment-temp-id-is-replay-stable-under-recorded-cofx
+  (testing "rf2-wbgb74 / EP-0017 — re-running `:comment-form/submit` with the
+            SAME recorded `:realworld/temp-comment-id` token (+ mint-policy
+            :strict) reproduces the SAME optimistic-card id (the join key);
+            an ambient write-site temp-id would have diverged run-to-run"
+    (let [token "temp-018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"
+          recorded {:realworld/temp-comment-id token}
+          id-1 (run-comment-form-submit! recorded)
+          id-2 (run-comment-form-submit! recorded)]
+      (is (= token id-1)
+          "run 1 folded the TOKEN's temp-id into the optimistic card (not a
+           fresh ambient draw)")
+      (is (= token id-2)
+          "run 2 re-presented the SAME recorded temp-id verbatim under :strict")
+      (is (= id-1 id-2)
+          "two runs of the same token produce IDENTICAL optimistic-card ids —
+           the join key is replay-stable (the EP-0017 contract)"))))

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -274,6 +274,90 @@
                    "leftover slots: " (pr-str (keys @ssr-request/request-slots)))))))))
 
 ;; ============================================================================
+;; ssr — per-request schema validation (rf2-i6p308, carved from rf2-9wc2ed).
+;;
+;; The fix held the app schema as a value (`ArticlesSchema`) and registered it
+;; explicitly against EACH frame family — the per-request server frame in
+;; `handle-request` (BEFORE `:on-create` fires `:rf/server-init`) and the
+;; fixed client hydration frame in `run`. The earlier bare ns-load
+;; registration either raised `:rf.error/no-frame-context` or (under a naive
+;; `with-frame :rf/default`) bound the schema to the client frame ONLY,
+;; leaving the per-request SERVER frame — where the server-side `:articles`
+;; commit actually validates — UNSCHEMA'd, so server-side validation silently
+;; never ran (the bug was masked precisely because no schema applied).
+;;
+;; The existing handle-request tests exercise this implicitly. This test
+;; locks it EXPLICITLY: the per-request server frame carries the `:articles`
+;; schema (NOT `:rf/default`), the server-init commit's articles PASS
+;; validation on THAT frame, and a malformed `:articles` value FAILS
+;; validation on THAT frame — proving validation is live + frame-scoped on
+;; the per-request frame, not routed around. Requiring `re-frame.schemas`
+;; (above) wires the default Malli validator (rf2-v96fh), so validation is
+;; genuinely live here.
+;; ============================================================================
+
+(deftest ssr-example-per-request-frame-carries-and-validates-articles-schema
+  (testing "examples/reagent/ssr — the per-request SERVER frame carries the
+            :articles schema (the rf2-9wc2ed per-request registration) and
+            validation runs ON THAT FRAME, not on :rf/default (rf2-i6p308)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (install-canned-articles-stub!)
+    (let [articles-schema @(resolve 'ssr.core/ArticlesSchema)
+          ;; Drive a per-request server frame exactly as handle-request does:
+          ;; register the schema against the gensym frame BEFORE :on-create
+          ;; fires :rf/server-init (which commits the canned articles).
+          fid             (keyword "rf.frame" (str (gensym "f")))
+          _               (ssr/set-request! fid {:uri "/articles"})
+          _               (rf/reg-app-schema [:articles] articles-schema {:frame fid})
+          f               (rf/with-fx-overrides
+                            {:rf.http/managed :ssr.http/canned-articles}
+                            (rf/reg-frame fid
+                              {:doc       "ssr-example per-request validation frame"
+                               :platform  :server
+                               :on-create [:rf/server-init]}))
+          final-db        (rf/app-db-value f)]
+      ;; 1. The schema is bound to the PER-REQUEST frame — explicitly.
+      (is (= articles-schema (schemas/app-schema-at [:articles] {:frame fid}))
+          "the :articles schema is registered against the per-request server frame")
+      ;; 2. …and NOT on :rf/default (the masking-default frame). The fixture
+      ;; pins :rf/default as ambient scope but the example never registered
+      ;; the SSR schema there — per-request scoping, not a default floor.
+      (is (nil? (schemas/app-schema-at [:articles] {:frame :rf/default}))
+          "the SSR :articles schema is NOT bound to :rf/default — it is
+           per-request frame-scoped (the rf2-9wc2ed contract)")
+      ;; 3. The server-init commit landed two valid articles…
+      (is (= 2 (count (:articles final-db)))
+          "precondition: the canned server-init commit loaded two articles")
+      ;; …and they PASS validation ON the per-request frame (the [:maybe]
+      ;; schema accepts both the pre-load nil and the loaded vector).
+      ;; `interop/debug-enabled?` is true by default on the JVM (the dev/prod
+      ;; gate), so `validate-app-schema!` actually runs — and requiring
+      ;; `re-frame.schemas` wired the default Malli validator (rf2-v96fh).
+      (is (true? (schemas/validate-app-schema! final-db :rf/server-init fid))
+          "the server-init :articles commit validates on the per-request frame")
+      ;; 4. A MALFORMED :articles value FAILS validation on the per-request
+      ;; frame — proving the validator is genuinely live + frame-scoped
+      ;; there (not a soft-pass no-op). A non-vector :articles violates
+      ;; ArticlesSchema ([:maybe [:vector …]]).
+      (let [bad-db (assoc final-db :articles "not-a-vector-of-articles")]
+        (is (false? (schemas/validate-app-schema! bad-db :rf/server-init fid))
+            "a malformed :articles commit FAILS validation on the per-request
+             frame — validation is live and frame-scoped (this is the gap
+             the per-request registration + [:maybe] schema closed)"))
+      ;; 5. The same malformed value validates TRUE against :rf/default —
+      ;; because no SSR schema is registered there — confirming the failure
+      ;; above is attributable to the PER-REQUEST frame's schema specifically.
+      (let [bad-db (assoc final-db :articles "not-a-vector-of-articles")]
+        (is (true? (schemas/validate-app-schema! bad-db :rf/server-init :rf/default))
+            ":rf/default carries no SSR schema, so the same bad value
+             soft-passes there — the per-request frame is where the
+             contract lives"))
+      ;; Teardown the per-request frame + its request slot (hygiene; mirrors
+      ;; the example's handle-request finally).
+      (rf/destroy-frame! f))))
+
+;; ============================================================================
 ;; ssr — client hydration path (rf2-kb7zis). The example now boots the
 ;; client via the framework `ssr/hydrate!` helper (it relies on the
 ;; framework-registered `:rf/hydrate`, no longer a stale local copy). These


### PR DESCRIPTION
Carved out of rf2-9wc2ed / rf2-wbgb74 (those fixed `examples/reagent/` only). The acceptance criteria asked for regressions in the **framework** test tree (`implementation/core/test/`), outside the examples-only worker surface. Examples stay test-free per rf2-8cevm — nothing added under `examples/`. Closes **rf2-i6p308**.

## The three regressions

**1. NS-load frame-scoping (rf2-9wc2ed)** — new CLJS test `re-frame.example-frame-scoping-cljs-test`. The affected entry namespaces (six seven_guis singletons + nine_states) are `.cljs`-only (Reagent `reg-view`), so this MUST be a CLJS node-test, not JVM. It requires those nses under **no ambient `with-frame` fixture** (`:ambient-frame nil` — the `:rf/default` pin `examples_test` carries is exactly what MASKED the bug, cf rf2-lo28u) and asserts ns-load did NOT raise `:rf.error/no-frame-context`:
- each example's app-schema landed on `:rf/default` (snapshotted at this ns's load, before per-test fixture churn of the per-frame schema side-table);
- a bare frameless `reg-app-schema` under the same no-ambient scope **does** raise `:rf.error/no-frame-context` — proving the guard is live right here, so a reverted bare ns-load call would have thrown at require and aborted the bundle.

**2. SSR per-request validation** — added to `re-frame.examples-test` (JVM, where the `.cljc` SSR example runs). Drives a per-request server frame the way `ssr.core/handle-request` does and asserts the `:articles` schema is registered + validating on **that** frame, not `:rf/default`: a malformed `:articles` value FAILS validation on the per-request frame, the canned server-init commit PASSES, and the same bad value soft-passes on `:rf/default` (no SSR schema there). Validation is genuinely live — requiring `re-frame.schemas` wires the default Malli validator (rf2-v96fh).

**3. Recordable-cofx replay-stability (rf2-wbgb74 / EP-0017)** — in the CLJS test. Dispatches `:new-todo/submit` (nine_states) and `:comment-form/submit` (realworld) TWICE with the SAME recorded `:rf.cofx` token + `:rf.cofx/mint-policy :strict`; asserts the durable id is the token's id on both runs (identical). A write-site `(random-uuid)` (the rf2-wbgb74 bug) would diverge run-to-run. Mirrors `world_inputs_test/supplied-uuid-replay-stable-where-ambient-would-diverge`, executed against the examples' own handlers.

## Load-bearing confirmation

- **#1** structurally load-bearing: a reverted bare ns-load `reg-app-schema` raises `:rf.error/no-frame-context` at require → the `:node-test` bundle fails to compile/init. The guard deftest independently pins the live error under the no-ambient scope.
- **#2** load-bearing: a malformed `:articles` value returns `false` (validation fails) on the per-request frame and `true` (soft-pass, no schema) on `:rf/default` — the failure is attributable to the per-request frame's schema specifically. Reverting to no per-request registration → the bad value soft-passes there too and the assertion fails.
- **#3** load-bearing: asserts the folded id equals the EXACT supplied token on both runs; a write-site random read would not equal the token (and the two runs would differ).

## Quality gates

- `clojure -M:test -n re-frame.examples-test` (JVM) — **14 tests / 65 assertions, 0 failures, 0 errors** (was 13/59; +1 test, +6 assertions for the SSR per-request validation regression).
- `npx shadow-cljs compile node-test` — clean (1 pre-existing unrelated warning in `resources_revalidation_cljs_test`).
- `node out/node-test.js --test=re-frame.example-frame-scoping-cljs-test` (focused) — **4 tests / 24 assertions, 0 failures, 0 errors**.
- Full CLJS suite `node out/node-test.js` — **7257 tests / 29937 assertions, 0 failures, 0 errors** (no cross-ns regression in the shared bundle).
- **Full JVM core suite `clojure -M:test` (from `implementation/core/`) — 1524 tests / 6740 assertions, 0 failures, 0 errors.** (The original run surfaced 3 failures in `error-catalogue-channel-conformance-test` — see the CI-fix note below — now resolved.)

## CI-fix follow-up (rf2-i6p308 — full JVM core suite)

The original push left the full JVM core sweep to CI, which then FAILED: 3 failures in `re-frame.error-catalogue-channel-conformance-test`. **Root cause: a pre-existing breakage, NOT this PR's regressions.** The conformance test parses the Spec 009 error-event catalogue table out of `spec/009-Instrumentation.md`; an ancestor commit (`14507d5d1`, present on both this branch and `origin/main`) added a `#### Per-`:operation` quick reference` table whose single-category back-ticked rows ALSO match the catalogue-row regex, so each row's *One-line meaning* cell parsed as the *Channel* column (17 out-of-set channels). The bounded local run (`-n re-frame.examples-test`) never executed that nse, so it slipped through. `origin/main` is affected identically — this is an existing-on-main breakage caught here.

**Fix (surgical, drift-guard scoping):** parse only the lines inside the canonical `### Error event catalogue` section (heading -> next sibling heading), so the quick-ref table (and any future second `:rf.*` table in the doc) can't pollute the parse. The rf2-9fvp25 blank/typo'd-channel invariant is unaffected — a malformed cell WITHIN the catalogue section still parses and fails. Only the test's parser changed; the three added regressions are untouched and remain load-bearing.

Rebased on `origin/main`; JVM examples-test + focused CLJS re-verified green post-rebase, and the full JVM core suite now runs green locally (1524/6740, 0 failures).

