### PR TITLE
feat(error): central human-message builder + Spec 009 thrown-error contract (vvixub)

### DIFF
--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_derived_container_replaced_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_derived_container_replaced_cljs_test.cljs
@@ -124,8 +124,10 @@
                 "the :where slot names the user-facing surface fn")
             (is (= :no-recovery (:recovery (ex-data thrown)))
                 "the :recovery slot is :no-recovery")
-            (is (= ":rf.error/derived-container-replaced" (ex-message thrown))
-                "the ex-message stringifies the discriminator keyword")))))))
+            ;; rf2-vvixub — message is the human :reason sentence + the
+            ;; trailing [:rf.error/<id>] token; assert the token, not equality.
+            (is (re-find #"\[:rf\.error/derived-container-replaced\]" (ex-message thrown))
+                "the ex-message carries the [:rf.error/derived-container-replaced] token")))))))
 
 (deftest replace-on-reaction-emits-error-trace
   (testing "replace-container! on a Reaction emits the :rf.error/derived-container-replaced trace"

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -1098,8 +1098,10 @@
                   (rf/install-adapter! reagent-adapter/adapter)
                   false
                   (catch :default e
-                    (= ":rf.error/adapter-already-installed"
-                       (ex-message e))))]
+                    ;; rf2-vvixub — branch on the canonical :rf.error/id
+                    ;; discriminator, never on the (now human-sentence) message.
+                    (= :rf.error/adapter-already-installed
+                       (:rf.error/id (ex-data e)))))]
     (is thrown?
         "second install-adapter! raises :rf.error/adapter-already-installed"))
   ;; Sanity-check the destroy-then-install path remains valid.

--- a/implementation/core/src/re_frame/error.cljc
+++ b/implementation/core/src/re_frame/error.cljc
@@ -1,23 +1,162 @@
 (ns re-frame.error
-  "Shared error-message helpers — short tag fns and reason-string
-  primitives used by error / warning trace emit sites across core and
-  the per-feature artefacts.
+  "Shared error-message helpers — the central thrown-error builder, plus
+  short tag fns and reason-string primitives used by error / warning
+  trace emit sites across core and the per-feature artefacts.
+
+  `thrown-ex-info` / `throw-error!` are the canonical thrown-error
+  builders (Spec 009 §The thrown-error shape). Every `(throw (ex-info …))`
+  site in the runtime routes through them so the human message and the
+  `:rf.error/id` machine discriminator cannot drift: the builder DERIVES
+  the message from `:reason` + the `[:rf.error/<id>]` greppability token
+  and sets the canonical ex-data shape. Keyword-only messages become
+  structurally impossible by construction (rf2-vvixub).
 
   `type-of-value` renders a short type tag in the `:reason` string of
   a `:rf.error/schema-validation-failure` trace event; consumed by
   `re-frame.spec` and `re-frame.schemas.validate`.
 
-  Lives in core because schemas depends on core (Spec 006 §Adapter
-  shipping convention) — pushing the helper down means the schemas-
-  side validate.cljc can `:require` it without inverting the dep
-  direction. Apps that don't load the schemas
-  artefact still get the helper for free under `re-frame.spec`'s
-  boundary-validation interceptor.
+  Lives in core because schemas / flows / routing depend on core (Spec
+  006 §Adapter shipping convention) — pushing the helpers down means the
+  per-feature artefacts can `:require` it without inverting the dep
+  direction. Apps that don't load the schemas artefact still get the
+  helpers for free under core.
 
-  Pure; no runtime state. Hot-path safe (single keyword cond cascade
-  with no allocation on the common branches).")
+  Pure; no runtime state. Hot-path safe (the type-tag cond cascade
+  allocates nothing on the common branches; the thrown-error builders
+  run only on the failure path).")
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the canonical thrown-error builder (rf2-vvixub) ----------------------
+;;
+;; Spec 009 §The thrown-error shape rules the human-message contract:
+;;
+;;   1. `(ex-message e)` is a human-actionable one-line sentence (the
+;;      public concept + the expected fix + key context). It is NOT the
+;;      stringified discriminator keyword.
+;;   2. `:rf.error/id` is the SOLE canonical machine discriminator; tools
+;;      and tests branch on it, never on the message.
+;;   3. The message is stable in MEANING, not bytes — tests MUST NOT
+;;      exact-equal it.
+;;   4. The message carries a trailing `[:rf.error/<id>]` token for
+;;      log/CI greppability, preserving the only thing the old
+;;      "category-from-message-alone" property bought.
+;;   5. `:reason` IS that required human sentence; there is no separate
+;;      `:rf.error/message` slot (it would duplicate `:reason`).
+;;
+;; The builder derives the message FROM `:reason` + the token, so the
+;; message and `:rf.error/id` cannot drift, and a keyword-only message is
+;; impossible to emit. Today's hand-rolled `(ex-info (str error-kw) …)`
+;; sites — which made the keyword the WHOLE message — route through here.
+
+(defn id-token
+  "The trailing greppability token for a thrown-error `:rf.error/id` —
+  the bracketed keyword `[:rf.error/<id>]` appended to every framework
+  exception message (Spec 009 §The thrown-error shape, rule 4). A log
+  line or raw stack trace still pivots to a stable category by grepping
+  the bracketed token, while the leading text carries the human sentence.
+
+  nil-safe — returns the empty string when `error-id` is nil so a
+  malformed call degrades to the bare reason rather than `[null]`."
+  [error-id]
+  (if (some? error-id)
+    (str "[" error-id "]")
+    ""))
+
+(defn human-message
+  "Derive the human-facing exception message (`ex-message`) from the
+  required human `reason` sentence and the `error-id` greppability token
+  (Spec 009 §The thrown-error shape). Shape:
+
+    \"<reason> [:rf.error/<id>]\"
+
+  e.g. \"rf/init! cannot continue because no adapter is installed;
+  require an adapter ns and install it before boot.
+  [:rf.error/no-adapter-installed]\".
+
+  The message LEADS with the human sentence (rule 1) and trails with the
+  category token (rule 4). Non-normative in bytes — consumers branch on
+  `:rf.error/id`, never on this string."
+  [error-id reason]
+  (let [sentence (if (and (string? reason) (seq reason))
+                   reason
+                   ;; Defensive: a missing :reason is a builder-call bug,
+                   ;; not a user-facing condition. Still emit a non-keyword
+                   ;; message so the conformance gate's "no bare keyword
+                   ;; message" invariant holds even on the degenerate path.
+                   "re-frame2 raised an error")
+        token    (id-token error-id)]
+    (if (seq token)
+      (str sentence " " token)
+      sentence)))
+
+(defn thrown-ex-info
+  "Build the canonical thrown-error `ex-info` (Spec 009 §The thrown-error
+  shape, rf2-vvixub). The SINGLE chokepoint every framework
+  `(throw (ex-info …))` site routes through.
+
+  Args:
+    error-id  — the `:rf.error/<category>` keyword. The SOLE canonical
+                machine discriminator; lands in the `:rf.error/id` slot.
+    where-sym — the user-facing fn symbol that threw (`'rf/init!`,
+                `'rf/reg-flow`, …) so a grep-for-symbol lands on the call
+                site; lands in `:where`.
+    reason    — the required one-sentence human diagnostic naming the
+                public concept, the expected fix, and key context. Lands
+                in `:reason` AND leads the derived message.
+
+  Options (a map; all optional):
+    :recovery — the [§Recovery contract] disposition; defaults to
+                `:no-recovery`.
+    :extra    — a map of surface-specific ex-data slots merged on top
+                (`:flow`, `:route-id`, `:received`, `:bad-entries`, …).
+
+  Returns the `ex-info`. The message is `(human-message error-id reason)`
+  — the human sentence + the `[:rf.error/<id>]` token — so the message
+  and the discriminator are derived from one source and cannot drift.
+  Use `throw-error!` to build AND throw in one call."
+  ([error-id where-sym reason] (thrown-ex-info error-id where-sym reason nil))
+  ([error-id where-sym reason {:keys [recovery extra]}]
+   (ex-info (human-message error-id reason)
+            (merge {:rf.error/id error-id
+                    :where       where-sym
+                    :recovery    (or recovery :no-recovery)
+                    :reason      reason}
+                   extra))))
+
+(defn throw-error!
+  "Build (via `thrown-ex-info`) and `throw` the canonical thrown-error
+  `ex-info` in one call (Spec 009 §The thrown-error shape, rf2-vvixub).
+  Same args as `thrown-ex-info`. Never returns normally."
+  ([error-id where-sym reason] (throw-error! error-id where-sym reason nil))
+  ([error-id where-sym reason opts]
+   (throw (thrown-ex-info error-id where-sym reason opts))))
+
+(defn keyword-only-message?
+  "Conformance predicate (rf2-vvixub): true when `message` is a bare
+  stringified `:rf.error/…` keyword — i.e. the OLD keyword-only message
+  shape the new contract forbids. A conformant framework message LEADS
+  with a human sentence and only carries the keyword inside the trailing
+  `[:rf.error/<id>]` token, so a conformant message is never `(str
+  some-keyword)` on its own.
+
+  Used by the thrown-error conformance test to reject any framework throw
+  that regresses to a keyword-only human message."
+  [message]
+  (boolean
+    (and (string? message)
+         (re-matches #":rf\.error/[A-Za-z0-9*+!_.?\-]+" message))))
+
+(defn message-has-id-token?
+  "Conformance predicate (rf2-vvixub): true when `message` contains the
+  trailing `[:rf.error/<id>]` greppability token (Spec 009 §The
+  thrown-error shape, rule 4). The conformance test asserts every
+  framework thrown message carries the token so a log/CI grep still
+  pivots to a stable category from the message alone."
+  [message]
+  (boolean
+    (and (string? message)
+         (re-find #"\[:rf\.error/[A-Za-z0-9*+!_.?\-]+\]" message))))
 
 (defn type-of-value
   "Best-effort short tag for a value's type — surfaced inside the

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -18,7 +18,8 @@
   drift test `implementation/core/test/re_frame/late_bind_drift_test.clj`
   asserts the directory matches the in-tree publications, walking both
   the per-key `set-fn!` form and the rf2-rtk2e map-form `set-fns!`
-  block.")
+  block."
+  (:require [re-frame.error :as error]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -231,11 +232,15 @@
   `:rf.error/<artefact>-artefact-missing` ex-info when the hook is
   unregistered.
 
-  Carries the canonical thrown-error shape (per Spec 009 §The
-  thrown-error shape):
+  Carries the canonical thrown-error shape via the central builder
+  `re-frame.error/throw-error!` (per Spec 009 §The thrown-error shape):
 
-    Message:  `<error-keyword>` printed as a string (e.g.
-              \":rf.error/flows-artefact-missing\").
+    Message:  the human `:reason` sentence + the trailing
+              `[:rf.error/<artefact>-artefact-missing]` greppability
+              token (e.g. \"rf/reg-flow requires
+              com.day8.re-frame/re-frame2-flows on the classpath; add it
+              to deps and require re-frame.flows at app boot.
+              [:rf.error/flows-artefact-missing]\").
     ex-data:  {:rf.error/id <error-keyword>  ;; canonical discriminator
                :where       <where-sym>
                :recovery    :no-recovery
@@ -244,23 +249,23 @@
                & extra-data}
 
   The `:rf.error/id` slot is the canonical discriminator consumers read
-  uniformly (Xray, pair-tool, `:on-error`); the message string is the
-  stringified kw so `.getMessage` pivots to the same category.
-  `where-sym` is the user-facing fn symbol stamped on the error.
-  `artefact-info` carries `{:error-keyword :maven :require-ns}`.
-  `extra-data` is the per-call ex-data merged in (e.g. `:flow-id`,
-  `:route-id`).
+  uniformly (Xray, pair-tool, `:on-error`); the message LEADS with the
+  human sentence and carries the category only inside the trailing token,
+  so `.getMessage` reads as actionable prose while a log grep still
+  pivots on the bracketed keyword. `where-sym` is the user-facing fn
+  symbol stamped on the error. `artefact-info` carries
+  `{:error-keyword :maven :require-ns}`. `extra-data` is the per-call
+  ex-data merged in (e.g. `:flow-id`, `:route-id`).
 
   Pairs with `re-frame.core-artefact/defwrapper`."
   ([hook-key where-sym artefact-info]
    (require-fn! hook-key where-sym artefact-info nil))
   ([hook-key where-sym {:keys [error-keyword maven require-ns]} extra-data]
    (or (get @hooks hook-key)
-       (throw (ex-info (str error-keyword)
-                       (merge {:rf.error/id error-keyword
-                               :where       where-sym
-                               :recovery    :no-recovery
-                               :reason      (str where-sym " requires " maven
-                                                 " on the classpath; add it to deps and require "
-                                                 require-ns " at app boot.")}
-                              extra-data))))))
+       (error/throw-error!
+         error-keyword
+         where-sym
+         (str where-sym " requires " maven
+              " on the classpath; add it to deps and require "
+              require-ns " at app boot.")
+         {:extra extra-data}))))

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -32,7 +32,8 @@
   explicitly via `(rf/init! reagent/adapter)`. Explicit > implicit
   at the call site, and an app requiring only the adapter it needs
   ships only that adapter's code."
-  (:require [re-frame.interop :as interop]
+  (:require [re-frame.error :as error]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.realm :as realm]
             [re-frame.trace :as trace]))
@@ -80,13 +81,12 @@
   `realm/install-realm-adapter!`."
   [adapter]
   (when-let [installed (realm/realm-adapter)]
-    (throw (ex-info ":rf.error/adapter-already-installed"
-                    {:rf.error/id :rf.error/adapter-already-installed
-                     :where       'rf/init!
-                     :recovery    :no-recovery
-                     :reason      "A second install-adapter! was called without an intervening (rf/destroy-adapter!); the existing adapter remains installed (per Spec 006 §Single adapter per process)."
-                     :installed   installed
-                     :attempted   adapter})))
+    (error/throw-error!
+      :rf.error/adapter-already-installed
+      'rf/init!
+      "A second install-adapter! was called without an intervening (rf/destroy-adapter!); the existing adapter remains installed (per Spec 006 §Single adapter per process)."
+      {:extra {:installed installed
+               :attempted adapter}}))
   (realm/install-realm-adapter! adapter)
   adapter)
 
@@ -207,22 +207,20 @@
   [where-sym]
   (or (realm/realm-adapter)
       (if (realm/realm-adapter-disposed?)
-        (throw (ex-info ":rf.error/adapter-disposed"
-                        {:rf.error/id :rf.error/adapter-disposed
-                         :where    where-sym
-                         :recovery :no-recovery
-                         :reason   (str where-sym " was called after"
-                                        " (rf/destroy-adapter!); the previously"
-                                        " installed adapter was torn down."
-                                        " Install a fresh adapter via"
-                                        " (rf/init! <adapter>) before calling.")}))
-        (throw (ex-info ":rf.error/no-adapter-installed"
-                        {:rf.error/id :rf.error/no-adapter-installed
-                         :where    where-sym
-                         :recovery :no-recovery
-                         :reason   (str where-sym " was called before (rf/init! ...);"
-                                        " require an adapter ns and pass its `adapter` Var,"
-                                        " e.g. (rf/init! reagent/adapter).")})))))
+        (error/throw-error!
+          :rf.error/adapter-disposed
+          where-sym
+          (str where-sym " was called after"
+               " (rf/destroy-adapter!); the previously"
+               " installed adapter was torn down."
+               " Install a fresh adapter via"
+               " (rf/init! <adapter>) before calling."))
+        (error/throw-error!
+          :rf.error/no-adapter-installed
+          where-sym
+          (str where-sym " was called before (rf/init! ...);"
+               " require an adapter ns and pass its `adapter` Var,"
+               " e.g. (rf/init! reagent/adapter).")))))
 
 (defn make-state-container
   "Build a fresh, writable substrate state container holding
@@ -379,11 +377,10 @@
                              {:category  :rf.error/derived-container-replaced
                               :recovery  :no-recovery
                               :reason    reason})
-          (throw (ex-info ":rf.error/derived-container-replaced"
-                          {:rf.error/id :rf.error/derived-container-replaced
-                           :where       'rf/replace-container!
-                           :recovery    :no-recovery
-                           :reason      reason})))
+          (error/throw-error!
+            :rf.error/derived-container-replaced
+            'rf/replace-container!
+            reason))
         ((:replace-container! a) container new-value)))))
 
 (defn make-derived-value

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -202,8 +202,13 @@
     (let [thrown (try (substrate-adapter/make-state-container {}) nil
                       (catch :default e e))]
       (is (some? thrown) "delegation call after dispose threw")
-      (is (= ":rf.error/adapter-disposed" (.-message thrown))
-          "the throw shape matches MUST (4)"))
+      ;; rf2-vvixub — message is a human sentence + the trailing
+      ;; [:rf.error/<id>] token; assert the token substring + the
+      ;; canonical :rf.error/id, not exact keyword-equality.
+      (is (= :rf.error/adapter-disposed (:rf.error/id (ex-data thrown)))
+          "the throw carries the canonical :rf.error/id discriminator (MUST 4)")
+      (is (re-find #"\[:rf\.error/adapter-disposed\]" (.-message thrown))
+          "the message carries the [:rf.error/adapter-disposed] token"))
     ;; Reinstall so the fixture's :after teardown lands on clean state.
     (substrate-adapter/install-adapter! adapter)))
 
