### PR TITLE
feat(errors): route ssr/adapters/story/machines-viz throws through the builder (vvixub children)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -763,9 +763,20 @@
 (defn- emit-vector
   [^StringBuffer sb argv]
   (when (zero? (count argv))
-    (throw (ex-info ":rf.error/static-markup-empty-vector"
-                    {:type :rf.error/static-markup-empty-vector
-                     :reason "Hiccup vector cannot be empty."})))
+    ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape
+    ;; (rf2-vvixub) replicated INLINE — reagent-slim is bundle-isolated and
+    ;; MUST NOT `:require` re-frame.* (the slim bundle-isolation gate), so
+    ;; the central `re-frame.error` builder is unavailable here. Human
+    ;; message + trailing [:rf.error/<id>] token; `:rf.error/id` the sole
+    ;; machine discriminator.
+    (throw (ex-info (str "Hiccup vector cannot be empty; give the vector a "
+                         "head tag (e.g. [:div …]). "
+                         "[:rf.error/static-markup-empty-vector]")
+                    {:rf.error/id :rf.error/static-markup-empty-vector
+                     :where       'reagent2.dom.server/render-to-static-markup
+                     :reason      (str "Hiccup vector cannot be empty; give the "
+                                       "vector a head tag (e.g. [:div …]).")
+                     :recovery    :supply-a-head-tag})))
   (let [head (nth argv 0 nil)]
     (cond
       (= :<> head)                (emit-fragment sb argv)
@@ -787,10 +798,20 @@
       ;; Plain user fn head — Form-1 or Form-2 (rf2-o3hqr).
       (fn? head)                  (emit-user-fn sb head argv)
       :else
-      (throw (ex-info ":rf.error/static-markup-bad-tag"
-                      {:type :rf.error/static-markup-bad-tag
-                       :tag  head
-                       :argv argv})))))
+      ;; Canonical shape replicated inline (bundle isolation — see above).
+      (throw (ex-info (str "Hiccup head " (pr-str head)
+                           " is not a valid element head; use a keyword "
+                           "(DOM tag or :>/:<>/:r>/:f>), a Reagent component "
+                           "class, a React component class, or a fn. "
+                           "[:rf.error/static-markup-bad-tag]")
+                      {:rf.error/id :rf.error/static-markup-bad-tag
+                       :where       'reagent2.dom.server/render-to-static-markup
+                       :reason      (str "Hiccup head must be a keyword (DOM tag "
+                                         "or :>/:<>/:r>/:f>), a Reagent component "
+                                         "class, a React component class, or a fn.")
+                       :recovery    :supply-a-valid-hiccup-head
+                       :tag         head
+                       :argv        argv})))))
 
 (defn- emit-element
   "Recursive walker. Per §8.1."
@@ -805,9 +826,18 @@
     (vector? x)     (emit-vector sb x)
     (sequential? x) (doseq [c x] (emit-element sb c))
     :else
-    (throw (ex-info ":rf.error/static-markup-bad-element"
-                    {:type :rf.error/static-markup-bad-element
-                     :got  x}))))
+    ;; Canonical shape replicated inline (bundle isolation — see above).
+    (throw (ex-info (str "Cannot render " (pr-str x)
+                         " as static markup; a hiccup child must be a string, "
+                         "number, keyword, symbol, hiccup vector, or a "
+                         "sequential of those. [:rf.error/static-markup-bad-element]")
+                    {:rf.error/id :rf.error/static-markup-bad-element
+                     :where       'reagent2.dom.server/render-to-static-markup
+                     :reason      (str "A hiccup child must be a string, number, "
+                                       "keyword, symbol, hiccup vector, or a "
+                                       "sequential of those.")
+                     :recovery    :supply-a-renderable-child
+                     :got         x}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Public entry

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -800,9 +800,19 @@
   "Dispatch on a hiccup vector's head and emit the React element."
   [argv]
   (when (zero? (count argv))
-    (throw (ex-info ":rf.error/template-empty-vector"
-                    {:type :rf.error/template-empty-vector
-                     :reason "Hiccup vector cannot be empty."})))
+    ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape
+    ;; (rf2-vvixub). The central `re-frame.error` builder is NOT used here:
+    ;; reagent-slim is bundle-isolated and MUST NOT `:require` re-frame.*
+    ;; (the slim bundle-isolation gate). The shape is replicated inline —
+    ;; human message + trailing [:rf.error/<id>] token, `:rf.error/id` the
+    ;; sole machine discriminator.
+    (throw (ex-info (str "Hiccup vector cannot be empty; give the vector a "
+                         "head tag (e.g. [:div …]). [:rf.error/template-empty-vector]")
+                    {:rf.error/id :rf.error/template-empty-vector
+                     :where       'reagent2.template/as-element
+                     :reason      (str "Hiccup vector cannot be empty; give the "
+                                       "vector a head tag (e.g. [:div …]).")
+                     :recovery    :supply-a-head-tag})))
   (let [tag (nth argv 0 nil)]
     (cond
       ;; Interop heads — checked first so they don't get treated as
@@ -829,12 +839,21 @@
       (react-component-element tag argv)
 
       :else
-      (throw (ex-info ":rf.error/template-bad-tag"
-                      {:type   :rf.error/template-bad-tag
-                       :tag    tag
-                       :argv   argv
-                       :reason "Hiccup head must be a keyword (DOM tag or :>/:<>/:r>/:f>),
-                                a Reagent component class, a React component class, or a fn."})))))
+      ;; Canonical shape replicated inline (bundle isolation — see the
+      ;; empty-vector throw above for the rationale).
+      (throw (ex-info (str "Hiccup head " (pr-str tag)
+                           " is not a valid element head; use a keyword "
+                           "(DOM tag or :>/:<>/:r>/:f>), a Reagent component "
+                           "class, a React component class, or a fn. "
+                           "[:rf.error/template-bad-tag]")
+                      {:rf.error/id :rf.error/template-bad-tag
+                       :where       'reagent2.template/as-element
+                       :reason      (str "Hiccup head must be a keyword (DOM tag "
+                                         "or :>/:<>/:r>/:f>), a Reagent component "
+                                         "class, a React component class, or a fn.")
+                       :recovery    :supply-a-valid-hiccup-head
+                       :tag         tag
+                       :argv        argv})))))
 
 (defn as-element
   "Top-level hiccup → React element conversion.

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -55,7 +55,8 @@
         (test-react/unmount! m)
         (mapv :phase (test-react/lifecycle-log m)))
       ;; => [:constructor :render :did-mount :render :did-update :will-unmount]"
-  (:require [re-frame.late-bind :as late-bind]
+  (:require [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.atom-container :as atom-container]
             [re-frame.subs.cache :as subs-cache]
@@ -208,16 +209,18 @@
     (let [mount @self-ref]
       (when @(:mounted? mount)
         (when (rendering?)
-          (throw (ex-info ":rf.error/sync-unmount-during-render"
-                          {:where    'rf/test-react-unmount
-                           :recovery :no-recovery
-                           :reason   (str "Attempted to synchronously unmount a root"
-                                          " while React was already rendering. React"
-                                          " 18+ raises the equivalent runtime error;"
-                                          " the Test-React adapter raises here so the"
-                                          " bug is caught at unit-test speed. See"
-                                          " rf2-4l7t2 for the production manifestation.")
-                           :mount-id (:id mount)})))
+          (error/throw-error!
+            :rf.error/sync-unmount-during-render
+            'rf/test-react-unmount
+            (str "Attempted to synchronously unmount a root"
+                 " while React was already rendering. React"
+                 " 18+ raises the equivalent runtime error;"
+                 " the Test-React adapter raises here so the"
+                 " bug is caught at unit-test speed. Do not"
+                 " unmount a root from inside a render body —"
+                 " defer the unmount until rendering settles.")
+            {:recovery :defer-the-unmount-until-render-settles
+             :extra    {:mount-id (:id mount)}})))
         ;; Children-first teardown (mirrors React). Each child's own thunk runs
         ;; the same guard + cascade, so a deep tree unwinds leaf-upward.
         (doseq [child @(:children mount)]
@@ -274,13 +277,14 @@
   [render-tree]
   (let [parent *rendering-mount*]
     (when (nil? parent)
-      (throw (ex-info ":rf.error/mount-child-outside-render"
-                      {:where    'rf/test-react-mount-child!
-                       :recovery :no-recovery
-                       :reason   (str "mount-child! must be called from inside an"
-                                      " :rf/component render body (a child needs a"
-                                      " parent render in flight); *rendering-mount*"
-                                      " was nil.")})))
+      (error/throw-error!
+        :rf.error/mount-child-outside-render
+        'rf/test-react-mount-child!
+        (str "mount-child! must be called from inside an"
+             " :rf/component render body (a child needs a"
+             " parent render in flight); *rendering-mount*"
+             " was nil. Call mount-child! only within a render body.")
+        {:recovery :call-from-inside-a-render-body}))
     (let [child (mount-tree! render-tree)]
       (swap! (:children parent) conj child)
       child)))
@@ -303,9 +307,14 @@
 (defn- render-to-string [render-tree opts]
   (if-let [emit @hiccup-emitter]
     (emit render-tree opts)
-    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason "Test-React adapter has no built-in hiccup emitter; call set-hiccup-emitter! if a test needs HTML output."
-                     :render-tree render-tree}))))
+    (error/throw-error!
+      :rf.error/no-hiccup-emitter-bound
+      'rf/render-to-string
+      (str "Test-React adapter has no built-in hiccup emitter; call "
+           "set-hiccup-emitter! (or require re-frame.ssr) before "
+           "render-to-string if a test needs HTML output.")
+      {:recovery :call-set-hiccup-emitter
+       :extra    {:render-tree render-tree}})))
 
 ;; ---- frame-provider --------------------------------------------------------
 
@@ -432,12 +441,14 @@
   accepted, matching the routed hooks' acceptance of the same copy."
   [render-tree]
   (when-not (substrate-adapter/same-adapter? adapter (substrate-adapter/current-adapter-spec))
-    (throw (ex-info ":rf.error/test-react-not-installed"
-                    {:where    'rf/test-react-mount!
-                     :recovery :no-recovery
-                     :reason   (str "test-react/mount! requires the Test-React adapter"
-                                    " to be the (rf/init!)-installed adapter; got "
-                                    (substrate-adapter/current-adapter) ".")})))
+    (error/throw-error!
+      :rf.error/test-react-not-installed
+      'rf/test-react-mount!
+      (str "test-react/mount! requires the Test-React adapter"
+           " to be the (rf/init!)-installed adapter; got "
+           (substrate-adapter/current-adapter)
+           ". Call (rf/init! test-react/adapter) before mount!.")
+      {:recovery :install-the-test-react-adapter}))
   (mount-tree! render-tree))
 
 (defn trigger-update!
@@ -446,11 +457,13 @@
   Throws if the mount has already been unmounted."
   [mount new-render-tree]
   (when-not @(:mounted? mount)
-    (throw (ex-info ":rf.error/update-after-unmount"
-                    {:where    'rf/test-react-trigger-update!
-                     :recovery :no-recovery
-                     :mount-id (:id mount)
-                     :reason   "trigger-update! called on a mount that has already been unmounted."})))
+    (error/throw-error!
+      :rf.error/update-after-unmount
+      'rf/test-react-trigger-update!
+      (str "trigger-update! called on a mount that has already been "
+           "unmounted; trigger updates only on a still-mounted root.")
+      {:recovery :trigger-only-on-a-mounted-root
+       :extra    {:mount-id (:id mount)}}))
   (run-render! mount new-render-tree)
   (log-phase! mount :did-update)
   mount)

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -220,7 +220,7 @@
                  " unmount a root from inside a render body —"
                  " defer the unmount until rendering settles.")
             {:recovery :defer-the-unmount-until-render-settles
-             :extra    {:mount-id (:id mount)}})))
+             :extra    {:mount-id (:id mount)}}))
         ;; Children-first teardown (mirrors React). Each child's own thunk runs
         ;; the same guard + cascade, so a deep tree unwinds leaf-upward.
         (doseq [child @(:children mount)]

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -18,6 +18,7 @@
                               it EXPLICITLY like any other id.
     :rf.frame/<gensym>       — anonymous instances from make-frame"
   (:require [clojure.string]
+            [re-frame.error :as error]
             [re-frame.registrar :as registrar]
             [re-frame.realm :as realm]
             [re-frame.substrate.adapter :as adapter]
@@ -1105,9 +1106,15 @@
                  :drain-depth  16}
     :ssr-server {:platform :server}
     nil         {}
-    (throw (ex-info ":rf.error/unknown-preset"
-                    {:preset preset
-                     :valid  #{:default :test :story :ssr-server}}))))
+    (error/throw-error!
+      :rf.error/unknown-preset
+      'rf/reg-frame
+      (str "unknown frame :preset " (pr-str preset)
+           "; valid presets are :default, :test, :story, :ssr-server "
+           "(or omit :preset). Use one of those.")
+      {:recovery :use-a-valid-preset
+       :extra    {:preset preset
+                  :valid  #{:default :test :story :ssr-server}}})))
 
 (defn- expand-preset [metadata]
   (let [preset    (:preset metadata)

--- a/implementation/core/src/re_frame/substrate/plain_atom.cljc
+++ b/implementation/core/src/re_frame/substrate/plain_atom.cljc
@@ -42,7 +42,8 @@
   shared with the test-react adapter via `re-frame.substrate.atom-container`
   — see that ns for the rationale on why only the container quartet (not
   `make-derived-value`) is shared."
-  (:require [re-frame.substrate.atom-container :as atom-container]
+  (:require [re-frame.error :as error]
+            [re-frame.substrate.atom-container :as atom-container]
             #?@(:clj  [[re-frame.interop :as interop]]
                 :cljs [[re-frame.disposable :as rf-disposable]
                        [re-frame.substrate.adapter :as substrate-adapter]])))
@@ -88,8 +89,13 @@
 (defn- render [_ _ _]
   ;; SSR uses render-to-string exclusively. Calling render on the JVM is
   ;; a programmer error worth surfacing loudly.
-  (throw (ex-info ":rf.error/render-on-headless-adapter"
-                  {:reason "render is not supported on the plain-atom adapter; use render-to-string"})))
+  (error/throw-error!
+    :rf.error/render-on-headless-adapter
+    'rf/render
+    (str "render is not supported on the plain-atom adapter (it is headless "
+         "— JVM/SSR, no React reactivity); render server-side HTML with "
+         "rf/render-to-string instead of rf/render.")
+    {:recovery :use-render-to-string}))
 
 ;; The hiccup emitter is set by re-frame.ssr at namespace-load time
 ;; via set-hiccup-emitter!. Stored in an atom so the lookup works on
@@ -106,9 +112,14 @@
 (defn- render-to-string [render-tree opts]
   (if-let [emit @hiccup-emitter]
     (emit render-tree opts)
-    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason "the SSR namespace must call set-hiccup-emitter! before render-to-string"
-                     :render-tree render-tree}))))
+    (error/throw-error!
+      :rf.error/no-hiccup-emitter-bound
+      'rf/render-to-string
+      (str "no hiccup emitter is bound on the plain-atom adapter; require the "
+           "re-frame.ssr namespace (which calls set-hiccup-emitter! on load) "
+           "before calling render-to-string.")
+      {:recovery :require-re-frame-ssr
+       :extra    {:render-tree render-tree}})))
 
 (defn- register-context-provider [_frame-keyword]
   ;; No React context on the JVM; users thread frames as arguments per

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -22,7 +22,8 @@
     - `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` /
       `clear-schemas-by-frame!` — test-support hooks consumed by
       `re-frame.test-support`'s reset-runtime fixture."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.path :as path]
@@ -67,9 +68,15 @@
     (keyword? opts-or-frame-id) {:frame opts-or-frame-id}
     (map?     opts-or-frame-id) opts-or-frame-id
     :else
-    (throw (ex-info ":rf.error/bad-app-schemas-arg"
-                    {:received opts-or-frame-id
-                     :expected "keyword frame-id or opts map"}))))
+    (error/throw-error!
+      :rf.error/bad-app-schemas-arg
+      'rf/app-schemas
+      (str "app-schemas expects a keyword frame-id or an opts map; got "
+           (pr-str opts-or-frame-id) ". Pass a frame-id keyword or a "
+           "{:frame <frame-id>} opts map.")
+      {:recovery :supply-a-frame-id-or-opts-map
+       :extra    {:received opts-or-frame-id
+                  :expected "keyword frame-id or opts map"}})))
 
 (defn- best-effort-frame
   "Resolve the registration frame for an error payload WITHOUT throwing —
@@ -228,33 +235,38 @@
   ([path] (assert-app-schema-path! path nil))
   ([path frame]
    (when-not (valid-app-schema-path? path)
-     (throw (ex-info ":rf.error/bad-app-schema-path"
-                     {:received path
-                      :expected (str "a sequential get-in path (vector/seq) "
-                                     "of CONCRETE :rf/path segments (keyword, "
-                                     "string, symbol, safe-range integer, "
-                                     "boolean, UUID, instant, or nil), or [] "
-                                     "for the app-db root — composite / "
-                                     "function / host / float / unsafe-integer "
-                                     "segments are rejected (EP-0012 §The "
-                                     ":rf/path algebra)")
-                      :rf.error/id :rf.error/bad-app-schema-path})))
+     (error/throw-error!
+       :rf.error/bad-app-schema-path
+       'rf/reg-app-schema
+       (str "reg-app-schema path " (pr-str path) " is invalid; pass "
+            "a sequential get-in path (vector/seq) "
+            "of CONCRETE :rf/path segments (keyword, "
+            "string, symbol, safe-range integer, "
+            "boolean, UUID, instant, or nil), or [] "
+            "for the app-db root — composite / "
+            "function / host / float / unsafe-integer "
+            "segments are rejected (EP-0012 §The "
+            ":rf/path algebra).")
+       {:recovery :supply-a-concrete-get-in-path
+        :extra    {:received path}}))
    (when (runtime-app-schema-path? path)
-     (throw (ex-info ":rf.error/app-schema-runtime-path"
-                     {:received    path
-                      :frame       frame
-                      :reason      (str "app schemas validate only app-db; a "
-                                        "path whose first segment is a "
-                                        ":rf.runtime/* keyword (or the legacy "
-                                        ":rf/runtime root) reaches into the "
-                                        "runtime-db partition. The runtime-db "
-                                        "partition is framework-owned and "
-                                        "validated by the framework (machine "
-                                        ":snapshots refined per-machine from "
-                                        "each machine's :data-schema); it is "
-                                        "NOT a user schema-registration "
-                                        "surface — drop the runtime path.")
-                      :rf.error/id :rf.error/app-schema-runtime-path})))))
+     (error/throw-error!
+       :rf.error/app-schema-runtime-path
+       'rf/reg-app-schema
+       (str "app schemas validate only app-db; a "
+            "path whose first segment is a "
+            ":rf.runtime/* keyword (or the legacy "
+            ":rf/runtime root) reaches into the "
+            "runtime-db partition. The runtime-db "
+            "partition is framework-owned and "
+            "validated by the framework (machine "
+            ":snapshots refined per-machine from "
+            "each machine's :data-schema); it is "
+            "NOT a user schema-registration "
+            "surface — drop the runtime path.")
+       {:recovery :drop-the-runtime-path
+        :extra    {:received path
+                   :frame    frame}}))))
 
 ;; ---- bulk first-argument shape validation (rf2-naihn1) --------------------
 ;;
