### PR TITLE
feat(xray): EP-0022 interceptor surfacing in epoch/dynamic panel + a15n62 realm in static browse

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -435,6 +435,31 @@ realm dimension is spelled only when more than one realm is present.**
   is reserved per disposition 2; the emit is a later core slice), so in a
   single-realm process every row's `:realm` is nil and the surface is
   inert — exactly the zero-ceremony posture.
+- **Static-registry browse + handler-resolution — qualify by realm**
+  (disposition-1/2, rf2-dfaey7). The static browse panels read
+  registrations via `(rf/registrations :kind)` — the DEFAULT realm only —
+  so a multi-realm host could not see which realm owns a registration nor
+  flag a cross-realm id conflict (the same id registered in two realms).
+  The shared `static/shared/realm.cljs` helper composes the EP-0013 stage-8
+  map-shaped query form `(rf/registrations {:realm r :kind k})` + the
+  installed-realm enumeration `rf/realm-ids` into the browse: it returns
+  realm-qualified `[realm-id reg-map]` pairs (`realm-qualified-registrations`),
+  attributes each row to its owning `:rf.realm/id` (`realm-of` blanks the
+  default realm — absence is the default), flags ids spanning >1 realm
+  (`cross-realm-ids`), and renders a per-row realm chip (`realm-badge`,
+  warning-toned on a cross-realm conflict) ONLY in a multi-realm browse.
+  **Handler-resolution is realm-scoped**: a chain entry resolves its
+  `:interceptor` descriptor against the SAME realm the event lives in
+  (`resolve-ref-fn-for` per realm). The named first consumer is the **Static
+  Interceptors** sub-tab (`static/interceptors/panel.cljs`,
+  `collect-interceptors-by-realm` + the `:rf.xray.static.interceptors/realm-pairs`
+  sub feeding `tab-data`); the same helper extends to the schemas / flows /
+  routes / machines browse panels when multi-realm demand lands. Single-realm
+  hosts (the common case: `(rf/realm-ids)` ⇒ `#{:rf.realm/default}`) read the
+  default-realm path — `realm-badge` renders nothing, no realm column appears,
+  the browse is byte-identical to the pre-rf2-dfaey7 surface. Fail-soft: a
+  core too old for the map-shaped query form / `rf/realm-ids` degrades to the
+  default-realm read.
 - **Module-view — the disposition-6 demand-trigger tab** (rf2-wtg9z4).
   A new Dynamic L4 tab (`panels/module_view.cljs`, label **Modules**,
   order 9, registered via `reg-l4-tab!` — an L4-only tab, no `mount-*!`

--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -574,6 +574,16 @@ was removed). The mode pill mounts at ribbon-left, `Cmd-Shift-M` /
 selected mode + sub-tab persist to localStorage. Per rf2-o5f5f.1 +
 rf2-o5f5f.2 + rf2-o5f5f.3 + rf2-ybjkx + rf2-8l3uk.
 
+**Realm-awareness (rf2-dfaey7 · a15n62).** The static browse panels qualify
+their registrations by realm via the shared `static/shared/realm.cljs`
+helper (`realm-qualified-registrations` / `realm-of` / `cross-realm-ids` /
+`realm-badge`) — see [`007-UX-IA.md`](./007-UX-IA.md) §EP-0013
+realm-awareness. The named first consumer is the Static Interceptors sub-tab,
+which adds the `:rf.xray.static.interceptors/realm-pairs` sub (the
+realm-qualified `:event` pairs feeding `tab-data`). Single-realm hosts read
+the default-realm path and render byte-identically; the realm dimension
+materialises only when >1 realm is installed.
+
 ### Subscriptions
 
 | Sub | Returns | Notes |

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -236,7 +236,7 @@ muted (`var(--text-secondary)`); the numbered circles + the rail carry the order
 
 The **mode-accent stripe** (the single GitHub-blue accent, both modes) sits at the panel's edge.
 
-Optional sections (COEFFECTS, FLOWS, AFTER INTERCEPTORS) are **shown only when present** —
+Optional sections (COEFFECTS, INTERCEPTORS, FLOWS) are **shown only when present** —
 absence is conveyed by omission, not an empty-state line. A throwing handler therefore simply
 has no APP-DB CHANGES / later sections; there is **no outcome badge** and **no "db committed"
 footer**.
@@ -247,7 +247,29 @@ Section order (numbered; optional sections shown only when present):
      click-to-source link).
   2. **COEFFECTS** *(optional)* — user-injected coeffects: each id (click-to-source) + the
      value it added to context (`+ [:now] #inst…`).
