### PR TITLE
fix(pair-mcp): frame-scoped cascade trace-events (group-cascades-with-events) + per-frame subscribe elision

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2300,6 +2300,24 @@
   views over the raw event stream. Per Spec 009 §Trace projection."}
   group-cascades  trace-projection/group-cascades)
 
+;; Facade-export classification (diff-time rule): TOOL-FACING projection
+;; primitive, sibling to `group-cascades`. Same `[frame dispatch-id]`
+;; grouping, additionally attaching each cascade's raw `:trace-events`.
+;; Justified: Tool-Pair streaming consumers (re-frame2-pair cascade
+;; bundles) need both the six-domino record AND each cascade's raw events
+;; keyed by the SAME frame-scoped key the framework uses — re-deriving the
+;; grouping consumer-side with a weaker (dispatch-id-only) key mixes
+;; foreign-frame events (rf2 trace-contract drift). Pure data; JVM + CLJS.
+(def ^{:doc "Like `group-cascades`, but each cascade record additionally
+  carries a `:trace-events` slot with the vector of raw trace events that
+  composed it — keyed by the same frame-scoped `[frame dispatch-id]`
+  grouping. Pure data — JVM and CLJS. The correct projection for
+  consumers needing both the six-domino record and each cascade's raw
+  events (e.g. re-frame2-pair streaming cascade bundles), so they never
+  re-derive the grouping with a weaker dispatch-id-only key. Per Spec 009
+  §Trace projection."}
+  group-cascades-with-events  trace-projection/group-cascades-with-events)
+
 (def ^{:doc "Classify a trace event into one of the six domino buckets
   (`:event` / `:event-handler` / `:fx` / `:db` / `:sub` / `:view`).
   Pure fn used by trace projections and cascade views. Per Spec 009

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -238,6 +238,32 @@
       #?(:clj  Long/MAX_VALUE
          :cljs js/Number.MAX_SAFE_INTEGER))))
 