@@ -288,10 +300,14 @@
   documented empty no-op)."
   [path->schema]
   (when-not (valid-bulk-schemas-arg? path->schema)
-    (throw (ex-info ":rf.error/bad-app-schemas-batch"
-                    {:received    path->schema
-                     :expected    "a {path -> schema} map (possibly empty)"
-                     :rf.error/id :rf.error/bad-app-schemas-batch}))))
+    (error/throw-error!
+      :rf.error/bad-app-schemas-batch
+      'rf/reg-app-schemas
+      (str "reg-app-schemas expects a {path -> schema} map (possibly empty); "
+           "got " (pr-str path->schema) ". Pass a map of path -> schema.")
+      {:recovery :supply-a-path-to-schema-map
+       :extra    {:received path->schema
+                  :expected "a {path -> schema} map (possibly empty)"}})))
 
 (defn coerce->frame-id
   "Resolve a frame-id from the `opts-or-frame-id` argument the read

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -133,9 +133,12 @@
           (is (instance? clojure.lang.ExceptionInfo thrown)
               (str "bad-arg " (pr-str bad-arg) " throws ex-info"))
           (when (instance? clojure.lang.ExceptionInfo thrown)
-            (is (= ":rf.error/bad-app-schemas-arg" (.getMessage ^Exception thrown))
-                "ex-info message names the error category")
+            ;; rf2-vvixub — the human message leads with the :reason sentence
+            ;; and trails the [:rf.error/<id>] token; branch on the canonical
+            ;; :rf.error/id, never on the (non-normative) message bytes.
             (let [data (ex-data thrown)]
+              (is (= :rf.error/bad-app-schemas-arg (:rf.error/id data))
+                  "ex-data carries the canonical :rf.error/id discriminator")
               (is (= bad-arg (:received data))
                   ":received slot carries the bad input verbatim"))))))))
 
@@ -175,8 +178,9 @@
         (is (instance? clojure.lang.ExceptionInfo thrown)
             (str "bad opts " (pr-str bad-arg) " throws ex-info"))
         (when (instance? clojure.lang.ExceptionInfo thrown)
-          (is (= ":rf.error/bad-app-schemas-arg" (.getMessage ^Exception thrown))
-              "ex-info names the same error category the read surface uses"))))))
+          ;; rf2-vvixub — branch on the canonical :rf.error/id, not the message.
+          (is (= :rf.error/bad-app-schemas-arg (:rf.error/id (ex-data thrown)))
+              "ex-data names the same error category the read surface uses"))))))
 
 (deftest reg-app-schema-valid-opts-map-registers-fine
   (testing "rf2-52dfy — a valid {:frame ...} opts map still registers
@@ -201,7 +205,8 @@
     (let [thrown (try (rf/reg-app-schemas {[:user] [:map]} "tenant-c")
                       (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo thrown))
-      (is (= ":rf.error/bad-app-schemas-arg" (.getMessage ^Exception thrown))))))
+      ;; rf2-vvixub — branch on the canonical :rf.error/id, not the message.
+      (is (= :rf.error/bad-app-schemas-arg (:rf.error/id (ex-data thrown)))))))
 
 ;; ---- path-shape validation (rf2-sk0ql) -----------------------------------
 ;;
