### PR TITLE
feat(core): canonicalize app-value/realm thrown discriminators via the error builder (vvixub child)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -94,6 +94,7 @@
   Closure DCE removes; an app that DOES call `rf/app` / `rf/install!` keeps
   exactly what it references."
   (:require [clojure.set        :as set]
+            [re-frame.error     :as error]
             [re-frame.realm     :as realm]
             [re-frame.frame     :as frame]
             [re-frame.registrar :as registrar]
@@ -402,10 +403,12 @@
   [descriptor-map]
   (let [id (:id descriptor-map)]
     (when (nil? id)
-      (throw (ex-info "rf/module requires an :id"
-                      {:error/id :rf.error/invalid-module
-                       :descriptor descriptor-map
-                       :recovery :supply-a-module-id})))
+      (error/throw-error!
+        :rf.error/invalid-module
+        'rf/module
+        "rf/module requires an :id — supply a module id (the provenance key every registration is owned by)."
+        {:recovery :supply-a-module-id
+         :extra    {:descriptor descriptor-map}}))
     (let [registrations
           (reduce-kv
             (fn [acc section entries]
@@ -419,11 +422,15 @@
                 ;; module — fail loudly rather than silently dropping it.
                 (if (contains? module-reserved-keys section)
                   acc
-                  (throw (ex-info (str "rf/module: unknown section key " section)
-                                  {:error/id :rf.error/invalid-module
-                                   :module id
-                                   :unknown-section section
-                                   :recovery :remove-or-correct-the-section-key})))))
+                  (error/throw-error!
+                    :rf.error/invalid-module
+                    'rf/module
+                    (str "rf/module: unknown section key " section
+                         " — remove or correct the section key (it is neither a"
+                         " registry-section name nor a reserved module key).")
+                    {:recovery :remove-or-correct-the-section-key
+                     :extra    {:module           id
+                                :unknown-section  section}}))))
             {}
             descriptor-map)]
       (cond-> {:rf.module/id       id
@@ -461,16 +468,19 @@
       (reduce-kv
         (fn [acc id desc]
           (if-let [existing (get-in acc [kind id])]
-            (throw (ex-info (str "app composition collision: two modules register "
-                                 kind " " id)
-                            {:error/id :rf.error/app-composition-collision
-                             :kind     kind
-                             :id       id
-                             :sources  [(cond-> {:module (:owner existing)}
-                                          (:source existing) (assoc :source (:source existing)))
-                                        (cond-> {:module (:owner desc)}
-                                          (:source desc) (assoc :source (:source desc)))]
-                             :recovery :rename-or-explicitly-replace}))
+            (error/throw-error!
+              :rf.error/app-composition-collision
+              'rf/app
+              (str "rf/app composition collision: two modules register "
+                   kind " " id " — composition is order-stable, never"
+                   " last-writer-wins; rename one or explicitly replace it.")
+              {:recovery :rename-or-explicitly-replace
+               :extra    {:kind    kind
+                          :id      id
+                          :sources [(cond-> {:module (:owner existing)}
+                                      (:source existing) (assoc :source (:source existing)))
+                                    (cond-> {:module (:owner desc)}
+                                      (:source desc) (assoc :source (:source desc)))]}})
             (assoc-in acc [kind id] desc)))
         acc
         id->desc))
@@ -516,17 +526,21 @@
   (let [id      (:id app-map)
         modules (vec (get app-map :modules []))]
     (when (nil? id)
-      (throw (ex-info "rf/app requires an :id"
-                      {:error/id :rf.error/invalid-app
-                       :app app-map
-                       :recovery :supply-an-app-id})))
+      (error/throw-error!
+        :rf.error/invalid-app
+        'rf/app
+        "rf/app requires an :id — supply an app id for the composed program."
+        {:recovery :supply-an-app-id
+         :extra    {:app app-map}}))
     (doseq [m modules]
       (when-not (and (map? m) (contains? m :rf.module/id))
-        (throw (ex-info "rf/app :modules entries must be module values (from rf/module)"
-                        {:error/id :rf.error/invalid-app
-                         :app id
-                         :bad-module m
-                         :recovery :wrap-the-descriptor-in-rf-module}))))
+        (error/throw-error!
+          :rf.error/invalid-app
+          'rf/app
+          "rf/app :modules entries must be module values (from rf/module) — wrap the descriptor in rf/module first."
+          {:recovery :wrap-the-descriptor-in-rf-module
+           :extra    {:app        id
+                      :bad-module m}})))
     ;; Module id is the PROVENANCE key — `:modules` is keyed by it, every
     ;; descriptor's `:owner` carries it, and `app-owns` resolves through it. A
     ;; duplicate `:rf.module/id` must not silently last-writer-win (rf2-c6armm.1
@@ -543,16 +557,18 @@
                             (if-let [prev (get acc mid)]
                               (if (= prev m)
                                 acc            ; exact-equal duplicate — idempotent
-                                (throw (ex-info
-                                         (str "rf/app: two distinct modules share the id "
-                                              mid " — module id is the provenance key, so a"
-                                              " divergent duplicate makes composition"
-                                              " order-dependent (not last-writer-wins).")
-                                         {:error/id :rf.error/app-composition-collision
-                                          :app      id
-                                          :kind     :module
-                                          :id       mid
-                                          :recovery :give-each-module-a-unique-id})))
+                                (error/throw-error!
+                                  :rf.error/app-composition-collision
+                                  'rf/app
+                                  (str "rf/app: two distinct modules share the id "
+                                       mid " — module id is the provenance key, so a"
+                                       " divergent duplicate makes composition"
+                                       " order-dependent (not last-writer-wins);"
+                                       " give each module a unique id.")
+                                  {:recovery :give-each-module-a-unique-id
+                                   :extra    {:app  id
+                                              :kind :module
+                                              :id   mid}}))
                               (assoc acc mid m))))
                         {}
                         modules)
