### PR TITLE
chore(impl): vestigial review — http/machines/routing/resources/schemas

### DIFF
--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -534,7 +534,7 @@
 ;; The bead's core failure: a `register-marks!` (not `union-marks!`) called
 ;; AFTER `reg-machine` previously REPLACED the `:event` entry and dropped the
 ;; schema-derived `[:data …]` marks. The separate schema-marks table + read-
-;; time union (plus skipping `reg-event-fx`'s bare-meta clear for machines)
+;; time union (plus skipping `reg-event`'s bare-meta clear for machines)
 ;; makes BOTH orders yield the identical union.
 
 (deftest manual-register-marks-before-reg-machine-unions
@@ -703,7 +703,7 @@
 ;; `reg-machine`): the validator walks only the grammar keys (`:states` /
 ;; `:initial` / `:guards` / `:actions` / `:on` / `:after` / `:always` /
 ;; `:spawn` / …), so a top-level `:sensitive` / `:large` key is NOT rejected —
-;; it is IGNORED. And `reg-event-fx`'s mark-stashing is SKIPPED for a machine
+;; it is IGNORED. And `reg-event`'s mark-stashing is SKIPPED for a machine
 ;; registration (`:rf/machine?` meta, rf2-qpibk0), so the top-level key feeds
 ;; NO marks entry. The disposition is therefore "provably a no-op": a token
 ;; written into `:data` under such a spec rides RAW at snapshot egress because
@@ -736,7 +736,7 @@
           "reg-machine does not throw on a top-level :sensitive / :large key
            — the key is ignored, never honoured as a classification route")
       ;; (b) NO marks entry is registered for the top-level key — it fed
-      ;; nothing into the marks table (reg-event-fx's mark-stash is skipped
+      ;; nothing into the marks table (reg-event's mark-stash is skipped
       ;; for machines; the top-level key is not a :data-schema prop).
       (is (nil? (marks/marks-for :event neg-id))
           "the top-level :sensitive / :large key registers NO marks — only

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -4,7 +4,7 @@
   Spec 009 §Trace correlation: every trace event emitted inside a
   handler's execution scope carries the in-scope handler's registration
   coord under the top-level `:rf.trace/trigger-handler` slot. Machines
-  register as event handlers via `reg-event-fx` (per
+  register as event handlers via `reg-event` (per
   `reg-machine*` in `lifecycle_fx/registration.cljc`), so when a machine transition
   trace fires inside the machine's event-handler scope it picks up the
   machine's own registration coord via `emit!`'s hoist of

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -167,7 +167,7 @@
 
 (def ^:private resource-event-family
   "The CURRENT, complete `:rf.resource/*` + `:rf.resource.internal/*` event
-  family the façade registers (re-frame.resources `reg-event-fx` calls). Kept
+  family the façade registers (re-frame.resources `reg-event` calls). Kept
   in lock-step with the façade registrations — when a resource event is
   added/removed there, this list moves with it so the smoke is never stale
   (rf2-l1a0s7). The `:rf.mutation/*` causal-write family is a SEPARATE

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -152,7 +152,7 @@
       ;; but the `:on-match` vector is the same across frames since
       ;; the framework dispatches each on-match event to the calling
       ;; frame (the `{:frame frame-id}` opt on the per-thread tick
-      ;; reg-event-db ensures the event lands on the right frame).
+      ;; reg-event ensures the event lands on the right frame).
       ;; Wait — :on-match dispatches honour the calling frame, so we
       ;; actually need ONE on-match event registered per frame. Use
       ;; per-frame routes so the `:on-match` payload is per-frame.
@@ -391,7 +391,7 @@
                            {:db (update db :n (fnil inc 0))})))
       ;; Stable route shared across all dispatcher threads. Each
       ;; thread's :on-match dispatch lands on its OWN frame (per
-      ;; reg-event-db {:frame frame-id} above) — but the route
+      ;; reg-event {:frame frame-id} above) — but the route
       ;; metadata's :on-match vector references each thread's tick
       ;; event in turn. Use one route per thread so the on-match
       ;; payload is per-thread.