@@ -238,8 +243,9 @@
         (is (instance? clojure.lang.ExceptionInfo thrown)
             (str "bad path " (pr-str bad-path) " throws ex-info"))
         (when (instance? clojure.lang.ExceptionInfo thrown)
-          (is (= ":rf.error/bad-app-schema-path" (.getMessage ^Exception thrown))
-              "ex-info message names the path-shape error category")
+          ;; rf2-vvixub — branch on the canonical :rf.error/id, not the message.
+          (is (= :rf.error/bad-app-schema-path (:rf.error/id (ex-data thrown)))
+              "ex-data names the path-shape error category")
           (let [data (ex-data thrown)]
             (is (= bad-path (:received data))
                 ":received slot carries the bad path verbatim")
@@ -399,7 +405,8 @@
       (is (instance? clojure.lang.ExceptionInfo thrown)
           "a batch with a bad path key throws")
       (when (instance? clojure.lang.ExceptionInfo thrown)
-        (is (= ":rf.error/bad-app-schema-path" (.getMessage ^Exception thrown))
+        ;; rf2-vvixub — branch on the canonical :rf.error/id, not the message.
+        (is (= :rf.error/bad-app-schema-path (:rf.error/id (ex-data thrown)))
             "names the path-shape error category"))
       (is (= before (schemas/snapshot-schemas-by-frame))
           "NO entry from the batch landed — all-or-nothing")
@@ -464,11 +471,10 @@
         (is (instance? clojure.lang.ExceptionInfo thrown)
             (str "runtime path " (pr-str bad-path) " throws ex-info"))
         (when (instance? clojure.lang.ExceptionInfo thrown)
-          (is (= ":rf.error/app-schema-runtime-path"
-                 (.getMessage ^Exception thrown))
-              "names the DISTINCT runtime-path error category")
           (let [data   (ex-data thrown)
                 reason (:reason data)]
+            ;; rf2-vvixub — branch on the canonical :rf.error/id, not the
+            ;; (non-normative) message bytes.
             (is (= :rf.error/app-schema-runtime-path (:rf.error/id data))
                 ":rf.error/id is the distinct runtime-path id")
             (is (= bad-path (:received data))
@@ -530,11 +536,10 @@
       (is (instance? clojure.lang.ExceptionInfo thrown)
           "a batch with a runtime path key throws")
       (when (instance? clojure.lang.ExceptionInfo thrown)
-        (is (= ":rf.error/app-schema-runtime-path"
-               (.getMessage ^Exception thrown))
-            "names the distinct runtime-path error category")
+        ;; rf2-vvixub — branch on the canonical :rf.error/id, not the message.
         (is (= :rf.error/app-schema-runtime-path
-               (:rf.error/id (ex-data thrown)))))
+               (:rf.error/id (ex-data thrown)))
+            "names the distinct runtime-path error category"))
       (is (= before (schemas/snapshot-schemas-by-frame))
           "NO entry from the batch landed — all-or-nothing")
       (is (nil? (schemas/app-schema-at [:good] :tenant/rt))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -91,7 +91,8 @@
 
     - Async Ring handler (3-arity) — synchronous-only in v1;
       extension is additive."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.cookie :as cookie]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
@@ -136,7 +137,18 @@
   of param vectors — is treated as DATA, not evaluated as a form."
   [src-sym]
   (when-not (resolve src-sym)
-    (throw (ex-info (str "import-fn: cannot resolve " src-sym) {:sym src-sym})))
+    ;; Internal compile-time author error: a typo'd source symbol in an
+    ;; `import-fn` re-export above. Routed through the canonical builder so
+    ;; even this build-time exception carries `:rf.error/id` + `:reason`
+    ;; (rf2-vvixub). It never reaches a runtime/app channel.
+    (error/throw-error!
+      :rf.error/ssr-ring-import-fn-unresolved
+      'rf.ssr.ring/import-fn
+      (str "import-fn cannot resolve the source var " src-sym
+           "; check the fully-qualified symbol and that its namespace is "
+           "required at the top of re-frame.ssr.ring.")
+      {:recovery :correct-the-import-fn-source-symbol
+       :extra    {:sym src-sym}}))
   (let [nm (symbol (name src-sym))]
     `(do
        (def ~nm ~src-sym)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -22,6 +22,7 @@
   CTLs, whitespace, or `( ) < > @ , ; : \\ \" / [ ] ? = { }`). Folds in
   the §P2.4 cookie-name grammar finding."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [re-frame.ssr.http-validation :as http-validation])
   (:import [java.net URLEncoder]
            [java.nio.charset StandardCharsets]
@@ -68,16 +69,16 @@
   [attr-key v]
   (let [s (str v)]
     (when (http-validation/contains-injection-char? s)
-      (throw (ex-info ":rf.error/cookie-invalid-attribute"
-                      {:rf.error/id :rf.error/cookie-invalid-attribute
-                       :where     'rf.ssr/cookie->set-cookie-header
-                       :reason    (str "cookie attribute " attr-key
-                                       " contains CR/LF/NUL — forbidden by"
-                                       " RFC 7230 §3.2.4 (header-splitting"
-                                       " injection)")
-                       :attribute attr-key
-                       :value     v
-                       :recovery  :no-recovery})))
+      (error/throw-error!
+        :rf.error/cookie-invalid-attribute
+        'rf.ssr/cookie->set-cookie-header
+        (str "cookie attribute " attr-key
+             " contains CR/LF/NUL — forbidden by"
+             " RFC 7230 §3.2.4 (header-splitting"
+             " injection). Strip CR/LF/NUL from the attribute value.")
+        {:recovery :remove-injection-chars-from-cookie-attr
+         :extra    {:attribute attr-key
+                    :value     v}}))
     s))
 
 ;; rf2-rpedl / §P2.4 — RFC 6265 §4.1.1 cookie-name = token. The token
@@ -94,15 +95,15 @@
   (let [s (clojure.core/name n)]
     (if (http-validation/valid-token-name? s)
       s
-      (throw (ex-info ":rf.error/cookie-invalid-name"
-                      {:rf.error/id :rf.error/cookie-invalid-name
-                       :where    'rf.ssr/cookie->set-cookie-header
-                       :reason   (str "cookie :name violates RFC 6265 §4.1.1"
-                                      " token grammar (no CTLs, whitespace,"
-                                      " or separators ()<>@,;:\\\"/[]?={}); got "
-                                      (pr-str s))
-                       :name     n
-                       :recovery :no-recovery})))))
+      (error/throw-error!
+        :rf.error/cookie-invalid-name
+        'rf.ssr/cookie->set-cookie-header
+        (str "cookie :name violates RFC 6265 §4.1.1"
+             " token grammar (no CTLs, whitespace,"
+             " or separators ()<>@,;:\\\"/[]?={}); got "
+             (pr-str s) ". Use a token-grammar cookie name.")
+        {:recovery :use-a-token-grammar-cookie-name
+         :extra    {:name n}}))))
 
 (defn- same-site-token [v]
   (case v
@@ -137,12 +138,12 @@
   [{:keys [name value max-age secure http-only same-site path domain expires]
     :as cookie}]
   (when (nil? name)
-    (throw (ex-info ":rf.error/cookie-missing-name"
-                    {:rf.error/id :rf.error/cookie-missing-name
-                     :where    'rf.ssr/cookie->set-cookie-header
-                     :reason   "cookie map must carry :name"
-                     :cookie   cookie
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/cookie-missing-name
+      'rf.ssr/cookie->set-cookie-header
+      "cookie map must carry :name; add a :name key to the cookie map."
+      {:recovery :supply-a-cookie-name
+       :extra    {:cookie cookie}}))
   ;; rf2-rpedl §P2.4 — RFC 6265 §4.1.1 cookie-name token grammar.
   (validate-cookie-name! name)
   ;; `Instant/ofEpochMilli` takes a primitive long; passing anything
@@ -152,13 +153,15 @@
   ;; `:rf.error/cookie-invalid-expires` so the misuse surfaces with the
   ;; cookie's actual shape attached.
   (when (and (some? expires) (not (integer? expires)))
-    (throw (ex-info ":rf.error/cookie-invalid-expires"
-                    {:rf.error/id :rf.error/cookie-invalid-expires
-                     :where    'rf.ssr/cookie->set-cookie-header
-                     :reason   (str ":expires must be an epoch-millis long; got " (.getName (class expires)))
-                     :expires  expires
-                     :cookie   cookie
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/cookie-invalid-expires
+      'rf.ssr/cookie->set-cookie-header
+      (str ":expires must be an epoch-millis long; got "
+           (.getName (class expires))
+           ". Pass :expires as a long count of milliseconds since the epoch.")
+      {:recovery :supply-epoch-millis-long
+       :extra    {:expires expires
+                  :cookie  cookie}}))
   ;; rf2-rpedl §P1.2 — gate every string-shaped attribute that gets
   ;; concatenated into the Set-Cookie wire form. `:value` is URL-encoded
   ;; (CR/LF/NUL come out as %0D/%0A/%00 — no injection path); `:expires`

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -458,7 +458,7 @@
            "ssr-handler when a custom one-piece shell is required.")
       {:recovery :drop-html-shell-or-use-non-streaming-handler
        :extra    {:opt-key :html-shell
-                  :got     (:html-shell opts)}})))
+                  :got     (:html-shell opts)}}))
   opts)
 
 (defn resolve-on-error

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -41,6 +41,7 @@
   forgot to destructure ended up with the request riding the unused-arg
   slot). Pre-alpha: one canonical surface, no fallback."
   (:require [re-frame.core :as rf]
+            [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr.payload-policy :as payload-policy]
@@ -212,12 +213,13 @@
     (vector? root-view) root-view
     (fn?     root-view) (root-view)
     :else
-    (throw (ex-info ":rf.error/invalid-root-view"
-                    {:rf.error/id :rf.error/invalid-root-view
-                     :where    'rf.ssr/ssr-handler
-                     :reason   "root-view must be a hiccup vector or a 0-arity fn"
-                     :received root-view
-                     :recovery :no-recovery}))))
+    (error/throw-error!
+      :rf.error/invalid-root-view
+      'rf.ssr/ssr-handler
+      (str "root-view must be a hiccup vector or a 0-arity fn returning "
+           "hiccup; pass one of those as :root-view.")
+      {:recovery :supply-a-hiccup-vector-or-0-arity-fn
+       :extra    {:received root-view}})))
 
 (defn resolve-head
   "Resolve the active route's `:head` against `frame-id` (or the default
@@ -328,12 +330,12 @@
   [on-create]
   (if (vector? on-create)
     on-create
-    (throw (ex-info ":rf.error/invalid-on-create"
-                    {:rf.error/id :rf.error/invalid-on-create
-                     :where    'rf.ssr/ssr-handler
-                     :reason   ":on-create must be a vector (event)"
-                     :received on-create
-                     :recovery :no-recovery}))))
+    (error/throw-error!
+      :rf.error/invalid-on-create
+      'rf.ssr/ssr-handler
+      ":on-create must be a vector (an event vector); pass an event vector as :on-create."
+      {:recovery :supply-an-event-vector
+       :extra    {:received on-create}})))
 
 (defn validate-required-opts!
   "Throw a structured `:rf.error/ssr-ring-missing-*` ex-info when a
@@ -356,17 +358,18 @@
   `trust`/`payload-policy`."
   [{:keys [on-create root-view] :as opts}]
   (when-not on-create
-    (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
-                    {:rf.error/id :rf.error/ssr-ring-missing-on-create
-                     :where    'rf.ssr/ssr-handler
-                     :reason   "ssr-handler requires :on-create (an event vector)"
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/ssr-ring-missing-on-create
+      'rf.ssr/ssr-handler
+      "ssr-handler requires :on-create (an event vector); supply :on-create in the handler opts."
+      {:recovery :supply-the-on-create-opt}))
   (when-not root-view
-    (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
-                    {:rf.error/id :rf.error/ssr-ring-missing-root-view
-                     :where    'rf.ssr/ssr-handler
-                     :reason   "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/ssr-ring-missing-root-view
+      'rf.ssr/ssr-handler
+      (str "ssr-handler requires :root-view (a hiccup vector or 0-arity fn); "
+           "supply :root-view in the handler opts.")
+      {:recovery :supply-the-root-view-opt}))
   opts)
 
 (defn validate-construction-opts!
@@ -440,22 +443,22 @@
   Returns `opts` unchanged on success."
   [opts]
   (when (some? (:html-shell opts))
-    (throw (ex-info ":rf.error/ssr-streaming-unsupported-opt"
-                    {:rf.error/id :rf.error/ssr-streaming-unsupported-opt
-                     :where    'rf.ssr/stream-handler
-                     :opt-key  :html-shell
-                     :got      (:html-shell opts)
-                     :reason   (str "stream-handler does not support :html-shell — the "
-                                    "streaming envelope is flushed as a SPLIT prefix/suffix "
-                                    "straddling the continuation chunks (Spec 011 §Streaming "
-                                    "SSR), so a one-piece (body-html payload-edn opts) → string "
-                                    ":html-shell fn cannot be applied after streaming starts. "
-                                    "Use the streaming envelope surface instead: the :head, "
-                                    ":body-end, :script-src, and :app-element-id trusted-shell "
-                                    "hooks (honoured by default-streaming-prefix / "
-                                    "default-streaming-suffix), or build a non-streaming "
-                                    "ssr-handler when a custom one-piece shell is required.")
-                     :recovery :drop-html-shell-or-use-non-streaming-handler})))
+    (error/throw-error!
+      :rf.error/ssr-streaming-unsupported-opt
+      'rf.ssr/stream-handler
+      (str "stream-handler does not support :html-shell — the "
+           "streaming envelope is flushed as a SPLIT prefix/suffix "
+           "straddling the continuation chunks (Spec 011 §Streaming "
+           "SSR), so a one-piece (body-html payload-edn opts) → string "
+           ":html-shell fn cannot be applied after streaming starts. "
+           "Use the streaming envelope surface instead: the :head, "
+           ":body-end, :script-src, and :app-element-id trusted-shell "
+           "hooks (honoured by default-streaming-prefix / "
+           "default-streaming-suffix), or build a non-streaming "
+           "ssr-handler when a custom one-piece shell is required.")
+      {:recovery :drop-html-shell-or-use-non-streaming-handler
+       :extra    {:opt-key :html-shell
+                  :got     (:html-shell opts)}})))
   opts)
 
 (defn resolve-on-error

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -35,6 +35,7 @@
   no fixed `\"Internal error\"` fallback string ever reaches a client
   (rf2-kzvwq)."
   (:require [re-frame.core :as rf]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
@@ -268,12 +269,13 @@
                      (keyword? error-view) [error-view public-error]
                      (fn? error-view)      (error-view public-error)
                      :else
-                     (throw (ex-info ":rf.error/ssr-ring-invalid-error-view"
-                                     {:rf.error/id :rf.error/ssr-ring-invalid-error-view
-                                      :where    'rf.ssr/ssr-handler
-                                      :reason   ":error-view must be a registered-view keyword or a 1-arity fn"
-                                      :received error-view
-                                      :recovery :no-recovery})))]
+                     (error/throw-error!
+                       :rf.error/ssr-ring-invalid-error-view
+                       'rf.ssr/ssr-handler
+                       (str ":error-view must be a registered-view keyword "
+                            "or a 1-arity fn; pass one of those to ssr-handler.")
+                       {:recovery :supply-a-view-keyword-or-1-arity-fn
+                        :extra    {:received error-view}}))]
         (rf/with-frame frame-id
           (ssr/render-to-string hiccup {:doctype? false :emit-hash? false})))
       (catch Throwable t

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
@@ -50,7 +50,8 @@
   façade. Sibling to `re-frame.ssr.payload-policy` (the equivalent
   consolidation of the fail-closed hydration-payload policy contract
   per rf2-gtgf9)."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]))
 
 (set! *warn-on-reflection* true)
 
@@ -83,19 +84,19 @@
     (when (contains? opts k)
       (let [v (get opts k)]
         (when (and (some? v) (not (string? v)))
-          (throw (ex-info ":rf.error/ssr-trusted-shell-opt-invalid"
-                          {:rf.error/id :rf.error/ssr-trusted-shell-opt-invalid
-                           :where    'rf.ssr/trusted-shell
-                           :reason   (str "ssr-handler / stream-handler " (pr-str k)
-                                          " must be a string (or nil) — the four "
-                                          "trusted shell-hook opts ("
-                                          (str/join ", " (map pr-str trusted-shell-string-opts))
-                                          ") are injected RAW into the rendered HTML "
-                                          "envelope (trusted-string contract per "
-                                          "Spec 011 §Trusted shell hook contract). "
-                                          "Got: " (pr-str (type v)) ".")
-                           :opt-key  k
-                           :got      v
-                           :got-type (type v)
-                           :recovery :supply-string-or-nil}))))))
+          (error/throw-error!
+            :rf.error/ssr-trusted-shell-opt-invalid
+            'rf.ssr/trusted-shell
+            (str "ssr-handler / stream-handler " (pr-str k)
+                 " must be a string (or nil) — the four "
+                 "trusted shell-hook opts ("
+                 (str/join ", " (map pr-str trusted-shell-string-opts))
+                 ") are injected RAW into the rendered HTML "
+                 "envelope (trusted-string contract per "
+                 "Spec 011 §Trusted shell hook contract). "
+                 "Got: " (pr-str (type v)) ".")
+            {:recovery :supply-string-or-nil
+             :extra    {:opt-key  k
+                        :got      v
+                        :got-type (type v)}})))))
   opts)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1242,8 +1242,10 @@
                         (assoc base-opts :body-end {:script "evil"}))
                       (catch clojure.lang.ExceptionInfo e e))]
           (is (some? ex) "an exception was thrown")
-          (is (= ":rf.error/ssr-trusted-shell-opt-invalid"
-                 (ex-message ex)))
+          ;; rf2-vvixub — branch on the canonical :rf.error/id; the message is
+          ;; the human :reason + the [:rf.error/<id>] token (non-normative bytes).
+          (is (= :rf.error/ssr-trusted-shell-opt-invalid
+                 (:rf.error/id (ex-data ex))))
           (is (= :body-end (:opt-key (ex-data ex))))
           (is (= {:script "evil"} (:got (ex-data ex))))
           (is (= :supply-string-or-nil (:recovery (ex-data ex))))))

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -62,7 +62,8 @@
   `day8/re-frame2-ssr` artefact alongside the rest of the SSR surface; it
   is re-exported from the `re-frame.ssr` façade as `ssr/hydrate!` /
   `ssr/read-server-payload`."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.router :as router]
@@ -185,22 +186,24 @@
   (let [payload-frame-id (:rf/frame-id payload)]
     (when (and (some? payload-frame-id)
                (not= payload-frame-id target))
-      (let [data {:rf.error/id      :rf.error/hydration-frame-id-mismatch
-                  :where            'rf.ssr/hydrate!
-                  :failing-id       :rf/hydrate
-                  :target-frame     target
-                  :payload-frame-id payload-frame-id
-                  :reason           (str "Hydration frame-id mismatch: the explicit "
-                                         ":frame target '" target "' conflicts with the "
-                                         "payload's :rf/frame-id '" payload-frame-id
-                                         "' (the frame the server rendered under). "
-                                         "Pass the same frame to hydrate! that the server "
-                                         "stamped, or correct the server's render frame — "
-                                         "the runtime will not silently choose a side.")
-                  :recovery         :supply-matching-frame}]
+      (let [ex   (error/thrown-ex-info
+                   :rf.error/hydration-frame-id-mismatch
+                   'rf.ssr/hydrate!
+                   (str "Hydration frame-id mismatch: the explicit "
+                        ":frame target '" target "' conflicts with the "
+                        "payload's :rf/frame-id '" payload-frame-id
+                        "' (the frame the server rendered under). "
+                        "Pass the same frame to hydrate! that the server "
+                        "stamped, or correct the server's render frame — "
+                        "the runtime will not silently choose a side.")
+                   {:recovery :supply-matching-frame
+                    :extra    {:failing-id       :rf/hydrate
+                               :target-frame     target
+                               :payload-frame-id payload-frame-id}})
+            data (ex-data ex)]
         (when interop/debug-enabled?
           (trace/emit-error! :rf.error/hydration-frame-id-mismatch data))
-        (throw (ex-info (str (:rf.error/id data)) data))))))
+        (throw ex)))))
 
 (defn hydrate!
   "Boot the client from the server's hydration payload — the symmetric

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -22,6 +22,7 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
+            [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -125,19 +126,19 @@
   [tag-name source-kw]
   (when-not (and (string? tag-name)
                  (re-matches tag-name-re tag-name))
-    (throw (ex-info ":rf.error/invalid-tag-name"
-                    {:rf.error/id :rf.error/invalid-tag-name
-                     :where    'rf.ssr/emit
-                     :reason   (str "tag-name " (pr-str tag-name)
-                                    " (from hiccup head " (pr-str source-kw) ")"
-                                    " does not match the HTML5/SVG/MathML"
-                                    " element-name grammar"
-                                    " ([A-Za-z][A-Za-z0-9-]*, optionally"
-                                    " namespaced prefix:local) — DOM tag-name"
-                                    " injection forbidden")
-                     :tag-name tag-name
-                     :source   source-kw
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/invalid-tag-name
+      'rf.ssr/emit
+      (str "tag-name " (pr-str tag-name)
+           " (from hiccup head " (pr-str source-kw) ")"
+           " does not match the HTML5/SVG/MathML"
+           " element-name grammar"
+           " ([A-Za-z][A-Za-z0-9-]*, optionally"
+           " namespaced prefix:local) — DOM tag-name"
+           " injection forbidden. Use a grammar-valid element name.")
+      {:recovery :use-a-valid-element-name
+       :extra    {:tag-name tag-name
+                  :source   source-kw}}))
   tag-name)
 
 ;; Tag-name parsing for the :div#id.cls syntax (Reagent / Hiccup
@@ -320,20 +321,20 @@
   [tag-name children source-head]
   (when (and (contains? raw-text-tags (clojure.string/lower-case tag-name))
              (some string? children))
-    (throw (ex-info ":rf.error/ssr-raw-text-in-body"
-                    {:rf.error/id :rf.error/ssr-raw-text-in-body
-                     :where    'rf.ssr/emit
-                     :reason   (str "Raw string content under a body-position <"
-                                    tag-name "> (hiccup head " (pr-str source-head)
-                                    ") is unsupported — the body emitter has no"
-                                    " single safe escape for raw script/style"
-                                    " content. Put JSON-LD / structured head"
-                                    " content through reg-head, and trusted"
-                                    " inline JS/CSS through the host shell's"
-                                    " trusted :body-end / :head-extra opt.")
-                     :tag      tag-name
-                     :source   source-head
-                     :recovery :no-recovery}))))
+    (error/throw-error!
+      :rf.error/ssr-raw-text-in-body
+      'rf.ssr/emit
+      (str "Raw string content under a body-position <"
+           tag-name "> (hiccup head " (pr-str source-head)
+           ") is unsupported — the body emitter has no"
+           " single safe escape for raw script/style"
+           " content. Put JSON-LD / structured head"
+           " content through reg-head, and trusted"
+           " inline JS/CSS through the host shell's"
+           " trusted :body-end / :head-extra opt.")
+      {:recovery :move-content-to-reg-head-or-shell-opts
+       :extra    {:tag    tag-name
+                  :source source-head}})))
 
 (defn emit-element
   "Emit a hiccup node as an HTML string. The optional `root-attrs` map
@@ -379,18 +380,18 @@
          ;; must wrap the React component in a `reg-view` (which the SSR
          ;; emitter resolves) or render it client-only.
          (= :> head)
-         (throw (ex-info ":rf.error/ssr-reagent-native-head"
-                         {:rf.error/id :rf.error/ssr-reagent-native-head
-                          :where    'rf.ssr/emit
-                          :reason   (str "Reagent-native interop head `:>` "
-                                         "(element " (pr-str el) ") cannot be "
-                                         "rendered server-side — it targets a "
-                                         "React component and there is no React "
-                                         "on the JVM. Wrap the component in a "
-                                         "reg-view for SSR, or render it "
-                                         "client-only.")
-                          :element  el
-                          :recovery :no-recovery}))
+         (error/throw-error!
+           :rf.error/ssr-reagent-native-head
+           'rf.ssr/emit
+           (str "Reagent-native interop head `:>` "
+                "(element " (pr-str el) ") cannot be "
+                "rendered server-side — it targets a "
+                "React component and there is no React "
+                "on the JVM. Wrap the component in a "
+                "reg-view for SSR, or render it "
+                "client-only.")
+           {:recovery :wrap-in-reg-view-or-render-client-only
+            :extra    {:element el}})
 
          ;; Reserved streaming marker `:rf/suspense-boundary` — recognised
          ;; ONLY by the streaming shell walker (`re-frame.ssr.streaming`).
@@ -405,23 +406,23 @@
          ;; silently producing malformed markup. Per Conventions §`:rf/*`
          ;; reserved hiccup heads + Spec 011 §Streaming SSR.
          (= :rf/suspense-boundary head)
-         (throw (ex-info ":rf.error/ssr-suspense-boundary-outside-stream"
-                         {:rf.error/id :rf.error/ssr-suspense-boundary-outside-stream
-                          :where    'rf.ssr/emit
-                          :reason   (str ":rf/suspense-boundary (element "
-                                         (pr-str el) ") is a streaming-only "
-                                         "marker recognised by the streaming "
-                                         "shell walker (re-frame.ssr.ring/"
-                                         "stream-handler), not the standard "
-                                         "emitter. It reached render-to-string "
-                                         "outside a stream — that path cannot "
-                                         "resolve the boundary's continuation, "
-                                         "so it would emit a phantom "
-                                         "<suspense-boundary> DOM element. Use "
-                                         "stream-handler to render trees "
-                                         "containing :rf/suspense-boundary.")
-                          :element  el
-                          :recovery :no-recovery}))
+         (error/throw-error!
+           :rf.error/ssr-suspense-boundary-outside-stream
+           'rf.ssr/emit
+           (str ":rf/suspense-boundary (element "
+                (pr-str el) ") is a streaming-only "
+                "marker recognised by the streaming "
+                "shell walker (re-frame.ssr.ring/"
+                "stream-handler), not the standard "
+                "emitter. It reached render-to-string "
+                "outside a stream — that path cannot "
+                "resolve the boundary's continuation, "
+                "so it would emit a phantom "
+                "<suspense-boundary> DOM element. Use "
+                "stream-handler to render trees "
+                "containing :rf/suspense-boundary.")
+           {:recovery :render-via-stream-handler
+            :extra    {:element el}})
 
          (keyword? head)
          (let [;; Look up registered view first.

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -19,6 +19,7 @@
   bookkeeping, and the late-bind hook registrations — live in the
   `re-frame.ssr.head` façade."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [re-frame.ssr.html-helpers :as html]))
 
 ;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
@@ -80,15 +81,16 @@
                        (ratio? v) (str (double v))
                        (and (or (instance? Double v) (instance? Float v))
                             (not (Double/isFinite (double v))))
-                       (throw (ex-info ":rf.error/invalid-json-ld-number"
-                                       {:rf.error/id :rf.error/invalid-json-ld-number
-                                        :where    'rf.ssr.head/emit
-                                        :reason   (str "JSON-LD number " (pr-str v)
-                                                       " is non-finite — JSON has no"
-                                                       " representation for ##Inf /"
-                                                       " ##-Inf / ##NaN")
-                                        :value    v
-                                        :recovery :no-recovery}))
+                       (error/throw-error!
+                         :rf.error/invalid-json-ld-number
+                         'rf.ssr.head/emit
+                         (str "JSON-LD number " (pr-str v)
+                              " is non-finite — JSON has no"
+                              " representation for ##Inf /"
+                              " ##-Inf / ##NaN. Emit a finite number in"
+                              " the JSON-LD head model.")
+                         {:recovery :supply-a-finite-number
+                          :extra    {:value v}})
                        :else (str v)))
                    (escape-json-control [^String s]
                      ;; rf2-hzttr finding 1 — JSON requires every control
@@ -148,14 +150,15 @@
                                                    (str ns "/" (name k))
                                                    (name k)))
                        (nil? k)