-  3. **EVENT HANDLER** — the verb (`reg-event`, the one public event-registration form after
+  3. **INTERCEPTORS** *(optional · rf2-se9a9t · EP-0022 §11)* — the **authored interceptor
+     chain** that wraps this event's handler, shown when the event carries authored
+     (non-`:rf/default?`) interceptor refs. The authored chain WRAPS the handler — frame-refs
+     then event-refs run `:before` on the way in — so it renders BEFORE EVENT HANDLER. Each
+     row is the AUTHORED ref (a bare keyword `:auth/required` or an `[id arg]` factory ref
+     `[:rf.interceptor/path [:cart]]`) as a click-to-source link, ENRICHED with the RESOLVED
+     descriptor's hook shape (`before` / `after` / `before/after` / `factory`) read via
+     `(handler-meta :interceptor id)`, a `ref` / `inline` badge, the factory `:arg`, and a
+     `missing` chip for an unregistered ref (`:rf.error/unregistered-interceptor`). This is
+     the **clean-chain** surfacing (EP-0022 §11 (a) authored refs + (b) resolved chain) — the
+     gap the exception-only INTERCEPTOR step (rf2-yz57h, below) left. The framework
+     auto-wrapper (`:rf/event-handler`, `:rf/default?`) is filtered out — it is not an
+     authored program member; **hidden entirely when the event carries no authored refs**
+     (the common case). The step is purely informational and does NOT inflate the epoch
+     outcome. The authored refs are not on the trace stream (a clean chain emits no
+     per-interceptor "ran" trace), so the panel reads them from the REGISTRY at render time;
+     the pure projection threads a resolver in (`projection/authored-interceptors-step` ←
+     `epoch-panel/resolve-event-interceptors`) and stays JVM-testable. *(Per-call /
+     per-frame `:interceptor-overrides` substitutions are not currently traced per dispatch,
+     so the post-hoc panel surfaces the AUTHORED + RESOLVED chain; override-substitution
+     surfacing (§11 (c)) is deferred until the substrate emits per-dispatch override trace —
+     it cannot project a substitution the core does not emit.)*
+  4. **EVENT HANDLER** — the verb (`reg-event`, the one public event-registration form after
      EP-0018; `reg-machine` for machine handlers) as a click-to-source
      link + the **syntax-highlighted handler source** in a code block + a **returned
      effects sub-block** (the t1 pre-commit observable: the pending `:db` VALUE + each
@@ -258,7 +280,7 @@ Section order (numbered; optional sections shown only when present):
      cost negligible). When the runtime is older than rf2-ta0y7 (no t1 on the stream)
      the block falls back gracefully to a presence-only placeholder pointing at APP-DB
      CHANGES for the committed diff.
-  4. **FLOWS** *(optional)* — flows that recomputed + the db path they wrote (the t1→t2
+  5. **FLOWS** *(optional)* — flows that recomputed + the db path they wrote (the t1→t2
      reshape · pre-commit). Flows fire at the outermost `:after` interceptor, right after
      the handler and any user `:after` interceptors — they reshape the pending `:db` BEFORE
      the single deferred install (the atomic commit), so they precede APP-DB CHANGES and run
@@ -270,8 +292,17 @@ Section order (numbered; optional sections shown only when present):
      above) → "what flows reshaped" (the per-flow rows) → "the post-flow result" (the
      trailing summary). The framework does NOT precompute a diff; the values are full at
      both endpoints, and any client-side diff is cheap.
-  5. **AFTER INTERCEPTORS** *(optional)* — non-standard after-interceptors: each id
-     (click-to-source) + the effect it contributed (`+ [:fx :local-storage] {…}`).
+
+     > **The INTERCEPTOR (exception-only) step (rf2-yz57h / rf2-vew2n).** Distinct from the
+     > authored-chain INTERCEPTORS step at (3) above, a SECOND, exception-only interceptor
+     > surface exists: when a USER interceptor THROWS, an `INTERCEPTOR` step renders the
+     > throwing interceptor (id + `:before`/`:after` phase chip + the shared exception card),
+     > phase-split — a `:before` throw renders BEFORE EVENT HANDLER, an `:after` throw AFTER
+     > it. It is conditional on a throw (the substrate emits no per-interceptor "ran" trace),
+     > so a clean chain leaves it empty; the clean chain is surfaced by the INTERCEPTORS step
+     > at (3) instead. *(The pre-rf2-se9a9t draft named a speculative "AFTER INTERCEPTORS"
+     > step at this position that the implementation never carried — rf2-se9a9t replaced it
+     > with the authored-chain INTERCEPTORS step at (3) + this exception-only note.)*
   6. **APP-DB CHANGES** — the **COMMITTED diff at t4** (the atomic install boundary). Carries
      a `committed diff (post-flow · atomic install boundary)` caption to keep users from
      reading the section as "what the handler returned" (the handler's pending effects map
@@ -291,13 +322,13 @@ The sketches below match the numbered section order above +
 `tools/xray/design-reference/xray_devtools_reference.cljs` (the `event-panel` component): a
 thin vertical rail down the left edge with a small **numbered step circle** (`①②…`) at each
 section, sections rendered top→bottom,
-optional sections (COEFFECTS / AFTER INTERCEPTORS / FLOWS) shown only when present. The `↗`
-glyphs mark click-to-source links (DISPATCH origin, each COEFFECT id, EVENT HANDLER, each AFTER
-INTERCEPTOR id, each FLOW id). There is **no outcome badge** and **no "db committed" footer** —
+optional sections (COEFFECTS / INTERCEPTORS / FLOWS) shown only when present. The `↗`
+glyphs mark click-to-source links (DISPATCH origin, each COEFFECT id, EVENT HANDLER, each
+authored INTERCEPTORS ref id, each FLOW id). There is **no outcome badge** and **no "db committed" footer** —
 absence of a step is conveyed by omission. Diff glyphs follow the cascade gutter (`~` modified ·
 `+` added · `-` removed).
 
-Dense case (default — focused epoch is a normal event with coeffects, after-interceptors,
+Dense case (default — focused epoch is a normal event with coeffects, authored interceptors,
 flows, and fx):
 
 ```
@@ -316,7 +347,12 @@ flows, and fx):
 │   │    :session ↗                                                         │
 │   │      + [:session]  {:user-id 42, :token "..."}                       │
 │   │                                                                       │
-│  ③  EVENT HANDLER ↗                                                       │
+│  ③  INTERCEPTORS                           (optional · shown when present) │
+│   │    authored chain (wraps the handler)                                 │
+│   │    :auth/required ↗            before    ref                          │
+│   │    :rf.interceptor/path ↗      factory   ref   [:counter]            │
+│   │                                                                       │
+│  ④  EVENT HANDLER ↗                                                       │
 │   │    (rf/reg-event :counter-inc             ← syntax-highlighted        │
 │   │      (fn [{:keys [db]} _]                                             │
 │   │        {:db (update db :counter inc)                                  │
@@ -326,15 +362,9 @@ flows, and fx):
 │   │       :fx   1 entry — see FX below for what ran                       │
 │   │             [:dispatch [:title/flow [:rf/init]]]                      │
 │   │                                                                       │
-│  ④  FLOWS                                  (optional · shown when present) │
+│  ⑤  FLOWS                                  (optional · shown when present) │
 │   │    :totals-flow ↗  →  [:totals] recomputed                           │
 │   │      + [:totals :sum]  42                                            │
-│   │                                                                       │
-│  ⑤  AFTER INTERCEPTORS                     (optional · shown when present) │
-│   │    :persist-db ↗                                                      │
-│   │      + [:fx :local-storage]  {:key "app-state" :value {...}}          │
-│   │    :analytics ↗                                                       │
-│   │      + [:fx :track]          {:event "counter-inc"}                   │
 │   │                                                                       │
 │  ⑥  APP-DB CHANGES                                                        │
 │   │    committed diff (post-flow · atomic install boundary)               │
@@ -348,7 +378,7 @@ flows, and fx):
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
-Sparse case (focused epoch is a noisy timer — no coeffects, no after-interceptors, no flows;
+Sparse case (focused epoch is a noisy timer — no coeffects, no authored interceptors, no flows;
 the optional sections are simply omitted, so the visible steps renumber `①②③`):
 
 ```
@@ -380,7 +410,7 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 | From | Reads |
 |---|---|
 | Focused epoch record | `:rf.event/dispatched` (step 1), `:rf.cofx/*` (step 2 — coeffect injection), `:rf.event/run-start` / `:rf.event/run-end` (step 3 — handler), `:rf.event/db-pending` (step 3 — t1, the handler's pending `:db` VALUE feeds the returned-effects sub-block under EVENT HANDLER · rf2-ta0y7), `:rf.fx/do-fx` (step 3 — also feeds the returned-effects sub-block under the handler, via `:rf.event/fx` + `:rf.event/db-present?`), `:rf.flow/computed` (step 4 — flows reshape the pending `:db` at the outermost `:after`, before commit), `:rf.event/db-pending-post-flow` (step 4 — t2, the flow-augmented `:db` VALUE feeds the trailing post-flow summary under FLOWS when flows changed the value · rf2-ta0y7), `:rf.event/db-changed` (step 6 — the committed diff), `:rf.fx/handled` per fx-id (step 7 — effects applied) — all read from the focused epoch record's `:trace-events` (one epoch = one dequeued event, §1.1) |
-| Registries | Handler metadata (`reg-event-*` form file:line, optional source string when DEBUG-gated) |
+| Registries | Handler metadata (`reg-event-*` form file:line, optional source string when DEBUG-gated). **INTERCEPTORS step (rf2-se9a9t · EP-0022 §11):** the authored interceptor chain is read from the registry at render time — `(rf/handler-meta :event event-id)` `:interceptors` for the authored refs (the framework `:rf/default?` wrapper filtered out), each ref resolved via `(rf/handler-meta :interceptor id)` for its descriptor hooks + source-coord. A clean chain emits no per-interceptor "ran" trace, so this is a REGISTRY read, not a trace read; the pure projection threads the resolver in via `epoch-panel/resolve-event-interceptors`. |
 | App-db panel (bridge) | Inline diff renderer for the committed `:db` — the APP-DB CHANGES section (reuses the shared renderer §10) |
 
 ### §2.4 Cross-panel navigation
@@ -388,7 +418,8 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 | Click | Navigates to |
 |---|---|
 | DISPATCH `FROM: <source>` link | Open-in-editor (Xray's existing `:rf.xray/open-in-editor`) at the dispatch-origin call-site |
-| COEFFECTS / AFTER-INTERCEPTORS id ↗ | Open-in-editor at the coeffect / interceptor registration file:line |
+| COEFFECTS id ↗ | Open-in-editor at the coeffect registration file:line |
+| INTERCEPTORS ref id ↗ (rf2-se9a9t) | Open-in-editor at the authored interceptor's `reg-interceptor` registration file:line (resolved off `(rf/handler-meta :interceptor id)`; drops to plain text when no coord — the `reg-interceptor*` fn path / framework interceptor / production-elided coord) |
 | EVENT HANDLER ↗ | Open-in-editor at handler file:line |
 | SIDE EFFECTS `:db` row `→ app-db` marker (rf2-j630b) | Switch to the **App-db** panel for the focused epoch (`[:rf.xray/select-tab :app-db]`; the panel reads the same shared focus). The marker is a DESTINATION pointer — the committed db diff lives in the App-db panel, not duplicated in the ledger |
 | SIDE EFFECTS `:fx` row fx-id ↗ (rf2-g1mfc) | Open-in-editor at the `reg-fx` registration file:line (shared `coord-chip`, parity with the HANDLER verb + SUBSCRIPTIONS / VIEWS rows; sources the absolute coord off `(rf/handler-meta :fx <fx-id>)`) |
@@ -1416,7 +1447,8 @@ is rendered iff its driving trace events surfaced in this epoch:
 |------|---------------|-------------|
 | **DISPATCH** | `:rf.event/dispatched` | always (every epoch starts here) |
 | **COEFFECT** | `:rf.cofx/run` (or `:rf.event/run-end` `:rf.event/coeffects` fallback) | **one COEFFECT step per user-injected coeffect** (rf2-s1jw4 · Mike pair-debug 2026-05-26, commit `ee9def224`). SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered at projection time (rf2-cq0ch). A cascade with 3 user cofx injections renders 3 numbered COEFFECT entries, not 1 entry containing 3 rows. A coeffect that THREW on injection (`:rf.error/coeffect-exception`) but produced no `:rf.cofx/run` gets a synthesised placeholder COEFFECT step (rf2-yz57h) so the exception card has a home. |
-| **INTERCEPTOR** | `:rf.error/interceptor-exception` (rf2-mszrz) | **only when a user interceptor threw** (rf2-yz57h). The substrate emits no per-interceptor "ran" trace (the chain runs as one unit), so a clean chain leaves nothing to show — the step is exception-only. PHASE-SPLIT (rf2-vew2n): a `:before` throw renders its step BEFORE HANDLER, an `:after` throw AFTER HANDLER (execution order: COEFFECTS → :before → HANDLER → :after). One row per throwing interceptor: id + `:before`/`:after` phase chip + the shared exception card; the badge carries no "N threw" summary verb (rf2-oqi0c). |
+| **INTERCEPTORS** | registry read — `(handler-meta :event event-id)` `:interceptors` (rf2-se9a9t) | **only when the event carries authored (non-`:rf/default?`) interceptor refs.** The authored chain wraps the handler, so the step renders BEFORE HANDLER. One row per authored ref: id (click-to-source) + the resolved descriptor's hook shape (`before` / `after` / `before/after` / `factory`) + a `ref` / `inline` badge + the factory `:arg` + a `missing` chip for an unregistered ref. This is the clean-chain surfacing (EP-0022 §11 (a)+(b)); read from the REGISTRY, not the trace (a clean chain emits no per-interceptor trace). Purely informational — does NOT inflate the epoch outcome. |
+| **INTERCEPTOR** | `:rf.error/interceptor-exception` (rf2-mszrz) | **only when a user interceptor threw** (rf2-yz57h). The substrate emits no per-interceptor "ran" trace (the chain runs as one unit), so a clean chain leaves nothing to show — the step is exception-only (the clean chain is the INTERCEPTORS step above). PHASE-SPLIT (rf2-vew2n): a `:before` throw renders its step BEFORE HANDLER, an `:after` throw AFTER HANDLER (execution order: COEFFECTS → :before → HANDLER → :after). One row per throwing interceptor: id + `:before`/`:after` phase chip + the shared exception card; the badge carries no "N threw" summary verb (rf2-oqi0c). |
 | **HANDLER** | every epoch settles through a handler | always (but rendered as **SKIPPED** — rf2-yz57h — when an upstream `:before`-chain throw aborted the cascade before the handler ran) |
 | **FLOW** | `:rf.flow/recomputed` | only when flows fired |
 | **FX** | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | only when fx-handlers fired (rendered as **SKIPPED** when an upstream `:before`-chain throw aborted the cascade) |
@@ -1429,7 +1461,7 @@ empty-state line. This matches the §2.2 dynamic-numbering contract
 from the Event lens — both panels share the same "absence is
 silence" rhythm.
 
-### §9.1.4 Badge taxonomy (the 10-badge inventory)
+### §9.1.4 Badge taxonomy (the badge inventory)
 
 Each step renders a uppercase badge pill at its numbered circle:
 
@@ -1438,6 +1470,7 @@ Each step renders a uppercase badge pill at its numbered circle:
 | `:DISPATCH`           | `:text-tertiary` | muted grey |
 | `:RECORDABLE-COFX`    | `:text-secondary` | muted (a step lighter than DISPATCH — rf2-9fyn40; reads as orienting causal-context metadata, EP-0010 provenance / EP-0017 §9 recordable coeffects, not a pipeline action) |
 | `:COEFFECT`           | `:magenta`       | purple |
+| `:INTERCEPTORS`       | `:accent`        | blue (rf2-se9a9t — the authored chain WRAPS the handler; same identity family as INTERCEPTOR + HANDLER) |
 | `:INTERCEPTOR`        | `:accent`        | blue (rf2-yz57h — the chain WRAPS the handler; one identity family) |
 | `:HANDLER`            | `:accent`        | blue (single Xray accent) |
 | `:FLOW`               | `:accent`        | blue (paired with HANDLER) |
@@ -1454,8 +1487,9 @@ Each step renders a uppercase badge pill at its numbered circle:
 > in commit `ee9def224`) is redundant with the HANDLER step's `:db`
 > sub-section (§9.1.5.1, FULL+DIFF single rendering post-rf2-vv3m6),
 > which surfaces the same data in-context. The projection's `badge-
-> set` enforces the inventory (9 entries with rf2-yz57h's
-> conditional `:INTERCEPTOR`).
+> set` enforces the inventory (with rf2-yz57h's conditional
+> exception-only `:INTERCEPTOR` + rf2-se9a9t's conditional authored-chain
+> `:INTERCEPTORS`).
 
 The inventory is LOCKED — the projection's `badge-set` enforces
 that every emitted step's `:badge` is a member, and the view's

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -103,6 +103,11 @@
    ;; FLOW accent, etc.).
    :RECORDABLE-COFX   :text-secondary
    :COEFFECT          :magenta
+   ;; rf2-se9a9t / EP-0022 §11 — INTERCEPTORS (plural, the AUTHORED chain)
+   ;; shares `:accent` with INTERCEPTOR (the exception-only step) + HANDLER:
+   ;; the authored chain WRAPS the handler, so both interceptor surfaces read
+   ;; as one identity family in the cascade (the chain around the body).
+   :INTERCEPTORS      :accent
    :INTERCEPTOR       :accent
    :HANDLER           :accent
    :FLOW              :accent
@@ -117,6 +122,7 @@
   {:DISPATCH          "DISPATCH"
    :RECORDABLE-COFX   "RECORDABLE COEFFECTS"
    :COEFFECT          "COEFFECT"
+   :INTERCEPTORS      "INTERCEPTORS"
    :INTERCEPTOR       "INTERCEPTOR"
    :HANDLER           "EVENT HANDLER"
    :FLOW              "FLOW"

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -3168,6 +3168,123 @@
                        :coord          (interceptor-row-coord raw)})
                     exc)})))
 
