### PR TITLE
fix(core): EP-0023 tighten image.cljc inline-tuple + replacement-entry validation (rf2-32siq3.18, rf2-32siq3.20)

### DIFF
--- a/implementation/core/src/re_frame/image.cljc
+++ b/implementation/core/src/re_frame/image.cljc
@@ -220,19 +220,30 @@
   Stamps the inline source coordinate (`:rf.provenance/image` + the
   `:rf.provenance/inline [section id]` pair) so an inline descriptor has a
   stable name for errors and replacement winners. The body (when present) is
-  carried under `:impl`; the metadata under `:metadata` (omitted when empty)."
+  carried under `:impl`; the metadata under `:metadata` (omitted when empty).
+
+  The arity is EXACT: an inline entry MUST be a 3-tuple `[id metadata body]`
+  (handler) or a 2-tuple `[id metadata]` (metadata-only) — EP-0023 §Image
+  Fragments admits only those two shapes. A 1-tuple `[id]` (no metadata slot)
+  and a 4+-tuple `[id metadata body extra…]` (a trailing slot that would be
+  silently ignored) both fail loud rather than be coerced — a malformed
+  registration entry is a typo or a stale call shape, not a metadata-only
+  entry with `nil` metadata or an entry with an extra argument the framework
+  drops."
   [image-id section kind entry]
