### PR TITLE
feat(core): EP-0023 export rf/image from re-frame.core (rf2-32siq3.17)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -113,6 +113,16 @@
             ;; A leaf on the registrar/late-bind spine; bundle-isolation
             ;; neutral. The default-realm keyword arities are byte-identical.
             [re-frame.realm :as realm]
+            ;; EP-0023 (rf2-32siq3.17): the public `rf/image` constructor —
+            ;; an IMAGE value, the selected registration-set value a frame
+            ;; resolves against (EP-0023 §Image, §Public API). PURE inert data
+            ;; (no realm, no registrar, no side effect), re-exported below as
+            ;; `rf/image`. `re-frame.image` lives in the core artefact and
+            ;; pulls only `clojure.string` + `re-frame.error` (the core
+            ;; spine), so it is bundle-isolation neutral; an app that never
+            ;; constructs an image leaves the constructor as Closure-DCE dead
+            ;; code.
+            [re-frame.image :as image]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.core-flows    :as rf-flows]
             [re-frame.core-routing  :as rf-routing]
@@ -690,6 +700,20 @@
   Implementation ships in `day8/re-frame2-ssr`. Late-bound via
   `:ssr/head-snapshot`."}
   head-snapshot    rf-ssr/head-snapshot)
+
+;; ---- images (EP-0023) ----------------------------------------------------
+
+(def ^{:doc "Construct an IMAGE value — the selected registration-set value a
+  frame resolves against (EP-0023 §Image, §Public API). `rf/image` is the
+  public constructor; `spec` is a map carrying `:id` (optional), `:include-ns`
+  (a vector of namespace-glob strings selecting registered descriptors by
+  their `:rf.provenance/ns`), `:registrations` (inline registrar-keyed
+  sections), `:rf.image/requires` (the `:rf.capability/*` set), and the
+  declared-winner maps `:replace` / `:replace-standard`. Returns a normalized,
+  INERT image value — PURE: no realm, no registrar, no side effect (an image
+  is data, not registration). Supplied to `make-frame` / `reg-frame` via the
+  `:images` vector. See `re-frame.image/image`."}
+  image    image/image)
 
 ;; ---- frame management ----------------------------------------------------
 

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -19,6 +19,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.machines]
+            [re-frame.image :as image]
             [re-frame.routing :as routing]
             ;; rf2-q4i9ko — replace-app-db! delegates to the epoch artefact's
             ;; replace-app-db! (synthetic-epoch recording); load it so the
@@ -527,3 +528,29 @@
         "register-observability-sink! returns the sink-id on install")
     (is (nil? (rf/unregister-observability-sink! :rn.sinks/test))
         "unregister-observability-sink! is the confirmed inverse — returns nil")))
