### PR TITLE
feat(core): EP-0023 frame-derived live registration resolution (rf2-32siq3.9)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -47,8 +47,24 @@
   app/realm surface while RETAINING the realm machinery as an internal
   substrate; this slice introduces the image-loaded public frame object without
   disturbing the existing `reg-frame` / `re-frame.frame/make-frame` callers. The
-  later slices wire frame-derived live resolution (.9) and reload (.10) on the
-  frame object this slice returns.
+  reload slice (.10) wires image replacement on the frame object this slice
+  returns.
+
+  ## Frame-derived live resolution (rf2-32siq3.9 — LANDED here)
+
+  This ns also owns the EP-0023 resolution-routing SEAM
+  ([[call-with-frame-resolution]]): bind `re-frame.registrar/*generation*` to a
+  frame object's sealed generation around a thunk, and every `(kind, id)` lookup
+  inside it — dispatch / subscribe / fx / cofx / view / resource all funnel
+  through `registrar/lookup` — resolves through the TARGET frame's OWN image
+  generation, not the global/default registrar (EP-0023 §Frame-derived live
+  registration resolution). This is the same observable contract the a15n62
+  slice shipped for the EP-0013 realm substrate (`registrar/*registrar*` bound
+  to a realm's atom), restated for an EP-0023 frame OBJECT that carries its
+  generation directly. Two frames running DIFFERENT images resolve the same
+  `[kind id]` to their OWN image's descriptor; absence (a nil target / no
+  generation) falls through to the registrar atom path, byte-identical for every
+  existing caller (absence-is-default).
 
   ## Production elision
 
@@ -56,10 +72,15 @@
   hot path, not a DEBUG-gated branch). It is pure map assembly over the result
   of `image-assembly/assemble` plus one registry `swap!`. An app that never
   calls `make-frame` with `:images` never reaches these fns (Closure DCE removes
-  them). The only requires are `re-frame.image-assembly` (the merged assembly
-  entry point) and `re-frame.error` (fail-loud diagnostics) — both already in
-  the core spine."
+  them). The resolution seam adds a single dynamic binding around the cascade
+  (the no-generation default path pays one `frame-object?` predicate then runs
+  with zero binding cost — see [[call-with-frame-resolution]]). The requires are
+  `re-frame.image-assembly` (the merged assembly entry point),
+  `re-frame.registrar` (the `*generation*` resolution seam + the closed kind
+  set), and `re-frame.error` (fail-loud diagnostics) — all already in the core
+  spine."
   (:require [re-frame.image-assembly :as asm]
+            [re-frame.registrar      :as registrar]
             [re-frame.error          :as error]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -159,6 +180,85 @@
   the live-resolution (.9) slice resolves registrations against."
   [frame-object]
   (get frame-object generation-key))