-                       (throw (ex-info ":rf.error/invalid-json-ld-key"
-                                       {:rf.error/id :rf.error/invalid-json-ld-key
-                                        :where    'rf.ssr.head/emit
-                                        :reason   (str "JSON-LD object key is nil"
-                                                       " — JSON object keys must be"
-                                                       " strings; nil has no key"
-                                                       " representation")
-                                        :recovery :no-recovery}))
+                       (error/throw-error!
+                         :rf.error/invalid-json-ld-key
+                         'rf.ssr.head/emit
+                         (str "JSON-LD object key is nil"
+                              " — JSON object keys must be"
+                              " strings; nil has no key"
+                              " representation. Use a string or keyword"
+                              " key in the JSON-LD head model.")
+                         {:recovery :supply-a-non-nil-key})
                        (number? k)  (emit-string (emit-number k))
                        :else        (emit-string (str k))))
                    (emit [v]

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -20,7 +20,8 @@
     `on-frame-destroyed!` — clear the per-frame snapshot entry. Wired
                           into the `:ssr.head/on-frame-destroyed` hook
                           chained from `re-frame.ssr`'s teardown."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]))
 
@@ -165,12 +166,14 @@
                    (frame/frame frame)
                    (fn [] (registrar/lookup :head head-id)))]
     (when-not head-reg
-      (throw (ex-info ":rf.error/no-such-head"
-                      {:rf.error/id :rf.error/no-such-head
-                       :where    'rf/active-head
-                       :head-id  head-id
-                       :reason   (str "No head registered under " head-id ".")
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/no-such-head
+        'rf/active-head
+        (str "No head registered under " head-id
+             "; register it with reg-head before rendering, or pass a "
+             "head-id that has been registered.")
+        {:recovery :register-the-head-id
+         :extra    {:head-id head-id}}))
     (let [head-fn (:handler-fn head-reg)
           ;; `frame` is a required non-nil stamp here (require-frame-stamp!
           ;; above), so the app-db read is unconditional.

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -27,7 +27,8 @@
                                     ` k1=\"v1\" k2=\"v2\"`. Boolean `true`
                                     → bare attribute name (`disabled`);
                                     `false` / `nil` → omitted entirely."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]))
 
 (defn escape-html
   "Full text-node HTML escape: `& < > \" '`. Stringifies non-strings."
@@ -163,19 +164,19 @@
               (if (or (= nxt \/) (= nxt \!))
                 ;; `</` or `<!` in token position is a real HTML breakout
                 ;; precursor with no readable in-token EDN escape.
-                (throw (ex-info ":rf.error/ssr-edn-script-breakout"
-                                {:rf.error/id :rf.error/ssr-edn-script-breakout
-                                 :where    'rf.ssr/html-helpers
-                                 :reason   (str "EDN script body carries a `<"
-                                                nxt "` HTML breakout precursor "
-                                                "in a non-string (keyword/symbol) "
-                                                "token, which has no readable EDN "
-                                                "escape; the offending token cannot "
-                                                "be safely emitted inside a "
-                                                "<script type=\"application/edn\"> "
-                                                "body. Restructure the offending "
-                                                "app-db key/value.")
-                                 :recovery :no-recovery}))
+                (error/throw-error!
+                  :rf.error/ssr-edn-script-breakout
+                  'rf.ssr/html-helpers
+                  (str "EDN script body carries a `<"
+                       nxt "` HTML breakout precursor "
+                       "in a non-string (keyword/symbol) "
+                       "token, which has no readable EDN "
+                       "escape; the offending token cannot "
+                       "be safely emitted inside a "
+                       "<script type=\"application/edn\"> "
+                       "body. Restructure the offending "
+                       "app-db key/value.")
+                  {:recovery :restructure-the-offending-app-db-value})
                 ;; Lone `<` in a token (`:<`, `:a<b`) — harmless in HTML
                 ;; script-data state; leave it so the token round-trips.
                 (recur (inc i) false false (conj! acc c))))
@@ -207,14 +208,15 @@
   (let [s (name k)]
     (if (re-matches attr-name-grammar s)
       s
-      (throw (ex-info ":rf.error/ssr-invalid-attribute-name"
-                      {:rf.error/id :rf.error/ssr-invalid-attribute-name
-                       :where     'rf.ssr/html-helpers
-                       :reason    (str "attribute name violates HTML5 grammar "
-                                       "[A-Za-z][A-Za-z0-9_:-]*; got "
-                                       (pr-str s))
-                       :attribute k
-                       :recovery  :no-recovery})))))
+      (error/throw-error!
+        :rf.error/ssr-invalid-attribute-name
+        'rf.ssr/html-helpers
+        (str "attribute name violates the HTML5 grammar "
+             "[A-Za-z][A-Za-z0-9_:-]*; got " (pr-str s)
+             ". Rename the attribute key to a letter-led name of "
+             "letters/digits/underscore/colon/hyphen.")
+        {:recovery :rename-the-attribute-key
+         :extra    {:attribute k}}))))
 
 ;; Prototype-pollution keys (rf2-dwds9 / security audit §XSS at output
 ;; boundaries). These three names, if they reach the underlying host's

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -18,7 +18,8 @@
   the handler fns only.
 
   Per the rf2-gxgo7 split of re-frame.ssr."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr.hash :as hash]
@@ -464,5 +465,6 @@
            (when trace-fn
              (trace-fn :rf.ssr/hydration-mismatch payload))
            (when strict?
-             (throw (ex-info ":rf.ssr/hydration-mismatch"
+             (throw (ex-info (error/human-message :rf.ssr/hydration-mismatch
+                                                  (:reason payload))
                              (assoc payload :rf.error/id :rf.ssr/hydration-mismatch))))))))))

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -99,7 +99,8 @@
     `re-frame.ssr.ring.payload/build-payload`     - non-streaming SSR
     `re-frame.ssr.streaming/build-final-payload`  - streaming SSR"
   (:refer-clojure :exclude [resolve])
