### PR TITLE
feat(pair): error diagnostics through builder + vestigial review

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -455,6 +455,58 @@
       {:ok? false :reason :no-such-frame :frame-id id}))
 
 ;; ---------------------------------------------------------------------------
+;; Ambiguous-frame diagnostics (rf2-n58jxo)
+;;
+;; A read/mutate op that can't resolve a single operating frame in a
+;; multi-frame session used to refuse with a bare `{:ok? false :reason
+;; :ambiguous-frame :hint "..."}` — no operation name, no available-frame
+;; list, no current-frame context. An agent then had to round-trip
+;; `frames-list` (or `discover-app`) just to learn WHICH frames it could
+;; pick from and HOW to pin one. `ambiguous-frame-error` builds the
+;; enriched envelope once so every refusal site carries:
+;;
+;;   :operation       the op that refused (`:dispatch`, `:read-sub`, …) —
+;;                    the machine handle for the failing call.
+;;   :event / :query  the event-vector / query-vector when the op knows it
+;;                    (omitted for context-free ops like `sub-cache-info`).
+;;   :available-frames the registered APP frames in the operating realm —
+;;                    the set the caller may pin / pass (`app-frame-ids`).
+;;   :operating-realm  the realm tier-3 resolution scopes to, so a
+;;                    multi-realm session sees which realm the candidate
+;;                    frames live in.
+;;   :selected-frame   the current session pin (nil = none), so the caller
+;;                    knows whether a prior `select-frame!` is in effect.
+;;   :hint             the human sentence + the concrete fix (pass `frame`
+;;                    or pin via `select-frame!` / `set-operating-frame`).
+;;
+;; `:reason :ambiguous-frame` stays the SOLE machine discriminator (the
+;; documented bare-dialect reason, Tool-Catalogue §307) — the new slots
+;; are additive context, never a discriminator change.
+;; ---------------------------------------------------------------------------
+
+(defn ambiguous-frame-error
+  "Build the enriched `:ambiguous-frame` refusal envelope (rf2-n58jxo).
+   `operation` is the refusing op keyword; `extra` (optional) carries the
+   op-specific context the caller knows — `:event`, `:query`, `:query-v`.
+   The envelope always carries the available app frames, the operating
+   realm, the current session pin, and the concrete fix in `:hint`."
+  ([operation] (ambiguous-frame-error operation nil))
+  ([operation extra]
+   (let [frames (app-frame-ids)]
+     (merge
+       {:ok?              false
+        :reason           :ambiguous-frame
+        :operation        operation
+        :available-frames frames
+        :operating-realm  (operating-realm)
+        :selected-frame   @selected-frame
+        :hint             (str "multiple app frames are registered and no frame is "
+                               "selected, so " (name operation) " cannot pick a target. "
+                               "Pass `frame` (one of " (pr-str frames) ") or pin one with "
+                               "`select-frame!` / set-operating-frame, then retry.")}
+       extra))))
+
+;; ---------------------------------------------------------------------------
 ;; app-db read/write
 ;; ---------------------------------------------------------------------------
 ;;
