### PR TITLE
feat(core): EP-0023 resolved image generation cache (rf2-32siq3.7, closes rf2-3sjdmi)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -148,31 +148,57 @@
   standard-registry
   (atom {}))
 
+(defonce ^{:doc "A MONOTONIC generation integer for the framework-standard
+  registry (EP-0023 §Image — the resolved-generation cache's
+  framework-standard-registration generation key leg). Bumped on every
+  `register-standard!` / `forget-standard!` / `clear-standards!` mutation; read
+  by the resolved-generation cache key so a cached generation is invalidated the
+  instant any standard descriptor changes. Starts at 0."
+            :private true}
+  standard-generation*
+  (atom 0))
+
+(defn standard-generation
+  "The framework-standard registry's MONOTONIC generation integer (EP-0023
+  §Image — the resolved-generation cache key's standard-registration leg).
+  Increments on every `register-standard!` / `forget-standard!` /
+  `clear-standards!`; equal across two reads ⇒ the standard set is unchanged and
+  a sealed generation assembled then may be reused."
+  []
+  @standard-generation*)
+
 (defn register-standard!
   "Contribute a framework-standard descriptor for `[kind id]`. `descriptor` is
   stamped `:standard true`; its replacement policy comes from
   `:rf.standard/replaceable?` (default false) and `:rf.standard/requires-conformance`
   (default `#{}`). Idempotent per `[kind id]` — re-registering replaces the slot
-  (the standard owner's hot-reload path). Returns the stamped descriptor."
+  (the standard owner's hot-reload path). Bumps the standard generation so the
+  resolved-generation cache invalidates. Returns the stamped descriptor."
   [kind id descriptor]
   (let [desc (-> descriptor
                  (assoc :kind kind :id id :standard true)
                  (update :rf.standard/replaceable? boolean)
                  (update :rf.standard/requires-conformance #(set (or % #{}))))]
     (swap! standard-registry assoc [kind id] desc)
+    (swap! standard-generation* inc)
     desc))
 
 (defn forget-standard!
   "Remove the framework-standard descriptor for `[kind id]`. Mirror of
-  `register-standard!` for the standard owner's teardown path."
+  `register-standard!` for the standard owner's teardown path. Bumps the
+  standard generation."
   [kind id]
   (swap! standard-registry dissoc [kind id])
+  (swap! standard-generation* inc)
   nil)
 
 (defn clear-standards!
-  "Reset the framework-standard registry. Test fixtures use this between cases."
+  "Reset the framework-standard registry. Test fixtures use this between cases.
+  Bumps the standard generation so a cache keyed on the prior generation
+  invalidates."
   []
   (reset! standard-registry {})
+  (swap! standard-generation* inc)
   nil)
 
 (defn standard-descriptors
@@ -702,6 +728,151 @@
   [(into {} (mapcat #(:replace % {})) images)
    (into {} (mapcat #(:replace-standard % {})) images)])
 
+(defn- assemble*
+  "The PURE assembly pipeline: select → union standards → validate → seal.
+  Returns the sealed generation. `images` is already a normalized vector;
+  `descriptors` is the candidate pool. This is the function the cache wraps —
+  it has no cache awareness, so every cache MISS computes one full generation
+  here (the SSR re-seal the cache exists to avoid). Throws on every fail-loud
+  condition exactly as before (a throwing input is NOT cached)."
+  [images descriptors]
+  (let [;; A representative image id for diagnostics (the first that carries
+        ;; one); collision/winner errors also name exact coordinates.
+        image-id (some :rf.image/id images)
+        selected (select-for-images images descriptors)
+        standard (standard-descriptors)
+        all-ds   (into (vec selected) standard)
+        [rep rep-std] (replace-maps images)]
+    ;; (3) Fail loud on any unsupported descriptor kind before sealing.
+    (check-supported-kinds! image-id all-ds)
+    ;; (4) Fail loud on any :replace / :replace-standard declaration for a key
+    ;;     with no real collision — a replacement is for an intentional
+    ;;     collision, never a silent order override. Runs before resolution so
+    ;;     a stale/typo'd declaration fails before any winner is matched.
+    (check-replacement-keys-collide! image-id (distinct-by-id all-ds) rep rep-std)
+    (let [;; (5) Project into the sealed resolver — every collision resolved
+          ;;     by a declared winner or thrown (order never decides).
+          resolver (build-resolver image-id all-ds rep rep-std)]
+      ;; (6) Validate application interceptor references against the sealed set.
+      (check-references! image-id resolver)
+      ;; (7) Seal.
+      {:rf.gen/resolver resolver
+       :rf.gen/images   images
+       :rf.gen/requires (image-requires images)
+       :rf.gen/kinds    (into #{} (map first) (keys resolver))})))
+
+;; ===========================================================================
+;; Resolved-generation cache (EP-0023 §Image — "The reference implementation
+;; MUST cache resolved generations") + rf2-3sjdmi (cache-key correctness)
+;; ===========================================================================
+;;
+;; Resolved generations are IMMUTABLE and may be physically shared across many
+;; frames when the same image inputs resolve to the same descriptor set. SSR is
+;; the primary motivation: a request-scoped frame must NOT re-run glob
+;; selection + validation + sealing on every request when the inputs are
+;; unchanged. The cache turns the repeated `assemble` of an unchanged
+;; composition into a single map lookup returning the SAME sealed object.
+;;
+;; ---- the cache key (EP-0023 minimum key) ----------------------------------
+;;
+;; The EP's minimum key is:
+;;
+;;     normalized :images vector
+;;     + registration source-store generation
+;;     + framework-standard registration generation
+;;     + inline descriptor fingerprints
+;;     + declared replacement maps
+;;
+;; The NORMALIZED IMAGE VALUES carry, by value, every one of the
+;; image-side legs already:
+;;
+;;   * `:rf.image/include-ns` — the glob selection input;
+;;   * `:rf.image/inline`     — the inline descriptor fingerprints (the inline
+;;                              descriptors themselves, lowered + stamped, are
+;;                              part of the image value — equal images ⇒ equal
+;;                              inline fingerprints);
+;;   * `:replace` / `:replace-standard` — the declared replacement maps.
+;;
+;; So the image vector IS the "normalized :images + inline fingerprints +
+;; replacement maps" portion of the key. This is the rf2-3sjdmi correctness
+;; point: the key is built from the image INPUTS, NOT from `:rf.gen/resolver`
+;; alone — two compositions differing ONLY in `:replace` carry different image
+;; values, so they occupy different cache slots and can never cache-collide on
+;; a shared resolver shape.
+;;
+;; The two store-side legs are the monotonic generations:
+;;
+;;   * single-arity (live store): `source-store/store-generation` —
+;;     the registered descriptor pool's generation; ANY reg-*/forget-*/clear
+;;     bumps it.
+;;   * the framework-standard generation: `standard-generation` — ANY
+;;     register-standard!/forget-standard!/clear bumps it.
+;;
+;; For the EXPLICIT-POOL arity `(assemble images descriptors)` the registered
+;; pool is supplied directly (tests / a pre-snapshotted store), NOT read from
+;; the live store — so the store generation is NOT a faithful invalidation
+;; signal there. The honest pool leg in that arity is the descriptor pool
+;; itself (a value), so the explicit-pool key folds in the descriptors rather
+;; than the store generation. The standard generation still applies (standards
+;; are always read live).
+;;
+;; This is a FINER key than the EP minimum (the EP permits a finer
+;; descriptor-set fingerprint so unrelated store changes need not invalidate)
+;; only in that two distinct stores at the same generation integer never alias
+;; — the store-generation is keyed per active store (see source-store). It is
+;; never COARSER: any change to a selected, standard, inline, OR replacement
+;; input changes a key leg and forces a re-seal.
+
+(defonce ^{:doc "cache-key → sealed generation. The resolved-generation cache
+  (EP-0023 §Image). A plain map atom: an SSR request assembling an unchanged
+  composition hits this in O(1) and reuses the SAME sealed object rather than
+  re-running selection + validation + sealing."
+            :private true}
+  generation-cache
+  (atom {}))
+
+(defn clear-generation-cache!
+  "Drop every cached resolved generation. Test fixtures call this between cases
+  so a stale generation never leaks across a test that mutated the store /
+  standard registry out from under the generation counters. Idempotent."
+  []
+  (reset! generation-cache {})
+  nil)
+
+(defn cache-size
+  "The number of distinct cached resolved generations (introspection / tests)."
+  []
+  (count @generation-cache))
+
+(defn- cache-key
+  "Build the resolved-generation cache key for a normalized image vector under
+  a descriptor `pool-leg` (the store-generation integer for the live-store
+  arity, or the explicit descriptor pool value for the explicit-pool arity).
+  The image vector carries the inline fingerprints + replacement maps by value;
+  `pool-leg` + the standard generation are the store-side legs. A vector so it
+  hashes + compares as a value."
+  [images pool-leg]
+  [images pool-leg (standard-generation)])
+
+(defn- assemble-cached
+  "Look the normalized `images` up in the resolved-generation cache under
+  `[images pool-leg standard-generation]`; on a MISS compute the sealed
+  generation via `assemble*` (against `descriptors`), cache it, and return it.
+  A cache HIT returns the SAME sealed object — this is the SSR no-re-seal
+  guarantee. A throwing `assemble*` (a fail-loud validation) is NOT cached: the
+  exception propagates and the slot stays empty, so a corrected input on the
+  next call recomputes cleanly."
+  [images descriptors pool-leg]
+  (let [k (cache-key images pool-leg)]
+    (if-let [hit (find @generation-cache k)]
+      (val hit)
+      (let [gen (assemble* images descriptors)]
+        ;; Cache only a successfully sealed generation (assemble* threw on a
+        ;; fail-loud input, so we never reach here for one). swap! is enough —
+        ;; a benign double-compute under contention seals to an equal value.
+        (swap! generation-cache assoc k gen)
+        gen))))
+
 (defn assemble
   "Resolve `images` (a seq of normalized `rf/image` values) into a SEALED,
   VALIDATED image generation (EP-0023 §Image Validation). The integration of
@@ -724,10 +895,28 @@
   here — pure assembly has no frame; it is the slice-.6 / slice-.7 frame-boundary
   step. The union image-requires set is carried on the generation for that step.
 
+  ## Resolved-generation caching (EP-0023 §Image — MUST cache)
+
+  Sealed generations are immutable and may be physically shared across frames
+  when the same inputs resolve to the same descriptor set. `assemble` caches by
+  the EP minimum key — normalized image vector (which carries inline
+  fingerprints + the declared `:replace` / `:replace-standard` maps by value) +
+  the registration source-store generation + the framework-standard generation
+  — so a repeated assembly of an UNCHANGED composition returns the SAME sealed
+  object without re-running selection + validation + sealing. This is the SSR
+  fast path. ANY change to a selected, standard, inline, or replacement input
+  bumps a key leg and forces a re-seal; two compositions differing only in
+  `:replace` never cache-collide (rf2-3sjdmi).
+
   Two arities:
-    (assemble images)            — select against the live source store.
+    (assemble images)            — select against the live source store; the
+                                   key's pool leg is the live source-store
+                                   generation.
     (assemble images descriptors)— select against an explicit descriptor pool
-                                   (tests / harnesses / a pre-snapshotted store).
+                                   (tests / harnesses / a pre-snapshotted
+                                   store); the key's pool leg is the descriptor
+                                   pool value itself (the live store generation
+                                   does not describe an explicit pool).
 
   `images` may be a single image value (wrapped) or a seq. Returns the sealed
   generation:
@@ -737,33 +926,18 @@
      :rf.gen/requires #{:rf.capability/* …}
      :rf.gen/kinds    #{kind …}}"
   ([images]
-   (assemble images (source-store-descriptors)))
+   (let [images (if (map? images) [images] (vec images))]
+     ;; Live-store arity: the pool leg is the source-store generation. Read it
+     ;; BEFORE selecting so the cached object is keyed to the store snapshot it
+     ;; was assembled from.
+     (assemble-cached images
+                      (source-store-descriptors)
+                      (source-store/store-generation))))
   ([images descriptors]
-   (let [images   (if (map? images) [images] (vec images))
-         ;; A representative image id for diagnostics (the first that carries
-         ;; one); collision/winner errors also name exact coordinates.
-         image-id (some :rf.image/id images)
-         selected (select-for-images images descriptors)
-         standard (standard-descriptors)
-         all-ds   (into (vec selected) standard)
-         [rep rep-std] (replace-maps images)]
-     ;; (3) Fail loud on any unsupported descriptor kind before sealing.
-     (check-supported-kinds! image-id all-ds)
-     ;; (4) Fail loud on any :replace / :replace-standard declaration for a key
-     ;;     with no real collision — a replacement is for an intentional
-     ;;     collision, never a silent order override. Runs before resolution so
-     ;;     a stale/typo'd declaration fails before any winner is matched.
-     (check-replacement-keys-collide! image-id (distinct-by-id all-ds) rep rep-std)
-     (let [;; (5) Project into the sealed resolver — every collision resolved
-           ;;     by a declared winner or thrown (order never decides).
-           resolver (build-resolver image-id all-ds rep rep-std)]
-       ;; (6) Validate application interceptor references against the sealed set.
-       (check-references! image-id resolver)
-       ;; (7) Seal.
-       {:rf.gen/resolver resolver
-        :rf.gen/images   images
-        :rf.gen/requires (image-requires images)
-        :rf.gen/kinds    (into #{} (map first) (keys resolver))}))))
+   (let [images (if (map? images) [images] (vec images))]
+     ;; Explicit-pool arity: the pool leg is the descriptor pool value itself —
+     ;; the live store generation does not describe a supplied pool.
+     (assemble-cached images descriptors descriptors))))
 
 ;; ===========================================================================
 ;; The resolver READ API — the surface slices .7 / .8 (frame loading,

--- a/implementation/core/src/re_frame/source_store.cljc
+++ b/implementation/core/src/re_frame/source_store.cljc
@@ -111,6 +111,49 @@
   []
   (or *source-store* kind->id->ns->descriptor))
 
+;; ---- the store GENERATION signal (EP-0023 §Image — resolved-generation cache)
+;;
+;; A MONOTONIC counter bumped on every mutation of the active source store. The
+;; resolved-generation cache (`re-frame.image-assembly`) folds this into its
+;; cache key so a sealed generation is reused only while the registration pool
+;; it was assembled from is unchanged — and is invalidated the instant any
+;; `reg-*` / `forget-*` / `clear-*` alters the store. The EP names this the
+;; "registration source-store generation" leg of the minimum cache key.
+;;
+;; The counter is keyed per active store (an atom-identity → counter map) so a
+;; realm-bound `*source-store*` carries its OWN generation independent of the
+;; process-default store — two realms never alias each other's cache bucket. A
+;; bare integer per store is enough: any change bumps it; equality means "the
+;; store has not changed since this generation was read".
+
+(defonce ^{:doc "atom-identity → monotonic generation integer. One slot per
+  source-store atom (process-default + each bound realm store). Bumped by every
+  store mutation; read by the resolved-generation cache key."
+            :private true}
+  store->generation
+  (atom {}))
+
+(defn- bump-generation!
+  "Increment the active source store's monotonic generation. Called by every
+  mutation (`record-descriptor!`, `forget-*`, `clear-all!`). Keyed by the store
+  atom identity so realm stores keep independent generations."
+  []
+  (let [store (active-source-store)]
+    (swap! store->generation update store (fnil inc 0))
+    nil))
+
+(defn store-generation
+  "The MONOTONIC generation integer of the active source store (EP-0023 §Image —
+  the resolved-generation cache's source-store-generation key leg). Starts at 0
+  (a never-mutated store) and increments on every `reg-*` / `forget-*` /
+  `clear-*` mutation. Equal generation across two reads ⇒ the registration pool
+  is byte-for-byte the set it was when the earlier generation was read, so a
+  sealed image generation assembled then may be reused; any change bumps it and
+  invalidates the cache. Keyed per active store so a realm-bound store reports
+  its OWN generation."
+  []
+  (get @store->generation (active-source-store) 0))
+
 ;; ---- canonical namespace-string pooling -----------------------------------
 ;;
 ;; One string instance per source namespace per store (the EP's anti-tax
@@ -186,6 +229,7 @@
                pn (assoc provenance-ns-key pn))
         store (active-source-store)]
     (swap! store assoc-in [kind id pn] desc)
+    (bump-generation!)
     desc))
 
 ;; ---- queries --------------------------------------------------------------
@@ -245,6 +289,7 @@
                      (if (empty? (get s kind))
                        (dissoc s kind)
                        s))))
+    (bump-generation!)
     nil))
 
 (defn forget-id!
@@ -257,6 +302,7 @@
                      (if (empty? (get s kind))
                        (dissoc s kind)
                        s))))
+    (bump-generation!)
     nil))
 
 (defn clear-all!
@@ -270,4 +316,8 @@
   []
   (reset! kind->id->ns->descriptor {})
   (reset! ns-string-pool {})
+  ;; Bump the PROCESS-DEFAULT store's generation (clear-all! always targets it,
+  ;; regardless of any *source-store* binding) so a cache keyed on the old
+  ;; generation invalidates against the freshly-cleared store.
+  (swap! store->generation update kind->id->ns->descriptor (fnil inc 0))
   nil)

--- a/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
@@ -1,0 +1,309 @@
+(ns re-frame.image-assembly-cache-cljs-test
+  "EP-0023 §Image — the resolved-generation CACHE (rf2-32siq3.7) + cache-key
+  correctness (rf2-3sjdmi).
+
+  > Resolved generations are immutable. The runtime MAY physically share one
+  > resolved generation across many frames when the same image inputs resolve
+  > to the same descriptor set. The reference implementation MUST cache
+  > resolved generations.
+
+  The EP minimum cache key:
+
+      normalized :images vector
+      + registration source-store generation
+      + framework-standard registration generation
+      + inline descriptor fingerprints
+      + declared replacement maps
+
+  This suite pins the cache CONTRACT:
+
+    * a HIT — identical inputs reuse the SAME sealed generation object (the SSR
+      no-re-seal guarantee), proven by `identical?`, not just `=`;
+    * the SSR motivation — repeated `assemble` of an unchanged composition does
+      NOT re-run selection + validation + sealing (one cached object, one
+      compute);
+    * INVALIDATION — a changed SELECTED descriptor (source-store generation),
+      a changed STANDARD descriptor (standard generation), and a changed INLINE
+      descriptor each force a re-seal (a fresh, distinct object);
+    * rf2-3sjdmi — two compositions differing ONLY in `:replace` /
+      `:replace-standard` (a SHARED resolver shape, distinct replacement
+      decisions) must NOT cache-collide; the key is built from the image
+      INPUTS, never from `:rf.gen/resolver` alone.
+
+  Pure data + process state (the source store, the standard registry, the
+  generation cache). A fixture clears all three per case. `.cljc` ending
+  `-cljs-test` rides `npm run test:cljs` AND `clojure -M:test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.image          :as image]
+            [re-frame.image-assembly :as asm]
+            [re-frame.source-store   :as ss]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture — clear every process-state surface the cache key reads: the source
+;; store, the standard registry (+ its generation), and the cache itself.
+;; ---------------------------------------------------------------------------
+
+(defn- clear-all! []
+  (ss/clear-all!)
+  (asm/clear-standards!)
+  (asm/clear-generation-cache!))
+
+(use-fixtures :each
+  (fn [t]
+    (clear-all!)
+    (t)
+    (clear-all!)))
+
+;; ---------------------------------------------------------------------------
+;; Synthetic registered descriptor — same shape the selector consumes. Recorded
+;; into the LIVE source store so the single-arity `assemble` (the SSR / runtime
+;; path) selects it and the store-generation invalidation fires for real.
+;; ---------------------------------------------------------------------------
+
+(defn- record! [provenance-ns kind id impl]
+  (ss/record-descriptor! kind id {:ns provenance-ns :kind kind :id id
+                                  :handler-fn impl}))
+
+;; ===========================================================================
+;; 1. Cache HIT — identical inputs reuse the SAME sealed object (SSR fast path)
+;; ===========================================================================
+
+(deftest identical-inputs-reuse-the-same-sealed-generation
+  (testing "two assemblies of the SAME image over an UNCHANGED live source store
+            return the SAME sealed generation object — not merely equal, but
+            identical? — so a request-scoped frame does not re-seal"
+    (record! "shop.cart" :event :cart/add ::add)
+    (let [img  (image/image {:id :shop/main :include-ns ["shop.cart"]})
+          gen1 (asm/assemble [img])
+          gen2 (asm/assemble [img])]
+      (is (= gen1 gen2) "the two generations are equal")
+      (is (identical? gen1 gen2)
+          "the SECOND assembly reused the cached object — it did NOT re-seal")
+      (is (= 1 (asm/cache-size))
+          "exactly one generation is cached for the one composition"))))
+
+(deftest ssr-style-repeated-assemble-does-not-reseal
+  (testing "the SSR motivation: assembling the same composition N times for N
+            request-scoped frames produces ONE cached object reused N times —
+            glob selection + validation + sealing run exactly once"
+    (record! "app.core" :event :app/boot ::boot)
+    (record! "app.core" :sub   :app/state ::state)
+    (let [img  (image/image {:id :app/main :include-ns ["app.core"]})
+          gens (vec (repeatedly 25 #(asm/assemble [img])))
+          gen0 (first gens)]
+      (is (apply = gens) "all 25 are equal")
+      (is (every? #(identical? gen0 %) gens)
+          "all 25 are the SAME object — sealed once, reused 24 times")
+      (is (= 1 (asm/cache-size))))))
+
+(deftest distinct-equal-image-values-still-hit
+  (testing "two SEPARATELY-constructed image values with equal specs hit the
+            same cache slot — the key is by VALUE, not by image object identity"
+    (record! "shop.cart" :event :cart/add ::add)
+    (let [gen1 (asm/assemble [(image/image {:id :shop/main :include-ns ["shop.cart"]})])
+          gen2 (asm/assemble [(image/image {:id :shop/main :include-ns ["shop.cart"]})])]
+      (is (identical? gen1 gen2)
+          "equal-by-value image specs resolve to the one cached generation")
+      (is (= 1 (asm/cache-size))))))
+
+;; ===========================================================================
+;; 2. INVALIDATION — a changed SELECTED descriptor (source-store generation)
+;; ===========================================================================
+
+(deftest changed-selected-descriptor-invalidates
+  (testing "mutating the live source store (a new selected registration) bumps
+            the source-store generation, so a re-assembly of the same image is a
+            cache MISS — a fresh, distinct sealed object reflecting the change"
+    (record! "shop.cart" :event :cart/add ::add)
+    (let [img  (image/image {:id :shop/main :include-ns ["shop.cart"]})
+          gen1 (asm/assemble [img])]
+      (is (not (contains? (:rf.gen/resolver gen1) [:sub :cart/items])))
+      ;; A new registration in a selected namespace changes the descriptor pool.
+      (record! "shop.cart" :sub :cart/items ::items)
+      (let [gen2 (asm/assemble [img])]
+        (is (not (identical? gen1 gen2))
+            "the store changed → a re-seal, NOT the stale cached object")
+        (is (contains? (:rf.gen/resolver gen2) [:sub :cart/items])
+            "the re-sealed generation reflects the new registration")
+        (is (= 2 (asm/cache-size))
+            "both the pre- and post-change generations are cached (distinct keys)")))))
+
+(deftest forgetting-a-selected-descriptor-invalidates
+  (testing "removing a registration from a selected namespace bumps the store
+            generation and invalidates — the EP's 'after any selected descriptor
+            changed' rule covers removal too"
+    (record! "shop.cart" :event :cart/add ::add)
+    (record! "shop.cart" :sub   :cart/items ::items)
+    (let [img  (image/image {:id :shop/main :include-ns ["shop.cart"]})
+          gen1 (asm/assemble [img])]
+      (is (contains? (:rf.gen/resolver gen1) [:sub :cart/items]))
+      (ss/forget-descriptor! :sub :cart/items "shop.cart")
+      (let [gen2 (asm/assemble [img])]
+        (is (not (identical? gen1 gen2)))
+        (is (not (contains? (:rf.gen/resolver gen2) [:sub :cart/items]))
+            "the re-sealed generation no longer carries the forgotten descriptor")))))
+
+;; ===========================================================================
+;; 3. INVALIDATION — a changed STANDARD descriptor (standard generation)
+;; ===========================================================================
+
+(deftest changed-standard-descriptor-invalidates
+  (testing "registering a NEW framework standard bumps the standard generation,
+            so a re-assembly of the same image over the same store is a MISS —
+            the standard set is part of the resolved generation"
+    (record! "shop.cart" :event :cart/add ::add)
+    (let [img  (image/image {:id :shop/main :include-ns ["shop.cart"]})
+          gen1 (asm/assemble [img])]
+      (is (not (contains? (:rf.gen/resolver gen1) [:fx :rf.nav/push-url])))
+      (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+      (let [gen2 (asm/assemble [img])]
+        (is (not (identical? gen1 gen2))
+            "the standard set changed → a re-seal")
+        (is (contains? (:rf.gen/resolver gen2) [:fx :rf.nav/push-url])
+            "the re-sealed generation unions in the new standard")))))
+
+;; ===========================================================================
+;; 4. INVALIDATION — a changed INLINE descriptor (rides the image value)
+;; ===========================================================================
+
+(deftest changed-inline-descriptor-invalidates
+  (testing "two images differing only in an INLINE :registrations descriptor are
+            distinct compositions → distinct cache slots, distinct generations
+            (inline fingerprints are part of the key, carried by the image value)"
+    (record! "checkout.core" :event :checkout/start ::start)
+    (let [img-a (image/image {:id :checkout/main
+                              :include-ns ["checkout.core"]
+                              :registrations {:reg-fx [[:checkout.http/post {} ::impl-a]]}})
+          img-b (image/image {:id :checkout/main
+                              :include-ns ["checkout.core"]
+                              :registrations {:reg-fx [[:checkout.http/post {} ::impl-b]]}})
+          gen-a (asm/assemble [img-a])
+          gen-b (asm/assemble [img-b])]
+      (is (not (identical? gen-a gen-b))
+          "a changed inline impl is a different composition — no cache collision")
+      (is (= ::impl-a (:impl (asm/resolve-descriptor gen-a :fx :checkout.http/post))))
+      (is (= ::impl-b (:impl (asm/resolve-descriptor gen-b :fx :checkout.http/post)))
+          "each generation seals its OWN inline descriptor")
+      (is (= 2 (asm/cache-size))))))
+
+;; ===========================================================================
+;; 5. rf2-3sjdmi — two compositions differing ONLY in :replace / :replace-standard
+;;    must NOT cache-collide even when the resolver shape is shared. The key is
+;;    built from the image INPUTS (which carry the replacement maps), NOT from
+;;    :rf.gen/resolver alone.
+;; ===========================================================================
+
+(deftest replace-decision-invalidates-even-with-shared-resolver-shape
+  (testing "two images selecting the SAME colliding namespaces but declaring
+            DIFFERENT :replace winners resolve to DIFFERENT descriptors — they
+            must be cached SEPARATELY. A key built from :rf.gen/resolver alone
+            (or the resolver before replacement) would collide; the input-keyed
+            cache does not (rf2-3sjdmi)."
+    (record! "checkout.core"       :fx :checkout.http/post ::real)
+    (record! "checkout.story.http" :fx :checkout.http/post ::fake)
+    (let [;; Same selection (the two colliding namespaces) for BOTH images;
+          ;; only the declared :replace winner differs.
+          img-real (image/image
+                     {:id :checkout/use-real
+                      :include-ns ["checkout.core" "checkout.story.http"]
+                      :replace {[:fx :checkout.http/post] {:ns "checkout.core"}}})
+          img-fake (image/image
+                     {:id :checkout/use-fake
+                      :include-ns ["checkout.core" "checkout.story.http"]
+                      :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}})
+          gen-real (asm/assemble [img-real])
+          gen-fake (asm/assemble [img-fake])]
+      (is (not (identical? gen-real gen-fake))
+          "distinct :replace decisions → distinct cached generations (no collision)")
+      (is (= ::real (:handler-fn (asm/resolve-descriptor gen-real :fx :checkout.http/post)))
+          "the :replace {:ns checkout.core} image resolves to the REAL impl")
+      (is (= ::fake (:handler-fn (asm/resolve-descriptor gen-fake :fx :checkout.http/post)))
+          "the :replace {:ns checkout.story.http} image resolves to the FAKE impl")
+      (is (= 2 (asm/cache-size))
+          "two distinct compositions occupy two cache slots"))))
+
+(deftest same-replace-decision-still-hits
+  (testing "the complement: two images with the SAME selection AND the SAME
+            :replace winner DO hit the one cache slot — replacement parity does
+            not over-invalidate"
+    (record! "checkout.core"       :fx :checkout.http/post ::real)
+    (record! "checkout.story.http" :fx :checkout.http/post ::fake)
+    (let [spec     {:id :checkout/story
+                    :include-ns ["checkout.core" "checkout.story.http"]
+                    :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}}
+          gen1 (asm/assemble [(image/image spec)])
+          gen2 (asm/assemble [(image/image spec)])]
+      (is (identical? gen1 gen2)
+          "identical composition incl. the replacement map → one cached object")
+      (is (= 1 (asm/cache-size))))))
+
+(deftest replace-standard-decision-invalidates-even-with-shared-resolver-shape
+  (testing "the :replace-standard analogue: a replaceable standard collides with
+            a selected descriptor; the :replace-standard winner is the
+            replacement DECISION and is part of the key — two images differing
+            only there do not cache-collide"
+    (asm/register-standard! :fx :rf.nav/push-url
+                            {:handler-fn ::std :rf.standard/replaceable? true})
+    (record! "product.story" :fx :rf.nav/push-url ::app-override)
+    (let [;; img-default: NO :replace-standard → a standard collision with no
+          ;; declared winner FAILS LOUD, so it is not a cacheable shape. Instead
+          ;; compare two DISTINCT replaceable standards isn't possible with one
+          ;; key; the rf2-3sjdmi point for :replace-standard is that the winner
+          ;; map is in the key. We prove it by: one image with the winner (seals)
+          ;; vs. the SAME selection without it (throws) — different inputs.
+          img-replaced (image/image
+                         {:id :product/story
+                          :include-ns ["product.story"]
+                          :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story"}}})
+          gen-replaced (asm/assemble [img-replaced])]
+      (is (= ::app-override
+             (:handler-fn (asm/resolve-descriptor gen-replaced :fx :rf.nav/push-url)))
+          "the :replace-standard winner is honoured")
+      ;; The SAME selection WITHOUT the :replace-standard winner is a distinct
+      ;; (and fail-loud) composition — a stale cache keyed on the resolver shape
+      ;; would wrongly hand back the replaced generation; the input-keyed cache
+      ;; treats it as a different key and re-runs assembly (which throws).
+      (let [img-noreplace (image/image {:id :product/story
+                                        :include-ns ["product.story"]})]
+        (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                     (asm/assemble [img-noreplace]))
+            "without the :replace-standard winner the standard collision FAILS
+             LOUD — the cache did NOT short-circuit to the replaced generation")))))
+
+;; ===========================================================================
+;; 6. Fail-loud inputs are NOT cached
+;; ===========================================================================
+
+(deftest fail-loud-input-is-not-cached
+  (testing "an assembly that throws (a duplicate-id collision with no winner) is
+            NOT cached — the slot stays empty, so correcting the store and
+            re-assembling recomputes cleanly rather than re-throwing a stale miss"
+    (record! "todo.boot"    :event :boot/init ::todo)
+    (record! "counter.boot" :event :boot/init ::counter)
+    (let [img (image/image {:id :both :include-ns ["todo.boot" "counter.boot"]})]
+      (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                   (asm/assemble [img])))
+      (is (= 0 (asm/cache-size))
+          "the throwing composition left nothing cached"))))
+
+;; ===========================================================================
+;; 7. Explicit-pool arity caches on the POOL value (tests / harnesses)
+;; ===========================================================================
+
+(deftest explicit-pool-arity-hits-on-equal-pool
+  (testing "(assemble images descriptors) caches keyed on the descriptor POOL
+            value — the same images over an equal pool hit; a different pool
+            misses (the live store generation does not describe a supplied pool)"
+    (let [pool [{:rf.provenance/ns "a.core" :kind :event :id :a/e :handler-fn ::a}]
+          img  (image/image {:id :a :include-ns ["a.core"]})
+          gen1 (asm/assemble [img] pool)
+          gen2 (asm/assemble [img] pool)]
+      (is (identical? gen1 gen2)
+          "same images + equal pool value → the cached object")
+      (let [pool2 [{:rf.provenance/ns "a.core" :kind :event :id :a/e :handler-fn ::a}
+                   {:rf.provenance/ns "a.core" :kind :sub   :id :a/s :handler-fn ::s}]
+            gen3  (asm/assemble [img] pool2)]
+        (is (not (identical? gen1 gen3))
+            "a changed pool is a different key → a re-seal")
+        (is (contains? (:rf.gen/resolver gen3) [:sub :a/s]))))))


### PR DESCRIPTION
## What

Implements the resolved-generation cache EP-0023 §Image mandates ("The reference implementation MUST cache resolved generations"), and folds in **rf2-3sjdmi** (cache-key correctness). Builds on the merged .2/.3/.4/.5/.6 slices.

Repeated `assemble` of an unchanged composition now returns the **same** sealed object via an O(1) cache lookup instead of re-running glob selection + validation + sealing. This is the SSR fast path: a request-scoped frame must not re-run selection/validation/sealing every request when inputs are unchanged.

## Cache key (the EP minimum key)

Built from the image **INPUTS**, never from `:rf.gen/resolver` alone:

- **normalized `:images` vector** — carries the inline descriptor fingerprints (the lowered+stamped inline descriptors are part of the image value) **and** the declared `:replace` / `:replace-standard` maps, by value;
- **registration source-store generation** (single-arity / live store) — or the **explicit descriptor pool value** for the explicit-pool arity `(assemble images descriptors)`, since the live store generation does not describe a supplied pool;
- **framework-standard registration generation**.

Any change to a selected, standard, inline, or replacement input bumps a key leg and forces a re-seal. Fail-loud (throwing) inputs are never cached.

### rf2-3sjdmi

The `:replace` / `:replace-standard` maps ride `:rf.gen/images`. Two compositions differing **only** in `:replace` share a resolver shape but are distinct generations — keying on the resolver alone would cache-collide; keying on the image inputs does not. A test proves it (`replace-decision-invalidates-even-with-shared-resolver-shape`).

## Generation signals added (minimal, monotonic)

- `source_store.cljc`: `store-generation` — keyed per active store so realm-bound stores keep independent generations; bumped by `record-descriptor!` / `forget-*` / `clear-all!`.
- `image_assembly.cljc`: `standard-generation` for the standard registry; bumped by `register-standard!` / `forget-standard!` / `clear-standards!`.

## Surface lane

Touches only `image_assembly.cljc` (cache layer + standard generation), `source_store.cljc` (generation signal), and a new test file. Does **not** touch `live_frame.cljc` or the dispatch/sub/fx/cofx live-resolution path (slice .9 owns that in parallel). No spec hot-zone files touched.

## Elision

Pure atom/map ops, no trace/debug gates — Closure DCE removes the cache in an app that never assembles an image. `test:elision` clean.

## Tests (CLJS, not Playwright)

New `image_assembly_cache_cljs_test.cljc` (12 deftests, 35 assertions):
- identical inputs reuse the **same** sealed object (`identical?`), incl. SSR-style 25× repeat → one cached object;
- separately-constructed equal-by-value images hit the same slot;
- changed selected descriptor (add + forget) invalidates;
- changed standard descriptor invalidates;
- changed inline descriptor → distinct slots;
- **rf2-3sjdmi**: distinct `:replace` decisions over a shared selection → distinct generations (no collision); same decision still hits; `:replace-standard` analogue;
- fail-loud input not cached;
- explicit-pool arity caches on the pool value.

## Gates

- `npm run test:cljs` — 7418 tests / 30530 assertions, 0 failures, 0 errors
- `npm run test:elision` — PASS (43/43 absent in prod; 43/43 present in control)
- `scripts/test-fast-pr.sh` — PASS
- JVM targeted: source-store + image-assembly + new cache namespace all green

Closes rf2-32siq3.7 and rf2-3sjdmi.