### PR TITLE
docs(EP): EP-0019 Q5 revision-token amendment — bump on every authoritative durable write (byl7bk)

### DIFF
--- a/docs/EP/EP-0019-optimistic-mutation-rollback.md
+++ b/docs/EP/EP-0019-optimistic-mutation-rollback.md
@@ -273,9 +273,17 @@ entry that existed, including its freshness, never a reconstructed approximation
 
 **Revision token.** Each resource entry gains a monotone per-entry
 `:revision` counter (a small fact on the entry, EP-0012-canonical), bumped on
-every authoritative write to that entry (load success, populate, patch,
-optimistic apply, invalidation-driven refetch success). The optimistic apply
-records the revision it observed. The conflict check at settle (Decision 3) is
+**every authoritative durable entry write** a rollback could clobber — load
+success, populate, patch, optimistic apply, invalidation-driven refetch success
+— and **never gated on `(= old new)` of `:data`** (byl7bk ruling; see Open Issue
+5). The bump is unconditional precisely because `entry-succeeded` re-stamps
+`:loaded-at` / `:stale-at` / `:tags` even when `:data` is `=`-shared
+(`state.cljc` 684, 690–691, 697): a value-changing-only token would miss that
+freshness settle and let a later rollback clobber newer freshness with a stale
+snapshot. `:revision` is a **distinct fact, not a reuse of `:generation`**
+(`:generation` bumps at load *start*, so it would false-conflict on every
+in-flight refetch). The optimistic apply records the revision it observed. The
+conflict check at settle (Decision 3) is
 `(= recorded-revision current-revision)` — a canonical-identity comparison, not
 a value compare. This is the EP-0012 disposition-5 identity substrate the
 EP-0016 ruling names.
@@ -577,9 +585,11 @@ Proposed sequence (not a one-PR requirement):
    ops to the `:rf.mutation/*` family, and worked examples. Un-defer
    `:optimistic` / `:rollback` from the registration-spec deferred-keys list
    (line 663). Hot-zone: sequence behind any other live spec/016 work.
-2. **Per-entry revision token** — add `:revision` to the resource entry, bump it
-   on every authoritative write; the conflict-check helper. (`state.cljc` +
-   `mutation_runtime.cljc`.)
+2. **Per-entry revision token** — add a **distinct** `:revision` fact to the
+   resource entry (NOT a reuse of `:generation`; base value `0`), bump it on
+   **every authoritative durable entry write** (unconditionally, never gated on
+   `(= old new)` of `:data` — see Open Issue 5); the conflict-check helper.
+   (`state.cljc` + `mutation_runtime.cljc`.)
 3. **Optimistic apply (phase 1.5)** — `:optimistic` resolution + snapshot-inverse
    recording on the instance row; reuse `resolve-exact-target-scope` +
    `validate-target-map!`. Emit `:rf.mutation/optimistic-applied`.
@@ -666,10 +676,40 @@ Proposed sequence (not a one-PR requirement):
    `:generation` (the work/stale-suppression identity). Is `:generation`
    sufficient as the conflict token, or does it move for reasons orthogonal to
    "the cached value changed" (e.g. a refetch that returns `=` data)?
