### PR TITLE
fix(mcp-base): deterministic descriptor manifest key order + vestigial review

### DIFF
--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -37,13 +37,14 @@ that ride on those framework surfaces.
 
 ## Index
 
-Eleven namespaces under `re-frame.mcp-base.*`. Each ships its own
+Twelve namespaces under `re-frame.mcp-base.*`. Each ships its own
 per-namespace contract doc; the table below indexes them:
 
 | ns | Surface | Per-namespace spec |
 |---|---|---|
 | `vocab` | `:rf.mcp/*` + `:rf.size/*` marker keys + envelope slots + JSON-RPC error codes. | [`vocab.md`](vocab.md) |
 | `sensitive` | spec/009 §Privacy fail-closed default-suppress filter (`sensitive-event?`, `strip-sensitive`, per-frame `scrub-snapshot`) + malformed-stamp counter. | [`sensitive.md`](sensitive.md) |
+| `egress` | Cross-MCP `:rf.egress/*` profile vocabulary + pure-data `profile-size-opts` resolver — the framework-runtime-free mirror of the closed six-member egress enum and its `:rf.size/*` floor (EP-0015 §10). | [`egress.md`](egress.md) |
 | `elision` | Wire-boundary `:rf.size/large-elided` walker (`count-elided-markers`, rf2-9fz64). | [`elision.md`](elision.md) |
 | `args` | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
 | `diff-encode` | Path-keyed structural diff for epoch `:db-after` slots projected into path-headed cluster sections (rf2-1wdzp / rf2-qeous) + encoder/decoder Malli gate. | [`diff-encode.md`](diff-encode.md) |

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the ALGORITHM that drives the overflow marker into a result. Until rf2-eyelu this pipeline was duplicated near-identically in re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped results). The only structural difference between the two implementations was the SHAPE of the result map and the platform-appropriate accessor used to read its `:text` slots — algorithm identical.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the cross-MCP cursor codec, the EDN-with-no-tagged-literals reader, the size cap, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope. The cursor PAYLOAD shape is consumer-side (story carries `{:offset :total :sig}`; pair carries `{:after-id :ms :until-ms :frame}`).
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/descriptor-manifest.md
+++ b/tools/mcp-base/spec/descriptor-manifest.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The shared, platform-agnostic serialiser + drift-check that lets BOTH MCP servers (`re-frame2-pair-mcp`, `story-mcp`) GENERATE / VALIDATE a committed `tool-descriptors.edn` manifest from their tool registry — so adding / removing / renaming an MCP tool goes RED in CI until the manifest is regenerated. Models the project's API-governance keystone (`rf2-3nbl5.2`, `spec/api-manifest.edn`) on the MCP descriptor surface (`rf2-sofwv`).
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md).
 
 ## The problem it solves
 
@@ -41,7 +41,7 @@ A generated, CI-guarded manifest prevents the drift the way the keystone's `spec
 
 `:required` and `:typicalTokens` (rf2-cwhod2) guard the live API-semantics facets the original narrow projection missed:
 
