### PR TITLE
feat(core): EP-0023 image capability requirements (rf2-32siq3.6)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -657,10 +657,15 @@
   diagnostic distinguishes a missing CAPABILITY from a missing REGISTRATION.
   Returns `requires`.
 
-  SLICE .6 SEAM: this is the fail-loud point the capability slice calls at the
-  FRAME boundary (slice .7 supplies the frame's `:capabilities`). `assemble`
-  does NOT call it — pure assembly has no frame capability map. Slice .6 owns
-  wiring this into frame creation."
+  `capabilities` may be nil — a frame that supplies NO `:capabilities` map
+  provides nothing, so ANY non-empty `requires` fails loud (a nil map is read as
+  `{}`, parallel to EP-0013's `app_value/check-capabilities!` reading an absent
+  realm capability map as `#{}`). A no-op only when `requires` is empty.
+
+  This is the fail-loud point the FRAME boundary calls (`live-frame/make-frame`
+  supplies the frame's `:capabilities`). `assemble` does NOT call it — pure
+  assembly has no frame capability map; the union `:rf.image/requires` set rides
+  the generation (`:rf.gen/requires`) for this frame-boundary step."
   [requires capabilities]
   (let [missing (remove #(contains? capabilities %) requires)]
     (when (seq missing)

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -258,10 +258,16 @@
                    frame concern, image is a behaviour concern (EP-0023 §Image
                    Patching And Overrides).
     :capabilities  the host capability map the image's `:rf.image/requires` is
-                   checked against (optional). When supplied, any required
-                   capability the map does not provide fails loud
-                   (`:rf.error/image-missing-capability`) BEFORE the generation is
-                   returned — the EP-0023 §Public API frame-boundary check.
+                   checked against (optional). The check runs UNCONDITIONALLY at
+                   the frame boundary: any required capability the map does not
+                   provide fails loud (`:rf.error/image-missing-capability`)
+                   BEFORE the generation is returned — the EP-0023 §Public API
+                   frame-boundary check. An ABSENT `:capabilities` map provides
+                   nothing, so an image with a non-empty `:rf.image/requires`
+                   fails just as it would against `{}` (EP-0013 fail-loud
+                   parity); supplying the map is therefore mandatory for any
+                   image that declares requirements. A no-op when the image
+                   requires nothing.
     :adapter       the active-substrate adapter binding/configuration (optional).
                    Carried on the object; the adapter binding is part of the live
                    frame object, never the frame-state value (EP-0023 §Host
@@ -284,11 +290,17 @@
                       (asm/assemble images)
                       (asm/assemble images descriptors))]
      ;; Capability check at the FRAME boundary (EP-0023 §Public API): a required
-     ;; capability absent from the supplied map fails BEFORE the generation is
-     ;; runnable. Only meaningful when capabilities are supplied; the union
-     ;; requires set rides the generation (`:rf.gen/requires`).
-     (when (some? capabilities)
-       (asm/check-capabilities! (:rf.gen/requires generation) capabilities))
+     ;; capability absent from the frame's `:capabilities` fails BEFORE the
+     ;; generation is runnable. The check runs UNCONDITIONALLY so a frame that
+     ;; supplies NO `:capabilities` map still fails any non-empty
+     ;; `:rf.image/requires` — an absent map provides nothing, exactly as
+     ;; `{}` does. This preserves EP-0013's fail-loud install-time capability
+     ;; check (`app_value/check-capabilities!`, which reads an absent realm
+     ;; capability map as `#{}` and fails any unmet requirement) at the new
+     ;; frame boundary; guarding the call on `(some? capabilities)` would let a
+     ;; frame run an image whose requirements were never satisfied. A no-op when
+     ;; the union `:rf.gen/requires` is empty (the common no-requirements path).
+     (asm/check-capabilities! (:rf.gen/requires generation) capabilities)
      (let [frame-object
            (cond-> {object-marker  true
                     generation-key generation}

--- a/implementation/core/test/re_frame/image_assembly_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cljs_test.cljc
@@ -22,7 +22,11 @@
       invariant-coupled standard);
     * `:replace-standard` on a replaceable standard succeeds;
     * missing application interceptor reference FAILS LOUD;
-    * missing capability FAILS LOUD (the .6 seam fn).
+    * capability checking (rf2-32siq3.6): missing capability FAILS LOUD; an
+      empty/absent `:rf.image/requires` is a no-op; an absent (nil) or empty
+      `:capabilities` map fails any non-empty requires (EP-0013 fail-loud
+      parity); a partial-capability map fails on exactly the unmet subset; the
+      multi-image requires UNION is collected and checked as one set.
 
   Each fail-loud assertion checks the `:rf.error/id` discriminator (NEVER the
   message bytes — Spec 009 §The thrown-error shape rule 3).
@@ -406,6 +410,70 @@
            (asm/check-capabilities! #{:rf.capability/http}
                                     {:rf.capability/http ::http-impl
                                      :rf.capability/schemas ::s})))))
+
+(deftest empty-requires-is-a-no-op
+  (testing "check-capabilities! with NO requirements is a no-op regardless of the
+            supplied map — including an empty or nil capability map"
+    (is (= #{} (asm/check-capabilities! #{} {:rf.capability/http ::http-impl})))
+    (is (= #{} (asm/check-capabilities! #{} {})))
+    (is (= #{} (asm/check-capabilities! #{} nil)))))
+
+(deftest absent-capability-map-fails-non-empty-requires
+  (testing "a nil :capabilities map provides nothing, so ANY non-empty requires
+            fails loud — an absent map is read as {} (EP-0013 fail-loud parity)"
+    (is (= :rf.error/image-missing-capability
+           (assembly-error-id
+             #(asm/check-capabilities! #{:rf.capability/http} nil))))
+    (testing "an empty {} map behaves identically to nil"
+      (is (= :rf.error/image-missing-capability
+             (assembly-error-id
+               #(asm/check-capabilities! #{:rf.capability/http} {})))))))
+
+(deftest partial-capabilities-fail-on-the-unmet-subset
+  (testing "when SOME required capabilities are supplied but not all, the check
+            fails loud and the diagnostic names exactly the missing subset"
+    (let [ex (try (asm/check-capabilities!
+                    #{:rf.capability/http :rf.capability/schemas :rf.capability/storage}
+                    {:rf.capability/http ::http-impl})
+                  nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))
+          d  (ex-data ex)]
+      (is (= :rf.error/image-missing-capability (:rf.error/id d)))
+      (testing "the missing subset is exactly the unmet capabilities, sorted
+                (the :extra slots are merged at the top level of the ex-data)"
+        (is (= [:rf.capability/schemas :rf.capability/storage]
+               (:missing-capabilities d))))
+      (testing "the supplied set names what the frame DID provide (a CAPABILITY
+                gap, not a registration gap)"
+        (is (= [:rf.capability/http]
+               (:supplied-capabilities d)))))))
+
+(deftest multi-image-requires-union-then-checked
+  (testing "the generation's :rf.gen/requires is the UNION across all images'
+            :rf.image/requires, and check-capabilities! is satisfied only when
+            EVERY image's requirement is supplied"
+    (let [pool [(reg-desc "a.core" :event :a/e ::a)
+                (reg-desc "b.core" :event :b/e ::b)]
+          img-a (image/image {:id :a/img :include-ns ["a.core"]
+                              :rf.image/requires #{:rf.capability/http}})
+          img-b (image/image {:id :b/img :include-ns ["b.core"]
+                              :rf.image/requires #{:rf.capability/schemas}})
+          gen   (asm/assemble [img-a img-b] pool)]
+      (testing "the union of both images' requires rides the generation"
+        (is (= #{:rf.capability/http :rf.capability/schemas}
+               (:rf.gen/requires gen))))
+      (testing "a map satisfying only ONE image's requirement still fails loud
+                — the union must be fully satisfied"
+        (is (= :rf.error/image-missing-capability
+               (assembly-error-id
+                 #(asm/check-capabilities! (:rf.gen/requires gen)
+                                           {:rf.capability/http ::http-impl})))))
+      (testing "a map satisfying the FULL union passes"
+        (is (= #{:rf.capability/http :rf.capability/schemas}
+               (asm/check-capabilities! (:rf.gen/requires gen)
+                                        {:rf.capability/http    ::http-impl
+                                         :rf.capability/schemas ::schemas
+                                         :rf.capability/extra   ::ignored})))))))
 
 ;; ===========================================================================
 ;; 8. Descriptor-coordinate identity (the source coordinate errors/winners use)

--- a/implementation/core/test/re_frame/live_frame_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_cljs_test.cljc
@@ -14,7 +14,11 @@
     * a duplicate live `:id` FAILS LOUD (`:rf.error/live-frame-id-conflict`);
     * a direct (no-id) frame object BYPASSES the registry;
     * a non-vector `:images` is REJECTED (`:rf.error/make-frame-bad-images`);
-    * the capability frame-boundary check fails loud on a missing capability.
+    * the capability frame-boundary check (rf2-32siq3.6): fails loud on a missing
+      capability; an image with requirements but NO `:capabilities` map fails
+      (the check is unconditional — EP-0013 fail-loud parity); an image with no
+      requirements needs no `:capabilities` map; the multi-image requires UNION
+      is checked as one set at the frame boundary.
 
   Each fail-loud assertion checks the `:rf.error/id` discriminator (NEVER the
   message bytes — Spec 009 §The thrown-error shape rule 3).
@@ -236,3 +240,55 @@
                                counter-pool)]
       (is (lf/frame-object? frame))
       (is (= {:rf.capability/http ::http-impl} (:rf.frame/capabilities frame))))))
+
+(deftest absent-capabilities-map-fails-a-required-image
+  (testing "an image declaring :rf.image/requires but supplied NO :capabilities
+            map fails loud at the frame boundary — an absent map provides
+            nothing (EP-0013 fail-loud parity), so the check is NOT skipped"
+    (let [img (image/image {:id :articles/browser
+                            :include-ns ["examples.counter"]
+                            :rf.image/requires #{:rf.capability/http}})]
+      (is (= :rf.error/image-missing-capability
+             (err-id #(lf/make-frame {:id :articles/main
+                                      :images [img]}
+                                     counter-pool)))
+          "no :capabilities key at all still fails the non-empty requires")
+      (testing "the frame id was NOT registered (creation aborted before insert)"
+        (is (not (contains? (lf/live-frame-ids) :articles/main)))))))
+
+(deftest no-requirements-needs-no-capabilities-map
+  (testing "an image with empty/absent :rf.image/requires creates a frame with
+            NO :capabilities map — the unconditional check is a no-op when the
+            generation requires nothing"
+    (let [img   (image/image {:include-ns ["examples.counter"]})
+          frame (lf/make-frame {:images [img]} counter-pool)]
+      (is (lf/frame-object? frame))
+      (is (= #{} (:rf.gen/requires (lf/frame-generation frame))))
+      (is (not (contains? frame :rf.frame/capabilities))
+          "no :capabilities supplied → the slot is absent on the object"))))
+
+(deftest multi-image-requires-union-checked-at-the-frame-boundary
+  (testing "two images each declaring a distinct capability: the frame's
+            generation carries the UNION, and the :capabilities map must satisfy
+            ALL of it or creation fails loud"
+    (let [pool  [(reg-desc "examples.counter" :event :counter/inc ::inc)
+                 (reg-desc "examples.cart"    :event :cart/add    ::add)]
+          img-a (image/image {:id :counter/img :include-ns ["examples.counter"]
+                              :rf.image/requires #{:rf.capability/http}})
+          img-b (image/image {:id :cart/img :include-ns ["examples.cart"]
+                              :rf.image/requires #{:rf.capability/schemas}})]
+      (testing "a :capabilities map satisfying only ONE image fails the union"
+        (is (= :rf.error/image-missing-capability
+               (err-id #(lf/make-frame {:images [img-a img-b]
+                                        :capabilities {:rf.capability/http ::http-impl}}
+                                       pool)))))
+      (testing "a :capabilities map satisfying the FULL union creates the frame,
+                and the union rides the generation"
+        (let [frame (lf/make-frame
+                      {:images [img-a img-b]
+                       :capabilities {:rf.capability/http    ::http-impl
+                                      :rf.capability/schemas ::schemas}}
+                      pool)]
+          (is (lf/frame-object? frame))
+          (is (= #{:rf.capability/http :rf.capability/schemas}
+                 (:rf.gen/requires (lf/frame-generation frame)))))))))


### PR DESCRIPTION
Completes + hardens the EP-0023 image capability-requirements path (rf2-32siq3.6). Builds on merged .2/.3/.4/.5/.8.

## What .8 already did (verified complete + correct)
- `image.cljc`: `:rf.image/requires` declaration/normalization (default `#{}`).
- `image_assembly.cljc`: `:rf.gen/requires` UNION collection across images + the `check-capabilities!` fail-loud point (`:rf.error/image-missing-capability`, diagnostic distinguishing a missing CAPABILITY from a missing REGISTRATION).
- `live_frame.cljc`: wired `check-capabilities!` at the `make-frame` frame boundary; `:capabilities` rides the frame object.

## Gap fixed
`make-frame`'s capability check was guarded by `(when (some? capabilities) ...)`. An image declaring `:rf.image/requires` but created with **no** `:capabilities` map silently bypassed the check — letting a frame run an image whose requirements were never satisfied.

EP-0013's `app_value/check-capabilities!` runs **unconditionally** (an absent realm capability map reads as `#{}` and fails any unmet requirement), and EP-0023 §Public API (line 1562) requires any capability *"absent from the frame's `:capabilities`"* to fail. The check now runs unconditionally; an absent `:capabilities` map provides nothing (read as `{}`), so any non-empty `:rf.image/requires` fails loud. No-op only when the generation requires nothing.

`check-capabilities!` itself already handled a nil map correctly (`(contains? nil k)` is false → all required missing → throws); the fix is removing the guard. Docstrings updated on `check-capabilities!`, `make-frame`'s `:capabilities`, and both test namespaces.

## Added CLJS coverage (not Playwright)
**assembly** (`image_assembly_cljs_test`): empty/absent requires is a no-op; nil and empty `:capabilities` fail any non-empty requires (EP-0013 parity); partial-capability fails on exactly the unmet subset (diagnostic names missing vs supplied); multi-image requires UNION collected + checked as one set.

**frame boundary** (`live_frame_cljs_test`): image with satisfiable requires loads; image with requirements but NO `:capabilities` map fails loud (frame **not** registered); no-requirements image needs no `:capabilities` map; multi-image union checked at the frame boundary.

## Surface lane
Stayed entirely in `image_assembly.cljc` (capability check) + `live_frame.cljc` (the .8 boundary guard — light touch, one-line semantic fix, no frame-object restructure) + capability tests. Did NOT touch the live-resolution path (slice .9). `image.cljc` unchanged.

## Gates
- `npm run test:cljs`: 7406 tests / 30495 assertions, 0 failures, 0 errors.
- `npm run test:elision`: PASS (production 43/43 absent, control 43/43 present).
- `scripts/test-fast-pr.sh`: PASS fast PR spine.