+
+;; ===========================================================================
+;; rf2-32siq3.17 — EP-0023 `rf/image` facade export
+;; ===========================================================================
+
+(deftest image-resolves-on-the-facade
+  (testing "re-frame.core/image is the public `rf/image` constructor — it
+            resolves to the re-frame.image/image var and builds an image value
+            through the facade (EP-0023 §Image, §Public API)"
+    ;; The facade var IS the constructor — `rf/image` and
+    ;; `re-frame.image/image` are the identical fn.
+    (is (identical? @#'rf/image @#'image/image)
+        "rf/image aliases re-frame.image/image (same constructor var value)")
+    ;; And it actually constructs the normalized, INERT image value through the
+    ;; facade — a `rf/image` call is data, not registration.
+    (let [img (rf/image {:id :docs.counter/v2
+                         :include-ns ["docs.quickstart.counter.v2"]})]
+      (is (= :docs.counter/v2 (:rf.image/id img))
+          "the :id is normalized to the owner-qualified :rf.image/id slot")
+      (is (= ["docs.quickstart.counter.v2"] (:rf.image/include-ns img))
+          ":include-ns is carried as the glob-pattern vector")
+      (is (= [] (:rf.image/inline img))
+          "no :registrations → empty inline-descriptor vector")
+      (is (= img (rf/image {:id :docs.counter/v2
+                            :include-ns ["docs.quickstart.counter.v2"]}))
+          "PURE: equal spec maps return equal image values"))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -377,6 +377,21 @@
   ["re-frame.core" "reg-interceptor*"]    {:tier :advanced    :owner "001" :status "EP-0022"}
   ["re-frame.core" "reg-frame"]           {:tier :front-porch :owner "002" :status "v1"}
   ["re-frame.core" "make-frame"]          {:tier :advanced    :owner "002" :status "v1"}
+  ;; EP-0023 (rf2-32siq3.17 — image-loaded frames): `image` is the public
+  ;; `rf/image` CONSTRUCTOR — it builds an IMAGE value, the selected
+  ;; registration-set value a frame resolves against (EP-0023 §Image, §Public
+  ;; API). CLASSIFICATION (EP-0015 diff-time rule): a deliberate public
+  ;; constructor. Tier `:advanced`, not `:front-porch` — EP-0023 is explicit
+  ;; that "most code should not have to name an image" (the ordinary `reg-*` +
+  ;; default-image path stays implicit); explicit images are for the advanced
+  ;; cases where the default visible registration set stops being enough
+  ;; (multiple surfaces on one page, progressive docs examples, Xray-beside-
+  ;; target, library packaging, test/story overrides). Same tier + owning Spec
+  ;; (002 — Frames, EP-0023's frame/image normative home) as its sibling
+  ;; advanced frame-construction input `make-frame`, which consumes the image
+  ;; via `:images`. Status `EP-0023` (proposal-stage surface; the row exists
+  ;; ahead of the spec/API.md projection, which EP-0023 graduates separately).
+  ["re-frame.core" "image"]               {:tier :advanced    :owner "002" :status "EP-0023"}
   ["re-frame.core" "reg-view"]            {:tier :front-porch :owner "004" :status "v1"}
   ["re-frame.core" "reg-view*"]           {:tier :advanced    :owner "004" :status "v1"}
   ["re-frame.core" "reg-machine"]         {:tier :advanced    :owner "005" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 505,
+ :var-count 506,
  :tier-vocab
  [:front-porch
   :advanced
@@ -132,6 +132,7 @@
   {:namespace "re-frame.core", :var "handler-meta", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "head-model->html", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "head-snapshot", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "image", :tier :advanced, :kind :fn, :owner "002", :status "EP-0023", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "init!", :tier :front-porch, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "init-platform", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "install!", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
## What

Exposes the EP-0023 `rf/image` constructor on the public `re-frame.core` facade. PR #4364 added `re-frame.image/image` but did not surface it on the facade; EP-0023 + the bead acceptance spell the public API as **`rf/image`**.

- Add a `re-frame.image` require + an `image` var alias to `implementation/core/src/re_frame/core.cljc` (in a new EP-0023 "images" section, just above `make-frame` — its sibling frame-construction input).
- `re-frame.image` lives in the core artefact and pulls only `clojure.string` + `re-frame.error` (the core spine), so the export is bundle-isolation neutral; an app that never constructs an image leaves the constructor as Closure-DCE dead code.

## New public facade export — classified + manifested

- **api-manifest (HOT-ZONE):** added the `["re-frame.core" "image"]` sidecar classification row and regenerated `spec/api-manifest.edn` (505 → 506 public vars). The manifest `--check` is **green**; all api-manifest projection tests (API.md projection, skills projection — 27 tests) pass.
- **Classification (EP-0015 diff-time rule):** a deliberate public constructor.
  - **Tier `:advanced`** (not `:front-porch`) — EP-0023 is explicit that *"most code should not have to name an image"* (the ordinary `reg-*` + default-image path stays implicit); explicit images are the advanced cases where the default visible registration set stops being enough (multiple surfaces on one page, progressive docs examples, Xray-beside-target, library packaging, test/story overrides).
  - **Owner `002`** (Frames — EP-0023's frame/image normative home), matching the sibling advanced input `make-frame`, which consumes the image via `:images`.
  - **Status `EP-0023`** — proposal-stage surface; the manifest row exists ahead of the `spec/API.md` projection, which EP-0023 graduates separately. (The API.md projection check is one-directional: an unmanifested API.md row fails, but a manifest row without an API.md row does not — verified green.)

## Test

Adds `image-resolves-on-the-facade` to `core_api_additions_test.clj`: asserts `re-frame.core/image` is `identical?` to `re-frame.image/image` and builds the normalized, inert image value through the facade (`:rf.image/id` / `:rf.image/include-ns` / `:rf.image/inline`; PURE — equal specs → equal values).

## Gates

- `clojure -M -m re-frame.api-manifest.gen --check` → exit 0 (green)
- `implementation/`: `npm run test:cljs` → 7414 tests, 0 failures
- repo root: `scripts/test-fast-pr.sh` → PASS (runs the manifest + facade + projection gates)
- new facade test: 5 assertions, 0 failures

## Scope

`core.cljc` facade + the api-manifest (+ sidecar) + one facade test only. `image.cljc` / `image_assembly.cljc` untouched (CALL/alias only — those are sibling slices' lane).