@@ -696,15 +712,17 @@
     (map? realm-or-id)                          (realm/realm-id realm-or-id)
     (some? (realm/realm realm-or-id))           realm-or-id
     :else
-    (throw (ex-info (str "rf/install!: realm " realm-or-id
-                         " is not registered — an explicit realm must be"
-                         " constructed (rf/realm) before an app value can be"
-                         " installed into it. Absence defaults to the default"
-                         " realm; an unknown explicit id does not.")
-                    {:error/id    :rf.error/unknown-realm
-                     :realm       realm-or-id
-                     :known-realms (realm/realm-ids)
-                     :recovery    :construct-the-realm-first}))))
+    (error/throw-error!
+      :rf.error/unknown-realm
+      'rf/install!
+      (str "rf/install!: realm " realm-or-id
+           " is not registered — an explicit realm must be"
+           " constructed (rf/realm) before an app value can be"
+           " installed into it. Absence defaults to the default"
+           " realm; an unknown explicit id does not.")
+      {:recovery :construct-the-realm-first
+       :extra    {:realm        realm-or-id
+                  :known-realms (realm/realm-ids)}})))
 
 (defn- realm-capabilities
   "The realm's capability map (`:rf.capability/* → service`), or `{}` when the
@@ -723,14 +741,17 @@
   (let [have (set (keys (realm-capabilities rid)))]
     (doseq [cap (app-requires app)]
       (when-not (contains? have cap)
-        (throw (ex-info (str "rf/install!: realm " rid
-                             " does not satisfy required capability " cap)
-                        {:error/id   :rf.error/missing-capability
-                         :realm      rid
-                         :capability cap
-                         :required   (app-requires app)
-                         :available  have
-                         :recovery   :install-capability}))))))
+        (error/throw-error!
+          :rf.error/missing-capability
+          'rf/install!
+          (str "rf/install!: realm " rid
+               " does not satisfy required capability " cap
+               " — install the capability into the realm before installing the app.")
+          {:recovery :install-capability
+           :extra    {:realm      rid
+                      :capability cap
+                      :required   (app-requires app)
+                      :available  have}})))))
 
 (defn- registrations-seq
   "Flatten an app value's `:registrations` (`kind → id → descriptor`) into a
@@ -1059,19 +1080,21 @@
             live-in-realm   (get frames-by-realm rid #{})
             blocking        (set/intersection removed-frame-ids live-in-realm)]
         (when (seq blocking)
-          (throw (ex-info (str "rf/reinstall!: cannot remove the live frame(s) "
-                               (pr-str (sort blocking)) " from realm " rid
-                               " — a :frame descriptor still backs a live frame"
-                               " container. Removing it through the descriptor"
-                               " diff would orphan the container (its :on-destroy,"
-                               " machine teardown, and sub-cache disposal would be"
-                               " skipped). Destroy the frame explicitly"
-                               " (re-frame.frame/destroy-frame!) before reinstalling"
-                               " without it.")
-                          {:error/id       :rf.error/live-frame-removal-unsupported
-                           :realm          rid
-                           :live-frames    (vec (sort blocking))
-                           :recovery       :destroy-frame-then-reinstall})))))))
+          (error/throw-error!
+            :rf.error/live-frame-removal-unsupported
+            'rf/reinstall!
+            (str "rf/reinstall!: cannot remove the live frame(s) "
+                 (pr-str (sort blocking)) " from realm " rid
+                 " — a :frame descriptor still backs a live frame"
+                 " container. Removing it through the descriptor"
+                 " diff would orphan the container (its :on-destroy,"
+                 " machine teardown, and sub-cache disposal would be"
+                 " skipped). Destroy the frame explicitly"
+                 " (re-frame.frame/destroy-frame!) before reinstalling"
+                 " without it.")
+            {:recovery :destroy-frame-then-reinstall
+             :extra    {:realm       rid
+                        :live-frames (vec (sort blocking))}}))))))
 
 (defn reinstall!
   "Hot-reload a realm by replacing its installed app VALUE with `new-app` —

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -55,6 +55,7 @@
             ;; loads the ns explicitly from its tools-side build.
             #?@(:clj [[re-frame.trace.cascade]])
             [re-frame.event-emit :as event-emit]
+            [re-frame.error :as error]
             [re-frame.error-emit :as error-emit]
             [re-frame.elision :as elision]
             [re-frame.projection :as projection]
@@ -1735,18 +1736,21 @@
                (some? owner) (assoc :owner owner))]
     (cond
       (contains? install-deferred-kinds kind)
-      (throw (ex-info (str "rf/install!: descriptor kind " kind
-                           " is not yet installable — its real registration"
-                           " logic is a later EP-0013 slice (step 8). install!"
-                           " wires " (pr-str install-wired-kinds) " so far;"
-                           " seating " kind " through the flat registrar would"
-                           " produce a slot the subsystem cannot consume.")
-                      {:error/id    :rf.error/unsupported-descriptor-kind
-                       :kind        kind
-                       :id          id
-                       :wired       install-wired-kinds
-                       :deferred    install-deferred-kinds
-                       :recovery    :register-through-reg-*-sugar}))
+      (error/throw-error!
+        :rf.error/unsupported-descriptor-kind
+        'rf/install!
+        (str "rf/install!: descriptor kind " kind
+             " is not yet installable — its real registration"
+             " logic is a later EP-0013 slice (step 8). install!"
+             " wires " (pr-str install-wired-kinds) " so far;"
+             " seating " kind " through the flat registrar would"
+             " produce a slot the subsystem cannot consume."
+             " Register it through its own reg-* sugar.")
+        {:recovery :register-through-reg-*-sugar
+         :extra    {:kind     kind
+                    :id       id
+                    :wired    install-wired-kinds
+                    :deferred install-deferred-kinds}})
 
       :else
       (case kind
@@ -1803,28 +1807,30 @@
         [first-kind
          first-id]    (first blocking)]
     (when (seq blocking)
-      (throw (ex-info (str "rf/install!: cannot seat the descriptor(s) "
-                           (pr-str blocking) " — their kinds are step-8-DEFERRED "
-                           "(" (pr-str install-deferred-kinds) "), whose real "
-                           "registration logic is a later EP-0013 slice. install! "
-                           "wires " (pr-str install-wired-kinds) " so far; seating "
-                           "a deferred kind through the flat registrar would produce "
-                           "a slot the subsystem cannot consume. Refused BEFORE any "
-                           "lowering so no partially-seated runtime state (e.g. a "
-                           "live :frame container) leaks from a failed install. "
-                           "Register the deferred kinds through their own reg-* "
-                           "sugar.")
-                      ;; `:kind`/`:id` name the FIRST blocking pair (the same shape
-                      ;; `install-descriptor!`'s in-loop throw carried, so the
-                      ;; single-deferred-kind diagnostic is unchanged); `:blocking`
-                      ;; enumerates every blocking pair (the whole-app preflight).
-                      {:error/id    :rf.error/unsupported-descriptor-kind
-                       :kind        first-kind
-                       :id          first-id
-                       :blocking    blocking
-                       :deferred    install-deferred-kinds
-                       :wired       install-wired-kinds
-                       :recovery    :register-through-reg-*-sugar})))))
+      (error/throw-error!
+        :rf.error/unsupported-descriptor-kind
+        'rf/install!
+        (str "rf/install!: cannot seat the descriptor(s) "
+             (pr-str blocking) " — their kinds are step-8-DEFERRED "
+             "(" (pr-str install-deferred-kinds) "), whose real "
+             "registration logic is a later EP-0013 slice. install! "
+             "wires " (pr-str install-wired-kinds) " so far; seating "
+             "a deferred kind through the flat registrar would produce "
+             "a slot the subsystem cannot consume. Refused BEFORE any "
+             "lowering so no partially-seated runtime state (e.g. a "
+             "live :frame container) leaks from a failed install. "
+             "Register the deferred kinds through their own reg-* "
+             "sugar.")
+        {:recovery :register-through-reg-*-sugar
+         ;; `:kind`/`:id` name the FIRST blocking pair (the same shape
+         ;; `install-descriptor!`'s in-loop throw carried, so the
+         ;; single-deferred-kind diagnostic is unchanged); `:blocking`
+         ;; enumerates every blocking pair (the whole-app preflight).
+         :extra    {:kind     first-kind
+                    :id       first-id
+                    :blocking blocking
+                    :deferred install-deferred-kinds
+                    :wired    install-wired-kinds}}))))
 
 (late-bind/set-fn! :app-value/refuse-unsupported-install! refuse-unsupported-install!)
 
