### PR TITLE
fix(impl): schemas cofx-conformance + resources byte-key introspection + routing fragment trace

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -158,9 +158,12 @@
     :schemas/runtime
     :schemas/event-payload
     :schemas/sub-return
-    ;; :schemas/cofx — UNCLAIMED in EP-0017 slice A.3 (rf2-oa2dun): cofx
-    ;; `:schema` validation is slice-B-deferred (the old inject-cofx-time
-    ;; validation is retired with `inject-cofx`). Skipped, not claimed.
+    ;; :schemas/cofx — CLAIMED (rf2-hqwki4): the landed EP-0017 recordable-cofx
+    ;; `:schema` path. A declared recordable value that fails its
+    ;; registration's `:schema` emits `:rf.error/cofx-value-invalid` and throws
+    ;; during context assembly; the `schema-cofx-validates.edn` fixture
+    ;; exercises it (the old inject-cofx-time validation is retired).
+    :schemas/cofx
     :routing/ranking
     :routing/fragment
     :routing/blocking
@@ -250,11 +253,7 @@
   ;; failing the suite.
   #{:ssr/suspense-boundary
     :ssr/hydration-payload
-    :ssr/chunked-response
-    ;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation is
-    ;; slice-B-deferred; `schema-cofx-validates.edn` is an intentional
-    ;; out-of-claim skip until slice B.
-    :schemas/cofx})
+    :ssr/chunked-response})
 
 ;; ---- fixture loading (compile-time inlined) -------------------------------
 

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -153,14 +153,16 @@
     :schemas/runtime
     :schemas/event-payload                            ;; rf2-jwm4
     :schemas/sub-return                               ;; rf2-wcam
-    ;; :schemas/cofx — UNCLAIMED in EP-0017 slice A.3 (rf2-oa2dun). The
-    ;; cofx `:schema` validation step is SLICE-B-built (per Spec 009
-    ;; §`:rf.error/cofx-value-invalid` — "the `:schema` validation step is
-    ;; slice-B-built; the structural EDN check is slice A"). The old
-    ;; `inject-cofx`-time validation path is retired with `inject-cofx`. The
-    ;; `schema-cofx-validates.edn` fixture is reported as an intentional
-    ;; out-of-claim skip until slice B wires recordable-value `:schema`
-    ;; validation. See `known-skipped-capabilities`.
+    ;; :schemas/cofx — CLAIMED (rf2-hqwki4). The EP-0017 recordable-cofx
+    ;; `:schema` path has landed (`re-frame.cofx/validate-recordable-value!`,
+    ;; reached from `deliver-declared-cofx` for supplied/replayed + generated
+    ;; values): a declared recordable value that fails its registration's
+    ;; `:schema` emits `:rf.error/cofx-value-invalid` and throws during context
+    ;; assembly. The `schema-cofx-validates.edn` fixture exercises that path
+    ;; (the old `inject-cofx`-time validation it pinned —
+    ;; `:rf.error/schema-validation-failure :where :cofx` — is retired with
+    ;; `inject-cofx`).
+    :schemas/cofx
     :routing/ranking
     :routing/fragment
     :routing/blocking
@@ -270,14 +272,7 @@
   ;; failure.
   #{:ssr/suspense-boundary
     :ssr/hydration-payload
-    :ssr/chunked-response
-    ;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation is
-    ;; slice-B-deferred (the structural EDN check is slice A; the `:schema`
-    ;; step is slice B per Spec 009 §`:rf.error/cofx-value-invalid`). The
-    ;; `schema-cofx-validates.edn` fixture is an intentional out-of-claim skip
-    ;; until slice B; the old `inject-cofx`-time validation it pinned is
-    ;; retired with `inject-cofx`.
-    :schemas/cofx})
+    :ssr/chunked-response})
 
 ;; ---- fixture loader -------------------------------------------------------
 
@@ -502,10 +497,10 @@
     ;; cofx registrations — value-returning suppliers + metadata (EP-0017
     ;; model). The supplier returns the coeffect VALUE; the runtime delivers
     ;; it flat under the cofx-id when a handler declares it via
