### PR TITLE
fix(core): EP-0023 image.cljc :replace key hint + validation tests (rf2-zngxtq)

### DIFF
--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -354,7 +354,8 @@
         :rf.error/invalid-image
         'rf/image
         (str "rf/image: unknown image key " k
-             " — use :id, :include-ns, :registrations, or :rf.image/requires.")
+             " — use :id, :include-ns, :registrations, :rf.image/requires, "
+             ":replace, or :replace-standard.")
         {:recovery :remove-or-correct-the-key
          :extra    {:image (:id spec) :unknown-key k}})))
   (let [id         (:id spec)

--- a/implementation/core/test/re_frame/image_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_cljs_test.cljc
@@ -156,6 +156,50 @@
                   (:rf.error/id (ex-data e))))))))
 
 ;; ============================================================================
+;; :replace / :replace-standard — declared-winner maps (EP-0023 §Image
+;; Patching And Overrides). BARE structural slots — validated here (must be
+;; maps when supplied) and carried through uninterpreted.
+;; ============================================================================
+
+(deftest image-rejects-non-map-replace-keys
+  (testing "a non-map :replace throws :rf.error/invalid-image"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x :replace [:not :a :map]}))))
+  (testing "a non-map :replace-standard throws :rf.error/invalid-image"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x :replace-standard :nope}))))
+  (testing "the bad-key/received surface slots ride the top-level ex-data"
+    ;; thrown-ex-info MERGES :extra onto the top-level ex-data (not nested) —
+    ;; read the surface slots at the top level.
+    (let [data (try (image/image {:id :y :replace 42})
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :replace (:bad-key data)))
+      (is (= 42 (:received data))))))
+
+(deftest image-carries-replace-keys-through
+  (testing "valid :replace / :replace-standard maps carry through to the value"
+    (let [rep      {[:event :counter/inc] :docs.counter.v3/counter-inc}
+          rep-std  {[:fx :http] :app.http/winner}
+          v        (image/image {:id :combo
+                                 :replace          rep
+                                 :replace-standard rep-std})]
+      (is (= rep     (:replace v)))
+      (is (= rep-std (:replace-standard v)))))
+  (testing "an empty :replace map is still carried through (present-when-supplied)"
+    ;; cond-> branches on (:replace spec) truthiness; an empty map is truthy.
+    (let [v (image/image {:id :e :replace {}})]
+      (is (contains? v :replace))
+      (is (= {} (:replace v)))))
+  (testing "absent :replace / :replace-standard keys are NOT stamped onto the value"
+    (let [v (image/image {:id :bare :include-ns ["docs.counter.v2"]})]
+      (is (not (contains? v :replace)))
+      (is (not (contains? v :replace-standard))))))
+
+;; ============================================================================
 ;; inline :registrations — lowering to inline descriptors
 ;; ============================================================================
 


### PR DESCRIPTION
EP-0023 review follow-up (rf2-zngxtq). Two minor clean-ups on the `:replace` / `:replace-standard` image keys (added to the `rf/image` constructor by an earlier slice).

## Changes

**1. Stale error hint** (`implementation/core/src/re_frame/image.cljc`)
The unknown-image-key error message listed only `:id, :include-ns, :registrations, :rf.image/requires` — but the constructor now also accepts `:replace` and `:replace-standard`. Hint updated to include them.

**2. Missing validation tests** (`implementation/core/test/re_frame/image_cljs_test.cljc`)
The `.3` slice owns this validation per the `image.cljc` docstring. Added:
- `image-rejects-non-map-replace-keys` — a non-map `:replace` throws `:rf.error/invalid-image`; a non-map `:replace-standard` throws `:rf.error/invalid-image`; the `:bad-key`/`:received` surface slots ride the top-level ex-data.
- `image-carries-replace-keys-through` — valid `:replace`/`:replace-standard` maps carry through to the normalized image value; empty `:replace` map still carried (present-when-supplied); absent keys are not stamped.

No other behavior changed; `image_assembly.cljc` and the frames code untouched.

## Gates
- `implementation/` `npm run test:cljs` — green (7382 tests / 30435 assertions, 0 failures, 0 errors)
- repo root `sh scripts/test-fast-pr.sh` — PASS