### PR TITLE
fix(cljs): stabilize/repair node-test (machines-viz share fn-as-state-id-survives-sanitisation)

### DIFF
--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -379,7 +379,7 @@
       ;; The `:fn` EVENT id (and its target) survive too.
       (is (= :done (get-in dfn [:states :fn :on :fn]))
           "the `:fn` EVENT id + its target are preserved")
-      (is (= :done (get-in dfn [:states :fn :on :next]))
+      (is (= :other (get-in dfn [:states :fn :on :next]))
           "sibling transitions on the `:fn` state are intact")
       (is (contains? (:states dfn) :other))
       (is (true? (get-in dfn [:states :done :final?]))))))


### PR DESCRIPTION
## Summary

The **CLJS (shadow-cljs :node-test)** check was failing **deterministically on `main`**, blocking PRs #4309, #4334, #4336, #4337 (none of which touch CLJS source). Not flaky — a real main breakage.

**Failing test:** `fn-as-state-id-survives-sanitisation` at `tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs:382`.

```
FAIL in (fn-as-state-id-survives-sanitisation)
expected: (= :done (get-in dfn [:states :fn :on :next]))
  actual: (not (= :done :other))
```

**Root cause:** commit `0e266e89f` (rf2-07gg7h, "preserve topology entries") added this regression test with a **wrong assertion**. The fixture maps event `:next` -> state `:other`:

```clojure
:fn {:on {:fn   :done    ;; :fn event -> :done   (asserted correctly, line 380)
          :next :other}} ;; :next event -> :other (asserted as :done — the typo)
```

The share sanitiser correctly round-trips `:next` -> `:other`, so `actual` was `:other` and the **test expectation** was the bug, not the source. The privacy/topology source fix itself is sound.

**Fix:** one-line — expect `:other` (the actual fixture target) for `[:states :fn :on :next]`.

## Quality gates

- `npm run test:cljs` (from `implementation/`):
  - **Pre-fix:** failed deterministically (runs 1 & 2, identical assertion).
  - **Post-fix:** green across **3 consecutive runs** — `Ran 7299 tests containing 30085 assertions. 0 failures, 0 errors.`

Closes rf2-pwcxo6. Do not merge without operator sign-off.