@@ -2320,7 +2325,10 @@
                     (rf/install-adapter! adapter)
                     false
                     (catch :default e
-                      (= ":rf.error/adapter-already-installed" (ex-message e))))]
+                      ;; rf2-vvixub — branch on the canonical :rf.error/id
+                      ;; discriminator, never on the (now human-sentence) message.
+                      (= :rf.error/adapter-already-installed
+                         (:rf.error/id (ex-data e)))))]
       (is thrown? "second install-adapter! raises :rf.error/adapter-already-installed"))
     (rf/destroy-adapter!)
     (rf/install-adapter! adapter)

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -111,9 +111,13 @@
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown)
           "a second install-adapter! call without an intervening dispose throws")
-      (is (= ":rf.error/adapter-already-installed"
-             (some-> thrown ex-message))
-          "the thrown exception carries the :rf.error/adapter-already-installed tag")
+      ;; rf2-vvixub — the message is now a human sentence carrying the
+      ;; trailing [:rf.error/<id>] greppability token (Spec 009 §The
+      ;; thrown-error shape); assert the token substring, NOT exact
+      ;; equality. The canonical discriminator is :rf.error/id below.
+      (is (re-find #"\[:rf\.error/adapter-already-installed\]"
+                   (str (some-> thrown ex-message)))
+          "the thrown message carries the [:rf.error/adapter-already-installed] token")
       (let [data (ex-data thrown)]
         (is (= :rf.error/adapter-already-installed (:rf.error/id data))
             "ex-data carries the canonical :rf.error/id discriminator (per Spec 009 §The thrown-error shape)")
@@ -407,9 +411,12 @@
         (let [thrown (catch-no-adapter thunk)]
           (is (some? thrown)
               (str where-sym " throws when called before (rf/init! ...)"))
-          (is (= ":rf.error/no-adapter-installed"
-                 (some-> thrown ex-message))
-              (str where-sym " ex-message carries the :rf.error/no-adapter-installed tag"))
+          ;; rf2-vvixub — message is a human sentence + the trailing
+          ;; [:rf.error/<id>] token; assert the token substring, not
+          ;; exact keyword-equality. Canonical discriminator is :rf.error/id.
+          (is (re-find #"\[:rf\.error/no-adapter-installed\]"
+                       (str (some-> thrown ex-message)))
+              (str where-sym " message carries the [:rf.error/no-adapter-installed] token"))
           (let [data (ex-data thrown)]
             ;; Per Spec 009 §The thrown-error shape: canonical
             ;; discriminator slot is `:rf.error/id` (require-adapter!
@@ -490,9 +497,12 @@
         (let [thrown (catch-no-adapter thunk)]
           (is (some? thrown)
               (str where-sym " throws when called after dispose-adapter!"))
-          (is (= ":rf.error/adapter-disposed"
-                 (some-> thrown ex-message))
-              (str where-sym " ex-message carries the :rf.error/adapter-disposed tag (not :no-adapter-installed)"))
+          ;; rf2-vvixub — message is a human sentence + the trailing
+          ;; [:rf.error/<id>] token; assert the token substring, not
+          ;; exact keyword-equality. Canonical discriminator is :rf.error/id.
+          (is (re-find #"\[:rf\.error/adapter-disposed\]"
+                       (str (some-> thrown ex-message)))
+              (str where-sym " message carries the [:rf.error/adapter-disposed] token (not :no-adapter-installed)"))
           (let [data (ex-data thrown)]
             (is (= :rf.error/adapter-disposed (:rf.error/id data))
                 (str where-sym " ex-data carries the canonical :rf.error/id discriminator"))

--- a/implementation/core/test/re_frame/core_artefact_test.clj
+++ b/implementation/core/test/re_frame/core_artefact_test.clj
@@ -68,6 +68,8 @@
                  (catch clojure.lang.ExceptionInfo e e))]
       (is (some? e) "the wrapper threw")
       (let [data (ex-data e)]
+        (is (= :rf.error/test-artefact-missing (:rf.error/id data))
+            ":rf.error/id carries the canonical discriminator (per Spec 009 §The thrown-error shape)")
         (is (= 'rf/throw-wrapper (:where data))
             ":where stamps the user-facing fn name (default rf/<name>)")
         (is (= :no-recovery (:recovery data))
@@ -76,9 +78,12 @@
             ":reason mentions the Maven artefact coordinates")
         (is (re-find #"re-frame.test-fake-artefact" (:reason data))
             ":reason mentions the producing ns name")
-        (is (= ":rf.error/test-artefact-missing"
-               (.getMessage ^Throwable e))
-            "the exception message is the :error-keyword printed as a string")))))
+        ;; rf2-vvixub — the message is now the human :reason sentence + the
+        ;; trailing [:rf.error/<id>] greppability token, NOT the bare
+        ;; stringified keyword. Assert the token substring, not equality.
+        (is (re-find #"\[:rf\.error/test-artefact-missing\]"
+                     (.getMessage ^Throwable e))
+            "the exception message carries the [:rf.error/test-artefact-missing] token")))))
 
 (deftest throw-policy-delegates-when-hook-registered
   (testing ":throw delegates to the hook fn when registered"

--- a/implementation/core/test/re_frame/substrate/derived_container_replaced_cljs_test.cljc
+++ b/implementation/core/test/re_frame/substrate/derived_container_replaced_cljs_test.cljc
@@ -92,9 +92,12 @@
             "the :recovery slot is :no-recovery")
         (is (string? (:reason (ex-data thrown)))
             "the :reason slot is a human-readable sentence")
-        (is (= ":rf.error/derived-container-replaced"
-               (ex-message thrown))
-            "the ex-message stringifies the discriminator keyword")))))
+        ;; rf2-vvixub — the message is the human :reason sentence + the
+        ;; trailing [:rf.error/<id>] greppability token, NOT the bare
+        ;; stringified keyword. Assert the token substring, not equality.
+        (is (re-find #"\[:rf\.error/derived-container-replaced\]"
+                     (ex-message thrown))
+            "the ex-message carries the [:rf.error/derived-container-replaced] token")))))
 
 (deftest replace-on-derived-container-emits-error-trace
   (testing "replace-container! on a derived container emits the :rf.error/derived-container-replaced trace"

--- a/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
@@ -1,0 +1,182 @@
+(ns re-frame.thrown-error-message-conformance-cljs-test
+  "rf2-vvixub — the thrown-error HUMAN-MESSAGE conformance gate.
+
+  Spec 009 §The thrown-error shape rules the human-message contract:
+
+    1. `(ex-message e)` is a human-actionable one-line sentence — NOT
+       the bare stringified `:rf.error/…` discriminator keyword.
+    2. `:rf.error/id` (ex-data) is the SOLE canonical machine
+       discriminator; tools/tests branch on it, never on the message.
+    3. The message is stable in MEANING, not bytes — tests MUST NOT
+       exact-equal it.
+    4. The message carries a trailing `[:rf.error/<id>]` token for
+       log/CI greppability.
+
+  This gate makes rule 1+4 REAL, not documentary: it rejects any
+  framework throw whose message regresses to a keyword-only shape, and
+  asserts the central builder + every CENTRAL per-surface site routed
+  through it (rf2-vvixub PR) emits the canonical message.
+
+  Dual-runtime: the ns ends in `-cljs-test` so it rides the always-on
+  `:node-test` gate (`npm run test:cljs`); cognitect-test-runner also
+  discovers the `.cljc` on the JVM (`clojure -M:test`). Pure data — no
+  adapter / runtime state required (the central sites are exercised
+  directly), so no reset-runtime fixture."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.flows.registry :as flows-registry]
+            [re-frame.routing.registry :as routing-registry]))
+
+;; ============================================================================
+;; The builder predicates — the conformance machinery itself
+;; ============================================================================
+
+(deftest keyword-only-message?-rejects-bare-keyword-strings
+  (testing "a bare stringified :rf.error/… keyword is flagged (the OLD shape)"
+    (is (true? (error/keyword-only-message? ":rf.error/no-adapter-installed")))
+    (is (true? (error/keyword-only-message? ":rf.error/flow-bad-id")))
+    (is (true? (error/keyword-only-message? ":rf.error/route-too-many-keys"))))
+  (testing "a human sentence carrying the token is NOT flagged (the NEW shape)"
+    (is (false? (error/keyword-only-message?
+                  "rf/init! cannot continue because no adapter is installed; require an adapter ns and install it before boot. [:rf.error/no-adapter-installed]")))
+    (is (false? (error/keyword-only-message?
+                  "some other text :rf.error/x in the middle"))))
+  (testing "nil / non-string degrade to false (never a true positive)"
+    (is (false? (error/keyword-only-message? nil)))
+    (is (false? (error/keyword-only-message? :rf.error/x)))))
+
+(deftest message-has-id-token?-detects-the-trailing-token
+  (testing "the bracketed [:rf.error/<id>] token is detected anywhere"
+    (is (true? (error/message-has-id-token?
+                 "human sentence here. [:rf.error/no-adapter-installed]")))
+    (is (true? (error/message-has-id-token? "[:rf.error/flow-bad-id]"))))
+  (testing "a message with NO token is rejected (rule 4 floor)"
+    (is (false? (error/message-has-id-token? "just a human sentence")))
+    (is (false? (error/message-has-id-token? ":rf.error/no-adapter-installed")))
+    (is (false? (error/message-has-id-token? nil)))))
+
+;; ============================================================================
+;; The central builder — derives a conformant message from reason + id
+;; ============================================================================
+
+(deftest thrown-ex-info-derives-the-canonical-shape
+  (let [e (error/thrown-ex-info
+            :rf.error/no-adapter-installed
+            'rf/init!
+            "rf/init! cannot continue because no adapter is installed; require an adapter ns and install it before boot.")
+        msg (ex-message e)
+        data (ex-data e)]
+    (testing "ex-data carries the canonical discriminator slot"
+      (is (= :rf.error/no-adapter-installed (:rf.error/id data))))
+    (testing ":where + :recovery default + :reason populate"
+      (is (= 'rf/init! (:where data)))
+      (is (= :no-recovery (:recovery data)))
+      (is (= "rf/init! cannot continue because no adapter is installed; require an adapter ns and install it before boot."
+             (:reason data))))
+    (testing "the message LEADS with the human sentence (rule 1)"
+      (is (not (error/keyword-only-message? msg))
+          "message must not be a bare keyword")
+      (is (re-find #"^rf/init! cannot continue" msg)
+          "message starts with the human sentence, not the keyword"))
+    (testing "the message TRAILS with the [:rf.error/<id>] token (rule 4)"
+      (is (error/message-has-id-token? msg))
+      (is (re-find #"\[:rf\.error/no-adapter-installed\]$" msg)))))
+
+(deftest thrown-ex-info-honours-recovery-and-extra-slots
+  (let [e (error/thrown-ex-info
+            :rf.error/flow-bad-id
+            'rf/reg-flow
+            ":id must be a keyword"
+            {:recovery :fix-registration
+             :extra    {:flow {:id "not-a-kw"} :bad-key :id}})
+        data (ex-data e)]
+    (is (= :fix-registration (:recovery data)) "explicit :recovery overrides the default")
+    (is (= {:id "not-a-kw"} (:flow data)) ":extra slots merge on top")
+    (is (= :id (:bad-key data)))
+    (is (= ":id must be a keyword" (:reason data)))
+    (is (error/message-has-id-token? (ex-message e)))))
+
+(deftest throw-error!-builds-and-throws
+  (let [thrown (try
+                 (error/throw-error! :rf.error/no-adapter-specified
+                                     'rf/init!
+                                     "rf/init! requires an adapter spec map")
+                 ::no-throw
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
+    (is (not= ::no-throw thrown) "throw-error! actually throws")
+    (is (= :rf.error/no-adapter-specified (:rf.error/id (ex-data thrown))))
+    (is (not (error/keyword-only-message? (ex-message thrown))))
+    (is (error/message-has-id-token? (ex-message thrown)))))
+
+;; ============================================================================
+;; The CENTRAL per-surface sites converted in the rf2-vvixub PR all emit
+;; the conformant shape (the "no keyword-only message regression" gate).
+;; Each site is exercised through its public throw path and its message is
+;; asserted to be a human sentence carrying the token, with the canonical
+;; discriminator in :rf.error/id. (The 10 surface CHILDREN are converted by
+;; their own beads; this gate covers the contract + the central conversions.)
+;; ============================================================================
+
+(defn- ex-info-class? [e]
+  #?(:clj (instance? clojure.lang.ExceptionInfo e)
+     :cljs (instance? ExceptionInfo e)))
+
+(defn- assert-conformant-throw!
+  "Assert `thunk` throws an ex-info whose message is conformant (human
+  sentence + token, never a bare keyword) and whose `:rf.error/id` equals
+  `expected-id`."
+  [label expected-id thunk]
+  (let [thrown (try (thunk) ::no-throw
+                    (catch #?(:clj Throwable :cljs :default) e e))]
+    (testing (str label " throws a conformant ex-info")
+      (is (ex-info-class? thrown) (str label " threw an ex-info"))
+      (when (ex-info-class? thrown)
+        (let [msg (ex-message thrown)]
+          (is (= expected-id (:rf.error/id (ex-data thrown)))
+              (str label " carries the canonical :rf.error/id discriminator"))
+          (is (not (error/keyword-only-message? msg))
+              (str label " message is NOT a bare keyword (rule 1)"))
+          (is (error/message-has-id-token? msg)
+              (str label " message carries the [:rf.error/<id>] token (rule 4)")))))))
+
+(deftest require-fn!-emits-conformant-missing-artefact-throw
+  ;; late-bind/require-fn! — the missing-artefact exemplar. An unregistered
+  ;; hook key (no producer published it) throws the *-artefact-missing shape.
+  (assert-conformant-throw!
+    "require-fn! (missing artefact)"
+    :rf.error/flows-artefact-missing
+    #(late-bind/require-fn!
+       ::vvixub-definitely-unregistered-hook
+       'rf/reg-flow
+       {:error-keyword :rf.error/flows-artefact-missing
+        :maven         "com.day8.re-frame/re-frame2-flows"
+        :require-ns     're-frame.flows})))
+
+(deftest flow-error-emits-conformant-validation-throw
+  ;; flows.registry validation — the :error→:rf.error/id exemplar. An
+  ;; invalid flow (non-keyword :id) trips the validation cascade. flow-error
+  ;; is private; reach it through the public reg-flow validation entry point.
+  (assert-conformant-throw!
+    "reg-flow (bad :id)"
+    :rf.error/flow-bad-id
+    #(#'flows-registry/validate-flow
+       {:id     "not-a-keyword"
+        :inputs [[:a]]
+        :output (fn [_] nil)
+        :path   [:out]})))
+
+(deftest route-error-emits-conformant-routing-throw
+  ;; routing.registry route-error — the routing exemplar. Build directly
+  ;; (route-error is the canonical helper every routing throw routes through).
+  (let [e (routing-registry/route-error
+            :rf.error/route-too-many-keys
+            'rf/match-url
+            "the decoded URL declared more keys than the interning cap allows"
+            {:limit 64 :count 99})]
+    (is (= :rf.error/route-too-many-keys (:rf.error/id (ex-data e))))
+    (is (= 64 (:limit (ex-data e))) "per-site :extras slots merge on top")
+    (is (not (error/keyword-only-message? (ex-message e)))
+        "route-error message is NOT a bare keyword (rule 1)")
+    (is (error/message-has-id-token? (ex-message e))
+        "route-error message carries the [:rf.error/<id>] token (rule 4)")))

--- a/implementation/epoch/test/re_frame/epoch_late_bind_missing_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_late_bind_missing_cljs_test.cljs
@@ -70,8 +70,13 @@
                           (catch :default e e))]
           (is (some? thrown)
               "replace-app-db! throws when the epoch artefact is absent")
-          (is (= ":rf.error/epoch-artefact-missing" (ex-message thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/epoch-artefact-missing\]" (ex-message thrown))
+              "the message carries the [:rf.error/epoch-artefact-missing] token")
+          (is (= :rf.error/epoch-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/replace-app-db! (:where data))
                 "ex-data carries :where = 'rf/replace-app-db!")

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2660,8 +2660,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "replace-app-db! throws when the epoch artefact is absent")
-          (is (= ":rf.error/epoch-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/epoch-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/epoch-artefact-missing] token")
+          (is (= :rf.error/epoch-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/replace-app-db! (:where data))
                 "ex-data carries :where = 'rf/replace-app-db!")
@@ -2754,8 +2759,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "replace-runtime-db! throws when the epoch artefact is absent")
-          (is (= ":rf.error/epoch-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/epoch-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/epoch-artefact-missing] token")
+          (is (= :rf.error/epoch-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/replace-runtime-db! (:where data))
                 "ex-data carries :where = 'rf/replace-runtime-db!")
@@ -2896,7 +2906,10 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "replace-frame-state! throws when the epoch artefact is absent")
-          (is (= ":rf.error/epoch-artefact-missing" (.getMessage thrown)))
+          ;; rf2-vvixub — assert the [:rf.error/<id>] token + canonical
+          ;; :rf.error/id, not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/epoch-artefact-missing\]" (.getMessage thrown)))
+          (is (= :rf.error/epoch-artefact-missing (:rf.error/id (ex-data thrown))))
           (let [data (ex-data thrown)]
             (is (= 'rf/replace-frame-state! (:where data))
                 "ex-data carries :where = 'rf/replace-frame-state!")

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -35,6 +35,7 @@
   `{flow-id {frame-id inputs}}` observation shape so its public contract
   is unchanged across the storage restructure."
   (:require [re-frame.elision :as elision]
+            [re-frame.error :as error]
             [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -313,20 +314,18 @@
 ;; / `:bad-elements`) merge on top.
 
 (defn- flow-error
-  "Build the validate-flow ex-info with the canonical thrown-error shape
-  (per Spec 009 §The thrown-error shape). `error-kw` becomes the message
-  AND the `:rf.error/id` discriminator slot; `reason` is the human-
-  readable diagnostic; `extras` merges per-clause slots (e.g.
-  `:bad-entries`)."
+  "Build the validate-flow ex-info via the central thrown-error builder
+  `re-frame.error/thrown-ex-info` (per Spec 009 §The thrown-error shape).
+  `error-kw` is the `:rf.error/id` discriminator slot; `reason` is the
+  human-readable diagnostic that LEADS the message (the message also
+  trails the `[:rf.error/<id>]` greppability token); `extras` merges
+  per-clause slots (e.g. `:bad-entries`)."
   ([error-kw reason flow] (flow-error error-kw reason flow nil))
   ([error-kw reason flow extras]
-   (ex-info (str error-kw)
-            (merge {:rf.error/id error-kw
-                    :where       'rf/reg-flow
-                    :recovery    :fix-registration
-                    :reason      reason
-                    :flow        flow}
-                   extras))))
+   (error/thrown-ex-info
+     error-kw 'rf/reg-flow reason
+     {:recovery :fix-registration
+      :extra    (merge {:flow flow} extras)})))
 
 ;; The validation rules, in evaluation order. Each rule has a predicate
 ;; over the flow map (returns truthy to accept), a stable `:error-kw`
@@ -929,18 +928,18 @@
      ;; destroyed frame id. `clear-flow` keeps its permissive absent-frame
      ;; no-op (teardown must be idempotent); only this MUTATING path rejects.
      (when (nil? (frame/frame frame-id))
-       (throw (ex-info (str :rf.error/flow-frame-not-live)
-                       {:rf.error/id :rf.error/flow-frame-not-live
-                        :where       'rf/reg-flow
-                        :recovery    :fix-registration
-                        :reason      (str "cannot register a flow against frame "
-                                          frame-id
-                                          " — the frame is not live (absent / never registered, "
-                                          "or torn down by destroy-frame!). Register the flow "
-                                          "against a live frame; a destroyed frame must not "
-                                          "acquire flow state (Spec 013 §destroy-frame!).")
-                        :frame       frame-id
-                        :flow        flow})))
+       (error/throw-error!
+         :rf.error/flow-frame-not-live
+         'rf/reg-flow
+         (str "cannot register a flow against frame "
+              frame-id
+              " — the frame is not live (absent / never registered, "
+              "or torn down by destroy-frame!). Register the flow "
+              "against a live frame; a destroyed frame must not "
+              "acquire flow state (Spec 013 §destroy-frame!).")
+         {:recovery :fix-registration
+          :extra    {:frame frame-id
+                     :flow  flow}}))
      ;; ATOMIC check-and-insert (rf2-qxwib). The cycle check and the
      ;; commit are ONE `swap!` update fn over `@flows`: it reads the
      ;; frame's CURRENTLY-COMMITTED flow-map, runs topo-sort on the

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -714,8 +714,10 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-marks (:rf.error/id data))
           ":rf.error/id carries the bad-marks discriminator")
-      (is (= ":rf.error/flow-bad-marks" (ex-message ex))
-          "message string is the stringified discriminator kw")
+      ;; rf2-vvixub — message is the human :reason sentence + the trailing
+      ;; [:rf.error/<id>] token; assert the token substring, not equality.
+      (is (re-find #"\[:rf\.error/flow-bad-marks\]" (ex-message ex))
+          "message carries the [:rf.error/flow-bad-marks] token")
       (is (= 'rf/reg-flow (:where data))         ":where names the user-facing surface")
       (is (= :fix-registration (:recovery data))  ":recovery names the disposition")
       (is (= :sensitive (:bad-key data))          ":bad-key names the offending classification key")

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -324,8 +324,10 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-missing-id (:rf.error/id data))
           ":rf.error/id carries the missing-id discriminator")
-      (is (= ":rf.error/flow-missing-id" (ex-message ex))
-          "message string is the stringified discriminator kw")
+      ;; rf2-vvixub — message is the human :reason sentence + the trailing
+      ;; [:rf.error/<id>] token; assert the token substring, not equality.
+      (is (re-find #"\[:rf\.error/flow-missing-id\]" (ex-message ex))
+          "message carries the [:rf.error/flow-missing-id] token")
       (is (= 'rf/reg-flow (:where data))     ":where names the user-facing surface")
       (is (= :fix-registration (:recovery data)) ":recovery names the disposition")
       (is (string? (:reason data))           ":reason is a human-readable sentence")))
@@ -336,8 +338,9 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-output (:rf.error/id data))
           ":rf.error/id carries the bad-output discriminator")
-      (is (= ":rf.error/flow-bad-output" (ex-message ex))
-          "message string is the stringified discriminator kw")
+      ;; rf2-vvixub — assert the [:rf.error/<id>] token substring, not equality.
+      (is (re-find #"\[:rf\.error/flow-bad-output\]" (ex-message ex))
+          "message carries the [:rf.error/flow-bad-output] token")
       (is (= 'rf/reg-flow (:where data))     ":where names the user-facing surface")
       (is (= :fix-registration (:recovery data)) ":recovery names the disposition"))))
 
@@ -362,8 +365,9 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-id (:rf.error/id data))
           ":rf.error/id carries the bad-id discriminator")
-      (is (= ":rf.error/flow-bad-id" (ex-message ex))
-          "message string is the stringified discriminator kw")
+      ;; rf2-vvixub — assert the [:rf.error/<id>] token substring, not equality.
+      (is (re-find #"\[:rf\.error/flow-bad-id\]" (ex-message ex))
+          "message carries the [:rf.error/flow-bad-id] token")
       (is (= 'rf/reg-flow (:where data))         ":where names the user-facing surface")
       (is (= :fix-registration (:recovery data))  ":recovery names the disposition")
       (is (string? (:reason data))               ":reason is a human-readable sentence")))
@@ -403,11 +407,13 @@
 ;; `:rf.error/flow-bad-path`) and ex-data that names the offending entries
 ;; so callers can fix their flow map without a stack-trace scavenger hunt.
 
+;; rf2-vvixub — branch on the canonical :rf.error/id discriminator, never
+;; on the (now human-sentence) message string.
 (defn- flow-bad-inputs? [^Throwable t]
-  (= ":rf.error/flow-bad-inputs" (ex-message t)))
+  (= :rf.error/flow-bad-inputs (:rf.error/id (ex-data t))))
 
 (defn- flow-bad-path? [^Throwable t]
-  (= ":rf.error/flow-bad-path" (ex-message t)))
+  (= :rf.error/flow-bad-path (:rf.error/id (ex-data t))))
 
 (deftest reg-flow-error-carries-canonical-rf-error-id-slot
   ;; Per Spec 009 §The thrown-error shape: every thrown runtime error
@@ -423,8 +429,9 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/flow-bad-inputs (:rf.error/id data))
           ":rf.error/id slot carries the discriminator keyword")
-      (is (= ":rf.error/flow-bad-inputs" (ex-message ex))
-          "message string is the stringified discriminator kw")
+      ;; rf2-vvixub — assert the [:rf.error/<id>] token substring, not equality.
+      (is (re-find #"\[:rf\.error/flow-bad-inputs\]" (ex-message ex))
+          "message carries the [:rf.error/flow-bad-inputs] token")
       (is (nil? (:error data))
           "the legacy :error slot is gone (rename, not back-compat shim)")
       (is (= 'rf/reg-flow (:where data)) ":where names the user-facing surface")

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -63,9 +63,15 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-flow throws when the flows artefact is absent")
-          (is (= ":rf.error/flows-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — the message is the human :reason sentence + the
+          ;; trailing [:rf.error/<id>] greppability token (Spec 009 §The
+          ;; thrown-error shape). Assert the token substring + the canonical
+          ;; :rf.error/id discriminator, NOT exact keyword-equality.
+          (is (re-find #"\[:rf\.error/flows-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/flows-artefact-missing] token")
           (let [data (ex-data thrown)]
+            (is (= :rf.error/flows-artefact-missing (:rf.error/id data))
+                "ex-data carries the canonical :rf.error/id discriminator")
             ;; Per rf2-hoiu the throw lives in `re-frame.core-flows/reg-flow`
             ;; — the sibling-namespace fn-form delegate the macro routes
             ;; through. Per rf2-j8icl the `:where` symbol is namespace-

--- a/implementation/http/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/http/test/re_frame/late_bind_missing_test.clj
@@ -58,8 +58,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "install-managed-request-stubs! throws when the http artefact is absent")
-          (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/http-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/http-artefact-missing] token")
+          (is (= :rf.error/http-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/install-managed-request-stubs! (:where data))
                 "ex-data carries :where = 'rf/install-managed-request-stubs!")
@@ -77,8 +82,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "uninstall-managed-request-stubs! throws when the http artefact is absent")
-          (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/http-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/http-artefact-missing] token")
+          (is (= :rf.error/http-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/uninstall-managed-request-stubs! (:where data))
                 "ex-data carries :where = 'rf/uninstall-managed-request-stubs!")
@@ -94,8 +104,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "with-managed-request-stubs* throws when the http artefact is absent")
-          (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/http-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/http-artefact-missing] token")
+          (is (= :rf.error/http-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/with-managed-request-stubs* (:where data))
                 "ex-data carries :where = 'rf/with-managed-request-stubs*")

--- a/implementation/machines/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/machines/test/re_frame/late_bind_missing_test.clj
@@ -61,8 +61,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-machine throws when the machines artefact is absent")
-          (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/machines-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/machines-artefact-missing] token")
+          (is (= :rf.error/machines-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in
             ;; `re-frame.core-machines/reg-machine` — the sibling-namespace

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -17,6 +17,7 @@
   facade's re-exports. Per the rf2-2yabr cohesion split: REGISTRY +
   MATCH/EMIT seam."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [re-frame.identity :as identity]
             [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]
@@ -39,18 +40,15 @@
 ;; the :rf.error/id discriminator and is preserved verbatim.
 
 (defn route-error
-  "Build a routing ex-info with the canonical thrown-error shape (per
-  Spec 009). `error-kw` becomes the message AND the `:rf.error/id`
-  discriminator slot; `where-sym` names the public surface; `reason` is
-  the human-readable diagnostic; `extras` merges per-site slots."
+  "Build a routing ex-info via the central thrown-error builder
+  `re-frame.error/thrown-ex-info` (per Spec 009 §The thrown-error shape).
+  `error-kw` is the `:rf.error/id` discriminator slot; `where-sym` names
+  the public surface; `reason` is the human-readable diagnostic that
+  LEADS the message (the message also trails the `[:rf.error/<id>]`
+  greppability token); `extras` merges per-site slots."
   ([error-kw where-sym reason] (route-error error-kw where-sym reason nil))
   ([error-kw where-sym reason extras]
-   (ex-info (str error-kw)
-            (merge {:rf.error/id error-kw
-                    :where       where-sym
-                    :recovery    :no-recovery
-                    :reason      reason}
-                   extras))))
+   (error/thrown-ex-info error-kw where-sym reason {:extra extras})))
 
 ;; ---- registration counter + table cache ----------------------------------
 

--- a/implementation/routing/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/routing/test/re_frame/late_bind_missing_test.clj
@@ -55,8 +55,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-route throws when the routing artefact is absent")
-          (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/routing-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/routing-artefact-missing] token")
+          (is (= :rf.error/routing-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in `re-frame.core-routing/reg-route`
             ;; — the sibling-namespace fn-form delegate the macro routes
@@ -84,8 +89,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "route-link throws when the routing artefact is absent")
-          (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/routing-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/routing-artefact-missing] token")
+          (is (= :rf.error/routing-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/route-link (:where data))
                 "ex-data carries :where = 'rf/route-link")

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -131,7 +131,9 @@
                    nil
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown) "route-link raises when :to is unregistered")
-      (is (= ":rf.error/no-such-route" (.getMessage thrown))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator
+      ;; (the message is now a human sentence + trailing token).
+      (is (= :rf.error/no-such-route (:rf.error/id (ex-data thrown)))
           "the missing-route error keyword matches route-url's contract")
       (is (= :route/nope (:route-id (ex-data thrown)))
           "ex-data carries the offending route-id"))))

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -31,7 +31,9 @@
                nil
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "route-url with absent required param raises")
-      (is (= ":rf.error/missing-route-param" (ex-message ex))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator
+      ;; (the message is now a human sentence + trailing token).
+      (is (= :rf.error/missing-route-param (:rf.error/id (ex-data ex)))
           "the structured error id is :rf.error/missing-route-param")
       (let [data (ex-data ex)]
         (is (= :id (:param data))
@@ -47,7 +49,8 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex)
           "nil :id behaves like an absent :id — same structured error")
-      (is (= ":rf.error/missing-route-param" (ex-message ex)))))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator.
+      (is (= :rf.error/missing-route-param (:rf.error/id (ex-data ex))))))
 
   (testing "providing the param works — sanity check the happy path"
     (rf/reg-route :route/article3 {:path "/articles/:id"})
@@ -62,7 +65,8 @@
                nil
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "absent splat raises")
-      (is (= ":rf.error/missing-route-param" (ex-message ex))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator.
+      (is (= :rf.error/missing-route-param (:rf.error/id (ex-data ex)))
           "splat absence uses the same structured error id"))))
 
 ;; ---- rf2-6iam6 + rf2-ede1h.2: falsy path params (false / 0) round-trip;