-  (:require [re-frame.late-bind :as late-bind]
+  (:require [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -215,49 +216,49 @@
     ;; missing-policy bucket where a `select-keys` would otherwise ship a
     ;; wrong/empty slice (rf2-hzttr finding 2).
     (malformed-allowlist? payload)
-    (throw (ex-info ":rf.error/ssr-malformed-payload-allowlist"
-                    {:rf.error/id   :rf.error/ssr-malformed-payload-allowlist
-                     :where         'rf.ssr/payload-policy
-                     :reason        (str "ssr-handler :payload allowlist must be a "
-                                         "non-empty VECTOR of KEYWORD "
-                                         "top-level app-db keys; got "
-                                         (pr-str payload)
-                                         " — these entries are not keywords: "
-                                         (pr-str (vec (remove keyword? payload)))
-                                         " (a string key like \"public/articles\" "
-                                         "should be the keyword :public/articles).")
-                     :got           payload
-                     :bad-entries   (vec (remove keyword? payload))
-                     :recovery      :declare-payload-policy}))
+    (error/throw-error!
+      :rf.error/ssr-malformed-payload-allowlist
+      'rf.ssr/payload-policy
+      (str "ssr-handler :payload allowlist must be a "
+           "non-empty VECTOR of KEYWORD "
+           "top-level app-db keys; got "
+           (pr-str payload)
+           " — these entries are not keywords: "
+           (pr-str (vec (remove keyword? payload)))
+           " (a string key like \"public/articles\" "
+           "should be the keyword :public/articles).")
+      {:recovery :declare-payload-policy
+       :extra    {:got         payload
+                  :bad-entries (vec (remove keyword? payload))}})
 
     ;; Caller passed a keyword that isn't the recognised whole-app-db
     ;; opt-in — surface as a distinct error so a typo (e.g.
     ;; `:rf.ssr.payload/whole-db`) doesn't silently land in the
     ;; missing-policy bucket.
     (keyword? payload)
-    (throw (ex-info ":rf.error/ssr-unknown-payload-policy"
-                    {:rf.error/id    :rf.error/ssr-unknown-payload-policy
-                     :where          'rf.ssr/payload-policy
-                     :reason         (str "ssr-handler :payload keyword must be "
-                                          (pr-str whole-app-db-policy)
-                                          " (or pass a vector allowlist of "
-                                          "top-level app-db keys instead)")
-                     :got            payload
-                     :recognised     #{whole-app-db-policy}
-                     :recovery       :declare-payload-policy}))
+    (error/throw-error!
+      :rf.error/ssr-unknown-payload-policy
+      'rf.ssr/payload-policy
+      (str "ssr-handler :payload keyword must be "
+           (pr-str whole-app-db-policy)
+           " (or pass a vector allowlist of "
+           "top-level app-db keys instead)")
+      {:recovery :declare-payload-policy
+       :extra    {:got        payload
+                  :recognised #{whole-app-db-policy}}})
 
     :else
-    (throw (ex-info ":rf.error/ssr-missing-payload-policy"
-                    {:rf.error/id :rf.error/ssr-missing-payload-policy
-                     :where    'rf.ssr/payload-policy
-                     :reason   (str "ssr-handler requires an explicit hydration-"
-                                    "payload policy: pass :payload "
-                                    "[<top-level-app-db-keys>] (allowlist, "
-                                    "preferred) OR :payload "
-                                    (pr-str whole-app-db-policy)
-                                    " to opt-in to shipping the whole app-db.")
-                     :got      payload
-                     :recovery :declare-payload-policy}))))
+    (error/throw-error!
+      :rf.error/ssr-missing-payload-policy
+      'rf.ssr/payload-policy
+      (str "ssr-handler requires an explicit hydration-"
+           "payload policy: pass :payload "
+           "[<top-level-app-db-keys>] (allowlist, "
+           "preferred) OR :payload "
+           (pr-str whole-app-db-policy)
+           " to opt-in to shipping the whole app-db.")
+      {:recovery :declare-payload-policy
+       :extra    {:got payload}})))
 
 (defn apply-policy
   "Project `app-db` to the wire slice per the caller's declared `:payload`

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -58,6 +58,7 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.ssr.http-validation :as http-validation]
             [re-frame.trace :as trace])
@@ -103,16 +104,17 @@
   [header-name v]
   (let [s (str v)]
     (when (http-validation/contains-injection-char? s)
-      (throw (ex-info ":rf.error/header-invalid-value"
-                      {:rf.error/id :rf.error/header-invalid-value
-                       :where    'rf.ssr/response
-                       :reason   (str "header " (pr-str header-name)
-                                      " value contains CR/LF/NUL — forbidden"
-                                      " by RFC 7230 §3.2.4 (header-splitting"
-                                      " injection)")
-                       :header   header-name
-                       :value    v
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/header-invalid-value
+        'rf.ssr/response
+        (str "header " (pr-str header-name)
+             " value contains CR/LF/NUL — forbidden"
+             " by RFC 7230 §3.2.4 (header-splitting"
+             " injection). Strip CR/LF/NUL from the header value before"
+             " setting it.")
+        {:recovery :remove-injection-chars-from-header-value
+         :extra    {:header header-name
+                    :value  v}}))
     s))
 
 (defn- structurally-valid-uri?
@@ -155,14 +157,15 @@
   [loc]
   (let [s (str loc)]
     (when (http-validation/contains-injection-char? s)
-      (throw (ex-info ":rf.error/redirect-invalid-location"
-                      {:rf.error/id :rf.error/redirect-invalid-location
-                       :where    'rf.ssr/response
-                       :reason   (str "redirect :location contains CR/LF/NUL"
-                                      " — forbidden by RFC 7230 §3.2.4"
-                                      " (header-splitting injection)")
-                       :location loc
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/redirect-invalid-location
+        'rf.ssr/response
+        (str "redirect :location contains CR/LF/NUL"
+             " — forbidden by RFC 7230 §3.2.4"
+             " (header-splitting injection). Strip CR/LF/NUL from the"
+             " redirect :location before setting it.")
+        {:recovery :remove-injection-chars-from-location
+         :extra    {:location loc}}))
     s))
 
 (defn- validate-redirect-location-shape!
@@ -187,18 +190,19 @@
   [loc]
   (let [s (str loc)]
     (when-not (structurally-valid-uri? s)
-      (throw (ex-info ":rf.error/redirect-invalid-location"
-                      {:rf.error/id :rf.error/redirect-invalid-location
-                       :where    'rf.ssr/response
-                       :reason   (str "redirect :location is not a"
-                                      " structurally-valid URI reference"
-                                      " (RFC 3986) — a structurally-malformed"
-                                      " redirect target cannot be written as a"
-                                      " Location header. Per Spec 011 §CRLF"
-                                      " fail-fast (structural URL-shape check).")
-                       :location loc
-                       :reason-tag :structural-url-shape
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/redirect-invalid-location
+        'rf.ssr/response
+        (str "redirect :location is not a"
+             " structurally-valid URI reference"
+             " (RFC 3986) — a structurally-malformed"
+             " redirect target cannot be written as a"
+             " Location header. Per Spec 011 §CRLF"
+             " fail-fast (structural URL-shape check)."
+             " Supply a well-formed URI reference as :location.")
+        {:recovery :supply-a-well-formed-uri
+         :extra    {:location   loc
+                    :reason-tag :structural-url-shape}}))
     s))
 
 ;; rf2-z7gor / security audit 2026-05-14 — header-name + cookie-field
@@ -227,15 +231,15 @@
   [n]
   (let [s (str n)]
     (when-not (http-validation/valid-token-name? s)
-      (throw (ex-info ":rf.error/header-invalid-name"
-                      {:rf.error/id :rf.error/header-invalid-name
-                       :where    'rf.ssr/response
-                       :reason   (str "header :name " (pr-str s)
-                                      " violates RFC 7230 §3.2.6 token grammar"
-                                      " (no CTLs, whitespace, or separators"
-                                      " ()<>@,;:\\\"/[]?={})")
-                       :header   n
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/header-invalid-name
+        'rf.ssr/response
+        (str "header :name " (pr-str s)
+             " violates RFC 7230 §3.2.6 token grammar"
+             " (no CTLs, whitespace, or separators"
+             " ()<>@,;:\\\"/[]?={}). Use a token-grammar header name.")
+        {:recovery :use-a-token-grammar-header-name
+         :extra    {:header n}}))
     s))
 
 (defn- validate-cookie-name!
@@ -245,23 +249,23 @@
   host adapters get the same gate. Per rf2-z7gor."
   [n]
   (when (nil? n)
-    (throw (ex-info ":rf.error/cookie-invalid-name"
-                    {:rf.error/id :rf.error/cookie-invalid-name
-                     :where    'rf.ssr/response
-                     :reason   "cookie :name is required"
-                     :name     n
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/cookie-invalid-name
+      'rf.ssr/response
+      "cookie :name is required; supply a non-nil :name on the cookie map."
+      {:recovery :supply-a-cookie-name
+       :extra    {:name n}}))
   (let [s (#?(:clj clojure.core/name :cljs cljs.core/name) n)]
     (when-not (http-validation/valid-token-name? s)
-      (throw (ex-info ":rf.error/cookie-invalid-name"
-                      {:rf.error/id :rf.error/cookie-invalid-name
-                       :where    'rf.ssr/response
-                       :reason   (str "cookie :name " (pr-str s)
-                                      " violates RFC 6265 §4.1.1 token grammar"
-                                      " (no CTLs, whitespace, or separators"
-                                      " ()<>@,;:\\\"/[]?={})")
-                       :name     n
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/cookie-invalid-name
+        'rf.ssr/response
+        (str "cookie :name " (pr-str s)
+             " violates RFC 6265 §4.1.1 token grammar"
+             " (no CTLs, whitespace, or separators"
+             " ()<>@,;:\\\"/[]?={}). Use a token-grammar cookie name.")
+        {:recovery :use-a-token-grammar-cookie-name
+         :extra    {:name n}}))
     s))
 
 (defn- validate-cookie-attr!
@@ -280,16 +284,17 @@
   (let [s (str v)]
     (when (http-validation/contains-injection-char? s)
       (let [error-kw (keyword "rf.error" (str "cookie-invalid-" (name field-key)))]
-        (throw (ex-info (str error-kw)
-                        {:rf.error/id error-kw
-                         :where    'rf.ssr/response
-                         :reason   (str "cookie " field-key " " (pr-str s)
-                                        " contains CR/LF/NUL — forbidden by"
-                                        " RFC 7230 §3.2.4 (header-splitting"
-                                        " injection)")
-                         :field    field-key
-                         :value    v
-                         :recovery :no-recovery}))))
+        (error/throw-error!
+          error-kw
+          'rf.ssr/response
+          (str "cookie " field-key " " (pr-str s)
+               " contains CR/LF/NUL — forbidden by"
+               " RFC 7230 §3.2.4 (header-splitting"
+               " injection). Strip CR/LF/NUL from the cookie "
+               (name field-key) ".")
+          {:recovery :remove-injection-chars-from-cookie-attr
+           :extra    {:field field-key
+                      :value v}})))
     s))
 
 (defn- validate-cookie!
@@ -517,20 +522,19 @@
   [redirect-map]
   (let [retired (filterv #(contains? redirect-map %) retired-redirect-target-keys)]
     (when (seq retired)
-      (throw (ex-info ":rf.error/redirect-retired-target-key"
-                      {:rf.error/id :rf.error/redirect-retired-target-key
-                       :where     'rf.ssr/response
-                       :reason    (str "redirect target key(s) " (pr-str retired)
-                                        " are retired — the canonical redirect"
-                                        " target key is :location. The SSR redirect"
-                                        " fx writes an HTTP Location response header,"
-                                        " so it uses header vocabulary; rewrite "
-                                        (pr-str (first retired)) " as :location."
-                                        " (rf2-vngir / EP-0007 one-name-per-fact;"
-                                        " no back-compat alias.)")
-                       :retired-keys retired
-                       :canonical-key :location
-                       :recovery  :no-recovery})))))
+      (error/throw-error!
+        :rf.error/redirect-retired-target-key
+        'rf.ssr/response
+        (str "redirect target key(s) " (pr-str retired)
+             " are retired — the canonical redirect"
+             " target key is :location. The SSR redirect"
+             " fx writes an HTTP Location response header,"
+             " so it uses header vocabulary; rewrite "
+             (pr-str (first retired)) " as :location."
+             " (EP-0007 one-name-per-fact; no back-compat alias.)")
+        {:recovery :rewrite-the-target-key-as-location
+         :extra    {:retired-keys  retired
+                    :canonical-key :location}}))))
 
 (defn redirect-fx
   "Handler fn for `:rf.server/redirect`. Defaults :status to 302 if

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -57,6 +57,7 @@
   Per the rf2-ojakd / rf2-olb64 cluster."
   (:require [clojure.data]
             [clojure.string]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -318,13 +319,15 @@
         children (vec (drop 2 el))
         n        (count children)]
     (when-not (suspense-attrs? attrs)
-      (throw (ex-info ":rf.error/suspense-boundary-invalid-attrs"
-                      {:rf.error/id :rf.error/suspense-boundary-invalid-attrs
-                       :where    'rf.ssr/streaming
-                       :reason   ":rf/suspense-boundary requires {:id … :fallback …} attrs map"
-                       :got      attrs
-                       :element  el
-                       :recovery :no-recovery})))
+      (error/throw-error!
+        :rf.error/suspense-boundary-invalid-attrs
+        'rf.ssr/streaming
+        (str ":rf/suspense-boundary requires an attrs map with both "
+             ":id and :fallback; give it {:id … :fallback …} as its "
+             "second element.")
+        {:recovery :supply-id-and-fallback-attrs
+         :extra    {:got     attrs
+                    :element el}}))
     (let [{:keys [id fallback]} attrs
           ;; The subtree is the rest of the hiccup vector after the
           ;; attrs map. Single-child or multi-child both work — we wrap

--- a/implementation/ssr/src/re_frame/ssr/substrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/substrate.cljc
@@ -23,7 +23,8 @@
   parent-var name clash.
 
   Per the rf2-gxgo7 split of re-frame.ssr."
-  (:require [re-frame.ssr.emit :as emit]))
+  (:require [re-frame.error :as error]
+            [re-frame.ssr.emit :as emit]))
 
 (defn- ssr-make-state-container [initial-value]
   (atom initial-value))
@@ -52,11 +53,13 @@
   ;; SSR uses render-to-string exclusively. Calling render on the SSR
   ;; adapter is a programmer error worth surfacing loudly. Per Spec 006
   ;; §Plain-atom adapter and rf2-z1ke.
-  (throw (ex-info ":rf.error/render-on-headless-adapter"
-                  {:rf.error/id :rf.error/render-on-headless-adapter
-                   :where    'rf/render
-                   :reason   "render is not supported on the SSR adapter; use render-to-string"
-                   :recovery :no-recovery})))
+  (error/throw-error!
+    :rf.error/render-on-headless-adapter
+    'rf/render
+    (str "render is not supported on the SSR adapter (it is headless — no "
+         "React reactivity); render server-side HTML with rf/render-to-string "
+         "instead of rf/render.")
+    {:recovery :use-render-to-string}))
 
 (defn- ssr-register-context-provider [_frame-keyword]
   ;; No React context on the JVM; users thread frames as arguments per

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -1194,8 +1194,14 @@
         (render-fn [:div] nil nil)
         (is false "render-fn must throw — did not")
         (catch clojure.lang.ExceptionInfo e
-          (is (= ":rf.error/render-on-headless-adapter" (ex-message e))
-              "ex-message names the contract violation")
+          ;; rf2-vvixub — branch on the canonical :rf.error/id; the message is
+          ;; the human :reason sentence + the [:rf.error/<id>] token, NOT a bare
+          ;; keyword (tests must not exact-equal the non-normative message).
+          (is (= :rf.error/render-on-headless-adapter
+                 (:rf.error/id (ex-data e)))
+              "ex-data carries the canonical discriminator")
+          (is (re-find #"\[:rf\.error/render-on-headless-adapter\]" (ex-message e))
+              "ex-message carries the [:rf.error/<id>] greppability token")
           (is (string? (-> e ex-data :reason))
               "ex-data carries a human :reason"))))))
 

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -118,7 +118,9 @@
         (rf/render-head :head/nope {:frame f})
         (is false "expected exception")
         (catch clojure.lang.ExceptionInfo e
-          (is (= ":rf.error/no-such-head" (.getMessage e)))
+          ;; rf2-vvixub — branch on the canonical :rf.error/id; the message is
+          ;; the human :reason + the [:rf.error/<id>] token (non-normative bytes).
+          (is (= :rf.error/no-such-head (:rf.error/id (ex-data e))))
           (is (= :head/nope (:head-id (ex-data e)))))))))
 
 (deftest render-head-records-fragment-in-snapshot

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1788,7 +1788,13 @@ or inject markup into a copied / exported artifact.
 Both image exporters throw `:rf.machines-viz.export/no-svg` when the
 chart has not rendered a viewport yet (an empty / nil-definition
 placeholder renders no chart), and `:rf.machines-viz.export/no-chart-state`
-when `chart-element` resolves to no seam-bearing chart root.
+when `chart-element` is not a rendered `MachineChart` root (or descendant
+of one). Per the thrown-error contract ([Spec 009 §The thrown-error
+shape](../../spec/009-Instrumentation.md)) the `ex-message` is a human
+sentence naming the public concept (a rendered MachineChart element) plus
+the trailing `[:rf.error/<id>]` token; `:rf.error/id` is the canonical
+machine discriminator and `:reason` carries the same human sentence — the
+private chart-state internals are never named in the user-facing message.
 
 ### Share URL
 
@@ -2032,7 +2038,13 @@ documenting comment and does **not** survive the parse back.
 
 ### Error modes
 
-| `:reason` | Meaning |
+Per the thrown-error contract ([Spec 009 §The thrown-error
+shape](../../spec/009-Instrumentation.md)): `:rf.error/id` is the canonical
+machine discriminator (tools branch on it), `:reason` is the human
+sentence, and `ex-message` leads with the sentence and trails the
+`[:rf.error/<id>]` token.
+
+| `:rf.error/id` | Meaning |
 |---|---|
 | `:scxml/invalid-spec` | Input spec missing `:initial` / `:states` (or `:type :parallel` / `:regions`). |
 | `:scxml/parse-error`  | Input XML is malformed or missing the `<scxml>` root. |
@@ -2093,7 +2105,13 @@ clean up or accept as-is).
 
 ### Error modes
 
-| `:reason` | Meaning |
+Per the thrown-error contract ([Spec 009 §The thrown-error
+shape](../../spec/009-Instrumentation.md)): `:rf.error/id` is the canonical
+machine discriminator (tools branch on it), `:reason` is the human
+sentence, and `ex-message` leads with the sentence and trails the
+`[:rf.error/<id>]` token.
+
+| `:rf.error/id` | Meaning |
 |---|---|
 | `:ai-generate/no-resolver`  | `:resolver` opt was not provided. |
 | `:ai-generate/parse-failed` | Resolver output could not be parsed as EDN. |

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -55,6 +55,7 @@
 
   Per [`API.md`](../../spec/API.md) §AI-generate-a-machine."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])))
 
@@ -189,14 +190,13 @@
 ;; chat / re-frame2-pair-mcp) which already has an LLM seam.
 
 (defn- default-resolver [_prompt]
-  (throw (ex-info
-           ":ai-generate/no-resolver"
-           {:rf.error/id :ai-generate/no-resolver
-            :where    'machines-viz/generate-machine
-            :recovery :no-recovery
-            :reason   (str "ai-generate/generate-machine called without a :resolver opt. "
-                           "Inject a resolver fn (string -> string) that bridges to "
-                           "your LLM of choice; see the ns docstring for the contract.")})))
+  (error/throw-error!
+    :ai-generate/no-resolver
+    'machines-viz/generate-machine
+    (str "AI machine generation: generate-machine was called without a "
+         ":resolver opt. Inject a resolver fn (string -> string) that bridges "
+         "to your LLM of choice; see the ns docstring for the contract.")
+    {:recovery :inject-a-resolver-fn}))
 
 ;; ---------------------------------------------------------------------------
 ;; Public API
@@ -232,7 +232,10 @@
 
   ## Throws
 
