### PR TITLE
feat(core): accept :realm in known dispatch opts (EP-0013)

### DIFF
--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -126,10 +126,18 @@
                             config's policy, else the router's `:live` default
                             (rf2-5spzo7)
     :rf.trace/call-site     macro-stamped invocation coord (dev-only)
-    :rf.machine/internal?   machine-internal continuation flag (front-queue)"
+    :rf.machine/internal?   machine-internal continuation flag (front-queue)
+    :realm                  EP-0013 step 4 (rf2-a15n62) realm-routing opt —
+                            the REALM half of the carried (realm, frame)
+                            address (a realm map or id). `build-envelope`
+                            reads it to resolve `realm-id` and stamps the
+                            non-default result onto the envelope as the
+                            SEPARATE `:rf.realm/id` fact. `:realm` is the
+                            PUBLIC opts spelling; `:rf.realm/id` is the carried
+                            envelope key, never a caller-supplied opt."
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
     :source-detail :origin :rf.cofx :rf.cofx/mint-policy :rf.trace/call-site
-    :rf.machine/internal?})
+    :rf.machine/internal? :realm})
 
 (defn reject-retired-dispatch-opts!
   "Throw `:rf.error/dispatched-at-retired` when a `dispatch` /

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -107,6 +107,22 @@
       (is (empty? (unknown-opt-warnings recorded))
           ":frame is a recognised opt — no warning"))))
 
+(deftest no-warning-for-realm-opt
+  (testing "EP-0013 step 4 (rf2-a15n62): a realm-routed `{:realm r :frame f}`
+            dispatch — the shipped public envelope — emits no unknown-opt
+            warning; `:realm` is a recognised opt build-envelope honours"
+    (rf/reg-frame :game {:doc "non-default frame target"})
+    (rf/reg-event :game/tick {:frame :game} (fn [{:keys [db]} _] {:db db}))
+    (let [recorded (record-traces! ::realm)]
+      ;; `:rf.realm/default` keeps the dispatch on the default realm (so the
+      ;; default-seated `:game` frame resolves and the dispatch completes),
+      ;; while exercising the `:realm` opts key through build-envelope's
+      ;; known-opts check — the path the conformance test drives live with a
+      ;; constructed non-default realm (`{:realm :live/a :frame :live/f}`).
+      (rf/dispatch-sync [:game/tick] {:realm :rf.realm/default :frame :game})
+      (is (empty? (unknown-opt-warnings recorded))
+          ":realm + :frame are both recognised opts — no warning"))))
+
 (deftest no-warning-for-source-and-origin-opts
   (testing "the full known set is accepted without warning"
     (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
@@ -145,7 +161,11 @@
     ;; EP-0017 §6 / slice-B.8 per-call cofx mint policy (rf2-5spzo7) —
     ;; build-envelope reads it and threads it through to the satisfaction
     ;; step's mint-policy resolution, so it belongs in the honoured set.
+    ;; `:realm` is the EP-0013 step 4 (rf2-a15n62) realm-routing opt —
+    ;; build-envelope reads it off the opts map to resolve `realm-id` and
+    ;; stamps the non-default result onto the envelope as `:rf.realm/id`, so
+    ;; the PUBLIC opts spelling `:realm` belongs in the honoured set.
     (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
              :source-detail :origin :rf.cofx :rf.cofx/mint-policy
-             :rf.trace/call-site :rf.machine/internal?}
+             :rf.trace/call-site :rf.machine/internal? :realm}
            diag/known-dispatch-opts))))


### PR DESCRIPTION
## Summary

EP-0013 step 4 (rf2-a15n62) shipped realm-aware dispatch: `re-frame.router/build-envelope` reads the public `:realm` opt off the `dispatch` / `dispatch-sync` opts map to resolve the realm half of the carried `(realm, frame)` address, then stamps the non-default result onto the envelope as the *separate* `:rf.realm/id` fact (never a caller-supplied opt). But `re-frame.router.diagnostics/known-dispatch-opts` — the closed set the `:rf.warning/unknown-dispatch-opt` check validates against — was never updated, so a legitimate realm-routed dispatch `{:realm r :frame f}` (the shipped live envelope) warned as carrying an unknown opt.

Fixes **rf2-fr7kjo**.

### Changes
- `implementation/core/src/re_frame/router/diagnostics.cljc` — add `:realm` to `known-dispatch-opts` and its docstring enumeration, noting `:realm` is the public opts spelling and `:rf.realm/id` is the carried envelope key.
- `implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj` — update the drift guard test (`known-set-matches-build-envelope-reads`) to include `:realm`; add `no-warning-for-realm-opt` proving `{:realm r :frame f}` emits no unknown-opt warning.

## Quality gates

Bounded to the core dispatch/diagnostics surface (Windows full-JVM sweeps can deadlock; node_modules not present in this worktree, so CLJS node run deferred to CI-Linux):

- `clojure -M:test -n re-frame.unknown-dispatch-opts-warn-test` (JVM) — **8 tests, 17 assertions, 0 failures** (includes the updated guard test + new realm regression test)
- `clojure -M:test -n re-frame.realm-conformance-cljs-test` (JVM) — **25 tests, 106 assertions, 0 failures** (exercises the live `{:realm ... :frame ...}` dispatch)
- `npm run test:cljs` — not run locally (no node_modules in worktree; bounded-gate guidance). CI-Linux covers the full CLJS spine.

The warning/guard test is a JVM-only `.clj` and fully covers the diagnostics change.