-    ;; `:rf.cofx/requires`. The `:schema` metadata still rides along (its
-    ;; validation step is slice-B-built; the only fixture exercising it,
-    ;; `schema-cofx-validates.edn`, is an intentional out-of-claim skip via
-    ;; `known-skipped-capabilities`).
+    ;; `:rf.cofx/requires`. The `:schema` metadata rides along and the landed
+    ;; EP-0017 recordable-cofx `:schema` path validates it (rf2-hqwki4); the
+    ;; `schema-cofx-validates.edn` fixture exercises that path (now CLAIMED via
+    ;; `:schemas/cofx`).
     (let [all-cofx-ids (into #{} (concat (keys cofx-bodies) (keys cofx-registry)))]
       (doseq [cofx-id all-cofx-ids]
         (let [body (get cofx-bodies cofx-id [[:noop]])

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -156,13 +156,31 @@
   static registry (every registered resource id) plus, when `:frame` is
   supplied, the live per-frame resource-instance entries map
   (`{<scoped-resource-key> <entry>}`). Without `:frame` only the static
-  registry is returned (no ambient frame fallback, EP-0002)."
+  registry is returned (no ambient frame fallback, EP-0002).
+
+  The `:entries` map is REKEYED to the public scoped-resource-key VECTOR
+  `[canonical-scope resource-id canonical-params]` (rf2-jtlq7l). The
+  internal runtime storage is keyed on the opaque CEDN-1 byte `key-id`
+  (`state/entries-path`, `state/key-id`); leaking that byte key through
+  the public accessor breaks the documented contract — callers can't
+  destructure `[scope resource-id params]`, filter by scope/resource, or
+  compare against scoped keys. The kind-preserving scoped-key lives on
+  each entry under `:resource/key` (the same fact identity the live
+  tooling view reads — `tooling/live-resource-nodes`), so rekey from
+  there, not from the map key. Internal storage stays byte-keyed."
   ([] {:resource-ids (resource-ids) :entries {}})
   ([{:keys [frame]}]
    {:resource-ids (resource-ids)
     :entries      (if frame
-                    (or (get-in (frame/frame-runtime-db-value frame)
-                                (state/entries-path)) {})
+                    (let [entries (get-in (frame/frame-runtime-db-value frame)
+                                          (state/entries-path))]
+                      (reduce-kv
+                        ;; rf2-jtlq7l — rekey the internal byte `key-id` map to
+                        ;; the public scoped-key vector carried on each entry.
+                        (fn [acc _k-id entry]
+                          (assoc acc (:resource/key entry) entry))
+                        {}
+                        (or entries {})))
                     {})}))
 
 (defn resource-state

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -1023,6 +1023,63 @@
                     :params {:slug "w"} :frame :rf/default}))))))
 
 ;; ===========================================================================
+;; 17b. `resources` introspection rekeys to the public scoped-key vector
+;;      (rf2-jtlq7l) — the internal byte `key-id` must not leak
+;; ===========================================================================
+
+(deftest resources-introspection-rekeys-to-scoped-key-vector
+  (testing "rf2-jtlq7l — `(resources {:frame f})` returns `:entries` keyed by
+            each entry's `:resource/key` VECTOR `[scope resource-id params]`,
+            not the internal CEDN byte `key-id` storage key"
+    (rf/reg-resource :intro/article (article-spec))
+    (let [k1 (state/scoped-resource-key :rf.scope/global :intro/article {:slug "one"})
+          k2 (state/scoped-resource-key :rf.scope/global :intro/article {:slug "two"})]
+      ;; Install two entries with DISTINCT scoped keys (distinct byte key-ids).
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :intro/article :scope :rf.scope/global
+                                              :params {:slug "one"} :owner [:lease :intro 1]}])
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :intro/article :scope :rf.scope/global
+                                              :params {:slug "two"} :owner [:lease :intro 2]}])
+      (let [{:keys [resource-ids entries]} (re-frame.resources/resources {:frame :rf/default})]
+        (testing "the static registry still lists the registered id"
+          (is (contains? (set resource-ids) :intro/article)))
+        (testing "entry keys are scoped-key VECTORS, not byte key-id strings"
+          (is (= #{k1 k2} (set (keys entries)))
+              "the public accessor keys by :resource/key vector")
+          (is (every? vector? (keys entries))
+              "every entry key is a [scope resource-id params] vector")
+          (is (not-any? string? (keys entries))
+              "no internal byte key-id (a string) leaks through the accessor")
+          (is (not (contains? entries (state/key-id k1)))
+              "the byte key-id is NOT a public entry key"))
+        (testing "callers can destructure the public key shape + filter by it"
+          (let [[scope rid params] k1]
+            (is (= :rf.scope/global scope))
+            (is (= :intro/article rid))
+            (is (= {:slug "one"} params)))
+          ;; Filtering by [scope resource-id] over the vector keys is the
+          ;; documented use the byte key-id blocked.
+          (is (= #{k1 k2}
+                 (set (for [[[scope rid params] _e] entries
+                            :when (and (= :rf.scope/global scope)
+                                       (= :intro/article rid))]
+                        [scope rid params])))
+              "every entry filters cleanly by scope + resource-id"))
+        (testing "the entry value is carried through unchanged (still byte-keyed
+                  in internal storage)"
+          (is (= :intro/article (-> entries (get k1) :resource/key second)))
+          (let [raw (get-in (rf/runtime-db-value :rf/default) (state/entries-path))]
+            (is (every? string? (keys raw))
+                "internal runtime storage remains byte-keyed (string key-ids)")))))))
+
+(deftest resources-introspection-without-frame-returns-empty-entries
+  (testing "rf2-jtlq7l — `(resources)` (no frame) still returns
+            `{:resource-ids [...] :entries {}}` (no ambient fallback)"
+    (rf/reg-resource :introf/article (article-spec))
+    (let [{:keys [resource-ids entries]} (re-frame.resources/resources)]
+      (is (contains? (set resource-ids) :introf/article))
+      (is (= {} entries) "frameless call yields an empty entries map"))))
+
+;; ===========================================================================
 ;; 18. param canonicalization is total over mixed EDN key types (rf2-ptz7z8)
 ;; ===========================================================================
 

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -34,13 +34,19 @@
   `:rf.route/transitioned`, which fires on every URL transition. The
   full URL transition path never emits this op and never coincides with
   a `:rf.route.nav-token/allocated` on the same drain. Consumers carry