+;; ---- INTERCEPTORS step — the authored / resolved chain (rf2-se9a9t) ------
+;;
+;; EP-0022 §11 + Spec 002 §Tooling and metadata: "Trace / Xray surfaces
+;; SHOULD distinguish: authored refs; the resolved executable chain;
+;; per-frame override substitutions; per-call override substitutions;
+;; removed refs; and missing-ref failures." The exception-only INTERCEPTOR
+;; step above (rf2-yz57h / rf2-vew2n) only ever surfaced a THROWING
+;; interceptor — a CLEAN chain left nothing on screen, so an operator could
+;; not see WHICH interceptors wrap an event until one failed. That deferral
+;; was tracked as rf2-rvxem change-4 (now closed → untracked); rf2-se9a9t
+;; completes it.
+;;
+;; The authored chain is NOT recoverable from the trace stream — the
+;; substrate emits no per-interceptor "ran" trace for a clean chain (the
+;; chain runs as one unit). It IS recoverable from the REGISTRY:
+;; `(rf/handler-meta :event event-id)` returns `:interceptors` carrying the
+;; authored refs (a bare keyword `:auth/required` or an `[id arg]` 2-vector
+;; like `[:rf.interceptor/path [:cart]]`) PLUS the framework auto-wrapper
+;; interceptor map (`:rf/event-handler`, `:rf/default? true`) at its tail
+;; (re-frame.events §register-event! stores the EFFECTIVE chain). A registry
+;; read is a runtime concern, so `project` cannot do it and stay pure / JVM-
+;; testable; instead the composite sub threads a `resolve-event-interceptors`
+;; fn (event-id → authored-ref-row vector) through `project`, and these pure
+;; builders shape its output into a step. Absent the resolver (the default
+;; arity, every existing test) NO step is emitted — byte-identical.
+
+(defn interceptor-ref-row
+  "Normalise ONE authored `:interceptors` chain entry (off
+  `handler-meta :event`) into a row for the INTERCEPTORS step, or nil for
+  the framework auto-wrapper (`:rf/default?` — the `:rf/event-handler`
+  interceptor the runtime appends; it is not an AUTHORED program member, so
+  it does not belong in the authored-chain surfacing). Mirrors the Static
+  Interceptors panel's `classify-entry` ref handling so the two surfaces
+  read an authored ref identically.
+
+  An entry is one of (EP-0022, Spec 002 §Interceptor references):
+    - a bare keyword id (`:my/logging`) — `{:interceptor-id :my/logging
+      :authored :my/logging :arg nil}`;
+    - an `[id arg]` 2-vector (`[:rf.interceptor/path [:cart]]`) — the head
+      keyword is the id, `:arg` carries the factory arg, `:authored` keeps
+      the full vector;
+    - the framework auto-wrapper map (`:rf/default? true`) — returns nil.
+
+  `resolve-meta-fn` (interceptor-id → registered `:interceptor` metadata, or
+  nil) enriches the row with the resolved descriptor's `:before?`/`:after?`/
+  `:factory?`/`:doc` + the definition-site `:coord` — the RESOLVED half of
+  the chain (EP-0022 §11 (b)). nil ⇒ a `:missing-ref?` row (a chain entry
+  whose id is not in the `:interceptor` registrar — surfaced, not dropped,
+  per Spec 002 §Error model `:rf.error/unregistered-interceptor`)."
+  [entry resolve-meta-fn]
+  (cond
+    ;; framework auto-wrapper — not an authored program member.
+    (and (map? entry) (:rf/default? entry))
+    nil
+
+    ;; a bare-keyword OR `[id arg]` authored reference.
+    (or (keyword? entry)
+        (and (vector? entry) (= 2 (count entry)) (keyword? (first entry))))
+    (let [vector-ref? (vector? entry)
+          icpt-id     (if vector-ref? (first entry) entry)
+          arg         (when vector-ref? (second entry))
+          meta        (when resolve-meta-fn (resolve-meta-fn icpt-id))
+          descriptor  (:rf/interceptor-descriptor meta)
+          coord       (let [c (or (when (map? meta) (select-keys meta [:file :line :ns]))
+                                  nil)]
+                        (when (and (map? c) (:file c) (seq (str (:file c)))) c))]
+      (cond-> {:interceptor-id icpt-id
+               :authored       entry
+               :arg            arg}
+        (some? coord)            (assoc :coord coord)
+        (some? meta)             (assoc :doc (:doc meta))
+        (nil? meta)              (assoc :missing-ref? true)
+        (map? descriptor)        (assoc :before?  (boolean (:before descriptor))
+                                        :after?   (boolean (:after descriptor))
+                                        :factory? (boolean (:factory descriptor)))))
+
+    ;; a stale inline value or structurally-malformed entry — surface it so
+    ;; the browse never silently swallows a shape it doesn't recognise.
+    (map? entry)
+    (cond-> {:interceptor-id (or (:id entry) ::inline)
+             :authored       nil
+             :inline?        true}
+      (boolean (:before entry)) (assoc :before? true)
+      (boolean (:after entry))  (assoc :after? true))
+
+    :else nil))
+
+(defn authored-interceptors-step
+  "Build the INTERCEPTORS step — the AUTHORED interceptor chain wrapping
+  `event-id`'s handler (EP-0022 §11, rf2-se9a9t) — or nil when the event
+  carries NO authored (non-`:rf/default?`) interceptors (the common case;
+  the step is then OMITTED so the numbered cascade reads HANDLER directly).
+
+  `authored-entries` is the raw `:interceptors` vector off
+  `(handler-meta :event event-id)`; `resolve-meta-fn` resolves each ref to
+  its registered `:interceptor` descriptor (see `interceptor-ref-row`).
+  Returns:
+
+    {:step  :interceptors      ; PLURAL — distinct from the exception-only
+     :badge :INTERCEPTORS      ;   :interceptor / :INTERCEPTOR step above
+     :event-id <id>
+     :rows  [<interceptor-ref-row> …]}
+
+  The step is placed BEFORE the EVENT HANDLER step (the authored chain
+  WRAPS the handler — frame refs then event refs run `:before` on the way
+  in, in chain order). It is purely informational (no `:status`), so it
+  never inflates the epoch outcome."
+  [event-id authored-entries resolve-meta-fn]
+  (let [rows (->> (or authored-entries [])
+                  (keep #(interceptor-ref-row % resolve-meta-fn))
+                  vec)]
+    (when (seq rows)
+      {:step     :interceptors
+       :badge    :INTERCEPTORS
+       :event-id event-id
+       :rows     rows})))
+
 ;; ---- SKIPPED-step marking (rf2-yz57h) -----------------------------------
 ;;
 ;; When an EARLIER pipeline step throws on the way IN — a coeffect injector
@@ -3506,6 +3623,12 @@
                          EP-0017 §9); sits right after DISPATCH SITE
       :coeffect…       — one row per declared AMBIENT coeffect (folded
                          into a single step group by the view layer)