--- a/implementation/routing/test/re_frame/routing_framework_authority_test.clj
+++ b/implementation/routing/test/re_frame/routing_framework_authority_test.clj
@@ -13,7 +13,7 @@
   warning is noise.
 
   The fix introduces the general `:rf/framework-authority? true` registration-
-  meta key (stamped by the routing façade's `reg-event-fx` registrations);
+  meta key (stamped by the routing façade's `reg-event` registrations);
   the router reads the general key (folding in the `:rf/machine?` implication
   via `events/framework-authority?`).
 

--- a/implementation/routing/test/re_frame/routing_test_support.clj
+++ b/implementation/routing/test/re_frame/routing_test_support.clj
@@ -15,7 +15,7 @@
   Per the long-established consumer-test pattern: `reset-runtime` wipes the
   registrar (`clear-all!`), re-inits the plain-atom substrate, and
   `(require 're-frame.routing :reload)` re-runs the façade's
-  `reg-event-fx` / `reg-fx` / `reg-sub` / hook / listener wires on the
+  `reg-event` / `reg-fx` / `reg-sub` / hook / listener wires on the
   fresh registrar. The `:rf.test/simulate-http-resolution` fixture event
   (`re-frame.routing.test-support`) and `re-frame.ssr`'s ns-load
   registrations are re-seated the same way."

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -36,7 +36,7 @@
 ;; machines) — fine while these tests ran in isolation, but hostile to
 ;; cross-ns CLJS test runs because CLJS cannot reload them. Snapshot/
 ;; restore preserves them and still rolls back per-test app-schema /
-;; reg-event-db / reg-sub on the way out.
+;; reg-event / reg-sub on the way out.
 ;;
 ;; `:clear-app-schemas? true` gives the test a clean app-schema slate
 ;; per-test (per rf2-cq1ak app-db schemas live OUTSIDE the registrar in


### PR DESCRIPTION
Actions five AUTHORITATIVE vestigial-review beads — one disjoint implementation slice each.

## Findings (per slice)

| Slice | Result |
| --- | --- |
| `implementation/http` | **Clean** — zero edits (18 src + 37 test files reviewed) |
| `implementation/machines` | 4 stale EP-0018 prose refs fixed |
| `implementation/routing` | 4 stale EP-0018 prose refs fixed |
| `implementation/resources` | 1 stale EP-0018 prose ref fixed |
| `implementation/schemas` | 1 stale EP-0018 prose ref fixed |

The single vestige category found across all five slices was **stale EP-0018 narrative**: test comments/docstrings presenting the removed `reg-event-fx` / `reg-event-db` as the *live* event-registration mechanism. Per EP-0018 the one public form is `reg-event` (facades register via `events/reg-event`). All fixes are comment/docstring-only — no code change.

The facade-exported throwing stubs that name the retired `reg-event-db` / `reg-event-fx` / `reg-event-ctx` (in core, out of scope here) are correct and untouched — only narrative prose presenting the retired names as live was corrected.

Verified each slice against shipped reality: EP-0022 (`reg-interceptor*` usage is the correct public form, no `->interceptor` misuse), EP-0002 (`init!` "no longer synthesises `:rf/default`" prose is correct current-behaviour doc, not vestige), EP-0003 (recent resources trace-op code is fresh/active), and schemas bundle-probe/prod-runner files have live npm-script + build-id consumers. No removed-API references, dead scaffolding, orphan helpers, or broken cross-refs found.

Closes rf2-37tzv2, rf2-qsolcd, rf2-g3gqdk, rf2-10r3x1, rf2-0fu4ku.

## Quality gates

- `clj-kondo --lint` on all 7 edited files: **0 errors**, 8 warnings (all pre-existing, unrelated to changed comment lines).
- Comment/docstring-only edits to test namespaces — no symbol or code change, so full-JVM test runs (Windows deadlock risk) are not warranted; the lint pass is the slice-appropriate bounded gate.
