### PR TITLE
docs(adapters): list use-current-frame/set-hiccup-emitter!/wrap-view in helix+uix READMEs

### DIFF
--- a/implementation/adapters/helix/README.md
+++ b/implementation/adapters/helix/README.md
@@ -11,6 +11,9 @@ See [`../README.md`](../README.md) for the wider adapter tier and the substrate 
 - `re-frame.adapter.helix/use-subscribe` — Helix hook returning the current value of a subscription; re-renders the calling component when the value changes. Resolves the frame from the surrounding `frame-provider` via React context. Override via the 2-arg form to pin to an explicit frame-id.
 - `re-frame.adapter.helix/frame-provider` — provider component that scopes a child tree to a named frame.
 - `re-frame.adapter.helix/flush-views!` — test helper; wraps React's `act()` to flush pending renders synchronously.
+- `re-frame.adapter.helix/use-current-frame` — Helix hook returning the current frame keyword from the surrounding React context (the narrow raw `useContext` read), or the no-provider sentinel when no `frame-provider` sits above. For the full resolution chain, prefer `(rf/current-frame-id)`.
+- `re-frame.adapter.helix/set-hiccup-emitter!` — installs a render-tree → HTML fn for `render-to-string`; idempotent. SSR consumers call this to wire the hiccup emitter explicitly.
+- `re-frame.adapter.helix/wrap-view` — wraps a Helix-shape user component to inject the `data-rf2-source-coord` attribute on the rendered root DOM element when debug is enabled; elided in production builds.
 
 ## Imperative escape hatch — when you need a DOM lifecycle
 

--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -13,6 +13,9 @@ See [`../README.md`](../README.md) for the wider adapter tier and the substrate 
 - `re-frame.adapter.uix/use-subscribe` — UIx hook returning the current value of a subscription; re-renders the calling component when the value changes. Resolves the frame from the surrounding `frame-provider` via React context. Override via the 2-arg form to pin to an explicit frame-id.
 - `re-frame.adapter.uix/frame-provider` — provider component that scopes a child tree to a named frame.
 - `re-frame.adapter.uix/flush-views!` — test helper; wraps React's `act()` to flush pending renders synchronously.
+- `re-frame.adapter.uix/use-current-frame` — UIx hook returning the current frame keyword from the surrounding React context (the narrow raw `useContext` read), or the no-provider sentinel when no `frame-provider` sits above. For the full resolution chain, prefer `(rf/current-frame-id)`.
+- `re-frame.adapter.uix/set-hiccup-emitter!` — installs a render-tree → HTML fn for `render-to-string`; idempotent. SSR consumers call this to wire the hiccup emitter explicitly.
+- `re-frame.adapter.uix/wrap-view` — wraps a UIx-shape user component to inject the `data-rf2-source-coord` attribute on the rendered root DOM element when debug is enabled; elided in production builds.
 
 ## Imperative escape hatch — when you need a DOM lifecycle
 


### PR DESCRIPTION
Adds the three omitted public APIs to the Helix and UIx adapter READMEs' 'Adapter-specific surface' sections. The lists previously enumerated only 3 of 6 public functions (use-subscribe, frame-provider, flush-views!); the three docstring-bearing public functions use-current-frame, set-hiccup-emitter!, and wrap-view were missing.

Each new entry was verified against the shipped adapter source (re-frame.adapter.helix / re-frame.adapter.uix): the var exists, is public, and the description matches its docstring. Doc-only; no code change.

## Quality gates

- `python scripts/check_readme_links.py` — PASS (exit 0)
- `python scripts/check_doc_slugs.py` — N/A (no new anchors/section links added)