+      :interceptors    — only when the dispatched event carries authored
+                         (non-`:rf/default?`) interceptor refs AND the
+                         caller supplied a `:resolve-event-interceptors`
+                         resolver (EP-0022 §11, rf2-se9a9t); sits right
+                         before HANDLER (the authored chain wraps the
+                         handler). OMITTED entirely otherwise.
       :handler        — always present; adapts to handler flavour
       :flow           — only when flows fired
       :side-effects   — when ANY side effect occurred (a :db commit —
@@ -3518,6 +3641,16 @@
   Returns a vector of step maps. The view layer numbers steps via
   `number-steps` so absent optional steps consume no number.
 
+  ## opts (rf2-se9a9t)
+
+  The 2-arg form takes an opts map. `:resolve-event-interceptors` is a fn
+  `event-id → {:entries <authored :interceptors vector> :resolve-meta-fn
+  <interceptor-id → meta>}` (or nil). When supplied AND it returns authored
+  (non-`:rf/default?`) refs, the INTERCEPTORS step is emitted before HANDLER.
+  The default (1-arg) form supplies no resolver — the registry-read concern
+  belongs to the composite sub (`epoch_panel`), so `project` stays pure /
+  JVM-testable and byte-identical for callers that don't pass opts.
+
   ## Coeffect folding
 
   COEFFECT renders as ONE step group containing N rows (one per
@@ -3528,9 +3661,13 @@
   ## Pure-data
 
   Reads only `:trace-events`, `:event-id`, `:dispatch-id` off the
-  record; no DOM, no substrate runtime, JVM-testable."
-  [epoch-record]
-  (let [events    (or (:trace-events epoch-record) [])
+  record; no DOM, no substrate runtime, JVM-testable. The optional opts
+  map's `:resolve-event-interceptors` (rf2-se9a9t) is the ONLY runtime-fed
+  input — a fn, not data — and is itself injectable for pure tests."
+  ([epoch-record] (project epoch-record nil))
+  ([epoch-record opts]
+  (let [resolve-icpts (:resolve-event-interceptors opts)
+        events    (or (:trace-events epoch-record) [])
         db-before (:db-before epoch-record)
         event-id  (or (:event-id epoch-record)
                       (when-let [ev (find-op events :rf.event/dispatched)]
@@ -3684,7 +3821,20 @@
                           ;; so it renders AFTER HANDLER. Both conditional —
                           ;; nil (filtered out below) when no interceptor
                           ;; threw in that phase this cascade.
-                          [(interceptor-step events :before)
+                          ;;
+                          ;; rf2-se9a9t / EP-0022 §11 — the AUTHORED chain
+                          ;; (the clean, non-throwing case) renders as the
+                          ;; INTERCEPTORS step (plural) right before HANDLER:
+                          ;; the chain WRAPS the handler, and frame-then-event
+                          ;; refs run `:before` on the way in. Conditional —
+                          ;; nil (filtered out below) when the event carries
+                          ;; no authored refs OR no resolver was supplied.
+                          [(when resolve-icpts
+                             (let [{:keys [entries resolve-meta-fn]}
+                                   (resolve-icpts event-id)]
+                               (authored-interceptors-step
+                                 event-id entries resolve-meta-fn)))
+                           (interceptor-step events :before)
                            (handler-row events event-id db-before)
                            (interceptor-step events :after)]
                           ;; APP-DB DIFF removed pair-debug 2026-05-26 —
@@ -3719,7 +3869,7 @@
             ;; as SKIPPED rather than 'ran, returned no :db'.
             skipped    (mark-skipped-handler with-errs events)
             steps      (mark-rolled-back-downstream skipped violations)]
-        steps))))
+        steps)))))
 
 (defn number-steps
   "Stamp each step with a sequential `:step-number` (1..N). The view
@@ -3729,9 +3879,11 @@
     (map-indexed (fn [i s] (assoc s :step-number (inc i))) steps)))
 
 (defn project-numbered
-  "Convenience: `(number-steps (project record))`."
-  [epoch-record]
-  (number-steps (project epoch-record)))
+  "Convenience: `(number-steps (project record opts))`. The 2-arg form
+  threads the projection opts (rf2-se9a9t — `:resolve-event-interceptors`)
+  through to `project`; the 1-arg form keeps the pure default."
+  ([epoch-record] (number-steps (project epoch-record nil)))
+  ([epoch-record opts] (number-steps (project epoch-record opts))))
 
 ;; ---- timing aggregation (rf2-nqt3d) -------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2656,6 +2656,122 @@
      (numbered-circle step-number :INTERCEPTOR)
      (map-indexed (fn [i row] (interceptor-row-view i row)) rows*)]))
 
+;; ---- INTERCEPTORS step — the authored / resolved chain (rf2-se9a9t) ------
+
+(def ^:private interceptor-hook-chip-style
+  {:display     "inline-flex"
+   :align-items "center"
+   :color       text-tertiary-colour
+   :font-family sans-stack
+   :font-size   "10px"})
+
+(def ^:private interceptor-ref-badge-style
+  {:color          text-tertiary-colour
+   :font-family    sans-stack
+   :font-size      "9px"
+   :padding        "1px 4px"
+   :border         border-subtle-1px
+   :border-radius  "2px"
+   :text-transform "uppercase"
+   :letter-spacing "0.5px"})
+
+(defn- authored-interceptor-row-view
+  "Render ONE row of the INTERCEPTORS step (rf2-se9a9t) — an AUTHORED
+  interceptor reference wrapping the handler. ONE inline line of
+  `<name ↗> [hook chip] [ref/factory/arg chips]` with a `MISSING` chip when
+  the ref resolves to no registration (EP-0022 / Spec 002 §Error model
+  `:rf.error/unregistered-interceptor`).
+
+  `:coord` (the registered descriptor's definition-site, captured by the
+  `reg-interceptor` macro) drives the `coord-link` go-to-source glyph; it
+  drops to plain text when absent (`reg-interceptor*` fn registration,
+  framework interceptor, or a production-elided coord)."
+  [idx {:keys [interceptor-id authored arg coord before? after? factory?
+               missing-ref? inline? doc]}]
+  (let [label (fmt/ns-keyword interceptor-id)]
+    [:div {:key (str "authored-interceptor-row-" idx)
+           :data-testid (str "rf-xray-epoch-interceptors-row-" idx)}
+     [:div {:style interceptor-row-style}
+      ;; the ref name hyperlinks via `coord-link` (`name ↗`, ONE glyph);
+      ;; drops to plain text when `coord` is nil.
+      (coord-link/coord-link coord label
+                             (str "rf-xray-epoch-interceptors-id-" idx)
+                             {:style       coeffect-verb-link-button-style
+                              :plain-style coeffect-verb-plain-style})
+      ;; the resolved descriptor's hook shape (the RESOLVED half — EP-0022
+      ;; §11 (b)). A factory builds hooks per-arg, so it is reported as a
+      ;; factory rather than guessing a hook shape.
+      [:span {:data-testid (str "rf-xray-epoch-interceptors-hook-" idx)
+              :style interceptor-hook-chip-style}
+       (cond
+         factory?             "factory"
+         (and before? after?) "before/after"
+         before?              "before"
+         after?               "after"
+         :else                "—")]
+      ;; a parameterized `[id arg]` ref shows its factory arg.
+      (when (some? arg)
+        [:span {:data-testid (str "rf-xray-epoch-interceptors-arg-" idx)
+                :title       "factory reference arg"
+                :style       {:color       text-tertiary-colour
+                              :font-family mono-stack
+                              :font-size   "10px"}}
+         (pr-str arg)])
+      ;; a by-reference chain entry carries a "ref" badge; a stale inline
+      ;; value carries "inline" so an author tells the two apart at a glance.
+      (when (some? authored)
+        [:span {:data-testid (str "rf-xray-epoch-interceptors-ref-" idx)
+                :title       (str "by-reference chain entry (resolved at "
+                                  "chain assembly from " (pr-str authored) ")")
+                :style       interceptor-ref-badge-style}
+         "ref"])
+      (when inline?
+        [:span {:data-testid (str "rf-xray-epoch-interceptors-inline-" idx)
+                :title       "inline interceptor value (EP-0022 retires these on public chains)"
+                :style       interceptor-ref-badge-style}
+         "inline"])
+      ;; an unregistered ref — surfaced, not dropped.
+      (when missing-ref?
+        [:span {:data-testid (str "rf-xray-epoch-interceptors-missing-" idx)
+                :title       (str "no :interceptor registration for "
+                                  (pr-str interceptor-id)
+                                  " (:rf.error/unregistered-interceptor)")
+                :style       (assoc interceptor-ref-badge-style
+                                    :color       warning-colour
+                                    :border-color warning-colour)}
+         "missing"])]
+     (when doc
+       [:div {:data-testid (str "rf-xray-epoch-interceptors-doc-" idx)
+              :style {:margin-left "0"
+                      :margin-top  "1px"
+                      :color       text-secondary-colour
+                      :font-family sans-stack
+                      :font-style  "italic"
+                      :font-size   "11px"}}
+        doc])]))
+
+(defn render-interceptors-step
+  "Render the INTERCEPTORS step (rf2-se9a9t / EP-0022 §11) — the AUTHORED
+  interceptor chain that wraps the dispatched event's handler. Present only
+  when the event carries authored (non-`:rf/default?`) refs (the projection
+  omits the step otherwise). Distinct from the exception-only INTERCEPTOR
+  step (rf2-yz57h) above: this surfaces the CLEAN chain (which interceptors
+  wrap this event + their resolved before/after/factory shape + a
+  jump-to-source), the gap the exception-only step left.
+
+  Numbered-circle + INTERCEPTORS badge header, then one row per authored
+  ref via `authored-interceptor-row-view`."
+  [{:keys [rows step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-interceptors"
+         :data-step-kw "interceptors"}
+   (numbered-circle step-number :INTERCEPTORS)
+   (step-header {:badge :INTERCEPTORS
+                 :verb  "authored chain (wraps the handler)"
+                 :testid "rf-xray-epoch-interceptors"}
+                nil)
+   (into [:div {:data-testid "rf-xray-epoch-interceptors-rows"}]
+         (map-indexed (fn [i row] (authored-interceptor-row-view i row)) rows))])
+
 ;; ---- HANDLER step --------------------------------------------------------
 
 ;; ---- Machine cascade view (rf2-u69j7) -----------------------------------
@@ -5542,6 +5658,7 @@
     :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
     :recordable-cofx   (render-recordable-cofx-step step)
     :coeffect          (render-coeffect-step step)
+    :interceptors      (render-interceptors-step step)
     :interceptor       (render-interceptor-step step)
     :handler           (render-handler-step step)
     :flow              (render-flow-step step)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -38,6 +38,34 @@
             [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
 
+;; ---- authored-interceptor resolver (rf2-se9a9t / EP-0022 §11) -------------
+;;
+;; The pure projection cannot read the registry; it threads this resolver in
+;; so the INTERCEPTORS step surfaces an event's AUTHORED interceptor chain
+;; (the clean, non-throwing case the exception-only step never showed).
+;; Reads `(rf/handler-meta :event event-id)` for the authored `:interceptors`
+;; refs and supplies a `resolve-meta-fn` reading `(rf/handler-meta
+;; :interceptor id)` for each ref's registered descriptor. Fail-soft: any
+;; lookup that throws (unregistered event, runtime that can't answer)
+;; degrades to no step rather than crashing the panel render.
+
+(defn resolve-event-interceptors
+  "Return `{:entries <authored :interceptors vector> :resolve-meta-fn <fn>}`
+  for `event-id`, or nil when the event is not registered / has no chain.
+  The projection's `authored-interceptors-step` filters the framework
+  auto-wrapper (`:rf/default?`) out of `:entries`, so a handler with no
+  authored interceptors yields no step."
+  [event-id]
+  (when (some? event-id)
+    (let [meta    (try (rf/handler-meta :event event-id)
+                       (catch :default _ nil))
+          entries (:interceptors meta)]
+      (when (seq entries)
+        {:entries         entries
+         :resolve-meta-fn (fn [icpt-id]
+                            (try (rf/handler-meta :interceptor icpt-id)
+                                 (catch :default _ nil)))}))))
+
 ;; ---- public Panel surface ------------------------------------------------
 
 ;; Re-export the view-side `Panel` so the spine + panel-registry
@@ -84,7 +112,15 @@
                                                        epoch-history)
             record         (focus/find-epoch-record focus-epoch-id
                                                     epoch-history)
-            steps          (when record (proj/project-numbered record))]
+            ;; rf2-se9a9t — thread the registry-reading resolver so the
+            ;; INTERCEPTORS step surfaces the dispatched event's AUTHORED
+            ;; interceptor chain (EP-0022 §11). The projection stays pure;
+            ;; the runtime read lives here, in the sub.
+            steps          (when record
+                             (proj/project-numbered
+                               record
+                               {:resolve-event-interceptors
+                                resolve-event-interceptors}))]
         {:status         status
          :epoch-id       (or focus-epoch-id (:epoch-id record))
          :record         record

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -56,6 +56,7 @@
             [re-frame.core :as rf]
             [re-frame.interceptor-registry :as icpt-reg]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shared.realm :as realm]
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale mono-stack sans-stack]]))
@@ -173,28 +174,78 @@
           (sort-by (fn [{:keys [id]}] (pr-str id)))
           vec))))
 