-  `(ex-info ... {:reason :ai-generate/<kw>})` for:
+  The canonical thrown-error shape (Spec 009 §The thrown-error shape) —
+  `:rf.error/id :ai-generate/<kw>` is the discriminator, `:reason` is the
+  human sentence, the message leads with the sentence + the
+  `[:ai-generate/<kw>]` token — for:
 
   - `:ai-generate/no-resolver` — `:resolver` was not provided.
   - `:ai-generate/parse-failed` — the resolver's output could not
@@ -251,34 +254,39 @@
          full-prompt   (build-prompt user-prompt)
          response      (resolver-fn full-prompt)
          _             (when-not (string? response)
-                         (throw (ex-info
-                                  ":ai-generate/parse-failed"
-                                  {:rf.error/id :ai-generate/parse-failed
-                                   :where    'machines-viz/generate-machine
-                                   :recovery :no-recovery
-                                   :reason   "resolver must return a string"
-                                   :response response})))
+                         (error/throw-error!
+                           :ai-generate/parse-failed
+                           'machines-viz/generate-machine
+                           (str "AI machine generation: the resolver must return "
+                                "a string (the LLM's EDN response); it returned a "
+                                "non-string value.")
+                           {:recovery :return-a-string-from-the-resolver
+                            :extra    {:response response}}))
          stripped      (strip-fences response)
          [stage spec-or-reason] (parse-edn stripped)]
      (cond
        (= :err stage)
-       (throw (ex-info ":ai-generate/parse-failed"
-                       {:rf.error/id :ai-generate/parse-failed
-                        :where    'machines-viz/generate-machine
-                        :recovery :no-recovery
-                        :reason   (str "could not parse resolver output as EDN: " spec-or-reason)
-                        :response response
-                        :stripped stripped}))
+       (error/throw-error!
+         :ai-generate/parse-failed
+         'machines-viz/generate-machine
+         (str "AI machine generation: could not parse the resolver output as "
+              "EDN (" spec-or-reason "). The resolver must return a single EDN "
+              "machine-spec map, optionally inside a ```edn fenced block.")
+         {:recovery :return-valid-edn-from-the-resolver
+          :extra    {:response response
+                     :stripped stripped}})
 
        :else
        (let [[stage2 ok-or-reason] (validate-spec spec-or-reason)]
          (if (= :ok stage2)
            ok-or-reason
-           (throw (ex-info ":ai-generate/invalid-spec"
-                           {:rf.error/id :ai-generate/invalid-spec
-                            :where    'machines-viz/generate-machine
-                            :recovery :no-recovery
-                            :reason   (str "resolver output was not a valid machine spec: "
-                                           ok-or-reason)
-                            :response response
-                            :spec     spec-or-reason}))))))))
+           (error/throw-error!
+             :ai-generate/invalid-spec
+             'machines-viz/generate-machine
+             (str "AI machine generation: the resolver output parsed as EDN but "
+                  "is not a valid machine spec (" ok-or-reason "). Have the "
+                  "resolver return a spec with :initial + :states (or :type "
+                  ":parallel + :regions).")
+             {:recovery :return-a-valid-machine-spec
+              :extra    {:response response
+                         :spec     spec-or-reason}})))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -50,6 +50,7 @@
 
   Per [`API.md`](../../spec/API.md) §Exporters."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [day8.re-frame2-machines-viz.mermaid :as mermaid]
             [day8.re-frame2-machines-viz.share :as share]))
 
@@ -130,12 +131,14 @@
   (let [^js root (chart-root chart-element)
         seam (some-> root .-_rfMvChartState)]
     (when-not (map? seam)
-      (throw (ex-info ":rf.machines-viz.export/no-chart-state"
-                      {:rf.error/id :rf.machines-viz.export/no-chart-state
-                       :where       'machines-viz.export
-                       :recovery    :no-recovery
-                       :reason      "chart-element carries no MachineChart state seam"
-                       :element     chart-element})))
+      (error/throw-error!
+        :rf.machines-viz.export/no-chart-state
+        'machines-viz.export
+        (str "export expects a rendered MachineChart element; the element "
+             "passed is not a MachineChart root (or descendant of one). "
+             "Pass the DOM node of a rendered MachineChart.")
+        {:recovery :pass-a-rendered-machinechart-element
+         :extra    {:element chart-element}})))
     seam))
 
 (defn- state-label
@@ -405,11 +408,13 @@
         cs       (chart-state-of chart-element)
         viewport (find-viewport root)]
     (when-not (and viewport (find-edge-svg root))
-      (throw (ex-info ":rf.machines-viz.export/no-svg"
-                      {:rf.error/id :rf.machines-viz.export/no-svg
-                       :where       'machines-viz.export/chart-as-svg
-                       :recovery    :no-recovery
-                       :reason      "chart has no rendered viewport to serialise"})))
+      (error/throw-error!
+        :rf.machines-viz.export/no-svg
+        'machines-viz.export/chart-as-svg
+        (str "the MachineChart has no rendered viewport to serialise to SVG "
+             "(an empty-state placeholder renders no chart); export after the "
+             "chart has rendered a non-empty topology.")
+        {:recovery :export-after-the-chart-renders}))
     (let [{:keys [width height] :as bounds} (viewport-content-bounds viewport)
           inner      (clone-viewport-html viewport bounds)
           ;; rf2-85a9do — <title>/<desc> are built by hand (not via
@@ -445,8 +450,13 @@
             item (js/ClipboardItem. #js {"image/svg+xml" blob})]
         (.write (.-clipboard js/navigator) #js [item]))
       (js/Promise.reject
-        (ex-info "clipboard API unavailable"
-                 {:rf.error/id :rf.machines-viz.export/no-clipboard})))))
+        (error/thrown-ex-info
+          :rf.machines-viz.export/no-clipboard
+          'machines-viz.export/copy-svg-to-clipboard!
+          (str "the browser clipboard API is unavailable; copy requires a "
+               "secure (https) context with navigator.clipboard + "
+               "ClipboardItem support.")
+          {:recovery :use-a-secure-context-with-clipboard-support})))))
 
 ;; ---------------------------------------------------------------------------
 ;; PNG
@@ -493,13 +503,24 @@
                                  (fn [blob]
                                    (if blob
                                      (resolve blob)
-                                     (reject (ex-info "canvas.toBlob returned nil"
-                                                      {:rf.error/id :rf.machines-viz.export/png-failed}))))
+                                     (reject (error/thrown-ex-info
+                                               :rf.machines-viz.export/png-failed
+                                               'machines-viz.export/chart-as-png!
+                                               (str "PNG export failed: canvas.toBlob "
+                                                    "returned nil; the browser could not "
+                                                    "rasterise the chart canvas. Retry, or "
+                                                    "export SVG/Mermaid instead.")
+                                               {:recovery :retry-or-export-svg-or-mermaid}))))
                                  "image/png")))
                     (catch :default e (reject e)))))
           (set! (.-onerror img)
-                (fn [_] (reject (ex-info "SVG image failed to load"
-                                         {:rf.error/id :rf.machines-viz.export/png-failed}))))
+                (fn [_] (reject (error/thrown-ex-info
+                                  :rf.machines-viz.export/png-failed
+                                  'machines-viz.export/chart-as-png!
+                                  (str "PNG export failed: the serialised SVG image "
+                                       "could not be loaded for rasterisation. Retry, "
+                                       "or export SVG/Mermaid instead.")
+                                  {:recovery :retry-or-export-svg-or-mermaid}))))
           (set! (.-src img) data-url))))))
 
 (defn copy-png-to-clipboard!
@@ -518,8 +539,13 @@
                                                  "text/plain" alt-blob})]
                 (.write (.-clipboard js/navigator) #js [item]))
               (js/Promise.reject
-                (ex-info "clipboard API unavailable"
-                         {:rf.error/id :rf.machines-viz.export/no-clipboard}))))))))
+                (error/thrown-ex-info
+                  :rf.machines-viz.export/no-clipboard
+                  'machines-viz.export/copy-png-to-clipboard!
+                  (str "the browser clipboard API is unavailable; copy requires a "
+                       "secure (https) context with navigator.clipboard + "
+                       "ClipboardItem support.")
+                  {:recovery :use-a-secure-context-with-clipboard-support}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Mermaid
@@ -545,8 +571,12 @@
     (if (and js/navigator (.-clipboard js/navigator))
       (.writeText (.-clipboard js/navigator) md)
       (js/Promise.reject
-        (ex-info "clipboard API unavailable"
-                 {:rf.error/id :rf.machines-viz.export/no-clipboard})))))
+        (error/thrown-ex-info
+          :rf.machines-viz.export/no-clipboard
+          'machines-viz.export/copy-mermaid-to-clipboard!
+          (str "the browser clipboard API is unavailable; copy requires a "
+               "secure (https) context with navigator.clipboard support.")
+          {:recovery :use-a-secure-context-with-clipboard-support})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Share URL
@@ -595,5 +625,9 @@
      (if (and js/navigator (.-clipboard js/navigator))
        (.writeText (.-clipboard js/navigator) url)
        (js/Promise.reject
-         (ex-info "clipboard API unavailable"
-                  {:rf.error/id :rf.machines-viz.export/no-clipboard}))))))
+         (error/thrown-ex-info
+           :rf.machines-viz.export/no-clipboard
+           'machines-viz.export/copy-share-url-to-clipboard!
+           (str "the browser clipboard API is unavailable; copy requires a "
+                "secure (https) context with navigator.clipboard support.")
+           {:recovery :use-a-secure-context-with-clipboard-support}))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -138,7 +138,7 @@
              "passed is not a MachineChart root (or descendant of one). "
              "Pass the DOM node of a rendered MachineChart.")
         {:recovery :pass-a-rendered-machinechart-element
-         :extra    {:element chart-element}})))
+         :extra    {:element chart-element}}))
     seam))
 
 (defn- state-label

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -84,7 +84,8 @@
   The returned string is suitable for paste into a GitHub README,
   a PR description, Notion, or any other Mermaid-aware markdown
   renderer."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]))
 
 (def ^:private header-comment
   ;; Inserted at the top of every emitted block so a reader who pastes
@@ -942,11 +943,17 @@
      (when-not (if parallel?
                  (valid-parallel-definition? definition)
                  (valid-state-tree? definition))
-       (throw (ex-info (if parallel?
-                         "parallel definition must carry non-empty :regions; each region must carry :initial + non-empty :states"
-                         "definition must carry :initial + non-empty :states")
-                       {:reason     :invalid-definition
-                        :definition definition}))))
+       (error/throw-error!
+         :mermaid/invalid-definition
+         'machines-viz.mermaid/emit
+         (if parallel?
+           (str "Mermaid export: a parallel definition must carry a non-empty "
+                ":regions map, and each region must carry :initial + a "
+                "non-empty :states map. Provide those.")
+           (str "Mermaid export: a definition must carry :initial + a "
+                "non-empty :states map. Provide those."))
+         {:recovery :supply-a-valid-definition
+          :extra    {:definition definition}})))
    (let [body (if (parallel-definition? definition)
                 (render-parallel-body definition header-comment?)
                 (render-flat-or-compound-body definition header-comment?))]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -120,11 +120,15 @@
   - Source-coord metadata — stripped at export time (same posture as
     share-URL encoding; see `Principles.md` §No session data in shares).
 
-  Round-trip failure modes throw `(ex-info ... {:reason :scxml/...})`
-  with a `:reason` keyword for programmatic dispatch.
+  Round-trip failure modes throw the canonical thrown-error shape (Spec
+  009 §The thrown-error shape): `:rf.error/id` is the `:scxml/...`
+  discriminator for programmatic dispatch, `:reason` is the human
+  sentence, and the message leads with the sentence + the
+  `[:scxml/<id>]` token.
 
   Per [`API.md`](../../spec/API.md) §SCXML import/export."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             ;; rf2-bs3us — share the canonical parallel-root done-state id
             ;; with the chart projector so the two emitters agree on the
             ;; `done.state.<id>` label (single source of truth).
@@ -761,8 +765,8 @@
    :regions {:data { ... } :form { ... }}}
   ```
 
-  Throws `(ex-info ... {:reason :scxml/invalid-spec})` if the spec
-  is missing required keys.
+  Throws the canonical thrown-error shape with
+  `:rf.error/id :scxml/invalid-spec` if the spec is missing required keys.
 
   Round-trips through `scxml->spec`:
 
@@ -782,12 +786,13 @@
     (= :parallel (:type machine-spec))
     (let [{:keys [regions]} machine-spec]
       (when-not (and (map? regions) (seq regions))
-        (throw (ex-info ":scxml/invalid-spec"
-                        {:rf.error/id :scxml/invalid-spec
-                         :where    'machines-viz/spec->scxml
-                         :recovery :no-recovery
-                         :reason   "parallel spec requires non-empty :regions"
-                         :spec     machine-spec})))
+        (error/throw-error!
+          :scxml/invalid-spec
+          'machines-viz/spec->scxml
+          (str "SCXML export: a parallel machine spec requires a non-empty "
+               ":regions map; add :regions to the parallel spec.")
+          {:recovery :supply-non-empty-regions
+           :extra    {:spec machine-spec}})))
       (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
            (str/join "\n" (emit-parallel machine-spec 0))))
 
@@ -796,12 +801,14 @@
          (str/join "\n" (emit-flat-or-compound machine-spec 0)))
 
     :else
-    (throw (ex-info ":scxml/invalid-spec"
-                    {:rf.error/id :scxml/invalid-spec
-                     :where    'machines-viz/spec->scxml
-                     :recovery :no-recovery
-                     :reason   "spec must carry :initial + non-empty :states, or :type :parallel + :regions"
-                     :spec     machine-spec}))))
+    (error/throw-error!
+      :scxml/invalid-spec
+      'machines-viz/spec->scxml
+      (str "SCXML export: a machine spec must carry :initial + a non-empty "
+           ":states map, or :type :parallel + :regions. Provide one of "
+           "those shapes.")
+      {:recovery :supply-a-valid-machine-spec
+       :extra    {:spec machine-spec}})))
 
 ;; ---------------------------------------------------------------------------
 ;; XML parse — minimal regex-based reader for the SCXML subset we
@@ -1205,12 +1212,14 @@
                                           rs (rest remaining)]
                                      (cond
                                        (empty? rs)
-                                       (throw (ex-info ":scxml/parse-error"
-                                                       {:rf.error/id :scxml/parse-error
-                                                        :where    'machines-viz/scxml->spec
-                                                        :recovery :no-recovery
-                                                        :reason   (str "unclosed <" tag ">")
-                                                        :tag      tag}))
+                                       (error/throw-error!
+                                         :scxml/parse-error
+                                         'machines-viz/scxml->spec
+                                         (str "SCXML import: unclosed <" tag
+                                              "> element; add the matching </"
+                                              tag "> closing tag.")
+                                         {:recovery :close-the-open-element
+                                          :extra    {:tag tag}})
 
                                        (and (= :end (:kind (first rs)))
                                             (= tag (:tag (first rs)))
@@ -1395,27 +1404,29 @@
 
   for the supported subset documented in the ns docstring.
 
-  Throws `(ex-info ... {:reason :scxml/parse-error})` when the input
-  is not a valid SCXML document our parser recognises (missing root
-  `<scxml>`, unclosed tags, etc.). Throws `:scxml/invalid-spec` if
+  Throws the canonical thrown-error shape with
+  `:rf.error/id :scxml/parse-error` when the input is not a valid SCXML
+  document our parser recognises (missing root `<scxml>`, unclosed tags,
+  etc.). Throws `:scxml/invalid-spec` if
   the parsed structure is missing required keys (no `:initial`, no
   `:states`)."
   [scxml-string]
   (when-not (string? scxml-string)
-    (throw (ex-info ":scxml/parse-error"
-                    {:rf.error/id :scxml/parse-error
-                     :where    'machines-viz/scxml->spec
-                     :recovery :no-recovery
-                     :reason   "scxml->spec expects a string"
-                     :input    scxml-string})))
+    (error/throw-error!
+      :scxml/parse-error
+      'machines-viz/scxml->spec
+      "SCXML import: scxml->spec expects an SCXML string; pass the SCXML document as a string."
+      {:recovery :pass-an-scxml-string
+       :extra    {:input scxml-string}}))
   (let [tokens (-> scxml-string strip-prolog lift-action-comments strip-comments tokenize vec)
         root-start (first (filter #(= "scxml" (:tag %)) tokens))]
     (when-not root-start
-      (throw (ex-info ":scxml/parse-error"
-                      {:rf.error/id :scxml/parse-error
-                       :where    'machines-viz/scxml->spec
-                       :recovery :no-recovery
-                       :reason   "no <scxml> root element found"})))
+      (error/throw-error!
+        :scxml/parse-error
+        'machines-viz/scxml->spec
+        (str "SCXML import: no <scxml> root element found; wrap the document "
+             "in a top-level <scxml>…</scxml> element.")
+        {:recovery :wrap-in-an-scxml-root}))
     (let [token-vec (vec tokens)
           start-idx (some (fn [i] (when (identical? (nth token-vec i) root-start) i))
                           (range (count token-vec)))
@@ -1425,11 +1436,12 @@
                 end-idx (loop [i 0 depth 1]
                           (cond
                             (>= i (count tail))
-                            (throw (ex-info ":scxml/parse-error"
-                                            {:rf.error/id :scxml/parse-error
-                                             :where    'machines-viz/scxml->spec
-                                             :recovery :no-recovery
-                                             :reason   "unclosed <scxml>"}))
+                            (error/throw-error!
+                              :scxml/parse-error
+                              'machines-viz/scxml->spec
+                              (str "SCXML import: unclosed <scxml> root element; "
+                                   "add the matching </scxml> closing tag.")
+                              {:recovery :close-the-scxml-root})
 
                             (and (= :start (:kind (nth tail i)))
                                  (= "scxml" (:tag (nth tail i))))
@@ -1457,11 +1469,12 @@
               end-idx (loop [i 0 depth 1]
                         (cond
                           (>= i (count tail))
-                          (throw (ex-info ":scxml/parse-error"
-                                          {:rf.error/id :scxml/parse-error
-                                           :where    'machines-viz/scxml->spec
-                                           :recovery :no-recovery
-                                           :reason   "unclosed <parallel>"}))
+                          (error/throw-error!
+                            :scxml/parse-error
+                            'machines-viz/scxml->spec
+                            (str "SCXML import: unclosed <parallel> element; "
+                                 "add the matching </parallel> closing tag.")
+                            {:recovery :close-the-parallel-element})
 
                           (and (= :start (:kind (nth tail i)))
                                (= "parallel" (:tag (nth tail i))))
@@ -1509,11 +1522,12 @@
               states (into {}
                            (map parse-state-block top-state-blocks))]
           (when (empty? states)
-            (throw (ex-info ":scxml/invalid-spec"
-                            {:rf.error/id :scxml/invalid-spec
-                             :where    'machines-viz/scxml->spec
-                             :recovery :no-recovery
-                             :reason   "scxml document has no <state> or <final> elements"})))
+            (error/throw-error!
+              :scxml/invalid-spec
+              'machines-viz/scxml->spec
+              (str "SCXML import: the document has no <state> or <final> "
+                   "elements; add at least one <state> (or <final>) child.")
+              {:recovery :add-a-state-or-final-element}))
           (cond-> {:states states}
             ;; rf2-mnp93.7 — the root `initial` is a top-level state's
             ;; qualified id; the re-frame2 `:initial` is its local key.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -792,7 +792,7 @@
           (str "SCXML export: a parallel machine spec requires a non-empty "
                ":regions map; add :regions to the parallel spec.")
           {:recovery :supply-non-empty-regions
-           :extra    {:spec machine-spec}})))
+           :extra    {:spec machine-spec}}))
       (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
            (str/join "\n" (emit-parallel machine-spec 0))))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -51,6 +51,7 @@
   [`DESIGN-RATIONALE.md`](../../spec/DESIGN-RATIONALE.md) Lock #3 +
   Lock #5."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [cognitect.transit :as transit]))
 
 ;; ---------------------------------------------------------------------------
@@ -401,13 +402,20 @@
 ;; Errors
 
 (defn- decode-error
-  "Throw the documented `:rf.machines-viz.share/decode-failed`
-  ex-info with a programmatic `:reason`."
+  "Throw the documented `:rf.machines-viz.share/decode-failed` ex-info.
+
+  The ex-MESSAGE is the human sentence `msg` + the trailing
+  `[:rf.machines-viz.share/decode-failed]` token (Spec 009 §The
+  thrown-error shape / rf2-vvixub) — no longer a bare keyword. The
+  fine-grained `:reason` keyword is the documented machines-viz
+  tool-classification slot (API.md §Share-URL decoding) — tools branch on
+  it; `:message` carries the same human sentence for the viewer's
+  `{:error {:reason … :message …}}` shape."
   [reason msg & [extra]]
-  (throw (ex-info (str ":rf.machines-viz.share/decode-failed — " (name reason))
+  (throw (ex-info (error/human-message :rf.machines-viz.share/decode-failed msg)
                   (merge {:rf.error/id :rf.machines-viz.share/decode-failed
                           :where       'machines-viz.share/decode-share-url
-                          :recovery    :no-recovery
+                          :recovery    :fix-the-share-url
                           :reason      reason
                           :message     msg}
                          extra))))
@@ -457,12 +465,20 @@
   ([chart-state {:keys [host] :or {host default-host}}]
    (let [allowlisted (allowlist-chart-state chart-state)]
      (when-not (valid-chart-state? allowlisted)
-       (throw (ex-info ":rf.machines-viz.share/encode-failed — invalid-chart-state"
-                       {:rf.error/id :rf.machines-viz.share/encode-failed
-                        :where       'machines-viz.share/encode-share-url
-                        :recovery    :no-recovery
-                        :reason      :invalid-chart-state
-                        :chart-state chart-state})))
+       ;; rf2-vvixub — the ex-message is the human sentence + the
+       ;; [:rf.machines-viz.share/encode-failed] token; the fine `:reason`
+       ;; keyword stays the documented tool-classification slot (API.md).
+       (let [msg (str "cannot encode a share-URL: the chart state does not "
+                      "validate against the share schema (a :machine-id, "
+                      ":frame-id, :definition, or :snapshot :state is missing "
+                      "or malformed). Pass a valid ChartState.")]
+         (throw (ex-info (error/human-message :rf.machines-viz.share/encode-failed msg)
+                         {:rf.error/id :rf.machines-viz.share/encode-failed
+                          :where       'machines-viz.share/encode-share-url
+                          :recovery    :supply-a-valid-chart-state
+                          :reason      :invalid-chart-state
+                          :message     msg
+                          :chart-state chart-state}))))
      (let [envelope    (canonicalise
                          {:rf.machines-viz.share/v       current-version
                           :rf.machines-viz.share/chart   allowlisted
@@ -502,8 +518,13 @@
   ;;     :rf.machines-viz.share/created 1736000000000}
   ```
 
