### PR TITLE
fix: derivation-conf machine-destroy + test-quiet stdout passthrough + 7GUIs cell errors

### DIFF
--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -125,40 +125,88 @@
        (remove str/blank?)
        (vec)))
 
+;; A formula's expected shape, in user terms — reused across every parse
+;; error message so the user always learns what a valid formula looks like.
+(def formula-shape-hint
+  "=(+ A1 B2) — start with '=', then numbers, cell refs (A1..Z100), and +-*/ inside ().")
+
 (defn parse-tokens [tokens]
-  ;; Returns [ast remaining-tokens] or throws on malformed input.
+  ;; Returns [ast remaining-tokens] or throws on malformed input. Each
+  ;; ex-info carries the offending token in its data so `parse-formula` can
+  ;; build an actionable, position-aware message (rf2-5tim8h).
   (if (empty? tokens)
     [nil tokens]
     (let [[t & more] tokens]
       (case t
         "(" (loop [acc [] toks more]
               (cond
-                (empty? toks)        (throw (ex-info "Unbalanced (" {}))
+                (empty? toks)        (throw (ex-info "a '(' is never closed — add a matching ')'"
+                                                     {:token "("}))
                 (= ")" (first toks)) [acc (rest toks)]
                 :else                (let [[child rest-toks] (parse-tokens toks)]
                                        (recur (conj acc child) rest-toks))))
-        ")" (throw (ex-info "Unexpected )" {}))
+        ")" (throw (ex-info "an extra ')' has no matching '(' — remove it or add a '('"
+                            {:token ")"}))
         ;; Atom: number, cell ref, or operator symbol.
         (let [num (parse-num t)]
           (cond
             (some? num)                    [num                             more]
             (re-matches cell-re t)         [{:cell t}                       more]
             (#{"+" "-" "*" "/"} t)         [(symbol t)                      more]
-            :else                          (throw (ex-info "Bad atom" {:token t}))))))))
+            :else                          (throw (ex-info (str "'" t "' is not a number, a cell ref "
+                                                                "(A1..Z100), or one of + - * /")
+                                                           {:token t}))))))))
 