@@ -1862,24 +1868,26 @@
                       (sort)
                       (vec))]
     (when (seq blocking)
-      (throw (ex-info (str "rf/reinstall!: cannot remove the descriptor(s) "
-                           (pr-str blocking) " — their kinds are step-8-DEFERRED "
-                           "(" (pr-str install-deferred-kinds) "), not yet "
-                           "installable through the descriptor diff, so they are "
-                           "not removable through it either. A step-8 kind "
-                           "registered via its own sugar (reg-mutation / "
-                           "reg-resource / reg-route / reg-flow / …) stays owned "
-                           "by that sugar's clear-* lifecycle — unregistering it "
-                           "through the app-value diff would skip the subsystem "
-                           "teardown (in-flight abort, routing :current, flow "
-                           "owner-rebind) and silently orphan its live instances. "
-                           "Clear it through its own clear-* surface before "
-                           "reinstalling without it.")
-                      {:error/id    :rf.error/unsupported-descriptor-kind
-                       :removed     blocking
-                       :deferred    install-deferred-kinds
-                       :wired       install-wired-kinds
-                       :recovery    :clear-through-reg-*-sugar})))))
+      (error/throw-error!
+        :rf.error/unsupported-descriptor-kind
+        'rf/reinstall!
+        (str "rf/reinstall!: cannot remove the descriptor(s) "
+             (pr-str blocking) " — their kinds are step-8-DEFERRED "
+             "(" (pr-str install-deferred-kinds) "), not yet "
+             "installable through the descriptor diff, so they are "
+             "not removable through it either. A step-8 kind "
+             "registered via its own sugar (reg-mutation / "
+             "reg-resource / reg-route / reg-flow / …) stays owned "
+             "by that sugar's clear-* lifecycle — unregistering it "
+             "through the app-value diff would skip the subsystem "
+             "teardown (in-flight abort, routing :current, flow "
+             "owner-rebind) and silently orphan its live instances. "
+             "Clear it through its own clear-* surface before "
+             "reinstalling without it.")
+        {:recovery :clear-through-reg-*-sugar
+         :extra    {:removed  blocking
+                    :deferred install-deferred-kinds
+                    :wired    install-wired-kinds}}))))
 
 (late-bind/set-fn! :app-value/refuse-unsupported-removal! refuse-unsupported-removal!)
 

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -67,7 +67,8 @@
   it survives `:advanced` + `goog.DEBUG=false` builds intact (it carries no
   feature sentinels and no per-feature `:require`, so the bundle-isolation
   gate is unaffected)."