-  Throws `:rf.machines-viz.share/decode-failed` (an ex-info) with a
-  programmatic `:reason`:
+  Throws `:rf.machines-viz.share/decode-failed` (an ex-info). Per the
+  thrown-error contract (Spec 009 §The thrown-error shape) the message is
+  the human sentence + the `[:rf.machines-viz.share/decode-failed]` token,
+  and `:rf.error/id` is the coarse machine discriminator. The fine-grained
+  `:reason` keyword below is the documented machines-viz tool-classification
+  slot (carried alongside the human `:message` in the safe-decode
+  `{:error {:reason … :message …}}` shape):
 
   | `:reason`              | Meaning |
   |---|---|

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
@@ -10,7 +10,8 @@
     tests inject a deterministic stub).
   - `generate-machine` handles fenced (```clojure / ```edn / bare)
     and unfenced responses.
-  - Error modes throw `ex-info` with `:reason :ai-generate/<kw>`.
+  - Error modes throw `ex-info` carrying `:rf.error/id :ai-generate/<kw>`
+    (the canonical discriminator; the message is the human sentence + token).
   - Generated specs are usable by sibling exporters (`scxml->spec`
     round-trip + `mermaid/emit`), so the AI-generate path connects
     end-to-end with the rest of the substrate."

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
@@ -110,10 +110,17 @@
       (is (not (str/starts-with? (str/trim md) "```"))))))
 
 (deftest no-seam-throws
-  (testing "an element with no _rfMvChartState seam throws :no-chart-state"
+  (testing "an element that is not a rendered MachineChart throws :no-chart-state"
     (let [d (try (export/share-url #js {})
                  (catch :default e (ex-data e)))]
-      (is (= "chart-element carries no MachineChart state seam" (:reason d))))))
+      ;; rf2-vvixub / rf2-s6rzia — branch on the canonical :rf.error/id, and
+      ;; the :reason names the PUBLIC concept (a rendered MachineChart
+      ;; element) without leaking the private "state seam" implementation term.
+      (is (= :rf.machines-viz.export/no-chart-state (:rf.error/id d)))
+      (is (string? (:reason d)))
+      (is (re-find #"(?i)machinechart" (:reason d)))
+      (is (not (re-find #"(?i)seam" (:reason d)))
+          ":reason no longer leaks the private 'state seam' implementation term"))))
 
 ;; ---- rf2-85a9do — SVG <title>/<desc> XML escaping -----------------------
 ;;

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -10,7 +10,8 @@
     structure.
   - Round-trip property: `(= spec (-> spec spec->scxml scxml->spec))`
     holds for every supported fixture.
-  - Error cases throw `ex-info` with a `:reason :scxml/*` key."
+  - Error cases throw `ex-info` carrying `:rf.error/id :scxml/*` (the
+    canonical discriminator; the message is the human sentence + token)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -568,10 +568,14 @@
 
 (deftest malformed-fragment-rejected
   (testing "a URL with no #machine= fragment throws :malformed-fragment"
-    (is (thrown-with-msg? :default #"malformed-fragment"
+    ;; rf2-vvixub — the message is now the human sentence + the
+    ;; [:rf.machines-viz.share/decode-failed] token; the fine-grained
+    ;; classification rides the documented :reason slot (branch on that).
+    (is (thrown? :default
           (share/decode-share-url "https://example.com/app")))
     (let [d (try (share/decode-share-url "https://example.com/app")
                  (catch :default e (ex-data e)))]
+      (is (= :rf.machines-viz.share/decode-failed (:rf.error/id d)))
       (is (= :malformed-fragment (:reason d))))))
 
 (deftest malformed-base64-rejected

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -40,6 +40,7 @@
   for the same source of truth (no parallel re-export here)."
   (:require [cheshire.core :as json]
             [clojure.string :as str]
+            [re-frame.error :as error]
             [re-frame.mcp-base.args :as args]
             [re-frame.mcp-base.vocab :as vocab]))
 
@@ -145,13 +146,17 @@
   (try
     (json/parse-string s false)
     (catch Throwable e
-      (throw (ex-info ":rf.error/story-mcp-json-parse-failure"
-                      {:rf.error/id :rf.error/story-mcp-json-parse-failure
-                       :where    'story-mcp/parse-json
-                       :recovery :no-recovery
-                       :reason   "re-frame2-story-mcp: JSON parse failure"
-                       :raw      (when s (subs s 0 (min 200 (count s))))}
-                      e)))))
+      ;; rf2-vvixub — the message + canonical ex-data are derived from the
+      ;; builder helpers; the 3-arg ex-info form preserves the original
+      ;; parser throwable as the cause.
+      (let [reason "re-frame2-story-mcp could not parse the incoming JSON frame; send a well-formed JSON-RPC frame."]
+        (throw (ex-info (error/human-message :rf.error/story-mcp-json-parse-failure reason)
+                        {:rf.error/id :rf.error/story-mcp-json-parse-failure
+                         :where    'story-mcp/parse-json
+                         :recovery :send-a-well-formed-json-frame
+                         :reason   reason
+                         :raw      (when s (subs s 0 (min 200 (count s))))}
+                        e))))))
 
 ;; ---- no-intern frame normalisation (rf2-3luf3) ---------------------------
 
@@ -375,13 +380,14 @@
     (let [line (read-bounded-line reader max-frame-bytes)]
       (cond
         (nil? line)                   eof-sentinel
-        (= ::frame-too-large line)    (throw (ex-info
-                                               ":rf.error/story-mcp-frame-too-large"
-                                               {:rf.error/id :rf.error/story-mcp-frame-too-large
-                                                :where     'story-mcp/read-frame
-                                                :recovery  :no-recovery
-                                                :reason    "re-frame2-story-mcp: frame exceeds cap"
-                                                :max-bytes max-frame-bytes}))
+        (= ::frame-too-large line)    (error/throw-error!
+                                        :rf.error/story-mcp-frame-too-large
+                                        'story-mcp/read-frame
+                                        (str "re-frame2-story-mcp frame exceeds the "
+                                             max-frame-bytes "-byte cap; send a smaller "
+                                             "frame (the run-loop recovers and continues).")
+                                        {:recovery :send-a-smaller-frame
+                                         :extra    {:max-bytes max-frame-bytes}})
         (str/blank? line)             (recur)
         :else                         (normalize-frame (parse-json line))))))
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -14,6 +14,7 @@
   `tools.registry/tool-registry` concatenates after `write/descriptors`
   so IMPL-SPEC §7.3 order survives the file split."
   (:require [clojure.edn :as edn]
+            [re-frame.error :as error]
             [re-frame.mcp-base.args :as args]
             [re-frame.story :as story]
             [re-frame.story.schemas :as story-schemas]
@@ -160,12 +161,14 @@
         (let [parsed (edn/read-string
                        {:readers {}
                         :default (fn [tag _]
-                                   (throw (ex-info ":rf.error/story-mcp-tagged-literal-rejected"
-                                                   {:rf.error/id :rf.error/story-mcp-tagged-literal-rejected
-                                                    :where    'story-mcp/parse-edn-body
-                                                    :recovery :no-recovery
-                                                    :reason   "tagged literals are not permitted in EDN write bodies"
-                                                    :tag      tag})))}
+                                   (error/throw-error!
+                                     :rf.error/story-mcp-tagged-literal-rejected
+                                     'story-mcp/parse-edn-body
+                                     (str "tagged literals are not permitted in EDN "
+                                          "write bodies; remove the #" tag " tagged "
+                                          "literal and send plain EDN.")
+                                     {:recovery :remove-the-tagged-literal
+                                      :extra    {:tag tag}}))}
                        body)]
           (if (> (value-depth parsed) max-edn-depth)
             ::edn-error

--- a/tools/story/src/re_frame/story/async.cljc
+++ b/tools/story/src/re_frame/story/async.cljc
@@ -34,7 +34,8 @@
   on core.async. Story's async surface uses native Promise (CLJS) and
   CompletableFuture (JVM) directly — the two surfaces the host runtime
   already exposes. No additional dependency."
-  (:refer-clojure :exclude [promise]))
+  (:refer-clojure :exclude [promise])
+  (:require [re-frame.error :as error]))
 
 ;; ---- construction ---------------------------------------------------------
 
