### PR TITLE
fix(pair-mcp): error-shape preflight failures + watch-until timeout validation

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -357,6 +357,21 @@ the common path; the dialect cost would tax the common case.
 - `:rf.mcp/cursor-stale` ⇒ drop the cursor; restart pagination from
   the head (same as cross-MCP cursor-staleness on story-mcp).
 
+**Every `:ok? false` response is `isError: true`.** A known-tool failure —
+whatever the dialect of its `:reason` — is returned with the `tools/call`
+result's `isError: true` flag set (API §Result shape; 001-Wire-Protocol
+§JSON-RPC error codes). This includes the runtime / preflight / transport
+rejections that ride back through the shared `probe/err->result` path
+(`:no-runtime-for-build`, `:runtime-loaded-but-preload-missing`, the
+`:<verb>-failed` fallbacks): they are NOT success-shaped values. The one
+deliberate exception is a tool's normal terminal-but-empty outcome that an
+agent reads as data rather than a fault — e.g. `watch-until`'s
+`:watch-timeout` (the predicate simply did not hold in the window) — which
+is documented as non-`isError` at each such tool. Keeping failures
+`isError` is also what keeps them out of the response cache (cache
+eligibility bypasses `isError` results), so a transient failure can never
+be cached and mask a later successful read.
+
 #### `:unknown-tool` recovery hint (rf2-tkmik)
 
 The bare `:unknown-tool` reason — emitted when a `tools/call` names a
@@ -2395,9 +2410,17 @@ sample map `{<signal-index> <value>}`:
 **Read-only by construction** — the runtime sampler only reads.
 
 **Args**: `signals` (required, non-empty), `pred` (required — without one
-the watch can only time out), `timeout-ms` (integer, default 30000),
-`elision` (boolean, default true), `include-sensitive` (boolean, default
-false), `frame` (string), `build` (string).
+the watch can only time out), `timeout-ms` (positive-millisecond integer,
+default 30000), `elision` (boolean, default true), `include-sensitive`
+(boolean, default false), `frame` (string), `build` (string).
+
+`timeout-ms` is validated up front against the same positive-millisecond
+contract the other timeout-aware tools use (`tail-build :wait-ms`,
+`eval-cljs` / `dispatch` `:timeout-ms`). A malformed, zero, negative, or
+fractional value short-circuits to an `isError` envelope
+(`:reason :invalid-numeric-arg`, naming the offending arg) **before** the
+runtime preflight — it is never silently rewritten to the default. An
+omitted `timeout-ms` uses the documented 30000 default.
 
 **Privacy** (rf2-8fin7.2): the `:app-db` / `:sub` values returned in the
 `:sample` (on hold) and `:last-sample` (on timeout) slots are walked by
