### PR TITLE
feat(core): EP-0023 image hot reload + reload-images! (rf2-32siq3.10)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -24,6 +24,45 @@
       build on (EP-0023 §Frame — \"a reference to the resolved image generation
       it is running\").
 
+  ## Image hot reload (rf2-32siq3.10 — LANDED here)
+
+  This ns also owns the EP-0023 HOT-RELOAD surface: `rf/reload-images!` plus
+  the source-store reprojection path (EP-0023 §Hot Reload / §Tests, Stories,
+  SSR, And Hot Reload).
+
+    * `reload-images!` — the public frame-targeted, composition-REPLACING
+      reload. It takes the SAME `:images` vector shape as `make-frame`, targets
+      ONE frame (by id or direct frame object), re-assembles the new `:images`
+      into a fresh sealed generation, and SWAPS that generation onto the frame
+      WHILE PRESERVING FRAME MEMORY — app-db, runtime-db, caches, lifecycle, and
+      every other frame-owned slot continue unchanged; ONLY `:rf.frame/generation`
+      moves (EP-0023 §Hot Reload — \"Hot reload must not be implemented by
+      tearing down and recreating the frame\"). It returns a reload REPORT naming
+      the `:added` / `:changed` / `:removed` / `:retained` `[kind id]` sets so
+      the runtime can invalidate only what changed. For an `:id`-bearing frame
+      the registry slot is updated IN PLACE (the same id keeps naming the same
+      live context); a direct (no-id) frame object's reloaded copy is returned
+      for the caller to hold.
+
+    * `reproject-live-frames!` — the source-store-change path (EP-0023 §Default
+      Image Semantics / §Hot Reload: \"a `reg-*` re-eval in a namespace selected
+      by an explicit `:include-ns` image reprojects and swaps affected
+      explicit-image frames\"). It re-resolves EVERY registered live frame from
+      its OWN `:rf.gen/images` composition against the CURRENT source store and
+      swaps the freshly-assembled generation onto any frame whose resolution
+      changed — EXPLICIT-image frames included, not only default-image frames. A
+      frame whose composition re-resolves byte-for-byte is left untouched (no
+      spurious swap).
+
+  Reload is frame-targeted: reloading `:counter/left` swaps the generation THAT
+  frame runs; it does not move `:counter/right` merely because the two frames
+  previously shared a sealed generation object (EP-0023 §Image — \"Reload is
+  frame-targeted\"). The generation is an immutable value, so the swap is a
+  single `assoc` that preserves frame identity for every other slot; a future
+  state-container slice that adds an app-db ATOM slot is preserved by identity
+  through the same `assoc` (the atom — hence the memory — is carried through
+  untouched).
+
   ## Id spaces — the heart of the same-id story (EP-0023 §Id Spaces)
 
   Two PUBLIC id spaces with DIFFERENT scopes meet here:
@@ -74,7 +113,12 @@
   calls `make-frame` with `:images` never reaches these fns (Closure DCE removes
   them). The resolution seam adds a single dynamic binding around the cascade
   (the no-generation default path pays one `frame-object?` predicate then runs
-  with zero binding cost — see [[call-with-frame-resolution]]). The requires are
+  with zero binding cost — see [[call-with-frame-resolution]]). Reload runs on
+  the development hot-reload / explicit `reload-images!` path (not a per-event
+  hot path, not a DEBUG-gated branch): pure re-assembly via
+  `image-assembly/assemble` plus one registry `swap!` per swapped frame. An app
+  that never hot-reloads never reaches them (Closure DCE removes them). The
+  requires are
   `re-frame.image-assembly` (the merged assembly entry point),
   `re-frame.registrar` (the `*generation*` resolution seam + the closed kind
   set), and `re-frame.error` (fail-loud diagnostics) — all already in the core
@@ -329,6 +373,40 @@
     frame-object))
 
 ;; ===========================================================================
+;; Generation resolution (shared by make-frame and reload-images!)
+;; ===========================================================================
+;;
+;; `make-frame` (.8/.6) and `reload-images!` (.10) BOTH turn an `:images` vector
+;; + a frame `:capabilities` map into ONE sealed, capability-checked generation.
+;; Factor that out so reload resolves a new generation with byte-identical
+;; semantics to creation: same `:images`-is-a-vector validation, same
+;; `image-assembly/assemble` path (live source store OR an explicit descriptor
+;; pool), same unconditional frame-boundary capability check.
+
+(defn- resolve-generation!
+  "Validate `images` (must be a vector — EP-0023 §Image Composition), assemble it
+  into ONE sealed generation (against the live source store when `descriptors` is
+  nil, else against the explicit pool — matching `assemble`'s two arities), and
+  run the FRAME-BOUNDARY capability check against `capabilities` (unconditional:
+  an absent map provides nothing, EP-0013 fail-loud parity). Returns the sealed
+  generation. The shared resolution `make-frame` and `reload-images!` both use,
+  so a reload resolves with byte-identical semantics to creation. Fail-loud on a
+  non-vector `:images`, an assembly error, or a missing capability."
+  [images capabilities descriptors]
+  (let [images     (if (some? images) (validate-images! images) [])
+        generation (if (nil? descriptors)
+                     (asm/assemble images)
+                     (asm/assemble images descriptors))]
+    ;; Capability check at the FRAME boundary (EP-0023 §Public API): a required
+    ;; capability absent from the frame's `:capabilities` fails BEFORE the
+    ;; generation is runnable. UNCONDITIONAL so a frame that supplies NO
+    ;; `:capabilities` map still fails any non-empty `:rf.image/requires` — an
+    ;; absent map provides nothing, exactly as `{}` does (EP-0013 fail-loud
+    ;; install-time parity). A no-op when the union `:rf.gen/requires` is empty.
+    (asm/check-capabilities! (:rf.gen/requires generation) capabilities)
+    generation))
+
+;; ===========================================================================
 ;; make-frame — the public constructor (EP-0023 §Public API)
 ;; ===========================================================================
 
@@ -385,33 +463,243 @@
                                    matching `image-assembly/assemble`'s 2-arity."
   ([opts] (make-frame opts nil))
   ([{:keys [images id initial-db capabilities adapter]} descriptors]
-   (let [images     (if (some? images) (validate-images! images) [])
-         generation (if (nil? descriptors)
-                      (asm/assemble images)
-                      (asm/assemble images descriptors))]
-     ;; Capability check at the FRAME boundary (EP-0023 §Public API): a required
-     ;; capability absent from the frame's `:capabilities` fails BEFORE the
-     ;; generation is runnable. The check runs UNCONDITIONALLY so a frame that
-     ;; supplies NO `:capabilities` map still fails any non-empty
-     ;; `:rf.image/requires` — an absent map provides nothing, exactly as
-     ;; `{}` does. This preserves EP-0013's fail-loud install-time capability
-     ;; check (`app_value/check-capabilities!`, which reads an absent realm
-     ;; capability map as `#{}` and fails any unmet requirement) at the new
-     ;; frame boundary; guarding the call on `(some? capabilities)` would let a
-     ;; frame run an image whose requirements were never satisfied. A no-op when
-     ;; the union `:rf.gen/requires` is empty (the common no-requirements path).
-     (asm/check-capabilities! (:rf.gen/requires generation) capabilities)
-     (let [frame-object
-           (cond-> {object-marker  true
-                    generation-key generation}
-             (some? id)           (assoc :rf.frame/id id)
-             (some? initial-db)   (assoc :rf.frame/initial-db initial-db)
-             (some? capabilities) (assoc :rf.frame/capabilities capabilities)
-             (some? adapter)      (assoc :rf.frame/adapter adapter))]
-       ;; An :id-bearing frame registers in the process-local live-frame
-       ;; registry (fail-loud on a duplicate). A direct (no-id) frame object
-       ;; BYPASSES the registry — the caller holds the returned object directly
-       ;; (EP-0023 §Frame / §Public API).
-       (if (some? id)
-         (register-live-frame! id frame-object)
-         frame-object)))))
+   (let [generation (resolve-generation! images capabilities descriptors)
+         frame-object
+         (cond-> {object-marker  true
+                  generation-key generation}
+           (some? id)           (assoc :rf.frame/id id)
+           (some? initial-db)   (assoc :rf.frame/initial-db initial-db)
+           (some? capabilities) (assoc :rf.frame/capabilities capabilities)
+           (some? adapter)      (assoc :rf.frame/adapter adapter))]
+     ;; An :id-bearing frame registers in the process-local live-frame
+     ;; registry (fail-loud on a duplicate). A direct (no-id) frame object
+     ;; BYPASSES the registry — the caller holds the returned object directly
+     ;; (EP-0023 §Frame / §Public API).
+     (if (some? id)
+       (register-live-frame! id frame-object)
+       frame-object))))
+
+;; ===========================================================================
+;; Image hot reload (EP-0023 §Hot Reload, rf2-32siq3.10)
+;; ===========================================================================
+;;
+;; The conceptual event (EP-0023 §Hot Reload):
+;;
+;;     registration set changed
+;;     execution context continues
+;;
+;; Reload swaps the sealed generation a frame runs WHILE PRESERVING FRAME
+;; MEMORY. Because the generation is an immutable VALUE the frame object carries
+;; under `:rf.frame/generation`, and the .9 resolution seam derives resolution
+;; SOLELY from that slot, swapping the generation is the whole job: a single
+;; `assoc` that replaces `:rf.frame/generation` and PRESERVES every other slot
+;; (id, initial-db, capabilities, adapter — and, once a later slice adds them,
+;; the app-db / runtime-db / cache ATOMS, carried through by identity, hence the
+;; memory). Reload must NOT tear down and recreate the frame (EP-0023 §Hot
+;; Reload), so it never re-runs `make-frame`; it re-assembles a generation and
+;; assocs it on.
+
+;; ---- the reload diff (EP-0023 §Hot Reload — "a concrete diff") ------------
+
+(defn generation-diff
+  "Compute the reload DIFF between an `old` and a `new` sealed generation as four
+  `[kind id]` sets (EP-0023 §Hot Reload — \"A good reload result should be a
+  concrete diff\"):
+
+    :added    keys present in `new` but not `old`
+    :removed  keys present in `old` but not `new`
+    :changed  keys present in BOTH whose resolved descriptor is not `=`
+    :retained keys present in BOTH whose resolved descriptor IS `=`
+
+  Keys are `[kind id]` pairs (the resolver's keys). \"changed\" is by descriptor
+  value equality, so an unchanged registration selected by a different image
+  composition is `:retained`, not `:changed` — that lets the runtime invalidate
+  only what actually changed (changed subs clear caches; retained frame memory
+  continues). Pure — a function of the two generations' resolvers."
+  [old new]
+  (let [old-res (:rf.gen/resolver old)
+        new-res (:rf.gen/resolver new)
+        old-ks  (set (keys old-res))
+        new-ks  (set (keys new-res))
+        both    (filter new-ks old-ks)
+        changed (into #{} (remove #(= (get old-res %) (get new-res %))) both)
+        retained (into #{} (filter #(= (get old-res %) (get new-res %))) both)]
+    {:added    (into #{} (remove old-ks) new-ks)
+     :removed  (into #{} (remove new-ks) old-ks)
+     :changed  changed
+     :retained retained}))
+
+;; ---- target resolution (frame id OR direct frame object) -------------------
+
+(defn- resolve-reload-target
+  "Resolve a `reload-images!` `target` to the live frame OBJECT to reload.
+  `target` is EITHER a frame id (looked up in the process-local live-frame
+  registry) OR a direct frame object (used as-is). FAIL-LOUD when an id names no
+  live frame (`:rf.error/reload-no-such-frame`) or `target` is neither a frame
+  object nor a registered id. Returns the live frame object."
+  [target]
+  (cond
+    (frame-object? target)
+    target
+
+    (some? (live-frame target))
+    (live-frame target)
+
+    :else
+    (error/throw-error!
+      :rf.error/reload-no-such-frame
+      'rf/reload-images!
+      (str "rf/reload-images!: target " (pr-str target) " names no live frame. "
+           "Reload targets ONE frame, by a frame id registered in the "
+           "process-local live-frame registry or a direct frame object returned "
+           "by rf/make-frame. Live frame ids: " (pr-str (vec (live-frame-ids)))
+           ".")
+      {:recovery :target-a-live-frame-id-or-a-direct-frame-object
+       :extra    {:target target
+                  :live-frame-ids (vec (live-frame-ids))}})))
+
+;; ---- the in-place generation swap (PRESERVES FRAME MEMORY) -----------------
+
+(defn- swap-generation
+  "Return `frame-object` with ONLY `:rf.frame/generation` replaced by
+  `new-generation`. Every other slot — id, initial-db, capabilities, adapter,
+  and any future state-container atoms — is preserved by `assoc` (atoms by
+  identity), so frame memory continues across the swap (EP-0023 §Hot Reload).
+  Pure."
+  [frame-object new-generation]
+  (assoc frame-object generation-key new-generation))
+
+(defn- swap-frame-generation!
+  "Swap `new-generation` onto `frame-object`, returning the RELOADED frame
+  object. For an `:id`-bearing frame the live-frame registry slot is updated IN
+  PLACE (the same id keeps naming the same live context, now running the new
+  generation) — but ONLY when the registry currently holds THIS object (so a
+  reload of a stale object handle does not clobber a frame re-registered under
+  the id since). A direct (no-id) frame object's reloaded copy is simply
+  returned for the caller to hold. Returns the reloaded frame object."
+  [frame-object new-generation]
+  (let [reloaded (swap-generation frame-object new-generation)
+        id       (:rf.frame/id frame-object)]
+    (when (some? id)
+      ;; Update the registry slot in place, but only if it still holds THIS
+      ;; object — guards against clobbering a frame re-registered under the id.
+      (swap! live-frames
+             (fn [m]
+               (if (identical? frame-object (get m id))
+                 (assoc m id reloaded)
+                 m))))
+    reloaded))
+
+;; ---- reload-images! — the public reload (EP-0023 §Public API) --------------
+
+(defn reload-images!
+  "Hot-reload ONE frame's whole image composition, PRESERVING FRAME MEMORY
+  (EP-0023 §Hot Reload / §Public API — `rf/reload-images!`). PUBLIC.
+
+  `target` is EITHER a frame id (looked up in the process-local live-frame
+  registry) OR a direct frame object (`make-frame`'s return value). `opts` is a
+  map taking the SAME `:images` vector shape as `make-frame`:
+
+    :images  a VECTOR of image values — the frame's NEW, COMPLETE image
+             composition (the only spelling; always a vector — EP-0023 §Image
+             Composition). Reload is composition-REPLACING: it replaces the whole
+             `:images` vector, not one member (EP-0023 deliberately does not
+             define a partial-image-member reload for v1). A non-vector `:images`
+             fails loud (`:rf.error/make-frame-bad-images`), exactly as in
+             `make-frame`.
+
+  Reload re-assembles `:images` into a FRESH sealed generation (capability-
+  checked against the frame's OWN `:rf.frame/capabilities`, byte-identical to
+  creation), then SWAPS that generation onto the frame — only
+  `:rf.frame/generation` moves; app-db, runtime-db, caches, lifecycle, and every
+  other frame slot continue unchanged (EP-0023 §Hot Reload — \"Hot reload must
+  not be implemented by tearing down and recreating the frame\"). It does NOT
+  mutate the old generation and does NOT move sibling frames that previously
+  shared it (reload is frame-targeted — EP-0023 §Image).
+
+  Returns the reload REPORT:
+
+    {:rf.frame/frame  <reloaded frame object>
+     :rf.reload/diff  {:added #{[kind id] …} :changed #{…}
+                       :removed #{…} :retained #{…}}}
+
+  For an `:id`-bearing frame, the live-frame registry slot is updated IN PLACE,
+  so the id keeps naming the same live context (now running the new generation);
+  the reloaded object is returned under `:rf.frame/frame` for callers holding a
+  direct reference. A direct (no-id) frame object's reloaded copy is returned the
+  same way for the caller to hold.
+
+  Two arities mirror `make-frame`:
+    (reload-images! target opts)             — re-assemble against the LIVE source store.
+    (reload-images! target opts descriptors) — against an explicit descriptor pool
+                                               (tests / harnesses / a pre-snapshotted
+                                               store), matching `assemble`'s 2-arity."
+  ([target opts] (reload-images! target opts nil))
+  ([target {:keys [images]} descriptors]
+   (let [frame-object   (resolve-reload-target target)
+         old-generation (frame-generation frame-object)
+         capabilities   (:rf.frame/capabilities frame-object)
+         new-generation (resolve-generation! images capabilities descriptors)
+         reloaded       (swap-frame-generation! frame-object new-generation)]
+     {:rf.frame/frame reloaded
+      :rf.reload/diff (generation-diff old-generation new-generation)})))
+
+;; ===========================================================================
+;; Source-store reprojection (EP-0023 §Default Image Semantics / §Hot Reload,
+;; rf2-32siq3.10)
+;; ===========================================================================
+;;
+;; The dirtying rule is NOT default-image-only (EP-0023 §Default Image
+;; Semantics): "Any source-store change invalidates resolved generations whose
+;; image selectors might include the changed source slot: default images,
+;; explicit `:include-ns` images, and composed images containing them." A
+;; `reg-*` re-eval in a namespace an EXPLICIT `:include-ns` image selects must
+;; reproject and swap THAT frame's generation too — not only default-image
+;; frames.
+;;
+;; Implementation: re-resolve EVERY registered live frame from its OWN image
+;; composition (the normalized `:rf.gen/images` carried on its generation)
+;; against the CURRENT live source store, and swap the freshly-assembled
+;; generation onto any frame whose resolution CHANGED. A frame that re-resolves
+;; byte-for-byte (= old generation) is left untouched — no spurious swap, no
+;; sibling movement. This is the `reg-*` hot-reload path the EP describes; the
+;; explicit `reload-images!` above is the composition-REPLACING counterpart.
+
+(defn reproject-live-frame!
+  "Re-resolve ONE registered live `frame-id` from its current generation's OWN
+  image composition (`:rf.gen/images`) against the CURRENT live source store,
+  and swap the freshly-assembled generation onto the frame when it CHANGED
+  (EP-0023 §Default Image Semantics — a source-store change reprojects affected
+  EXPLICIT-image frames, not only default-image frames). Returns the reload diff
+  `{:added … :changed … :removed … :retained …}` when the frame moved, or nil
+  when its composition re-resolved byte-for-byte (no swap). A no-op for a
+  frame-id not currently live."
+  [frame-id]
+  (when-let [frame-object (live-frame frame-id)]
+    (let [old-generation (frame-generation frame-object)
+          images         (vec (:rf.gen/images old-generation))
+          capabilities   (:rf.frame/capabilities frame-object)
+          new-generation (resolve-generation! images capabilities nil)]
+      (when-not (= old-generation new-generation)
+        (swap-frame-generation! frame-object new-generation)
+        (generation-diff old-generation new-generation)))))
+
+(defn reproject-live-frames!
+  "Reproject EVERY registered live frame against the CURRENT live source store
+  (the `reg-*` hot-reload path — EP-0023 §Default Image Semantics / §Hot Reload).
+  For each live frame, re-resolve its OWN `:rf.gen/images` composition and swap
+  the new generation on when it changed; this reprojects EXPLICIT-image frames
+  (whose `:include-ns` selectors match a changed namespace) as well as
+  default-image frames, not only the latter. A frame whose composition
+  re-resolves byte-for-byte is left untouched.
+
+  Returns `{frame-id reload-diff}` for every frame that MOVED (empty when none
+  did). Direct (no-id) frame objects are not in the registry, so they are not
+  reprojected here — their owners reload them explicitly via `reload-images!`."
+  []
+  (reduce (fn [moved frame-id]
+            (if-let [diff (reproject-live-frame! frame-id)]
+              (assoc moved frame-id diff)
+              moved))
+          {}
+          (live-frame-ids)))

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -1,0 +1,323 @@
+(ns re-frame.live-frame-reload-cljs-test
+  "EP-0023 §Hot Reload / §Default Image Semantics — the IMAGE HOT-RELOAD slice
+  (rf2-32siq3.10): `rf/reload-images!` swaps the generation a frame runs WHILE
+  PRESERVING FRAME MEMORY, and a source-store change reprojects affected
+  EXPLICIT-image frames (not only default-image frames).
+
+  Pins the bead's enumerated coverage:
+
+    * `reload-images!` swaps the generation but PRESERVES frame memory
+      (app-db/initial-db, capabilities, adapter, id — only `:rf.frame/generation`
+      moves; frame object identity for every other slot is carried through);
+    * resolution AFTER reload uses the NEW image (the swapped generation resolves
+      the new descriptor; the old is gone / changed);
+    * the reload REPORT names the added/changed/removed/retained `[kind id]` diff;
+    * reload is FRAME-TARGETED — reloading one registered frame does not move a
+      sibling that previously shared a generation object;
+    * an `:id`-bearing reload updates the registry slot IN PLACE (the id keeps
+      naming the same live context, now running the new generation);
+    * a non-vector `:images` is REJECTED (`:rf.error/make-frame-bad-images`),
+      and an unknown target FAILS LOUD (`:rf.error/reload-no-such-frame`);
+    * a source-store `reg-*` change reprojects an EXPLICIT-`:include-ns` frame —
+      `reproject-live-frames!` re-resolves it and swaps the new generation.
+
+  Each fail-loud assertion checks the `:rf.error/id` discriminator (NEVER the
+  message bytes — Spec 009 §The thrown-error shape rule 3).
+
+  The reload/diff tests resolve against an explicit synthetic descriptor pool
+  (the `reload-images!` 3-arity), so there is no live source-store wiring — the
+  same decoupling idiom `live-frame-cljs-test` / `image-assembly-cljs-test` use.
+  The reprojection test exercises the LIVE source store and so SNAPSHOTS +
+  RESTORES it around the case (NOT `registrar/clear-all!`, which would wipe the
+  shared node-test-bundle registrations — slice .9's note). `.cljc` ends
+  `-cljs-test` so it rides `npm run test:cljs` AND `clojure -M:test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.image        :as image]
+            [re-frame.image-assembly :as asm]
+            [re-frame.source-store :as source-store]
+            [re-frame.live-frame   :as lf]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture — clear the EP-0023 process-state atoms (the live-frame registry and
+;; the framework-standard registry) per case. Does NOT touch the shared
+;; registrar (slice .9 note); the source-store reprojection test snapshots +
+;; restores the source store itself, locally.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (fn [t]
+    (lf/clear-live-frames!)
+    (asm/clear-standards!)
+    (t)
+    (lf/clear-live-frames!)
+    (asm/clear-standards!)))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- reg-desc
+  "A synthetic REGISTERED descriptor authored in `provenance-ns` (mirrors the
+  source-store output shape the selector consumes)."
+  [provenance-ns kind id impl]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :handler-fn       impl})
+
+(defn- err-id
+  "The `:rf.error/id` discriminator of a thrown re-frame2 error, or nil."
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+;; Two pools selected by the SAME image (one explicit :include-ns over
+;; "counter.core"), mirroring the realistic hot-reload case: a namespace
+;; re-evaluates and replaces its OWN registrations. `:counter/inc` changes impl
+;; (v1 → v2), `:counter/value` is byte-identical across both (same provenance ns
+;; AND impl → retained), and `:counter/reset` is added only in v2. That yields a
+;; concrete added/changed/removed/retained diff with honest retained semantics
+;; (a descriptor unchanged in BOTH provenance and impl).
+(def ^:private value-desc (reg-desc "counter.core" :sub :counter/value ::value))
+
+(def ^:private pool-v1
+  [(reg-desc "counter.core" :event :counter/inc ::inc-v1)
+   value-desc])
+
+(def ^:private pool-v2
+  [(reg-desc "counter.core" :event :counter/inc   ::inc-v2)    ;; changed impl
+   value-desc                                                  ;; identical → retained
+   (reg-desc "counter.core" :event :counter/reset ::reset)])   ;; added
+
+;; One image selects "counter.core"; the reload changes only the descriptor POOL
+;; (the source store), not the image composition — exactly as a same-namespace
+;; reg-* re-eval does. (reload-images! also replaces composition; the diff is
+;; over the resolved generations either way.)
+(def ^:private img (image/image {:id :counter/img :include-ns ["counter.core"]}))
+
+;; ===========================================================================
+;; 1. reload-images! swaps the generation but PRESERVES frame memory
+;; ===========================================================================
+
+(deftest reload-swaps-generation-preserving-frame-memory
+  (testing "reload-images! replaces ONLY :rf.frame/generation; id, initial-db,
+            capabilities, and adapter are carried through unchanged (EP-0023
+            §Hot Reload — not a teardown/recreate)"
+    (let [frame (lf/make-frame {:id :counter/main
+                                :images [img]
+                                :initial-db {:count 7}
+                                :adapter ::reagent}
+                               pool-v1)
+          old-gen (lf/frame-generation frame)
+          report  (lf/reload-images! :counter/main {:images [img]} pool-v2)
+          reloaded (:rf.frame/frame report)]
+      (testing "a NEW generation is on the reloaded object"
+        (is (not (identical? old-gen (lf/frame-generation reloaded))))
+        (is (not= old-gen (lf/frame-generation reloaded))))
+      (testing "every OTHER frame slot is preserved (frame memory continues)"
+        (is (= :counter/main (:rf.frame/id reloaded)))
+        (is (= {:count 7} (:rf.frame/initial-db reloaded)))
+        (is (= ::reagent (:rf.frame/adapter reloaded)))
+        (is (lf/frame-object? reloaded))))))
+
+;; ===========================================================================
+;; 2. Resolution AFTER reload uses the NEW image
+;; ===========================================================================
+
+(deftest resolution-after-reload-uses-the-new-image
+  (testing "the swapped generation resolves the NEW descriptor; the v1 impl is
+            gone and v2's added id is present (EP-0023 — code changed, the VM
+            kept its memory)"
+    (let [frame    (lf/make-frame {:id :counter/main :images [img]} pool-v1)
+          gen-v1   (lf/frame-generation frame)
+          reloaded (:rf.frame/frame (lf/reload-images! :counter/main {:images [img]} pool-v2))
+          gen-v2   (lf/frame-generation reloaded)]
+      (testing "the v1 generation resolved the v1 impl (control)"
+        (is (= ::inc-v1 (:handler-fn (asm/resolve-descriptor gen-v1 :event :counter/inc)))))
+      (testing "after reload, :counter/inc resolves the v2 impl"
+        (is (= ::inc-v2 (:handler-fn (asm/resolve-descriptor gen-v2 :event :counter/inc)))))
+      (testing "the v2-only :counter/reset is now resolvable"
+        (is (some? (asm/resolve-descriptor gen-v2 :event :counter/reset))))
+      (testing "registry lookup returns the reloaded object (id keeps naming the
+                same live context, now on the new generation)"
+        (is (identical? reloaded (lf/live-frame :counter/main)))
+        (is (= ::inc-v2 (:handler-fn (asm/resolve-descriptor
+                                       (lf/frame-generation (lf/live-frame :counter/main))
+                                       :event :counter/inc))))))))
+
+;; ===========================================================================
+;; 3. The reload REPORT names a concrete added/changed/removed/retained diff
+;; ===========================================================================
+
+(deftest reload-report-names-a-concrete-diff
+  (testing "reload-images! returns a diff of [kind id] sets (EP-0023 §Hot
+            Reload — \"A good reload result should be a concrete diff\")"
+    (let [frame  (lf/make-frame {:id :counter/main :images [img]} pool-v1)
+          {diff :rf.reload/diff} (lf/reload-images! :counter/main {:images [img]} pool-v2)]
+      (testing ":added names the v2-only id"
+        (is (contains? (:added diff) [:event :counter/reset])))
+      (testing ":changed names the id whose impl changed (v1 → v2)"
+        (is (contains? (:changed diff) [:event :counter/inc])))
+      (testing ":retained names the id whose descriptor is unchanged"
+        (is (contains? (:retained diff) [:sub :counter/value])))
+      (testing ":removed is empty here (v1's ids all survive in v2)"
+        (is (empty? (:removed diff))))
+      (testing "a changed id is NOT also retained, and vice versa (disjoint)"
+        (is (not (contains? (:retained diff) [:event :counter/inc])))
+        (is (not (contains? (:changed diff)  [:sub :counter/value])))))))
+
+(deftest reload-report-names-removed-ids
+  (testing "reloading to a NARROWER image reports the dropped ids as :removed"
+    (let [narrow (image/image {:id :counter/narrow :include-ns ["counter.narrow"]})
+          pool-n [(reg-desc "counter.narrow" :event :counter/inc ::inc-n)]
+          frame  (lf/make-frame {:id :counter/main :images [img]} pool-v1)
+          {diff :rf.reload/diff} (lf/reload-images! :counter/main {:images [narrow]} pool-n)]
+      (is (contains? (:removed diff) [:sub :counter/value])
+          ":counter/value is gone after reloading to the narrower image")
+      (is (contains? (:changed diff) [:event :counter/inc])
+          ":counter/inc survives with a different impl → changed"))))
+
+;; ===========================================================================
+;; 4. Reload is FRAME-TARGETED — it does not move a sibling frame
+;; ===========================================================================
+
+(deftest reload-is-frame-targeted-does-not-move-siblings
+  (testing "two frames created from the SAME image inputs; reloading one does
+            NOT move the other (EP-0023 §Image — reload is frame-targeted; a
+            reload of :counter/left must not move :counter/right)"
+    (let [left  (lf/make-frame {:id :counter/left  :images [img]} pool-v1)
+          right (lf/make-frame {:id :counter/right :images [img]} pool-v1)
+          right-gen-before (lf/frame-generation right)]
+      (lf/reload-images! :counter/left {:images [img]} pool-v2)
+      (testing "right's generation is UNTOUCHED (still resolves v1)"
+        (is (identical? right-gen-before (lf/frame-generation (lf/live-frame :counter/right))))
+        (is (= ::inc-v1 (:handler-fn (asm/resolve-descriptor
+                                       (lf/frame-generation (lf/live-frame :counter/right))
+                                       :event :counter/inc)))))
+      (testing "left moved to v2"
+        (is (= ::inc-v2 (:handler-fn (asm/resolve-descriptor
+                                       (lf/frame-generation (lf/live-frame :counter/left))
+                                       :event :counter/inc))))))))
+
+;; ===========================================================================
+;; 5. A direct (no-id) frame object reloads too — caller holds the copy
+;; ===========================================================================
+
+(deftest reload-a-direct-frame-object
+  (testing "reload-images! accepts a direct frame OBJECT as the target; the
+            registry is untouched (a no-id frame never entered it) and the
+            reloaded copy is returned for the caller to hold"
+    (let [frame    (lf/make-frame {:images [img]} pool-v1)
+          reloaded (:rf.frame/frame (lf/reload-images! frame {:images [img]} pool-v2))]
+      (is (empty? (lf/live-frame-ids)) "registry stays empty for a no-id reload")
+      (is (= ::inc-v2 (:handler-fn (asm/resolve-descriptor
+                                     (lf/frame-generation reloaded) :event :counter/inc))))
+      (testing "the original object is unchanged (immutable value; caller swaps
+                its own reference)"
+        (is (= ::inc-v1 (:handler-fn (asm/resolve-descriptor
+                                       (lf/frame-generation frame) :event :counter/inc))))))))
+
+;; ===========================================================================
+;; 6. Fail-loud — bad :images and unknown target
+;; ===========================================================================
+
+(deftest reload-non-vector-images-rejected
+  (testing "reload-images! :images must be a VECTOR (the one spelling), exactly
+            as make-frame; a bare image map throws :rf.error/make-frame-bad-images"
+    (let [_ (lf/make-frame {:id :counter/main :images [img]} pool-v1)]
+      (is (= :rf.error/make-frame-bad-images
+             (err-id #(lf/reload-images! :counter/main {:images img} pool-v2)))))))
+
+(deftest reload-unknown-target-fails-loud
+  (testing "reloading a target that names no live frame throws
+            :rf.error/reload-no-such-frame (fail-loud — reload targets ONE frame)"
+    (is (= :rf.error/reload-no-such-frame
+           (err-id #(lf/reload-images! :counter/nope {:images [img]} pool-v2))))))
+
+;; ===========================================================================
+;; 7. generation-diff is pure and correct in isolation
+;; ===========================================================================
+
+(deftest generation-diff-is-pure-and-correct
+  (testing "generation-diff classifies every [kind id] as added/changed/removed
+            /retained by descriptor value equality"
+    (let [gen-a (asm/assemble [img] pool-v1)
+          gen-b (asm/assemble [img] pool-v2)
+          diff  (lf/generation-diff gen-a gen-b)]
+      (is (= #{[:event :counter/reset]} (:added diff)))
+      (is (= #{[:event :counter/inc]}   (:changed diff)))
+      (is (= #{[:sub :counter/value]}   (:retained diff)))
+      (is (= #{} (:removed diff))))
+    (testing "two equal generations diff to all-retained, nothing else"
+      (let [g (asm/assemble [img] pool-v1)
+            d (lf/generation-diff g g)]
+        (is (empty? (:added d)))
+        (is (empty? (:changed d)))
+        (is (empty? (:removed d)))
+        (is (= #{[:event :counter/inc] [:sub :counter/value]} (:retained d)))))))
+
+;; ===========================================================================
+;; 8. Source-store change reprojects an EXPLICIT-image frame (not only default)
+;; ===========================================================================
+
+(deftest source-store-change-reprojects-an-explicit-image-frame
+  (testing "a reg-* change in a namespace an explicit :include-ns image selects
+            reprojects THAT frame's generation (EP-0023 §Default Image Semantics
+            — reproject affected EXPLICIT-image frames, not only default-image
+            frames). Uses the LIVE source store; snapshot + restore around the
+            case (NOT registrar/clear-all!)."
+    (let [snapshot @source-store/kind->id->ns->descriptor]
+      (try
+        ;; A registration authored in an explicit namespace, recorded into the
+        ;; LIVE source store (the same path reg-* writes through).
+        (source-store/record-descriptor!
+          :event :explicit/inc
+          {:rf.provenance/ns "explicit.feature" :kind :event :id :explicit/inc
+           :handler-fn ::inc-original})
+        (let [img   (image/image {:id :explicit/img :include-ns ["explicit.feature"]})
+              frame (lf/make-frame {:id :explicit/main :images [img]})
+              gen-before (lf/frame-generation frame)]
+          (testing "the frame resolves the original impl against the live store"
+            (is (= ::inc-original
+                   (:handler-fn (asm/resolve-descriptor gen-before :event :explicit/inc)))))
+          ;; Hot reload of that source: re-eval the SAME (kind,id,namespace) slot
+          ;; with a new impl (the same-namespace replacement path).
+          (source-store/record-descriptor!
+            :event :explicit/inc
+            {:rf.provenance/ns "explicit.feature" :kind :event :id :explicit/inc
+             :handler-fn ::inc-reloaded})
+          (let [moved (lf/reproject-live-frames!)]
+            (testing "reproject reports the EXPLICIT-image frame as moved"
+              (is (contains? moved :explicit/main))
+              (is (contains? (:changed (get moved :explicit/main)) [:event :explicit/inc])))
+            (testing "the live frame now resolves the RELOADED impl through its
+                      swapped generation"
+              (is (= ::inc-reloaded
+                     (:handler-fn (asm/resolve-descriptor
+                                    (lf/frame-generation (lf/live-frame :explicit/main))
+                                    :event :explicit/inc)))))))
+        (finally
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+(deftest reproject-leaves-unchanged-frames-untouched
+  (testing "reproject-live-frames! does NOT swap a frame whose composition
+            re-resolves byte-for-byte — no spurious movement"
+    (let [snapshot @source-store/kind->id->ns->descriptor]
+      (try
+        (source-store/record-descriptor!
+          :event :stable/inc
+          {:rf.provenance/ns "stable.feature" :kind :event :id :stable/inc
+           :handler-fn ::stable})
+        (let [img   (image/image {:id :stable/img :include-ns ["stable.feature"]})
+              frame (lf/make-frame {:id :stable/main :images [img]})
+              gen-before (lf/frame-generation frame)
+              ;; No source change between creation and reproject.
+              moved (lf/reproject-live-frames!)]
+          (testing "no frame moved"
+            (is (empty? moved)))
+          (testing "the frame's generation is the SAME object (untouched)"
+            (is (identical? gen-before (lf/frame-generation (lf/live-frame :stable/main))))))
+        (finally
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))


### PR DESCRIPTION
EP-0023 slice rf2-32siq3.10 — image hot reload. Builds on the merged .2–.9 slices.

## What this adds (live_frame.cljc only)

- **`rf/reload-images!`** — frame-targeted, composition-replacing hot reload (EP-0023 §Hot Reload). Takes the same `:images` vector shape as `make-frame`, targets one frame (by id or direct frame object), re-assembles the new `:images` into a fresh sealed generation, and swaps it onto the frame **while preserving frame memory** — only `:rf.frame/generation` moves; id, initial-db, capabilities, adapter (and future state-container atoms, by identity) are carried through. Returns a reload report:
  ```clojure
  {:rf.frame/frame  <reloaded frame object>
   :rf.reload/diff  {:added #{[kind id]…} :changed #{…} :removed #{…} :retained #{…}}}
  ```
  An `:id`-bearing reload updates the registry slot in place (the id keeps naming the same live context, now on the new generation); a direct frame object's reloaded copy is returned for the caller. Reload is frame-targeted: reloading one frame never moves a sibling that previously shared a generation object.

- **`reproject-live-frames!`** — the source-store-change path. Re-resolves every registered live frame from its own `:rf.gen/images` composition against the current source store and swaps the new generation onto any frame whose resolution changed. Reprojects **explicit-`:include-ns` frames**, not only default-image frames (EP-0023 §Default Image Semantics). A frame that re-resolves byte-for-byte is left untouched.

- **`resolve-generation!`** — extracted from `make-frame` (validate + assemble + capability-check) so reload resolves with byte-identical semantics to creation. `make-frame` behaviour is unchanged.

- New `:rf.error/reload-no-such-frame` for an unknown reload target.

## Surface lane

`image_assembly.cljc` and `source_store.cljc` are NOT edited (only their public API is called). The `image-assembly` require was already present from .9.

## The reload contract

The generation is an immutable value the frame carries at `:rf.frame/generation`, and the .9 resolution seam derives resolution solely from that slot — so swapping the generation is the whole job: a single `assoc` that preserves every other slot. Reload never tears down / recreates the frame.

## Tests (new live_frame_reload_cljs_test.cljc, CLJS not Playwright)

generation swap preserving frame memory · post-reload resolution uses the new image · concrete added/changed/removed/retained diff · frame-targeted isolation (sibling not moved) · direct-object reload · fail-loud bad-`:images` + unknown-target · pure `generation-diff` · source-store reprojection of an explicit-image frame (live store snapshot/restore — **not** `registrar/clear-all!`).

## Gates

- `npm run test:cljs` — 0 failures / 0 errors (7425 tests)
- `npm run test:elision` — 43/43 absent in prod, present in control
- `scripts/test-fast-pr.sh` — PASS