@@ -74,8 +75,13 @@
                reject-fn  (fn [e] (.completeExceptionally cf
                                                           (if (instance? Throwable e)
                                                             e
-                                                            (ex-info "re-frame.story.async rejection"
-                                                                     {:rejection e}))))]
+                                                            (error/thrown-ex-info
+                                                              :rf.error/story-async-rejection
+                                                              'rf.story.async/promise
+                                                              (str "a Story async operation rejected with a "
+                                                                   "non-throwable value; the original rejection "
+                                                                   "is preserved under :rejection.")
+                                                              {:extra {:rejection e}}))))]
            (if (= 2 arity)
              (f resolve-fn reject-fn)
              (f resolve-fn)))
@@ -96,8 +102,13 @@
      :clj  (let [cf (java.util.concurrent.CompletableFuture.)]
              (.completeExceptionally cf (if (instance? Throwable e)
                                           e
-                                          (ex-info "re-frame.story.async rejection"
-                                                   {:rejection e})))
+                                          (error/thrown-ex-info
+                                            :rf.error/story-async-rejection
+                                            'rf.story.async/rejected
+                                            (str "a Story async operation rejected with a "
+                                                 "non-throwable value; the original rejection "
+                                                 "is preserved under :rejection.")
+                                            {:extra {:rejection e}})))
              cf)))
 
 ;; ---- composition ----------------------------------------------------------

--- a/tools/story/src/re_frame/story/generate/test_check.cljc
+++ b/tools/story/src/re_frame/story/generate/test_check.cljc
@@ -47,7 +47,8 @@
   optional namespace at runtime. The `:test` alias (where test.check lives)
   runs on the JVM, so this adapter targets the JVM half of `clojure -M:test`.
   On CLJS the adapter throws a clear message — the dependency-free `gen-fn`
-  path is the cross-host default and needs no library.")
+  path is the cross-host default and needs no library."
+  (:require [re-frame.error :as error]))
 
 (def ^:private absent-msg
   (str "re-frame.story.generate.test-check requires org.clojure/test.check on "
@@ -65,7 +66,12 @@
      (or (try (requiring-resolve sym)
               (catch java.io.FileNotFoundException _ nil)
               (catch Throwable _ nil))
-         (throw (ex-info absent-msg {:missing-var sym})))))
+         (error/throw-error!
+           :rf.error/story-test-check-absent
+           'rf.story.generate/gen->gen-fn
+           absent-msg
+           {:recovery :add-test-check-or-use-a-gen-fn
+            :extra    {:missing-var sym}}))))
 
 (defn available?
   "True iff `org.clojure/test.check` is resolvable on the classpath right now.
@@ -103,7 +109,15 @@
         (fn [seed]
           (vec (generate g size seed))))
       :cljs
-      (throw (ex-info absent-msg {:host :cljs})))))
+      (error/throw-error!
+        :rf.error/story-test-check-unsupported-host
+        'rf.story.generate/gen->gen-fn
+        (str "re-frame.story.generate.test-check is JVM-only — CLJS cannot "
+             "dynamically resolve the optional test.check namespace. Use the "
+             "dependency-free (fn [seed] event-program) gen-fn over the "
+             "splitmix64 PRNG, which is the cross-host default.")
+        {:recovery :use-a-gen-fn-on-cljs
+         :extra    {:host :cljs}}))))
 
 (defn check-property-gen!
   "Sugar: run `re-frame.story.generate/check-property!` driven by a

--- a/tools/story/src/re_frame/story/invariants.cljc
+++ b/tools/story/src/re_frame/story/invariants.cljc
@@ -66,6 +66,7 @@
   core."
   #?(:cljs (:require-macros [re-frame.story.invariants]))
   (:require [re-frame.core :as rf]
+            [re-frame.error :as error]
             #?(:clj  [clojure.test :as ctest]
                :cljs [cljs.test :as ctest :include-macros true])))
 
@@ -97,9 +98,14 @@
           (= 1 (count rst))
           [::no-expected (first rst)]
           :else
-          (throw (ex-info "re-frame2-story: :db invariant shorthand is [:db path pred] or [:db path = expected]"
-                          {:rf.error/id :rf.error/story-bad-invariant
-                           :shorthand   (into [:db path] rst)})))]
+          (error/throw-error!
+            :rf.error/story-bad-invariant
+            'rf.story/with-invariants
+            (str "re-frame2-story :db invariant shorthand must be "
+                 "[:db path pred] or [:db path = expected]; correct the "
+                 "shorthand to one of those forms.")
+            {:recovery :use-a-valid-db-invariant-shorthand
+             :extra    {:shorthand (into [:db path] rst)}}))]
     (fn db-path-invariant [epoch]
       (let [actual (get-in (:db-after epoch) path)]
         {:ok?      (boolean (pred actual))
@@ -132,15 +138,24 @@
     (map? invariant)
     (let [check (or (:check invariant) (:pred invariant))]
       (when-not (fn? check)
-        (throw (ex-info "re-frame2-story: invariant map needs a `:check` (or `:pred`) fn"
-                        {:rf.error/id :rf.error/story-bad-invariant
-                         :invariant   invariant})))
+        (error/throw-error!
+          :rf.error/story-bad-invariant
+          'rf.story/with-invariants
+          (str "re-frame2-story invariant map needs a `:check` (or `:pred`) "
+               "fn; add a `:check` fn (epoch → boolean / {:ok? …}) to the "
+               "invariant map.")
+          {:recovery :add-a-check-fn
+           :extra    {:invariant invariant}}))
       (merge {:id (keyword (str "invariant-" idx))} invariant {:check check}))
 
     :else
-    (throw (ex-info "re-frame2-story: invariant must be a fn, a `[:db path …]` vector, or a map"
-                    {:rf.error/id :rf.error/story-bad-invariant
-                     :invariant   invariant}))))
+    (error/throw-error!
+      :rf.error/story-bad-invariant
+      'rf.story/with-invariants
+      (str "re-frame2-story invariant must be a fn, a `[:db path …]` vector, "
+           "or a map; pass one of those shapes as an invariant spec.")
+      {:recovery :use-a-fn-vector-or-map-invariant
+       :extra    {:invariant invariant}})))
 
 (defn coerce-invariants
   "Normalize a vector of authored invariants. Pure."
@@ -433,6 +448,11 @@
      {:arglists '([[invariant-spec*] body+])}
      [invariants & body]
      (when-not (vector? invariants)
-       (throw (ex-info "with-invariants expects a vector of invariant specs"
-                       {:invariants invariants})))
+       (error/throw-error!
+         :rf.error/story-bad-invariants-vector
+         'rf.story/with-invariants
+         (str "with-invariants expects a vector of invariant specs as its "
+              "first form; pass `[invariant-spec …]` before the body.")
+         {:recovery :supply-a-vector-of-invariant-specs
+          :extra    {:invariants invariants}}))
      `(run-with-invariants* [~@invariants] (fn [] ~@body))))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -901,7 +901,7 @@
                "the registered schema(s).")
           {:recovery :fix-the-db-seed-to-satisfy-the-schema
            :extra    {:variant/id variant-id
-                      :violations violations}})))))
+                      :violations violations}}))))
   ctx)
 
 (defn- run-phase-1!

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -38,6 +38,7 @@
   production code that accidentally calls `run-variant` does not throw
   — it returns empty."
   (:require [re-frame.core            :as rf]
+            [re-frame.error           :as error]
             [re-frame.late-bind       :as late-bind]
             [re-frame.story.args      :as args]
             [re-frame.story.assertions :as assertions]
@@ -233,18 +234,20 @@
         story-events (or (:events story-body) [])
         plan-setup   (get-in plan [:world :setup] [])]
     (when-let [offenders (seq (filter non-dispatch-setup-step? plan-setup))]
-      (throw (ex-info
-               (str "re-frame2-story: variant " variant-id
-                    " — :setup carries a non-dispatch step "
-                    (pr-str (vec offenders))
-                    " that the headless runner cannot execute. A "
-                    ":wait / :wait-until / :click / :type / :focus step is "
-                    "legal in :setup but requires a :dom / :cljs-reactive "
-                    "runner; run this variant under a richer runner, or move "
-                    "the step to :script.")
-               {:rf.error/id     :rf.error/story-setup-step-unrunnable
-                :variant/id      variant-id
-                :offending-steps (vec offenders)})))
+      (error/throw-error!
+        :rf.error/story-setup-step-unrunnable
+        'rf.story/run-variant
+        (str "re-frame2-story: variant " variant-id
+             " — :setup carries a non-dispatch step "
+             (pr-str (vec offenders))
+             " that the headless runner cannot execute. A "
+             ":wait / :wait-until / :click / :type / :focus step is "
+             "legal in :setup but requires a :dom / :cljs-reactive "
+             "runner; run this variant under a richer runner, or move "
+             "the step to :script.")
+        {:recovery :use-a-richer-runner-or-move-to-script
+         :extra    {:variant/id      variant-id
+                    :offending-steps (vec offenders)}}))
     (vec (concat story-events
                  (map setup-step->event plan-setup)))))
 
@@ -885,17 +888,20 @@
     (rf/dispatch-sync [::apply-db-seed seed] {:frame variant-id})
     (let [violations (db-seed-violations variant-id (rf/app-db-value variant-id))]
       (when (seq violations)
-        (throw (ex-info
-                 (str "re-frame2-story: variant " variant-id
-                      " — :db-seed does not satisfy the registered app-db "
-                      "schema(s) at path(s) "
-                      (pr-str (mapv :path violations))
-                      ". A direct app-db seed bypasses event/cofx validation "
-                      "but MUST validate the affected app-db schema "
-                      "(spec/017 §Setup).")
-                 {:rf.error/id :rf.error/story-db-seed-invalid
-                  :variant/id  variant-id
-                  :violations  violations})))))
+        (error/throw-error!
+          :rf.error/story-db-seed-invalid
+          'rf.story/run-variant
+          (str "re-frame2-story: variant " variant-id
+               " — :db-seed does not satisfy the registered app-db "
+               "schema(s) at path(s) "
+               (pr-str (mapv :path violations))
+               ". A direct app-db seed bypasses event/cofx validation "
+               "but MUST validate the affected app-db schema "
+               "(spec/017 §Setup). Fix the :db-seed value(s) to satisfy "
+               "the registered schema(s).")
+          {:recovery :fix-the-db-seed-to-satisfy-the-schema
+           :extra    {:variant/id variant-id
+                      :violations violations}})))))
   ctx)
 
 (defn- run-phase-1!


### PR DESCRIPTION
Routes the SSR, adapters/schemas, Story, and machines-viz throw sites through the central `re-frame.error/throw-error!` / `thrown-ex-info` builder landed by the merged `vvixub` contract. The builder derives `ex-message` = `"<reason> [:rf.error/<id>]"`; `:rf.error/id` stays the sole machine discriminator; message bytes are non-normative.

Closes the four `vvixub` children: `rf2-7vuq2q` (ssr), `rf2-940efq` (adapters/schemas), `rf2-o04xwn` (story), `rf2-s6rzia` (machines-viz).

## Per-surface conversions

**ssr / ssr-ring (7vuq2q)** — 24 sites: `substrate` render-on-headless, `html-helpers` edn-script-breakout + invalid-attribute-name, `boot` hydration-frame-id-mismatch (reuses builder ex-data for the trace), `streaming` suspense-boundary-invalid-attrs, `response` header/cookie/redirect validation (8), `hydrate` `:rf.ssr/hydration-mismatch` (builder-derived message, payload preserved for trace), `emit` tag-name/raw-text/reagent-native-head/suspense-outside-stream, `head/registry` no-such-head, `payload_policy` (3), `head/emit` json-ld number/key, `ring` `import-fn` (build-time author error, documented as an internal compile-time exception + canonical shape), `ring/trust`, `ring/pipeline` invalid-error-view, `ring/cookie` (4), `ring/lifecycle` (5). Blanket `:no-recovery` replaced with actionable recovery tags where the repair is obvious.

**adapters/schemas (940efq)** — `schemas/storage` (4: app-schemas-arg / app-schema-path / runtime-path / schemas-batch), `core/substrate/plain_atom` render + no-hiccup-emitter (the vvixub-deferred site), `core/frame` `:rf.error/unknown-preset`, `adapters/test-react` (5). `reagent-slim` `reagent2.impl.template` + `reagent2.dom.server` (5) replicate the canonical shape **inline** (human message + `[:rf.error/<id>]` token, `:rf.error/id` discriminator, legacy `:type` removed) — they do NOT require `re-frame.*` because reagent-slim is bundle-isolated.

**story (o04xwn)** — `invariants` (3 + the `with-invariants` macro authoring throw), `generate/test_check` (absent / unsupported-host), `async` rejection wrappers (preserve the original `:rejection` cause), `runtime` setup-step-unrunnable + db-seed-invalid, `story-mcp/protocol` json-parse (3-arg ex-info preserves the parser cause) + frame-too-large, `story-mcp/tools/write` tagged-literal-rejected.

**machines-viz (s6rzia)** — `scxml` (7), `mermaid` invalid-definition, `ai_generate` (4), `export` (8 incl. PNG/clipboard Promise rejections), `share` encode/decode. Kept the documented machines-viz namespaces (`:scxml/*`, `:ai-generate/*`, `:mermaid/*`, `:rf.machines-viz.*`) as the `:rf.error/id` values. The `no-chart-state` message no longer leaks the private "state seam" term — it names a rendered MachineChart element. Share decode keeps its documented `:reason`-keyword tool-classification slot alongside the now-human `:message`; `API.md` error-mode tables re-labelled `:reason` → `:rf.error/id` and the no-chart-state prose updated.

## Migration

Exact-equality message assertions the conversion broke were migrated to `:rf.error/id` (+ token) checks, keeping the discriminator: `schemas_storage_test` (7), `ssr_end_to_end_test` (render-on-headless), `ssr_head_test` (no-such-head), `ssr-ring/ring_test` (trusted-shell-opt-invalid), `machines-viz/export_cljs_test` (the seam-string assertion now asserts the public-concept wording + no "seam" leak), `machines-viz/share_cljs_test` (malformed-fragment). The `thrown-with-msg?` substring cohort survives unchanged (the trailing `[:rf.error/<id>]` token still matches). Story/Story-MCP/ai-generate tests already branched on `:rf.error/id` and survive as-is. Story specs need no edit (ids + ex-data slots unchanged); machines-viz `API.md` updated.

## Quality gates

All run locally, all green:

| Gate | Result |
|---|---|
| `core` JVM (`clojure -M:test`) | 1535 tests, 0 failures |
| `schemas` JVM | 295 tests, 0 failures |
| `ssr` JVM | 343 tests, 0 failures |
| `ssr-ring` JVM | 162 tests, 0 failures |
| `story` JVM | 1685 tests, 0 failures |
| `story-mcp` JVM | 275 tests, 0 failures |
| `test-react` JVM | 24 tests, 0 failures |
| `machines-viz` (node) | 514 tests, 0 failures |
| `npm run test:cljs` (node-runtime, incl. thrown-error conformance gate + reagent-slim CLJS) | 7322 tests, 0 failures |
| `npm run test:reagent-slim:bundle-isolation` | 4 contracts / 21 sentinels passed (slim pulls no re-frame.*; `static-markup-bad-tag` presence sentinel still binds) |

Scope: edits confined to ssr / adapters+schemas / story / machines-viz (+ the 940efq-enumerated core `substrate/plain_atom` + `frame/:rf.error/unknown-preset` sites). `core.cljc` facade and pair-mcp untouched.