@@ -899,9 +951,7 @@
    (let [{:keys [frame include-values?]} opts
          frame-id (current-frame frame)]
      (if (nil? frame-id)
-       {:ok?    false
-        :reason :ambiguous-frame
-        :hint   "Multi-frame session with no selected frame — pass `frame` or call `select-frame!` first."}
+       (ambiguous-frame-error :sub-cache-info)
        (let [cache (or (subs-tooling/sub-cache-snapshot frame-id) {})
              qvs   (sort-by pr-str (keys cache))]
          {:ok?   true
@@ -935,8 +985,7 @@
   ([query-v frame-id]
    (cond
      (nil? frame-id)
-     {:ok? false :reason :ambiguous-frame
-      :hint "Multi-frame session with no selected frame — pass `frame-id` or call `select-frame!` first."}
+     (ambiguous-frame-error :subs-sample {:query query-v})
 
      :else
      (try
@@ -994,10 +1043,7 @@
          (assoc v :subscribed? false)
 
          (nil? frame-id)
-         {:ok?    false
-          :reason :ambiguous-frame
-          :query-v query-v
-          :hint   "Multi-frame session with no selected frame — pass `frame-id` or call `select-frame!` first."}
+         (ambiguous-frame-error :read-sub {:query query-v :query-v query-v})
 
          :else
          (try
@@ -2327,7 +2373,12 @@
   ([event-v opts]
    (let [frame-id  (or (:frame opts) (current-frame))
          _         (when-not frame-id
-                     (throw (ex-info "ambiguous frame" {:reason :ambiguous-frame})))
+                     ;; rf2-n58jxo — carry the enriched ambiguous-frame
+                     ;; context (operation, event, available frames, current
+                     ;; pin, fix) as ex-data so the MCP `.catch` →
+                     ;; `err->result` surfaces it verbatim, not a bare reason.
+                     (throw (ex-info "ambiguous frame"
+                                     (ambiguous-frame-error :dispatch {:event event-v}))))
          ;; EP-0002 (rf2-9o48ih): thread the resolved operating frame in as
          ;; the explicit `:frame` override — the nREPL eval thread carries no
          ;; ambient `with-frame` scope, so `rf/dispatch-sync` would otherwise
@@ -2621,7 +2672,10 @@
   ([event-v opts]
    (let [frame-id  (or (:frame opts) (current-frame))
          _         (when-not frame-id
-                     (throw (ex-info "ambiguous frame" {:reason :ambiguous-frame})))
+                     ;; rf2-n58jxo — enriched ambiguous-frame context (see
+                     ;; pair-dispatch-sync!); dry-run knows the event vector.
+                     (throw (ex-info "ambiguous frame"
+                                     (ambiguous-frame-error :dispatch-dry-run {:event event-v}))))
          before-id (some-> (rf/epoch-history frame-id) peek :epoch-id)
          overrides (build-dry-run-overrides)
          _         (reset! dry-run-recordings [])
@@ -3763,8 +3817,7 @@
        :hint "pass a non-empty :signals vector, e.g. [{:focus true} {:dom \"#count\"} {:app-db [:cart :items]}]"}
 
       (and needs-frame? (nil? frame-id))
-      {:ok? false :reason :ambiguous-frame
-       :hint "an :app-db / :sub signal needs a frame — pass :frame or call select-frame! first."}
+      (ambiguous-frame-error :record)
 
       :else
       (let [rid (str "rec-" (random-uuid))

--- a/skills/re-frame2-pair/references/errors.md
+++ b/skills/re-frame2-pair/references/errors.md
@@ -10,7 +10,7 @@ Every script returns structured edn like `{:ok? false :reason ...}` rather than 
 - `:debug-disabled` → re-frame2's `interop/debug-enabled?` is false (production build, or `goog.DEBUG` was set false). The trace stream and epoch history are elided in this build.
 - `:ns-not-loaded :missing :re-frame2` → re-frame2 isn't loaded; check the user's deps.
 - `:no-frames-registered` → no frame is up yet. Tell the user to call `(rf/init!)` (or wait for app boot).
-- `:ambiguous-frame` → multiple frames are registered and no session pin is set. Pin one with `set-operating-frame {frame: ":foo"}` (the escape from this refusal — SKILL.md §Multi-frame model), or pass a per-call `frame: ":foo"` arg.
+- `:ambiguous-frame` → multiple frames are registered and no session pin is set. The envelope is recovery-shaped: `:operation` (the refusing op), `:available-frames` (the app frames you may pick from), `:operating-realm`, `:selected-frame` (the current pin, nil = none), and `:event` / `:query` when the op knew it. Pin one of `:available-frames` with `set-operating-frame {frame: ":foo"}` (the escape from this refusal — SKILL.md §Multi-frame model), or pass a per-call `frame: ":foo"` arg.
 - `:handler-error` inside an epoch → the user's handler threw; surface the `:rf.error/handler-exception` trace event from `(re-frame.trace.tooling/trace-buffer {:op-type :error})`. (Use the `re-frame.trace.tooling` ns — `rf/trace-buffer` is JVM-only and returns nil in the browser runtime.)
 
 ## A structured read came back blank

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -280,14 +280,23 @@
       :else
       (let [outer (safe-edn (str (:value res)))]
         (cond
+          ;; rf2-n58jxo (mirrors the MCP-side rf2-mvdwv fix in nrepl.cljs) —
+          ;; a populated `:err` on shadow's outer response is an analyzer
+          ;; warning (unresolved symbol) or a compile error. It MUST surface
+          ;; even though shadow ALSO pushes a "nil" into `:results`: peeking
+          ;; `:results` FIRST (the pre-fix order) swallowed the compile
+          ;; failure as a silent nil — the CLI eval reported success-shaped
+          ;; while the form never produced a real value. The `:err` branch
+          ;; now takes precedence so a compile error/warning is DISTINCT from
+          ;; a runtime throw (`:eval-error`, the `:ex` path above).
+          (and (map? outer) (not (str/blank? (str (:err outer)))))
+          (throw (ex-info "cljs eval compile error/warning"
+                          {:reason :cljs-eval-error
+                           :err (str/trim (str (:err outer)))}))
+
           (and (map? outer) (vector? (:results outer)))
           (when-let [last-result (peek (:results outer))]
             (safe-edn last-result))
-
-          (and (map? outer) (:err outer))
-          (throw (ex-info "cljs eval error"
-                          {:reason :cljs-eval-error
-                           :err (:err outer)}))
 
           :else outer)))))
 

--- a/skills/re-frame2-pair/tests/runtime/multi_frame_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/multi_frame_test.clj
@@ -153,6 +153,31 @@
            (first app-fids))))))
 
 ;; ---------------------------------------------------------------------------
+;; Mirror of `ambiguous-frame-error` (rf2-n58jxo) — the enriched refusal
+;; envelope: operation, op-specific context, available app frames, the
+;; operating realm, the current pin, and the concrete fix.
+;;
+;; KEEP IN SYNC WITH preload/re_frame2_pair/runtime.cljs `ambiguous-frame-error`.
+;; ---------------------------------------------------------------------------
+
+(defn ambiguous-frame-error
+  ([operation] (ambiguous-frame-error operation nil))
+  ([operation extra]
+   (let [frames (app-frame-ids)]
+     (merge
+       {:ok?              false
+        :reason           :ambiguous-frame
+        :operation        operation
+        :available-frames frames
+        :operating-realm  (operating-realm)
+        :selected-frame   @selected-frame
+        :hint             (str "multiple app frames are registered and no frame is "
+                               "selected, so " (name operation) " cannot pick a target. "
+                               "Pass `frame` (one of " (pr-str frames) ") or pin one with "
+                               "`select-frame!` / set-operating-frame, then retry.")}
+       extra))))
+
+;; ---------------------------------------------------------------------------
 ;; Mirror of `subs-sample` — threads the resolved frame through
 ;; `subscribe` and refuses on :ambiguous-frame.
 ;;
@@ -164,8 +189,7 @@
   ([query-v frame-id]
    (cond
      (nil? frame-id)
-     {:ok? false :reason :ambiguous-frame
-      :hint "Multi-frame session with no selected frame — pass `frame-id` or call `select-frame!` first."}
+     (ambiguous-frame-error :subs-sample {:query query-v})
 
      :else
      (try
@@ -187,7 +211,8 @@
   ([event-v opts]
    (let [frame-id (or (:frame opts) (current-frame))]
      (when-not frame-id
-       (throw (ex-info "ambiguous frame" {:reason :ambiguous-frame})))
+       (throw (ex-info "ambiguous frame"
+                       (ambiguous-frame-error :dispatch {:event event-v}))))
      ;; Real impl runs `dispatch-sync` and walks epoch-history; for the
      ;; test the guard is the contract — return a success shape so the
      ;; non-ambiguous case still asserts something meaningful.
@@ -401,7 +426,18 @@
       (pair-dispatch-sync! [:cart/apply-coupon "SPRING25"])
       (is false "expected ex-info :ambiguous-frame to be thrown")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :ambiguous-frame (:reason (ex-data e))))))))
+        (let [data (ex-data e)]
+          (is (= :ambiguous-frame (:reason data)))
+          ;; rf2-n58jxo — the throw carries the enriched diagnostics: the
+          ;; operation, the event being dispatched, the available app
+          ;; frames, the current pin, and a fix-bearing hint.
+          (is (= :dispatch (:operation data)))
+          (is (= [:cart/apply-coupon "SPRING25"] (:event data)))
+          (is (= #{:rf/default :stories} (set (:available-frames data)))
+              "available-frames enumerates the app frames the caller can pin")
+          (is (nil? (:selected-frame data)) "no pin set in an ambiguous session")
+          (is (re-find #"select-frame!|frame" (:hint data))
+              "hint names the fix"))))))
 
 (deftest pair-dispatch-sync-succeeds-on-single-frame
   (testing "single-frame session: pair-dispatch-sync! succeeds against :rf/default"
@@ -437,7 +473,11 @@
     (register-frame! :stories {:counter 1})
     (let [result (subs-sample [:counter])]
       (is (false? (:ok? result)))
-      (is (= :ambiguous-frame (:reason result))))))
+      (is (= :ambiguous-frame (:reason result)))
+      ;; rf2-n58jxo — enriched: operation, the query, the available frames.
+      (is (= :subs-sample (:operation result)))
+      (is (= [:counter] (:query result)))
+      (is (= #{:rf/default :stories} (set (:available-frames result)))))))
 
 (deftest subs-sample-reads-selected-frame
   (testing "select-frame! steers subs-sample to the chosen frame"

--- a/skills/re-frame2-pair/tests/runtime/read_sub_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/read_sub_test.clj
@@ -104,10 +104,14 @@
     (is (some? form))
     (doseq [slot [:unknown-id :ambiguous-frame :sub-error :not-a-sub-vector]]
       ;; :unknown-id is produced by validate-registered (called via
-      ;; validate-sub-id); the others are literal in read-sub!.
+      ;; validate-sub-id); :ambiguous-frame is now produced via the shared
+      ;; enriched builder `ambiguous-frame-error` (rf2-n58jxo) rather than an
+      ;; inline keyword; the others are literal in read-sub!.
       (is (or (form-contains? #(= slot %) form)
               (and (= slot :unknown-id)
-                   (form-contains? #(= 'validate-sub-id %) form)))
+                   (form-contains? #(= 'validate-sub-id %) form))
+              (and (= slot :ambiguous-frame)
+                   (form-contains? #(= 'ambiguous-frame-error %) form)))
           (str "read-sub! MUST surface " slot
                " (no silent nil — no-silent-swallow parity with dispatch).")))))
 
@@ -169,6 +173,16 @@
       (throw (ex-info "boom" {}))
       v)))
 
+;; Mirror of `ambiguous-frame-error` (rf2-n58jxo). The full runtime helper
+;; carries realm context; this read-sub mirror uses the simpler frame model
+;; (no realms) so it surfaces the load-bearing slots: operation, the query,
+;; the available frames, the current pin. KEEP THE SLOT CONTRACT IN SYNC.
+(defn ambiguous-frame-error [operation extra]
+  (merge {:ok? false :reason :ambiguous-frame :operation operation
+          :available-frames (vec (frame-ids))
+          :selected-frame @selected-frame}
+         extra))
+
 ;; Mirror of `read-sub!`. KEEP IN SYNC.
 (defn read-sub!
   ([query-v] (read-sub! query-v (current-frame)))
@@ -183,7 +197,7 @@
          (not (:ok? v)) (assoc v :subscribed? false)
 
          (nil? frame-id)
-         {:ok? false :reason :ambiguous-frame :query-v query-v}
+         (ambiguous-frame-error :read-sub {:query query-v :query-v query-v})
 
          :else
          (try
@@ -238,7 +252,12 @@
   (register-sub! :cart/total)
   (let [r (read-sub! [:cart/total])]
     (is (false? (:ok? r)))
-    (is (= :ambiguous-frame (:reason r)))))
+    (is (= :ambiguous-frame (:reason r)))
+    ;; rf2-n58jxo — enriched diagnostics on the refusal.
+    (is (= :read-sub (:operation r)))
+    (is (= [:cart/total] (:query r)))
+    (is (= #{:rf/default :rf/other} (set (:available-frames r)))
+        "available-frames enumerates the candidate frames")))
 
 (deftest sub-error-is-structured-not-nil
   ;; A sub handler that throws while computing returns :sub-error with the

--- a/skills/re-frame2-pair/tests/runtime/recorder_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/recorder_test.clj
@@ -178,8 +178,12 @@
         "start-recording! must default a wall-clock stop when none given")
     (is (form-contains? #(= % :no-signals) start)
         "start-recording! must refuse an empty signal-set")
-    (is (form-contains? #(= % :ambiguous-frame) start)
-        "start-recording! must refuse an unresolvable frame for app-db/sub signals")))
+    ;; rf2-n58jxo — the bare `:ambiguous-frame` literal was replaced by a
+    ;; call to the shared enriched builder `ambiguous-frame-error`; the
+    ;; contract (refuse an unresolvable frame for app-db/sub signals) is now
+    ;; carried by that call rather than an inline keyword.
+    (is (mentions-sym? start 'ambiguous-frame-error)
+        "start-recording! must refuse an unresolvable frame via ambiguous-frame-error")))
 
 ;; ---------------------------------------------------------------------------
 ;; READ-ONLY invariant — the recorder must never mutate the app.

--- a/skills/re-frame2-pair/tests/runtime/sub_cache_info_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/sub_cache_info_test.clj
@@ -104,14 +104,20 @@
 ;; preload/re_frame2_pair/runtime.cljs §Subscriptions.
 ;; ---------------------------------------------------------------------------
 
+;; Mirror of `ambiguous-frame-error` (rf2-n58jxo) — the load-bearing slots
+;; (operation, available frames, current pin). KEEP THE SLOT CONTRACT IN SYNC.
+(defn ambiguous-frame-error [operation]
+  {:ok? false :reason :ambiguous-frame :operation operation
+   :available-frames (vec (frame-ids))
+   :selected-frame @selected-frame})
+
 (defn sub-cache-info
   ([] (sub-cache-info {}))
   ([opts]
    (let [{:keys [frame include-values?]} opts
          frame-id (current-frame frame)]
      (if (nil? frame-id)
-       {:ok? false :reason :ambiguous-frame
-        :hint "Multi-frame session with no selected frame — pass `frame` or call `select-frame!` first."}
+       (ambiguous-frame-error :sub-cache-info)
        (let [cache (or (sub-cache-snapshot frame-id) {})
              qvs   (sort-by pr-str (keys cache))]
          {:ok?   true
@@ -233,7 +239,10 @@
   (let [r (sub-cache-info)]
     (is (false? (:ok? r)))
     (is (= :ambiguous-frame (:reason r))
-        "two frames + no selection ⇒ refuse rather than silently read :rf/default")))
+        "two frames + no selection ⇒ refuse rather than silently read :rf/default")
+    ;; rf2-n58jxo — enriched: operation + the available frames the caller can pin.
+    (is (= :sub-cache-info (:operation r)))
+    (is (= #{:rf/default :rf/xray} (set (:available-frames r))))))
 
 (deftest explicit-frame-and-pin-both-steer-the-read
   (register-frame! :rf/default)

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -357,6 +357,27 @@ the common path; the dialect cost would tax the common case.
 - `:rf.mcp/cursor-stale` ⇒ drop the cursor; restart pagination from
   the head (same as cross-MCP cursor-staleness on story-mcp).
 
+#### `:ambiguous-frame` carries enriched diagnostics
+
+A multi-frame session with no resolvable operating frame refuses every
+read/mutate op with `:reason :ambiguous-frame`. Beyond the bare reason
+the envelope carries the context an agent needs to recover in one step
+(no `frames-list` / `discover-app` round-trip):
+
+| Slot                | Meaning                                                                 |
+|---------------------|-------------------------------------------------------------------------|
+| `:operation`        | The op that refused (`:dispatch`, `:dispatch-dry-run`, `:read-sub`, `:subs-sample`, `:sub-cache-info`, `:record`). |
+| `:event` / `:query` | The event-vector (dispatch) or query-vector (sub reads) the op was about to act on, when known. |
+| `:available-frames` | The registered **app** frames in the operating realm — the exact set the caller may pin or pass. |
+| `:operating-realm`  | The realm tier-3 resolution scopes to, so a multi-realm session sees which realm the candidates live in. |
+| `:selected-frame`   | The current session pin (nil = none) — whether a prior `select-frame!` is in effect. |
+| `:hint`             | The human sentence + the concrete fix (pass `frame`, or pin via `select-frame!` / `set-operating-frame`). |
+
+`:reason :ambiguous-frame` remains the SOLE machine discriminator (a
+bare-dialect reason); the additional slots are additive context. An
+agent pins one of `:available-frames` and retries, or passes it as the
+`frame` arg.
+
 **Every `:ok? false` response is `isError: true`.** A known-tool failure —
 whatever the dialect of its `:reason` — is returned with the `tools/call`
 result's `isError: true` flag set (API §Result shape; 001-Wire-Protocol

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -537,8 +537,10 @@
   Promise resolving to a combined response `{:value :out :err :status :ex}`
   once a frame with `\"status\":[\"done\"]` arrives for this id.
 
-  Auto-(re)connects if the socket has dropped. Caller manages the
-  reinjection sentinel — see `tools.cljs`.
+  Auto-(re)connects if the socket has dropped. The runtime ships via the
+  shadow-cljs `:devtools :preloads` mechanism, so no per-op reinjection is
+  needed (the per-session inject fallback was cut for rf2-7dvg; tools probe
+  the preload marker via `tools.probe/ensure-runtime!`).
 
   ## Options (rf2-ambfv)
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_sub_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_sub_test.cljs
@@ -202,14 +202,26 @@
 
 (deftest ambiguous-frame-surfaces-as-error
   (async done
-    (let [runtime-result {:ok? false :reason :ambiguous-frame
-                          :query-v [:cart/total]
-                          :hint "Multi-frame session with no selected frame — pass `frame-id`..."}]
+    ;; rf2-n58jxo — the runtime now refuses with the enriched ambiguous-frame
+    ;; envelope (operation, query, available frames, current pin, fix-hint).
+    ;; The tool wrap must carry every slot back to the agent verbatim.
+    (let [runtime-result {:ok?              false
+                          :reason           :ambiguous-frame
+                          :operation        :read-sub
+                          :query            [:cart/total]
+                          :query-v          [:cart/total]
+                          :available-frames [:rf/default :stories]
+                          :selected-frame   nil
+                          :hint             "pass `frame` (one of [:rf/default :stories]) or pin one"}]
       (stub-eval! nil runtime-result)
       (-> (read-sub/read-sub-tool (fresh-conn) #js {:sub "[:cart/total]"})
           (.then (fn [r]
                    (is (err? r))
-                   (is (= :ambiguous-frame (:reason (read-result-text r))))
+                   (let [edn (read-result-text r)]
+                     (is (= :ambiguous-frame (:reason edn)))
+                     (is (= :read-sub (:operation edn)))
+                     (is (= [:rf/default :stories] (:available-frames edn))
+                         "the candidate frames ride back so the agent can pin one"))
                    (done)))))))
 
 (deftest sub-error-surfaces-as-error-not-nil


### PR DESCRIPTION
Actions two pair-mcp / pair-skill beads in one worker.

## rf2-n58jxo — standardize frame/build/eval error diagnostics

Pair tooling surfaces failures as result-envelopes following the
deliberately-documented three-dialect `:reason` vocabulary (Tool-Catalogue
§307) — that IS the "intentionally documented result-envelope reason
contract" the acceptance criteria allow as the alternative to a framework
`:rf.error/id` throw (pair tooling does not throw framework-style errors at
the user; it returns `{:ok? false :reason ...}` envelopes).

Assessed against the four acceptance criteria:

- **Eval cluster (compile / runtime-throw / rejection / disabled /
  timeout)** — already covered (`:rf.error/eval-cljs-compile-error` in
  `nrepl.cljs`, `-threw` / `-rejected` / `-timeout` / `-disabled` /
  unserializable / mailbox-missing in `eval_cljs.cljs`). One CLI gap
  closed: `ops.clj`'s `cljs-eval-value` peeked `:results` before `:err`,
  swallowing a compile warning as a silent nil — fixed to surface
  `:cljs-eval-error` (mirrors the MCP-side rf2-mvdwv fix).
- **Build/runtime probe** — already preserves hints + enumerates running
  builds / port candidates (`probe.cljs` diagnostic ladder).
- **Ambiguous-frame (the real gap)** — refusals carried only a bare reason
  + generic hint. Added a shared `ambiguous-frame-error` builder in the
  runtime preload that enriches every refusal with the **operation**, the
  **event/query** when known, the **available app frames**, the
  **operating realm**, the **current session pin**, and a **fix-bearing
  hint**. Applied at all six refusal sites. `:reason :ambiguous-frame`
  stays the sole machine discriminator; the slots are additive context so
  an agent recovers in one step (no `frames-list` round-trip). Documented
  in spec §307 + `references/errors.md`.

## rf2-30tod6 — vestigial review (tools/re-frame2-pair-mcp)

Slice is clean. Evidence: all 52 `tools/*.cljs` namespaces are required
somewhere; no orphaned descriptors; `descriptor_manifest_gen` is wired via
`package.json`; the documented "legacy passthrough" arms in
`result_envelope.cljs` are deliberate additive-codec compatibility, not
vestige; `TODO/FIXME/deprecated` greps surface only a generic policy line.
One genuine finding actioned: a stale `send-op!` docstring cross-reference
to a removed reinjection sentinel (the per-session inject fallback was cut
for rf2-7dvg) — corrected to point at the preload-probe mechanism. No
follow-up beads filed.

## Quality gates

- `npm test` (pair-mcp `shadow-cljs compile server-test`): **1075 tests,
  3446 assertions, 0 failures, 0 errors, 0 warnings** — includes the
  updated MCP `read_sub_test.cljs`.
- bb runtime suite (all `tests/runtime/*.clj`): green — `multi_frame`
  (31/64), `read_sub` (11/32), `sub_cache_info` (10/26), `recorder`
  (9/36), plus the 12 untouched suites all 0/0.
- bb shim suite (drives `ops.clj`): 11 tests / 43 assertions, 0 failures.
- `npm run test:mcp-conformance`: **not affected** — the changes are
  additive ex-data slots on existing `:reason` envelopes; they don't touch
  the wire protocol, tool descriptors, or cross-MCP conformance surface.
  The in-tree `conformance_test.cljs` passed as part of the 1075.