-   **Recommendation:** a distinct `:revision` bumped only on a value-changing
-   authoritative write, to avoid false-conflict refetches; but confirm against
-   the landed `:generation` semantics (`state.cljc`) before committing to a new
-   fact.
+
+   **Ruling (byl7bk, 2026-06-15) — load-bearing amendment, gates the
+   settle-protocol slice.** Use a **distinct `:revision` fact** (NOT a reuse of
+   `:generation`), bumped on **every authoritative durable entry write a rollback
+   could clobber** — *not* "value-changing only." This corrects the EP's earlier
+   weaker lean toward bumping only on a value-changing write.
+
+   - **Why not gate on `(= old new)` of `:data`.** `entry-succeeded` re-stamps
+     `:loaded-at` / `:stale-at` *even when `:data` is `=`-shared* — the
+     structural-sharing branch keeps the old `:data` identity but still writes a
+     fresh `:loaded-at` / `:stale-at` / `:tags` (`state.cljc` 684, 690–691, 697).
+     `patch-entry` and `populate-entry` do the same. So a "value-changing only"
+     token would **miss a refetch-returning-equal-data freshness settle**: a later
+     rollback would then silently clobber newer authoritative
+     `:loaded-at` / `:stale-at` / `:tags` with a stale snapshot — a real
+     cache-coherence bug. The conflict token therefore tracks *any* authoritative
+     durable write to the entry, not just value changes.
+   - **Why a distinct `:revision`, not `:generation`.** `:generation` bumps at
+     load **start** (`entry-start-load`, `state.cljc` ~660), so reusing it would
+     **false-conflict on every in-flight refetch** — the entry's identity would
+     "move" the instant any load begins, before any authoritative write lands.
+     `:revision` is the per-entry write identity; `:generation` is the
+     work/stale-suppression identity. They are distinct facts.
+   - **Bump rule.** Bump `:revision` on `entry-succeeded` **unconditionally** (not
+     gated on `(= old new)`), on populate, on patch, on optimistic apply, and on
+     an invalidation-driven settle — every authoritative durable write.
+   - **Bias to over-bump.** When in doubt, bump. A *false* conflict costs one
+     refetch (and is made safe by the `:on-conflict :invalidate` default — the
+     read path recovers truth). A *missed* conflict means a stale inverse silently
+     clobbers newer truth — silent corruption. The asymmetry favours over-bumping.
+   - **New entry fact (impl note).** The base entry shape (`empty-entry*`,
+     `state.cljc` 188–211) has **no `:revision` key today**; the deferred EP-0019
+     impl wave adds `:revision` as a new durable entry fact (base value `0`,
+     alongside `:generation`).
 
 6. **Optimistic `:removes` and `:populates`-of-absent.** Decision 1 covers
    forward *patch* of existing entries. Should an optimistic plan also support


### PR DESCRIPTION
## Summary

Doc-only amendment to `docs/EP/EP-0019-optimistic-mutation-rollback.md` per the **rf2-byl7bk** ruling (EP-0019 Q5). This is the one load-bearing EP amendment that gates the deferred settle-protocol impl slice — no spec/016 or `implementation/resources` code is touched.

Amends the EP's revision-token decision from the earlier weaker "**bumped only on a value-changing authoritative write**" lean to "**bumped on every authoritative durable entry write**" a rollback could clobber.

### What changed
- **Open Issue 5** (the load-bearing recommendation): replaced the weaker "value-changing only" recommendation with the byl7bk ruling — distinct `:revision` fact (NOT `:generation`), bumped unconditionally on every authoritative durable entry write, with the verified rationale, the over-bump bias, and the new-entry-fact impl note.
- **Decision 2** (revision-token body): tightened to state the bump is unconditional and never gated on `(= old new)` of `:data`, and that `:revision` is distinct from `:generation`.
- **Implementation plan step 2**: clarified `:revision` is a distinct new fact (base `0`), bumped on every authoritative durable write, never gated on `(= old new)`.

### Rationale (verified against source)
- `entry-succeeded` re-stamps `:loaded-at` / `:stale-at` / `:tags` even when `:data` is `=`-shared (`state.cljc` 684, 690–691, 697); `patch`/`populate` likewise. A "value-changing only" token would **miss a refetch-returning-equal-data freshness settle**, letting a later rollback silently clobber newer authoritative freshness with a stale snapshot — a real cache-coherence bug.
- `:generation` bumps at load **start** (`entry-start-load`, `state.cljc` ~660), so reusing it would false-conflict on every in-flight refetch — hence a **distinct `:revision`** fact.
- Bias to over-bump: a false conflict costs one refetch (made safe by `:on-conflict :invalidate`); a missed conflict = silent corruption.
- `empty-entry*` (`state.cljc` 188–211) has **no `:revision` key today** — adding it is a new durable entry fact for the deferred impl wave.

### Scope
- EP **Status unchanged** (`proposal`).
- `spec/016-Resources.md` **not** edited.
- No impl code. EP-0019 impl + EP-0020 / EP-0021 remain **DEFERRED** per the ruling. The parent epic rf2-byl7bk stays open tracking the impl waves.

## Quality gates
- `python scripts/check_ep_status_sync.py` — PASS (exit 0)
- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `python scripts/check_readme_links.py` — PASS (exit 0)
- `mkdocs build --strict` — PASS (exit 0; only pre-existing relative-link INFO notices, no warnings/errors)