@@ -106,7 +110,8 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex)
           "\"\" path param throws (it would emit \"/articles/\", which match-url normalises to \"/articles\" and fails to match)")
-      (is (= ":rf.error/missing-route-param" (ex-message ex))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator.
+      (is (= :rf.error/missing-route-param (:rf.error/id (ex-data ex)))
           "the empty-string rejection reuses the missing-required-param error id")
       (is (= "" (:value (ex-data ex)))
           "the ex-data carries the offending empty-string value"))))
@@ -119,7 +124,8 @@
                nil
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/no-such-route" (ex-message ex))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator.
+      (is (= :rf.error/no-such-route (:rf.error/id (ex-data ex)))
           ":rf.error/no-such-route is the structured error for an unregistered id"))))
 
 ;; ---- rf2-94o54l.1/.3: route-url fails closed on host-stringified values --
@@ -168,8 +174,10 @@
         ;; stable discriminator) as the primary check; the message is secondary.
         (is (= :rf.error/route-url-non-edn-value (:rf.error/id (ex-data ex)))
             (str "the structured :rf.error/id for a " (name label) " path value"))
-        (is (= ":rf.error/route-url-non-edn-value" (ex-message ex))
-            (str "the message string (secondary) for a " (name label) " path value"))
+        ;; rf2-vvixub — message is a human sentence + the trailing
+        ;; [:rf.error/<id>] token; assert the token, not exact equality.
+        (is (re-find #"\[:rf\.error/route-url-non-edn-value\]" (ex-message ex))
+            (str "the message token (secondary) for a " (name label) " path value"))
         (let [data (ex-data ex)]
           (is (= :route/item (:route-id data)) "ex-data names the route-id")
           (is (= :params (:slot data)) "ex-data names the offending slot")
@@ -190,8 +198,10 @@
             (str "a " (name label) " query value must fail closed"))
         (is (= :rf.error/route-url-non-edn-value (:rf.error/id (ex-data ex)))
             (str "the structured :rf.error/id for a " (name label) " query value"))
-        (is (= ":rf.error/route-url-non-edn-value" (ex-message ex))
-            (str "the message string (secondary) for a " (name label) " query value"))
+        ;; rf2-vvixub — message is a human sentence + the trailing
+        ;; [:rf.error/<id>] token; assert the token, not exact equality.
+        (is (re-find #"\[:rf\.error/route-url-non-edn-value\]" (ex-message ex))
+            (str "the message token (secondary) for a " (name label) " query value"))
         (let [data (ex-data ex)]
           (is (= :route/search (:route-id data)) "ex-data names the route-id")
           (is (= :query (:slot data)) "ex-data names the :query slot")
@@ -205,7 +215,8 @@
       (is (some? ex) "a fn in an entered optional group fails closed")
       (is (= :rf.error/route-url-non-edn-value (:rf.error/id (ex-data ex)))
           "structured :rf.error/id (primary)")
-      (is (= ":rf.error/route-url-non-edn-value" (ex-message ex)) "message (secondary)")
+      ;; rf2-vvixub — assert the [:rf.error/<id>] token, not exact equality.
+      (is (re-find #"\[:rf\.error/route-url-non-edn-value\]" (ex-message ex)) "message token (secondary)")
       (is (= :section (:param (ex-data ex)))))))
 
 (deftest route-url-admitted-scalars-still-emit-rf2-94o54l
@@ -238,7 +249,9 @@
     (let [ex (route-url-throws-non-edn? :route/order
                                         {:id (atom :x)}
                                         {:note "ok"})]
-      (is (= ":rf.error/route-url-non-edn-value" (ex-message ex))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator
+      ;; (a structured error, never a string return value).
+      (is (= :rf.error/route-url-non-edn-value (:rf.error/id (ex-data ex)))
           "a structured error, never a string return value"))))
 
 ;; ---- rf2-u1na: match-url malformed-input edge cases ----------------------
@@ -761,8 +774,13 @@
                       (catch clojure.lang.ExceptionInfo e e))]
           (is (some? ex)
               "non-conformant path-params raise")