-  (when-not (and (vector? entry) (>= (count entry) 1))
+  (when-not (and (vector? entry) (<= 2 (count entry) 3))
     (error/throw-error!
       :rf.error/invalid-image
       'rf/image
-      (str "rf/image: inline " section " entry must be a [id metadata body] or "
-           "[id metadata] tuple — got " (pr-str entry) ".")
+      (str "rf/image: inline " section " entry must be a [id metadata body] "
+           "(handler) or [id metadata] (metadata-only) tuple — got " (pr-str entry)
+           " (" (if (vector? entry) (str "arity " (count entry)) "not a vector")
+           ").")
       {:recovery :use-a-call-shaped-tuple
        :extra    {:image image-id :section section :entry entry}}))
   (let [id       (nth entry 0)
         metadata (nth entry 1 nil)
-        has-body (>= (count entry) 3)
+        has-body (= 3 (count entry))
         body     (when has-body (nth entry 2))]
     (cond-> {:kind                kind
              :id                  id
@@ -295,10 +306,93 @@
   declared-winner maps (`{[kind id] winner-source-coordinate}`). They are BARE
   structural slots (the EP-0017 v5 line, per Conventions §`:rf.image/*`) carried
   through UNINTERPRETED here — the image value is inert data; the assembly slice
-  (rf2-32siq3.4) reads them to resolve collisions. This slice validates only
-  that each is a map (its detailed winner-coordinate validation against the
-  actual selected collisions is the assembly slice's fail-loud job)."
+  (rf2-32siq3.4) reads them to resolve collisions. The constructor validates the
+  STRUCTURAL shape of each entry (`validate-replacement-map!`): the map and each
+  key/value, so a malformed key or winner coordinate fails loud at `rf/image`
+  with an actionable diagnostic rather than reaching assembly's collision checks
+  as a generic `nth not supported` destructuring error or a misleading
+  no-collision report (rf2-32siq3.20). The SEMANTIC winner-coordinate validation
+  AGAINST the actual selected collisions (does this key really collide? does the
+  coordinate name exactly one selected descriptor?) stays the assembly slice's
+  fail-loud job."
   #{:id :include-ns :registrations :rf.image/requires :replace :replace-standard})
+
+(def ^:private valid-kinds
+  "The closed registry-kind set a `:replace` / `:replace-standard` key may name,
+  derived from `reg-section->kind`'s values so it stays in lockstep with the
+  closed `re-frame.registrar/kinds` set without coupling this pure ns to the
+  registrar (which would pull `interop` and friends onto this otherwise
+  `re-frame.error`-only slice)."
+  (set (vals reg-section->kind)))
+
+(defn- valid-winner-coordinate?
+  "True when `coord` is a structurally well-formed replacement winner SOURCE
+  coordinate (EP-0023 §Image Fragments — the descriptor source-coordinate shape
+  produced by `image-assembly/descriptor-coordinate`). One of:
+
+    {:ns \"source.ns\"}                      a registered descriptor (string ns)
+    {:image <id> :inline [section id]}      an inline descriptor
+    {:standard true}                        a framework-standard descriptor
+
+  Structural only — whether the coordinate actually names a selected descriptor
+  is the assembly slice's semantic job. Pure."
+  [coord]
+  (boolean
+    (and (map? coord)
+         (or (and (string? (:ns coord)) (= #{:ns} (set (keys coord))))
+             (and (some? (:image coord))
+                  (let [inl (:inline coord)]
+                    (and (vector? inl) (= 2 (count inl))))
+                  (= #{:image :inline} (set (keys coord))))
+             (and (true? (:standard coord)) (= #{:standard} (set (keys coord))))))))
+
+(defn- validate-replacement-map!
+  "Fail-loud STRUCTURAL validation of a `:replace` / `:replace-standard` map at
+  the image boundary (rf2-32siq3.20). `map-key` is `:replace` or
+  `:replace-standard` (named in diagnostics); `m` the declared-winner map;
+  `image-id` the containing image's id (when known). Pure.
+
+  Each entry MUST be an exact two-element `[kind id]` vector key — the `kind` a
+  member of the closed registry-kind set — mapping to a supported winner source
+  coordinate (`{:ns …}`, `{:image … :inline [section id]}`, or
+  `{:standard true}`). A malformed key (non-vector, wrong arity, or an
+  unsupported kind) or a malformed winner coordinate throws
+  `:rf.error/invalid-image` with an actionable diagnostic BEFORE assembly's
+  `check-replacement-keys-collide!` destructures the key — so a keyword key no
+  longer surfaces as `nth not supported`, and a typo'd coordinate no longer
+  masquerades as a stale winner. The SEMANTIC checks (real collision? winner
+  names exactly one selected descriptor?) remain the assembly slice's job."
+  [image-id map-key m]
+  (doseq [[k winner] m]
+    (when-not (and (vector? k) (= 2 (count k)))
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: " map-key " key must be an exact two-element [kind id] "
+             "vector — got " (pr-str k)
+             " (" (if (vector? k) (str "arity " (count k)) "not a vector") ").")
+        {:recovery :use-a-kind-id-pair-key
+         :extra    {:image image-id :replace-map map-key :bad-key k}}))
+    (let [kind (nth k 0)]
+      (when-not (contains? valid-kinds kind)
+        (error/throw-error!
+          :rf.error/invalid-image
+          'rf/image
+          (str "rf/image: " map-key " key " (pr-str k) " names an unsupported "
+               "registration kind " (pr-str kind) " — use one of "
+               (pr-str (vec (sort valid-kinds))) ".")
+          {:recovery :use-a-supported-registration-kind
+           :extra    {:image image-id :replace-map map-key :bad-key k :bad-kind kind}})))
+    (when-not (valid-winner-coordinate? winner)
+      (error/throw-error!
+        :rf.error/invalid-image
+        'rf/image
+        (str "rf/image: " map-key " winner for key " (pr-str k)
+             " must be a source coordinate map — {:ns \"source.ns\"}, "
+             "{:image image-id :inline [section id]}, or {:standard true} — got "
+             (pr-str winner) ".")
+        {:recovery :use-a-supported-winner-source-coordinate
+         :extra    {:image image-id :replace-map map-key :bad-key k :bad-winner winner}}))))
 
 (defn image
   "Construct an IMAGE value — a selected registration-set value, as INERT data
@@ -338,8 +432,11 @@
 
   PURE — no realm, no registrar, no side effect (an `image` call is data, not
   registration). Throws `:rf.error/invalid-image` when `:include-ns` is not a
-  vector of strings, when an inline entry is malformed, or when the spec carries
-  an unknown top-level key."
+  vector of strings, when an inline entry is not a `[id metadata]` /
+  `[id metadata body]` tuple, when the spec carries an unknown top-level key,
+  or when a `:replace` / `:replace-standard` entry is structurally malformed
+  (a non-`[kind id]` key, an unsupported kind, or an unsupported winner source
+  coordinate)."
   [spec]
   (when-not (map? spec)
     (error/throw-error!
@@ -379,7 +476,10 @@
             (str "rf/image: " k " must be a map from a [kind id] pair to a "
                  "winner source coordinate — got " (pr-str m) ".")
             {:recovery :use-a-replacement-winner-map
-             :extra    {:image id :bad-key k :received m}}))))
+             :extra    {:image id :bad-key k :received m}}))
+        ;; Structural validation of each entry (rf2-32siq3.20): the [kind id]
+        ;; key and the winner source coordinate, fail-loud before assembly.
+        (validate-replacement-map! id k m)))
     (cond-> {:rf.image/include-ns include-ns
              :rf.image/inline     (registrations->inline-descriptors
                                     id (get spec :registrations {}))

--- a/implementation/core/test/re_frame/image_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_cljs_test.cljc
@@ -157,8 +157,10 @@
 
 ;; ============================================================================
 ;; :replace / :replace-standard — declared-winner maps (EP-0023 §Image
-;; Patching And Overrides). BARE structural slots — validated here (must be
-;; maps when supplied) and carried through uninterpreted.
+;; Patching And Overrides). The constructor validates the STRUCTURAL shape of
+;; each entry (the [kind id] key + the winner source coordinate, rf2-32siq3.20)
+;; and carries the validated map through uninterpreted; the SEMANTIC winner
+;; resolution against the actual selected collisions is the assembly slice's job.
 ;; ============================================================================
 
 (deftest image-rejects-non-map-replace-keys
@@ -182,13 +184,18 @@
 
 (deftest image-carries-replace-keys-through
   (testing "valid :replace / :replace-standard maps carry through to the value"
-    (let [rep      {[:event :counter/inc] :docs.counter.v3/counter-inc}
-          rep-std  {[:fx :http] :app.http/winner}
+    (let [rep      {[:event :counter/inc] {:ns "docs.counter.v3"}}
+          rep-std  {[:fx :http] {:standard true}}
           v        (image/image {:id :combo
                                  :replace          rep
                                  :replace-standard rep-std})]
       (is (= rep     (:replace v)))
       (is (= rep-std (:replace-standard v)))))
+  (testing "an inline winner coordinate carries through"
+    (let [rep {[:fx :checkout.http/post]
+               {:image :checkout/story :inline [:reg-fx :checkout.http/post]}}
+          v   (image/image {:id :checkout/story :replace rep})]
+      (is (= rep (:replace v)))))
   (testing "an empty :replace map is still carried through (present-when-supplied)"
     ;; cond-> branches on (:replace spec) truthiness; an empty map is truthy.
     (let [v (image/image {:id :e :replace {}})]
@@ -198,6 +205,92 @@
     (let [v (image/image {:id :bare :include-ns ["docs.counter.v2"]})]
       (is (not (contains? v :replace)))
       (is (not (contains? v :replace-standard))))))
+
+;; rf2-32siq3.20 — replacement map ENTRY-shape validation at the image boundary.
+;; Malformed keys / winner coordinates must fail loud at rf/image with an
+;; actionable :rf.error/invalid-image, BEFORE assembly's collision checks
+;; destructure the key (where a keyword key would surface as `nth not supported`).
+
+(deftest replace-key-must-be-a-kind-id-pair
+  (testing "a keyword :replace key (not a [kind id] vector) throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {:counter/inc {:ns "a.b"}}}))))
+  (testing "a wrong-arity key (1- or 3-element vector) throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:event] {:ns "a.b"}}})))
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:event :counter/inc :extra]
+                                                  {:ns "a.b"}}}))))
+  (testing "the bad-key diagnostic rides the top-level ex-data"
+    (let [data (try (image/image {:id :y :replace {:nope {:ns "a.b"}}})
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :replace (:replace-map data)))
+      (is (= :nope (:bad-key data))))))
+
+(deftest replace-key-kind-must-be-supported
+  (testing "an unsupported registration kind in the key throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:bogus-kind :counter/inc]
+                                                  {:ns "a.b"}}}))))
+  (testing "the unsupported-kind diagnostic carries the bad kind"
+    (let [data (try (image/image {:id :y
+                                  :replace-standard {[:nope :x] {:standard true}}})
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :replace-standard (:replace-map data)))
+      (is (= :nope (:bad-kind data))))))
+
+(deftest replace-winner-must-be-a-supported-coordinate
+  (testing "a keyword winner (not a coordinate map) throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:event :counter/inc]
+                                                  :docs.counter.v3/winner}}))))
+  (testing "a malformed registered coordinate (:ns not a string) throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:event :counter/inc]
+                                                  {:ns :not-a-string}}}))))
+  (testing "a registered coordinate with extra keys throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:event :counter/inc]
+                                                  {:ns "a.b" :stray 1}}}))))
+  (testing "a malformed inline coordinate (:inline not a 2-vector) throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :x
+                                        :replace {[:fx :checkout.http/post]
+                                                  {:image :s :inline [:reg-fx]}}}))))
+  (testing "the bad-winner diagnostic rides the top-level ex-data"
+    (let [data (try (image/image {:id :y
+                                  :replace {[:event :counter/inc] 99}})
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= 99 (:bad-winner data)))))
+  (testing "all three valid coordinate shapes are accepted"
+    (is (some? (image/image {:id :a :replace {[:event :e] {:ns "x.y"}}})))
+    (is (some? (image/image {:id :b
+                             :replace {[:fx :p]
+                                       {:image :s :inline [:reg-fx :p]}}})))
+    (is (some? (image/image {:id :c
+                             :replace-standard {[:fx :rf.nav/push-url]
+                                                {:standard true}}})))))
 
 ;; ============================================================================
 ;; inline :registrations — lowering to inline descriptors