-(defn parse-formula [raw]
-  ;; raw is "=..."; returns the parsed AST.
-  (let [body (subs raw 1)]
-    (try
-      (let [[ast leftover] (parse-tokens (tokenise body))]
-        (when (seq leftover)
-          (throw (ex-info "Trailing tokens" {:tokens leftover})))
-        ast)
-      (catch :default _e :error/parse))))
+(defn parse-error-message
+  "Build an actionable parse-error message for cell `id` (may be nil) whose
+   formula text is `raw`, given the caught exception `e`. Names the cell, shows
+   the formula, points at the offending token where known, and states the
+   expected shape in user terms (rf2-5tim8h)."
+  [id raw e]
+  (let [reason (or (ex-message e) "could not be parsed")
+        token  (:token (ex-data e))
+        ;; Token position in the formula body (1-based, after the '='), where
+        ;; the offending token can be located. Best-effort: nil when unknown.
+        pos    (when (and token (string? raw))
+                 (let [i (str/index-of raw token)]
+                   (when i (inc i))))]
+    (str "Cell " (or id "?") ": can't parse formula \"" raw "\""
+         (when pos (str " (near position " pos
+                        (when token (str ", token \"" token "\"")) ")"))
+         " — " reason ". Expected " formula-shape-hint)))
+
+(defn parse-formula
+  "Parse `raw` (a \"=...\" formula) for cell `id` (used only to make the error
+   message name the cell). Returns the AST on success, or a `[:error/parse msg]`
+   pair carrying an actionable message on failure (rf2-5tim8h)."
+  ([raw] (parse-formula nil raw))
+  ([id raw]
+   (let [body (subs raw 1)]
+     (try
+       (let [[ast leftover] (parse-tokens (tokenise body))]
+         (when (seq leftover)
+           (throw (ex-info (str "extra tokens after the formula: "
+                                (str/join " " leftover))
+                           {:token (first leftover)})))
+         ast)
+       (catch :default e
+         [:error/parse (parse-error-message id raw e)])))))
+
+(defn parse-error?
+  "True iff `ast` is the `[:error/parse msg]` failure pair."
+  [ast]
+  (and (vector? ast) (= :error/parse (first ast))))
+
+(defn parse-error-text
+  "The actionable message from a `[:error/parse msg]` pair (nil otherwise)."
+  [ast]
+  (when (parse-error? ast) (second ast)))
 
 (defn collect-deps [ast]
-  ;; Returns the set of cell ids referenced anywhere in the AST.
+  ;; Returns the set of cell ids referenced anywhere in the AST. A parse-error
+  ;; pair (`[:error/parse msg]`) is not an AST and carries no deps.
   (cond
+    (parse-error? ast)    #{}
     (vector? ast)         (apply clojure.set/union (map collect-deps ast))
     (and (map? ast)
          (:cell ast))     #{(:cell ast)}
@@ -188,18 +236,24 @@
           "*" (apply * vals)
           "/" (if (some zero? (rest vals)) :error/div-by-zero (apply / vals))
           :error/unknown-op)
-        (or (first (filter keyword? vals)) :error/type)))
+        ;; Surface the first upstream error marker that reached us — a
+        ;; referenced cell's parse-error pair or a keyword error marker — else
+        ;; :error/type for text-in-arithmetic.
+        (or (first (filter parse-error? vals))
+            (first (filter keyword? vals))
+            :error/type)))
 
     :else :error/eval))
 
 (defn evaluate-cell [id cells visited]
-  ;; Returns the cell's display value, or :error/cycle, or :error/parse.
+  ;; Returns the cell's display value, :error/cycle, or the parse-error pair
+  ;; `[:error/parse msg]` (the actionable message rides through to the view).
   (cond
     (visited id)  :error/cycle
     :else
     (if-let [{:keys [raw formula? ast]} (get cells id)]
       (cond
-        (= ast :error/parse) :error/parse
+        (parse-error? ast)   ast
         formula?             (evaluate-ast ast cells (conj visited id))
         :else                (let [n (parse-num raw)]
                                (if (some? n) n raw)))
@@ -231,7 +285,7 @@
    :schema [:cat [:= :cells/commit] :string :string]}
   (fn handler-cells-commit [{:keys [db]} [_ id raw]]
     {:db (let [formula? (and (string? raw) (str/starts-with? raw "="))
-          ast      (when formula? (parse-formula raw))
+          ast      (when formula? (parse-formula id raw))
           deps     (when formula? (collect-deps ast))
           entry    (cond
                      (str/blank? raw) nil           ;; empty → remove the cell
@@ -293,9 +347,12 @@
         editing?   (= editing-id id)
         raw        @(subscribe [:cells/raw   id])
         value      @(subscribe [:cells/value id])
+        ;; A parse error rides through as `[:error/parse msg]`; pull out the
+        ;; actionable message to surface on hover (rf2-5tim8h).
+        parse-err  (parse-error-text value)
         display    (cond
                      editing?                  raw
-                     (= value :error/parse)    "#PARSE"
+                     parse-err                 "#PARSE"
                      (= value :error/cycle)    "#CYCLE"
                      (= value :error/eval)     "#EVAL"
                      (= value :error/type)     "#TYPE"
@@ -303,10 +360,16 @@
                      :else                     (str value))]
     ;; `data-cell`/`data-cell-input` carry the grid coordinate as a domain
     ;; attribute; `data-testid` mirrors the cluster's test-hook scheme so the
-    ;; six examples share one selector convention.
-    [:td.cell {:data-cell   id
-               :data-testid (str "cells-cell-" id)
-               :on-click    #(dispatch [:cells/start-editing id])}
+    ;; six examples share one selector convention. On a parse error the
+    ;; actionable message rides in `title` (native hover tooltip) and is
+    ;; mirrored to `data-parse-error` so it is inspectable, with an
+    ;; `cell--parse-error` class for styling.
+    [:td.cell (cond-> {:data-cell   id
+                       :data-testid (str "cells-cell-" id)
+                       :on-click    #(dispatch [:cells/start-editing id])}
+                parse-err (assoc :title parse-err
+                                 :data-parse-error parse-err
+                                 :class "cell--parse-error"))
      (if editing?
        [:input {:type      "text"
                 :auto-focus true

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -863,6 +863,22 @@
                              :done    {:final? true}}})
   ;; Materialize the live singleton snapshot.
   (rf/dispatch-sync [:job/runner [:job/finish-noop]]) ;; no-op event: stays :running, installs snapshot
+  ;; PRE-TEARDOWN materialization is a FAILING PRECONDITION (rf2-mp1p28):
+  ;; the original test only asserted ABSENCE after the final-state
+  ;; auto-destroy, so "absent after destroy" was indistinguishable from
+  ;; "never present" — a regression where `:job/runner` never materializes a
+  ;; live snapshot, or where the live graph stops surfacing machine
+  ;; instances, would still pass vacuously. Prove a LIVE instance existed
+  ;; (spec/Derivations.md §`:machine-instance` lifecycle: released by machine
+  ;; destroy) BEFORE driving the machine to its final state.
+  (let [g-before    (graph/live-derivation-graph :rf/default all-contributors)
+        node-before (get (:nodes g-before) [:machine :job/runner])
+        rt-before   (frame/frame-runtime-db-value :rf/default)]
+    (testing "the machine instance materialized a live snapshot BEFORE destroy (failing precondition)"
+      (is (some? node-before)
+          "the no-op dispatch MUST materialize the [:machine :job/runner] live snapshot node — absence is a failure, not a skip")
+      (is (some? (get-in rt-before (machine-paths/snapshot-path :job/runner)))
+          "the machine-owned snapshot MUST be live in runtime-db before the final event — proving a live instance existed to release")))
   (rf/dispatch-sync [:job/runner [:job/finish]])      ;; → :done (:final?) → auto-destroy
   (let [g-after (graph/live-derivation-graph :rf/default all-contributors)
         node    (get (:nodes g-after) [:machine :job/runner])

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -175,7 +175,13 @@
      literal's closing `}`.  We keep buffering the remainder and decide at
      the line's newline — drop the line only if the remainder is a
      balanced set literal followed by nothing but whitespace
-     (`banner-line-remainder?`); otherwise the prefix was shared by a
+     (`banner-line-remainder?`) AND this line was preceded by the held
+     leading blank.  cognitect's banner is `(format \"\\nRunning tests in
+     %s\" dirs)`, so the genuine banner is ALWAYS opened by a blank line;
+     requiring that held blank means an exact-shape user/fixture line such
+     as a bare `(println \"Running tests in #{:fixture}\")` — same text,
+     but no leading blank — is forwarded rather than silently overdropped
+     (rf2-m8dbb9).  Otherwise the prefix was shared by a
      user/fixture diagnostic such as `Running tests in #{:fixture} MARKER`
      and the whole buffered line is forwarded (the rf2-14nojy.2 overdrop
      guard).
@@ -284,15 +290,29 @@
                                 ;; the line is complete (rf2-14nojy.2). The
                                 ;; remainder is everything buffered after the
                                 ;; prefix; if it is a balanced set literal +
-                                ;; only whitespace this IS the discovery
-                                ;; banner → drop the whole line (and the
-                                ;; pending blank that was its leading
+                                ;; only whitespace AND this line was preceded
+                                ;; by the held leading blank, this IS the
+                                ;; discovery banner → drop the whole line (and
+                                ;; the pending blank that was its leading
                                 ;; newline). Otherwise the prefix was shared
                                 ;; by a real diagnostic → flush the pending
                                 ;; blank and forward the whole buffered line.
+                                ;;
+                                ;; The leading-blank requirement (rf2-m8dbb9)
+                                ;; distinguishes cognitect's banner — printed
+                                ;; via `(format "\nRunning tests in %s" dirs)`,
+                                ;; so ALWAYS opened by a blank line — from a
+                                ;; user/fixture line that exact-matches the
+                                ;; banner shape (`Running tests in #{:fixture}`)
+                                ;; but is emitted by a bare `println` with no
+                                ;; preceding blank. Without this, such a line
+                                ;; was indistinguishable from the banner and
+                                ;; silently overdropped, contradicting the
+                                ;; pass-through stdout contract.
                                 :banner-candidate
                                 (let [remainder (subs (.toString buf) prefix-len)]
-                                  (if (banner-line-remainder? remainder)
+                                  (if (and @pending-blank?
+                                           (banner-line-remainder? remainder))
                                     (drop-pending-blank!)
                                     (do (flush-pending-blank!)
                                         (.write target (.toString buf))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -614,6 +614,72 @@
               (str "no part of the banner may reach stdout; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
+;; Banner EXACT-SHAPE overdrop — rf2-m8dbb9.
+;;
+;; The rf2-14nojy.2 fix above forwards a banner-shaped line that carries
+;; TRAILING content after the set literal, but a user/fixture line whose
+;; WHOLE text exactly matches the banner — `Running tests in #{:fixture}`
+;; with no trailing marker — was still indistinguishable from cognitect's
+;; own banner and silently overdropped, contradicting the pass-through
+;; stdout contract.  cognitect prints its banner via
+;; `(format "\nRunning tests in %s" dirs)`, so the genuine banner is ALWAYS
+;; opened by a leading blank line; a bare `(println "Running tests in
+;; #{:fixture}")` is not.  The fix requires that held leading blank before
+;; dropping a banner-shaped line, so an exact-shape user line printed with
+;; no preceding blank survives while the real banner stays absent.
+
+(deftest banner-exact-shape-user-line-survives
+  (testing "an exact-shape `Running tests in #{...}` user line (no trailing marker, no leading blank) survives (rf2-m8dbb9)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; A bare `println` of the EXACT banner shape — no trailing content,
+        ;; no preceding blank line. Pre-fix this was swallowed wholesale; it
+        ;; must now reach stdout because it lacks the banner's leading blank.
+        (write-fixture! dir "exact_shape_fixture_test" "exact-shape-fixture-test"
+                        (str "(deftest an-exact-shape-test"
+                             " (println \"Running tests in #{:fixture}\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the exact-shape suite is green; must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The CORE of rf2-m8dbb9: a fixture line whose WHOLE text matches
+          ;; the banner shape but is emitted with no leading blank is NOT the
+          ;; banner and must survive.
+          (is (str/includes? out "Running tests in #{:fixture}")
+              (str "an exact-shape user line `Running tests in #{:fixture}`"
+                   " printed via bare println (no leading blank) is NOT the"
+                   " cognitect banner and must survive (rf2-m8dbb9); got:\n"
+                   out))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the green summary must still print; got:\n" out)))))))
+
+(deftest real-banner-still-dropped-alongside-exact-shape-user-line
+  (testing "the real banner is STILL dropped even when a fixture also prints an exact-shape line (rf2-m8dbb9 negative control)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; The fixture prints an exact-shape line of its own; cognitect's
+        ;; genuine banner (leading blank + `Running tests in #{...}`) is the
+        ;; ONLY banner-shaped line preceded by a blank. The user line must
+        ;; survive AND there must be exactly ONE `Running tests in #{` on
+        ;; stdout — the user's — proving the genuine banner was still dropped.
+        (write-fixture! dir "exact_shape_neg_test" "exact-shape-neg-test"
+                        (str "(deftest a-neg-test"
+                             " (println \"Running tests in #{:user-only}\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)
+              hits (count (re-seq #"Running tests in #\{" out))]
+          (is (zero? exit)
+              (str "green suite must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "Running tests in #{:user-only}")
+              (str "the user's exact-shape line must survive; got:\n" out))
+          (is (= 1 hits)
+              (str "exactly one `Running tests in #{` must reach stdout (the"
+                   " user's) — the genuine cognitect banner must STILL be"
+                   " dropped; got " hits " occurrences:\n" out)))))))
+
+;; ----------------------------------------------------------------------
 ;; Unterminated-partial survival across System/exit — rf2-pjlx6.2.
 ;;
 ;; cognitect exits straight from the computed fail/error counts, so the


### PR DESCRIPTION
Three small fixes on disjoint surfaces (rf2-mp1p28, rf2-m8dbb9, rf2-5tim8h).

## rf2-mp1p28 — derivation-conformance machine-destroy was vacuous
The machine destroy/release conformance test only asserted ABSENCE after the final-state auto-destroy, so "absent after destroy" was indistinguishable from "never present" — a regression where `:job/runner` never materializes a snapshot, or where the live graph stops surfacing machine instances, would pass vacuously. Added failing-precondition assertions that the `[:machine :job/runner]` live graph node AND its runtime-db snapshot EXIST before dispatching `[:job/finish]`, then assert both are released afterward (spec/Derivations.md `:machine-instance` lifecycle).

## rf2-m8dbb9 — test-quiet banner filter dropped exact-shape user stdout
The JVM banner filter dropped any line exactly shaped like `Running tests in #{...}`, swallowing legitimate user/fixture stdout that matched the banner shape with no trailing content — contradicting the documented pass-through contract. cognitect's banner is always opened by a leading blank line (`(format "\nRunning tests in %s" dirs)`), so the fix requires the held pending-blank before dropping a banner-shaped line. An exact-shape user line printed via bare `println` (no leading blank) now survives; the genuine banner (leading blank + text) is still suppressed. Added two subprocess regression tests.

## rf2-5tim8h — 7GUIs Cells formula errors now actionable
Formula parse errors threw terse messages (`Unbalanced (`, `Bad atom`, …) caught and shown as a bare `#PARSE`. The parser now produces an actionable message naming the cell, the formula text, the offending token/position where known, and the expected formula shape. It rides through evaluation as `[:error/parse msg]` and surfaces in the cell's `title` (hover tooltip) + `data-parse-error`, with a `cell--parse-error` class. Example stays test-free (no `*.spec.cjs`).

## Quality gates
- **rf2-mp1p28**: `clojure -M:test` in `implementation/derivation-conformance` — 15 tests, **326 assertions** (was 324; the 2 new precondition assertions ran and passed, confirming the snapshot IS materialized before destroy). Focused CLJS node-test not run (fresh worktree; the `.cljc` namespace exercises identical runtime-agnostic logic under JVM).
- **rf2-m8dbb9**: `clojure -M:test` in `implementation/test-quiet` — **23 tests, 83 assertions** (was 21/77; 2 new deftests + 6 assertions). The existing real-cognitect-banner drop tests still pass.
- **rf2-5tim8h**: `shadow-cljs release examples/cells` — Build completed, 100 compiled, **0 warnings, 0 errors**.

Scope: only the three named dirs touched (4 files).