+(defn- grouped-cascades
+  "The single grouping pass shared by `group-cascades` and
+  `group-cascades-with-events`. Groups `events` by the stable
+  `[frame dispatch-id]` `cascade-key` (dispatch ids are unique only
+  within a frame — see `cascade-key`), reduces each group into a cascade
+  record, and returns a vector of `[[frame dispatch-id] evs record]`
+  triples sorted into emission order (lowest `:id` per cascade first).
+
+  Both public projections consume this so the grouping key never drifts
+  between them: `group-cascades` keeps the slim record; the
+  `-with-events` sibling additionally attaches `evs` as `:trace-events`."
+  [events]
+  (let [index  (frame-index events)
+        groups (group-by #(cascade-key index %) events)]
+    (->> groups
+         (map (fn [[[frame dispatch-id :as key] evs]]
+                [key
+                 evs
+                 (reduce absorb
+                         (assoc empty-cascade
+                                :dispatch-id dispatch-id
+                                :frame frame)
+                         evs)]))
+         (sort-by (fn [[_key _evs record]] (first-id record)))
+         vec)))
+
 (defn group-cascades
   "Project a sequence of raw trace events into one cascade record per
   `:rf.trace/dispatch-id`. Pure data — JVM and CLJS.
@@ -279,14 +305,32 @@
   want richer projections of `:other` can call `domino-bucket`
   directly on each event."
   [events]
-  (let [index  (frame-index events)
-        groups (group-by #(cascade-key index %) events)]
-    (->> groups
-         (map (fn [[[frame dispatch-id] evs]]
-                (reduce absorb
-                        (assoc empty-cascade
-                               :dispatch-id dispatch-id
-                               :frame frame)
-                        evs)))
-         (sort-by first-id)
-         vec)))
+  (->> (grouped-cascades events)
+       (mapv (fn [[_key _evs record]] record))))
+
+(defn group-cascades-with-events
+  "Like `group-cascades`, but each record additionally carries a
+  `:trace-events` slot holding the VECTOR of raw trace events that
+  composed that cascade. The same `[frame dispatch-id]` grouping that
+  `group-cascades` uses is reused verbatim — the `:trace-events` slot is
+  the exact set of events the record was reduced from, in input order.
+
+  This is the correct projection for consumers that need both the
+  six-domino record AND the raw events of a cascade per the portable
+  trace contract — notably re-frame2-pair's streaming cascade bundles,
+  whose wire shape mirrors `(re-frame.trace.tooling/trace-buffer frame)`.
+  Such consumers MUST NOT re-derive the grouping with a weaker key
+  (`:rf.trace/dispatch-id` alone): dispatch ids are unique only WITHIN a
+  frame (see `cascade-key`), so a dispatch-id-only group-by merges two
+  same-id cascades from different frames and attaches each the UNION of
+  both frames' raw events. Keying by `[frame dispatch-id]` here keeps
+  every record's `:trace-events` scoped to its own frame.
+
+  `group-cascades` is deliberately left slim — its seven-slot shape is
+  pinned and Xray-consumed; this sibling carries the extra `:trace-events`
+  slot for the consumers that need it. Returns a vector sorted by
+  emission order, identical to `group-cascades`."
+  [events]
+  (->> (grouped-cascades events)
+       (mapv (fn [[_key evs record]]
+               (assoc record :trace-events (vec evs))))))

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -335,6 +335,55 @@
   (is (contains? (rf/elision-declarations :rf/default) [:blob]))
   (is (not (contains? (rf/elision-declarations :elision-test/other) [:blob]))))
 
+(deftest streamed-cascades-elide-per-element-frame
+  ;; rf2-1we9fa defect 2 — the streaming subscribe drain walks several
+  ;; frames' cascade bundles in one tick (all-frame streams, or a filter
+  ;; frame != the operating frame). Per EP-0015 sensitive/large
+  ;; declarations are PER FRAME, so eliding each bundle MUST resolve the
+  ;; `:frame` opt from THAT bundle's own frame — NOT a single operating
+  ;; frame applied to every bundle. The sharp edge is UNDER-redaction: a
+  ;; frame-A value A declares sensitive but the operating frame B does not
+  ;; would leak across the off-box MCP→LLM boundary.
+  (frame/reg-frame :elision-test/frame-a {})
+  (frame/reg-frame :elision-test/frame-b {})
+  ;; Frame A declares :secret-a sensitive; frame B declares :secret-b
+  ;; sensitive. Neither marks the OTHER frame's slot.
+  (install-class! :elision-test/frame-a [[:secret-a]] [])
+  (install-class! :elision-test/frame-b [[:secret-b]] [])
+  ;; Two bundles streamed in one tick, each carrying both slots, each
+  ;; stamped with its own frame (as group-cascades-with-events emits).
+  (let [bundle-a {:frame :elision-test/frame-a
+                  :secret-a "A-private" :secret-b "A-public"}
+        bundle-b {:frame :elision-test/frame-b
+                  :secret-a "B-public" :secret-b "B-private"}
+        ;; Mirror the drain-form walk: resolve :frame PER ELEMENT off the
+        ;; bundle's own :frame slot, then elide. (current-frame fallback is
+        ;; exercised separately by the existing frameless tests.)
+        walk     (fn [bundles]
+                   (mapv (fn [x]
+                           (rf/elide-wire-value
+                             x {:frame (:frame x)}))
+                         bundles))
+        [out-a out-b] (walk [bundle-a bundle-b])]
+    (testing "each bundle redacts ONLY its own frame's declared-sensitive slot"
+      (is (= :rf/redacted (:secret-a out-a))
+          "frame A's bundle redacts :secret-a (A declared it sensitive)")
+      (is (= "A-public" (:secret-b out-a))
+          "frame A's bundle leaves :secret-b verbatim (A did not declare it)")
+      (is (= :rf/redacted (:secret-b out-b))
+          "frame B's bundle redacts :secret-b (B declared it sensitive)")
+      (is (= "B-public" (:secret-a out-b))
+          "frame B's bundle leaves :secret-a verbatim (B did not declare it)"))
+    (testing "the buggy single-operating-frame walk UNDER-redacts the other frame"
+      ;; Applying frame A (the would-be operating frame) to BOTH bundles
+      ;; leaks frame B's :secret-b — the exact off-box leak the per-element
+      ;; fix prevents.
+      (let [buggy (mapv #(rf/elide-wire-value
+                           % {:frame :elision-test/frame-a})
+                        [bundle-a bundle-b])]
+        (is (= "B-private" (:secret-b (second buggy)))
+            "operating-frame-for-every-bundle leaks frame B's secret — the defect")))))
+
 ;; ---------------------------------------------------------------------------
 ;; Sub-cache direct-read wire-egress posture (rf2-0hert / rf2-vflrg).
 ;;

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -124,6 +124,68 @@
       (is (= [[:counter/a-inc] [:counter/b-inc]]
              (mapv :event cs))))))
 