-          (is (= ":rf.error/route-url-validation" (ex-message ex))
+          ;; rf2-vvixub — message is a human sentence + the trailing
+          ;; [:rf.error/<id>] token; anchor on the canonical :rf.error/id
+          ;; and assert the token substring, not exact equality.
+          (is (= :rf.error/route-url-validation (:rf.error/id (ex-data ex)))
               "structured error id is :rf.error/route-url-validation")
+          (is (re-find #"\[:rf\.error/route-url-validation\]" (ex-message ex))
+              "the message carries the [:rf.error/route-url-validation] token")
           (let [data (ex-data ex)]
             (is (= :route/article (:route-id data)))
             (is (= :params (:slot data)))
@@ -789,7 +807,9 @@
                       (catch clojure.lang.ExceptionInfo e e))]
           (is (some? ex)
               "empty :q rejects against the query schema")
-          (is (= ":rf.error/route-url-validation" (ex-message ex)))
+          ;; rf2-vvixub — anchor on :rf.error/id; assert the token, not equality.
+          (is (= :rf.error/route-url-validation (:rf.error/id (ex-data ex))))
+          (is (re-find #"\[:rf\.error/route-url-validation\]" (ex-message ex)))
           (is (= :query (:slot (ex-data ex)))))
         (let [ex (try (routing/route-url :route/search {} {})
                       nil
@@ -830,7 +850,9 @@
                       (catch clojure.lang.ExceptionInfo e e))]
           (is (some? ex)
               "a non-nil invalid :sort (a number) STILL fails validation")
-          (is (= ":rf.error/route-url-validation" (ex-message ex)))
+          ;; rf2-vvixub — anchor on :rf.error/id; assert the token, not equality.
+          (is (= :rf.error/route-url-validation (:rf.error/id (ex-data ex))))
+          (is (re-find #"\[:rf\.error/route-url-validation\]" (ex-message ex)))
           (is (= :query (:slot (ex-data ex))))
           (is (= {:sort 123} (:value (ex-data ex)))
               ":value reports the elided map actually validated (nil-free)"))
@@ -1378,7 +1400,8 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex)
           "\"\" optional-group param throws (it would emit \"/articles/\", which match-url normalises to \"/articles\" and re-parses with :id ABSENT)")
-      (is (= ":rf.error/missing-route-param" (ex-message ex))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator.
+      (is (= :rf.error/missing-route-param (:rf.error/id (ex-data ex)))
           "reuses the missing/empty-required-param error id")
       (is (= "" (:value (ex-data ex)))
           "ex-data carries the offending empty-string value")))
@@ -1400,7 +1423,8 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex)
           "\"\" optional-group :slug throws — it would emit the un-round-trippable \"/articles/5/\"")