-(defn- row-haystack [{:keys [id doc authored]}]
+(defn collect-interceptors-by-realm
+  "Realm-aware `collect-interceptors` (rf2-dfaey7 / a15n62). `realm-pairs`
+  is the `[realm-id registrations-map]` vector from
+  `realm/realm-qualified-registrations` (one pair per installed realm; the
+  default realm's own `resolve-ref-fn`). For each realm it collects the
+  interceptor rows, stamps each with the OWNING `:realm` (the realm whose
+  event chains carry it — `realm/realm-of` blanks the default realm), and
+  unions the realm set per interceptor id so a `:cross-realm?` row (the same
+  interceptor id appearing in MORE THAN ONE realm) is flagged.
+
+  `resolve-ref-fn-for` maps a realm-id → that realm's `resolve-ref-fn` (so
+  handler-resolution is REALM-SCOPED: a ref resolves against the same realm
+  the event lives in, EP-0013 D1). Defaults to `default-resolve-ref` for
+  every realm (the default-realm registrar) — fine for the single-realm
+  case.
+
+  Single-realm (the common case): `realm-pairs` is one pair, every row's
+  `:realm` is nil (default), no row is `:cross-realm?` — the output is the
+  same shape `collect-interceptors` produces, so the browse renders
+  unchanged."
+  ([realm-pairs] (collect-interceptors-by-realm realm-pairs (constantly default-resolve-ref)))
+  ([realm-pairs resolve-ref-fn-for]
+   (let [;; per realm: the collapsed rows, each tagged with its realm.
+         per-realm (for [[realm-id reg-map] realm-pairs
+                         row (collect-interceptors reg-map (resolve-ref-fn-for realm-id))]
+                     (assoc row :realm (realm/realm-of realm-id)
+                                :realm-id realm-id))
+         ;; which realms does each id span? (the cross-realm conflict set)
+         id->realms (reduce (fn [acc {:keys [id realm-id]}]
+                              (update acc id (fnil conj #{}) realm-id))
+                            {}
+                            per-realm)]
+     (->> per-realm
+          (map (fn [{:keys [id] :as row}]
+                 (cond-> (dissoc row :realm-id)
+                   (> (count (get id->realms id)) 1) (assoc :cross-realm? true))))
+          (sort-by (fn [{:keys [id realm]}] [(pr-str id) (pr-str realm)]))
+          vec))))
+
+(defn- row-haystack [{:keys [id doc authored realm]}]
   (str/lower-case
     (str (pr-str id) " "
          (or doc "") " "
          ;; EP-0022 — a reference row is findable by its authored form too
          ;; (e.g. searching the factory arg `[:cart]`).
-         (if (some? authored) (pr-str authored) ""))))
+         (if (some? authored) (pr-str authored) "") " "
+         ;; a15n62 — a multi-realm row is findable by its owning realm.
+         (if (some? realm) (pr-str realm) ""))))
 
 (defn filter-rows
   [rows query]
   (search-box/filter-rows row-haystack rows query))
 
 (defn project-data
-  [registrations-map query]
-  (let [rows     (collect-interceptors registrations-map)
-        silent?  (empty? rows)
-        filtered (filter-rows rows query)]
-    {:silent?      silent?
-     :interceptors filtered
-     :total        (count rows)
-     :filtered?    (not= (count rows) (count filtered))
-     :query        query}))
+  "Project the interceptor rows for the browse. `registrations-map` is
+  either the default-realm `(rf/registrations :event)` map (the 2-arity
+  legacy/test shape) OR — when called with realm pairs — the realm-qualified
+  pairs vector (rf2-dfaey7). The 1-arg legacy form is preserved for the test
+  seam + the single-realm fast path."
+  ([registrations-map query]
+   (project-data registrations-map query nil))
+  ([registrations-map query realm-pairs]
+   (let [rows     (if (seq realm-pairs)
+                    (collect-interceptors-by-realm realm-pairs)
+                    (collect-interceptors registrations-map))
+         silent?  (empty? rows)
+         filtered (filter-rows rows query)]
+     {:silent?      silent?
+      :interceptors filtered
+      :total        (count rows)
+      :filtered?    (not= (count rows) (count filtered))
+      :query        query})))
 
 ;; ---- header --------------------------------------------------------------
 
@@ -226,7 +277,8 @@
 ;; ---- row -----------------------------------------------------------------
 
 (defn- interceptor-row
-  [{:keys [id ref? authored arg factory? before? after? default? chain-count doc] :as _row}]
+  [{:keys [id ref? authored arg factory? before? after? default? chain-count
+           doc realm cross-realm?] :as _row}]
   (let [id-text (pr-str id)
         row-id  (if (and (> (count id-text) 0) (= \: (first id-text)))
                   (subs id-text 1)
@@ -252,6 +304,12 @@
                       :font-weight 500
                       :flex        1}}
        id-text]
+      ;; a15n62 (rf2-dfaey7) — the owning realm chip, shown ONLY in a
+      ;; multi-realm browse for a non-default realm; `:cross-realm?` paints
+      ;; it in the warning tone (this id also lives in another realm).
+      (realm/realm-badge realm
+                         (str "rf-xray-static-interceptors-realm-" row-id)
+                         {:conflict? cross-realm?})
       [:span {:title (str (cond
                             (and before? after?) "both before AND after"
                             before?              "before-only"
@@ -360,7 +418,10 @@
                                     :flex-direction "column"
                                     :gap            "2px"}}]
                 (for [row interceptors]
-                  ^{:key (pr-str (:id row))}
+                  ;; a15n62 — the key includes the owning realm: a multi-realm
+                  ;; browse can carry the same interceptor id in two realms as
+                  ;; two distinct rows.
+                  ^{:key (str (pr-str (:id row)) "@" (pr-str (:realm row)))}
                   [interceptor-row row])))])]))
 
 ;; ---- production value source ---------------------------------------------
@@ -371,10 +432,21 @@
 
 (defn- registry-value
   "The event-chain registry off the public `(rf/registrations :event)`
-  surface — each entry carries its interceptor chain."
+  surface — each entry carries its interceptor chain. Default-realm read;
+  the test seam overrides this map directly."
   []
   (try (rf/registrations :event)
        (catch :default _ {})))
+
+(defn- realm-pairs-value
+  "The realm-qualified `[realm-id reg-map]` pairs for `:event` registrations
+  across every installed realm (a15n62, rf2-dfaey7). Single-realm apps get
+  one pair `[default <the same map registry-value returns>]`, so the browse
+  is unchanged; a multi-realm host gets one pair per realm so each
+  interceptor row is attributed to its owning realm. Fail-soft."
+  []
+  (try (realm/realm-qualified-registrations :event)
+       (catch :default _ nil)))
 
 ;; ---- registrations -------------------------------------------------------
 
@@ -416,13 +488,29 @@
     (fn [_buffer _query]
       (registry-value)))
 