@@ -2411,8 +2434,16 @@ are honoured only under `--allow-sensitive-reads`; otherwise forced safe.
 :held? true :elapsed-ms <n> :sample {<i> <v>} :t <ms>}`. On timeout:
 `{:ok? false :reason :watch-timeout :timed-out? true :timeout-ms <n>
 :last-sample {...}}` — `:last-sample` is the final reading, to see how
-close the condition got. `:reason :no-signals` / `:reason :missing-pred`
-on the respective omission.
+close the condition got. The timeout is the watch's normal terminal
+outcome (the predicate did not hold in time), not a tool fault, so it
+rides as a non-`isError` success-shaped result.
+
+**Error envelopes** (all `isError: true`, short-circuit before the runtime
+preflight): `:reason :no-signals` / `:reason :missing-pred` on the
+respective omission; `:reason :invalid-numeric-arg` (naming the arg) on a
+malformed / zero / negative / fractional `timeout-ms`. A runtime /
+preflight rejection (no live runtime for the build) rides back via the
+shared `probe/err->result` path as an `isError` result too.
 
 ## subscribe
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -637,13 +637,23 @@
 ;; ---------------------------------------------------------------------------
 
 (defn err->result
-  "Translate a Promise rejection into an `ok-text` result. Structured
-  ex-info reasons (e.g. `:runtime-not-preloaded`) surface verbatim;
-  other errors fall through to a generic eval-error shape."
+  "Translate a Promise rejection (a runtime / preflight / transport
+  failure surfaced by the shared eval-path guards) into an MCP ERROR
+  result. Structured ex-info reasons (e.g. `:no-runtime-for-build`,
+  `:runtime-loaded-but-preload-missing`) surface verbatim; other errors
+  fall through to a generic `fallback-reason` shape.
+
+  A rejection here is a known-tool failure with `:ok? false`, which the
+  MCP error-handling contract requires be returned with `isError: true`
+  (API §Result shape; 001-Wire-Protocol §JSON-RPC error codes). Using
+  `wire/err-text` (not `wire/ok-text`) is what makes that true: the host
+  surfaces the failure to the LLM as an error rather than a success-shaped
+  value, AND the response cache (which bypasses `:isError` results) can no
+  longer cache a transient failure and mask a later successful read."
   [fallback-reason err]
   (if-let [data (ex-data err)]
-    (wire/ok-text (merge {:ok? false} data))
-    (wire/ok-text {:ok? false :reason fallback-reason :message (.-message err)})))
+    (wire/err-text (merge {:ok? false} data))
+    (wire/err-text {:ok? false :reason fallback-reason :message (.-message err)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Shared eval-prelude (rf2-jkake.19).

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
@@ -112,8 +112,17 @@
                        (object? p) (try (js->clj p :keywordize-keys true)
                                         (catch :default _ nil))
                        :else nil))
-        timeout-ms (let [t (wire/arg raw-args :timeout-ms)]
-                     (if (and (number? t) (pos? t)) (long t) default-timeout-ms))
+        ;; Validate `:timeout-ms` as a positive-millisecond integer up
+        ;; front, the SAME contract the other timeout-aware tools use
+        ;; (`tail-build :wait-ms`, `eval-cljs` / `dispatch` `:timeout-ms`
+        ;; — all via `args/parse-timeout-arg`, rf2-wz66k7). A malformed,
+        ;; zero, negative, or fractional value used to silently become
+        ;; `default-timeout-ms`, hiding the caller's bad input behind a 30s
+        ;; wait; it now short-circuits to an honest `:invalid-numeric-arg`
+        ;; error (the `cond` below). An ABSENT arg ⇒ `[:ok nil]` ⇒ the
+        ;; documented default.
+        timeout-r  (args/parse-timeout-arg "timeout-ms" (wire/arg raw-args :timeout-ms))
+        timeout-ms (or (second timeout-r) default-timeout-ms)
         pred-src   (record/pred-source pred)
         ;; rf2-8fin7.2 — the `:sample` (on hold) and `:last-sample` (on
         ;; timeout) slots ship raw `:app-db` / `:sub` values back to the
@@ -129,6 +138,13 @@
                      false)
         elision-opts (elision/elision-opts-edn (not elision?) incl?)]
     (cond
+      ;; A bad `:timeout-ms` is a caller error worth telling the agent
+      ;; about, not a value to silently paper over with the default.
+      ;; Short-circuit BEFORE the runtime preflight, like eval-cljs's
+      ;; `:timeout-ms` validation (rf2-wz66k7).
+      (= :err (first timeout-r))
+      (js/Promise.resolve (wire/err-text (second timeout-r)))
+
       (or (nil? signals) (empty? signals))
       (js/Promise.resolve
         (wire/err-text

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
@@ -15,6 +15,7 @@
             [cljs.reader :as edn]
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.cache :as cache]))
 
 ;; ---------------------------------------------------------------------------
@@ -230,6 +231,42 @@
       (let [out (cache/apply-cache ok opts)]
         (is (identical? ok out)
             "successful follow-up is a fresh miss")))))
+
+(deftest preflight-rejection-is-error-shaped-and-bypasses-cache
+  ;; A runtime/preflight/transport rejection routes through
+  ;; probe/err->result, which now emits an :isError result (NOT a
+  ;; success-shaped ok-text). Two guarantees:
+  ;;   (a) the result carries :isError true (the known-tool-failure
+  ;;       contract: API §Result shape / 001 §JSON-RPC error codes), and
+  ;;   (b) because apply-cache bypasses :isError, such a failure can never
+  ;;       be cached and can never produce a later :rf.mcp/cache-hit on the
+  ;;       same (tool, args) key — masking a subsequent successful read.
+  (let [;; A structured ex-info exactly like resolve-and-preflight! rejects
+        ;; with on a runtime-absent build.
+        rej   (ex-info "no re-frame2-pair runtime for build"
+                       {:reason :no-runtime-for-build :build :app})
+        err   (probe/err->result :snapshot-failed rej)
+        args  (args-js {:frame ":rf/default"})
+        opts  {:tool "snapshot" :args args :enabled? true}]
+    ;; (a) error-shaped.
+    (is (true? (j/get err :isError))
+        "preflight rejection surfaces as :isError true")
+    (let [edn-out (some-> (extract-text err) edn/read-string)]
+      (is (false? (:ok? edn-out)))
+      (is (= :no-runtime-for-build (:reason edn-out))
+          "structured ex-info reason surfaces verbatim"))
+    ;; (b) not cached — passes through untouched, leaves no entry.
+    (let [out (cache/apply-cache err opts)]
+      (is (identical? err out)
+          "preflight-failure result passes through apply-cache untouched"))
+    (is (zero? (cache/size))
+        "a preflight failure must not poison the cache")
+    ;; And it cannot manufacture a later cache-hit: a second identical
+    ;; failure is again a pass-through, never a :rf.mcp/cache-hit marker.
+    (let [err2 (probe/err->result :snapshot-failed rej)
+          out2 (cache/apply-cache err2 opts)]
+      (is (not (cache-hit-result? out2))
+          "a repeated preflight failure never returns a :rf.mcp/cache-hit"))))
 
 (deftest different-tools-same-args-do-not-collide
   ;; (snapshot, args) and (get-path, args) are different keys.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -430,7 +430,7 @@
                   :type "object" :build :app}}}
 
    {:fixture/id    :eval-cljs/no-runtime-for-build
-    :fixture/doc   "eval-cljs against a build with no live runtime fails loud (:no-runtime-for-build), never :ok? true :value nil (rf2-ivlb3)."
+    :fixture/doc   "eval-cljs against a build with no live runtime fails loud (:no-runtime-for-build), never :ok? true :value nil (rf2-ivlb3). A preflight rejection routes through probe/err->result, so it surfaces as isError: true per the known-tool-failure contract (API §Result shape)."
     :fixture/tool  "eval-cljs"
     ;; Explicit :build so the path is deterministic against the
     ;; cljs-eval-only stub; sentinel probe returns false → fail loud.
@@ -439,7 +439,7 @@
     [["__re_frame2_pair_runtime"  false]
      [:default                    nil]]
     :fixture/expect
-    {:isError? false
+    {:isError? true
      :edn-submap {:ok? false :reason :no-runtime-for-build}}}
 
    {:fixture/id    :eval-cljs/missing-form
@@ -1180,21 +1180,23 @@
 
    ;; ---------- list-subscriptions (reactive sub-cache, rf2-qicji) --------
    {:fixture/id    :list-subscriptions/empty
-    :fixture/doc   "list-subscriptions on a frame with no live reactive subs returns an empty list envelope."
+    :fixture/doc   "list-subscriptions on a frame with no live reactive subs returns an empty list envelope. The runtime sentinel is present (only the sub-cache query is empty) — a missing sentinel would be a preflight failure (isError), not an empty success."
     :fixture/tool  "list-subscriptions"
     :fixture/args  {}
     :fixture/eval-script
-    [[:default nil]]
+    [["__re_frame2_pair_runtime"  true]
+     [:default                    nil]]
     :fixture/expect
     {:isError? false}}
 
    ;; ---------- list-streams (streaming-tap diagnostic, rf2-qicji) --------
    {:fixture/id    :list-streams/empty
-    :fixture/doc   "list-streams with no active streaming-tap subscriptions returns an empty list envelope."
+    :fixture/doc   "list-streams with no active streaming-tap subscriptions returns an empty list envelope. The runtime sentinel is present (only the subscription-info query is empty) — a missing sentinel would be a preflight failure (isError), not an empty success."
     :fixture/tool  "list-streams"
     :fixture/args  {}
     :fixture/eval-script
-    [[:default nil]]
+    [["__re_frame2_pair_runtime"  true]
+     [:default                    nil]]
     :fixture/expect
     {:isError? false}}
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
@@ -24,6 +24,8 @@
   fn so we can directly assert how many round-trips the probe
   costs across N tool calls."
   (:require [cljs.test :refer-macros [deftest is testing async]]
+            [cljs.reader :as edn]
+            [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
@@ -338,3 +340,47 @@
         (fn []
           (assert-ladder-rejects-with-reason
             (fresh-conn) :runtime-loaded-but-preload-missing #"preload" done nil))))))
+
+;; ---------------------------------------------------------------------------
+;; `err->result`. A runtime/preflight/transport REJECTION is a known-tool
+;; failure with `:ok? false`; per the MCP error-handling contract
+;; (API §Result shape; 001-Wire-Protocol §JSON-RPC error codes) it MUST
+;; surface as `isError: true`, NOT a success-shaped `ok-text` (which a host
+;; reads as a value and the response cache could store, masking later reads).
+;; ---------------------------------------------------------------------------
+
+(defn- result-edn
+  "Read the EDN payload back off an MCP result envelope."
+  [^js result]
+  (let [content (j/get result :content)
+        item    (when (array? content) (aget content 0))
+        text    (when item (j/get item :text))]
+    (some-> text edn/read-string)))
+
+(deftest err->result-structured-rejection-is-error
+  ;; A structured ex-info (the shape resolve-and-preflight! rejects with)
+  ;; surfaces its reason verbatim AND carries :isError true.
+  (let [rej (ex-info "no re-frame2-pair runtime for build"
+                     {:reason :no-runtime-for-build :build :app
+                      :running-builds [:other]})
+        out (probe/err->result :snapshot-failed rej)]
+    (is (true? (j/get out :isError))
+        "structured preflight rejection is :isError true")
+    (let [edn (result-edn out)]
+      (is (false? (:ok? edn)))
+      (is (= :no-runtime-for-build (:reason edn)) "ex-info reason rides verbatim")
+      (is (= :app (:build edn)))
+      (is (= [:other] (:running-builds edn))
+          "the running-build enumeration survives so the operator can re-aim"))))
+
+(deftest err->result-bare-rejection-is-error-with-fallback-reason
+  ;; A plain (non-ex-info) rejection falls through to the fallback-reason
+  ;; shape — still :isError true, carrying the error message.
+  (let [out (probe/err->result :watch-until-failed (js/Error. "socket boom"))]
+    (is (true? (j/get out :isError))
+        "bare rejection is also :isError true")
+    (let [edn (result-edn out)]
+      (is (false? (:ok? edn)))
+      (is (= :watch-until-failed (:reason edn))
+          "fallback-reason keys the generic shape")
+      (is (= "socket boom" (:message edn))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_until_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_until_test.cljs
@@ -1,0 +1,118 @@
+(ns re-frame2-pair-mcp.watch-until-test
+  "Unit tests for the watch-until tool.
+
+  ## `:timeout-ms` is validated, not silently coerced
+
+  THE BUG: `watch-until` accepted only a positive numeric `:timeout-ms`;
+  anything else — `\"bogus\"`, `0`, a negative value, a fractional value —
+  was SILENTLY rewritten to the 30-second default. A malformed deadline
+  could therefore block the MCP call for 30s and hide the caller's bad
+  input, unlike the other timeout-aware tools (`tail-build :wait-ms`,
+  `eval-cljs` / `dispatch` `:timeout-ms`) which reject bad values via the
+  shared `args/parse-timeout-arg` positive-millisecond contract.
+
+  THE FIX: route `:timeout-ms` through `args/parse-timeout-arg` and
+  short-circuit a bad value to an honest `{:ok? false :reason
+  :invalid-numeric-arg}` `isError` envelope BEFORE the runtime preflight —
+  the validation is the first `cond` branch, so a bad value never touches
+  the nREPL socket. An ABSENT arg keeps the documented default.
+
+  The validation branch fires ahead of the runtime preflight, so these
+  tests use a `fresh-conn` with no live socket: if validation did NOT
+  short-circuit, the tool would reach the preflight and fail with a
+  different reason, so `:invalid-numeric-arg` is a precise pin on the
+  early-exit."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.watch-until :as watch-until]))
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+(defn- fresh-conn []
+  (nrepl/make-conn 0 "127.0.0.1"))
+
+;; A well-formed signals + pred pair so the ONLY thing under test is the
+;; timeout validation (a missing signals/pred would short-circuit first on
+;; its own reason).
+(def ^:private good-args
+  {:signals "[{:app-db [:upload :status]}]"
+   :pred    "{:signal 0 :equals :done}"})
+
+(defn- watch-with-timeout
+  "Invoke watch-until with the good signals/pred plus the given
+  `:timeout-ms` value. Returns the tool Promise."
+  [timeout-ms]
+  (watch-until/watch-until-tool
+    (fresh-conn)
+    (tu/args->js (assoc good-args :timeout-ms timeout-ms))))
+
+(defn- assert-invalid-timeout [r]
+  (is (err? r) "a bad :timeout-ms surfaces as :isError true")
+  (let [edn (read-edn r)]
+    (is (false? (:ok? edn)))
+    (is (= :invalid-numeric-arg (:reason edn)))
+    (is (= "timeout-ms" (:arg edn))
+        "the error names the offending arg")))
+
+;; ---------------------------------------------------------------------------
+;; Invalid values — reject, don't coerce.
+;; ---------------------------------------------------------------------------
+
+(deftest non-numeric-timeout-ms-rejected
+  (async done
+    (-> (watch-with-timeout "bogus")
+        (.then (fn [r] (assert-invalid-timeout r) (done))))))
+
+(deftest zero-timeout-ms-rejected
+  ;; 0 is not a meaningful "wait for no time" sentinel here — the deadline
+  ;; must be a positive millisecond integer.
+  (async done
+    (-> (watch-with-timeout 0)
+        (.then (fn [r] (assert-invalid-timeout r) (done))))))
+
+(deftest negative-timeout-ms-rejected
+  (async done
+    (-> (watch-with-timeout -1)
+        (.then (fn [r] (assert-invalid-timeout r) (done))))))
+
+(deftest fractional-timeout-ms-rejected
+  ;; A non-integral number is rejected, matching the other timeout tools.
+  (async done
+    (-> (watch-with-timeout 1500.5)
+        (.then (fn [r] (assert-invalid-timeout r) (done))))))
+
+(deftest numeric-string-zero-timeout-ms-rejected
+  ;; The MCP host can pass the arg as a string; "0" is still rejected.
+  (async done
+    (-> (watch-with-timeout "0")
+        (.then (fn [r] (assert-invalid-timeout r) (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Valid / absent values still flow (the validation only rejects bad input).
+;; ---------------------------------------------------------------------------
+
+(deftest valid-timeout-ms-passes-validation
+  ;; A well-formed positive timeout must NOT be rejected by the validation
+  ;; branch. With no live runtime the call proceeds past validation and
+  ;; fails at the preflight — the key point is the reason is NOT
+  ;; :invalid-numeric-arg.
+  (async done
+    (-> (watch-with-timeout 2000)
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not= :invalid-numeric-arg (:reason edn))
+                       "a valid :timeout-ms clears the validation gate"))
+                 (done))))))
+
+(deftest numeric-string-timeout-ms-accepted-by-validation
+  ;; "2000" (a numeric string) is a valid positive integer and must clear
+  ;; the validation gate, same as the other timeout tools.
+  (async done
+    (-> (watch-with-timeout "2000")
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not= :invalid-numeric-arg (:reason edn))
+                       "a numeric-string :timeout-ms is accepted"))
+                 (done))))))


