### PR TITLE
fix(core): remove public rf/path value constructor → :rf.interceptor/path (EP-0022 drift)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2044,16 +2044,28 @@
   to inject an effect into the cascade. Per spec/API.md §Interceptors."}
   assoc-effect    interceptor/assoc-effect)
 
-(def ^{:doc "Returns an interceptor value that focuses the handler on the
-  app-db sub-slice at the given path — the handler receives the slice
-  value as `:db` (not the full app-db); its returned `:db` is spliced
-  back. Since EP-0022 (chains are reference-only) the standard way to use
-  `path` in a chain is the framework-registered factory ref
-  `[:rf.interceptor/path <path-vector>]`, not this value-constructor:
-  `(reg-event :inc {:interceptors [[:rf.interceptor/path [:counter]]]} (fn [{:keys [db]} _] {:db (inc db)}))`.
-  This fn remains the underlying value builder the standard factory
-  consumes. Per spec/API.md §Interceptors."}
-  path            std-interceptors/path)
+;; EP-0022 (accepted) removed the public `rf/path` VALUE constructor
+;; (EP-0022:552 "There is no public rf/path value constructor."; :932 lists the
+;; removal). spec/API.md + spec/002-Frames.md already follow it — the one public
+;; path surface is the framework-registered factory ref
+;; `[:rf.interceptor/path <path-vector>]`. The implementation had DRIFTED (kept
+;; exporting `rf/path` aliased to a legacy std-interceptors `path` fn whose
+;; weaker `:after` defeated the rf2-ekq28v commit no-op). rf2-dgtdna reconciles:
+;; the legacy fn is gone and this facade name survives ONLY as a `^:no-doc`
+;; throwing stub (the project's actionable-removed-API pattern, like the
+;; EP-0018 `reg-event-db` / EP-0017 `inject-cofx` stubs) — a stale `(rf/path …)`
+;; resolves to a real var and fails LOUDLY with `:rf.error/path-removed`, naming
+;; the `[:rf.interceptor/path …]` ref as the replacement. `^:no-doc` drops it
+;; from the API manifest generator + the CLJS publics probe: it carries no
+;; manifest row and is not part of the documented public surface. See
+;; spec/API.md §Standard interceptors and docs/api/15-removed.md.
+(def ^{:no-doc true
+       :doc "REMOVED in EP-0022 (no alias). Calling `path` raises the hard
+  error `:rf.error/path-removed`, naming the framework-registered ref
+  `[:rf.interceptor/path <path-vector>]` (used in a handler's `:interceptors`
+  chain) as the replacement. See `re-frame.std-interceptors/path-removed!` and
+  spec/API.md §Standard interceptors."}
+  path            std-interceptors/path-removed!)
 
 (def ^{:doc "Interceptor VALUE (not a fn) that asserts the dispatched event
   has shape `[<id> <payload-map>]` and replaces the `:event` coeffect with

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1703,8 +1703,8 @@
         ;; — it fires after the rest of the `:after` chain (handler body
         ;; + every user / framework `:after`) has fully reshaped the
         ;; pending `:db` effect into the complete app-db form. This is
-        ;; load-bearing: a `(rf/path :slice)` interceptor's `:after`
-        ;; splices the handler's slice back into the FULL db, so the flow
+        ;; load-bearing: a `[:rf.interceptor/path [:slice]]` interceptor's
+        ;; `:after` splices the handler's slice back into the FULL db, so the flow
         ;; transform (which reads full-db `:inputs` paths) MUST run after
         ;; that splice — i.e. outermost. The rest of the `:after` chain
         ;; therefore precedes flows and sees its INPUT; the flow output

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -2,9 +2,11 @@
   "Standard interceptors. Per Spec 002 / API.md §Standard interceptors and
   Spec 001 §Hot-reload semantics M-21.
 
-  Ships TWO specific helpers plus the ->interceptor primitive:
-    path        — focus a handler on an app-db sub-slice (this ns)
-    unwrap      — assert [id payload-map] event shape (this ns)
+  Ships ONE framework-standard interceptor plus the ->interceptor primitive:
+    :rf.interceptor/path — focus a handler on an app-db sub-slice, referenced
+                           as `[:rf.interceptor/path <path-vector>]` (this ns)
+    unwrap-interceptor   — the [id payload-map] event-shape assertion VALUE,
+                           registered + referenced by id (this ns)
 
   (Coeffects are no longer wired by a `inject-cofx` interceptor — they
   are declared via `:rf.cofx/requires` on the handler and delivered flat;
@@ -14,11 +16,11 @@
   those that are just (->interceptor :before f) or (->interceptor :after f)
   with no other logic. Custom before/after work uses ->interceptor directly.
 
-  EP-0022 (Slice C, rf2-0adhqs.3): this ns also registers the
-  framework-standard `:rf.interceptor/path` interceptor as a `:factory`,
-  referenced as `[:rf.interceptor/path <path-vector>]`. Its `:factory`
-  builds the FULL standard-path interceptor (`standard-path-interceptor`)
-  implementing the normative rules 1-5 of [Spec 002 §Standard
+  EP-0022 (Slice C, rf2-0adhqs.3): this ns registers the framework-standard
+  `:rf.interceptor/path` interceptor as a `:factory`, referenced as
+  `[:rf.interceptor/path <path-vector>]`. Its `:factory` builds the FULL
+  standard-path interceptor (`standard-path-interceptor`) implementing the
+  normative rules 1-5 of [Spec 002 §Standard
   `:rf.interceptor/path`](../../../spec/002-Frames.md), notably **rule 4**:
   when the handler emits a `:db` effect whose focused value is `identical?`
   to the original focused slice, the interceptor widens back to the
@@ -26,78 +28,64 @@
   the frame-commit `identical?` no-op (rf2-ekq28v). A non-vector / malformed
   path argument is `:rf.error/path-interceptor-bad-path`.
 
-  This standard interceptor is DISTINCT from the legacy `path` fn / the
-  `rf/path` value constructor: the standard interceptor is the canonical
-  `:factory` consumer and is the carrier of the rule-4 identity-fast-path.
-  Since the EP-0022 reference-only flip (rf2-0adhqs.9) chains carry refs
-  only, the `path` fn's value is no longer a legal inline chain entry —
-  it is the underlying value builder the `:rf.interceptor/path` factory
-  consumes, and may still be registered at the `reg-interceptor` boundary
-  and referenced by id. (The legacy `path` value's own `:after` only
-  short-circuits the no-`:db` case, not the unchanged-slice case — which is
-  why the standard interceptor, not the legacy value, carries rule 4.)"
+  EP-0022 removed the public `rf/path` VALUE constructor (EP-0022:552/932):
+  there is no public path value-builder, only the `[:rf.interceptor/path
+  <path-vector>]` ref. The legacy `path` fn that the removed facade var aliased
+  is gone (rf2-dgtdna); a stale `(rf/path …)` call hits the `^:no-doc` throwing
+  stub `path-removed!` below, which names the ref form as the replacement. The
+  legacy value also had WEAKER semantics — its `:after` always re-spliced via
+  `assoc-in` when a `:db` effect was present, allocating a fresh top-level map
+  even for an UNCHANGED slice and defeating the rule-4 commit no-op
+  (rf2-ekq28v). The surviving `standard-path-interceptor` (the factory's
+  consumer) is the one path surface and is the carrier of that no-op."
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
+            [re-frame.error :as error]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- path -----------------------------------------------------------------
+;; ---- path: the removed value constructor (EP-0022, rf2-dgtdna) -------------
 ;;
-;; Focus a handler on an app-db sub-slice. The handler sees and returns
-;; only the slice; the interceptor splices the result back into the
-;; parent app-db. Per Spec 002 / API.md.
+;; EP-0022 (accepted) removed the public `rf/path` VALUE constructor: there is
+;; NO public path value-builder, only the framework-registered factory ref
+;; `[:rf.interceptor/path <path-vector>]` (EP-0022:552 "There is no public
+;; rf/path value constructor."; :932 lists the removal). The implementation had
+;; DRIFTED — it kept exporting `rf/path` aliased to a legacy `path` fn here —
+;; and that fn was a footgun: its `:after` always re-spliced via `assoc-in`
+;; when a `:db` effect was present, allocating a fresh top-level map even for an
+;; UNCHANGED slice, defeating the rf2-ekq28v frame-commit `identical?` no-op
+;; the canonical `standard-path-interceptor` (below) preserves. rf2-dgtdna
+;; removes the legacy fn and replaces the facade var with a `^:no-doc` throwing
+;; stub (the project's actionable-removed-API pattern, like
+;; `:rf.error/inject-cofx-removed` / `reg-event-db-removed`).
+;;
+;; The stub throws the canonical `re-frame.error/throw-error!` hard error
+;; naming the replacement ref, so a stale `(rf/path …)` call fails LOUDLY and
+;; actionably rather than as an opaque "no such var" or a working footgun. It
+;; does NOT fan out onto the always-on error-emit channel: unlike the
+;; reg-event / inject-cofx removed stubs (whose Spec 009 §Error event catalogue
+;; rows + always-on conformance pins were authored alongside them), this is an
+;; implementation-only drift fix (API.md + EP-0022 already correct) and rides
+;; no catalogued category — just the actionable throw.
 
-(defn path
-  "(path :a :b :c) returns an interceptor that focuses the handler on the
-  sub-slice at [:a :b :c]. The handler receives the slice value as :db
-  (not the full app-db); its returned :db is spliced back into the
-  full app-db at the same path."
+(defn ^:no-doc path-removed!
+  "REMOVED in EP-0022 (no alias). The public `rf/path` VALUE constructor is
+  gone; the one path surface is the framework-registered factory ref
+  `[:rf.interceptor/path <path-vector>]` in a handler's `:interceptors` chain.
+  Calling `rf/path` is the hard error `:rf.error/path-removed`, naming that ref
+  as the replacement. See spec/API.md §Standard interceptors,
+  EP-0022 §Registered interceptors, and docs/api/15-removed.md."
   [& path-segs]
   (let [path-vec (vec path-segs)]
-    (interceptor/->interceptor*
-      :id    :path
-      :path  path-vec
-      :before
-      (fn [ctx]
-        (-> ctx
-            ;; Stash the original db on a stack (supports nested path
-            ;; interceptors). Reserved-namespace slot per Spec
-            ;; Conventions §Reserved namespaces — framework keys on the
-            ;; interceptor context belong under :rf/...
-            (update :rf/path-stack (fnil conj []) (:db (:coeffects ctx)))
-            (assoc-in [:coeffects :db]
-                      (get-in (:db (:coeffects ctx)) path-vec))))
-      :after
-      (fn [ctx]
-        ;; Guard: only unwind when our `:before` actually pushed. When an
-        ;; EARLIER interceptor's `:before` throws, `execute-chain`
-        ;; short-circuits all downstream `:before` stages (including
-        ;; ours) yet still runs every `:after` in reverse (Spec 002
-        ;; §rule 2). With no push, `:rf/path-stack` is absent — `(pop [])`
-        ;; would throw a SPURIOUS second error masking the original. The
-        ;; sibling `unwrap` interceptor mirrors this guard via its
-        ;; `:rf/unwrap-stash` presence check. No stack → no-op teardown.
-        (let [stack (:rf/path-stack ctx)]
-          (if (empty? stack)
-            ctx
-            ;; The splice-back only fires when the handler actually
-            ;; emitted a `:db` effect. If the handler returned no `:db`,
-            ;; the slice didn't change and we MUST NOT synthesise a `:db`
-            ;; effect — downstream tools rely on "no `:db` effect = no DB
-            ;; write" (the docstring contract). Synthesising would be
-            ;; idempotent at the value level (same `original-db`
-            ;; re-spliced with the same pre-handler slice) but allocated a
-            ;; fresh map per path-walk-step and produced a spurious `:db`
-            ;; effect from a no-`:db` handler.
-            (let [original-db (peek stack)
-                  new-stack   (pop stack)
-                  handler-emitted-db? (contains? (:effects ctx) :db)]
-              (cond-> (assoc ctx :rf/path-stack new-stack)
-                handler-emitted-db?
-                (assoc-in [:effects :db]
-                          (assoc-in original-db path-vec
-                                    (get-in ctx [:effects :db])))))))))))
+    (error/throw-error!
+      :rf.error/path-removed
+      'rf/path
+      (str "`rf/path` is REMOVED in EP-0022 (no public path value "
+           "constructor). Reference the framework-standard path interceptor by "
+           "id in the handler's `:interceptors` chain: "
+           "`{:interceptors [[:rf.interceptor/path " (pr-str path-vec) "]]}`.")
+      {:extra {:got path-vec}})))
 
 ;; ---- standard :rf.interceptor/path (EP-0022 Slice C — FULL contract) -------
 ;;
@@ -108,13 +96,14 @@
 ;; unchanged focused slice widens back to the ORIGINAL full app-db OBJECT so
 ;; the frame-commit `identical?` no-op (rf2-ekq28v) is preserved.
 ;;
-;; This is DISTINCT from the legacy `path` fn above. The legacy fn (the
-;; `rf/path` value builder) only short-circuits the no-`:db`
-;; case; it still does `(assoc-in original-db path slice)` when a `:db` effect
-;; is present, allocating a fresh top-level map even for an unchanged slice —
-;; which defeats the commit no-op. The standard interceptor knows BOTH the
-;; original full app-db object AND the original focused slice, so it can detect
-;; the unchanged-slice case and re-emit the original object.
+;; This is the ONE path surface (the removed legacy `path` fn / `rf/path` value
+;; builder only short-circuited the no-`:db` case; it still did
+;; `(assoc-in original-db path slice)` when a `:db` effect was present,
+;; allocating a fresh top-level map even for an unchanged slice — which defeated
+;; the commit no-op, and is why EP-0022 removed it; rf2-dgtdna). The standard
+;; interceptor knows BOTH the original full app-db object AND the original
+;; focused slice, so it can detect the unchanged-slice case and re-emit the
+;; original object.
 
 (defn- throw-bad-path!
   "Throw the canonical `:rf.error/path-interceptor-bad-path` error (Spec 002

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -2,12 +2,15 @@
   "Dedicated coverage for the v2 retained interceptor surface (Spec 002).
 
   v2 trims the v1 interceptor stdlib down to a tiny retained set:
-    - path
-    - unwrap
+    - the framework-standard `[:rf.interceptor/path <path-vector>]` ref
+      (its consumer `standard-path-interceptor`)
+    - unwrap (the `unwrap-interceptor` value)
     - ->interceptor (and the supporting context plumbing)
 
   (`inject-cofx` is removed — EP-0017 / rf2-w9xyx1 — not on the facade;
-  coeffect delivery is the `:rf.cofx/requires` declaration.)
+  coeffect delivery is the `:rf.cofx/requires` declaration. The public
+  `rf/path` VALUE constructor is removed too — EP-0022 / rf2-dgtdna — a stale
+  `(rf/path …)` call is the hard error `:rf.error/path-removed` naming the ref.)
 
   These are exercised obliquely by smoke / conformance tests, but nothing
   pins their contract directly. This namespace does — one deftest per
@@ -22,6 +25,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.interceptor :as interceptor]
+            [re-frame.std-interceptors :as std-interceptors]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -109,11 +113,11 @@
           "the rename did not break the path interceptor's splice-back behaviour"))))
 
 (deftest path-interceptor-nesting
-  (testing "nested (path ...) interceptors compose correctly — the LIFO
-            stack semantics of :rf/path-stack mean an inner path's :after
-            restores the outer slice and the outer :after splices back into
-            the full app-db. Pins the stack semantics independent of the
-            slot-key rename (rf2-mn0qc)."
+  (testing "nested [:rf.interceptor/path …] interceptors compose correctly —
+            the LIFO stack semantics of :rf.interceptor.path/stack mean an inner
+            path's :after restores the outer slice and the outer :after splices
+            back into the full app-db. Pins the stack semantics independent of
+            the slot-key rename (rf2-mn0qc)."
     (rf/reg-event :path-nest/init (fn [{:keys [db]} _] {:db {:a {:b {:c 7} :sib :keep}}}))
     (rf/reg-event :path-nest/inc
                      ;; The outer `path` focuses to {:b {:c 7} :sib :keep};
@@ -196,27 +200,31 @@
 
 ;; Per rf2-mas2y: when an EARLIER interceptor's `:before` throws,
 ;; `execute-chain` short-circuits all downstream `:before` stages
-;; (including `path`'s) yet still runs every `:after` in reverse
-;; (teardown contract). `path`'s `:before` therefore never pushed onto
-;; `:rf/path-stack`, so its `:after` must NOT call `(pop [])` — that
-;; would throw a SPURIOUS second error masking the original cause. The
-;; sibling `unwrap` interceptor is already guarded for this case (it
-;; no-ops when `:rf/unwrap-stash` is absent); `path` mirrors that guard.
+;; (including the path interceptor's) yet still runs every `:after` in reverse
+;; (teardown contract). The path interceptor's `:before` therefore never pushed
+;; onto `:rf.interceptor.path/stack`, so its `:after` must NOT call `(pop [])` —
+;; that would throw a SPURIOUS second error masking the original cause. The
+;; sibling `unwrap` interceptor is already guarded for this case (it no-ops when
+;; `:rf/unwrap-stash` is absent); the path interceptor mirrors that guard.
 ;;
-;; Source: std_interceptors.cljc — `path`'s `:after` no-ops when
-;; `:rf/path-stack` is empty.
+;; rf2-dgtdna: the legacy `rf/path` value constructor is removed (EP-0022); the
+;; surviving path surface is `standard-path-interceptor` (the
+;; `[:rf.interceptor/path …]` factory's consumer), so this raw-chain test builds
+;; that interceptor value directly. Source: std_interceptors.cljc —
+;; `standard-path-interceptor`'s `:after` no-ops when
+;; `:rf.interceptor.path/stack` is empty.
 
 (deftest path-interceptor-after-no-ops-when-before-short-circuited
-  (testing "(path ...) :after does not throw and preserves the original
-            error when an upstream interceptor's :before throws first"
+  (testing "the path interceptor's :after does not throw and preserves the
+            original error when an upstream interceptor's :before throws first"
     (let [boom    (interceptor/->interceptor*
                     :id     :path-short/boom
                     :before (fn [_ctx]
                               (throw (ex-info "before blew up"
                                               {:src :path-short/boom}))))
-          ;; Order: boom (throws in :before) → path (its :before is
+          ;; Order: boom (throws in :before) → path interceptor (its :before is
           ;; short-circuited, but its :after still runs in reverse).
-          chain   [boom (rf/path :foo :bar)]
+          chain   [boom (std-interceptors/standard-path-interceptor [:foo :bar])]
           final   (interceptor/execute-chain
                     chain
                     {:coeffects {:db {:foo {:bar 10}}} :effects {}})
@@ -226,13 +234,14 @@
       (is (= :before (get-in final [:rf/interceptor-error :phase]))
           "the FIRST error is the upstream :before throw")
       (is (= 1 (count errs))
-          "exactly one error — path's :after did NOT synthesise a spurious
-           second error from (pop [])")
+          "exactly one error — the path interceptor's :after did NOT synthesise
+           a spurious second error from (pop [])")
       (is (= [:path-short/boom] (mapv :id errs))
-          "no error attributed to :path — its :after no-opped cleanly")
+          "no error attributed to the path interceptor — its :after no-opped
+           cleanly")
       (is (not (contains? (:effects final) :db))
-          "path's no-op :after produced no :db effect when its :before
-           never ran"))))
+          "the path interceptor's no-op :after produced no :db effect when its
+           :before never ran"))))
 
 ;; ---- unwrap ---------------------------------------------------------------
 

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -517,10 +517,11 @@
 ;; ===========================================================================
 
 (deftest reg-event-path-interceptor-works-with-db-slice-return
-  (testing "EP-0018 §6: `(rf/path …)` focuses the handler on a sub-slice — the
-            handler sees the SLICE as `:db` and returns `{:db slice}`, which the
-            interceptor splices back at the path (the bare-slice return is gone;
-            it is `{:db slice}` now)"
+  (testing "EP-0018 §6: the `[:rf.interceptor/path …]` ref focuses the handler
+            on a sub-slice — the handler sees the SLICE as `:db` and returns
+            `{:db slice}`, which the interceptor splices back at the path (the
+            bare-slice return is gone; it is `{:db slice}` now). EP-0022: there
+            is no public `rf/path` value constructor — the chain carries the ref"
     (rf/reg-sub :evt-conf/counter (fn [db _] (:counter db)))
     (rf/reg-event :evt-conf/inc-via-path
       {:interceptors [[:rf.interceptor/path [:counter]]]}

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -1578,7 +1578,7 @@
 
 (deftest flow-reads-full-db-under-path-scoped-handler
   (testing "rf2-u0zz5: a flow reading a full-db path sees the FULL reshaped db
-            even when the triggering handler is `(rf/path ...)`-scoped"
+            even when the triggering handler is `[:rf.interceptor/path …]`-scoped"
     ;; The handler writes the :counter slice (path-scoped). The flow reads
     ;; the FULL-DB path [:counter :n] and writes [:counter :doubled]. The
     ;; flow transform must run against the FULL db (after the path

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -504,7 +504,18 @@
   ["re-frame.core" "assoc-coeffect"]      {:tier :advanced :owner "002" :status "v1 (preserved)"}
   ["re-frame.core" "get-effect"]          {:tier :advanced :owner "002" :status "v1 (preserved)"}
   ["re-frame.core" "assoc-effect"]        {:tier :advanced :owner "002" :status "v1 (preserved)"}
-  ["re-frame.core" "path"]                {:tier :front-porch :owner "002" :status "v1 (preserved)"}
+  ;; EP-0022 + rf2-dgtdna: the public `re-frame.core/path` VALUE constructor is
+  ;; REMOVED (EP-0022:552 "There is no public rf/path value constructor."; :932
+  ;; lists the removal; spec/API.md + spec/002-Frames.md already follow it). The
+  ;; one public path surface is the framework-registered factory ref
+  ;; `[:rf.interceptor/path <path-vector>]`. rf2-dgtdna removed the legacy
+  ;; std-interceptors `path` fn and replaced the facade var with a `^:no-doc`
+  ;; throwing stub naming the ref (`:rf.error/path-removed`) — like the EP-0018
+  ;; `reg-event-db` / EP-0017 `inject-cofx` removed stubs, a removed-name `^:no-
+  ;; doc` stub carries NO manifest row (the generator drops `^:no-doc` vars; a
+  ;; `:deprecated`/preserved row would still read as supported public API). The
+  ;; migration alarm is the always-loud throw itself. Migration docs live in
+  ;; docs/api/15-removed.md.
   ["re-frame.core" "unwrap-interceptor"]  {:tier :advanced :owner "002" :status "v1"}
   ["re-frame.core" "with-fx-overrides"]   {:tier :testing :owner "002" :status "v1"}
   ;; EP-0015 §7 + bead item 2 (rf2-mngp4o): `redact-interceptor` is removed

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 507,
+ :var-count 506,
  :tier-vocab
  [:front-porch
   :advanced
@@ -147,7 +147,6 @@
   {:namespace "re-frame.core", :var "mutation-meta", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutation-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutations", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
-  {:namespace "re-frame.core", :var "path", :tier :front-porch, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "project-egress", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "project-error", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "projected-history", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
## Summary

EP-0022 (accepted) ruled the public `rf/path` **value constructor** removed (EP-0022:552 "There is no public rf/path value constructor."; :932 lists the removal). `spec/API.md` + `spec/002-Frames.md` already follow it — the one public path surface is the framework-registered factory ref `[:rf.interceptor/path <path-vector>]`. The **implementation had drifted**: it kept exporting `rf/path` aliased to a legacy `std-interceptors/path` fn. This PR reconciles the implementation to the already-correct spec (rf2-dgtdna, ruling option (a)).

The legacy fn was also a footgun: its `:after` always re-spliced via `assoc-in` when a `:db` effect was present, allocating a fresh top-level map even for an **unchanged** slice — defeating the rf2-ekq28v frame-commit `identical?` no-op that the canonical `standard-path-interceptor` (the factory's consumer, kept) preserves.

## Changes

- **Drop the dead legacy `std-interceptors/path` fn.** Its only consumer was the facade var; the `:rf.interceptor/path` factory uses the **distinct** `standard-path-interceptor` (verified by grep). `standard-path-interceptor` + the `:rf.interceptor/path` factory are kept — the one v2 path surface.
- **Replace `re-frame.core/path` with a `^:no-doc` throwing removed-name stub** (`std-interceptors/path-removed!`) built via the new `re-frame.error/throw-error!`. A stale `(rf/path …)` call is the hard error `:rf.error/path-removed`, naming `[:rf.interceptor/path <path-vector>]` as the replacement (the project's actionable-removed-API pattern, like the EP-0018 `reg-event-db` / EP-0017 `inject-cofx` stubs). The stub does **not** fan out onto the always-on error-emit channel — this is an implementation-only drift fix (API.md + EP-0022 already correct), so it rides no Spec 009 catalogue category and needs no catalogue co-edit.
- **Manifest (var first, sidecar second):** removed the `["re-frame.core" "path"]` row from `spec/api-manifest-metadata.edn` and regenerated `spec/api-manifest.edn`. The `^:no-doc` generator drop means the live var carries no sidecar classification gap.
- **Swept call-sites:** the one live `(rf/path …)` invocation (`interceptor_test.clj` raw-chain no-op test) now builds `standard-path-interceptor` directly. The other two named sites were prose-only testing-string labels (their bodies already used the `[:rf.interceptor/path …]` ref) — updated for accuracy. A `router.cljc` comment + the test ns docstrings were updated to match.

`unwrap-interceptor` was **not** touched (separate bead rf2-3qeu38).

## Rebase reconciliation (onto current main)

Rebased onto `origin/main` after #4345 (rf2-1we9fa) merged, which **added** the `re-frame.core/group-cascades-with-events` facade export + its manifest row. Conflicts resolved keeping **both** intents:

- `implementation/core/src/re_frame/core.cljc` — auto-merged cleanly (the `path` removed-stub at ~L2044 and the new `group-cascades-with-events` export at ~L2331 are far apart). Both present.
- `spec/api-manifest-metadata.edn` — auto-merged cleanly: `path` row absent, `group-cascades-with-events` row present.
- `spec/api-manifest.edn` (**generated**) — only conflict was the `:var-count` scalar (main 507 vs this 505). Not hand-merged; **regenerated** with `clojure -M -m re-frame.api-manifest.gen`. Net **506** vars (506 base − 1 `path` + 1 `group-cascades-with-events`); `gen --check` GREEN.

## Quality gates

| Gate | Result |
| --- | --- |
| `clojure -M -m re-frame.api-manifest.gen --check` (post-rebase regen) | GREEN — in sync (506 public vars; `group-cascades-with-events` present, `path` absent) |
| `re-frame.interceptor-test` (JVM, swept to `standard-path-interceptor`) | GREEN — 19 tests, 106 assertions, 0 failures |
| core JVM suite (`clojure -M:test`) | GREEN — 1539 tests, 6808 assertions, 0 failures |
| `group-cascades-with-events` resolves (REPL) | GREEN — `(resolve 're-frame.core/group-cascades-with-events)` non-nil |
| `path` removed-stub behaviour (REPL) | `(rf/path [:a :b])` throws `:rf.error/path-removed`, names the `[:rf.interceptor/path …]` ref as replacement |

`npm run test:elision` not run — the change does not touch elision (per the bead's own guidance).

Closes rf2-dgtdna.