-      (is (= ":rf.error/missing-route-param" (ex-message ex)))
+      ;; rf2-vvixub — anchor on the canonical :rf.error/id discriminator.
+      (is (= :rf.error/missing-route-param (:rf.error/id (ex-data ex))))
       (is (= "" (:value (ex-data ex))))))
 
   (testing "rf2-8xvyo: false and 0 inside an optional group STILL round-trip —

--- a/implementation/routing/test/re_frame/routing_url_non_edn_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_url_non_edn_cljs_test.cljc
@@ -81,8 +81,10 @@
         ;; stable discriminator), not just the message string.
         (is (= :rf.error/route-url-non-edn-value (:rf.error/id (ex-data ex)))
             (str "structured :rf.error/id for a " (name label) " path value"))
-        (is (= ":rf.error/route-url-non-edn-value" (ex-message ex))
-            (str "message string (secondary) for a " (name label) " path value"))
+        ;; rf2-vvixub — message is a human sentence + the trailing
+        ;; [:rf.error/<id>] token; assert the token, not exact equality.
+        (is (re-find #"\[:rf\.error/route-url-non-edn-value\]" (ex-message ex))
+            (str "message token (secondary) for a " (name label) " path value"))
         (let [data (ex-data ex)]
           (is (= :route/item (:route-id data)))
           (is (= :params (:slot data)))
@@ -98,8 +100,10 @@
             (str "a " (name label) " query value must throw"))
         (is (= :rf.error/route-url-non-edn-value (:rf.error/id (ex-data ex)))
             (str "structured :rf.error/id for a " (name label) " query value"))
-        (is (= ":rf.error/route-url-non-edn-value" (ex-message ex))
-            (str "message string (secondary) for a " (name label) " query value"))
+        ;; rf2-vvixub — message is a human sentence + the trailing
+        ;; [:rf.error/<id>] token; assert the token, not exact equality.
+        (is (re-find #"\[:rf\.error/route-url-non-edn-value\]" (ex-message ex))
+            (str "message token (secondary) for a " (name label) " query value"))
         (let [data (ex-data ex)]
           (is (= :route/search (:route-id data)))
           (is (= :query (:slot data)))

--- a/implementation/schemas/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/schemas/test/re_frame/late_bind_missing_test.clj
@@ -56,8 +56,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-app-schema throws when the schemas artefact is absent")
-          (is (= ":rf.error/schemas-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/schemas-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/schemas-artefact-missing] token")
+          (is (= :rf.error/schemas-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in
             ;; `re-frame.core-schemas/reg-app-schema` — the sibling-

--- a/implementation/ssr/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/ssr/test/re_frame/late_bind_missing_test.clj
@@ -47,8 +47,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "render-to-string throws when the ssr artefact is absent")
-          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/ssr-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/ssr-artefact-missing] token")
+          (is (= :rf.error/ssr-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/render-to-string (:where data))
                 "ex-data carries :where = 'rf/render-to-string")
@@ -66,8 +71,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "render-tree-hash throws when the ssr artefact is absent")
-          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/ssr-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/ssr-artefact-missing] token")
+          (is (= :rf.error/ssr-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/render-tree-hash (:where data))
                 "ex-data carries :where = 'rf/render-tree-hash")
@@ -87,8 +97,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "reg-error-projector throws when the ssr artefact is absent")
-          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/ssr-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/ssr-artefact-missing] token")
+          (is (= :rf.error/ssr-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             ;; Per rf2-j8icl the `:where` symbol is namespace-qualified
             ;; to the user-facing surface (`rf/reg-error-projector`) so
@@ -112,8 +127,13 @@
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
               "project-error throws when the ssr artefact is absent")
-          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
-              "the documented error category appears in the message")
+          ;; rf2-vvixub — message is the human :reason + trailing
+          ;; [:rf.error/<id>] token; assert the token + canonical :rf.error/id,
+          ;; not exact keyword-equality.
+          (is (re-find #"\[:rf\.error/ssr-artefact-missing\]" (.getMessage thrown))
+              "the message carries the [:rf.error/ssr-artefact-missing] token")
+          (is (= :rf.error/ssr-artefact-missing (:rf.error/id (ex-data thrown)))
+              "ex-data carries the canonical :rf.error/id discriminator")
           (let [data (ex-data thrown)]
             (is (= 'rf/project-error (:where data))
                 "ex-data carries :where = 'rf/project-error")

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1589,27 +1589,38 @@ All error trace events are open maps with these required keys:
 
 Most runtime failures emit a **trace event** (the shape above) and let the cascade recover. A minority are **thrown** — a registration is rejected, an optional artefact is absent, a delegation surface is reached before `(rf/init! …)`. These surface as `ex-info` rather than as trace events (the catalogue's "Surfaced as a thrown ex-info, not a trace" rows). Thrown errors carry their own canonical ex-data shape so a single consumer path — Xray's error widget, the pair-tool overlay, an error listener, a `try`/`catch` in user code — reads one discriminator slot uniformly regardless of which surface threw.
 
-The discriminator slot is **`:rf.error/id`** — a `:rf.error/<category>` keyword from the [§Error event catalogue](#error-event-catalogue). This is the **single normative discriminator for thrown errors**; the four-slot skeleton below is the canonical shape every `(throw (ex-info …))` site in the runtime conforms to:
+The discriminator slot is **`:rf.error/id`** — a `:rf.error/<category>` keyword from the [§Error event catalogue](#error-event-catalogue). This is the **single normative discriminator for thrown errors**; the four-slot skeleton below is the canonical shape every framework throw conforms to. Every `(throw (ex-info …))` site in the runtime is built through the central builder `re-frame.error/throw-error!` / `re-frame.error/thrown-ex-info` (the `re-frame.error.cljc` chokepoint), which DERIVES the message from `:reason` + the `:rf.error/id` token and sets the canonical ex-data shape — so the human message and the machine discriminator are derived from one source and cannot drift, and a keyword-only message is structurally impossible to emit:
 
 ```clojure
-(throw (ex-info ":rf.error/<id>"               ;; message = the stringified discriminator kw
-                {:rf.error/id <category-kw>     ;; CANONICAL DISCRIMINATOR — :rf.error/<category>
-                 :where       'rf/<surface>     ;; the user-facing fn symbol that threw
-                 :recovery    <disposition>     ;; :no-recovery / :fix-registration / :skipped / …
-                 :reason      "<one sentence>"  ;; what failed + why, human-readable
-                 ;; + surface-specific payload merges on top:
-                 ;; :flow / :route-id / :machine-id / :received / :cycle / …
-                 }))
+(error/throw-error!
+  <category-kw>                       ;; :rf.error/id — CANONICAL DISCRIMINATOR, :rf.error/<category>
+  'rf/<surface>                       ;; :where — the user-facing fn symbol that threw
+  "<one human-actionable sentence>"   ;; :reason — public concept + expected fix + key context
+  {:recovery <disposition>            ;; :no-recovery / :fix-registration / :skipped / … (default :no-recovery)
+   :extra    {…}})                    ;; surface-specific payload: :flow / :route-id / :machine-id / :received / :cycle / …
+
+;; The builder produces this canonical ex-info:
+(ex-info
+  "<reason> [:rf.error/<id>]"          ;; message LEADS with the human sentence, TRAILS the [:rf.error/<id>] token
+  {:rf.error/id <category-kw>          ;; CANONICAL DISCRIMINATOR — the SOLE machine pivot
+   :where       'rf/<surface>          ;; the user-facing fn symbol that threw
+   :recovery    <disposition>          ;; :no-recovery / :fix-registration / :skipped / …
+   :reason      "<one sentence>"       ;; the required human sentence (also leads the message)
+   …})                                 ;; + surface-specific payload merged on top
 ```
 
 Required slots on every thrown runtime error: `:rf.error/id`, `:where`, `:recovery`, `:reason`. Surface-specific payload (`:flow`, `:bad-entries`, `:cycle`, `:installed`, `:attempted`, `:received`, …) merges on top.
 
-Two consumer pivots, both stable:
+**The human-message policy (a refinement, not a reversal).** Earlier the message string *was* the stringified discriminator keyword — machine-branchable from the message alone, but not human-actionable. The contract now **separates the two channels** while keeping the property the old shape bought:
 
-- **Message string** — the `.getMessage` / `(ex-message e)` is the stringified discriminator kw (e.g. `":rf.error/flows-artefact-missing"`). A consumer with no ex-data access (a raw stack trace, a log line) still pivots to a stable category from the message alone.
-- **`:rf.error/id` slot** — `(:rf.error/id (ex-data e))` returns the discriminator as a keyword for structured branching. Tools `case` / `condp` on this slot rather than parsing the message string.
+- **`(ex-message e)` is a human-actionable one-line sentence** naming the public concept, the expected fix, and key context — e.g. `"rf/init! cannot continue because no adapter is installed; require an adapter ns and install it before boot. [:rf.error/no-adapter-installed]"`. It is **no longer** the bare stringified keyword. A reader of a raw REPL/browser/CI exception gets an actionable message without having to render `ex-data`.
+- **The message carries a trailing `[:rf.error/<id>]` token** so a log line or raw stack trace still grep-pivots to a stable category from the message alone — the *only* thing the old "category-from-message" property bought, retained without making the keyword the whole message. This is the refinement: the message now **leads** with the human sentence and **retains** the category as a bracketed trailing token.
+- **The message string is non-normative — stable in MEANING, not bytes.** Tools and tests MUST NOT branch on it or assert exact-equality against it. Greppability is via the bracketed token (substring / `thrown-with-msg?` regex), never via whole-string equality.
+- **`:rf.error/id` is the SOLE canonical machine discriminator.** `(:rf.error/id (ex-data e))` returns the keyword for structured branching. Tools `case` / `condp` on this slot, never on the message. Machine branching never depended on the message, so this separation is correctness-neutral.
 
-The `:where` slot names the **user-facing surface fn symbol** (`'rf/reg-flow`, `'rf/make-state-container`) so a grep-for-symbol lands on the call site in user code; `:recovery` reuses the [§Recovery contract](#recovery-contract) vocabulary plus `:fix-registration` (the caller fixes their registration map and retries); `:reason` is one human-readable sentence naming what failed and the fix.
+`:reason` is the required structured human sentence that both lands in the `:reason` slot and leads the derived message; there is **no separate `:rf.error/message` slot** — it would duplicate `:reason`. Renderers show the message (or `:reason`) as the title and `:rf.error/id` as the category badge.
+
+The `:where` slot names the **user-facing surface fn symbol** (`'rf/reg-flow`, `'rf/make-state-container`) so a grep-for-symbol lands on the call site in user code; `:recovery` reuses the [§Recovery contract](#recovery-contract) vocabulary plus `:fix-registration` (the caller fixes their registration map and retries); `:reason` is one human-readable sentence naming what failed and the fix. A conformance test (`re-frame.error/keyword-only-message?` + `message-has-id-token?`) rejects any framework throw whose message regresses to a bare keyword or drops the token.
 
 This shape is the throw-side companion of the trace-event shape above. A category that can both throw and emit (e.g. a registration rejection that is also catalogued) uses `:operation` on the trace event and `:rf.error/id` on the thrown ex-info — the **same `:rf.error/<category>` keyword** in both slots, so a consumer reads one vocabulary across both surfaces. The pairing with `re-frame.core-artefact/defwrapper` (per [Conventions §single-import contract](Conventions.md#feature-modularity-prefix-convention)) and the missing-artefact wrappers (`:rf.error/<feature>-artefact-missing`) is the canonical reference.
 
@@ -1625,9 +1636,9 @@ Pre-canonicalisation, thrown-error ex-data carried the discriminator under **fiv
 | `:reason` (overloaded) | the kw doubling as the human reason | machines-viz scxml, ai-generate |
 | *(none)* | kw only in the message string, no ex-data slot | most other sites (`require-fn!`, `require-adapter!`, …) |
 
-All five collapse to the single canonical `:rf.error/id` slot. The migration is a **rename, not a deprecation** (pre-alpha posture — no back-compat shim): the old slot is removed and `:rf.error/id` added in its place. Where the kw lived only in the message string (the *(none)* row), `:rf.error/id` is added as a new slot carrying the same keyword the message stringifies — the message string is unchanged, the structured slot is new. Where `:reason` was overloaded to carry the discriminator kw, `:reason` reverts to a human-readable sentence and `:rf.error/id` carries the keyword.
+All five collapse to the single canonical `:rf.error/id` slot. The migration is a **rename, not a deprecation** (pre-alpha posture — no back-compat shim): the old slot is removed and `:rf.error/id` added in its place. Where the kw lived only in the message string (the *(none)* row), `:rf.error/id` is the structured slot and the message becomes the human sentence + the `[:rf.error/<id>]` token (per the human-message policy above — the bare-keyword message is dropped, not preserved). Where `:reason` was overloaded to carry the discriminator kw, `:reason` reverts to a human-readable sentence and `:rf.error/id` carries the keyword.
 
-The three reference exemplars — `re-frame.flows.registry/flow-error` (was `:error`), `re-frame.late-bind/require-fn!` (was *none*), `re-frame.substrate.adapter/require-adapter!` (was *none*) — demonstrate the canonical shape on first read.
+The three reference exemplars — `re-frame.flows.registry/flow-error` (was `:error`), `re-frame.late-bind/require-fn!` (was *none*), `re-frame.substrate.adapter/require-adapter!` (was *none*) — all route through `re-frame.error/throw-error!` / `thrown-ex-info` and demonstrate the canonical shape on first read.
 
 #### `:rf.trace/trigger-handler` — naming the in-scope handler
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3307,15 +3307,24 @@ is carried by the fill + edge + glyph, not a lift:
 - **Spacing + radius** — padding from the 4px `tokens/spacing` scale
   (`:gap-2` / `:gap-3`); radius matches the surrounding cards.
 - **Typographic hierarchy** — the `✗ Exception Thrown` headline (sans,
-  `:error` accent, `:body-tight`) → the verbatim mono message
-  (`:text-primary`, `:mono-body`) → the quiet collapsed-detail affordance
-  (`:text-tertiary`, `:caption`).
+  `:error` accent, `:body-tight`) + the quiet `:rf.error/id` category
+  badge (rf2-vvixub; mono, `:bg-3` chip, `:text-tertiary`) → the verbatim
+  mono message (`:text-primary`, `:mono-body`) → the quiet
+  collapsed-detail affordance (`:text-tertiary`, `:caption`).
 - **Glyph** — the `✗` is a sized + baseline-aligned badge in the `:error`
   accent (a fixed 14px box), not a bare floating character.
 
 The card carries, top to bottom:
 
-1. a `✗ Exception Thrown` title bar + a `Rolled back` recovery chip
+1. a `✗ Exception Thrown` title bar carrying (rf2-vvixub) the
+   `:rf.error/id` **category badge** — a quiet mono chip rendering the
+   row's `:operation` (the canonical machine discriminator). Under the
+   Spec 009 thrown-error human-message contract the verbatim message
+   (item 2) now **leads with a human-actionable sentence** rather than
+   the bare keyword, so the machine category surfaces here as
+   at-a-glance metadata (the `:rf.error/<id>` pivot), distinct from the
+   prose message below and no longer buried in collapsed `ex-data`. The
+   title bar also carries a `Rolled back` recovery chip
    that paints **ONLY** when the cascade **ACTUALLY rolled back**
    (`db-rolled-back?` — a `:where :app-db` schema-validation failure
    reverted the commit, stamped onto each exception row by `project`).
@@ -3329,12 +3338,16 @@ The card carries, top to bottom:
    actual rollback (rf2-s6oqd) paints the chip on a `:db` schema-fail
    rollback (correct) and omits it on a post-commit fx throw AND a
    pre-commit handler throw;
-2. the verbatim `ex-info` message (monospace) — the punchline. rf2-oqi0c
-   **DROPPED** the one-line category-reason boilerplate headline ("The
-   event handler threw." / "…interceptor threw." — formerly
-   `error-block-label`): it was redundant with the card's position (under
-   the failing step) + the "Exception Thrown" heading, which already
-   attribute the failure. The card now leads with the real `.getMessage`;
+2. the verbatim `ex-info` message (monospace) — the punchline. Under the
+   Spec 009 thrown-error contract (rf2-vvixub) this message **leads with
+   a human-actionable sentence** (public concept + expected fix + key
+   context) and trails the `[:rf.error/<id>]` greppability token — no
+   longer the bare stringified keyword. rf2-oqi0c **DROPPED** the
+   one-line category-reason boilerplate headline ("The event handler
+   threw." / "…interceptor threw." — formerly `error-block-label`): it
+   was redundant with the card's position (under the failing step) + the
+   "Exception Thrown" heading, which already attribute the failure. The
+   card leads with the real `.getMessage`;
 3. a **collapsible** `<details>` disclosure ("Details", collapsed by
    default) carrying the exception's `ex-data` (via `ei/edn-inspector`)
    + its stack trace (monospace `<pre>`), read off the raw `:exception`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1666,6 +1666,24 @@
   (assoc schema-violation-rollback-chip-style
          :text-transform "none"))
 
+(def ^:private error-block-category-badge-style
+  ;; rf2-vvixub — the `:rf.error/id` category badge. Under the
+  ;; thrown-error human-message contract the verbatim message LEADS with
+  ;; a human-actionable sentence (no longer the bare keyword), so the
+  ;; machine discriminator (`:rf.error/id`, projected as `:operation`)
+  ;; now rides as a quiet metadata badge in the title bar — the category
+  ;; pivot the operator reads at a glance, distinct from the prose
+  ;; message below. Mono face (it quotes a keyword) + a calm tertiary
+  ;; tone so it stays subordinate to the `✗ Exception Thrown` headline.
+  {:padding        "1px 6px"
+   :border-radius  "3px"
+   :background     bg-3-colour
+   :color          text-tertiary-colour
+   :font-family    mono-stack
+   :font-size      "10px"
+   :font-weight    600
+   :letter-spacing "0.2px"})
+
 ;; rf2-wnvid — collapsible exception details (`<details>`/`<summary>`).
 ;; The stack trace + ex-data are diagnostic depth the operator wants on
 ;; demand, not always-expanded clutter under every failed step. A native
@@ -5465,10 +5483,20 @@
            :data-testid testid-base
            :data-error-op (when (:operation row) (name (:operation row)))
            :style error-block-style}
-     ;; 1. Title bar — ✗ glyph + 'Exception Thrown' + recovery chip
+     ;; 1. Title bar — ✗ glyph + 'Exception Thrown' + `:rf.error/id`
+     ;; category badge (rf2-vvixub) + recovery chip. Under the
+     ;; thrown-error human-message contract the verbatim message (below)
+     ;; LEADS with a human sentence, so the machine discriminator
+     ;; (`:operation` = `:rf.error/id`) surfaces HERE as a quiet metadata
+     ;; badge — the category pivot at a glance, not buried in collapsed
+     ;; ex-data.
      [:div {:style error-block-title-style}
       [:span {:aria-hidden true :style error-block-glyph-style} "✗"]
       [:span {:data-testid (str testid-base "-title")} "Exception Thrown"]
+      (when (keyword? operation)
+        [:span {:data-testid (str testid-base "-category")
+                :style error-block-category-badge-style}
+         (fmt/ns-keyword operation)])
       [:span {:style schema-violation-title-spacer-style}]
       (when recovery-label
         [:span {:data-testid (str testid-base "-recovery")


### PR DESCRIPTION
Implements **rf2-vvixub** — the thrown-error human-message CONTRACT (RULED 2026-06-15). The contract bead; the 10 surface children dep-gate on it.

## What changed

**The ruling, implemented.** `(ex-message e)` is now a human-actionable one-line sentence (public concept + expected fix + key context) carrying a trailing `[:rf.error/<id>]` greppability token — NOT the bare stringified discriminator keyword. `:rf.error/id` (ex-data) remains the sole canonical machine discriminator; the message is non-normative (stable in meaning, not bytes).

- **Central builder** (`re-frame.error.cljc`): `thrown-ex-info` / `throw-error!` DERIVE the message from `:reason` + the `[:rf.error/<id>]` token and set the canonical ex-data shape — keyword-only messages are structurally impossible and message↔ex-data cannot drift. Adds `keyword-only-message?` / `message-has-id-token?` conformance predicates. (`:reason` stays the required human sentence; no separate `:rf.error/message` slot.)
- **Spec 009 amendment** (§1588-1630): framed as a *refinement* — the message now leads with the human sentence and retains the category as a bracketed trailing token — not a flat reversal of the category-from-message property.
- **Central per-surface conversions** (cover many sites cheaply): `late-bind/require-fn!`, `substrate.adapter/require-adapter!` (+ `install-adapter!` / `derived-container-replaced` throws), `flows.registry/flow-error` (+ `flow-frame-not-live`), `routing/registry` `route-error`.
- **Conformance test** (`thrown_error_message_conformance_cljs_test.cljc`): rejects keyword-only framework messages; asserts the id token; exercises the builder + all four converted central sites. Dual-runtime (`-cljs-test.cljc` → node-test + JVM).
- **Xray render** (`panels/epoch/view.cljs`): the human message renders first (already did); `:rf.error/id` now surfaces as a quiet category badge in the title bar. Xray spec (`021-Dynamic-Panel-Designs.md`) updated.
- **Migration** (~converted sites): exact-equality message assertions switched to `:rf.error/id` anchoring + `[:rf.error/<id>]` token-substring checks. The `thrown-with-msg?` regex cohort survives the trailing token untouched.

**Not in scope** (separate beads): the 10 surface children's throw sites (p7kwpt/43pyf7/pwzevu/tqlwzr/yl39ub/7vuq2q/940efq/n58jxo/o04xwn/s6rzia). Bare-keyword sites NOT among the four central conversions stay as-is: `no-adapter-specified` (core.cljc → p7kwpt), `no-hiccup-emitter-bound` (plain-atom/spine/test-react → 940efq), and **flows/topo.cljc** throws (`flow-cycle` / `flow-path-overlap` / `flow-cycle-extract-invariant`) which have no surface-child — tracked in **rf2-1jh98u**.

## Quality gates

| Gate | Result |
|---|---|
| New conformance test (JVM) | PASS — 8 tests / 41 assertions |
| `npm run test:cljs` (node-test, full) | PASS — 7309 tests / 30143 assertions |
| `clojure -M:test` core (full) | PASS — 1535 tests / 6791 assertions |
| flows / routing / http / machines / schemas / ssr / epoch (JVM) | PASS — all 0 failures |
| `python scripts/check_doc_slugs.py` | PASS (exit 0) |
| `mkdocs build --strict` | PASS (exit 0) |