### PR DESCRIPTION
Two correctness fixes to the re-frame2-pair MCP server.

## Fix 1 — runtime/preflight failures return a proper MCP error

The shared `probe/err->result` helper wrapped Promise rejections with `wire/ok-text`, so known-tool failures with `:ok? false` (`:no-runtime-for-build`, `:runtime-loaded-but-preload-missing`, the `:<verb>-failed` fallbacks) were returned as non-`isError` successes. An agent host read them as values, and the response cache — which bypasses only `:isError` results — could cache such a transient failure and mask a later successful read.

`err->result` now uses `wire/err-text`, fixing every tool that routes a rejection through it in one place: snapshot, get-path, dispatch, read-sub, record, restore-epoch, replace-app-db, discover-app, list-subscriptions, list-streams, eval-cljs, watch-until. Because `apply-cache` already bypasses `:isError` results, these failures can no longer poison the cache.

## Fix 2 — `watch-until` validates `:timeout-ms`

`watch-until` accepted only a positive numeric `:timeout-ms`; a malformed, zero, negative, or fractional value silently became the 30s default, hiding the caller's bad input behind a long wait — unlike the other timeout-aware tools. It now uses the shared positive-millisecond parser (`args/parse-timeout-arg`) and short-circuits a bad value to an `isError` envelope (`:reason :invalid-numeric-arg`, naming the arg) **before** touching the nREPL socket. An omitted arg keeps the documented 30000 default.

