### PR TITLE
fix(core): EP-0023 source-store descriptors carry kind/id + provenance survives elision (rf2-32siq3.21, rf2-32siq3.22)

### DIFF
--- a/implementation/core/src/re_frame/source_store.cljc
+++ b/implementation/core/src/re_frame/source_store.cljc
@@ -64,7 +64,8 @@
   same `app-value/install!` path that binds `registrar/*registrar*`) route
   `reg-*` writes into a realm's OWN source store. [[active-source-store]] is the
   single resolution point — nil binding ⇒ the process-default store, the
-  byte-identical single-realm path.")
+  byte-identical single-realm path."
+  (:require [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -198,34 +199,64 @@
 
 (defn record-descriptor!
   "Record `descriptor` for `(kind, id)` under its source namespace in the
-  active source store, returning the descriptor as stored (with
-  `:rf.provenance/ns` stamped as a canonical string).
+  active source store, returning the descriptor as stored (with `:kind` /
+  `:id` stamped and `:rf.provenance/ns` stamped as a canonical string).
 
   Provenance namespace resolution, in order:
     1. an explicit `:rf.provenance/ns` already on the descriptor (a tool or
        generated-code path that stamps its own provenance), canonicalized;
     2. otherwise the descriptor's `:ns` slot (the symbol a reg-* macro
-       captured via `*pending-coords*`), canonicalized to a string.
+       captured), canonicalized to a string;
+    3. otherwise the `:ns` of the live `source-coords/*pending-coords*`
+       binding, canonicalized.
 
-  When neither yields a namespace (a programmatic / REPL registration with no
-  macro-captured `:ns`), the descriptor is recorded under the nil-provenance
-  slot. Nil-provenance descriptors still occupy ONE slot per `(kind, id)`
-  (they cannot be image-isolation-distinguished — they have no namespace), so a
-  later programmatic re-register of the same `(kind, id)` replaces it. They are
-  NOT silently dropped: a later image-assembly slice still sees them.
+  Step 3 is the PRODUCTION-ELISION path (rf2-32siq3.22). The descriptor's `:ns`
+  slot (step 2) only survives in DEV: a reg-* macro captures coords into
+  `*pending-coords*`, and the registration fn folds them into the stored
+  metadata via `source-coords/merge-coords` — but in CLJS production
+  (`:advanced` + `goog.DEBUG=false`) `merge-coords` returns the user metadata
+  UNCHANGED, stripping `:ns` from the descriptor (consistent with `:file` /
+  `:line` / `:doc` elision). The `*pending-coords*` BINDING itself survives
+  production (the reg-* macro emits `prod-coords-form`, which keeps `:ns`), so
+  reading the namespace off the live binding is the path that survives
+  optimized builds — `:rf.provenance/ns` must survive elision or `:include-ns`
+  image assembly cannot work (EP-0023 §Namespace-Selected Images). The store
+  is written from `register!` while the macro's `*pending-coords*` binding is
+  still in flight, so the binding is live at this call.
+
+  When none of the three yields a namespace (a programmatic / REPL
+  registration with no macro-captured `:ns`), the descriptor is recorded under
+  the nil-provenance slot. Nil-provenance descriptors still occupy ONE slot per
+  `(kind, id)` (they cannot be image-isolation-distinguished — they have no
+  namespace), so a later programmatic re-register of the same `(kind, id)`
+  replaces it. They are NOT silently dropped: a later image-assembly slice
+  still sees them.
+
+  The stored descriptor is stamped with `:kind` and `:id` (rf2-32siq3.21).
+  They are the store KEY, so the stamp is deterministic — and image assembly
+  reads `(:kind descriptor)` / `(:id descriptor)` (`descriptor-kind+id`,
+  `check-supported-kinds!`), so a registered descriptor selected by
+  `:include-ns` MUST carry them or assembly fails on an `nil` kind. The
+  registrar's resolver-map metadata does not carry `:kind` / `:id` (the slot is
+  keyed by them), so the store stamps its own provenance-tagged copy here.
 
   This is additive to `registrar/register!`'s resolver-map write — the store
   preserves every provenance-distinct descriptor; the resolver map remains the
   unchanged default-image runtime path until a later slice projects from here."
   [kind id descriptor]
   (let [pn   (canonical-ns (or (get descriptor provenance-ns-key)
-                               (:ns descriptor)))
-        ;; Stamp the canonical provenance string onto the stored descriptor so
-        ;; `(rf/handler-meta kind id)` consumers and `:include-ns` selection
-        ;; (slice .3) read a string at :rf.provenance/ns. When there is no
-        ;; provenance (programmatic path), leave the key off rather than store
-        ;; a nil — absence is the honest signal "no source namespace".
-        desc (cond-> descriptor
+                               (:ns descriptor)
+                               ;; Production-surviving fallback: the live
+                               ;; *pending-coords* binding's :ns (rf2-32siq3.22).
+                               (:ns source-coords/*pending-coords*)))
+        ;; Stamp `:kind` / `:id` (the store key, so deterministic) — image
+        ;; assembly reads them off the descriptor (rf2-32siq3.21) — plus the
+        ;; canonical provenance string so `(rf/handler-meta kind id)` consumers
+        ;; and `:include-ns` selection (slice .3) read a string at
+        ;; :rf.provenance/ns. When there is no provenance (programmatic path),
+        ;; leave the key off rather than store a nil — absence is the honest
+        ;; signal "no source namespace".
+        desc (cond-> (assoc descriptor :kind kind :id id)
                pn (assoc provenance-ns-key pn))
         store (active-source-store)]
     (swap! store assoc-in [kind id pn] desc)

--- a/implementation/core/test/re_frame/source_store_cljs_test.cljc
+++ b/implementation/core/test/re_frame/source_store_cljs_test.cljc
@@ -19,8 +19,11 @@
   `npm run test:cljs`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [re-frame.registrar   :as registrar]
-            [re-frame.source-store :as ss]))
+            [re-frame.registrar      :as registrar]
+            [re-frame.source-coords  :as source-coords]
+            [re-frame.image          :as image]
+            [re-frame.image-assembly :as assembly]
+            [re-frame.source-store   :as ss]))
 
 ;; Each case starts from a clean process-default store + ns-string pool.
 ;; `registrar/clear-all!` resets the source store in lockstep (EP-0023 wiring),
@@ -29,9 +32,16 @@
   (fn [t]
     (ss/clear-all!)
     (reset! registrar/kind->id->metadata {})
+    ;; The assembly-path cases (rf2-32siq3.21) read the live standard registry
+    ;; + generation cache; reset both so a stale generation never leaks across
+    ;; a case that mutated the store.
+    (assembly/clear-standards!)
+    (assembly/clear-generation-cache!)
     (t)
     (ss/clear-all!)
-    (reset! registrar/kind->id->metadata {})))
+    (reset! registrar/kind->id->metadata {})
+    (assembly/clear-standards!)
+    (assembly/clear-generation-cache!)))
 
 ;; ===========================================================================
 ;; 1. Same id, different namespaces — BOTH descriptors retained
@@ -247,3 +257,109 @@
         "all three event descriptors across two ids and three namespaces")
     (is (= #{:a :b :c} (set (map :handler-fn (ss/all-descriptors :event))))
         "every descriptor is present")))
+
+;; ===========================================================================
+;; 6. Stored descriptor carries :kind / :id (rf2-32siq3.21) — image assembly
+;;    reads (:kind d) / (:id d), so a registered descriptor MUST carry them
+;; ===========================================================================
+
+(deftest stored-descriptor-carries-kind-and-id
+  (testing "record-descriptor! stamps :kind and :id onto the stored descriptor
+            (the store KEY, so deterministic). Image assembly reads (:kind d) /
+            (:id d) via descriptor-kind+id / check-supported-kinds!, so a real
+            registered descriptor selected by :include-ns must carry them
+            (rf2-32siq3.21)"
+    (let [stored (ss/record-descriptor! :event :counter/inc
+                                        {:ns 'docs.counter.v2 :handler-fn :f})]
+      (is (= :event (:kind stored)) "stored descriptor carries its :kind")
+      (is (= :counter/inc (:id stored)) "stored descriptor carries its :id"))
+    ;; Reachable through the query surfaces too, not just the return value.
+    (let [slot (ss/descriptor-for :event :counter/inc 'docs.counter.v2)]
+      (is (= :event (:kind slot)))
+      (is (= :counter/inc (:id slot))))
+    (is (= [:event :counter/inc]
+           ((juxt :kind :id) (first (ss/all-descriptors :event))))
+        "the flattened all-descriptors entry carries :kind / :id")))
+
+(deftest registrar-recorded-descriptor-assembles-via-all-descriptors
+  (testing "a descriptor recorded via registrar/register! carries :kind / :id
+            and assembles through image-assembly (selecting from the live source
+            store's all-descriptors) WITHOUT a kind/id error — the real
+            default-image / :include-ns path the synthetic-descriptor tests
+            masked (rf2-32siq3.21)"
+    (registrar/register! :event :counter/inc
+                         {:ns 'docs.counter.v2 :handler-fn (fn [_ _] {})})
+    (let [slot (ss/descriptor-for :event :counter/inc 'docs.counter.v2)]
+      (is (= :event (:kind slot)) "register!-recorded descriptor carries :kind")
+      (is (= :counter/inc (:id slot)) "register!-recorded descriptor carries :id"))
+    ;; Assemble an :include-ns image against the live source store. Without the
+    ;; :kind/:id stamp this threw :rf.error/image-unsupported-kind (nil kind).
+    (let [img (image/image {:id :docs.counter/v2
+                            :include-ns ["docs.counter.v2"]})
+          gen (assembly/assemble [img])]
+      (is (some? (assembly/resolve-descriptor gen :event :counter/inc))
+          "the registered descriptor resolves in the sealed generation")
+      (is (= #{:event} (assembly/generation-kinds gen))
+          "the sealed generation reports :event as a present kind"))))
+
+;; ===========================================================================
+;; 7. Provenance survives production elision (rf2-32siq3.22) — derive the
+;;    provenance ns from the elision-surviving *pending-coords* binding when
+;;    the descriptor's :ns slot has been stripped (the production path)
+;; ===========================================================================
+
+(deftest provenance-from-pending-coords-when-ns-stripped
+  (testing "in production (`:advanced` + goog.DEBUG=false) source-coords/
+            merge-coords returns the user metadata UNCHANGED, so the descriptor
+            reaching record-descriptor! carries NO :ns. The reg-* macro's
+            *pending-coords* BINDING still carries :ns (prod-coords-form keeps
+            it), so provenance is derived from the live binding — :rf.provenance/
+            ns must survive optimized builds or :include-ns assembly cannot work
+            (rf2-32siq3.22, EP-0023 §Namespace-Selected Images)"
+    ;; Model the production descriptor shape: NO :ns slot (merge-coords
+    ;; stripped it), but the macro's *pending-coords* binding is in flight.
+    (binding [source-coords/*pending-coords* {:ns "docs.counter.prod"}]
+      (let [stored (ss/record-descriptor! :event :counter/inc
+                                          {:handler-fn :f})]
+        (is (= "docs.counter.prod" (:rf.provenance/ns stored))
+            "provenance derived from the surviving *pending-coords* :ns")
+        (is (string? (:rf.provenance/ns stored))
+            "it is a canonical string")
+        (is (identical? (ss/canonical-ns "docs.counter.prod")
+                        (:rf.provenance/ns stored))
+            "the *pending-coords*-derived provenance is pooled too")))
+    ;; The slot is keyed by that provenance namespace, so :include-ns selection
+    ;; (the production image-assembly path) reaches it.
+    (is (some? (ss/descriptor-for :event :counter/inc "docs.counter.prod"))
+        "the descriptor is recorded under its provenance namespace slot")))
+
+(deftest provenance-precedence-descriptor-ns-wins-over-pending
+  (testing "the descriptor's own :ns slot (DEV path, present when merge-coords
+            folded it in) takes precedence over the *pending-coords* fallback —
+            the fallback is a production safety net, not an override"
+    (binding [source-coords/*pending-coords* {:ns "from.pending"}]
+      (let [stored (ss/record-descriptor! :event :counter/inc
+                                          {:ns 'from.descriptor :handler-fn :f})]
+        (is (= "from.descriptor" (:rf.provenance/ns stored))
+            "the descriptor :ns slot wins over the *pending-coords* fallback")))))
+
+(deftest explicit-provenance-wins-over-pending-coords
+  (testing "an explicit :rf.provenance/ns on the descriptor still wins over both
+            the :ns slot and the *pending-coords* fallback"
+    (binding [source-coords/*pending-coords* {:ns "from.pending"}]
+      (let [stored (ss/record-descriptor! :event :gen/handler
+                                          {:ns 'macro.captured.ns
+                                           :rf.provenance/ns "tool.synthesised.ns"
+                                           :handler-fn :f})]
+        (is (= "tool.synthesised.ns" (:rf.provenance/ns stored))
+            "explicit provenance overrides both the :ns slot and *pending-coords*")))))
+
+(deftest no-provenance-when-no-source-anywhere
+  (testing "a truly programmatic registration — no descriptor :ns, no
+            *pending-coords* binding — records under the nil-provenance slot,
+            unchanged by the production-elision fallback"
+    (let [stored (ss/record-descriptor! :event :prog/handler {:handler-fn :v1})]
+      (is (nil? (:rf.provenance/ns stored))
+          "no provenance stamped when no source namespace is available anywhere")
+      (is (some? (get (ss/descriptors-for :event :prog/handler) nil))
+          "recorded under the nil-provenance slot, not dropped"))))


### PR DESCRIPTION
Two EP-0023 source-store gap-fixes on `implementation/core/src/re_frame/source_store.cljc` (review follow-ups from PR #4363).

## rf2-32siq3.21 — descriptors must carry `:kind` and `:id` (REAL default-image/`:include-ns` bug)

`record-descriptor!` keyed the store under `[kind id provenance-ns]` but did **not** stamp `:kind`/`:id` onto the stored descriptor. Image assembly reads `(:kind descriptor)` / `(:id descriptor)` (`descriptor-kind+id`, `check-supported-kinds!`, `build-resolver`), so a **real** registered descriptor selected by `:include-ns` failed assembly with a `nil` kind → `:rf.error/image-unsupported-kind`. The existing tests recorded synthetic `{:ns … :handler-fn …}` maps and asserted only on `:handler-fn`, never on `:kind`/`:id` — masking the bug.

**Fix:** stamp `:kind`/`:id` onto the stored descriptor (deterministic — they're the store key). New test records a descriptor via `registrar/register!` and assembles it through `image-assembly/assemble` against the live `all-descriptors`, confirming it resolves in the sealed generation with no kind/id error.

## rf2-32siq3.22 — provenance must survive production elision

Provenance was derived from `(:ns descriptor)`. But `:ns` arrives on the descriptor only via `source-coords/merge-coords`, which in CLJS production (`:advanced` + `goog.DEBUG=false`) returns user metadata **unchanged** — stripping `:ns` (consistent with `:file`/`:line`/`:doc` elision). So under an optimized build the provenance namespace was lost and `:include-ns` image assembly could not work.

**Fix:** add a third provenance fallback — the `:ns` of the live `source-coords/*pending-coords*` binding. That binding survives production (the reg-* macro emits `prod-coords-form`, which keeps `:ns`) and is in flight when `register!` writes the store. Precedence is unchanged: explicit `:rf.provenance/ns` > descriptor `:ns` slot > `*pending-coords*` `:ns`.

## Gates
- `npm run test:cljs` — 7432 tests, 30583 assertions, **0 failures / 0 errors** (incl. 6 new tests)
- `npm run test:elision` — **PASS** (production 43/43 sentinels absent; control 43/43 present). The new `source-coords` require + `*pending-coords*` read introduce no leaking dev-only strings.
- `scripts/test-fast-pr.sh` — **PASS** (core JVM gate + CLJS integration green; the `.cljc` tests run under both)

## Surface
Only `source_store.cljc` + its test file. No edit to `image_assembly.cljc` (sibling worker), `image.cljc`, or `live_frame.cljc`.