-  `:prev-fragment` / `:next-fragment` in `:tags`. Scroll-capture (for the
-  position the user is leaving) still rides along."
-  [rdb prev next-fragment]
+  `:prev-fragment` / `:next-fragment` in `:tags`, plus the `:frame` stamp
+  (rf2-n0851k) so the fragment-only trace is frame-attributed exactly
+  like every other routing trace inside a known navigation cascade (Spec
+  012 §Multi-frame routing / Spec 009 — without `:frame`, epoch/Xray
+  capture and frame-level trace suppression can drop or bypass the op).
+  Scroll-capture (for the position the user is leaving) still rides
+  along."
+  [rdb prev next-fragment frame]
   (trace/emit! :rf.event :rf.route/fragment-changed
                {:route-id      (:route-id prev)
                 :prev-fragment (:fragment prev)
-                :next-fragment next-fragment})
+                :next-fragment next-fragment
+                :frame         frame})
   ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db
   ;; state — read/write the runtime-db partition.
   (let [capture-fx (scroll/capture-scroll-fx-entry rdb)]
@@ -185,9 +191,12 @@
       ;; Spec 012 §Fragments rules 3-4 (rf2-8oxj6): short-circuit BEFORE
       ;; the nav-token allocation / on-match drain below. Honoured on
       ;; both `:rf.route/transitioned` and `:rf.route/handle-url-change`
-      ;; (popstate) because the branch lives in the shared helper.
+      ;; (popstate) because the branch lives in the shared helper. The
+      ;; carried `frame` is threaded through so the emitted
+      ;; `:rf.route/fragment-changed` trace is frame-attributed (rf2-n0851k),
+      ;; consistent with the commit-path lifecycle traces below.
       fragment-only?
-      (fragment-only-fx rdb prev fragment)
+      (fragment-only-fx rdb prev fragment frame)
 
       :else
       (do

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -814,6 +814,12 @@
         (is (= "section-2"
                (:next-fragment (first @fragment-changed)))
             "trace carries :next-fragment")
+        ;; rf2-n0851k: the fragment-only trace carries the frame stamp
+        ;; under :tags :frame so epoch/Xray capture and the frame
+        ;; trace-disable gate cover fragment-only changes (Spec 012
+        ;; §Multi-frame routing / Spec 009).
+        (is (= :rf/default (:frame (first @fragment-changed)))
+            "rf2-n0851k: fragment-only trace is frame-attributed")
         (is (zero? (count @allocations))
             "fragment-only nav does NOT allocate a new nav-token")
 

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -799,7 +799,17 @@
           (is (= "scroll-restoration" (-> second-ev :tags :prev-fragment))
               "second transition: prev-fragment is the previous value")
           (is (= "fragments" (-> second-ev :tags :next-fragment))
-              "second transition: next-fragment is the new value"))))))
+              "second transition: next-fragment is the new value")
+          ;; rf2-n0851k: the fragment-only trace must carry the frame
+          ;; stamp under :tags :frame (Spec 012 §Multi-frame routing /
+          ;; Spec 009). Without it the trace is dropped from epoch/Xray
+          ;; capture (which buffers only frame-tagged events) and bypasses
+          ;; the frame-level trace-disable gate. The forward-nav
+          ;; (:rf.route/transitioned) path runs on the :rf/default frame.
+          (is (= :rf/default (-> first-ev :tags :frame))
+              "rf2-n0851k: forward-nav fragment-only trace is frame-attributed")
+          (is (= :rf/default (-> second-ev :tags :frame))
+              "rf2-n0851k: second fragment-only trace is frame-attributed too"))))))
 
 ;; ---- rf2-8oxj6: popstate honours the fragment-only rule ----------------
 ;;
@@ -854,7 +864,16 @@
         (is (some #(= :rf.route/fragment-changed (:operation %)) @traces)
             "fragment-only popstate emits :rf.route/fragment-changed")
         (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
-            "fragment-only popstate emits NO :rf.route.nav-token/allocated")))))
+            "fragment-only popstate emits NO :rf.route.nav-token/allocated")
+        ;; rf2-n0851k: the popstate (handle-url-change) fragment-only trace
+        ;; carries the frame stamp too — same contract as the forward-nav
+        ;; path, so epoch/Xray capture and the frame trace-disable gate
+        ;; cover popstate fragment-only changes.
+        (is (= :rf/default
+               (some->> @traces
+                        (filter #(= :rf.route/fragment-changed (:operation %)))
+                        first :tags :frame))
+            "rf2-n0851k: popstate fragment-only trace is frame-attributed")))))
 
 ;; ============================================================================
 ;; rf2-ee38b.8 — Spec 012 §Per-route data loading rule 3:

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -63,9 +63,12 @@
 
   The claim covers `:schemas/runtime` (app-db slice validation,
   baseline since rf2-p7va), `:schemas/event-payload` (rf2-jwm4),
