### PR TITLE
docs(EP): refresh corpus cross-references (earlier finals → later EPs)

### DIFF
--- a/docs/EP/EP-0010-causal-world-inputs.md
+++ b/docs/EP/EP-0010-causal-world-inputs.md
@@ -127,7 +127,7 @@ closing bead-ids / commits are cited per step.
   framework `reg-cofx` for them ships yet — by design, not as a gap. This item
   graduates with that EP.
 - **Successor — [EP-0017 Recordable Coeffects](EP-0017-recordable-coeffects.md)
-  (accepted 2026-06-13).** EP-0017 is that follow-on EP: it completes and
+  (final).** EP-0017 is that follow-on EP: it completes and
   continues this EP's authoring surface, renaming the envelope field
   `:rf.world/inputs` → `:rf.cofx` (flat), re-expressing the deferred recordable
   `:uuid` / `:random` slice as app-registered value-returning suppliers, and

--- a/docs/EP/EP-0016-resource-mutation-completion.md
+++ b/docs/EP/EP-0016-resource-mutation-completion.md
@@ -393,6 +393,20 @@ and inspect.
   (final).** This EP is a post-final amendment to the resources contract. It
   does not reopen the read-resource foundation, work ledger, route ownership,
   SSR, cache-hit, lifecycle, or HTTP-only graduation decisions.
+- **[EP-0019](EP-0019-optimistic-mutation-rollback.md) (proposal) — successor.**
+  The optimistic rollback / tag-addressed patching this EP defers (see
+  [§Non-Goals](#non-goals), [§Synthesis from alternatives](#synthesis-from-alternatives),
+  and issue 9 in [§Open Issues](#open-issues)) is the subject of EP-0019. It
+  reuses this EP's scoped-invalidation descriptors, map-form exact targets, and
+  `:reply-to` continuation unchanged.
+- **[EP-0020](EP-0020-active-owner-polling.md) (proposal) — successor.**
+  Interval revalidation (polling) is the cache-freshness sibling of this EP's
+  mutation/invalidation surface; it reuses the same named scope resolvers and
+  refetch substrate.
+- **[EP-0021](EP-0021-infinite-resources.md) (proposal) — successor.** The
+  pagination / infinite-feed primitives this EP lists as a non-goal
+  ([§Non-Goals](#non-goals): "No pagination primitives") are designed in
+  EP-0021, which builds on the read-resource and invalidation surfaces here.
 - **[EP-0011](EP-0011-uniform-async-reply-envelope.md) (accepted).** Mutation
   `:reply-to` uses the same core idea: async completion is a causal reply map
   delivered to an event target. EP-0016 is the concrete resources/mutations

--- a/docs/EP/EP-0018-one-event-registration.md
+++ b/docs/EP/EP-0018-one-event-registration.md
@@ -141,6 +141,15 @@ stubbing by re-registration.
 
 ## Relationships
 
+- **[EP-0022](EP-0022-registered-interceptors.md) (Registered Interceptors) —
+  forward errata.** This EP names `->interceptor` as the public form for the
+  full-context work it moves off `reg-event-ctx` (see §3, §7, and the Rationale).
+  **EP-0022 supersedes that guidance:** `->interceptor` is no longer a public
+  authoring form, and full-context interceptor behavior is now authored with
+  **`reg-interceptor`** and referenced by id in event/frame `:interceptors`
+  chains. Where the `->interceptor` examples below appear, read them as
+  `reg-interceptor` + an interceptor ref per EP-0022 §10. The decisions of this
+  EP (the `reg-event` collapse, the `reg-event-ctx` demotion) are unchanged.
 - **[EP-0017](EP-0017-recordable-coeffects.md) (Recordable Coeffects)** — the
   decisive driver: `reg-event-db` cannot declare `:rf.cofx/requires` (a
   registration-time error today), so the collapse closes a hole EP-0017

--- a/docs/EP/EP-0020-active-owner-polling.md
+++ b/docs/EP/EP-0020-active-owner-polling.md
@@ -139,6 +139,11 @@ concept. A poll is "while a live cause keeps this entry alive, keep it fresh."
   cancel-then-arm reschedule, frame-destroy teardown via the single
   `:resources/on-frame-destroyed!` hook). The proposed §Polling section lives
   next to it.
+- **[EP-0016](EP-0016-resource-mutation-completion.md) (final).** EP-0016
+  amended Spec 016 with mutation completion, scoped invalidation descriptors,
+  and named scope resolvers. Polling composes with that surface: a poll tick is
+  an ordinary `:rf.resource/refetch` and a polled scoped resource resolves its
+  scope through the same `reg-resource-scope` resolvers.
 - **Focus/reconnect active-stale revalidation (landed, `rf2-vtblcq`).** Polling
   reuses the exact scan-and-refetch discipline of
   `re-frame.resources.events/revalidate-handler`: select active-owner entries,


### PR DESCRIPTION
Refreshes the EP-corpus cross-reference web (rf2-rortt5): earlier `final` EPs were not updated to point forward to landed/proposed successors. Errata-grade cross-ref / see-also prose only — no EP design body rewritten, no `Status` changed. Edits confined to `docs/EP/*.md`; every target verified to exist and every relationship verified real.

## Cross-references added

1. **EP-0018 → EP-0022 (MED).** EP-0018 named `->interceptor` as the public replacement for retired `reg-event-ctx` full-context work with zero mention of EP-0022. Added a forward-errata Relationships bullet: EP-0022 supersedes that guidance — full-context authoring is now `reg-interceptor` + interceptor refs (per EP-0022 §10); the `reg-event` collapse / `reg-event-ctx` demotion decisions are unchanged. (EP-0022 already back-references EP-0018; this closes the doc-layer half of rf2-0adhqs.12/.13.)
2. **EP-0016 → EP-0019 / EP-0020 / EP-0021 (MED).** EP-0016 defers optimistic rollback, polling, and pagination "to a dedicated EP" but cited none of the now-existing successors. Added three successor Relationships bullets: deferred optimistic-rollback → EP-0019, cache-freshness/polling → EP-0020, pagination/infinite → EP-0021.
3. **EP-0020 → EP-0016 (MED, bidirectional polling pair).** EP-0020's Relationships listed EP-0003/0010/0002/0011/0015/0014 but not EP-0016. Added the EP-0016 bullet (polling composes with mutation completion / scoped invalidation / named scope resolvers).
4. **EP-0010 → EP-0017 (LOW, stale status).** EP-0010's successor note called EP-0017 "(accepted 2026-06-13)"; EP-0017 is now `final`. Refreshed the annotation to "(final)".

## Quality gates

- `python scripts/check_ep_status_sync.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0; only pre-existing INFO lines, no warnings/errors; new intra-doc anchor links resolve)
- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_readme_links.py` — pass (exit 0)

All four re-run green after rebase onto current `origin/main`.

Refs: rf2-rortt5