+
+;; ===========================================================================
+;; Frame-derived live registration resolution (EP-0023 §Frame-derived live
+;; registration resolution, rf2-32siq3.9)
+;; ===========================================================================
+;;
+;; EP-0023 restates the a15n62 invariant in image/frame terms:
+;;
+;;     target frame -> resolved image generation -> registration resolution
+;;
+;; The headline use cases (same-id / different-image frames on one page, Xray
+;; beside the target, progressive docs examples) all depend on ONE prerequisite:
+;; live dispatch / subscribe / fx / cofx / view / resource lookups must resolve
+;; through the TARGET frame's resolved image generation, not the global/default
+;; registrar. The a15n62 slice already shipped this for the EP-0013 realm
+;; substrate by binding `registrar/*registrar*` to a frame's REALM registrar
+;; atom; this slice ships the same observable contract for an EP-0023 frame
+;; OBJECT, which carries its generation directly under `:rf.frame/generation`.
+;;
+;; The mechanism is a SINGLE binding seam, mirroring
+;; `re-frame.frame/call-with-frame-realm-registrar`: bind `registrar/*generation*`
+;; to the frame object's sealed generation around a thunk, and EVERY `(kind, id)`
+;; lookup inside it (`registrar/lookup` is the universal chokepoint dispatch /
+;; subscribe / fx / cofx / view / resource all funnel through) resolves through
+;; the frame's OWN image's resolver. Two frames running DIFFERENT images thus
+;; resolve the same `[:event :boot/init]` to their OWN image's descriptor.
+;;
+;; ALL-OR-NOTHING (the a15n62 coherence rule, restated): the binding covers the
+;; WHOLE cascade — event handler + every cofx injection + the whole fx walk +
+;; view/resource lookup — so a frame-local handler's effects resolve in the same
+;; image as the handler. Routing only some lookups would be an incoherent
+;; half-dispatch.
+;;
+;; ABSENCE-IS-DEFAULT (the load-bearing fall-through): a nil frame object, or a
+;; frame object carrying no generation, binds NOTHING — `registrar/*generation*`
+;; stays nil and resolution falls through to the registrar atom path (the
+;; single-realm default AND the a15n62 realm-routed path alike), byte-identical
+;; for every existing caller. This slice is purely ADDITIVE: it introduces a new
+;; resolution dimension for EP-0023 frame objects without disturbing any path
+;; that does not target one.
+;;
+;; DERIVED from the carried frame object, never an ambient binding (EP-0002
+;; carried-invariant): the generation is read off the frame the caller targets,
+;; not inferred from process state. A plain fn (not a macro) so CLJS sibling-ns
+;; callers use it with no `:require-macros` plumbing.
+
+(defn frame-resolution-generation
+  "Return the resolved image generation a `frame-target` resolves registrations
+  through, or nil when the target carries none. `frame-target` is an EP-0023
+  frame OBJECT (the only target this slice resolves a generation from); a nil
+  target, a non-object value, or an object with no `:rf.frame/generation` slot
+  yields nil — the absence-is-default signal that no generation routing is
+  needed and resolution falls through to the registrar atom path. Pure."
+  [frame-target]
+  (when (frame-object? frame-target)
+    (frame-generation frame-target)))
+
+(defn call-with-frame-resolution
+  "Invoke `thunk` with `registrar/*generation*` bound to `frame-target`'s
+  resolved image generation WHEN the target carries one; otherwise invoke
+  `thunk` with NO binding (the absence-is-default registrar-atom path). Returns
+  the thunk's value. This is the EP-0023 frame-derived resolution seam
+  (rf2-32siq3.9): every event / subscription / fx / cofx / view / resource
+  `(kind, id)` lookup inside `thunk` resolves through the targeted frame's OWN
+  image generation coherently (ALL-OR-NOTHING — `registrar/lookup` is the single
+  chokepoint they all funnel through).
+
+  `frame-target` is an EP-0023 frame OBJECT (`make-frame`'s return value). A nil
+  target, a non-object value, or an object with no generation binds nothing and
+  runs `thunk` on the default registrar-atom path — byte-identical to every
+  existing caller. DERIVED from the carried frame object, never an ambient
+  binding (EP-0002 carried-invariant). The default (no-generation) path pays
+  one `frame-object?` predicate + one keyword read and then runs `thunk` with
+  ZERO dynamic-binding cost."
+  [frame-target thunk]
+  (if-let [gen (frame-resolution-generation frame-target)]
+    (binding [registrar/*generation* gen]
+      (thunk))
+    (thunk)))
 
 ;; ===========================================================================
 ;; :images validation (EP-0023 §Image Composition — \"`:images`, always a

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -162,6 +162,77 @@
   []
   (or *registrar* kind->id->metadata))
 
+;; ---- the active resolved image GENERATION (EP-0023 §Frame-derived live
+;;      registration resolution, rf2-32siq3.9) --------------------------------
+;;
+;; EP-0023 restates the a15n62 invariant in image/frame terms:
+;;
+;;     target frame -> resolved image generation -> registration resolution
+;;
+;; A live frame OBJECT (`re-frame.live-frame/make-frame`) carries a SEALED
+;; image generation under `:rf.frame/generation` rather than addressing a realm
+;; registrar atom. The generation's `:rf.gen/resolver` is the id-disjoint
+;; `{[kind id] descriptor}` map a frame resolves `(kind, id)` lookups through
+;; (the descriptor is the SAME registration-metadata shape `register!` stores —
+;; it carries `:handler-fn` and every standard metadata key — because the
+;; source store records `register!`'s metadata verbatim, so a generation-routed
+;; `lookup` returns a value byte-shape-identical to a registrar-routed one).
+;;
+;; `*generation*` is the resolution-routing seam: when BOUND (a dispatch /
+;; subscribe / fx / cofx / view / resource lookup is in flight against an
+;; EP-0023 frame object), `lookup` / `handler` / `registrations` / `ids`
+;; resolve through the generation's resolver FIRST instead of the registrar
+;; atom. When nil — the absence-is-default path, EVERY existing caller (the
+;; EP-0013 realm-routed dispatch and the single-realm default path alike) — the
+;; reads target `active-registrar`'s atom exactly as before, byte-identical.
+;; This var is consulted with ONE nil check on the read hot path; the dominant
+;; production path leaves it unbound and pays a single `nil?` branch.
+;;
+;; PERF / coherence: like `*registrar*`, the binding is established ONCE per
+;; cascade / subscribe-build by `re-frame.live-frame/call-with-frame-resolution`
+;; (DERIVED from the carried frame object, never an ambient binding — EP-0002),
+;; so event + cofx + fx + sub resolve coherently through the SAME generation
+;; (ALL-OR-NOTHING — routing only some would be an incoherent half-dispatch
+;; where a frame-local handler's effects resolve in the global registrar).
+;;
+;; No `:require` on `re-frame.image-assembly` (that ns requires THIS one — a
+;; back-require would cycle): the resolver is read as plain map data via the
+;; documented `:rf.gen/*` shape. `re-frame.live-frame` (which DOES require
+;; image-assembly) owns the binding seam and the generation read API.
+(def ^:dynamic *generation*
+  "The active resolved image GENERATION (a sealed `re-frame.image-assembly`
+  generation value), or nil for the registrar-atom path. Bound by
+  `re-frame.live-frame/call-with-frame-resolution` around a dispatch /
+  subscribe / fx / cofx / view / resource resolution targeting an EP-0023 frame
+  OBJECT, so `(kind, id)` lookups resolve through the frame's OWN image
+  generation rather than the global/default registrar (EP-0023 §Frame-derived
+  live registration resolution, rf2-32siq3.9). nil ⇒ the absence-is-default
+  registrar-atom path — byte-identical for every existing caller."
+  nil)
+
+(defn- generation-resolver
+  "The `{[kind id] descriptor}` resolver map of the currently-bound
+  `*generation*`, or nil when no generation is bound. Reads the documented
+  `:rf.gen/resolver` slot directly (no `image-assembly` require — that ns
+  requires this one). Pure."
+  []
+  (when-let [gen *generation*]
+    (:rf.gen/resolver gen)))
+
+(defn- kind-registrations-from-resolver
+  "Project a generation `resolver` (keyed `[kind id]`) into the registrar's
+  `{id metadata}` query shape for one `kind` — the frame's OWN registrations
+  of that kind. Pure. Used by the generation-routed `registrations` / `ids`
+  query API so a frame-scoped query sees only the frame's image registrations."
+  [resolver kind]
+  (persistent!
+    (reduce-kv (fn [acc [k id] descriptor]
+                 (if (= k kind)
+                   (assoc! acc id descriptor)
+                   acc))
+               (transient {})
+               resolver)))
+
 ;; ---- registration ---------------------------------------------------------
 
 (defonce ^:private replacement-hooks
@@ -633,11 +704,25 @@
 (defn lookup
   "Return the metadata map registered for (kind, id), or nil.
 
+  EP-0023 §Frame-derived live registration resolution (rf2-32siq3.9): when an
+  EP-0023 frame OBJECT's image generation is in scope (`*generation*` bound by
+  `re-frame.live-frame/call-with-frame-resolution`), the `(kind, id)` resolves
+  through the FRAME'S OWN generation resolver — so two frames running different
+  images resolve the same `[kind id]` to their OWN image's descriptor. The
+  generation's resolver is keyed `[kind id]`; the descriptor is the same
+  registration-metadata shape `register!` stores (the source store records it
+  verbatim), so the return value is byte-shape-identical to the registrar path.
+  When `*generation*` is unbound — the absence-is-default path, EVERY existing
+  caller (single-realm + the a15n62 realm-routed dispatch) — resolution targets
+  the `active-registrar` atom exactly as before, one `nil?` branch on the read.
+
   Uses paired `get` calls rather than `(get-in ... [kind id])` — `get-in`
   allocates a path vector per call (rf2-mqv4m), and `lookup` runs per
   dispatch (event handler), per fx (handler), and per sub (handler)."
   [kind id]
-  (-> @(active-registrar) (get kind) (get id)))
+  (if-let [resolver (generation-resolver)]
+    (get resolver [kind id])
+    (-> @(active-registrar) (get kind) (get id))))
 
 (defn handler
   "Return just the handler fn from the metadata, or nil. The handler is
@@ -668,13 +753,24 @@
   argument is the metadata-map only — the registration id is reachable
   from the metadata's `:ns` / `:line` / `:file` / `:doc` / `:tags` /
   custom slots (id-by-keyword filtering composes via the caller's own
-  `filter` over the result map's keys when needed)."
+  `filter` over the result map's keys when needed).
+
+  EP-0023 (rf2-32siq3.9): when a frame generation is in scope (`*generation*`
+  bound), the `{id metadata}` map is PROJECTED from the generation's resolver
+  for `kind` — only the ids the frame's OWN image carries, so a generation-
+  scoped query (a per-frame fx walk, a view-id resolution) sees the frame's
+  registration universe, not the global registrar's. Unbound ⇒ the registrar
+  atom path, byte-identical."
   ([kind]
-   (get @(active-registrar) kind {}))
+   (if-let [resolver (generation-resolver)]
+     (kind-registrations-from-resolver resolver kind)
+     (get @(active-registrar) kind {})))
   ([kind pred-fn]
    (into {}
          (filter (fn [[_id meta]] (pred-fn meta)))
-         (get @(active-registrar) kind {}))))
+         (if-let [resolver (generation-resolver)]
+           (kind-registrations-from-resolver resolver kind)
+           (get @(active-registrar) kind {})))))
 
 (defn handler-meta
   "Public alias for lookup. Used by tooling."

--- a/implementation/core/test/re_frame/frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_resolution_cljs_test.cljc
@@ -1,0 +1,280 @@
+(ns re-frame.frame-resolution-cljs-test
+  "EP-0023 §Frame-derived live registration resolution (rf2-32siq3.9): live
+  registration lookup — dispatch (event), subscribe (sub), fx, cofx,
+  view/resource lookup — derives from the TARGET frame's resolved image
+  generation, not the global/default registrar.
+
+  > target frame -> resolved image generation -> registration resolution
+
+  This is the prerequisite that makes the same-id / different-image use cases
+  work: two frames running different images resolve the same `[kind id]` to
+  their OWN image's descriptor. The default fall-through (absence-is-default)
+  leaves every existing caller unaffected.
+
+  The HEADLINE case: two frame objects each carrying a DIFFERENT image both
+  registering `[:event :boot/init]` (and friends) resolve that id to their OWN
+  image's descriptor when their generation is in scope. `registrar/lookup` is
+  the single chokepoint dispatch / subscribe / fx / cofx / view / resource all
+  funnel through, so the seam is exercised through `registrar/lookup` /
+  `registrar/handler` / `registrar/registrations` / `registrar/ids` for every
+  kind — proving the binding routes ALL of them coherently (all-or-nothing).
+
+  Resolution runs against explicit synthetic descriptor pools (the `make-frame`
+  2-arity), so there is no live source-store wiring — the same decoupling idiom
+  `image-assembly-cljs-test` / `live-frame-cljs-test` use. Fixtures clear the
+  framework-standard registry and the process-default registrar between cases.
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` AND `clojure -M:test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.image          :as image]
+            [re-frame.image-assembly :as asm]
+            [re-frame.registrar      :as registrar]
+            [re-frame.test-support   :as test-support]
+            [re-frame.live-frame     :as lf]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures.
+;;
+;; The default registrar is snapshot/restored via `make-reset-runtime-fixture`
+;; — NOT `registrar/clear-all!`, which is hostile to CLJS isolation (it wipes
+;; framework-shipped ns-load registrations a sibling test ns depends on, and
+;; CLJS has no `(require … :reload)` to reinstate them — see
+;; `re-frame.test-support`). Snapshot/restore rolls back THIS test's
+;; registrations (`:app/boot`, `:global/only`, …) while leaving framework state
+;; intact, run-order-independently. No adapter is installed — these tests never
+;; render; they exercise pure `(kind, id)` resolution.
+;;
+;; The EP-0023 framework-standard registry and the live-frame registry are this
+;; wave's OWN process-state defonce atoms (not framework ns-load state a sibling
+;; depends on), so a direct clear is safe and keeps generation-routing tested
+;; against a known baseline.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {})
+  (fn [t]
+    (asm/clear-standards!)
+    (lf/clear-live-frames!)
+    (t)
+    (asm/clear-standards!)
+    (lf/clear-live-frames!)))
+
+;; ---------------------------------------------------------------------------
+;; Helpers — synthetic REGISTERED descriptors (the source-store output shape
+;; the selector consumes). `:handler-fn` is the registrar impl slot, so a
+;; resolved descriptor is shape-identical to a registered registrar entry.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-desc
+  [provenance-ns kind id impl]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :handler-fn       impl})
+
+;; ===========================================================================
+;; 1. The binding seam routes registrar/lookup through a frame's generation
+;; ===========================================================================
+
+(deftest lookup-derives-from-the-bound-frame-generation
+  (testing "with no frame generation in scope, registrar/lookup resolves
+            through the registrar atom (the absence-is-default path)"
+    ;; Register a descriptor into the process-default registrar.
+    (registrar/register! :event :app/boot {:handler-fn ::default-boot})
+    (is (= ::default-boot (:handler-fn (registrar/lookup :event :app/boot)))
+        "the default registrar path resolves the globally-registered handler")
+    (testing "binding a frame's generation routes the SAME id to the FRAME'S
+              own image descriptor instead"
+      (let [pool  [(reg-desc "examples.app" :event :app/boot ::image-boot)]
+            img   (image/image {:include-ns ["examples.app"]})
+            frame (lf/make-frame {:images [img]} pool)]
+        (lf/call-with-frame-resolution frame
+          (fn []
+            (is (= ::image-boot (:handler-fn (registrar/lookup :event :app/boot)))
+                "inside the seam, lookup resolves the frame's image descriptor")))
+        (testing "OUTSIDE the seam, lookup reverts to the registrar atom path"
+          (is (= ::default-boot (:handler-fn (registrar/lookup :event :app/boot)))))))))
+
+;; ===========================================================================
+;; 2. THE HEADLINE — two frames running DIFFERENT images resolve the same
+;;    [kind id] to their OWN image's descriptor
+;; ===========================================================================
+
+(deftest two-frames-different-images-resolve-same-id-to-own-descriptor
+  (testing "two frame objects running DIFFERENT images both registering
+            [:event :boot/init] resolve that id to their OWN image's descriptor
+            (EP-0023 §Independent Surfaces On One Page — the heart of the
+            same-id story)"
+    (let [todo-pool    [(reg-desc "examples.todo"    :event :boot/init ::todo-boot)]
+          counter-pool [(reg-desc "examples.counter" :event :boot/init ::counter-boot)]
+          todo-img     (image/image {:id :examples/todo
+                                     :include-ns ["examples.todo"]})
+          counter-img  (image/image {:id :examples/counter
+                                     :include-ns ["examples.counter"]})
+          todo-frame    (lf/make-frame {:id :todo/main    :images [todo-img]}    todo-pool)
+          counter-frame (lf/make-frame {:id :counter/main :images [counter-img]} counter-pool)]
+      (testing "the TODO frame resolves :boot/init to the todo image's handler"
+        (lf/call-with-frame-resolution todo-frame
+          (fn []
+            (is (= ::todo-boot (registrar/handler :event :boot/init))))))
+      (testing "the COUNTER frame resolves the SAME id to the counter image's handler"
+        (lf/call-with-frame-resolution counter-frame
+          (fn []
+            (is (= ::counter-boot (registrar/handler :event :boot/init))))))
+      (testing "neither frame's id leaks into the other (no global clobber):
+                resolving each frame again still yields its own descriptor"
+        (lf/call-with-frame-resolution todo-frame
+          (fn [] (is (= ::todo-boot (registrar/handler :event :boot/init)))))
+        (lf/call-with-frame-resolution counter-frame
+          (fn [] (is (= ::counter-boot (registrar/handler :event :boot/init)))))))))
+
+;; ===========================================================================
+;; 3. dispatch / sub / fx / cofx all derive from the target frame
+;;    (registrar/lookup is the single chokepoint for every kind — all-or-nothing)
+;; ===========================================================================
+
+(deftest event-sub-fx-cofx-view-all-derive-from-the-frame-generation
+  (testing "every registration KIND dispatch / subscribe / fx / cofx /
+            view / resource resolves through (event :sub :fx :cofx :view
+            :resource) derives from the bound frame generation — proving the
+            single binding routes them ALL coherently (all-or-nothing)"
+    (let [pool  [(reg-desc "examples.feat" :event    :feat/go        ::ev)
+                 (reg-desc "examples.feat" :sub      :feat/value     ::sub)
+                 (reg-desc "examples.feat" :fx       :feat/save      ::fx)
+                 (reg-desc "examples.feat" :cofx     :feat/now       ::cofx)
+                 (reg-desc "examples.feat" :view     :feat/root      ::view)
+                 (reg-desc "examples.feat" :resource :feat/by-id     ::resource)]
+          img   (image/image {:include-ns ["examples.feat"]})
+          frame (lf/make-frame {:images [img]} pool)]
+      (lf/call-with-frame-resolution frame
+        (fn []
+          (testing "event (dispatch)"    (is (= ::ev       (registrar/handler :event    :feat/go))))
+          (testing "sub (subscribe)"     (is (= ::sub      (registrar/handler :sub      :feat/value))))
+          (testing "fx"                  (is (= ::fx       (registrar/handler :fx       :feat/save))))
+          (testing "cofx"                (is (= ::cofx     (registrar/handler :cofx     :feat/now))))
+          (testing "view"                (is (= ::view     (registrar/handler :view     :feat/root))))
+          (testing "resource"            (is (= ::resource (registrar/handler :resource :feat/by-id))))
+          (testing "an id NOT in the image resolves nil (the frame's image is
+                    the registration universe, not the global registrar)"
+            (registrar/register! :event :other/not-in-image {:handler-fn ::global-only})
+            (is (nil? (registrar/lookup :event :other/not-in-image))
+                "a globally-registered id absent from the frame's image is nil
+                 under generation routing")))))))
+
+;; ===========================================================================
+;; 4. registrations / ids project from the bound generation
+;; ===========================================================================
+
+(deftest registrations-and-ids-project-from-the-generation
+  (testing "the registrar query API (registrations / ids) projects from the
+            bound generation — a frame-scoped query sees only the frame's image
+            registrations of that kind"
+    ;; A globally-registered :event the frame's image does NOT carry.
+    (registrar/register! :event :global/only {:handler-fn ::global})
+    (let [pool  [(reg-desc "examples.q" :event :q/a ::a)
+                 (reg-desc "examples.q" :event :q/b ::b)
+                 (reg-desc "examples.q" :sub   :q/s ::s)]
+          img   (image/image {:include-ns ["examples.q"]})
+          frame (lf/make-frame {:images [img]} pool)]
+      (testing "the default (unbound) registrations sees the global registry"
+        (is (contains? (registrar/registrations :event) :global/only))
+        (is (not (contains? (registrar/registrations :event) :q/a))))
+      (lf/call-with-frame-resolution frame
+        (fn []
+          (testing "the generation-scoped query sees ONLY the frame's image ids"
+            (is (= #{:q/a :q/b} (registrar/ids :event))
+                "ids :event projects the frame's image events, not the global :global/only")
+            (is (= #{:q/s} (registrar/ids :sub)))
+            (is (not (contains? (registrar/registrations :event) :global/only))
+                "the globally-registered id is invisible under the frame's generation")
+            (testing "the filtered arity also projects from the generation"
+              (is (= #{:q/a} (set (keys (registrar/registrations
+                                          :event
+                                          #(= ::a (:handler-fn %)))))))))))
+      (testing "after the seam, the query reverts to the global registry"
+        (is (contains? (registrar/registrations :event) :global/only))))))
+
+;; ===========================================================================
+;; 5. Absence-is-default — a nil / non-object / no-generation target binds
+;;    nothing; resolution falls through to the registrar atom path
+;; ===========================================================================
+
+(deftest absence-is-default-leaves-existing-callers-unaffected
+  (testing "a nil target, a non-object value, or an object with no generation
+            binds NOTHING — resolution falls through to the registrar atom path
+            (the load-bearing absence-is-default fall-through)"
+    (registrar/register! :event :app/boot {:handler-fn ::default-boot})
+    (testing "a nil frame target runs the thunk on the default registrar path"
+      (lf/call-with-frame-resolution nil
+        (fn []
+          (is (= ::default-boot (:handler-fn (registrar/lookup :event :app/boot))))
+          (is (nil? registrar/*generation*) "no generation is bound for a nil target"))))
+    (testing "a non-object value (a frame-id keyword) binds nothing"
+      (lf/call-with-frame-resolution :counter/main
+        (fn []
+          (is (= ::default-boot (:handler-fn (registrar/lookup :event :app/boot))))
+          (is (nil? registrar/*generation*)))))
+    (testing "a frame object carrying NO generation binds nothing"
+      ;; A hand-built frame-object marker with no :rf.frame/generation slot.
+      (let [no-gen-obj {:rf.frame/object true}]
+        (lf/call-with-frame-resolution no-gen-obj
+          (fn []
+            (is (= ::default-boot (:handler-fn (registrar/lookup :event :app/boot))))
+            (is (nil? registrar/*generation*))))))))
+
+(deftest frame-resolution-generation-reads-the-target-generation
+  (testing "frame-resolution-generation returns a frame object's generation and
+            nil for any non-frame-object / no-generation target"
+    (let [pool  [(reg-desc "examples.g" :event :g/go ::go)]
+          img   (image/image {:include-ns ["examples.g"]})
+          frame (lf/make-frame {:images [img]} pool)]
+      (is (= (lf/frame-generation frame) (lf/frame-resolution-generation frame)))
+      (is (nil? (lf/frame-resolution-generation nil)))
+      (is (nil? (lf/frame-resolution-generation :counter/main)))
+      (is (nil? (lf/frame-resolution-generation {:rf.frame/object true}))
+          "a frame object with no generation slot yields nil (absence-is-default)"))))
+
+;; ===========================================================================
+;; 6. Same image in two frames resolves identically (shared behaviour) — the
+;;    complement of the same-id/different-image case
+;; ===========================================================================
+
+(deftest same-image-two-frames-resolve-identically
+  (testing "two frames running the SAME image resolve the same id to the same
+            descriptor (same behaviour, different memory — EP-0023 §Same
+            Behavior, Many Instances)"
+    (let [pool  [(reg-desc "examples.counter" :event :counter/inc ::inc)]
+          img   (image/image {:include-ns ["examples.counter"]})
+          left  (lf/make-frame {:id :counter/left  :images [img]} pool)
+          right (lf/make-frame {:id :counter/right :images [img]} pool)]
+      (lf/call-with-frame-resolution left
+        (fn [] (is (= ::inc (registrar/handler :event :counter/inc)))))
+      (lf/call-with-frame-resolution right
+        (fn [] (is (= ::inc (registrar/handler :event :counter/inc))))))))
+
+;; ===========================================================================
+;; 7. Coherence — a nested resolution stays in the frame's generation across
+;;    the cascade (the binding covers the WHOLE thunk, not just the top lookup)
+;; ===========================================================================
+
+(deftest nested-resolution-stays-in-the-frames-generation
+  (testing "the binding covers the WHOLE thunk: a lookup issued from a nested
+            call inside the seam still resolves through the frame's generation
+            (ALL-OR-NOTHING coherence — the event handler, its cofx, and its fx
+            all resolve in the same image)"
+    (let [pool  [(reg-desc "examples.c" :event :c/go   ::go)
+                 (reg-desc "examples.c" :cofx  :c/now  ::now)
+                 (reg-desc "examples.c" :fx    :c/save ::save)]
+          img   (image/image {:include-ns ["examples.c"]})
+          frame (lf/make-frame {:images [img]} pool)
+          ;; A nested fn that resolves a DIFFERENT kind, simulating the cofx
+          ;; injection / fx walk that runs deeper in the cascade.
+          resolve-fx (fn [] (registrar/handler :fx :c/save))]
+      (lf/call-with-frame-resolution frame
+        (fn []
+          (is (= ::go (registrar/handler :event :c/go)))
+          ;; cofx injection (runs as an interceptor :before inside the cascade)
+          (is (= ::now (registrar/handler :cofx :c/now)))
+          ;; the fx walk (runs post-commit inside the SAME call) — nested resolve
+          (is (= ::save (resolve-fx))
+              "a nested fx resolution stays in the frame's generation"))))))


### PR DESCRIPTION
## What

Routes live `(kind, id)` registration lookup through the **targeted frame's resolved image generation**, restating the a15n62 invariant in EP-0023 image/frame terms:

```
target frame -> resolved image generation -> registration resolution
```

This is the prerequisite that makes same-id / different-image examples work: two frames running different images resolve the same `[:event :boot/init]` to their OWN image's descriptor. Builds on merged .2/.3/.4/.5/.6/.8.

## How

- **`registrar`**: add the `*generation*` resolution-routing dynamic var. When bound, `lookup` / `handler` / `registrations` / `ids` resolve through the generation's sealed `:rf.gen/resolver` FIRST (the descriptor is the same registration-metadata shape `register!` stores, so the return value is byte-shape-identical). Unbound = the **absence-is-default** registrar-atom path, byte-identical for every existing caller (single-realm + the a15n62 realm-routed dispatch). No `image-assembly` require (that ns requires this one) — the resolver is read as plain `:rf.gen/*` map data.
- **`live-frame`**: add `call-with-frame-resolution`, the binding seam mirroring `frame/call-with-frame-realm-registrar`. Bind `*generation*` to a frame object's sealed generation around a thunk; every event/sub/fx/cofx/view/resource lookup inside resolves through the frame's OWN image (ALL-OR-NOTHING — `registrar/lookup` is the single chokepoint they all funnel through). A nil / non-object / no-generation target binds nothing (absence-is-default). Derived from the carried frame object, never ambient (EP-0002).

## Resolution contract (for .10/.11)

`registrar/*generation*` is the seam. Slice .10 (reload) and .11 build on it: bind a frame object's `:rf.frame/generation` via `live-frame/call-with-frame-resolution` around any dispatch/subscribe/cascade, and all `registrar/lookup`-routed resolution derives from that generation. Reload swaps the generation a frame object carries; the resolution path needs no change.

## Tests (CLJS, not Playwright)

`re-frame.frame-resolution-cljs-test`:
- **Headline**: two frames running DIFFERENT images resolve the same `[kind id]` to their OWN image's descriptor (no global clobber).
- dispatch/sub/fx/cofx/view/resource all derive from the target generation (all-or-nothing).
- `registrations`/`ids` project from the bound generation.
- absence-is-default for nil / non-object / no-generation targets (existing callers unaffected).
- same-image/two-frame parity; nested-resolution coherence across the cascade.

Fixture uses snapshot/restore (`make-reset-runtime-fixture`), NOT `registrar/clear-all!` (which is hostile to CLJS isolation — it wiped framework ns-load state a sibling Reagent test depended on; caught and fixed).

## Gates

- `npm run test:cljs`: 7414 tests, 0 failures, 0 errors.
- `npm run test:elision`: PASS (43/43 absent in prod) — resolution adds no debug-gated branch.
- `scripts/test-fast-pr.sh`: PASS fast PR spine.

## Coupling note

Slice .6 (capability requirements) landed on `live_frame.cljc` + `image_assembly.cljc` while this slice ran. Rebased onto origin/main; .6's `make-frame` capability code and this slice's new resolution fns auto-merged cleanly (no overlapping hunks). Did NOT touch `image_assembly.cljc` or restructure `live_frame.cljc`'s core — only additive (a require + two new fns).