### PR TITLE
docs(guide): fix footer/contract drift (rf2-0kyck2)

### DIFF
--- a/docs/guide/25-from-re-frame-v1.md
+++ b/docs/guide/25-from-re-frame-v1.md
@@ -184,3 +184,12 @@ You reach past that only when v2 gives you a shape v1 didn't have. The explicit 
 One last orientation point that trips people who lived in v1's tooling. `re-frame-10x` — the v1 devtools panel — has been renamed and reimplemented as **Xray** (`day8/re-frame2-xray`). Weight the word reimplemented: Xray is not 10x ported to v2, it's a from-scratch build against re-frame2's own trace bus and epoch-history surfaces. The mental model carries over completely — events, subs, app-db diff, time-travel are all there — but the wiring underneath is new. If your v1 project depended on 10x during development, the v2 equivalent is Xray, and [the Xray tutorial](../xray/index.md) is where you meet it.
 
 That's the migration in one read. The architecture is the same architecture, the sweep is automated, and the few genuinely-new shapes (managed HTTP, flows) are improvements you'll be glad to adopt, not taxes you'll resent paying. The one rule that keeps it all honest is don't invent migration rules: the tool does what it's sure of and asks about the rest. When the migration settles, [chapter 26](reference.md) points at how to operate from there.
+
+---
+
+**You can now:**
+
+- plan a v1 migration as a bounded sweep, not a rewrite — knowing what crosses over unchanged and what genuinely changed
+- drive the automated migration from the kickoff prompt, and answer the Type B judgment calls instead of hand-editing
+- migrate the deps pay-as-you-go: swap the core coord, add a substrate adapter, and pull only the per-feature artefacts you use
+- recognise the genuinely-new shapes — single `reg-event`, managed HTTP, flows, realms, Xray — and adopt them where they improve the code they touch

--- a/docs/guide/derivations-and-algebra-views.md
+++ b/docs/guide/derivations-and-algebra-views.md
@@ -186,7 +186,7 @@ When you want the full normative contract — the node schema, every classificat
 
 ---
 
-**You can now…**
+**You can now:**
 
 - read a dependency graph a tool draws over an app you didn't write, and classify any node by its five fields
 - explain why a subscription and a flow with the same formula are one derivation under two policies

--- a/docs/guide/explanation/resources-vs-query-libraries.md
+++ b/docs/guide/explanation/resources-vs-query-libraries.md
@@ -200,4 +200,12 @@ Reach for resources when cached server reads start multiplying and the per-read 
 - **Not built yet:** optimistic rollback (EP-0019), polling (EP-0020), infinite feeds (EP-0021).
 - **Out of scope:** normalized/GraphQL caches, offline/cross-tab.
 
+---
+
+**You can now:**
+
+- map any TanStack Query / RTK Query / SWR feature onto its re-frame2 resource counterpart, and read each row's landed / different / not-built status
+- explain the "same problem, different physics" line — a cache wired to causes, not to component lifecycle — and why scope is a required structural key
+- decide when a resource is the wrong tool, reaching instead for managed HTTP or a machine
+
 [pre-alpha resource parity tranche]: ../concepts/server-state.md

--- a/docs/guide/where-state-lives.md
+++ b/docs/guide/where-state-lives.md
@@ -146,7 +146,7 @@ A value graduates to a heavier home only when it earns the upgrade — a handler
 
 ---
 
-**You can now…**
+**You can now:**
 
 - route any new value to a subscription, a flow, a resource, or a machine by asking the four questions in order
 - say what each heavier home costs, and what a value must need before it earns the promotion


### PR DESCRIPTION
Docs-only fix bringing four `docs/guide/` pages into line with the AUTHORING.md footer contract (every guide page closes with a **"You can now:"** capabilities checklist). Scope is exactly the four footer items from the read-only audit; the audit found the guide API-clean, so nothing else was touched.

## Changes

| File | Change |
|---|---|
| `docs/guide/where-state-lives.md:149` | footer heading ellipsis → colon (`You can now…` → `You can now:`) |
| `docs/guide/derivations-and-algebra-views.md:189` | same ellipsis → colon fix |
| `docs/guide/25-from-re-frame-v1.md` | **add** missing `You can now:` footer |
| `docs/guide/explanation/resources-vs-query-libraries.md` | **add** missing `You can now:` footer |

## Decision on the two missing-footer pages

AUTHORING.md gives the footer **no tier exemption**: the page contract states "Every guide page commits to all five" (item 5 is *The footer* — a "You can now:" checklist, "that is the whole footer"), and both pages appear as ordinary guide tiers in the Tiers-and-modes table (`25-from-re-frame-v1.md` = migration; `explanation/` = explanation). So both require the footer.

- **Migration page** — added a four-bullet capabilities checklist (plan the sweep, drive the automation + Type B calls, migrate deps pay-as-you-go, recognise the new shapes).
- **Explanation page** — added a three-bullet capabilities checklist. Its existing `**The summary, one more time:**` block recaps *topics covered* (Matched / Different / Not built / Out of scope), which the contract explicitly says is **not** the footer's job ("capabilities the reader earned, not the topics you covered"); the scorecard summary is kept as page content and the "You can now:" checklist added as the actual close.

Both new footers follow corpus convention: `---` separator, capabilities-not-topics bullets, ≤2 links (well within limit).

## Gates

- `mkdocs build --strict` — exit 0, zero WARNING/ERROR (spec staged via `cp -r spec docs/spec`; generated `docs/spec` + `site` removed before commit).
- `python scripts/check_doc_slugs.py` — exit 0.