-  (:require [re-frame.registrar :as registrar]
+  (:require [re-frame.error     :as error]
+            [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -206,14 +207,16 @@
   [rid f & args]
   (let [snapshot @realms]
     (when-not (contains? snapshot rid)
-      (throw (ex-info (str "realm " rid " is not registered — a realm-owned"
-                           " mutation cannot target a realm that was never"
-                           " constructed. Absence defaults to the default realm;"
-                           " an unknown explicit id does not.")
-                      {:error/id     :rf.error/unknown-realm
-                       :realm        rid
-                       :known-realms (set (keys snapshot))
-                       :recovery     :construct-the-realm-first}))))
+      (error/throw-error!
+        :rf.error/unknown-realm
+        'rf/install!
+        (str "rf/realm " rid " is not registered — a realm-owned"
+             " mutation cannot target a realm that was never"
+             " constructed. Absence defaults to the default realm;"
+             " an unknown explicit id does not.")
+        {:recovery :construct-the-realm-first
+         :extra    {:realm        rid
+                    :known-realms (set (keys snapshot))}})))
   (rid (swap! realms
               (fn [m]
                 ;; Single-threaded host: the guard above already proved `rid`
@@ -361,25 +364,32 @@
   [opts]
   (let [id (:id opts)]
     (when (nil? id)
-      (throw (ex-info "rf/realm requires an :id"
-                      {:error/id   :rf.error/invalid-realm
-                       :opts       opts
-                       :recovery   :supply-a-realm-id})))
+      (error/throw-error!
+        :rf.error/invalid-realm
+        'rf/realm
+        "rf/realm requires an :id — supply a realm id (the process-unique key the realm is registered under)."
+        {:recovery :supply-a-realm-id
+         :extra    {:opts opts}}))
     ;; An `:app` here would create a FALSE installed-app state — the value is
     ;; recorded without its descriptors being seated (rf2-c6armm.2 #1). The
     ;; realm's `:app` slot is install-owned; reject it loudly at the constructor.
     (when (contains? opts :app)
-      (throw (ex-info (str "rf/realm: :app is install-owned state, not a constructor"
-                           " input — an app value is inert until rf/install! seats it."
-                           " Use (-> (rf/realm {:id " id "}) (rf/install! app)).")
-                      {:error/id :rf.error/invalid-realm
-                       :realm    id
-                       :recovery :install-the-app-with-rf-install})))
+      (error/throw-error!
+        :rf.error/invalid-realm
+        'rf/realm
+        (str "rf/realm: :app is install-owned state, not a constructor"
+             " input — an app value is inert until rf/install! seats it."
+             " Use (-> (rf/realm {:id " id "}) (rf/install! app)).")
+        {:recovery :install-the-app-with-rf-install
+         :extra    {:realm id}}))
     (when (contains? @realms id)
-      (throw (ex-info (str "rf/realm: a realm with id " id " is already registered")
-                      {:error/id   :rf.error/realm-id-conflict
-                       :realm      id
-                       :recovery   :use-a-unique-realm-id-or-dispose-the-existing-realm})))
+      (error/throw-error!
+        :rf.error/realm-id-conflict
+        'rf/realm
+        (str "rf/realm: a realm with id " id " is already registered"
+             " — use a unique realm id or dispose the existing realm first.")
+        {:recovery :use-a-unique-realm-id-or-dispose-the-existing-realm
+         :extra    {:realm id}}))
     (let [;; Hermetic by default: a fresh OWN registrar atom unless the caller
           ;; shares one explicitly. This is the isolation the public realm
           ;; constructor exists to provide.

--- a/implementation/core/test/re_frame/app_value_compose_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_compose_cljs_test.cljc
@@ -108,7 +108,7 @@
     (let [ed (try (rf/module {:id :m :bogus {:x {:handler cart-add}}})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/invalid-module (:error/id ed)))
+      (is (= :rf.error/invalid-module (:rf.error/id ed)))
       (is (= :bogus (:unknown-section ed))
           "the unknown section key is named in the diagnostic"))))
 
@@ -135,7 +135,7 @@
     (let [ed (try (rf/module {:id :m :owns {:app-db [[:cart]]}})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/invalid-module (:error/id ed))
+      (is (= :rf.error/invalid-module (:rf.error/id ed))
           "a bare :owns throws :rf.error/invalid-module")
       (is (= :owns (:unknown-section ed))
           "the bare key is named as the offending unknown section")))
@@ -143,7 +143,7 @@
     (let [ed (try (rf/module {:id :m :requires #{:rf.capability/http}})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/invalid-module (:error/id ed))
+      (is (= :rf.error/invalid-module (:rf.error/id ed))
           "a bare :requires throws :rf.error/invalid-module")
       (is (= :requires (:unknown-section ed))
           "the bare key is named as the offending unknown section")))
@@ -204,7 +204,7 @@
     (let [ed (try (rf/app {:id :a :modules [{:not :a-module}]})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/invalid-app (:error/id ed))
+      (is (= :rf.error/invalid-app (:rf.error/id ed))
           "a non-module :modules entry throws :rf.error/invalid-app"))))
 
 ;; ---------------------------------------------------------------------------
@@ -222,7 +222,7 @@
           ed (try (rf/app {:id :bad/app :modules [ma mb]})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/app-composition-collision (:error/id ed)))
+      (is (= :rf.error/app-composition-collision (:rf.error/id ed)))
       (is (= :event (:kind ed)))
       (is (= :shared/save (:id ed)))
       (is (= #{:a :b} (set (map :module (:sources ed))))
@@ -256,7 +256,7 @@
           ed (try (rf/app {:id :dup/app :modules [ma mb]})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/app-composition-collision (:error/id ed)))
+      (is (= :rf.error/app-composition-collision (:rf.error/id ed)))
       (is (= :module (:kind ed)) "the collision names the :module provenance kind")
       (is (= :dup/m  (:id ed))   "the colliding module id is named"))))
 
@@ -269,10 +269,10 @@
           mb (rf/module {:id :dup/m :events {:dup/b {:handler auth-login}}})
           ed-ab (try (rf/app {:id :dup/app :modules [ma mb]}) :no-throw
                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
-                       (:error/id (ex-data e))))
+                       (:rf.error/id (ex-data e))))
           ed-ba (try (rf/app {:id :dup/app :modules [mb ma]}) :no-throw
                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
-                       (:error/id (ex-data e))))]
+                       (:rf.error/id (ex-data e))))]
       (is (= :rf.error/app-composition-collision ed-ab) "[ma mb] throws")
       (is (= :rf.error/app-composition-collision ed-ba) "[mb ma] throws too — order-independent"))))
 

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -133,7 +133,7 @@
           ed (try (rf/install! a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/missing-capability (:error/id ed))
+      (is (= :rf.error/missing-capability (:rf.error/id ed))
           "the missing-capability error is raised")
       (is (= :rf.capability/http (:capability ed))
           "the unmet capability is named")
@@ -392,7 +392,7 @@
                                                        :events {:fr0/ev {:handler (fn [_ _] {})}}})]}))
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/live-frame-removal-unsupported (:error/id ed))
+      (is (= :rf.error/live-frame-removal-unsupported (:rf.error/id ed))
           "removing a live :frame refuses loudly with the targeted error id")
       (is (= [:fr0/live] (:live-frames ed))
           "the diagnostic enumerates exactly the blocking live frame-id")