-- **`:required`** — the SORTED subset of `:input-keys` the descriptor's `:inputSchema :required` marks mandatory (empty when none). Surfaces an argument silently flipping required↔optional — a contract change a `:input-keys`-only gate (which sees only that the key *exists*) would miss.
+- **`:required`** — the SORTED subset of `:input-keys` the descriptor's `:inputSchema :required` marks mandatory (empty when none). Surfaces an argument silently flipping required↔optional — a contract change a `:input-keys`-only gate (which sees only that the key *exists*) would miss. **This subset relation is ENFORCED, not assumed.** `:input-keys` (from `:inputSchema :properties`) and `:required` (from `:inputSchema :required`) are read from independent descriptor sources, so the raw shape does not force the relation. `descriptor->row` rejects a descriptor whose required keys are not a subset of its property keys — it throws an `ex-info` (`:tool` / `:required` / `:input-keys` / `:missing`) rather than emitting a self-inconsistent row (`:input-keys ["known"]` with `:required ["missing"]`) that would bless a mandatory argument the advertised input surface never declares and break the default/gate-open surface derivation.
 - **`:typicalTokens`** — the integer response-payload token-budget hint AI clients read to pick size-conscious args (`max-tokens` / `cache` / `cursor`). `nil` when a tool declares no hint (forward-compatible; the slot still renders so every row shares one shape). Surfaces a token-budget hint drifting.
 
 `:gated-input-keys` (rf2-qo3wvp) models the **two-profile** `tools/list` surface explicitly:

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Each `:rf/epoch-record` carries `:db-before` and `:db-after` — near-identical full app-db snapshots. `pr-str` doesn't preserve structural sharing, so on the wire the pair is roughly 2× app-db per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db. This ns replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before` so the wire payload approaches the structural-sharing cost rather than the deep-copy cost. The patch list is grouped into path-breadcrumb sections via [`section-grouping.md`](section-grouping.md).
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/egress.md
+++ b/tools/mcp-base/spec/egress.md
@@ -1,0 +1,66 @@
+# `egress` — cross-MCP `:rf.egress/*` profile vocabulary + resolver
+
+> **Type:** Reference (`tools/mcp-base/spec/`)
+> The cross-MCP, framework-runtime-free mirror of the closed six-member `:rf.egress/*` profile enum and its `:rf.size/*` floor (EP-0015 §10). A pure-data table + `profile-size-opts` resolver an MCP server uses to express its egress boundary as a NAMED profile — *which boundary is this?* — without pulling the framework runtime graph into its bundle.
+
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+
+## The problem it solves
+
+EP-0015 graduates the named-egress model: an off-box surface chooses *which boundary is this?* — a named `:rf.egress/*` profile — not *which combination of `:rf.size/*` booleans did I remember?*. The framework owns the authoritative table in `re-frame.projection/profile-size-opts` (`implementation/core`), but that namespace transitively requires the framework runtime graph (`re-frame.elision` → `re-frame.frame` → substrate adapter, …). The MCP servers must NOT pull that graph into their wire-egress decision:
+
+- **re-frame2-pair-mcp** ships as a self-contained Node `server.js` bundle; requiring the runtime graph would bloat it and trip bundle-isolation.
+- The profile→opts resolution is a *server-side* decision (it renders the resolved `:rf.size/*` map into the eval form before it crosses the wire), so it cannot defer to the live app's `project-egress`.
+
+This namespace is the pure-data, framework-runtime-free mirror of the six-member closed profile enum and its `:rf.size/*` floor. It is pure data over the keys [`vocab`](vocab.md) already owns (`:rf.size/include-sensitive?` / `:rf.size/include-large?` / `:rf.size/include-digests?`). No transport, no runtime, no framework dep — it loads identically into the JVM (story-mcp) and CLJS (re-frame2-pair-mcp).
+
+## Scope
+
+`egress` owns:
+
+- `profiles` — the closed six-member `:rf.egress/*` set.
+- `profile->size-opts` — the profile → `:rf.size/*` opt-set table.
+- `profile-size-opts` — the resolver (`[profile] → opt-set | nil`).
+
+`egress` does NOT own:
+
+- **The authoritative table.** `re-frame.projection/profile-size-opts` (`implementation/core`) is the single source of truth; this is a MIRROR pinned byte-identical to it by the conformance gate (below).
+- **Applying the floor.** Walking a value against the resolved `:rf.size/*` opt-set is the framework's `project-egress` job; this namespace only RESOLVES the named profile to the opt-set the server splices into its eval form.
+
+## The six profiles (EP-0015 §10, CLOSED enum)
+
+| Profile | `:rf.size/*` floor |
+|---|---|
+| `:rf.egress/off-box-observability` | sensitive redact, large elide, no digests |
+| `:rf.egress/off-box-tool`          | sensitive redact, large elide, digests ON (structural indicators) |
+| `:rf.egress/local-redacted`        | sensitive redact, large elide, no digests |
+| `:rf.egress/local-raw`             | sensitive AND large pass through |
+| `:rf.egress/ssr-hydration`         | sensitive redact, large elide, no digests |
+| `:rf.egress/public-error`          | sensitive redact, large elide, no digests |
+
+- `:rf.egress/off-box-tool` is the only off-box profile that turns `:rf.size/include-digests?` ON — the §10 "include structural indicators / counters so the tool can reason about shape without seeing content" clause. It is the MCP servers' DEFAULT off-box boundary.
+- `:rf.egress/local-raw` is the only profile that opts sensitive AND large back in (the trusted-local, operator-opt-in boundary, e.g. `--allow-sensitive-reads`).
+
+The opt-set keys are `vocab/include-sensitive-opt` / `vocab/include-large-opt` / `vocab/include-digests-opt` (the `:rf.size/include-*?` keywords [`vocab`](vocab.md) defines), so a rename of those keys is a one-edit change here.
+
+## Surface
+
+| Fn / def | Signature | Returns |
+|---|---|---|
+| `profiles` | (def) | the closed `#{:rf.egress/…}` six-member set |
+| `profile->size-opts` | (def) | `{profile → {:rf.size/include-*? bool}}` table |
+| `profile-size-opts` | `[profile]` | the `:rf.size/*` floor map, or `nil` for an unknown / absent profile |
+
+`profile-size-opts` returns `nil` (not a permissive default) for an unknown or `nil` profile — the closed enum means a caller never silently gets a permissive walk from a typo'd profile name.
+
+## Determinism + drift protection
+
+- **Pure-data, cross-platform.** No transport, no runtime, no framework dep; loads identically into JVM (story-mcp) and CLJS (re-frame2-pair-mcp).
+- **Pinned to the framework table.** The cross-MCP conformance gate `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/egress_profile_test.clj` loads BOTH the framework table (`re-frame.projection/profile-size-opts` over `re-frame.projection/profiles`) and this mirror, and asserts (1) the profile NAME sets are identical and (2) every profile resolves to the SAME `:rf.size/*` floor in both. A profile added / renamed in the framework, or an opt-set change (e.g. flipping `off-box-tool`'s digests), that does not also land here fails the gate. So the off-box-tool default the MCP servers ship is provably the framework's off-box-tool floor.
+
+## See also
+
+- [`README.md`](README.md) — the per-namespace index this doc is part of.
+- [`vocab.md`](vocab.md) — the `:rf.size/*` opt keys this table's values are keyed by.
+- [`tools/mcp-conformance/wire-vocab/`](../../mcp-conformance/wire-vocab/) — the JVM-side gate that pins this mirror byte-identical to the framework table.
+- [`/spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md) — EP-0015, the named-egress model this namespace mirrors for the MCP wire.

--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Per [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md), the framework's `rf/elide-wire-value` walker substitutes over-threshold leaves with a `{:rf.size/large-elided {…}}` marker before the payload leaves the runtime. Every MCP tool that returns a tree-typed payload surfaces a scalar count of those substitutions on its response envelope (the `:elided-large` slot — see [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)). This namespace owns the **counter**, not the walker.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the indicator-field splice (`with-indicators`) enforcing the MUST-level "omit when zero" rule, plus the wire-bounded `:rf.mcp/*` marker detection used by the cache + cap boundary steps. The indicator KEYS themselves live in [`vocab.md`](vocab.md); this ns owns the splice + detection logic.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/overflow.md
+++ b/tools/mcp-base/spec/overflow.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the overflow marker (the `{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens … :tool … :hint …}}` map). The cap-enforcement glue (counting tokens, replacing the payload) lives in [`cap.md`](cap.md).
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/section-grouping.md
+++ b/tools/mcp-base/spec/section-grouping.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Projects a flat diff patch-list into path-headed cluster **sections** — the same sections-per-cluster decomposition Xray's panel renderer ships (rf2-gfxmk Phase 1 of rf2-abts7), but computed from the patch list rather than the annotated tree. [`diff-encode.md`](diff-encode.md) consumes this to shape the `:db-after` marker's `:sections` slot.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP (xray-mcp was dropped in rf2-bu21t; xray now ships as a Clojars-only library, not an MCP server) — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The single source of truth for the marker keys an agent learns once and recognises across every MCP server in the re-frame2 pair — `re-frame2-pair-mcp` and `story-mcp`. A rename here is a wire-protocol break; the cross-MCP conformance gate under `tools/mcp-conformance/wire-vocab/` fails loud when that happens.
 
-This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
@@ -52,7 +52,11 @@
   integer ballpark of the response payload size (nil when a tool
   declares no hint — forward-compatible, the slot still renders so the
   row shape is uniform). Both are read from the RAW registry descriptor
-  exactly like the other facets.
+  exactly like the other facets. The `:required`-subset-of-`:input-keys`
+  relation is ENFORCED by `descriptor->row` (it throws on a descriptor
+  whose required keys are absent from its properties) — nothing in the
+  raw shape forces it, since the two slots are read from independent
+  descriptor sources.
 
   WIRE-SPLICED INPUTS (rf2-cwhod2). re-frame2-pair-mcp splices the
   universal `max-tokens` (and, for read tools, `cache`) knobs onto every
@@ -177,16 +181,38 @@
   `gated-keys` is a SET of input-key strings the server KNOWS it gates
   (e.g. story-mcp's `#{\"include-sensitive\"}`) — config-independent (the
   static slot set, not a read of the live gate atom), so the projection
-  stays deterministic + byte-stable."
+  stays deterministic + byte-stable.
+
+  ## Required-subset invariant
+
+  The row contract (this ns's spec) states `:required` is a SORTED
+  SUBSET of `:input-keys`. The two slots are read from INDEPENDENT
+  descriptor sources — `:input-keys` from `:inputSchema :properties`,
+  `:required` from `:inputSchema :required` — so nothing in the raw
+  shape forces the subset relation. A descriptor that names a required
+  argument absent from its advertised properties would emit an
+  inconsistent row (`:input-keys [\"known\"]` with `:required
+  [\"missing\"]`), blessing a mandatory argument the input surface never
+  declares and breaking the default/gate-open surface derivation
+  downstream. This fn now ENFORCES the invariant: a descriptor whose
+  required keys are not a subset of its property keys is REJECTED with an
+  `ex-info` naming the offending tool + the missing keys, rather than
+  emitting a self-inconsistent row."
   ([descriptor] (descriptor->row descriptor #{}))
   ([{:keys [name description inputSchema outputSchema annotations typicalTokens]} gated-keys]
    (let [input-keys (sorted-string-keys (:properties inputSchema))
+         required   (sorted-string-vec (:required inputSchema))
+         missing    (vec (sort (set/difference (set required) (set input-keys))))
          gated      (set (or gated-keys #{}))]
+     (when (seq missing)
+       (throw (ex-info (str "descriptor->row: required keys not a subset of input keys for tool "
+                            (pr-str name) " — missing from :inputSchema :properties: " (pr-str missing))
+                       {:tool name :required required :input-keys input-keys :missing missing})))
      {:name             name
       :description      description
       :input-keys       input-keys
       :gated-input-keys (filterv gated input-keys)
-      :required         (sorted-string-vec (:required inputSchema))
+      :required         required
       :output?          (some? outputSchema)
       :annotations      (sorted-string-keys annotations)
       :typicalTokens    typicalTokens})))

--- a/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
@@ -61,6 +61,43 @@
                                                :required [:b "a"]}})]
     (is (= ["a" "b"] (:required row)) "sorted + stringified")))
 
+(deftest descriptor->row-rejects-required-not-subset-of-input-keys
+  ;; manifest-contract invariant: :required is a SORTED SUBSET of
+  ;; :input-keys. The two slots are read from independent descriptor
+  ;; sources (:inputSchema :properties vs :inputSchema :required), so a
+  ;; descriptor can name a required argument absent from its advertised
+  ;; properties. Emitting that inconsistent row (input-keys ["known"]
+  ;; with required ["missing"]) blesses a mandatory argument the input
+  ;; surface never declares. descriptor->row must REJECT it.
+  (testing "a required key missing from :properties throws an ex-info naming the tool + missing keys"
+    (let [bad  {:name "broken"
+                :description "Names a required arg it does not declare."
+                :inputSchema {:type "object"
+                              :properties {:known {:type "string"}}
+                              :required ["missing"]}}
+          data (ex-data (is (thrown? clojure.lang.ExceptionInfo (dm/descriptor->row bad))))]
+      (is (= "broken" (:tool data)) "the ex-data names the offending tool")
+      (is (= ["missing"] (:missing data)) "and the keys absent from :properties")
+      (is (= ["known"] (:input-keys data)) "and the actual advertised input keys")))
+  (testing "a partially-valid required set still rejects on the missing member"
+    (let [bad {:name "partial"
+               :description "One valid, one missing required arg."
+               :inputSchema {:type "object"
+                             :properties {:event {:type "string"}}
+                             :required ["event" "absent"]}}]
+      (is (thrown? clojure.lang.ExceptionInfo (dm/descriptor->row bad)))))
+  (testing "the same rejection holds via build-manifest (the consumer entry-point)"
+    (let [bad {:name "broken" :description "d"
+               :inputSchema {:type "object"
+                             :properties {:known {:type "string"}}
+                             :required ["missing"]}}]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (dm/build-manifest :test [bad])))))
+  (testing "a valid subset (and the empty-required case) still projects cleanly"
+    ;; the happy path the original gate covered must keep passing.
+    (is (= ["event"] (:required (dm/descriptor->row (second sample-descriptors)))))
+    (is (= [] (:required (dm/descriptor->row (first sample-descriptors)))))))
+
 (deftest descriptor->row-handles-missing-optional-slots
   (let [row (dm/descriptor->row {:name "x" :description "d"
                                  :inputSchema {:type "object"}})]


### PR DESCRIPTION
Fixes the descriptor-manifest row-contract violation and brings the mcp-base per-namespace spec index current. Surface confined to `tools/mcp-base/`.

## BUG: required keys outside input-keys (rf2-cg0jxy)

`descriptor->row` read `:input-keys` (from `:inputSchema :properties`) and `:required` (from `:inputSchema :required`) from **independent** descriptor sources, so nothing forced the documented invariant that `:required` is a SORTED SUBSET of `:input-keys`. A descriptor naming a required argument absent from its properties emitted a self-inconsistent row — `:input-keys ["known"]` with `:required ["missing"]` — blessing a mandatory argument the advertised input surface never declares and breaking the default/gate-open surface derivation downstream.

Fix: `descriptor->row` now rejects such a descriptor with an `ex-info` (`:tool` / `:required` / `:input-keys` / `:missing`) instead of emitting the inconsistent row; `build-manifest` inherits the rejection. `:required` is already sorted (deterministic order); the enforcement closes the gap the spec assumed but never enforced.

**Backward-compatible:** every committed story-mcp + pair-mcp manifest row already satisfies the invariant (verified: 20/20 story rows, 29/29 pair rows, 0 violations), so the consumer generators regenerate byte-identically. Verified by the JVM story-mcp `--check` and the wire-vocab gate (both green below).

Regression tests added: missing-required-property rejection (direct + via `build-manifest`), partially-valid-required, and the valid-subset / empty-required happy paths still project cleanly.

## Vestigial review (rf2-kdmalg)

One real in-slice vestige found and fixed: the `egress` namespace (EP-0015 §10 cross-MCP `:rf.egress/*` profile mirror) shipped **without** a per-namespace spec doc and was **absent from the spec index**, while every per-namespace doc claimed "Eleven namespaces" against **twelve** shipped `src/` namespaces.

- Added `spec/egress.md` (authored faithfully from the shipped `egress.cljc` source + its `mcp-conformance` egress-profile gate — no speculative content).
- Added the `egress` row to `spec/README.md`'s index, bumped the count to "Twelve", and cross-linked `egress.md` into every sibling doc's See-also list.
- `egress.cljc` itself is **live** (consumed by `story-mcp/tools/egress.cljc`; pinned byte-identical to the framework table by `tools/mcp-conformance/wire-vocab/.../egress_profile_test.clj`) — not vestigial.
- The `xray-mcp` "Historical" notes (deps.edn, README, handler-arity.md, sensitive.md) are correct retained context explaining why the triplet became a pair — left as-is.

## Quality gates

- `clojure -M:test` in `tools/mcp-base` — **236 tests, 780 assertions, 0 failures, 0 errors**.
- `npm run test:mcp-conformance` (from `implementation/`) — **all six gates GREEN** (JVM story-mcp incl. `--check`; story-mcp stdio roundtrip; pair-mcp shadow-cljs `:server-test`; pair-mcp + story-mcp SDK conformance; wire-vocab `72 tests / 762 assertions / 0 failures`). Run because mcp-base is shared infra; confirms no consumer (story-mcp / pair-mcp / #4305 ratchet) breakage.