-  `:schemas/cofx` (rf2-7leq), `:schemas/sub-return` (rf2-wcam), plus
-  the bare `:core/*` capabilities every schema fixture cross-cuts
-  (event / sub / error / trace).
+  `:schemas/cofx` (rf2-hqwki4 — the landed EP-0017 recordable-cofx
+  `:schema` path; a declared recordable value that fails its
+  registration's `:schema` emits `:rf.error/cofx-value-invalid` and skips
+  the handler), `:schemas/sub-return` (rf2-wcam), plus the bare `:core/*`
+  capabilities every schema fixture cross-cuts (event / sub / error /
+  trace).
 
   ## Coverage scope
 
@@ -81,7 +84,6 @@
             [clojure.string :as str]
             [re-frame.conformance :as conformance]
             [re-frame.core :as rf]
-            [re-frame.cofx :as cofx]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
             ;; Per rf2-v96fh (schema implies validation) requiring
@@ -151,11 +153,15 @@
   "The schemas-surface capabilities plus the `:core/*` cross-cuts that
   every schema fixture declares. The four `:schemas/*` tags map 1:1 to
   the four validation points in Spec 010 §Validation order."
-  ;; :schemas/cofx — UNCLAIMED in EP-0017 slice A.3 (rf2-oa2dun): cofx
-  ;; `:schema` validation is slice-B-built (the old inject-cofx-time
-  ;; validation path is retired with `inject-cofx`). The
-  ;; `schema-cofx-validates.edn` fixture is non-runnable (out of claim) until
-  ;; slice B wires recordable-value `:schema` validation.
+  ;; :schemas/cofx — CLAIMED (rf2-hqwki4): the EP-0017 recordable-cofx
+  ;; `:schema` path has landed (`re-frame.cofx/validate-recordable-value!`,
+  ;; reached from `deliver-declared-cofx` for both supplied/replayed and
+  ;; generated values). A declared recordable value that fails its
+  ;; registration's `:schema` emits `:rf.error/cofx-value-invalid` and skips
+  ;; the handler. The `schema-cofx-validates.edn` fixture now exercises THAT
+  ;; landed path (the old inject-cofx injection-time validation it pinned —
+  ;; `:rf.error/schema-validation-failure :where :cofx` — was retired with
+  ;; `inject-cofx`).
   #{:core/event-handler
     :core/sub
     :core/fx
@@ -163,6 +169,7 @@
     :core/trace
     :schemas/runtime
     :schemas/event-payload
+    :schemas/cofx
     :schemas/sub-return})
 
 (def claimed-spec-versions
@@ -224,30 +231,26 @@
      steps)
     @out))
 
-(defn- realise-cofx-handler
-  "DSL → a cofx handler fn (ctx) → ctx. Mirrors core's runner: a
-  `:set` step's value is the value injected at `[:coeffects cofx-id]`.
-  The path slot is symbolic — convention is `[k]` where `k` is the
-  bare key the handler reads via `[:cofx-key k]`.
+(defn- realise-cofx-supplier
+  "DSL → a value-returning cofx supplier `(fn [] value)` (EP-0017 model,
+  rf2-hqwki4). Mirrors core's runner: a `:set` step's value IS the value the
+  supplier returns; the runtime delivers it FLAT under the cofx-id when a
+  handler declares it via `:rf.cofx/requires`. The ctx→ctx `inject-cofx` form
+  that placed the value at `[:coeffects cofx-id]` is RETIRED with
+  `inject-cofx`.
 
-  Per rf2-g25p, the body is realised against the inject-cofx ctx —
-  values pass through `eval-value` so reflection forms resolve against
-  the inbound coeffects/event the same way they do in event-handler
-  bodies."
-  [cofx-id steps]
-  (fn [ctx]
-    (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)
-          dsl-ctx    {:db    (get-in ctx [:coeffects :db])
-                      :event (get-in ctx [:coeffects :event])
-                      :cofx  (:coeffects ctx)}]
-      (reduce (fn [c step]
+  Per rf2-g25p the `:set` value passes through `eval-value*`; multiple `:set`
+  steps run in order and the final step wins (single-delivery convention)."
+  [steps]
+  (fn []
+    (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)]
+      (reduce (fn [v step]
                 (case (first step)
-                  :set  (let [[_ _path value] step
-                              v (eval-value value dsl-ctx)]
-                          (assoc-in c [:coeffects cofx-id] v))
-                  :noop c
-                  c))
-              ctx
+                  :set  (let [[_ _path value] step]
+                          (eval-value value {}))
+                  :noop v
+                  v))
+              nil
               steps))))
 
 (defn- realise-handlers
@@ -261,10 +264,9 @@
         cofx-registry (get-in fixture [:fixture/registry :cofx] {})
         cofx-bodies   (get hmap :cofx)
         helpers       (adapter-helpers)
-        ;; cofx that auto-wire as generated interceptors on event handlers
-        ;; (per rf2-g25p — the runner's first-pass auto-injection
-        ;; convention). Stable lex order on cofx-id so the last-write-wins
-        ;; outcome is deterministic.
+        ;; cofx that auto-wire onto a consuming event's `:rf.cofx/requires`
+        ;; declaration (EP-0017 model — rf2-hqwki4). Stable lex order on
+        ;; cofx-id so the last-write-wins outcome is deterministic.
         cofx-by-key
         (->> cofx-registry
              (sort-by key)
@@ -273,20 +275,32 @@
                           (assoc acc k (mapv first pairs)))
                         {}))]
     ;; ---- cofx ----------------------------------------------------------