+  ;; a15n62 (rf2-dfaey7) — the realm-qualified pairs sub. Recomputes off the
+  ;; same trace-buffer tick the registry sub does (registrations change on
+  ;; hot-reload, which emits a trace). Single-realm hosts read one pair.
+  (rf/reg-sub :rf.xray.static.interceptors/realm-pairs
+    :<- [:rf.xray/trace-buffer]
+    (fn [_buffer _query]
+      (realm-pairs-value)))
+
   ;; ---- view-facing composite -------------------------------------------
 
   (rf/reg-sub :rf.xray.static.interceptors/tab-data
     :<- [:rf.xray.static.interceptors/registry]
+    :<- [:rf.xray.static.interceptors/realm-pairs]
     :<- [:rf.xray.static.interceptors/query]
-    (fn [[registrations-map query] _query]
-      (project-data registrations-map query)))
+    (fn [[registrations-map realm-pairs query] _query]
+      ;; a15n62 — when MORE THAN ONE realm is installed, project off the
+      ;; realm-qualified pairs (each row attributed to its owning realm + the
+      ;; cross-realm id-conflict flag). Single-realm hosts (and the test
+      ;; override seam, which feeds the flat registry map) take the legacy
+      ;; default-realm path so the browse is byte-identical.
+      (if (realm/multi-realm?)
+        (project-data registrations-map query realm-pairs)
+        (project-data registrations-map query))))
 
   ;; rf2-2moh1 — register the Static Interceptors tab. Contiguous order:
   ;; machines 0 · routes 1 · schemas 2 · flows 3 · interceptors 4.

