### PR TITLE
docs(spec): 011-SSR id-scrub residue + 008-Testing arity + TransducerRouter trailer

### DIFF
--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -57,7 +57,7 @@ The plain-atom adapter (JVM, SSR, headless) does NOT ship `flush-views!` — the
 | Replace interceptor | `{:interceptor-overrides {:logger nil}}` per-call or per-frame |
 | Add interceptor (recorder) | `(rf/reg-frame :test-frame {:interceptors [event-recorder]})` |
 | Assertion: read app-db | `(rf/app-db-value :test-frame)` |
-| Assertion: read snapshot | `@(rf/sub-machine :auth/state-machine)` (or `(get-in (rf/runtime-db-value) [:rf.runtime/machines :snapshots :auth/state-machine])` for storage-layer assertions) |
+| Assertion: read snapshot | `@(rf/sub-machine :auth/state-machine)` (or `(get-in (rf/runtime-db-value f) [:rf.runtime/machines :snapshots :auth/state-machine])` for storage-layer assertions) |
 | Pure machine simulation | `(machine-transition definition snapshot event)` — no frame needed |
 | Machine cleanup on destroy | `(rf/destroy-frame! f)` — disposes sub-cache, stops router, clears overrides |
 | Static sub-graph inspection | `(rf/sub-topology)` |

--- a/spec/Design-TransducerRouter.md
+++ b/spec/Design-TransducerRouter.md
@@ -1,5 +1,5 @@
 > **Type:** Design (post-v1 / v1.1 design pass)
-> Status: deferred from v1; design-only pass tracked by.
+> Status: deferred from v1; design-only pass.
 
 # Design — Transducer-shaped event router (substrate-agnostic)
 


### PR DESCRIPTION
Three small P4 spec-doc fixes (disjoint files, one pass).

## Changes

- **rf2-10vfhi** — `spec/008-Testing.md`: the Normative-surface 'read snapshot' table cell showed `(rf/runtime-db-value)` with no frame-id arg. Added the missing arg → `(rf/runtime-db-value f)`, matching `API.md` (`(runtime-db-value frame-id)`) and the correct prose form already in the doc.
- **rf2-jpie8g** — `spec/Design-TransducerRouter.md:2`: stripped the dangling `tracked by.` trailer left by a removed bead-id → `design-only pass.`. No `rf2-` bead-id reintroduced (spec-prose convention).
- **rf2-9r05nh** — `spec/011-SSR.md`: **no change needed.** The spec-wide `rf2-` id scrub (#4336, e5h43y) already removed every bead-id and dangling `[rf2-](#)` stub from this doc. The only remaining `rf2-` strings are legitimate `data-rf2-source-coord` / `data-rf2-suspense-*` HTML attribute names that are part of the shipped SSR wire contract — correctly preserved. Closed as done-by-#4336.

## Quality gates

- `mkdocs build --strict` (staging `rm -rf docs/spec && cp -r spec docs/spec`) — PASS (built in 15.7s; INFO-only, no warnings escalated)
- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `python scripts/check_readme_links.py` — PASS (exit 0)

## Scope

Edited only the three named spec files (011-SSR unchanged). No `rf2-` bead-ids introduced into spec prose. Verified against shipped reality (`API.md` signature; existing in-doc prose form).