### PR TITLE
chore: vestigial review — examples-scripts/reagent-slim/impl-scripts

### DIFF
--- a/implementation/scripts/_path-policy.cjs
+++ b/implementation/scripts/_path-policy.cjs
@@ -47,8 +47,7 @@ const DEFAULT_OUT_ROOT = path.join(IMPL_ROOT, 'out');
 const DEFAULT_HTML_ROOTS = [
   path.join(REPO_ROOT, 'examples'),
   // rf2-p8f2s — tool-owned testbeds may host index.html templates
-  // (e.g. tools/story/testbeds/counter_with_stories/story_static.index.html
-  // and tools/xray/testbeds/perf_counter/index.html).
+  // (e.g. tools/story/testbeds/counter_with_stories/story_static.index.html).
   path.join(REPO_ROOT, 'tools'),
   IMPL_ROOT,
 ];


### PR DESCRIPTION
Vestigial-content review of three directories (rf2-45u55n examples/scripts, rf2-dx9lov examples/reagent-slim, rf2-wztkfj implementation/scripts). Verified against shipped reality (existing files, live npm scripts, current spec/EP names, no retired-tool refs).

## Findings per directory

**examples/scripts/** — CLEAN. All path/script references resolve to existing targets; bead-id comments are descriptive and current; no removed-API refs, no Causa residue. No edits.

**examples/reagent-slim/** — CLEAN. README + counter_slim_and_fast (.cljs/.html) verified: every namespace (`reagent2.dom.client/server`, `re-frame.adapter.reagent-slim`, `re-frame.views`), file path (`_shared/` assets, boundary/bundle-isolation scripts), EP ref (EP-0002), and CI job (`cljs-reagent-slim-bundle-isolation`) resolve. Terminology is current ("Xray feature-matrix gate", not retired "Causa"). No edits.

**implementation/scripts/** — ONE vestige fixed. `_path-policy.cjs` `DEFAULT_HTML_ROOTS` comment cited `tools/xray/testbeds/perf_counter/index.html` as an example tool-owned template; that testbed was deleted in Wave 4 (smoke migrated to pure CLJS) and the directory no longer exists. Dropped the stale clause, kept the still-valid `counter_with_stories` example. Comment-only; behaviour unchanged. No `perf_counter`/Causa residue remains in the slice (only the unrelated English word "causal").

Scope: edits confined to `implementation/scripts/_path-policy.cjs`. No new `rf2-` bead-ids in committed prose. Examples remain test-free.

## Quality gates

- `npm run test:script-policy` (implementation/) — PASS. All 16 sub-suites green, including `_path-policy.test.cjs` which directly covers the edited file.