--- a/tools/xray/src/day8/re_frame2_xray/static/shared/realm.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shared/realm.cljs
@@ -1,0 +1,175 @@
+(ns day8.re-frame2-xray.static.shared.realm
+  "Realm dimension for Xray's static-registry browse + handler-resolution
+  (rf2-dfaey7, a15n62 / EP-0013).
+
+  ## Why this exists
+
+  Post-a15n62 the registrar is realm-aware: a realm owns the `(kind, id) →
+  metadata` table it dispatches / subscribes / resolves against (EP-0013
+  D1). The default-realm `(rf/registrations :kind)` call the static browse
+  panels (schemas / flows / interceptors / routes / machines) make reads
+  ONLY the default realm's table — so xray could not show WHICH realm owns a
+  registration, nor flag a cross-realm id conflict (the same id registered
+  in two realms). EP-0013 stage 8 added the map-shaped
+  `(rf/registrations {:realm r :kind k})` query form + `rf/realm-ids` (the
+  installed-realm enumeration) that this helper composes into the static
+  surfaces.
+
+  ## Absence is the default realm — single-realm renders unchanged
+
+  The OVERWHELMING common case is a single-realm app: `(rf/realm-ids)`
+  returns exactly `#{:rf.realm/default}`. In that case:
+
+    - `multi-realm?` is false;
+    - `realm-qualified-registrations` returns one `[default-realm-id
+      registrations-map]` pair — the SAME map `(rf/registrations :kind)`
+      already returned;
+    - `realm-badge` / `realm-of` render NOTHING (no realm column appears).
+
+  So a single-realm browse is byte-identical to the pre-rf2-dfaey7 surface;
+  the realm dimension only MATERIALISES when a second realm is installed
+  (multi-tenant / parallel-app / hermetic-test hosts). This is exactly the
+  multi-realm-demand-gated posture the bead calls for.
+
+  ## What it surfaces
+
+    - `realm-of` — the owning `:rf.realm/id` of a registration row (nil ⇒
+      the default realm; rendered as nothing in single-realm browse).
+    - `cross-realm-ids` — the set of ids that appear in MORE THAN ONE realm
+      under a kind (the id-conflict signal a multi-realm author wants).
+    - `realm-badge` — a small chip rendering a row's owning realm, shown
+      ONLY when the browse spans more than one realm.
+
+  Pure-read + fail-soft: a browse catalogue must never throw on a runtime
+  that can't answer (an older core without `realm-ids` / the map-shaped
+  query form), so every registry touch is `try`-guarded and degrades to the
+  default-realm path."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- realm enumeration ---------------------------------------------------
+
+(def default-realm-id
+  "The process default realm's id (Spec Runtime-Subsystems §realm). A
+  registration carrying this realm (or nil) is the default realm — absence
+  is the default, the documented a15n62 rule."
+  :rf.realm/default)
+
+(defn realm-ids
+  "Return the set of installed realm ids via the public `(rf/realm-ids)`
+  (EP-0013 stage 9, tier `:tooling`). Fail-soft: a core too old to expose
+  it (or any throw) degrades to `#{default-realm-id}` so the browse always
+  has at least the default realm. Always includes the default realm."
+  []
+  (try
+    (let [ids (rf/realm-ids)]
+      (if (and (set? ids) (seq ids))
+        (conj ids default-realm-id)
+        #{default-realm-id}))
+    (catch :default _ #{default-realm-id})))
+
+(defn multi-realm?
+  "True when MORE THAN ONE realm is installed — the only condition under
+  which the realm dimension materialises in a browse. Single-realm apps
+  (the common case) read this false and render the pre-rf2-dfaey7 surface
+  unchanged."
+  []
+  (> (count (realm-ids)) 1))
+
+;; ---- realm-qualified registrations ---------------------------------------
+
+(defn registrations-in-realm
+  "Return `(rf/registrations {:realm realm-id :kind kind})` — the
+  `{id metadata}` map registered under `kind` in `realm-id`'s OWN registrar
+  (EP-0013 stage 8). Fail-soft: a core too old for the map-shaped form (or
+  any throw) falls back to the default-realm `(rf/registrations kind)` for
+  the default realm, and `{}` for any other realm (an old core has no other
+  realm to read). Pure-read."
+  [realm-id kind]
+  (try
+    (rf/registrations {:realm realm-id :kind kind})
+    (catch :default _
+      (if (= realm-id default-realm-id)
+        (try (rf/registrations kind) (catch :default _ {}))
+        {}))))
+
+(defn realm-qualified-registrations
+  "Return a vector of `[realm-id registrations-map]` pairs — one per
+  installed realm — for `kind`. In the single-realm common case this is one
+  pair, `[default-realm-id <the same map (rf/registrations kind) returned>]`,
+  so callers that flatten it get the byte-identical default-realm browse.
+  In a multi-realm app each realm contributes its OWN registrar's entries,
+  so a tool can attribute every registration to its owning realm. Pure-read,
+  fail-soft."
+  [kind]
+  (mapv (fn [realm-id] [realm-id (registrations-in-realm realm-id kind)])
+        (sort (realm-ids))))
+
+(defn realm-of
+  "The owning realm-id to DISPLAY for a registration row, or nil when it is
+  the default realm (absence is the default — nothing renders). Pure."
+  [realm-id]
+  (when (and (some? realm-id) (not= realm-id default-realm-id))
+    realm-id))
+
+(defn cross-realm-ids
+  "Given `realm-qualified` (the `[realm-id reg-map]` pairs from
+  `realm-qualified-registrations`), return the SET of ids that appear in
+  MORE THAN ONE realm under this kind — the cross-realm id-conflict signal
+  (EP-0013 §Realm Conformance: the same id may legally exist in two realms;
+  a multi-realm author wants to SEE that). Empty in the single-realm case.
+  Pure."
+  [realm-qualified]
+  (let [id->realms (reduce
+                     (fn [acc [realm-id reg-map]]
+                       (reduce (fn [a id] (update a id (fnil conj #{}) realm-id))
+                               acc
+                               (keys reg-map)))
+                     {}
+                     realm-qualified)]
+    (->> id->realms
+         (keep (fn [[id realms]] (when (> (count realms) 1) id)))
+         set)))
+
+;; ---- realm chip ----------------------------------------------------------
+
+(defn realm-badge
+  "Render a small chip naming a row's owning realm — shown ONLY when the
+  browse spans more than one realm AND the row is NOT in the default realm
+  (the default realm reads as 'unqualified', so it carries no chip even in a
+  multi-realm browse — only the explicit, non-default realms get a label).
+
+  `opts`:
+    :testid     — the data-testid to stamp (required so each panel scopes it
+                  under its own prefix).
+    :conflict?  — true ⇒ paint the chip in the warning tone (a cross-realm
+                  id conflict — this id also lives in another realm).
+
+  Returns nil when there is nothing to render (single-realm browse, or the
+  default realm), so a single-realm panel paints exactly as before."
+  ([realm-id testid] (realm-badge realm-id testid {}))
+  ([realm-id testid {:keys [conflict?]}]
+   (when (and (multi-realm?) (realm-of realm-id))
+     [:span {:data-testid testid
+             :title       (str "owning realm " (pr-str realm-id)
+                               (when conflict?
+                                 " · this id also exists in another realm"))
+             :style       {:display        "inline-flex"
+                           :align-items    "center"
+                           :margin-left    "6px"
+                           :padding        "1px 5px"
+                           :background     (:bg-3 tokens)
+                           :color          (if conflict?
+                                             (:warning tokens)
+                                             (:text-tertiary tokens))
+                           :border         (str "1px solid "
+                                                (if conflict?
+                                                  (:warning tokens)
+                                                  (:text-tertiary tokens)))
+                           :border-radius  "2px"
+                           :font-family    (if (keyword? realm-id) mono-stack sans-stack)
+                           :font-size      "9px"
+                           :letter-spacing "0.3px"
+                           :white-space    "nowrap"}}
+      (str "realm " (if (keyword? realm-id) (name realm-id) (pr-str realm-id)))])))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -4273,6 +4273,133 @@
         (is (= :app/before (:failing-id (first (:errors before-step)))))
         (is (= :app/after  (:failing-id (first (:errors after-step)))))))))
 
+;; -- INTERCEPTORS step (authored / resolved chain, rf2-se9a9t) ------------
+
+(deftest interceptor-ref-row-test
+  (testing "rf2-se9a9t — the framework auto-wrapper (:rf/default?) is dropped"
+    (is (nil? (proj/interceptor-ref-row
+                {:id :rf/event-handler :rf/default? true :before identity}
+                (constantly nil)))))
+
+  (testing "rf2-se9a9t — a bare-keyword authored ref resolves its descriptor"
+    (let [resolve-fn (fn [id]
+                       (when (= id :auth/required)
+                         {:doc "auth gate" :file "auth.cljs" :line 12
+                          :rf/interceptor-descriptor {:before identity}}))
+          row        (proj/interceptor-ref-row :auth/required resolve-fn)]
+      (is (= :auth/required (:interceptor-id row)))
+      (is (= :auth/required (:authored row)) "authored keeps the keyword ref")
+      (is (nil? (:arg row)))
+      (is (true? (:before? row)))
+      (is (false? (:after? row)))
+      (is (= "auth gate" (:doc row)))
+      (is (= {:file "auth.cljs" :line 12} (:coord row)) "resolved coord present")
+      (is (not (:missing-ref? row)))))
+
+  (testing "rf2-se9a9t — an [id arg] factory ref keeps the vector + arg"
+    (let [resolve-fn (fn [id]
+                       (when (= id :rf.interceptor/path)
+                         {:rf/interceptor-descriptor {:factory identity}}))
+          row        (proj/interceptor-ref-row [:rf.interceptor/path [:cart]] resolve-fn)]
+      (is (= :rf.interceptor/path (:interceptor-id row)))
+      (is (= [:rf.interceptor/path [:cart]] (:authored row)))
+      (is (= [:cart] (:arg row)))
+      (is (true? (:factory? row)) "a :factory descriptor reports as a factory")))
+
+  (testing "rf2-se9a9t — an UNREGISTERED ref is flagged :missing-ref?, not dropped"
+    (let [row (proj/interceptor-ref-row :nope/unregistered (constantly nil))]
+      (is (= :nope/unregistered (:interceptor-id row)))
+      (is (true? (:missing-ref? row)))
+      (is (nil? (:coord row)))))
+
+  (testing "rf2-se9a9t — a stale inline value surfaces under :inline?"
+    (let [row (proj/interceptor-ref-row {:id :legacy/inline :before identity}
+                                        (constantly nil))]
+      (is (= :legacy/inline (:interceptor-id row)))
+      (is (true? (:inline? row)))
+      (is (true? (:before? row)))
+      (is (nil? (:authored row))))))
+
+(deftest authored-interceptors-step-test
+  (testing "rf2-se9a9t — nil when only the framework wrapper is present"
+    (is (nil? (proj/authored-interceptors-step
+                :evt
+                [{:id :rf/event-handler :rf/default? true}]
+                (constantly nil)))))
+
+  (testing "rf2-se9a9t — nil for an empty / absent chain"
+    (is (nil? (proj/authored-interceptors-step :evt [] (constantly nil))))
+    (is (nil? (proj/authored-interceptors-step :evt nil (constantly nil)))))
+
+  (testing "rf2-se9a9t — builds an INTERCEPTORS step over the authored refs,
+            wrapper filtered out, order preserved"
+    (let [resolve-fn (fn [id] {:rf/interceptor-descriptor {:before identity}})
+          step (proj/authored-interceptors-step
+                 :cart/add
+                 [:auth/required
+                  [:rf.interceptor/path [:cart]]
+                  {:id :rf/event-handler :rf/default? true}]
+                 resolve-fn)]
+      (is (= :interceptors (:step step)) "PLURAL — distinct from the :interceptor step")
+      (is (= :INTERCEPTORS (:badge step)))
+      (is (= :cart/add (:event-id step)))
+      (is (= 2 (count (:rows step))) "wrapper filtered out")
+      (is (= [:auth/required :rf.interceptor/path]
+             (mapv :interceptor-id (:rows step)))
+          "authored order preserved (frame-then-event chain order)")
+      ;; the step carries no :status — it is informational, never an error
+      (is (nil? (:status step))))))
+
+(deftest project-authored-interceptors-end-to-end-test
+  (testing "rf2-se9a9t — the resolver opts inject the INTERCEPTORS step
+            BEFORE the HANDLER step in a clean cascade"
+    (let [rec   (record [(dispatched-ev [:cart/add] :ui nil)
+                         (db-changed-ev [[[:cart] 0 1 :modified]])
+                         (run-end-ev 1)]
+                        :cart/add)
+          opts  {:resolve-event-interceptors
+                 (fn [event-id]
+                   (when (= event-id :cart/add)
+                     {:entries [:auth/required
+                                {:id :rf/event-handler :rf/default? true}]
+                      :resolve-meta-fn
+                      (fn [_id]
+                        {:rf/interceptor-descriptor {:before identity}})}))}
+          steps (proj/project rec opts)
+          step-kws (mapv :step steps)
+          i-idx (.indexOf step-kws :interceptors)
+          h-idx (.indexOf step-kws :handler)
+          istep (some #(when (= :interceptors (:step %)) %) steps)]
+      (is (some? istep) "INTERCEPTORS step present")
+      (is (= [:auth/required] (mapv :interceptor-id (:rows istep))))
+      (is (< i-idx h-idx) "INTERCEPTORS renders BEFORE HANDLER")
+      ;; the clean authored chain does NOT inflate the outcome
+      (is (= :ok (proj/epoch-outcome steps)))))
+
+  (testing "rf2-se9a9t — NO INTERCEPTORS step when the event carries only the
+            framework wrapper (the common case)"
+    (let [rec   (record [(dispatched-ev [:plain/evt] :ui nil)
+                         (db-changed-ev [[[:n] 0 1 :modified]])
+                         (run-end-ev 1)]
+                        :plain/evt)
+          opts  {:resolve-event-interceptors
+                 (fn [_event-id]
+                   {:entries [{:id :rf/event-handler :rf/default? true}]
+                    :resolve-meta-fn (constantly nil)})}
+          steps (proj/project rec opts)]
+      (is (not (some #(= :interceptors (:step %)) steps))
+          "no INTERCEPTORS step — only the wrapper")))
+
+  (testing "rf2-se9a9t — the default (no-opts) project is byte-identical:
+            NO INTERCEPTORS step is ever emitted without a resolver"
+    (let [rec   (record [(dispatched-ev [:cart/add] :ui nil)
+                         (db-changed-ev [[[:cart] 0 1 :modified]])
+                         (run-end-ev 1)]
+                        :cart/add)
+          steps (proj/project rec)]
+      (is (not (some #(= :interceptors (:step %)) steps))
+          "no resolver → no INTERCEPTORS step (pure / back-compat)"))))
+
 ;; -- SKIPPED-step marking -------------------------------------------------
 
 (deftest mark-skipped-handler-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -3323,6 +3323,73 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
           "no coord → no go-to-source glyph"))))
 
+(deftest interceptors-step-renders-authored-chain-test
+  (testing "rf2-se9a9t / EP-0022 §11 — the INTERCEPTORS step (plural) renders
+            the AUTHORED chain: each ref's id + hook shape + coord link"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-interceptors-step
+                   {:step :interceptors :badge :INTERCEPTORS :step-number 3
+                    :event-id :cart/add
+                    :rows [{:interceptor-id :auth/required
+                            :authored :auth/required
+                            :before? true :after? false
+                            :coord {:ns 'app.auth :file "/abs/auth.cljs" :line 12}
+                            :doc "Require auth before the handler."}
+                           {:interceptor-id :rf.interceptor/path
+                            :authored [:rf.interceptor/path [:cart]]
+                            :arg [:cart] :factory? true}]}))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-interceptors"))
+          "the INTERCEPTORS step renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-badge-interceptors"))
+          "the INTERCEPTORS badge pill renders")
+      (is (= "INTERCEPTORS" (badge/label :INTERCEPTORS)))
+      ;; row 0 — a coord-bearing keyword ref renders as a coord-link button
+      (let [id0 (th/find-by-testid tree "rf-xray-epoch-interceptors-id-0")]
+        (is (= :button (first id0))
+            "a coord-bearing ref renders the id as a clickable coord-link"))
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptors-hook-0") "before")
+          "the resolved :before hook shape renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-interceptors-ref-0"))
+          "a by-reference entry carries a ref badge")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptors-doc-0") "Require auth")
+          "the resolved descriptor doc renders")
+      ;; row 1 — an [id arg] factory ref shows its arg + factory hook
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptors-arg-1") "[:cart]")
+          "the factory arg renders")
+      (is (string/includes?
+            (text-of tree "rf-xray-epoch-interceptors-hook-1") "factory")
+          "the :factory descriptor reports as a factory")))
+
+  (testing "rf2-se9a9t — an UNREGISTERED ref renders a MISSING badge"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/render-interceptors-step
+                   {:step :interceptors :badge :INTERCEPTORS :step-number 3
+                    :event-id :cart/add
+                    :rows [{:interceptor-id :nope/unregistered
+                            :authored :nope/unregistered
+                            :missing-ref? true}]}))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-interceptors-missing-0"))
+          "the missing-ref badge renders for an unregistered ref")))
+
+  (testing "rf2-se9a9t — :interceptors is wired into render-step (the dispatcher)"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (let [tree (rf/with-frame :rf/xray
+                 (view/pipeline-view
+                   [{:step :interceptors :badge :INTERCEPTORS :step-number 1
+                     :event-id :cart/add
+                     :rows [{:interceptor-id :auth/required
+                             :authored :auth/required :before? true}]}]))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-interceptors"))
+          "render-step dispatches :interceptors to render-interceptors-step"))))
+
 (deftest handler-skipped-renders-as-skipped-not-no-db-test
   (testing "rf2-yz57h — a HANDLER marked :skipped (upstream :before-chain
             threw) renders the SKIPPED body, NOT the misleading

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -355,6 +355,10 @@
    ;; (rf2-e8330v).
    :rf.xray.static.interceptors/query
    :rf.xray.static.interceptors/registry
+   ;; rf2-dfaey7 (a15n62) — the realm-qualified `:event` pairs sub the
+   ;; tab-data composite reads to attribute each interceptor to its owning
+   ;; realm + flag cross-realm id conflicts.
+   :rf.xray.static.interceptors/realm-pairs
    :rf.xray.static.interceptors/tab-data
    ;; rf2-hga49 — tab-ribbon Reset rewind affordance: the transient
    ;; inline failure-flash slot the ribbon reads.

--- a/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
@@ -195,6 +195,52 @@
     (is (false? (:before? row)) "unresolved ref reports no hooks")))
 
 ;; -------------------------------------------------------------------------