@@ -477,7 +477,7 @@
                                                            :events {ev-id {:handler (fn [_ _] {})}}})]}))
                       (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                         (ex-data e)))]
-          (is (= :rf.error/unsupported-descriptor-kind (:error/id ed))
+          (is (= :rf.error/unsupported-descriptor-kind (:rf.error/id ed))
               (str "removing a sugar-registered " kind " refuses loudly, not silently"))
           (is (some #{[kind slot-id]} (:removed ed))
               (str "the diagnostic enumerates the blocking removed [" kind " " slot-id "]"))
@@ -603,7 +603,7 @@
           ed (try (rf/reinstall! v2)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/missing-capability (:error/id ed))
+      (is (= :rf.error/missing-capability (:rf.error/id ed))
           "a reinstall that raises an unmet requirement throws")
       ;; The pre-reinstall handler is untouched — the check ran before mutation.
       (is (identical? cart-add (registrar/handler :event :e))
@@ -786,7 +786,7 @@
           ed (try (rf/install! :xms/ghost a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/unknown-realm (:error/id ed))
+      (is (= :rf.error/unknown-realm (:rf.error/id ed))
           "an explicit unknown realm id throws :rf.error/unknown-realm")
       (is (= :xms/ghost (:realm ed)) "the diagnostic names the unknown realm id")
       (is (= :construct-the-realm-first (:recovery ed)))
@@ -942,7 +942,7 @@
           ed  (try (rf/realm {:id :false/r :app app})
                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                      (ex-data e)))]
-      (is (= :rf.error/invalid-realm (:error/id ed))
+      (is (= :rf.error/invalid-realm (:rf.error/id ed))
           "a public :app on rf/realm is rejected")
       (is (= :false/r (:realm ed)) "the diagnostic names the realm")
       (is (nil? (realm/realm :false/r))
@@ -956,7 +956,7 @@
             re-ed (try (rf/reinstall! :false/r v2)
                        (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                          (ex-data e)))]
-        (is (= :rf.error/unknown-realm (:error/id re-ed))
+        (is (= :rf.error/unknown-realm (:rf.error/id re-ed))
             "a reinstall! against the never-created realm throws unknown-realm — no
              phantom :app to diff against (the false installed-app state is closed)")))))
 
@@ -1054,7 +1054,7 @@
             ed (try (rf/install! a)
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                       (ex-data e)))]
-        (is (= :rf.error/unsupported-descriptor-kind (:error/id ed))
+        (is (= :rf.error/unsupported-descriptor-kind (:rf.error/id ed))
             (str "install! of a " kind " descriptor refuses loudly"))
         (is (= kind (:kind ed))
             (str "the refusal names the unsupported kind " kind))
@@ -1096,7 +1096,7 @@
           ed (try (rf/install! a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/unsupported-descriptor-kind (:error/id ed))
+      (is (= :rf.error/unsupported-descriptor-kind (:rf.error/id ed))
           "the deferred kind refuses the whole install loudly")
       (is (= :route (:kind ed)) "the refusal names the blocking deferred kind")
       (is (some #{[:route :leak/route]} (:blocking ed))

--- a/implementation/core/test/re_frame/realm_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_cljs_test.cljc
@@ -420,7 +420,7 @@
           ed (try (realm/set-installed-app! :ghost/realm {:rf.app/id :ghost})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/unknown-realm (:error/id ed))
+      (is (= :rf.error/unknown-realm (:rf.error/id ed))
           "mutating an unknown realm id throws :rf.error/unknown-realm")
       (is (= :ghost/realm (:realm ed)) "the diagnostic names the unknown realm id")
       (is (contains? (:known-realms ed) :rf.realm/default)
@@ -449,7 +449,7 @@
       (let [ed (try (thunk)
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                       (ex-data e)))]
-        (is (= :rf.error/unknown-realm (:error/id ed))
+        (is (= :rf.error/unknown-realm (:rf.error/id ed))
             (str label " throws :rf.error/unknown-realm on an unknown id"))
         (is (= :ghost/realm (:realm ed))
             (str label " names the unknown realm id"))))

--- a/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
@@ -106,7 +106,7 @@
     (let [ed (try (rf/realm {})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/invalid-realm (:error/id ed)))
+      (is (= :rf.error/invalid-realm (:rf.error/id ed)))
       (is (= :supply-a-realm-id (:recovery ed))))))
 
 (deftest realm-is-hermetic-and-registered
@@ -131,7 +131,7 @@
     (let [ed (try (rf/realm {:id :conf/dup})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/realm-id-conflict (:error/id ed)))
+      (is (= :rf.error/realm-id-conflict (:rf.error/id ed)))
       (is (= :conf/dup (:realm ed)) "the conflicting id is named"))))
 
 (deftest dispose-realm-drops-it-default-is-never-disposed
@@ -411,7 +411,7 @@
           ed (try (rf/install! r a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
-      (is (= :rf.error/missing-capability (:error/id ed)))
+      (is (= :rf.error/missing-capability (:rf.error/id ed)))
       (is (= :conf/needs-caps (:realm ed)) "the constructed realm is named")
       (is (= :rf.capability/http (:capability ed)))
       ;; Nothing was seated into the realm's own registrar (pre-mutation fail).

--- a/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
@@ -25,6 +25,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.error :as error]
             [re-frame.late-bind :as late-bind]
+            [re-frame.app-value :as app-value]
+            [re-frame.realm :as realm]
             [re-frame.flows.registry :as flows-registry]
             [re-frame.flows.topo :as flows-topo]
             [re-frame.routing.registry :as routing-registry]))
@@ -215,3 +217,31 @@
     "extract-cycle-path (internal dead-end invariant)"
     :rf.error/flow-cycle-extract-invariant
     #(#'flows-topo/extract-cycle-path {:a #{}} #{:a})))
+
+;; ============================================================================
+;; app-value / realm throws (rf2-p7kwpt) — the app-as-value and realm surface
+;; exemplars. Both previously threw with the legacy `:error/id` discriminator;
+;; they now route through the central builder so the message is a human sentence
+;; naming the public concept (rf/app / rf/realm) carrying the [:rf.error/<id>]
+;; token, with the canonical discriminator in `:rf.error/id`.
+;; ============================================================================
+
+(deftest app-value-throw-emits-conformant-shape
+  ;; rf2-p7kwpt — the app-as-value surface exemplar. A bad rf/app input (a
+  ;; non-module :modules entry) routes through the central builder, so the
+  ;; message is a human sentence naming the public concept (rf/app) carrying
+  ;; the [:rf.error/<id>] token, with the canonical discriminator in
+  ;; :rf.error/id (NOT the legacy :error/id slot).
+  (assert-conformant-throw!
+    "rf/app (non-module :modules entry)"
+    :rf.error/invalid-app
+    #(app-value/app {:id :conf/app :modules [{:not :a-module}]})))
+
+(deftest realm-throw-emits-conformant-shape
+  ;; rf2-p7kwpt — the realm surface exemplar. A bad rf/realm input (a missing
+  ;; :id) routes through the central builder: the message names rf/realm and
+  ;; carries the token, with :rf.error/id as the SOLE discriminator.
+  (assert-conformant-throw!
+    "rf/realm (missing :id)"
+    :rf.error/invalid-realm
+    #(realm/construct-realm {})))


### PR DESCRIPTION
Fixes **rf2-p7kwpt** (P2). vvixub child — converts the app-as-value / realm / deferred-install surfaces in `implementation/core/` to route their `(throw (ex-info …))` sites through the central `re-frame.error` builder, so they carry the Spec 009 canonical `:rf.error/id` discriminator instead of the legacy `:error/id` slot.

## What changed

Each converted throw now goes through `error/throw-error!`, which sets:
- the canonical `:rf.error/id` discriminator (subsuming the `:error/id`→`:rf.error/id` slot-axis fix),
- a human `:reason` sentence (the existing user-facing wording, preserved — still names `rf/module` / `rf/app` / `rf/realm` / `rf/install!` / `rf/reinstall!`),
- the trailing `[:rf.error/<id>]` greppability token (derived from `:reason` + id),
- `:where` (the public fn symbol) and `:recovery` (the prior recovery keyword), with surface-specific slots folded into `:extra`.

Converted sites (13):
- `app_value.cljc` — `invalid-module` (×2), `app-composition-collision` (×2), `invalid-app` (×2), `unknown-realm`, `missing-capability`, `live-frame-removal-unsupported`
- `realm.cljc` — `unknown-realm` (the `update-realm!` mutation guard), `invalid-realm` (×2), `realm-id-conflict`
- `core.cljc` deferred install-descriptor throws — `unsupported-descriptor-kind` (×3: in-loop, install preflight, removal preflight)

No legacy `:error/id` alias retained (pre-alpha, no shim — per the bead default).

## Migration

- Repointed the discriminator reads in the affected core test nses from `(:error/id ed)` → `(:rf.error/id ed)` (realm / realm-conformance / app-value-install / app-value-compose).
- The two **test-internal** stub throws (`:atomic.test/boom`, `:rb.test/boom`) keep `:error/id` — they assert rollback-on-arbitrary-throw, not the framework discriminator contract.
- Added `rf/app` + `rf/realm` exemplar cases to the thrown-error-message conformance gate (`assert-conformant-throw!`), satisfying the bead's "conformance covers ≥1 app-value and ≥1 realm failure."

Scope confined to `implementation/core/` — no overlap with the A2/B2 error-cluster wave (cofx/http/reply/machines/flows/ssr/adapters/story/mviz).

## Rebase note

Rebased onto current `origin/main` (the A2/B2 error-cluster wave merged after this branched). The only conflict was the thrown-error-message conformance gate, where the merged wave (#4349) added three flows/topo exemplar deftests at the same tail position this PR added its `rf/app` + `rf/realm` exemplars. Resolved by **unioning both exemplar sets** — all five deftests retained (`flow-path-overlap`, `flow-cycle`, `flow-cycle-extract-invariant` from the wave; `app-value-throw-emits-conformant-shape`, `realm-throw-emits-conformant-shape` from this PR), each under its own section header. The `:require` block (already carrying both `flows-topo` and `app-value`/`realm` aliases) merged cleanly. Both intents move the same direction (canonical `:rf.error/id`); no refactor reverted.

## Quality gates (re-run post-rebase)

- **`npm run test:cljs` (shadow node-test, canonical CLJS runtime):** **7327 tests / 30238 assertions, 0 failures, 0 errors**. ✅ (includes the thrown-error conformance gate with BOTH exemplar sets.)
- **JVM core nses (affected):** `clojure -M:test -d core/test` over `re-frame.realm-cljs-test`, `re-frame.realm-conformance-cljs-test`, `re-frame.app-value-install-cljs-test`, `re-frame.app-value-compose-cljs-test`, `re-frame.thrown-error-message-conformance-cljs-test` — **112 tests / 560 assertions, 0 failures, 0 errors**. ✅
