### PR TITLE
fix(story): preserve keyword namespaces in share URLs + vestigial review

### DIFF
--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -71,12 +71,10 @@
             ;; (`register-listener!` / `unregister-listener!`) lives in
             ;; `re-frame.trace.tooling` (production-DCE split).
             [re-frame.trace.tooling    :as trace-tooling]
-            [re-frame.interop          :as interop]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
             [re-frame.story.error      :as story-error]
-            [re-frame.story.frames     :as frames]
             [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.registrar  :as registrar]))

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -35,7 +35,8 @@
                                   `WxH` custom (e.g. `800x600`)
   - `<id-or-#rrggbb>` for background — preset keyword (`dark`) or a
                                        hex colour string (`#abc123`)
-  - `<s>` — substrate id (omitted when `:reagent` default)
+  - `<s>` — substrate id, namespace-preserving like `<id>`
+            (`:my.lib/uix` → `my.lib/uix`); omitted when `:reagent` default
 
   Per rf2-o4u18 the URL is the sharability surface of the testbed: a
   teammate pasting a URL must land on the exact same view (workspace
@@ -450,7 +451,7 @@
     (conj (kv-pair :overrides (build-overrides-token cell-overrides)))
 
     (and substrate (not= substrate :reagent))
-    (conj (kv-pair :substrate (url-encode (name substrate))))))
+    (conj (kv-pair :substrate (url-encode (kw->str substrate))))))
 
 (defn parse-params
   "Pure inverse of `build-params` — given a `{param-name → string}`

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -48,6 +48,19 @@
                                   :substrate  :uix})]
       (is (some #(str/starts-with? % "substrate=") ps)))))
 
+(deftest build-params-substrate-preserves-namespace
+  (testing "rf2-j5yv6y — a qualified substrate id (e.g. a host app's
+            :my.lib/uix) keeps its namespace on the wire instead of being
+            collapsed to its bare name. Mirrors the namespace-preserving
+            encoding used for :variant / :workspace."
+    (let [ps (share/build-params {:variant-id :story.foo/bar
+                                  :substrate  :my.lib/uix})
+          sp (some #(when (str/starts-with? % "substrate=") %) ps)]
+      (is (some? sp))
+      ;; The `/` is percent-encoded to %2F on the wire.
+      (is (str/includes? sp "my.lib%2Fuix")
+          "the namespace survives encoding (no bare `uix`)"))))
+
 ;; ---- variant-share-url ---------------------------------------------------
 
 (deftest variant-share-url-no-base
@@ -111,6 +124,24 @@
   would), and parse it back. Returns the reconstructed overrides map."
   [ov]
   (share/parse-overrides-param (url-decode (share/build-overrides-token ov))))
+
+;; ---- rf2-j5yv6y: substrate id round-trips namespace ----------------------
+
+(deftest substrate-round-trips-qualified
+  (testing "rf2-j5yv6y — a qualified substrate id round-trips through
+            build-params → URL decoding → parse-params without losing its
+            namespace. A registered custom substrate like :my.lib/uix must
+            hydrate back to the SAME id, not a different bare :uix."
+    (let [substrate :my.lib/uix
+          ps        (share/build-params {:variant-id :story.foo/bar
+                                         :substrate  substrate})
+          sp        (some #(when (str/starts-with? % "substrate=") %) ps)
+          ;; URLSearchParams.get returns the decoded value; emulate it.
+          decoded   (url-decode (subs sp (count "substrate=")))]
+      (is (= substrate (share/parse-substrate-param decoded))
+          "qualified substrate id survives the full encode → decode → parse")
+      (is (= substrate (:substrate (share/parse-params {"substrate" decoded})))
+          "and through the full parse-params inverse"))))
 
 (deftest overrides-codec-round-trips-simple
   (testing "rf2-j0hwf — simple overrides round-trip through build/parse"


### PR DESCRIPTION
@
## What

Fixes two `tools/story/` beads (both AUTHORITATIVE).

### rf2-j5yv6y — substrate share URLs drop keyword namespaces (BUG)

`build-params` encoded the active substrate with `(name substrate)`, dropping the keyword namespace. A registered custom substrate like `:my.lib/uix` produced `substrate=uix` on the wire; on hydration that parsed back to `:uix` — a *different* id that may miss the substrate registry or select the wrong substrate.

The decode side already preserved namespaces (`parse-substrate-param` → `parse-keyword-token`, which reads qualified tokens). Only the encode dropped them, diverging from the namespace-preserving `:variant` / `:workspace` encoders that use `kw->str`.

**Fix:** switch the substrate encoder from `(name substrate)` to `(kw->str substrate)`. Qualified substrate ids now round-trip `build-params` → URL decode → `parse-params` without losing the namespace; unqualified ids are unchanged (`(kw->str :uix)` = `"uix"`). The `:reagent`-default omission is untouched.

**Tests added** (`story_share_test.clj`):
- `build-params-substrate-preserves-namespace` — `:my.lib/uix` encodes to `substrate=my.lib%2Fuix`, not bare `uix`.
- `substrate-round-trips-qualified` — full encode → URL-decode → `parse-substrate-param` / `parse-params` round-trip recovers the SAME qualified id.

Docstring URL-scheme line updated to note the substrate is namespace-preserving like `<id>`.

### rf2-s0dyer — vestigial review: tools/story

Reviewed the slice. Removed two genuinely-dead requires from `re-frame.story.play` (`re-frame.interop`, `re-frame.story.frames`) — both aliases appeared only inside docstrings, never in code (verified by grep; the only `frames/` hits are descriptive `frames/destroy!` mentions in two docstrings).

Rest of the slice reviewed clean:
- The "retired"/"legacy"/"no longer" comments are live historical context, not vestige.
- The QR/share-popover surfaces are already removed (regression-gated by `no-third-party-qr-endpoint` / `no-qrserver-literal-in-share-source`).
- `deps.cljs` is `{:npm-deps {}}` by design (the retired `qrcode-generator` dep is gone; the comment explains why and the live axe-core CDN constraint).
- `ensure-xray-mounted!` is already removed (only a removal-note comment remains).
- Public share/play/loader/recorder/xray-preset surfaces all have live consumers or are exported facade.

## Scope

Only `tools/story/` touched. No contract change requiring a spec edit (the namespace-drop was a bug, not a documented wire contract); the share.cljc URL-scheme docstring was clarified in-slice.

## Quality gates

- `clojure -M:test` in `tools/story/`: **1685 tests, 6239 assertions, 0 failures, 0 errors** (includes the two new substrate tests; confirms the `play.cljc` require removal compiles).
@