### PR TITLE
chore(core): vestigial review

### DIFF
--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -48,7 +48,7 @@
   "Per Spec 012 §Trace events and rf2-dn26r. Remove a registered
   route; emits `:rf.route/cleared` so tools subscribing to route
   lifecycle observe the removal. Symmetric with `:rf.flow/cleared`
-  (per [013-Flows.md §Flow tracing](013-Flows.md#flow-tracing)).
+  (per [013-Flows.md §Flow tracing](../../../../../spec/013-Flows.md#flow-tracing)).
   No-op when the route id is not registered. Late-bound via
   `:routing/clear-route`."
   {:hook :routing/clear-route :artefact routing-artefact :on-absent :throw

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -204,8 +204,8 @@
           ;; trace surface sees them as :rf/redacted
           ...))
 
-  Per [Spec 009 §Privacy](009-Instrumentation.md) and
-  [Security.md §Behavioural MUSTs across the privacy surface](Security.md#behavioural-musts-across-the-privacy-surface)."
+  Per [Spec 009 §Privacy](../../../../../spec/009-Instrumentation.md) and
+  [Security.md §Behavioural MUSTs across the privacy surface](../../../../../spec/Security.md#behavioural-musts-across-the-privacy-surface)."
   [paths]
   (let [paths (vec paths)]
     (interceptor/->interceptor*


### PR DESCRIPTION
## Summary

Vestigial review of `implementation/core/` (rf2-orp5zb). Scanned `src/` and `test/` for dead code, removed-API references in narrative prose, stale EP spellings, dead scaffolding, and broken cross-refs.

**Outcome: near-clean.** The only real vestige found was two stale bare-filename cross-references in core docstrings, now fixed to the established `spec/`-relative form. Everything else was verified as either live or intentional.

## Changes

- `core_routing.cljc` — `clear-route` docstring: `013-Flows.md` link was a bare filename (`](013-Flows.md#...)`) that does not resolve from the source-file location and is inconsistent with the dominant convention. Fixed to `../../../../../spec/013-Flows.md#...`.
- `privacy.cljc` — `redact-interceptor` docstring: `009-Instrumentation.md` and `Security.md` links were bare filenames; fixed to the `../../../../../spec/...` form.

All three target files exist (`spec/013-Flows.md`, `spec/009-Instrumentation.md`, `spec/Security.md`); only the link paths were stale. These were the only 2 bare-filename markdown links in core src against 19+ full-path references — genuine outliers.

## Verified clean (no action)

- **Retired-name throwing stubs + "is removed/retired" prose** (`reg-event-db`/`-fx`/`-ctx`, `inject-cofx`, `add-marks`/`set-marks`, `reg-machine*`) — intentional and correct; left as-is. No prose presents a retired form as live/recommended.
- **Dead private helpers** — none found in `.cljc` or `.cljs` src (all `defn-`/`def ^:private` have callers).
- **Commented-out code / dead scaffolding** — none (only legitimate explanatory comments and one `#_:clj-kondo/ignore` directive).
- **Disabled/unreachable tests** — none (`^:disabled`, `#_deftest`, whole-body `(comment ...)` — none present).
- **Stale EP spellings + broken spec/docs/EP cross-refs** — none beyond the two links above; EP-0001..EP-0022 and referenced spec files all exist.
- **Test-tree narrative** — clean; the #4325 narrative fixes held.

## Quality gates

Comment/docstring-only change (no code semantics altered). Reader-conditional-aware read of both touched `.cljc` namespaces succeeds (core_routing.cljc 11 top-forms, privacy.cljc 18 top-forms) — files remain syntactically valid. No behavioural test warranted.
