### PR TITLE
fix(core): source-coords absolutise-file preserves literal + in file paths (URI.getPath)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -420,12 +420,20 @@
          (if-let [url (.getResource (context-class-loader) path)]
            (if (= "file" (.getProtocol url))
              ;; URL paths come out URL-encoded (e.g. `%20` for spaces)
-             ;; and use `/` on every platform. URLDecoder handles the
-             ;; encoding; the result on Windows is `/C:/Users/...` so
-             ;; strip a leading slash before a drive-letter to get the
-             ;; canonical `C:/Users/...` shape `compose-path` already
-             ;; handles.
-             (let [decoded (java.net.URLDecoder/decode (.getPath url) "UTF-8")]
+             ;; and use `/` on every platform. Decode via `URI.getPath`
+             ;; rather than `URLDecoder`: `URLDecoder` is a form-body
+             ;; (`application/x-www-form-urlencoded`) decoder that maps a
+             ;; literal `+` to a space — but a `file:` URL path is NOT
+             ;; form-encoded, so a literal `+` in a checkout path (e.g.
+             ;; `C:/code/re-frame2+wip`) must survive verbatim. `URI.getPath`
+             ;; decodes percent-escapes (`%20` → space, `%2B` → `+`) while
+             ;; leaving a literal `+` untouched — the correct grammar for a
+             ;; `file:` URL path (mirrors `file-url->path` in
+             ;; re-frame.testbed.open-in-editor-server, the runtime twin).
+             ;; The result on Windows is `/C:/Users/...` so strip a leading
+             ;; slash before a drive-letter to get the canonical
+             ;; `C:/Users/...` shape `compose-path` already handles.
+             (let [decoded (.getPath (.toURI url))]
                (if (and (> (.length ^String decoded) 2)
                         (= \/ (.charAt ^String decoded 0))
                         (= \: (.charAt ^String decoded 2)))

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -41,7 +41,12 @@
             ;; file regression coverage.
             [re-frame.source-coords :as sc]
             [re-frame.source-coords.editor-uri :as eu]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            ;; rf2-st3ax4 — build a throwaway `+`-bearing classpath root to
+            ;; assert absolutise-file preserves a literal `+` in the path.
+            [clojure.java.io :as io])
+  (:import [java.net URL URLClassLoader]
+           [java.io File]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -278,6 +283,91 @@
   call-sites already gate on non-nil, but defense-in-depth)"
     (is (nil? (#'sc/absolutise-file nil)))
     (is (= "" (#'sc/absolutise-file "")))))
+
+;; ---- rf2-st3ax4: a literal `+` in the classpath path survives -------------
+;;
+;; The macro-expansion-time twin of the open-in-editor server's resolve-file
+;; had the same URLDecoder-+-plus bug: URLDecoder is a form-body decoder that
+;; maps a literal `+` to a space, so a checkout/source path containing a
+;; literal `+` (e.g. `C:/code/re-frame2+wip/core.cljs`) got the `+` turned
+;; into a space, baking a nonexistent space-bearing absolute :file into the
+;; emitted coord literal. The fix decodes via `URI.getPath` (which leaves a
+;; literal `+` intact while still decoding `%20`/`%2B`), mirroring
+;; `file-url->path` in re-frame.testbed.open-in-editor-server.
+
+(deftest absolutise-file-preserves-literal-plus-in-classpath
+  (testing "rf2-st3ax4: absolutise-file resolves a classpath-relative :file
+  to its on-disk absolute path when the classpath root directory itself
+  contains a literal + — the + is returned verbatim, NOT form-decoded to a
+  space-bearing nonexistent path (the URLDecoder bug)"
+    ;; Build a throwaway classpath root dir whose name carries a `+`, drop a
+    ;; fake source file under it, push a class-loader rooted there onto the
+    ;; context, and confirm absolutise-file finds the real on-disk file.
+    (let [tmp      (File. (System/getProperty "java.io.tmpdir")
+                          (str "scoords+test-" (System/nanoTime)))
+          rel-path "fake_ns/core.cljs"
+          src-file (io/file tmp "fake_ns" "core.cljs")]
+      (try
+        (io/make-parents src-file)
+        (spit src-file ";; fixture\n")
+        (let [root-url (.toURL (.toURI tmp))
+              cl       (URLClassLoader. (into-array URL [root-url])
+                                        (.getContextClassLoader (Thread/currentThread)))
+              prev     (.getContextClassLoader (Thread/currentThread))]
+          (try
+            (.setContextClassLoader (Thread/currentThread) cl)
+            (let [resolved (#'sc/absolutise-file rel-path)]
+              (is (string? resolved) "the classpath resource resolved")
+              (is (not= rel-path resolved)
+                  "classpath-relative path resolved to a different (absolute) path")
+              (is (.contains ^String resolved "+")
+                  "the literal + in the classpath root survived resolution")
+              (is (not (.contains ^String resolved " "))
+                  "the literal + was NOT form-decoded into a space")
+              (is (= (.getCanonicalPath src-file)
+                     (.getCanonicalPath (File. ^String resolved)))
+                  "resolved to the REAL on-disk fixture file, not a
+                   space-corrupted sibling that does not exist"))
+            (finally
+              (.setContextClassLoader (Thread/currentThread) prev))))
+        (finally
+          ;; Best-effort cleanup of the throwaway tree.
+          (when (.exists src-file) (.delete src-file))
+          (.delete (io/file tmp "fake_ns"))
+          (.delete tmp))))))
+
+(deftest absolutise-file-decodes-percent-escapes
+  (testing "rf2-st3ax4: percent-escapes in the resource URL still decode
+  correctly — a classpath root whose name contains a real space (URL-encoded
+  as %20) round-trips to the space, and %2B (the encoded plus) decodes to a
+  literal +. This is the other half of the URI.getPath contract: it decodes
+  percent-escapes while leaving a literal + intact."
+    (let [tmp      (File. (System/getProperty "java.io.tmpdir")
+                          (str "scoords space-test-" (System/nanoTime)))
+          rel-path "fake_ns/core.cljs"
+          src-file (io/file tmp "fake_ns" "core.cljs")]
+      (try
+        (io/make-parents src-file)
+        (spit src-file ";; fixture\n")
+        (let [root-url (.toURL (.toURI tmp))
+              cl       (URLClassLoader. (into-array URL [root-url])
+                                        (.getContextClassLoader (Thread/currentThread)))
+              prev     (.getContextClassLoader (Thread/currentThread))]
+          (try
+            (.setContextClassLoader (Thread/currentThread) cl)
+            (let [resolved (#'sc/absolutise-file rel-path)]
+              (is (string? resolved) "the classpath resource resolved")
+              (is (.contains ^String resolved " ")
+                  "%20 in the resource URL decoded back to a real space")
+              (is (= (.getCanonicalPath src-file)
+                     (.getCanonicalPath (File. ^String resolved)))
+                  "resolved to the REAL on-disk fixture file"))
+            (finally
+              (.setContextClassLoader (Thread/currentThread) prev))))
+        (finally
+          (when (.exists src-file) (.delete src-file))
+          (.delete (io/file tmp "fake_ns"))
+          (.delete tmp))))))
 
 (deftest reg-event-emits-absolute-file
   (testing "rf2-wvsxg: a reg-* macro fired against a real classpath-


### PR DESCRIPTION
## Summary

`absolutise-file` (`implementation/core/src/re_frame/source_coords.cljc`, the macro-expansion-time helper that bakes the absolute `:file` into every emitted source-coord) decoded a classpath `file:` resource URL path with `java.net.URLDecoder/decode`. `URLDecoder` is an `application/x-www-form-urlencoded` form-body decoder that maps a literal `+` to a space — but a `file:` URL path is not form-encoded. A checkout/source path containing a literal `+` (e.g. `C:/code/re-frame2+wip/core.cljs`) therefore had its `+` turned into a space at macro-expansion time, baking a nonexistent space-bearing absolute `:file` into the emitted coord literal; the downstream editor URI then pointed at a path that does not exist.

This is the macro-expansion-time twin of the `tools/testbed-support` open-in-editor endpoint bug fixed in rf2-l3qexe (#4322). The endpoint's docstring documents itself as the runtime twin of `absolutise-file`.

## Fix

Decode via `URI.getPath` instead of `URLDecoder/decode`. `URI.getPath` decodes percent-escapes (`%20` → space, `%2B` → `+`) while leaving a literal `+` untouched — the correct grammar for a `file:` URL path. This mirrors the `file-url->path` helper added to `re-frame.testbed.open-in-editor-server` by the rf2-l3qexe fix (now on main).

The Windows `/C:/` leading-slash strip is preserved unchanged, so behaviour for normal (no-`+`) paths is identical — confirmed by the full pre-existing source-coords test suite still passing.

## Tests

Adds two JVM regression tests in `source_coords_test.clj`:

- `absolutise-file-preserves-literal-plus-in-classpath` — builds a throwaway classpath root directory whose name carries a literal `+`, drops a fixture source file under it, pushes a `URLClassLoader` rooted there onto the context, and asserts `absolutise-file` resolves to the REAL on-disk file with the `+` intact (and no space corruption).
- `absolutise-file-decodes-percent-escapes` — the other half of the `URI.getPath` contract: a `%20`-bearing (space) classpath root round-trips to the real space-bearing on-disk file.

## Quality gates

- `clojure -M:test -n re-frame.source-coords-test` (from `implementation/core/`): **25 tests, 140 assertions, 0 failures, 0 errors** (2 new tests + 23 pre-existing, which exercise the normal no-`+` path → confirms unchanged behaviour).
- `clojure -M:test -n re-frame.source-coords-editor-uri-test`: **45 tests, 147 assertions, 0 failures, 0 errors**.
- Full CLJS run not executed locally; CI-Linux covers it. This is a macro/JVM-expansion path, so the JVM `clojure -M:test` gate is the directly-relevant one.
