### PR TITLE
feat(core): EP-0023 rf/image constructor + namespace selectors (rf2-32siq3.3)

### DIFF
--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -1,0 +1,460 @@
+(ns re-frame.image
+  "`rf/image` — the public registration-set VALUE, plus the namespace-glob
+  selector that projects descriptors out of a registration source store
+  (EP-0023 §Image, §Namespace-Selected Images, §Image Fragments).
+
+  > An image is not state. It is not the running object. It is not the event
+  > stream. It answers one question: which registrations are visible to this
+  > frame?
+
+  This namespace is the FOUNDATION slice of the EP-0023 wave (rf2-32siq3.3):
+  the constructor (`image`), the normalized image value, the exact `:include-ns`
+  glob grammar, inline `:registrations` lowering, and the PURE selector that
+  given a collection of descriptors — each carrying its source-code provenance
+  namespace at `:rf.provenance/ns` — returns the subset an image selects. It is
+  self-contained, pure logic.
+
+  ## What this slice OWNS and what it defers
+
+  OWNED here:
+
+    * `image` — the public `rf/image` constructor (PURE; no realm, no
+      registrar, no side effect — an image value is inert data, EP-0023
+      §Public API \"An image is not itself a registration entry; it is a
+      selected registration-set value\").
+    * the normalized image VALUE shape (see §The image value below).
+    * the `:include-ns` glob grammar — dot-separated namespace strings, `*`
+      matches exactly one segment, `**` matches zero or more segments,
+      case-sensitive whole-namespace matching (EP-0023 §Namespace-glob
+      language).
+    * inline `:registrations` — registrar-keyed sections (`:reg-event`,
+      `:reg-sub`, …) lowered to inline descriptors carrying inline provenance
+      (EP-0023 §Image Fragments).
+    * `select-descriptors` — the PURE selector: given a collection of
+      descriptors carrying `:rf.provenance/ns` and an image value, return the
+      selected subset (matched-by-glob registered descriptors PLUS the image's
+      inline descriptors), with zero-match `:include-ns` patterns failing loud
+      (EP-0023 §Namespace-Selected Images \"Zero matches are fail-loud\").
+
+  DEFERRED to sibling slices (NOT touched here):
+
+    * the provenance-preserving registration SOURCE STORE keyed by
+      `[kind id provenance-namespace]` (slice .2) — the live store that
+      PRODUCES the descriptors this selector consumes. This slice tests the
+      selector against SYNTHETIC descriptor collections so the two slices can
+      land in parallel; the live wiring is slice .4 (assembly).
+    * image ASSEMBLY into a sealed `[kind id]` generation, collision
+      validation, framework-standard registrations, replacement winners
+      (`:replace` / `:replace-standard`), capability checks, and resolved-
+      generation caching (later wave beads).
+    * `make-frame` / `reload-images!` frame loading (later wave beads).
+
+  ## The selector contract (input shape from the source store)
+
+  `select-descriptors` consumes a COLLECTION (seq) of descriptor maps. The
+  ONLY field this slice reads off each descriptor is:
+
+    :rf.provenance/ns   the source-code namespace STRING the descriptor was
+                        authored in (EP-0023 §Registration Source Store — the
+                        canonical-string provenance stamp every registered
+                        `reg-*` descriptor carries). Selection is BY THIS
+                        STRING, never by the registration-id's namespace: a
+                        descriptor with id `:counter/inc` is selected because
+                        it was authored in `\"docs.quickstart.counter.v2\"`,
+                        not because the keyword starts with `counter`.
+
+  Other descriptor fields (`:kind`, `:id`, `:impl`/`:handler`, source coords,
+  metadata) are carried THROUGH untouched — the selector neither requires nor
+  inspects them. That keeps this slice decoupled from slice .2's exact
+  descriptor shape: as long as a registered descriptor carries
+  `:rf.provenance/ns`, the selector works. (Descriptors with NO
+  `:rf.provenance/ns` — e.g. framework-standard or programmatic ones — are
+  never matched by an `:include-ns` glob, exactly as the EP requires:
+  \"namespaces must already be loaded\"; selection chooses from registrations
+  the runtime already knows about, by provenance string.)
+
+  ## Production elision
+
+  Pure data + string ops over plain maps; no trace emit sites, no DEBUG-gated
+  branches, no feature sentinels. The only require is `re-frame.error` (already
+  in the core spine) for fail-loud zero-match / malformed-input diagnostics. An
+  image value is inert; nothing here runs on the registration hot path, so in
+  an app that never constructs an image these fns are dead code Closure DCE
+  removes."
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the namespace-glob grammar (EP-0023 §Namespace-glob language) ---------
+;;
+;;   namespace        = dot-separated Clojure namespace string
+;;   pattern          = segment-pattern ( "." segment-pattern )*
+;;   segment-pattern  = literal segment | "*" | "**"
+;;   "*"              = exactly one dot-free namespace segment
+;;   "**"             = zero or more namespace segments
+;;   match            = case-sensitive, whole-namespace match
+;;
+;; There is no substring matching and no regex mode in v1. A pattern either
+;; matches the WHOLE `:rf.provenance/ns` string under the segment rules or it
+;; does not. Matching is a backtracking segment walk (the only backtracking
+;; source is `**`, which may absorb zero or more segments).
+
+(defn- split-segments
+  "Split a dot-separated namespace string into its segment vector. An empty
+  string yields `[\"\"]` (a single empty segment) — but namespaces are never
+  empty in practice; this is the literal `clojure.string/split` behaviour and
+  the matcher's literal-segment compare handles it without a special case."
+  [s]
+  (str/split s #"\." -1))
+
+(defn- match-segments?
+  "Case-sensitive backtracking match of a `pattern` segment vector against a
+  `ns` segment vector under the EP-0023 grammar:
+
+    literal  — matches exactly that one segment (string =)
+    \"*\"      — matches exactly ONE segment (any)
+    \"**\"     — matches ZERO OR MORE segments (greedy with backtrack)
+
+  Pure. Returns true iff the whole pattern matches the whole ns segments."
+  [pattern ns-segs]
+  (cond
+    ;; Both exhausted — full match.
+    (and (empty? pattern) (empty? ns-segs))
+    true
+
+    ;; Pattern exhausted but ns segments remain — no match.
+    (empty? pattern)
+    false
+
+    :else
+    (let [p (first pattern)]
+      (cond
+        ;; "**" — zero or more segments. Try consuming zero (advance the
+        ;; pattern, keep the ns) first, else consume one ns segment and retry
+        ;; the same "**". This ordering makes "**" match the EMPTY tail too
+        ;; (e.g. "docs.shared.**" matches "docs.shared").
+        (= "**" p)
+        (or (match-segments? (rest pattern) ns-segs)
+            (and (seq ns-segs)
+                 (match-segments? pattern (rest ns-segs))))
+
+        ;; Any remaining single-segment pattern ("*" or a literal) needs at
+        ;; least one ns segment to consume.
+        (empty? ns-segs)
+        false
+
+        ;; "*" — exactly one segment (any).
+        (= "*" p)
+        (match-segments? (rest pattern) (rest ns-segs))
+
+        ;; literal — must equal the ns segment (case-sensitive).
+        :else
+        (and (= p (first ns-segs))
+             (match-segments? (rest pattern) (rest ns-segs)))))))
+
+(defn ns-matches?
+  "True iff the namespace string `ns-str` matches the `:include-ns` glob
+  `pattern` under the EP-0023 grammar (case-sensitive whole-namespace match;
+  `*` = one segment, `**` = zero or more). Both args are strings. Pure.
+
+  This is the single matching primitive: exact inclusion is a pattern with no
+  wildcard (`\"docs.quickstart.counter.v2\"`), prefix inclusion is a normal
+  glob (`\"docs.shared.widgets.*\"`), recursive inclusion uses `**`
+  (`\"docs.shared.**\"`)."
+  [pattern ns-str]
+  (boolean
+    (and (string? pattern)
+         (string? ns-str)
+         (match-segments? (split-segments pattern) (split-segments ns-str)))))
+
+;; ---- inline descriptors (EP-0023 §Image Fragments) ------------------------
+;;
+;; Inline `:registrations` are registrar-keyed sections that mirror the public
+;; `reg-*` names. Each section's entries are call-shaped tuples:
+;;
+;;   [id metadata body]   ;; handler entry
+;;   [id metadata]        ;; metadata-only entry
+;;
+;; Inline descriptors do NOT enter the provenance source store and are NOT
+;; selected by `:include-ns`. They are selected because their containing image
+;; value was supplied. They still need a descriptor source coordinate so errors
+;; and replacements can name them (EP-0023):
+;;
+;;   {:kind :event
+;;    :id :counter/inc
+;;    :rf.provenance/image :test/small
+;;    :rf.provenance/inline [:reg-event :counter/inc]
+;;    :impl <fn>}
+;;
+;; The section→kind map mirrors `re-frame.registrar/kinds` (the Spec 001
+;; closed taxonomy); the section KEY is the public `reg-*` spelling.
+
+(def ^:private reg-section->kind
+  "The inline `:registrations` section keys (the public `reg-*` spellings)
+  mapped to their Spec 001 registry kind. Adding a registry kind that an inline
+  image section can carry is a one-row addition here, kept in lockstep with the
+  closed `re-frame.registrar/kinds` set."
+  {:reg-event          :event
+   :reg-sub            :sub
+   :reg-fx             :fx
+   :reg-cofx           :cofx
+   :reg-interceptor    :interceptor
+   :reg-view           :view
+   :reg-frame          :frame
+   :reg-route          :route
+   :reg-head           :head
+   :reg-error-projector :error-projector
+   :reg-flow           :flow
+   :reg-resource       :resource
+   :reg-mutation       :mutation
+   :reg-resource-scope :resource-scope})
+
+(defn- inline-entry->descriptor
+  "Lower one inline registrar-section entry into an inline descriptor. `entry`
+  is a call-shaped tuple `[id metadata body]` (handler) or `[id metadata]`
+  (metadata-only). `image-id` is the containing image's `:id` (nil for an
+  anonymous image — valid for local tests/examples that do not participate in
+  replacement, EP-0023). Pure.
+
+  Stamps the inline source coordinate (`:rf.provenance/image` + the
+  `:rf.provenance/inline [section id]` pair) so an inline descriptor has a
+  stable name for errors and replacement winners. The body (when present) is
+  carried under `:impl`; the metadata under `:metadata` (omitted when empty)."
+  [image-id section kind entry]
+  (when-not (and (vector? entry) (>= (count entry) 1))
+    (error/throw-error!
+      :rf.error/invalid-image
+      'rf/image
+      (str "rf/image: inline " section " entry must be a [id metadata body] or "
+           "[id metadata] tuple — got " (pr-str entry) ".")
+      {:recovery :use-a-call-shaped-tuple
+       :extra    {:image image-id :section section :entry entry}}))
+  (let [id       (nth entry 0)
+        metadata (nth entry 1 nil)
+        has-body (>= (count entry) 3)
+        body     (when has-body (nth entry 2))]
+    (cond-> {:kind                kind
+             :id                  id
+             :rf.provenance/inline [section id]}
+      image-id        (assoc :rf.provenance/image image-id)
+      has-body        (assoc :impl body)
+      (seq metadata)  (assoc :metadata metadata))))
+
+(defn- registrations->inline-descriptors
+  "Lower an image's `:registrations` map (`{:reg-event [[id meta body] …] …}`)
+  into a vector of inline descriptors, stamped with the image id. Pure. Throws
+  `:rf.error/invalid-image` on an unknown section key (fail loud rather than
+  silently drop an entry)."
+  [image-id registrations]
+  (into []
+        (mapcat
+          (fn [[section entries]]
+            (let [kind (reg-section->kind section)]
+              (when-not kind
+                (error/throw-error!
+                  :rf.error/invalid-image
+                  'rf/image
+                  (str "rf/image: unknown inline registrations section " section
+                       " — use a reg-* section key (:reg-event, :reg-sub, …).")
+                  {:recovery :correct-the-section-key
+                   :extra    {:image image-id :unknown-section section}}))
+              (map #(inline-entry->descriptor image-id section kind %) entries))))
+        registrations))
+
+;; ---- the image value (EP-0023 §Image) -------------------------------------
+;;
+;; The normalized image value this slice produces:
+;;
+;;   :rf.image/id        the image id, when supplied (`:id` in the spec map).
+;;                       Anonymous images (no `:id`) are valid for local
+;;                       tests/examples that do not participate in replacement;
+;;                       the slot is absent there. Owner-qualified per the
+;;                       EP-0007 one-name-per-fact convention (a FACT about the
+;;                       image), parallel to `:rf.app/id` / `:rf.module/id`.
+;;   :rf.image/include-ns the vector of `:include-ns` glob patterns (always a
+;;                       vector; `[]` when none supplied). The selector runs
+;;                       each pattern against descriptor `:rf.provenance/ns`.
+;;   :rf.image/inline    the vector of inline descriptors lowered from
+;;                       `:registrations` (`[]` when none supplied). These are
+;;                       selected unconditionally (their image was supplied),
+;;                       never by `:include-ns`.
+;;   :rf.image/requires  the set of `:rf.capability/*` requirements the image
+;;                       declares (defaults to `#{}`). Carried through for the
+;;                       later capability-check slice; this slice neither reads
+;;                       nor enforces it. Owner-qualified FACT key.
+;;
+;; The image value is INERT data. Two `image` calls with equal spec maps return
+;; equal values.
+
+(def ^:private image-reserved-keys
+  "Recognized top-level image spec keys. Any other key is a malformed image —
+  failed loudly rather than silently ignored."
+  #{:id :include-ns :registrations :rf.image/requires})
+
+(defn image
+  "Construct an IMAGE value — a selected registration-set value, as INERT data
+  (EP-0023 §Image, §Public API). PUBLIC (`rf/image`).
+
+  `spec` carries:
+
+    :id            the image id (optional). Stamped as `:rf.image/id`. An image
+                   that participates in replacement (named as a `:replace` /
+                   `:replace-standard` winner) MUST have an `:id`; anonymous
+                   images are valid for local tests/examples. BARE structural
+                   input key; normalized to the owner-qualified `:rf.image/id`.
+    :include-ns    a vector of namespace-glob strings (EP-0023 grammar). Each
+                   pattern selects registered descriptors by their
+                   `:rf.provenance/ns`. Optional (defaults to `[]`).
+    :registrations inline registrar-keyed sections (`{:reg-event [[id meta
+                   body] …] :reg-sub [[id meta body] …] …}`). Lowered to inline
+                   descriptors. Optional.
+    :rf.image/requires the set of `:rf.capability/*` requirements (defaults to
+                   `#{}`). Carried through for a later slice; not enforced here.
+
+  Returns a normalized image value:
+
+    {:rf.image/id         <id>          ;; present only when :id supplied
+     :rf.image/include-ns [<glob> …]
+     :rf.image/inline     [<inline-descriptor> …]
+     :rf.image/requires   #{<:rf.capability/* …>}}
+
+  PURE — no realm, no registrar, no side effect (an `image` call is data, not
+  registration). Throws `:rf.error/invalid-image` when `:include-ns` is not a
+  vector of strings, when an inline entry is malformed, or when the spec carries
+  an unknown top-level key."
+  [spec]
+  (when-not (map? spec)
+    (error/throw-error!
+      :rf.error/invalid-image
+      'rf/image
+      "rf/image expects a spec map — e.g. {:id :counter/v2 :include-ns [\"docs.counter.v2\"]}."
+      {:recovery :pass-a-spec-map
+       :extra    {:spec spec}}))
+  (doseq [k (keys spec)]
+    (when-not (contains? image-reserved-keys k)
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: unknown image key " k
+             " — use :id, :include-ns, :registrations, or :rf.image/requires.")
+        {:recovery :remove-or-correct-the-key
+         :extra    {:image (:id spec) :unknown-key k}})))
+  (let [id         (:id spec)
+        include-ns (vec (get spec :include-ns []))]
+    (doseq [p include-ns]
+      (when-not (string? p)
+        (error/throw-error!
+          :rf.error/invalid-image
+          'rf/image
+          (str "rf/image: :include-ns patterns must be namespace-glob STRINGS — got "
+               (pr-str p) ". Use \"docs.counter.v2\", \"docs.shared.widgets.*\", "
+               "or \"docs.shared.**\".")
+          {:recovery :use-namespace-glob-strings
+           :extra    {:image id :bad-pattern p}})))
+    (cond-> {:rf.image/include-ns include-ns
+             :rf.image/inline     (registrations->inline-descriptors
+                                    id (get spec :registrations {}))
+             :rf.image/requires   (set (get spec :rf.image/requires #{}))}
+      (some? id) (assoc :rf.image/id id))))
+
+;; ---- the selector (EP-0023 §Namespace-Selected Images) --------------------
+;;
+;; The PURE projection step this slice delivers: given the image value and a
+;; collection of registered descriptors (the source store's output — slice .2),
+;; return the selected subset. Selection has two sources:
+;;
+;;   1. `:include-ns` globs — match registered descriptors by their
+;;      `:rf.provenance/ns` string. Each pattern MUST match at least one
+;;      descriptor or selection fails loud (zero-match diagnostic naming the
+;;      image id, the pattern, and the loaded provenance namespaces).
+;;   2. inline `:registrations` — selected unconditionally (their image was
+;;      supplied), never by glob.
+;;
+;; The result preserves every selected descriptor exactly once (a registered
+;; descriptor selected by two patterns is included once). Collision validation,
+;; framework-standard registrations, and sealing are NOT this slice's job (the
+;; assembly slice runs after selection).
+
+(defn- descriptor-provenance-ns
+  "The source-code provenance namespace string a registered descriptor carries
+  at `:rf.provenance/ns`, or nil when it carries none (framework-standard /
+  programmatic descriptors — never `:include-ns`-selectable). Pure."
+  [descriptor]
+  (:rf.provenance/ns descriptor))
+
+(defn select-by-include-ns
+  "Select the subset of `descriptors` whose `:rf.provenance/ns` matches AT
+  LEAST ONE of the `:include-ns` `patterns` (EP-0023 grammar). Pure.
+
+  Each pattern MUST match at least one descriptor; an `:include-ns` pattern
+  matching zero descriptors throws `:rf.error/image-zero-match` (fail-loud,
+  EP-0023 §Namespace-Selected Images — keeps typos, forgotten requires, DCE
+  surprises, and stale namespace names from producing a silently incomplete
+  image). The diagnostic names `image-id`, the zero-match pattern, and the
+  loaded provenance namespaces considered.
+
+  Selection is BY `:rf.provenance/ns`, never by the registration-id's
+  namespace. Descriptors with no `:rf.provenance/ns` are never matched.
+  Returns a vector of the selected registered descriptors, each at most once,
+  in input order."
+  [image-id patterns descriptors]
+  (let [;; The loaded provenance namespaces considered — distinct, for the
+        ;; zero-match diagnostic + the membership scan.
+        loaded-ns (into (sorted-set)
+                        (keep descriptor-provenance-ns)
+                        descriptors)]
+    ;; Fail loud on any zero-match pattern BEFORE returning a partial set.
+    (doseq [pattern patterns]
+      (when-not (some #(ns-matches? pattern %) loaded-ns)
+        (error/throw-error!
+          :rf.error/image-zero-match
+          'rf/image
+          (str "rf/image: :include-ns pattern " (pr-str pattern)
+               " matched no loaded registration — every pattern must select at "
+               "least one descriptor (a zero match is a typo, a forgotten "
+               "require, a DCE-removed namespace, or a stale namespace name). "
+               "Loaded provenance namespaces considered: "
+               (pr-str (vec loaded-ns)) ".")
+          {:recovery :fix-the-pattern-or-require-the-namespace
+           :extra    {:image           image-id
+                      :pattern         pattern
+                      :loaded-ns       (vec loaded-ns)}})))
+    ;; Select every descriptor matching any pattern, preserving input order and
+    ;; including each descriptor at most once.
+    (into []
+          (filter (fn [d]
+                    (when-let [pns (descriptor-provenance-ns d)]
+                      (some #(ns-matches? % pns) patterns))))
+          descriptors)))
+
+(defn select-descriptors
+  "The PURE image selector (EP-0023 §Namespace-Selected Images, §Image
+  Fragments). Given an `image` value and a collection of registered
+  `descriptors` (each carrying its source-code provenance namespace at
+  `:rf.provenance/ns` — the source store's output, slice .2), return the subset
+  the image selects:
+
+    * registered descriptors whose `:rf.provenance/ns` matches one of the
+      image's `:include-ns` globs (selected BY provenance namespace, never by
+      the registration-id's namespace; each `:include-ns` pattern must match at
+      least one descriptor or selection fails loud); PLUS
+    * the image's inline descriptors (from `:registrations`), selected
+      unconditionally because the image value was supplied.
+
+  Returns a vector: the glob-selected registered descriptors (in input order,
+  each at most once) followed by the inline descriptors. Collision validation
+  across the selected set, framework-standard registrations, and sealing into a
+  `[kind id]` generation are the ASSEMBLY slice's job, not this selector's.
+
+  Pure — a function of the image value and the descriptor collection only.
+  This is the surface the assembly slice (.4) calls to turn an image + the
+  live source store's descriptors into the candidate registration set."
+  [image descriptors]
+  (let [image-id   (:rf.image/id image)
+        patterns   (:rf.image/include-ns image)
+        inline     (:rf.image/inline image)
+        selected   (if (seq patterns)
+                     (select-by-include-ns image-id patterns descriptors)
+                     [])]
+    (into (vec selected) inline)))

--- a/implementation/core/test/re_frame/image_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_cljs_test.cljc
@@ -1,0 +1,350 @@
+(ns re-frame.image-cljs-test
+  "EP-0023 §Image / §Namespace-Selected Images / §Image Fragments — the
+  foundation slice (rf2-32siq3.3): `rf/image` constructor, the normalized image
+  value, the `:include-ns` glob grammar, inline `:registrations`, and the PURE
+  `select-descriptors` selector against SYNTHETIC descriptor collections.
+
+  Pins the bead's enumerated coverage:
+
+    * single `*` (exactly one segment);
+    * `**` (zero AND multiple segments);
+    * case-sensitivity (whole-namespace, case-sensitive matching);
+    * multi-segment literal paths;
+    * exact (no-wildcard) inclusion vs prefix (`*`) vs recursive (`**`);
+    * inline `:registrations` lowering + unconditional selection;
+    * selection BY `:rf.provenance/ns`, NOT by the registration-id namespace;
+    * zero-match `:include-ns` patterns fail loud;
+    * each selected descriptor included at most once.
+
+  Dual-runtime: the ns ends in `-cljs-test` so it rides the always-on
+  `:node-test` gate (`npm run test:cljs`); cognitect-test-runner also discovers
+  the `.cljc` on the JVM (`clojure -M:test`). Pure data — no adapter/runtime
+  state, so no reset-runtime fixture."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.image :as image]))
+
+;; ============================================================================
+;; ns-matches? — the glob grammar primitive
+;; ============================================================================
+
+(deftest exact-inclusion-no-wildcard
+  (testing "a pattern with no wildcard matches the whole namespace exactly"
+    (is (true?  (image/ns-matches? "docs.quickstart.counter.v2"
+                                   "docs.quickstart.counter.v2")))
+    (is (false? (image/ns-matches? "docs.quickstart.counter.v2"
+                                   "docs.quickstart.counter.v3"))))
+  (testing "exact pattern does NOT match a longer or shorter namespace"
+    (is (false? (image/ns-matches? "docs.quickstart.counter"
+                                   "docs.quickstart.counter.v2")))
+    (is (false? (image/ns-matches? "docs.quickstart.counter.v2"
+                                   "docs.quickstart.counter")))))
+
+(deftest single-star-matches-exactly-one-segment
+  (testing "`*` matches exactly one dot-free segment"
+    (is (true?  (image/ns-matches? "docs.*.counter" "docs.foo.counter")))
+    (is (true?  (image/ns-matches? "docs.*.counter" "docs.bar.counter"))))
+  (testing "`*` matches ONE segment, never zero"
+    (is (false? (image/ns-matches? "docs.*.counter" "docs.counter"))))
+  (testing "`*` matches ONE segment, never two"
+    (is (false? (image/ns-matches? "docs.*.counter" "docs.a.b.counter"))))
+  (testing "trailing `*` — exactly one more segment (EP prefix example)"
+    ;; "docs.shared.widgets.*" matches docs.shared.widgets.button but NOT
+    ;; docs.shared.widgets and NOT docs.shared.widgets.forms.input.
+    (is (true?  (image/ns-matches? "docs.shared.widgets.*"
+                                   "docs.shared.widgets.button")))
+    (is (false? (image/ns-matches? "docs.shared.widgets.*"
+                                   "docs.shared.widgets")))
+    (is (false? (image/ns-matches? "docs.shared.widgets.*"
+                                   "docs.shared.widgets.forms.input"))))
+  (testing "multiple `*` segments each consume exactly one"
+    (is (true?  (image/ns-matches? "docs.*.counter.*"
+                                   "docs.x.counter.v2")))
+    (is (false? (image/ns-matches? "docs.*.counter.*"
+                                   "docs.x.counter")))
+    (is (false? (image/ns-matches? "docs.*.counter.*"
+                                   "docs.x.y.counter.v2")))))
+
+(deftest double-star-matches-zero-or-more-segments
+  (testing "`**` matches ZERO segments (the EP `docs.shared.**` ⊇ docs.shared)"
+    (is (true? (image/ns-matches? "docs.shared.**" "docs.shared"))))
+  (testing "`**` matches ONE segment"
+    (is (true? (image/ns-matches? "docs.shared.**" "docs.shared.widgets"))))
+  (testing "`**` matches MULTIPLE segments"
+    (is (true? (image/ns-matches? "docs.shared.**"
+                                  "docs.shared.widgets.forms.input"))))
+  (testing "`**` is anchored — the prefix must still match"
+    (is (false? (image/ns-matches? "docs.shared.**" "docs.other")))
+    (is (false? (image/ns-matches? "docs.shared.**" "docs")))
+    (is (false? (image/ns-matches? "docs.shared.**" "other.shared.x"))))
+  (testing "a bare `**` matches everything (zero or more from the root)"
+    (is (true? (image/ns-matches? "**" "anything")))
+    (is (true? (image/ns-matches? "**" "deeply.nested.namespace")))
+    ;; bare ** absorbing zero segments matches the empty string too
+    (is (true? (image/ns-matches? "**" ""))))
+  (testing "`**` in the middle bridges any number of segments"
+    (is (true?  (image/ns-matches? "shop.**.http" "shop.cart.http")))
+    (is (true?  (image/ns-matches? "shop.**.http" "shop.a.b.c.http")))
+    ;; `**` zero-segment in the middle: shop.**.http ⊇ shop.http
+    (is (true?  (image/ns-matches? "shop.**.http" "shop.http")))
+    (is (false? (image/ns-matches? "shop.**.http" "shop.cart.https")))))
+
+(deftest matching-is-case-sensitive
+  (testing "whole-namespace match is case-sensitive (literal segments)"
+    (is (false? (image/ns-matches? "Docs.counter" "docs.counter")))
+    (is (false? (image/ns-matches? "docs.Counter" "docs.counter")))
+    (is (true?  (image/ns-matches? "docs.counter" "docs.counter"))))
+  (testing "case-sensitivity holds under wildcards too"
+    (is (false? (image/ns-matches? "Docs.*" "docs.counter")))
+    (is (false? (image/ns-matches? "Docs.**" "docs.counter.v2")))
+    (is (true?  (image/ns-matches? "docs.**" "docs.Counter.V2")))))
+
+(deftest multi-segment-literal-paths
+  (testing "deep literal paths match whole-namespace only"
+    (is (true?  (image/ns-matches? "a.b.c.d.e" "a.b.c.d.e")))
+    (is (false? (image/ns-matches? "a.b.c.d.e" "a.b.c.d")))
+    (is (false? (image/ns-matches? "a.b.c.d.e" "a.b.c.d.e.f"))))
+  (testing "single-segment namespace"
+    (is (true?  (image/ns-matches? "core" "core")))
+    (is (false? (image/ns-matches? "core" "core.sub")))
+    (is (true?  (image/ns-matches? "*" "core")))
+    (is (false? (image/ns-matches? "*" "core.sub")))))
+
+;; ============================================================================
+;; image — the constructor + normalized value
+;; ============================================================================
+
+(deftest image-normalizes-the-spec
+  (testing "id stamps :rf.image/id; include-ns becomes a vector; requires a set"
+    (let [v (image/image {:id :docs.counter/v2
+                          :include-ns ["docs.counter.v2"]
+                          :rf.image/requires [:rf.capability/http]})]
+      (is (= :docs.counter/v2 (:rf.image/id v)))
+      (is (= ["docs.counter.v2"] (:rf.image/include-ns v)))
+      (is (= #{:rf.capability/http} (:rf.image/requires v)))
+      (is (= [] (:rf.image/inline v)))))
+  (testing "anonymous image (no :id) omits :rf.image/id — valid for local use"
+    (let [v (image/image {:include-ns ["docs.counter.**"]})]
+      (is (not (contains? v :rf.image/id)))
+      (is (= ["docs.counter.**"] (:rf.image/include-ns v)))
+      (is (= #{} (:rf.image/requires v)))))
+  (testing "empty spec yields an empty-but-well-formed image value"
+    (let [v (image/image {})]
+      (is (= [] (:rf.image/include-ns v)))
+      (is (= [] (:rf.image/inline v)))
+      (is (= #{} (:rf.image/requires v)))))
+  (testing "equal specs produce equal image values (inert data)"
+    (is (= (image/image {:id :x :include-ns ["a.b.*"]})
+           (image/image {:id :x :include-ns ["a.b.*"]})))))
+
+(deftest image-rejects-malformed-specs
+  (testing "non-map spec throws :rf.error/invalid-image"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image [:not :a :map]))))
+  (testing "unknown top-level key throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x :includeNS ["a"]}))))
+  (testing "non-string :include-ns pattern throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:include-ns ['docs.counter]}))))
+  (testing "the ex-data carries :rf.error/id for machine branching"
+    (is (= :rf.error/invalid-image
+           (try (image/image {:bogus 1})
+                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                  (:rf.error/id (ex-data e))))))))
+
+;; ============================================================================
+;; inline :registrations — lowering to inline descriptors
+;; ============================================================================
+
+(deftest inline-registrations-lower-to-descriptors
+  (let [body-inc (fn [_ _] {})
+        body-val (fn [_ _] 0)
+        v (image/image
+            {:id :test/small
+             :registrations
+             {:reg-event [[:counter/inc {:doc "Increment."} body-inc]]
+              :reg-sub   [[:counter/value {:doc "Value."} body-val]]}})
+        inline (:rf.image/inline v)
+        by-id  (into {} (map (juxt :id identity)) inline)]
+    (testing "each inline entry lowers to a descriptor with kind + id"
+      (is (= 2 (count inline)))
+      (is (= :event (:kind (by-id :counter/inc))))
+      (is (= :sub   (:kind (by-id :counter/value)))))
+    (testing "the body is carried under :impl"
+      (is (= body-inc (:impl (by-id :counter/inc))))
+      (is (= body-val (:impl (by-id :counter/value)))))
+    (testing "metadata is carried under :metadata"
+      (is (= {:doc "Increment."} (:metadata (by-id :counter/inc)))))
+    (testing "inline source coordinate names the image + the inline slot"
+      (is (= :test/small (:rf.provenance/image (by-id :counter/inc))))
+      (is (= [:reg-event :counter/inc] (:rf.provenance/inline (by-id :counter/inc)))))
+    (testing "inline descriptors carry NO :rf.provenance/ns (not glob-selectable)"
+      (is (not (contains? (by-id :counter/inc) :rf.provenance/ns))))))
+
+(deftest inline-metadata-only-entry
+  (testing "a [id metadata] tuple lowers without an :impl"
+    (let [v (image/image {:id :m
+                          :registrations {:reg-fx [[:my/fx {:doc "meta only"}]]}})
+          d (first (:rf.image/inline v))]
+      (is (= :fx (:kind d)))
+      (is (= :my/fx (:id d)))
+      (is (not (contains? d :impl)))
+      (is (= {:doc "meta only"} (:metadata d))))))
+
+(deftest inline-rejects-unknown-section-and-malformed-entry
+  (testing "unknown inline section key throws :rf.error/invalid-image"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:registrations {:reg-bogus [[:x {}]]}}))))
+  (testing "a non-tuple inline entry throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:registrations {:reg-event [:not-a-tuple]}})))))
+
+(deftest anonymous-image-inline-omits-image-coordinate
+  (testing "anonymous image inline descriptors omit :rf.provenance/image"
+    (let [v (image/image {:registrations {:reg-event [[:x {} (fn [_ _] {})]]}})
+          d (first (:rf.image/inline v))]
+      (is (not (contains? d :rf.provenance/image)))
+      ;; the inline slot coordinate is still present (id is nameable locally)
+      (is (= [:reg-event :x] (:rf.provenance/inline d))))))
+
+;; ============================================================================
+;; select-descriptors — the PURE selector against synthetic descriptors
+;; ============================================================================
+
+(defn- desc
+  "A synthetic registered descriptor — the source store's output shape this
+  slice consumes. The ONLY load-bearing field is :rf.provenance/ns (the
+  source-code namespace). :kind/:id/:impl are carried through untouched."
+  [provenance-ns kind id]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :impl             (fn [_ _] ::stub)})
+
+(def ^:private synthetic-store
+  "A synthetic descriptor collection spanning several provenance namespaces,
+  deliberately REUSING the registration-id namespace `:counter/inc` across
+  DIFFERENT source namespaces — so a test can prove selection is by
+  :rf.provenance/ns, not by the id's namespace."
+  [(desc "docs.quickstart.counter.v2"  :event :counter/inc)
+   (desc "docs.quickstart.counter.v2"  :sub   :counter/value)
+   (desc "docs.quickstart.counter.v3"  :event :counter/inc) ; same id, diff ns
+   (desc "docs.shared.widgets"         :view  :widgets/button)
+   (desc "docs.shared.widgets.button"  :view  :button/root)
+   (desc "shop.cart"                   :event :cart/add)
+   (desc "shop.auth"                   :event :auth/set-user)])
+
+(deftest select-by-provenance-ns-not-id-ns
+  (testing "exact :include-ns selects only the matching provenance namespace"
+    (let [img (image/image {:id :i :include-ns ["docs.quickstart.counter.v2"]})
+          sel (image/select-descriptors img synthetic-store)]
+      (is (= 2 (count sel)))
+      ;; BOTH selected descriptors came from v2 — the v3 :counter/inc (same id
+      ;; namespace!) is NOT selected. This is the headline EP rule.
+      (is (every? #(= "docs.quickstart.counter.v2" (:rf.provenance/ns %)) sel))
+      (is (= #{:counter/inc :counter/value} (set (map :id sel))))))
+  (testing "the v3 :counter/inc is reachable only via its own provenance ns"
+    (let [img (image/image {:id :i :include-ns ["docs.quickstart.counter.v3"]})
+          sel (image/select-descriptors img synthetic-store)]
+      (is (= 1 (count sel)))
+      (is (= "docs.quickstart.counter.v3" (:rf.provenance/ns (first sel))))
+      (is (= :counter/inc (:id (first sel)))))))
+
+(deftest select-glob-prefix-and-recursive
+  (testing "prefix `*` selects exactly-one-deeper provenance namespaces"
+    (let [img (image/image {:id :i :include-ns ["docs.shared.widgets.*"]})
+          sel (image/select-descriptors img synthetic-store)]
+      ;; matches docs.shared.widgets.button but NOT docs.shared.widgets
+      (is (= ["docs.shared.widgets.button"] (map :rf.provenance/ns sel)))))
+  (testing "recursive `**` selects the base ns AND any deeper ns"
+    (let [img (image/image {:id :i :include-ns ["docs.shared.**"]})
+          sel (image/select-descriptors img synthetic-store)]
+      (is (= #{"docs.shared.widgets" "docs.shared.widgets.button"}
+             (set (map :rf.provenance/ns sel))))))
+  (testing "a `*.*` mid-glob selects across sibling counter versions"
+    (let [img (image/image {:id :i :include-ns ["docs.*.counter.*"]})
+          sel (image/select-descriptors img synthetic-store)]
+      (is (= #{"docs.quickstart.counter.v2" "docs.quickstart.counter.v3"}
+             (set (map :rf.provenance/ns sel)))))))
+
+(deftest select-multiple-patterns-deduped-and-ordered
+  (testing "a descriptor matched by two patterns is included at most once"
+    (let [img (image/image {:id :i
+                            :include-ns ["docs.shared.**"
+                                         "docs.shared.widgets.button"]})
+          sel (image/select-descriptors img synthetic-store)]
+      ;; docs.shared.widgets.button matches BOTH patterns — but appears once.
+      (is (= 2 (count sel)))
+      (is (= #{"docs.shared.widgets" "docs.shared.widgets.button"}
+             (set (map :rf.provenance/ns sel))))))
+  (testing "selection preserves input order of the descriptor collection"
+    (let [img (image/image {:id :i :include-ns ["shop.**"]})
+          sel (image/select-descriptors img synthetic-store)]
+      (is (= [:cart/add :auth/set-user] (map :id sel))))))
+
+(deftest select-zero-match-fails-loud
+  (testing "an :include-ns pattern matching no descriptor throws"
+    (let [img (image/image {:id :i :include-ns ["does.not.exist.**"]})]
+      (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                            #"\[:rf\.error/image-zero-match\]"
+                            (image/select-descriptors img synthetic-store)))))
+  (testing "the diagnostic names the image, the pattern, and loaded namespaces"
+    (let [img (image/image {:id :my/image :include-ns ["nope.*"]})]
+      (try
+        (image/select-descriptors img synthetic-store)
+        (is false "expected a zero-match throw")
+        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+          ;; thrown-ex-info MERGES :extra onto the top-level ex-data (it is not
+          ;; nested under :extra) — read the surface slots at the top level.
+          (let [data (ex-data e)]
+            (is (= :rf.error/image-zero-match (:rf.error/id data)))
+            (is (= :my/image (:image data)))
+            (is (= "nope.*" (:pattern data)))
+            (is (some #{"shop.cart"} (:loaded-ns data))))))))
+  (testing "ONE matching + ONE zero-match pattern still fails (every pattern must match)"
+    (let [img (image/image {:id :i :include-ns ["shop.**" "ghost.*"]})]
+      (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                            #"\[:rf\.error/image-zero-match\]"
+                            (image/select-descriptors img synthetic-store))))))
+
+(deftest select-includes-inline-descriptors-unconditionally
+  (testing "inline descriptors are selected even with NO :include-ns globs"
+    (let [body (fn [_ _] {})
+          img  (image/image
+                 {:id :test/small
+                  :registrations {:reg-event [[:counter/inc {} body]]}})
+          sel  (image/select-descriptors img synthetic-store)]
+      ;; no :include-ns → no glob selection, but the inline descriptor is present
+      (is (= 1 (count sel)))
+      (is (= :counter/inc (:id (first sel))))
+      (is (= :test/small (:rf.provenance/image (first sel))))))
+  (testing "inline descriptors are appended AFTER the glob-selected ones"
+    (let [img (image/image
+                {:id :combo
+                 :include-ns ["shop.auth"]
+                 :registrations {:reg-event [[:extra/evt {} (fn [_ _] {})]]}})
+          sel (image/select-descriptors img synthetic-store)]
+      (is (= 2 (count sel)))
+      (is (= :auth/set-user (:id (first sel))))     ; glob-selected first
+      (is (= :extra/evt     (:id (second sel))))))) ; inline appended
+
+(deftest select-ignores-descriptors-without-provenance-ns
+  (testing "a descriptor with no :rf.provenance/ns is never glob-selected"
+    (let [store (conj synthetic-store
+                      {:kind :fx :id :standard/fx :impl (fn [_] nil)}) ; no provenance
+          img   (image/image {:id :i :include-ns ["**"]})
+          sel   (image/select-descriptors img store)]
+      ;; bare `**` matches every PROVENANCE ns, but the provenance-less
+      ;; descriptor is excluded (it carries no :rf.provenance/ns to match).
+      (is (not (some #(= :standard/fx (:id %)) sel)))
+      (is (= (count synthetic-store) (count sel))))))
+
+(deftest select-empty-image-selects-nothing
+  (testing "an image with no globs and no inline selects an empty set"
+    (let [img (image/image {:id :empty})]
+      (is (= [] (image/select-descriptors img synthetic-store))))))


### PR DESCRIPTION
## Summary

Foundation slice of the EP-0023 (image-loaded frames) implementation wave (rf2-32siq3.3), built to run in PARALLEL with slice .2 (the registration source store). Adds the public `rf/image` constructor and the first image selector surface as **self-contained, pure logic** in a new namespace `re-frame.image`.

## What this slice delivers

- **`rf/image`** — the public constructor producing a normalized, inert image value:
  `{:rf.image/id <id> :rf.image/include-ns [<glob> …] :rf.image/inline [<descriptor> …] :rf.image/requires #{…}}`.
- **The `:include-ns` glob grammar** exactly per EP-0023 §Namespace-glob language: dot-separated namespace strings; `*` matches exactly one segment; `**` matches zero or more segments (backtracking match); case-sensitive, whole-namespace matching. No substring/regex mode.
- **Inline `:registrations`** — registrar-keyed sections (`:reg-event`, `:reg-sub`, …) lowered to inline descriptors carrying inline provenance (`:rf.provenance/image` + `:rf.provenance/inline [section id]`). Not glob-selectable; selected because the image was supplied.
- **`select-descriptors`** — the PURE selector: given an image value and a collection of descriptors each carrying `:rf.provenance/ns`, returns the selected subset (glob-matched registered descriptors + inline descriptors). Zero-match `:include-ns` patterns fail loud (`:rf.error/image-zero-match`) naming the image, the pattern, and the loaded provenance namespaces.

**Selection is by `:rf.provenance/ns`** (the source-code namespace), NOT by the registration-id's namespace — the headline EP rule, pinned by a test reusing `:counter/inc` across two source namespaces.

## Selector input contract (for slice .2 / .4 verification)

`select-descriptors` consumes a seq of descriptor maps. The ONLY field it reads is **`:rf.provenance/ns`** (a source-code namespace STRING). All other fields (`:kind`, `:id`, `:impl`, coords, metadata) are carried through untouched. Descriptors without `:rf.provenance/ns` are never glob-selected. This keeps the slice decoupled from slice .2's exact descriptor shape: as long as a registered descriptor carries `:rf.provenance/ns`, the selector works.

## Surface lane

- New namespace only: `implementation/core/src/re_frame/image.cljc`; only requires `re-frame.error`.
- Did NOT touch the registrar / source-store internals (slice .2), `spec/Conventions.md` (slice .2 owns the EP-0023 reserved-namespace rows), or any hot-zone file. No `shadow-cljs.edn` / `deps.edn` edits (the `core/src` + `core/test` paths are already enumerated; the `*-cljs-test` ns rides the existing `:node-test` gate).
- No coupling with slice .2 was hit.

## Tests

`implementation/core/test/re_frame/image_cljs_test.cljc` — CLJC, runs on both CLJS (`npm run test:cljs`) and JVM (`clojure -M:test`). Exhaustive glob-grammar coverage (single `*`, `**` zero/one/multiple, mid-glob `**`, case-sensitivity, multi-segment literals), inline registrations, dedup/ordering, zero-match fail-loud, and selection-by-provenance-ns.

## Gates

- `npm run test:cljs` — green (7346 tests, 30351 assertions, 0 failures).
- `scripts/test-fast-pr.sh` — green (core JVM + CLJS node + JS harness helpers).
- `clojure -M:test` (core JVM) — green (1576 tests, 0 failures).