-    ;; Per Spec 010 §step 2 (rf2-7leq): cofx registrations carry :schema
-    ;; metadata; the runtime calls `:schemas/validate-cofx!` after
-    ;; injection. We register both bodies AND any registry-only entries.
+    ;; EP-0017 model (rf2-hqwki4): cofx registrations carry value-returning
+    ;; suppliers (NOT ctx→ctx injection handlers) plus their metadata
+    ;; (`:recordable?` / `:provided?` / `:schema`). The runtime delivers the
+    ;; recordable value flat under the cofx-id when a handler declares it via
+    ;; `:rf.cofx/requires`, and validates it against `:schema`
+    ;; (`re-frame.cofx/validate-recordable-value!`, a production hard error on
+    ;; mismatch → `:rf.error/cofx-value-invalid`). A `:provided?` recordable
+    ;; fact carries NO supplier — its value rides the dispatch token's
+    ;; `:rf.cofx` map; `reg-cofx` rejects `:provided?` + a supplier, so register
+    ;; it bare. The old `inject-cofx`-time `:schema` validation path is retired
+    ;; with `inject-cofx`.
     (let [all-cofx-ids (into #{} (concat (keys cofx-bodies) (keys cofx-registry)))]
       (doseq [cofx-id all-cofx-ids]
-        (let [body    (get cofx-bodies cofx-id [[:noop]])
-              meta    (get cofx-registry cofx-id {})
-              handler (realise-cofx-handler cofx-id body)]
-          (rf/reg-cofx cofx-id (assoc meta :handler-fn handler) handler))))
+        (let [body (get cofx-bodies cofx-id [[:noop]])
+              meta (get cofx-registry cofx-id {})]
+          (if (:provided? meta)
+            (rf/reg-cofx cofx-id meta)
+            (rf/reg-cofx cofx-id meta (realise-cofx-supplier body))))))
     ;; ---- events --------------------------------------------------------
     ;; Per Spec 010 §step 1 (rf2-jwm4): event meta carries :schema; the
     ;; runtime calls `:schemas/validate-event!` before the handler runs.
-    ;; Per rf2-g25p: scan the body for [:cofx-key K]; for each K, auto-wire a
-    ;; generated cofx interceptor for every C whose namespace matches K.
+    ;; EP-0017 model (rf2-hqwki4): a body that reads `[:cofx-key K]` declares
+    ;; the consumed coeffect ids via the `:rf.cofx/requires` registration-
+    ;; metadata key (the ctx→ctx `inject-cofx` interceptor wiring is retired).
+    ;; The runtime delivers each declared recordable value flat under its
+    ;; cofx-id and validates it against `:schema`.
     (doseq [[id steps] (:event hmap)]
       (let [[kind handler] (conformance/realise-event-handler steps)
             meta           (get event-meta id {})
@@ -295,10 +309,9 @@
                                           (or (get cofx-by-key k)
                                               (when (contains? cofx-registry k) [k])))
                                         ks))
-            interceptors   (mapv cofx/inject-cofx cofx-ids)
             meta'          (cond-> meta