+;; ---- group-cascades-with-events -------------------------------------------
+
+(deftest group-cascades-with-events-attaches-raw-events
+  (testing "each record carries its raw composing events under :trace-events
+            (the slim group-cascades record plus the raw events)"
+    (let [evs        (cascade-evs 100 [:user/login {:id 42}])
+          [c & more] (p/group-cascades-with-events evs)]
+      (is (empty? more) "single cascade yields one record")
+      ;; The slim record is identical to group-cascades' output…
+      (is (= (first (p/group-cascades evs))
+             (dissoc c :trace-events))
+          ":trace-events is purely ADDITIVE — the slim shape is unchanged")
+      ;; …plus the :trace-events slot holds exactly the composing events.
+      (is (= (vec evs) (:trace-events c))
+          ":trace-events is the vector of raw events that composed the cascade")
+      (is (= 100 (:dispatch-id c)))
+      (is (= :rf/default (:frame c))))))
+
+(deftest group-cascades-with-events-isolates-trace-events-by-frame
+  ;; rf2-1we9fa defect 1 — the drain-time projection. Two frames sharing a
+  ;; SINGLE dispatch-id (the portable trace contract guarantees dispatch-id
+  ;; uniqueness only WITHIN a frame; per-frame/per-realm id allocation
+  ;; under EP-0010 / EP-0013 makes such collisions live). Each frame's
+  ;; bundle MUST carry ONLY its own frame's raw :trace-events — NOT the
+  ;; union of both frames' events. The prior consumer keyed :trace-events
+  ;; by :rf.trace/dispatch-id ALONE, which merged both frames' events into
+  ;; each bundle. group-cascades-with-events keys by [frame dispatch-id],
+  ;; so the events stay isolated.
+  (testing "same dispatch-id across two frames ⇒ two bundles, each holding
+            only its own frame's :trace-events"
+    (let [a   (cascade-evs 10 [:counter/a-inc] :counter/a)
+          b   (mapv #(update % :id + 100)
+                    (cascade-evs 10 [:counter/b-inc] :counter/b))
+          ;; Interleave so a naive dispatch-id-only group-by could not rely
+          ;; on input ordering to separate the frames.
+          cs  (p/group-cascades-with-events (interleave a b))
+          by-frame (into {} (map (juxt :frame identity)) cs)
+          ca  (get by-frame :counter/a)
+          cb  (get by-frame :counter/b)]
+      (is (= 2 (count cs)) "two frames sharing dispatch-id 10 ⇒ two bundles")
+      (is (= #{:counter/a :counter/b} (set (keys by-frame))))
+      ;; The load-bearing assertion: NO foreign-frame events leak in.
+      (is (= (vec a) (:trace-events ca))
+          "frame :counter/a's bundle holds ONLY frame :counter/a events")
+      (is (= (vec b) (:trace-events cb))
+          "frame :counter/b's bundle holds ONLY frame :counter/b events")
+      (is (every? #(= :counter/a (get-in % [:tags :frame]))
+                  (:trace-events ca))
+          "no frame :counter/b event leaks into frame :counter/a's bundle")
+      (is (every? #(= :counter/b (get-in % [:tags :frame]))
+                  (:trace-events cb))
+          "no frame :counter/a event leaks into frame :counter/b's bundle"))))
+
+(deftest group-cascades-with-events-drops-nothing
+  (testing ":trace-events across all records accounts for every input event"
+    (let [evs (concat (cascade-evs 1 [:a] :frame/x)
+                      (cascade-evs 2 [:b] :frame/y))
+          cs  (p/group-cascades-with-events evs)]
+      (is (= (count evs)
+             (reduce + 0 (map (comp count :trace-events) cs)))
+          "every input event lands in exactly one bundle's :trace-events"))))
+
 (deftest group-cascades-events-without-dispatch-id-land-in-ungrouped
   (testing "events emitted outside any drain (registry-time, frame
             lifecycle) carry no :rf.trace/dispatch-id and group under :ungrouped"

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1530,27 +1530,31 @@
   (nil? (get-in ev [:tags :rf.trace/dispatch-id])))
 
 (defn- cascade-bundle-events
-  "Group a vector of raw trace events by `:rf.trace/dispatch-id` and
-   project each group into a cascade-bundle map matching the framework's
-   `(rf/trace-buffer frame-id)` shape — the `group-cascades` projection
-   PLUS a `:trace-events` slot carrying the raw events for the cascade.
-   The returned vector is sorted by emission order (lowest `:id` first,
-   the order `rf/group-cascades` returns).
+  "Group a vector of raw trace events into cascade-bundle maps matching
+   the framework's `(rf/trace-buffer frame-id)` shape — the
+   `group-cascades` projection PLUS a `:trace-events` slot carrying the
+   raw events for the cascade. The returned vector is sorted by emission
+   order (lowest `:id` first, the order the projection returns).
+
+   Delegates the grouping entirely to `rf/group-cascades-with-events` —
+   the framework projection that keys cascades by `[frame dispatch-id]`.
+   This is load-bearing: dispatch ids are unique only WITHIN a frame
+   (the portable trace contract), so two cascades sharing a dispatch id
+   across frames are distinct bundles, each carrying only its own frame's
+   raw `:trace-events`. Re-deriving the grouping here keyed by
+   `:rf.trace/dispatch-id` alone (the prior `by-id` group-by) merged
+   foreign-frame events into both bundles — latent today (the runtime's
+   global dispatch counter never collides cross-frame) but live the
+   moment per-frame/per-realm id allocation lands. Reuse the framework
+   key; never re-derive a weaker one.
 
    Events whose `:rf.trace/dispatch-id` tag is missing are NOT included
    — the caller is expected to have filtered them upstream (cascade-
    bundle topics) or routed them to the frameless channel."
   [events]
-  (let [;; rf/group-cascades returns a vector of cascade records sorted
-        ;; by emission order, keyed by `:dispatch-id`. We then splice
-        ;; the raw events per cascade into the `:trace-events` slot.
-        cascades   (rf/group-cascades events)
-        by-id      (group-by #(get-in % [:tags :rf.trace/dispatch-id])
-                             events)]
-    (->> cascades
-         (remove #(= :ungrouped (:dispatch-id %)))
-         (mapv (fn [c]
-                 (assoc c :trace-events (vec (get by-id (:dispatch-id c) []))))))))
+  (->> (rf/group-cascades-with-events events)
+       (remove #(= :ungrouped (:dispatch-id %)))
+       vec))
 
 (defn- compose-trace-filter
   "Compose the topic's base trace-filter with the user-supplied filter.

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -653,7 +653,8 @@
   ["re-frame.core" "trace-buffer"]          {:tier :tooling :owner "009" :status "v1 (dev-only)"}
   ["re-frame.core" "clear-trace-buffer!"]   {:tier :tooling :owner "009" :status "v1 (dev-only)"}
   ["re-frame.core" "clear-listeners!"]      {:tier :tooling :owner "009" :status "v1 (dev-only)"}
-  ["re-frame.core" "group-cascades"]        {:tier :tooling :owner "009" :status "v1 (dev-only)"}
+  ["re-frame.core" "group-cascades"]            {:tier :tooling :owner "009" :status "v1 (dev-only)"}
+  ["re-frame.core" "group-cascades-with-events"] {:tier :tooling :owner "009" :status "v1 (dev-only)"}
   ["re-frame.core" "domino-bucket"]         {:tier :tooling :owner "009" :status "v1 (dev-only)"}
   ;; Epoch history re-exports (canonical home: re-frame.epoch) — §Tool-Pair.
   ["re-frame.core" "epoch-history"]              {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 506,
+ :var-count 507,
  :tier-vocab
  [:front-porch
   :advanced
@@ -127,6 +127,7 @@
   {:namespace "re-frame.core", :var "get-coeffect", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "get-effect", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "group-cascades", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "group-cascades-with-events", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "handler-ids", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "handler-meta", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "head-model->html", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2430,7 +2430,7 @@ summary `{:ok? true :sub-id :delivered N :dropped-events N
 
 | Topic       | What gets pushed                                                                                                |
 |-------------|-----------------------------------------------------------------------------------------------------------------|
-| `trace`     | Every raw trace event matching `filter` — grouped into cascade bundles by `:rf.trace/dispatch-id` (rf2-mscih).  |
+| `trace`     | Every raw trace event matching `filter` — grouped into cascade bundles keyed by `:frame` + `:dispatch-id`; consumers may merge by `:dispatch-id` (rf2-mscih).  |
 | `epoch`     | Every assembled `:rf/epoch-record` matching `filter`. Already cascade-shaped by construction.                   |
 | `fx`        | Sugar — `topic :trace` with base filter `{:op-type :rf.fx}`. Cascade-bundle delivery as for `:trace`.            |
 | `error`     | Sugar — `topic :trace` with base filter `{:op-type :error}`. Cascade-bundle delivery as for `:trace`.            |
@@ -2468,6 +2468,18 @@ One tick = one drain's worth of cascade bundles. A cascade is the
 "atomic" delivery unit — consumers can reason about cause→effect at
 the granularity of `:dispatch-id` without re-folding flat-event
 streams (the pre-rf2-mscih posture).
+
+Each bundle is grouped by `(frame, dispatch-id)` — `:dispatch-id` is
+unique only *within* a frame, so a bundle's `:trace-events` are scoped
+to its own frame (the framework projection `group-cascades-with-events`
+keys on `[frame dispatch-id]`; consumers MUST NOT re-derive the grouping
+with a weaker `:dispatch-id`-only key). Trace-event elision is likewise
+**per-bundle-frame**: each bundle is run through the egress walker against
+*its own* `:frame`'s declared sensitive/large registry (the operating
+frame is only a fallback for genuinely frameless values). Eliding a
+foreign-frame bundle against one shared operating frame would mis-redact
+across the per-frame EP-0015 classification — the under-redaction
+direction leaks declared-sensitive slots off-box.
 
 Events with no `:rf.trace/dispatch-id` tag (registration emits, REPL
 evals, lifecycle outside any cascade) NEVER ride the cascade-bundle

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -346,19 +346,29 @@
   PROJECTED epoch records, because epoch projection tracks the sensitive
   axis, not the large-slot toggle.
 
-  EP-0002 (rf2-bd4div) — the elide-wire-value opts thread the resolved
-  operating frame in as the explicit `:frame` override. The drain form
-  runs on the nREPL eval thread, which carries NO ambient `with-frame`
-  scope, so a frameless `re-frame.core/elide-wire-value` would FAIL
-  CLOSED and redact every cascade slot to `:rf/redacted` (the
-  carried-frame invariant). We resolve the operating frame app-side via
-  `(re-frame2-pair.runtime/current-frame)` and merge it into the opts —
-  the same idiom `elision/elide-sub-value-src` uses for the sub-cache
-  walker and `runtime/pair-dispatch!` uses for the dispatch override — so
-  the walker resolves against the frame's `[:rf.runtime/elision]`
-  runtime-db registry instead of failing closed. `projected-record`
-  resolves the frame off each record's own `:frame` slot, so the
-  `:epoch` arm needs no `current-frame` thread.
+  rf2-1we9fa — the trace-walk arm resolves the elision `:frame` PER
+  ELEMENT inside the walk: a cascade record's own `:frame` slot (cascade
+  bundles are keyed by `[frame dispatch-id]`), else a frameless event's
+  `[:tags :frame]` / `:frame`. An all-frame stream — or a filter frame
+  that differs from the operating frame — carries cascades from several
+  frames in one tick, and per EP-0015 sensitive/large declarations are
+  per-frame; eliding a foreign-frame cascade against the operating
+  frame's registry mis-redacts (under-redaction leaks across the off-box
+  boundary). The operating frame is the genuinely-frameless FALLBACK
+  only.
+
+  EP-0002 (rf2-bd4div) — the drain form runs on the nREPL eval thread,
+  which carries NO ambient `with-frame` scope, so a frameless
+  `re-frame.core/elide-wire-value` would FAIL CLOSED and redact every
+  slot to `:rf/redacted` (the carried-frame invariant). We resolve the
+  operating frame app-side via `(re-frame2-pair.runtime/current-frame)`
+  and use it as the per-element fallback — the same idiom
+  `elision/elide-sub-value-src` uses for the sub-cache walker and
+  `runtime/pair-dispatch!` uses for the dispatch override — so a truly
+  frameless element resolves against the operating frame's
+  `[:rf.runtime/elision]` runtime-db registry instead of failing closed.
+  `projected-record` resolves the frame off each record's own `:frame`
+  slot, so the `:epoch` arm needs no `current-frame` thread.
 
   Public (not `defn-`) so unit tests can pin the form shape directly —
   the form-string is the contract surface between MCP server and the
@@ -434,19 +444,42 @@
       ;;
       ;; rf2-suoj2 — `elision-opts-edn` first arg is walker-aligned
       ;; `include-large?` (subscribe always elides, so emit markers ⇒ pass
-      ;; `false`). EP-0002 (rf2-bd4div): merge the resolved operating frame
-      ;; in as the explicit `:frame` override (the nREPL eval thread carries
-      ;; no ambient frame scope, so a frameless elide-wire-value would fail
-      ;; closed → redact every cascade to `:rf/redacted`).
+      ;; `false`).
+      ;;
+      ;; rf2-1we9fa — the elision `:frame` is resolved PER ELEMENT inside
+      ;; the walk, NOT once for the whole drain. Cascade bundles are keyed
+      ;; by `[frame dispatch-id]` (group-cascades-with-events), so an
+      ;; all-frame stream — or a filter frame that differs from the
+      ;; operating frame — carries cascades from several frames in one
+      ;; tick. Per EP-0015 sensitive/large declarations are PER FRAME, so
+      ;; eliding a frame-B cascade against frame-A's (the operating
+      ;; frame's) registry mis-redacts — the sharp edge is UNDER-redaction
+      ;; (frame-A values A marks sensitive but B does not would leak across
+      ;; the off-box MCP→LLM boundary). Each element supplies its own
+      ;; frame: a cascade record's `:frame` slot, else a frameless event's
+      ;; `[:tags :frame]` / `:frame`.
+      ;;
+      ;; EP-0002 (rf2-bd4div): `current-frame` survives as the genuinely
+      ;; frameless FALLBACK only. The nREPL eval thread carries no ambient
+      ;; frame scope, so a truly frameless element would otherwise fail
+      ;; closed and redact every slot to `:rf/redacted`; resolving the
+      ;; operating frame app-side preserves the deliberate frame-thread for
+      ;; that case without applying it to frame-qualified elements.
       :else
       (ef/emit
         (ef/rt-let
-          ['drain drain-call
-           'opts  (ef/rt-raw
-                    (str "(merge {:frame (re-frame2-pair.runtime/current-frame)} "
-                         (elision/elision-opts-edn false incl?) ")"))]
+          ['drain     drain-call
+           'cur-frame (ef/rt-raw "(re-frame2-pair.runtime/current-frame)")
+           'base-opts (ef/rt-raw (elision/elision-opts-edn false incl?))]
           (ef/rt-raw
-            (str "(let [walk (fn [xs] (mapv (fn [x] (re-frame.core/elide-wire-value x opts)) xs))]"
+            (str "(let [walk (fn [xs]"
+                 "             (mapv (fn [x]"
+                 "                     (let [frame (or (:frame x)"
+                 "                                     (get-in x [:tags :frame])"
+                 "                                     cur-frame)]"
+                 "                       (re-frame.core/elide-wire-value"
+                 "                         x (assoc base-opts :frame frame))))"
+                 "                   xs))]"
                  " (cond-> drain"
                  " (contains? drain :cascades)"
                  " (update :cascades walk)"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -596,24 +596,40 @@
     (is (str/includes? form ":rf.size/include-sensitive? false")
         "sensitive slots redact when the caller did NOT opt in")))
 
-(deftest drain-form-threads-operating-frame
-  ;; EP-0002 (rf2-bd4div) — the drain runs on the nREPL eval thread, which
-  ;; carries NO ambient `with-frame` scope, so a frameless
-  ;; `re-frame.core/elide-wire-value` fails CLOSED and redacts every cascade
-  ;; slot to `:rf/redacted`. The walker opts MUST therefore thread the
-  ;; resolved operating frame in as the explicit `:frame` override
-  ;; (`(re-frame2-pair.runtime/current-frame)`), the same idiom the
-  ;; sub-cache walker + pair-dispatch override use. Without this the live
-  ;; subscribe streaming gate goes RED (the cascade event vector — and its
-  ;; causal nonce — never crosses the wire; it redacts away). Trace-event
-  ;; topic — the walker arm carries the frame thread.
+(deftest drain-form-resolves-elision-frame-per-element
+  ;; rf2-1we9fa — the trace-walk arm resolves the elision `:frame` PER
+  ;; ELEMENT inside the walk, NOT once for the whole drain. Cascade
+  ;; bundles are keyed by `[frame dispatch-id]`, so an all-frame stream —
+  ;; or a filter frame that differs from the operating frame — carries
+  ;; cascades from several frames in one tick. Per EP-0015 sensitive/large
+  ;; declarations are per-frame, so each element MUST be elided against its
+  ;; OWN frame: a cascade record's `:frame` slot, else a frameless event's
+  ;; `[:tags :frame]` / `:frame`. The operating frame
+  ;; (`(re-frame2-pair.runtime/current-frame)`) survives as the GENUINELY
+  ;; FRAMELESS FALLBACK only (EP-0002 rf2-bd4div: the nREPL eval thread
+  ;; carries no ambient `with-frame` scope, so a truly frameless element
+  ;; would otherwise fail closed and redact away).
+  ;;
+  ;; This test REPLACES the prior `drain-form-threads-operating-frame`,
+  ;; which PINNED the buggy "one operating frame for every cascade"
+  ;; behaviour. Trace-event topic — the walker arm carries the per-element
+  ;; frame resolution.
   (let [form (sub/drain-form "sub-frame" :trace true false)]
     (is (str/includes? form "(re-frame2-pair.runtime/current-frame)")
-        "the walker opts resolve the operating frame app-side")
-    (is (str/includes? form ":frame")
-        "the resolved frame is merged in as the explicit :frame override")
-    (is (str/includes? form "merge")
-        "the frame override is merged onto the elision opts map")))
+        "the operating frame is resolved app-side as the frameless fallback")
+    ;; The per-element resolution: cascade record `:frame`, then frameless
+    ;; `[:tags :frame]`, then the operating-frame fallback.
+    (is (str/includes? form "(:frame x)")
+        "each element's own :frame slot is the first elision-frame source")
+    (is (str/includes? form "(get-in x [:tags :frame])")
+        "a frameless event's [:tags :frame] is the second source")
+    (is (str/includes? form "(or (:frame x)")
+        "the per-element frame falls through (or ...) to the fallback")
+    (is (str/includes? form "(assoc base-opts :frame frame)")
+        "the per-element frame is assoc'd onto the base elision opts per element")
+    (is (not (str/includes?
+               form "(merge {:frame (re-frame2-pair.runtime/current-frame)}"))
+        "the buggy single-frame-for-every-cascade merge is GONE")))
 
 (deftest drain-form-gated-elision-honours-include-sensitive
   ;; Gate ON path — when the operator passed `--allow-sensitive-reads` AND the


### PR DESCRIPTION
Fixes rf2-1we9fa. Two coupled correctness defects in the multi-frame streaming subscribe drain path, landed together (per-frame elision is meaningless while a bundle still holds foreign trace-events).

## Root cause
The pair preload consumer re-derived the cascade grouping with a WEAKER key (`:rf.trace/dispatch-id` alone) than the framework projection uses (`[frame dispatch-id]`). Dispatch ids are unique only *within* a frame in the portable trace contract, so the consumer drifted from the framework.

**Defect 1 — cross-frame trace-event mixing.** `cascade-bundle-events` keyed `:trace-events` by dispatch-id alone, so two cascades sharing a dispatch-id across frames each got the UNION of both frames' raw events. Latent today (router allocates from a process-global counter, so cross-frame collisions don't occur) but live the moment per-frame/per-realm id allocation lands (EP-0010 deterministic replay ids, EP-0013 N realms per page).

**Defect 2 — wrong-frame elision.** The drain form built one `{:frame (current-frame)}` opts and applied it to every cascade/event. Per EP-0015 sensitive/large declarations are per-frame, so eliding a foreign-frame bundle against the operating frame's registry mis-redacts. The sharp edge is UNDER-redaction at the off-box MCP→LLM boundary: a frame-A value A marks sensitive but the operating frame B does not would leak.

## Changes
- **`implementation/core/.../trace/projection.cljc`** — new PUBLIC `group-cascades-with-events` sibling that reuses the internal `[frame dispatch-id]` grouping (via a shared private `grouped-cascades` helper) and attaches `:trace-events`. `group-cascades` kept slim — its 7-slot shape is pinned + Xray-consumed.
- **`implementation/core/.../core.cljc`** — facade export for `group-cascades-with-events` (classified: tool-facing projection primitive, sibling to `group-cascades`).
- **`skills/re-frame2-pair/preload/.../runtime.cljs`** — `cascade-bundle-events` delegates to the framework helper; the buggy dispatch-id-only `by-id` is deleted (no re-derivation of frame inference — that is the exact drift that caused the bug).
- **`tools/re-frame2-pair-mcp/.../subscribe.cljs`** — elision `:frame` resolved PER ELEMENT off each bundle's own frame (`(:frame x)` / `[:tags :frame]`); `current-frame` survives as the genuinely-frameless fallback only (EP-0002 — nREPL eval thread has no ambient frame). The `:elision false` + `:include-sensitive true` full-raw bypass is unchanged.
- **`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`** — topic table tightened from "by `:rf.trace/dispatch-id`" to "keyed by `:frame` + `:dispatch-id`; consumers may merge by `:dispatch-id`"; added the per-bundle-frame elision contract statement (previously unstated). The impl drifted FROM the spec; this restores conformance.

## Tests
- Replaced the `subscribe_test.cljs` `:599` test (`drain-form-threads-operating-frame`) which actively PINNED the buggy single-operating-frame behaviour → now `drain-form-resolves-elision-frame-per-element`, asserting per-element frame resolution and that the buggy merge is gone.
- `projection_test.cljc` — two frames sharing a dispatch-id yield two bundles, each `:trace-events` only its own frame's events (defect 1 isolation), plus an additive-shape pin and a no-drop accounting test.
- `elision_test.clj` — two frames with different sensitive declarations streamed in one tick redact per their OWN frame; includes a negative assertion that the buggy single-operating-frame walk under-redacts (defect 2).

## Quality gates
- `clojure -M:test -n re-frame.trace.projection-test -n re-frame.elision-test` (core JVM): **63 tests, 168 assertions, 0 failures**
- `npm test` (pair-mcp `:server-test`, incl. updated `subscribe_test.cljs`): **1065 tests, 3407 assertions, 0 failures**
- `npm run test:cljs` (CLJS substrate): **7314 tests, 30174 assertions, 0 failures**
- `npm run test:mcp-conformance` — not run: not affected (the `subscribe` tool descriptor/schema is unchanged; the change is internal to the drain-form + projection, and the spec edit is prose).

- `clojure -M -m re-frame.api-manifest.gen --check` (Public-API manifest drift-check, from `implementation/scripts/api-manifest/`): **OK — spec/api-manifest.edn in sync (507 public vars)**. Added the missing sidecar classification row for `["re-frame.core" "group-cascades-with-events"]` (`{:tier :tooling :owner "009" :status "v1 (dev-only)"}`, matching its `group-cascades` sibling) to `spec/api-manifest-metadata.edn` and regenerated `spec/api-manifest.edn`. This clears the previously-failing **Public-API manifest drift-check** + the cascaded **Lint required** check.