@@ -247,6 +340,62 @@
     (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
                           #"\[:rf\.error/invalid-image\]"
                           (image/image {:registrations {:reg-event [:not-a-tuple]}})))))
+
+;; rf2-32siq3.18 — inline tuple ARITY is exact. EP-0023 §Image Fragments admits
+;; only [id metadata body] (handler) and [id metadata] (metadata-only). [id],
+;; [], non-vectors, and 4+-tuples fail loud at rf/image rather than being
+;; coerced (a [id] silently treated as nil-metadata, a [id meta body extra]
+;; silently dropping the extra slot).
+
+(deftest inline-accepts-exactly-two-and-three-tuples
+  (testing "a 3-tuple [id metadata body] is accepted (handler)"
+    (let [body (fn [_ _] {})
+          v    (image/image {:id :i
+                             :registrations {:reg-event [[:counter/inc {:doc "x"} body]]}})
+          d    (first (:rf.image/inline v))]
+      (is (= :counter/inc (:id d)))
+      (is (= body (:impl d)))
+      (is (= {:doc "x"} (:metadata d)))))
+  (testing "a 2-tuple [id metadata] is accepted (metadata-only)"
+    (let [v (image/image {:id :i :registrations {:reg-fx [[:my/fx {:doc "y"}]]}})
+          d (first (:rf.image/inline v))]
+      (is (= :my/fx (:id d)))
+      (is (not (contains? d :impl)))
+      (is (= {:doc "y"} (:metadata d))))))
+
+(deftest inline-rejects-too-short-tuple
+  (testing "a 1-tuple [id] (no metadata slot) throws :rf.error/invalid-image"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :i :registrations {:reg-event [[:counter/inc]]}}))))
+  (testing "an empty tuple [] throws"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image {:id :i :registrations {:reg-event [[]]}}))))
+  (testing "the diagnostic names the image, the section, and the offending entry"
+    (let [data (try (image/image {:id :my/image
+                                  :registrations {:reg-sub [[:counter/value]]}})
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= :my/image (:image data)))
+      (is (= :reg-sub (:section data)))
+      (is (= [:counter/value] (:entry data))))))
+
+(deftest inline-rejects-too-long-tuple
+  (testing "a 4-tuple [id metadata body extra] throws (extra slot not silently dropped)"
+    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                          #"\[:rf\.error/invalid-image\]"
+                          (image/image
+                            {:id :i
+                             :registrations {:reg-event [[:counter/inc {} (fn [_ _] {}) :extra]]}}))))
+  (testing "the offending 4-tuple is named in the diagnostic"
+    (let [entry [:counter/inc {} (fn [_ _] {}) :extra]
+          data  (try (image/image {:id :i :registrations {:reg-event [entry]}})
+                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                       (ex-data e)))]
+      (is (= :rf.error/invalid-image (:rf.error/id data)))
+      (is (= entry (:entry data))))))
 
 (deftest anonymous-image-inline-omits-image-coordinate
   (testing "anonymous image inline descriptors omit :rf.provenance/image"


### PR DESCRIPTION
Two EP-0023 fail-loud validation gap-fixes in `implementation/core/src/re_frame/image.cljc` (review follow-ups). Surface lane: ONLY `image.cljc` + `image_cljs_test.cljc`; no `image_assembly.cljc` touch. No new `:rf.error/*` id and no spec/009 change — both reuse the existing, already-cataloged `:rf.error/invalid-image`.

## rf2-32siq3.18 — reject malformed inline registration tuple arities
`inline-entry->descriptor` previously checked only `vector?` + `count >= 1`, so `[id]` was wrongly accepted (metadata-only with nil metadata) and `[id metadata body extra]` silently dropped the extra slot. EP-0023 §Image Fragments admits ONLY `[id metadata body]` (handler) and `[id metadata]` (metadata-only). The arity is now exact (`2 <= count <= 3`); `[id]`, `[]`, non-vectors, and 4+-tuples throw `:rf.error/invalid-image`. Diagnostic names the image id, section, offending entry, and arity.

## rf2-32siq3.20 — validate replacement map entry shapes before assembly
The constructor previously validated only that `:replace` / `:replace-standard` are maps. It now structurally validates each ENTRY before assembly: the key must be an exact two-element `[kind id]` vector whose kind is in the closed registry-kind set, and the winner must be a supported source coordinate map (`{:ns "..."}`, `{:image id :inline [section id]}`, or `{:standard true}`). Malformed keys/coordinates now fail loud at `rf/image` with an actionable `:rf.error/invalid-image` instead of reaching assembly's `check-replacement-keys-collide!` as a generic `nth not supported` destructuring error or a misleading no-collision report. SEMANTIC winner resolution (real collision? names exactly one selected descriptor?) stays the assembly slice's job.

The valid-kind set is derived from the existing local `reg-section->kind` map's values (kept in lockstep with `re-frame.registrar/kinds`), so the pure `image` ns stays `re-frame.error`-only — no registrar coupling.

## Tests
- `.18`: accepted 2- and 3-tuples; rejected `[id]`, `[]`, and 4-tuple; diagnostic slots (image/section/entry).
- `.20`: rejected non-`[kind id]` key (keyword, wrong arity), unsupported kind, keyword winner, malformed `{:ns ...}` (non-string / extra keys), malformed inline coordinate; accepted all three valid coordinate shapes. Existing `image-carries-replace-keys-through` updated to use valid coordinate maps (the prior keyword winners are now correctly rejected).

## Gates
- `implementation/`: `npm run test:cljs` green — 7420 tests / 30566 assertions, 0 failures.
- repo root: `sh scripts/test-fast-pr.sh` green (PASS fast PR spine).
- JVM: `clojure -M:test -n re-frame.image-cljs-test` green (26 tests / 145 assertions); `error-catalogue-channel-conformance` green (no new error id).