### PR TITLE
fix(examples/_shared): asset gate detects CSS url() fetches + vestigial review

### DIFF
--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -90,9 +90,9 @@ is `flex-shrink: 0` with a 320px `min-width`, the side-by-side layout needs
 ~624px before any app content shows, so on a phone it would overflow
 horizontally even though the pages declare a responsive viewport.
 
-`structure.css` therefore **stacks** the shell below the
-`--rf-testbed-shell-stack` breakpoint (900px): the columns become rows (app on
-top, Xray host below), the host drops its fixed width / min-width and goes
+`structure.css` therefore **stacks** the shell below a 900px breakpoint: the
+columns become rows (app on top, Xray host below), the host drops its fixed
+width / min-width and goes
 full-bleed, and its height is capped (`max-height: 60vh` + internal scroll) so
 the panel never crowds the app off-screen. The host/app DOM contract
 (`.rf2-testbed-shell > #app` + `[data-rf-xray-host]`) is **unchanged**, so Xray

--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -209,8 +209,10 @@ hr {
  * (default 560px) on the right. With `flex-shrink:0` + a 320px host min-width
  * that desktop shell needs ~624px before any app content shows, so on a phone
  * it would overflow horizontally even though the pages declare a responsive
- * viewport. Below the --rf-testbed-shell-stack breakpoint (900px) we STACK:
- * the columns become rows (app on top, Xray host below), the host drops its
+ * viewport. Below a 900px breakpoint (the narrowest the side-by-side layout can
+ * be without overflow is ~624px; 900px keeps a comfortable app column before
+ * stacking) we STACK: the columns become rows (app on top, Xray host below),
+ * the host drops its
  * fixed width / min-width and goes full-bleed, and its height is capped so the
  * panel never crowds the app off-screen. The host/app DOM contract
  * (`.rf2-testbed-shell > #app` + `[data-rf-xray-host]`) is untouched, so Xray
@@ -220,10 +222,6 @@ hr {
 
 :root {
   --rf-xray-accent: #7C5CFF;
-  /* The viewport width at/under which the inline-Xray shell stacks instead of
-     sitting side-by-side. ~624px is the narrowest the side-by-side layout can
-     be without overflow; 900px keeps a comfortable app column before stacking. */
-  --rf-testbed-shell-stack: 900px;
 }
 
 .rf2-testbed-shell {

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -60,6 +60,15 @@
  *      examples/_shared/README.md §Visual identity), so the contract is
  *      fail-closed — a re-introduced external @import turns the gate RED.
  *
+ *      REMOTE CSS url() FETCHES are NOT skipped either (rf2-o18ava). A
+ *      stylesheet can pull a third-party font / image without an @import — a
+ *      `@font-face { src: url(https://…) }`, a `background-image: url(//cdn…)`,
+ *      or a mask / cursor / border-image remote `url(...)` fires the same
+ *      load-time third-party request the @import policy guards. So the gate
+ *      ALSO REJECTS any unallowlisted network `url(...)` (http(s) / `//host`)
+ *      in scanned CSS, reusing EXTERNAL_IMPORT_ALLOWLIST. `data:` URIs (inlined,
+ *      no request) and same-document `url(#fragment)` paint refs stay exempt.
+ *
  *      Staging-aware resolution: a page references _shared assets at the
  *      relative path `_shared/...`, but in the SOURCE tree _shared lives
  *      ONCE at examples/_shared/ (not next to each page) — the orchestrator
@@ -164,17 +173,20 @@ const ALLOWLIST = {
 };
 
 // ---------------------------------------------------------------------------
-// External CSS @import allowlist (rf2-vou5mm) — the ONE encoded place that
-// names an external `@import url(https://…|http://…|//…)` the scanner is
-// permitted to see inside scanned CSS, each with a reason. Any external CSS
-// @import NOT listed here fails the gate.
+// External CSS network allowlist (rf2-vou5mm + rf2-o18ava) — the ONE encoded
+// place that names an external CSS network reference the scanner is permitted to
+// see inside scanned CSS, each with a reason. It covers BOTH an external
+// `@import url(https://…|http://…|//…)` AND a remote `url(...)` fetch in a
+// declaration (`@font-face src`, `background-image`, mask, cursor, …). Any
+// external CSS network ref NOT listed here fails the gate.
 //
-// Why this exists: an external CSS @import (e.g. Google Fonts) makes every
-// staged example fire a third-party network request at load time — the exact
-// regression rf2-byf7y removed. The shared design system deliberately loads
-// NO remote fonts/hosts (examples/_shared/README.md §Visual identity), so this
-// allowlist starts EMPTY and the contract is fail-closed: re-introducing an
-// external @import without an entry here turns the gate RED.
+// Why this exists: an external CSS @import (e.g. Google Fonts) OR a remote
+// `url()` font/image makes every staged example fire a third-party network
+// request at load time — the exact regression rf2-byf7y removed. The shared
+// design system deliberately loads NO remote fonts/hosts (examples/_shared/
+// README.md §Visual identity), so this allowlist starts EMPTY and the contract
+// is fail-closed: re-introducing an external @import / url() without an entry
+// here turns the gate RED.
 //
 // Shape mirrors ALLOWLIST: key = the external URL with any ?query/#hash
 // STRIPPED (the scanner normalises @import targets that way before the lookup);
@@ -445,6 +457,38 @@ function extractCssImports(css) {
   return out;
 }
 
+// Extract every `url(...)` target a CSS source can fetch at load time —
+// `@font-face { src: url(...) }`, `background`/`background-image`,
+// `mask`/`mask-image`, `cursor`, `border-image`, `list-style-image`, etc. The
+// `@import url(...)` form is intentionally SKIPPED (it is the @import policy's
+// job, enforced via extractCssImports above) so a remote @import is reported
+// once, not twice. Handles `url("x")` / `url('x')` / bare `url(x)` (with
+// surrounding whitespace). Returns the RAW (un-stripped) targets so the caller
+// can tell a `url(#fragment)` local paint-ref and a `data:` URI apart from a
+// network fetch — query/hash stripping happens at the network-classification
+// step, not here, or `url(#grain)` would normalise to the empty string.
+// Order-preserving, de-duplicated.
+function extractCssUrls(css) {
+  const out = [];
+  const seen = new Set();
+  // Blank out `@import url(...)` occurrences first so they are not re-collected
+  // here (extractCssImports already owns the @import contract).
+  const body = css.replace(
+    /@import\s+url\(\s*(?:"[^"]*"|'[^']*'|[^)'"]*)\s*\)/gi,
+    '',
+  );
+  for (const m of body.matchAll(
+    /\burl\(\s*("([^"]*)"|'([^']*)'|([^)'"]+))\s*\)/gi,
+  )) {
+    const raw = (m[2] != null ? m[2] : m[3] != null ? m[3] : m[4] || '').trim();
+    if (!raw) continue;
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    out.push(raw);
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // The pure scan. Returns { errors: string[], pages: [...] }; the CLI and the
 // test both consume this. Filesystem reads are injected so the test can pin
@@ -614,15 +658,43 @@ function resolveRef(ref, pageDir, sharedParent = EXAMPLES_ROOT) {
   return path.resolve(pageDir, ref);
 }
 
+// Reject any unallowlisted network `url(...)` reference inside a CSS source
+// (rf2-o18ava). An `@font-face { src: url(https://…) }`, a
+// `background-image: url(//cdn…)`, a masked/cursor/border-image remote `url()`,
+// etc. fires a third-party network request at load time — the SAME
+// reproducibility / offline-dev / hidden-dependency regression the external CSS
+// `@import` policy (rf2-vou5mm / rf2-byf7y) already guards, just via a `url()`
+// declaration rather than an `@import`. Only http(s) and the protocol-relative
+// `//host/...` form are gated: `data:` URIs are inlined (no request) and a
+// `url(#fragment)` is a same-document paint reference (SVG filter/gradient), not
+// a fetch. Pushes one error per offending raw URL into `errors`.
+function checkCssNetworkUrls(css, displayRef, errors, externalAllowlist = EXTERNAL_IMPORT_ALLOWLIST) {
+  for (const raw of extractCssUrls(css)) {
+    if (!isNetworkRef(raw)) continue; // data:/#fragment/relative local — not a network fetch
+    const key = raw.split(/[?#]/)[0].trim(); // allowlist keys are query/hash-stripped
+    if (Object.prototype.hasOwnProperty.call(externalAllowlist, key)) continue;
+    errors.push(
+      `${displayRef}: CSS url('${raw}') pulls a third-party network ` +
+        `dependency (remote font / image / mask / cursor) into staged ` +
+        `examples at load time. Remote CSS url() fetches are forbidden unless ` +
+        `explicitly allowlisted with a reason in EXTERNAL_IMPORT_ALLOWLIST in ` +
+        `check-examples-assets.cjs (rf2-o18ava).`,
+    );
+  }
+}
+
 // Resolve + check a single local CSS file's @import targets, recursively.
 // Records an error for any local import that does not resolve to a real file,
-// and for any EXTERNAL @import (http/https/protocol-relative) not present in
-// the external-import allowlist (rf2-vou5mm).
+// for any EXTERNAL @import (http/https/protocol-relative) not present in the
+// external-import allowlist (rf2-vou5mm), and for any remote `url(...)` fetch
+// in the CSS body (rf2-o18ava).
 function checkCssImports(io, cssAbsPath, displayRef, errors, seen, externalAllowlist = EXTERNAL_IMPORT_ALLOWLIST) {
   if (seen.has(cssAbsPath)) return;
   seen.add(cssAbsPath);
   const css = readFileSafe(io, cssAbsPath);
   if (css == null) return; // a missing CSS file is reported by its referrer
+  // Remote url() fetches (font-face/background/mask/cursor/…) — rf2-o18ava.
+  checkCssNetworkUrls(css, displayRef, errors, externalAllowlist);
   for (const imp of extractCssImports(css)) {
     if (isExternalRef(imp)) {
       // An external CSS @import pulls a third-party network dependency into
@@ -878,6 +950,19 @@ function checkSharedTree(io, opts = {}) {
         );
       }
     }
+    // No remote `url(...)` fetch in the shared CSS (rf2-o18ava). A
+    // `@font-face { src: url(https://…) }` / `background-image: url(//cdn…)` /
+    // mask / cursor remote url() here makes every staged example fire a
+    // third-party request at load time — the SAME no-remote-styling contract
+    // (examples/_shared/README.md §Visual identity) the @import policy guards.
+    // Checked HERE, independent of the page reference graph, so the contract
+    // holds even if no scanned page happens to link the file.
+    checkCssNetworkUrls(
+      css,
+      `examples/_shared/css/${cssName}`,
+      errors,
+      externalImportAllowlist,
+    );
   }
 
   // structure.css reachable from style.css's @import.
@@ -1047,8 +1132,10 @@ module.exports = {
   extractAssetRefs,
   extractOgImageRefs,
   extractCssImports,
+  extractCssUrls,
   resolveRef,
   checkCssImports,
+  checkCssNetworkUrls,
   scanPage,
   checkSharedTree,
   scanAll,

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -43,6 +43,7 @@ const {
   extractAssetRefs,
   extractOgImageRefs,
   extractCssImports,
+  extractCssUrls,
   resolveRef,
   scanPage,
   checkSharedTree,
@@ -495,6 +496,143 @@ it('TEETH: a data: @import is NOT treated as a network dep (not rejected)', () =
     errors,
     [],
     `a data: @import must not be rejected as a network dep, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: remote CSS url() fetches are REJECTED (rf2-o18ava) -----------
+//
+// rf2-o18ava found the gate enforced external CSS @import but SKIPPED remote
+// `url(...)` fetches — a `@font-face { src: url(https://…) }` or a
+// `background-image: url(//cdn…)` could re-introduce a third-party font/image
+// request and stay green, despite the no-remote-styling contract. The contract
+// is now fail-closed for url() too: an unallowlisted network url() in any
+// scanned CSS fails the gate, while data: URIs and url(#fragment) stay exempt.
+
+it('extractCssUrls extracts url() targets but SKIPS @import url() (owned by @import)', () => {
+  const urls = extractCssUrls(
+    [
+      "@import url('structure.css');",
+      "@font-face { src: url('https://fonts.example.com/a.woff2'); }",
+      'body { background-image: url(//cdn.example.com/bg.png); }',
+      '.x { cursor: url("img/cursor.png"), auto; }',
+      '.y { mask-image: url(#grain); }',
+      '.z { background: url(data:image/png;base64,AAAA); }',
+    ].join('\n'),
+  );
+  // The @import target is NOT collected here.
+  assert.ok(!urls.includes('structure.css'), 'extractCssUrls must skip @import url()');
+  assert.ok(urls.includes('https://fonts.example.com/a.woff2'));
+  assert.ok(urls.includes('//cdn.example.com/bg.png'));
+  assert.ok(urls.includes('img/cursor.png'));
+  // Fragment + data refs are returned RAW (so the caller can classify them).
+  assert.ok(urls.includes('#grain'));
+  assert.ok(urls.includes('data:image/png;base64,AAAA'));
+});
+
+it('TEETH: a remote @font-face src: url(https://…) is REJECTED', () => {
+  // The exact rf2-o18ava repro: a remote web-font pulled in via url() rather
+  // than an @import. The gate must fail it (and never resolve it on disk).
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('structure.css');",
+      "@font-face { font-family: 'Inter';",
+      "  src: url('https://fonts.example.com/inter.woff2') format('woff2'); }",
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e.includes("CSS url('https://fonts.example.com/inter.woff2')") &&
+        e.includes('rf2-o18ava'),
+    ),
+    `expected a rejected remote @font-face url(), got: ${errors.join(' | ')}`,
+  );
+  assert.ok(
+    !errors.some((e) => e.includes('does not resolve to a file')),
+    `a remote url() must never be checked on disk, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a protocol-relative background-image: url(//cdn…) is REJECTED', () => {
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('structure.css');",
+      'body { background-image: url(//cdn.example.com/bg.png); }',
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes("CSS url('//cdn.example.com/bg.png')") && e.includes('rf2-o18ava'),
+    ),
+    `expected a rejected protocol-relative url(), got: ${errors.join(' | ')}`,
+  );
+});
+
+it('a data: url() and a url(#fragment) paint ref are NOT rejected (no network fetch)', () => {
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('structure.css');",
+      '.icon { background: url(data:image/svg+xml,%3Csvg/%3E) no-repeat; }',
+      '.grain { fill: url(#grain); }',
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `data: + url(#fragment) refs must not trip the network gate, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('a remote CSS url() whose exact URL is allowlisted (with reason) scans clean', () => {
+  // The scanner strips ?query/#hash before the allowlist lookup, so the key is
+  // the query-stripped URL — sharing EXTERNAL_IMPORT_ALLOWLIST with @import.
+  const written = 'https://fonts.example.com/inter.woff2?v=3';
+  const allowKey = 'https://fonts.example.com/inter.woff2';
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('structure.css');",
+      `@font-face { src: url('${written}') format('woff2'); }`,
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE, {
+    externalImportAllowlist: {
+      [allowKey]: { reason: 'deliberate remote font for this test' },
+    },
+  });
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `an allowlisted remote url() should scan clean, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a remote url() in the _shared tree is rejected by checkSharedTree', () => {
+  // checkSharedTree enforces the no-remote-styling contract directly on the
+  // _shared source, independent of any page's reference graph.
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]:
+      GOOD_SHARED_STYLE +
+      "\n@font-face { src: url('https://fonts.example.com/x.woff2'); }",
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }\n' +
+      RESPONSIVE_SHELL,
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some(
+      (e) =>
+        e.includes('style.css') &&
+        e.includes('fonts.example.com') &&
+        e.includes('rf2-o18ava'),
+    ),
+    `expected checkSharedTree to reject the remote url(), got: ${errors.join(' | ')}`,
   );
 });
 


### PR DESCRIPTION
## What

Two `examples/_shared/` tasks.

### Asset gate: detect remote CSS `url()` fetches

The examples asset gate (`examples/scripts/check-examples-assets.cjs`) enforced external CSS `@import` but **skipped remote `url()` fetches**. A stylesheet could re-introduce a third-party font/image request through `@font-face { src: url(https://…) }`, `background-image: url(//cdn…)`, masks, cursors, etc. and stay green — despite the no-remote-styling contract (`examples/_shared/README.md` §Visual identity).

- New `extractCssUrls()` extracts every `url(...)` target in a CSS body (skips `@import url()`, which the existing `@import` policy already owns, so a remote `@import` is reported once not twice).
- New `checkCssNetworkUrls()` rejects any **unallowlisted network** `url()` (http(s) / protocol-relative `//host`), reusing `EXTERNAL_IMPORT_ALLOWLIST`. `data:` URIs (inlined) and same-document `url(#fragment)` paint refs stay exempt.
- Wired into `checkCssImports` (page reference graph, recursive) and directly into `checkSharedTree` for `style.css` / `structure.css` (so the contract holds even if no scanned page links the file).
- Header/allowlist doc comments updated; the file's bead-cited contract convention is preserved.

Repro from the task (append a remote `@font-face`/`background-image` to `style.css` in-memory) now fails closed; previously it returned no errors.

### Vestigial review of `examples/_shared/`

Reviewed the slice with repo-wide consumer greps. **One real vestige found and removed**: the `--rf-testbed-shell-stack: 900px` custom property in `structure.css` was declared but never referenced — the responsive media query hardcodes `900px`, and CSS `@media` conditions cannot consume `var()`, so the token could only ever be dead. Removed it plus its two comment mentions and the README reference (the 900px breakpoint behaviour is unchanged and still described in prose).

Everything else verified live: `--rg-*` (notebook) and `--hx-*` (process_monitor_helix) aliases are consumed 1:1 (no dead rows); `--rf-xray-accent` is used by the Xray theme + testbeds; `--rf-xray-inline-width` is set at runtime by Xray (CSS fallback is intentional); all spot-checked structural classes (`.cells-grid`, `.send-form`, `.article-preview`, `.pill`, `.boot-progress`, `.rf2-testbed-shell`) have live consumers; the README's `counter`/`flows` claims are accurate.

## Quality gates

- `test:script-policy` suite — all 16 policy test files pass (run file-by-file; includes `_examples-staging.test.cjs` and `check-examples-assets.test.cjs` with the new `url()` teeth). The live scan over the real tree (33 example host pages + `_shared`) stays green.
- `shadow-cljs release examples/counter` (a `_shared`-consuming example: links `_shared/css/style.css` + uses `.rf2-testbed-shell` / `data-rf-xray-host`) — Build completed, 0 warnings, output at `out/examples/counter/main.js`.