## Spec

`003-Tool-Catalogue.md`: documented the "every `:ok? false` response is `isError: true`" rule (with the documented `watch-until` `:watch-timeout` non-error exception), and the watch-until `:timeout-ms` positive-millisecond validation contract. The top-level error contract (`API.md`, `001-Wire-Protocol.md`) already stated the correct rule; the bug was implementation-only.

## Quality gates

- `tools/re-frame2-pair-mcp` `npm test` (shadow-cljs `:server-test`): **PASS** — 1075 tests / 3441 assertions, 0 failures, 0 errors; full conformance corpus 76/76.
- `npm run check:descriptors` (tool-descriptor manifest drift): **PASS** — in sync (29 tools); no descriptor surface changed.
- New regression coverage: probe `err->result` unit tests (structured + bare rejection → `isError`); a cache test proving a preflight failure is error-shaped and never cached / never produces a later `:rf.mcp/cache-hit`; a new `watch_until_test` suite (non-numeric / zero / negative / fractional / numeric-string-zero rejected; valid + numeric-string accepted); corrected conformance fixtures (`eval-cljs/no-runtime-for-build`, `list-subscriptions/empty`, `list-streams/empty`).
- `test:mcp-conformance` not run in this environment (heavy multi-package + clojure toolchain; the affected gate is the pair-mcp `:server-test` corpus, which passed). The SDK-client end-to-end conformance only asserts `isError: true` for failures, so it is aligned with this fix, not regressed.