+;; (1c) a15n62 realm-aware collection (rf2-dfaey7)
+;; -------------------------------------------------------------------------
+
+(deftest collect-by-realm-single-realm-renders-unchanged
+  (testing "rf2-dfaey7 — one (default) realm pair → rows carry NO realm
+            (absence is the default), no row is cross-realm"
+    (let [pairs [[:rf.realm/default sample-events-with-chains]]
+          rows  (panel/collect-interceptors-by-realm pairs)
+          by-id (into {} (map (juxt :id identity) rows))]
+      (is (= 3 (count rows)) "same row count as the default-realm browse")
+      (is (every? (fn [r] (nil? (:realm r))) rows)
+          "the default realm renders unqualified — no :realm on any row")
+      (is (not-any? :cross-realm? rows) "single realm → no cross-realm flag")
+      (is (= 2 (get-in by-id [:my/logging :chain-count]))
+          "chain-count is preserved through the realm path"))))
+
+(deftest collect-by-realm-attributes-owning-realm
+  (testing "rf2-dfaey7 — a non-default realm's rows carry its :rf.realm/id"
+    (let [pairs [[:rf.realm/default {:counter/inc
+                                     {:interceptors [:default/only
+                                                     {:id :rf/event-handler :rf/default? true}]}}]
+                 [:tenant/acme {:acme/save
+                                {:interceptors [:acme/audit
+                                                {:id :rf/event-handler :rf/default? true}]}}]]
+          rows  (panel/collect-interceptors-by-realm pairs)
+          by-key (into {} (map (juxt (juxt :id :realm) identity) rows))]
+      (is (nil? (get-in by-key [[:default/only nil] :realm]))
+          "the default-realm interceptor carries no realm label")
+      (is (= :tenant/acme (get-in by-key [[:acme/audit :tenant/acme] :realm]))
+          "the acme-realm interceptor is attributed to :tenant/acme")
+      ;; the framework wrapper exists in BOTH realms → cross-realm
+      (let [wrapper-rows (filterv #(= :rf/event-handler (:id %)) rows)]
+        (is (= 2 (count wrapper-rows)) "one wrapper row per realm")
+        (is (every? :cross-realm? wrapper-rows)
+            ":rf/event-handler spans both realms → flagged cross-realm")))))
+
+(deftest realm-haystack-finds-by-realm
+  (testing "rf2-dfaey7 — a multi-realm row is findable by its owning realm"
+    (let [pairs [[:tenant/acme {:acme/save
+                                {:interceptors [:acme/audit
+                                                {:id :rf/event-handler :rf/default? true}]}}]]
+          rows  (panel/collect-interceptors-by-realm pairs)]
+      (is (seq (panel/filter-rows rows "acme"))
+          "search matches the owning realm id"))))
+
+;; -------------------------------------------------------------------------
 ;; (2) registry wiring
 ;; -------------------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/shared/realm_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shared/realm_cljs_test.cljs
@@ -1,0 +1,59 @@
+(ns day8.re-frame2-xray.static.shared.realm-cljs-test
+  "Pure-helper tests for the static-browse realm dimension (rf2-dfaey7,
+  a15n62). The registry-touching fns (`realm-ids` / `registrations-in-realm`
+  / `multi-realm?`) are exercised against the live default realm through the
+  reset fixture; the pure projections (`realm-of` / `cross-realm-ids`) are
+  tested directly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.static.shared.realm :as realm]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest realm-ids-always-includes-default
+  (testing "rf2-dfaey7 — realm-ids always carries the default realm and is
+            fail-soft on a runtime that can't answer"
+    (is (contains? (realm/realm-ids) realm/default-realm-id)
+        "the default realm is always present")))
+
+(deftest single-realm-is-the-default-case
+  (testing "rf2-dfaey7 — a fresh runtime is single-realm (the common case)"
+    (is (false? (realm/multi-realm?))
+        "no extra realm installed → single-realm browse")))
+
+(deftest realm-of-blanks-the-default
+  (testing "rf2-dfaey7 — absence is the default; the default realm displays
+            as nothing"
+    (is (nil? (realm/realm-of nil)) "nil ⇒ default ⇒ no label")
+    (is (nil? (realm/realm-of realm/default-realm-id))
+        "the explicit default-realm id also displays as nothing")
+    (is (= :tenant/acme (realm/realm-of :tenant/acme))
+        "a non-default realm displays its id")))
+
+(deftest realm-qualified-registrations-single-realm-shape
+  (testing "rf2-dfaey7 — single-realm yields one [default reg-map] pair"
+    (let [pairs (realm/realm-qualified-registrations :event)]
+      (is (= 1 (count pairs)) "one pair in a single-realm app")
+      (is (= realm/default-realm-id (ffirst pairs))
+          "the one pair is the default realm")
+      (is (map? (second (first pairs))) "the pair carries the {id meta} map"))))
+
+(deftest cross-realm-ids-detects-id-conflict
+  (testing "rf2-dfaey7 — an id present in >1 realm is a cross-realm conflict"
+    (let [pairs [[:rf.realm/default {:shared/id {} :only-default/id {}}]
+                 [:tenant/acme      {:shared/id {} :only-acme/id {}}]]]
+      (is (= #{:shared/id} (realm/cross-realm-ids pairs))
+          "only :shared/id appears in both realms")))
+  (testing "rf2-dfaey7 — single realm has no cross-realm conflicts"
+    (is (empty? (realm/cross-realm-ids
+                  [[:rf.realm/default {:a {} :b {}}]])))))
+
+(deftest realm-badge-renders-nothing-in-single-realm
+  (testing "rf2-dfaey7 — the chip is suppressed in a single-realm browse so
+            the surface renders byte-identical to pre-rf2-dfaey7"
+    (is (nil? (realm/realm-badge :tenant/acme "test-id"))
+        "single-realm (no second realm installed) → no chip")
+    (is (nil? (realm/realm-badge nil "test-id"))
+        "the default realm never carries a chip")))


### PR DESCRIPTION
Two authoritative tools/xray beads (sole-toucher; xray surface only).

## rf2-se9a9t — EP-0022 §11 interceptor surfacing in the epoch/dynamic panel

The epoch panel surfaced interceptors **only on exception** (the rf2-yz57h
INTERCEPTOR step); a clean chain showed nothing, so an operator could not see
which interceptors wrap an event until one failed. EP-0022 §11 + Spec 002
§Tooling and metadata call for surfacing the **authored refs** + the
**resolved chain**.

- New **INTERCEPTORS** step (plural, badge `:INTERCEPTORS`, `:accent`) renders
  **before HANDLER** (the authored chain wraps the handler). One row per
  authored ref read off `(rf/handler-meta :event id)` `:interceptors` — the
  framework `:rf/default?` wrapper filtered out — each ENRICHED with its
  resolved descriptor (`before` / `after` / `before/after` / `factory`),
  source-coord (click-to-source), doc, the factory `:arg`, a `ref`/`inline`
  badge, and a `missing` chip for an unregistered ref
  (`:rf.error/unregistered-interceptor`).
- A clean chain emits no per-interceptor trace, so the refs are read from the
  **registry**. The pure `project` stays JVM-testable: it threads a resolver
  in (`projection/authored-interceptors-step` ← `epoch-panel/resolve-event-interceptors`);
  with no resolver (every existing caller) it is byte-identical. The step is
  informational and never inflates the epoch outcome.
- **Spec reconciled (021):** the speculative "AFTER INTERCEPTORS" step the impl
  never carried is replaced by the implemented authored-chain INTERCEPTORS step
  (+ badge taxonomy, conditional-cascade table, dense/sparse sketches,
  cross-nav + queries tables).
- Per-call / per-frame `:interceptor-overrides` (§11 (c)) are **not traced per
  dispatch** by the core, so override-substitution surfacing is documented as
  deferred until the core emits it — xray cannot project a substitution the
  core does not emit.

## rf2-dfaey7 — a15n62 realm dimension in the static browse + handler-resolution

Static browse panels read `(rf/registrations :kind)` (default realm only), so
a multi-realm host could not see which realm owns a registration nor flag a
cross-realm id conflict.

- New shared `static/shared/realm.cljs` composes the EP-0013 stage-8
  `(rf/registrations {:realm r :kind k})` form + `rf/realm-ids` into
  realm-qualified `[realm-id reg-map]` pairs, attributes each row to its owning
  `:rf.realm/id` (absence = default realm), flags cross-realm ids, and renders
  a per-row realm chip (warning-toned on conflict) **only in a multi-realm
  browse**.
- Named first consumer: the **Static Interceptors** sub-tab
  (`collect-interceptors-by-realm` + the `:rf.xray.static.interceptors/realm-pairs`
  sub feeding `tab-data`); **handler-resolution is realm-scoped** (a ref
  resolves against the realm its event lives in). The helper extends to the
  other static panels when multi-realm demand lands.
- **Single-realm hosts render byte-identical** (`(rf/realm-ids)` ⇒
  `#{:rf.realm/default}` → no chip, no realm column). Fail-soft on an older
  core. **Spec (007 §EP-0013 realm-awareness + 014 §Static mode)** documents
  the dimension.

## Quality gates

- `clojure -M:test` in `tools/xray/` — **1200 tests, 5376 assertions, 0 failures, 0 errors** (post-rebase).
- `npm run test:cljs` (node-runtime, includes xray view + static-panel tests) — **7312 tests, 30158 assertions; 0 failures from this PR.** (One pre-existing, unrelated failure on `main`: `machines-viz/share_cljs_test fn-as-state-id-survives-sanitisation` — reproduced with this PR's changes stashed; not touched by this PR.)
- `npm run test:xray-feature-gate` (nightly-full sweep) — all 8 testbed builds compiled clean (0 warnings); **15 scenarios, 0 failures, 13 matrix rows.**

New tests: projection (`interceptor-ref-row` / `authored-interceptors-step` / `project` resolver e2e), view (`render-interceptors-step` incl. missing-ref + `render-step` dispatch), static interceptors realm-aware collection, shared `realm` helper, and the registry snapshot updated for the new `realm-pairs` sub.

Closes rf2-se9a9t, rf2-dfaey7.