-                             (seq interceptors)
-                             (update :interceptors (fnil into []) interceptors))]
+                             (seq cofx-ids)
+                             (assoc :rf.cofx/requires cofx-ids))]
         (case kind
           ;; EP-0018 Slice Z: one public `reg-event` (cofx-in, effects-map-out).
           ;; A :db-kind fixture handler is `(fn [db event] new-db)`; adapt it to
@@ -432,8 +445,39 @@
 
 ;; ---- :fixture/dispatches runner ------------------------------------------
 
-(defn- run-dispatch [ev]
+(defn- run-dispatch
+  "Drive one `:fixture/dispatches` entry. `dispatch-error-failures` is an atom
+  collecting `:expect-error` mismatch strings.
+
+  A map entry with `:expect-error` (EP-0017 boundary-throw shape, rf2-hqwki4)
+  asserts the dispatch RAISES that `:rf.error/id`. Context-assembly throws (the
+  cofx delivery errors — `:rf.error/cofx-value-invalid` / missing-required /
+  unregistered) escape `dispatch-sync` rather than being captured into the
+  interceptor chain, so the runner catches the throw here and compares the
+  ex-data `:rf.error/id`. The remaining opts (e.g. `:rf.cofx`) pass through to
+  `dispatch-sync`. Mirrors core's `re-frame.conformance-test` runner."
+  [ev dispatch-error-failures]
   (cond
+    (and (map? ev) (contains? ev :expect-error))
+    (let [{event :event want :expect-error} ev
+          opts (dissoc ev :event :expect-error)
+          got  (try (rf/dispatch-sync event opts) ::no-throw
+                    (catch clojure.lang.ExceptionInfo e
+                      (:rf.error/id (ex-data e)))
+                    (catch Throwable e e))]
+      (cond
+        (= got ::no-throw)
+        (swap! dispatch-error-failures conj
+               (str "dispatch " (pr-str event) " expected to throw "
+                    want " but did not throw"))
+        (not= got want)
+        (swap! dispatch-error-failures conj
+               (str "dispatch " (pr-str event) " expected error " want
+                    " but got " (if (instance? Throwable got)
+                                  (str "a non-ExceptionInfo throw: "
+                                       (some-> ^Throwable got .getMessage))
+                                  got)))))
+
     (map? ev)
     (let [{event :event :as opts} ev]
       (rf/dispatch-sync event (dissoc opts :event)))
@@ -486,9 +530,12 @@
           ;; handler), which would land the seed AFTER the first dispatch.
           _            (binding [frame/*current-frame* nil]
                          (rf/reg-frame :rf/default frame-config))
-          dispatches   (or (:fixture/dispatches fixture) [])]
+          dispatches   (or (:fixture/dispatches fixture) [])
+          ;; EP-0017 `:expect-error` mismatches (rf2-hqwki4) — a context-assembly
+          ;; throw the dispatch declared but did not raise (or raised wrong).
+          dispatch-error-failures (atom [])]
       (doseq [ev dispatches]
-        (run-dispatch ev))
+        (run-dispatch ev dispatch-error-failures))
       (let [expect        (or (:fixture/expect fixture) {})
             expected-db   (:final-app-db expect)
             final-db      (rf/app-db-value :rf/default)
@@ -505,7 +552,9 @@
         {:fixture-id     fid
          :passed?        (and (or (nil? expected-db) (submap? expected-db final-db))
                               (every? #(= (:expected %) (:actual %)) sub-checks)
-                              (empty? trace-failures))
+                              (empty? trace-failures)
+                              (empty? @dispatch-error-failures))
+         :dispatch-error-failures @dispatch-error-failures
          :final-db       final-db
          :expected-db    expected-db
          :sub-checks     sub-checks
@@ -580,7 +629,9 @@
                        "expected:" (:expected sc)
                        "actual:" (:actual sc))))
           (doseq [tf (:trace-failures f)]
-            (println "    trace:" tf))))
+            (println "    trace:" tf))
+          (doseq [df (:dispatch-error-failures f)]
+            (println "    dispatch-error:" df))))
       (is (zero? (count failed))
           (str "All claim-runnable schemas conformance fixtures must pass; "
                (count failed) " failed.")))))

--- a/spec/conformance/fixtures/schema-cofx-validates.edn
+++ b/spec/conformance/fixtures/schema-cofx-validates.edn
@@ -1,66 +1,81 @@
 ;; Conformance fixture: schemas/cofx-validates
-;; Per Spec 010 §Validation order step 2 — after a cofx injects its value
-;; into the merged context, the runtime validates that value against the
-;; cofx's :schema. Well-formed values flow through to the handler; malformed
-;; values emit :rf.error/schema-validation-failure with :where :cofx and
-;; the handler is NOT invoked (recovery: :no-recovery; downstream queue
-;; continues, mirroring the event-payload step).
+;; Per EP-0017 §5 + Spec 009 §`:rf.error/cofx-value-invalid` + Spec 010
+;; §Where schemas attach — a RECORDABLE coeffect declared on the handler's
+;; `:rf.cofx/requires` is delivered FLAT into the coeffects map, and its
+;; value is validated against the cofx registration's `:schema`. A
+;; well-formed recordable value flows through to the handler; a malformed
+;; value (supplied/replayed or generated) emits :rf.error/cofx-value-invalid
+;; and THROWS — the handler is NOT invoked (recovery: :no-recovery). This is
+;; the EP-0017 recordable-cofx schema path that REPLACES the retired
+;; ctx-mutating `inject-cofx` injection-time validation (the old
+;; :rf.error/schema-validation-failure :where :cofx shape is gone with
+;; `inject-cofx`).
 ;;
-;; This fixture pairs with reg-cofx's :schema metadata (Spec 010 §Where
-;; schemas attach §On every reg-*).
+;; This fixture pairs with reg-cofx's `{:recordable? true :schema …}`
+;; metadata (Spec 010 §Where schemas attach §On every reg-*). The recordable
+;; value is supplied on the dispatch token's `:rf.cofx` map (the
+;; supplied/replayed path) so the fixture is host-agnostic — no generator
+;; nondeterminism, just the declared `:schema` contract on a flat value.
 ;;
 ;; This capability — :schemas/cofx — is finer-grained than the baseline
-;; :schemas/runtime. Ports that have wired cofx-injection validation
-;; declare :schemas/cofx alongside :schemas/runtime; ports that haven't
-;; are skipped on this fixture.
+;; :schemas/runtime. Ports that have wired EP-0017 recordable-cofx :schema
+;; validation declare :schemas/cofx alongside :schemas/runtime; ports that
+;; haven't are skipped on this fixture.
 ;;
 ;; Dynamic-host only.
 
 {:fixture/id           :schemas/cofx-validates
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/error :schemas/runtime :schemas/cofx}
- :fixture/doc          "A reg-cofx handler with a :schema validates the value the cofx injects, after injection and before the event-fx handler runs. A well-formed coeffect map flows through to the handler; a malformed value emits :rf.error/schema-validation-failure with :where :cofx, and the handler is NOT invoked."
+ :fixture/doc          "A reg-cofx RECORDABLE registration with a :schema validates the value the handler takes delivery of via :rf.cofx/requires. A well-formed recordable value flows through to the handler; a malformed value emits :rf.error/cofx-value-invalid and the handler is NOT invoked (EP-0017 §5, the recordable-cofx :schema path that replaces the retired inject-cofx injection-time validation)."
  :fixture/dynamic-host-only? true
 
  :fixture/registry
- ;; Two cofx, both injecting :app-version under :coeffects. The well cofx
- ;; returns a string (passes the :string schema). The bad cofx returns a
- ;; number (fails the :string schema).
- {:cofx  {:app-version/well
-          {:doc  "Inject a well-typed app-version string."
-           :schema :string}
-          :app-version/bad
-          {:doc  "Inject a malformed app-version (number, schema rejects)."
-           :schema :string}}
+ ;; A single PROVIDED recordable cofx `:app-version/v` with a :string :schema.
+ ;; A provided recordable fact carries no supplier — its VALUE rides the
+ ;; dispatch token's :rf.cofx map (the supplied / replayed path). Delivery
+ ;; validates the supplied value against :schema, fails (a number is not a
+ ;; :string), and throws :rf.error/cofx-value-invalid before the event-fx
+ ;; handler runs (EP-0017 §5; deliver-declared-cofx supplied-value branch).
+ {:cofx  {:app-version/v
+          {:doc         "A provided recordable app-version coeffect; declared :string."
+           :recordable? true
+           :provided?   true
+           :schema      :string}}
   :event {:cap/seed
-          {:doc "Read :app-version from coeffects and stash it in app-db."}}}
+          {:doc "Read the recordable cofx; the runner auto-wires :rf.cofx/requires."}}}
 
  :fixture/handlers
- ;; Per rf2-g25p the runner now realises cofx bodies via `eval-value`,
- ;; so the `:set` step's value is the value injected at [:coeffects cofx-id].
- ;; The path slot is symbolic — convention is `[k]` where `k` is the
- ;; bare key shared by namespaced cofx-ids (matches `[:cofx-key k]`
- ;; reads in event bodies via the runner's auto-injection heuristic).
- {:cofx  {:app-version/well [[:set [:app-version] "1.4.5"]]
-          :app-version/bad  [[:set [:app-version] 42]]}
-  :event {:cap/seed [[:set [:app-version] [:cofx-key :app-version]]]}}
+ ;; The event reads the delivered recordable value flat under its id and
+ ;; stashes it. Reading `[:cofx-key :app-version/v]` declares the dependency
+ ;; (the runner auto-wires it onto the handler's :rf.cofx/requires, EP-0017
+ ;; model). The cofx has NO body — a provided recordable value is supplied on
+ ;; the token, not produced by a supplier.
+ {:event {:cap/seed [[:set [:app-version] [:cofx-key :app-version/v]]]}}
 
  :fixture/frame-config {}
 
  :fixture/dispatches
- [[:cap/seed]]
+ ;; Supply the malformed recordable value on the dispatch token's :rf.cofx
+ ;; map. Delivery validates it against the registration's :string :schema,
+ ;; fails, emits :rf.error/cofx-value-invalid, and THROWS during context
+ ;; assembly (a production hard error — an out-of-contract durable value is
+ ;; corrupt causal state). The throw escapes dispatch-sync, so the dispatch
+ ;; declares the expected `:rf.error/id` via `:expect-error` (the EP-0017
+ ;; boundary-throw assertion shape; the trace still fires BEFORE the throw and
+ ;; is asserted below).
+ [{:event        [:cap/seed]
+   :rf.cofx      {:app-version/v 42}
+   :expect-error :rf.error/cofx-value-invalid}]
 
  :fixture/expect
- ;; The malformed cofx triggered :where :cofx and the handler was skipped —
- ;; :app-version stays unset.
+ ;; The malformed recordable value failed :schema validation, the handler was
+ ;; skipped (the throw pre-empts it), and the error trace fired.
  {:final-app-db {}
 
   :trace-emissions
-  [{:operation :rf.event/run-start :tags {:rf.trace/event-id :cap/seed}}
-   {:operation :rf.error/schema-validation-failure
+  [{:operation :rf.error/cofx-value-invalid
     :op-type   :error
-    :tags      {:category   :rf.error/schema-validation-failure
-                :failing-id :cap/seed
-                :where      :cofx
-                :rf.cofx/id    :app-version/bad}
+    :tags      {:rf.cofx/id :app-version/v
+                :failing-id :cap/seed}
     :recovery  :no-recovery}]}}


### PR DESCRIPTION
Three disjoint implementation-dir bug fixes (rf2-hqwki4 + rf2-jtlq7l + rf2-n0851k), each with a regression test.

## routing — fragment-only route trace drops frame attribution (rf2-n0851k)

`fragment-only-fx` emitted `:rf.route/fragment-changed` with `:route-id` / `:prev-fragment` / `:next-fragment` but no `:frame`. Per Spec 012 routing traces inside a known navigation cascade must carry `:tags :frame`; without it the trace is dropped from epoch/Xray capture (which buffers only frame-tagged events) and bypasses the frame-level trace-disable gate.

Fix: thread the validated `frame` stamp (already in scope in `url-change-fx`, validated at both handler tops via `require-frame-stamp!`) into the fragment-only trace tags. Honoured on both `:rf.route/transitioned` (forward nav) and `:rf.route/handle-url-change` (popstate), since the branch lives in the shared helper. No nav-token allocation / no `:on-match` re-fire behaviour is preserved.

Tests: `routing_navigation_test` (forward-nav + popstate frame-tag assertions) and `routing_history_cljs_test` (CLJS hashchange frame-tag assertion).

## resources — introspection exposes byte-keyed internal entries (rf2-jtlq7l)

`(resources {:frame f})` returned the raw runtime `:entries` map keyed by internal CEDN byte `key-id` strings, contradicting the documented `{<scoped-key-vector> <entry>}` shape — callers couldn't destructure `[scope resource-id params]`, filter by scope/resource, or compare against scoped keys.

Fix: rekey `:entries` to each entry's `:resource/key` scoped-key vector (the same fact identity the live tooling view reads), via `reduce-kv`. Internal runtime storage stays byte-keyed; the frameless `(resources)` call still returns `{:resource-ids [...] :entries {}}`.

Test: `resources_runtime_cljs_test` — installs two entries with distinct scoped keys; asserts vector keys, no byte-key string leak, clean scope/resource filtering, and frameless empty-entries.

## schemas — cofx conformance still targets the removed inject-cofx behavior (rf2-hqwki4)

`schema-cofx-validates.edn` modelled cofx validation through the removed ctx-mutating `inject-cofx` API and the retired `:rf.error/schema-validation-failure :where :cofx` shape, leaving the landed EP-0017 recordable-cofx `:schema` path outside conformance coverage (`:schemas/cofx` was unclaimed).

Fix: rewrote the fixture to the EP-0017 recordable-cofx semantics — a provided recordable value supplied on the dispatch token's `:rf.cofx`, validated against the registration's `:schema`, failing with `:rf.error/cofx-value-invalid` (a context-assembly throw, asserted via `:expect-error`; the error trace fires before the throw and is asserted too). Updated the schemas conformance runner to the EP-0017 model (value-returning suppliers instead of ctx→ctx handlers, `:rf.cofx/requires` auto-wiring instead of `inject-cofx` interceptors, `:expect-error` dispatch support) and claimed `:schemas/cofx`.

Cross-dir note: the conformance corpus fixture is shared and the slice-B deferral was coordinated across the core + schemas runner claim sets, so this fix necessarily also updates `spec/conformance/fixtures/schema-cofx-validates.edn` and the core JVM + CLJS conformance runner claims (`implementation/core/test/`). Both core runners already support the EP-0017 cofx shape + `:expect-error`; only the claim-set moves.

## Quality gates

Ran (Windows full-JVM, bounded per-dir):
- `clojure -M:test` full suite, `implementation/schemas` — 295 tests / 18764 assertions, 0 failures
- `clojure -M:test` full suite, `implementation/routing` — 264 tests / 1292 assertions, 0 failures
- `clojure -M:test` full suite, `implementation/resources` — 414 tests / 1642 assertions, 0 failures
- `clojure -M:test -n re-frame.conformance-test`, `implementation/core` — 0 failures (the shared cofx fixture now runs in-claim there too)
- Targeted verification (temporary deftest, since removed): confirmed the cofx fixture is IN-CLAIM (not skipped) and PASSES in the schemas runner

Not run locally (covered by CI-Linux): `npm run test:cljs` — shadow-cljs is not installed in `implementation/node_modules` and an `npm install` risks the Windows full-JVM deadlock. The CLJS-only additions (routing_history_cljs_test, the `.cljs` arm of resources_runtime, the CLJS conformance corpus runner) mirror JVM-verified logic and are gated by CI.

Closes rf2-hqwki4, rf2-jtlq7l, rf2-n0851k.