### PR TITLE
feat(core): EP-0023 wire frame-derived resolution into the live cascade (rf2-uejnt3)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -9,6 +9,7 @@
   any further external event is processed for that frame, and before any
   view re-renders."
   (:require [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
@@ -2210,8 +2211,25 @@
           (run-handler-cascade! envelope event-id event frame
                                 frame-record handler-meta))))))
 
+(defn- frame-resolution-target
+  "EP-0023 §Frame-derived live registration resolution (rf2-uejnt3): given the
+  CARRIED frame target an envelope holds in `:frame`, return the EP-0023 frame
+  OBJECT to derive the resolution generation from — the object itself when the
+  target IS one (the direct-object dispatch form), or the live-frame registry's
+  object for a frame-id KEYWORD (the `{:frame :counter/main}` form). nil for any
+  target that names no live image-loaded frame — the absence-is-default signal
+  that `call-with-frame-resolution` binds NOTHING and the cascade resolves
+  through the registrar atom path, byte-identical for every existing caller
+  (the EP-0013 realm-routed dispatch and the single-realm default alike).
+  Pure read of the carried target + the process-local live-frame registry."
+  [target]
+  (cond
+    (live-frame/frame-object? target) target
+    (keyword? target)                 (live-frame/live-frame target)
+    :else                             nil))
+
 (defn- process-event!
-  "Wrap process-event* in two dynamic bindings:
+  "Wrap process-event* in four dynamic bindings:
 
    1. `trace/*handler-scope*` — set with the cascade's `:dispatch-id`
       and the envelope's `:call-site`, inheriting the rest from parent.
@@ -2261,7 +2279,30 @@
       realm is preserved across the cascade automatically. The
       default-realm frame (every single-realm app) takes the no-binding
       fast path inside `call-with-frame-realm-registrar` — byte-identical
-      to the pre-realm hot path."
+      to the pre-realm hot path.
+
+   4. `registrar/*generation*` — bound to the target frame's resolved
+      IMAGE GENERATION for the WHOLE cascade WHEN the carried `:frame`
+      names an EP-0023 image-loaded frame (rf2-uejnt3, operationalising
+      the rf2-32siq3.9 seam). This is the EP-0023 restatement of the
+      a15n62 invariant in image/frame terms — `target frame -> resolved
+      image generation -> registration resolution`. The SAME chokepoint
+      (`registrar/lookup`) the realm binding above routes — event-handler
+      lookup, every cofx injection, the whole fx walk — resolves through
+      the frame's OWN image generation's resolver, so two frames running
+      DIFFERENT images resolve the same `[kind id]` to their own image's
+      descriptor (ALL-OR-NOTHING — `call-with-frame-resolution` covers the
+      whole thunk, exactly like the realm wrap it nests inside). The
+      generation is DERIVED from the carried frame target
+      (`frame-resolution-target` resolves a direct frame OBJECT verbatim,
+      a frame-id keyword through the live-frame registry), never an
+      ambient binding (EP-0002). A target that names no live image-loaded
+      frame — every EP-0013 realm-only frame and the single-realm default
+      alike — yields no generation, so `call-with-frame-resolution` binds
+      NOTHING and resolution falls through to the registrar-atom path,
+      byte-identical (absence-is-default). Child dispatches re-enter
+      `process-event!` for their frame and re-derive the binding, so the
+      generation is preserved across the cascade automatically."
   [envelope]
   (trace/with-dispatch-id+call-site (:dispatch-id envelope) (:call-site envelope)
     (binding [frame/*current-frame* (:frame envelope)]
@@ -2274,7 +2315,19 @@
       ;; `handle-frame-destroyed!` branch as before.
       (frame/call-with-frame-realm-registrar
         (frame/frame (:frame envelope))
-        (fn [] (process-event* envelope))))))
+        (fn []
+          ;; EP-0023 (rf2-uejnt3): ALSO route the cascade through the target
+          ;; frame's resolved IMAGE generation when the carried `:frame` names
+          ;; an image-loaded frame, NESTED inside the realm binding so event +
+          ;; cofx + fx resolve coherently through the frame's own image
+          ;; (rf2-32siq3.9's seam, invoked at the live entry). A target that
+          ;; names no image-loaded frame (every realm-only / single-realm
+          ;; frame) derives no generation, so this binds nothing and the
+          ;; cascade resolves through the registrar atom exactly as before
+          ;; (absence-is-default). DERIVED from the carried target (EP-0002).
+          (live-frame/call-with-frame-resolution
+            (frame-resolution-target (:frame envelope))
+            (fn [] (process-event* envelope))))))))
 
 (def ^:private drain-depth-default
   ;; Deep enough for typical cascade depths. When exceeded, the runtime

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -34,6 +34,7 @@
   policies, no deferred-grace timer, no batched dispose."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -862,6 +863,23 @@
                v*       (maybe-validate-sub-override! v query-v sub-meta frame-id)]
            (adapter/make-derived-value [] (constantly v*)))))))
 
+(defn- frame-resolution-target
+  "EP-0023 §Frame-derived live registration resolution (rf2-uejnt3): given the
+  CARRIED frame target `subscribe` holds in `frame-id`, return the EP-0023 frame
+  OBJECT to derive the resolution generation from — the object itself when the
+  target IS one (the direct-object `(rf/subscribe frame query-v)` form), or the
+  live-frame registry's object for a frame-id KEYWORD. nil for any target that
+  names no live image-loaded frame — the absence-is-default signal that
+  `live-frame/call-with-frame-resolution` binds NOTHING and the build resolves
+  through the registrar atom path, byte-identical for every existing caller.
+  Mirrors `re-frame.router/frame-resolution-target` (the dispatch-side twin).
+  Pure read of the carried target + the process-local live-frame registry."
+  [target]
+  (cond
+    (live-frame/frame-object? target) target
+    (keyword? target)                 (live-frame/live-frame target)
+    :else                             nil))
+
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
   build-and-cache on miss; reuse on hit. The 1-arity ambient form
@@ -992,8 +1010,22 @@
    ;; (`frame/realm-registrar-for-frame` returns nil) — byte-identical to the
    ;; pre-realm subscribe path. DERIVED from the carried frame-id, never ambient
    ;; (EP-0002).
+   ;;
+   ;; EP-0023 (rf2-uejnt3): ALSO route the BUILD path through the target frame's
+   ;; resolved IMAGE generation when `frame-id` names an image-loaded frame —
+   ;; NESTED inside the realm binding so `registrar/lookup :sub` (and the layer-2+
+   ;; input `subscribe` calls inside `compute-and-cache!`) resolve the sub handler
+   ;; through the frame's OWN image (rf2-32siq3.9's seam, invoked at the live
+   ;; subscribe entry). Two frames running DIFFERENT images thus build the same
+   ;; sub-id against their own image's descriptor. A target naming no image-loaded
+   ;; frame (every realm-only / single-realm frame) derives no generation, so this
+   ;; binds nothing and the build resolves through the registrar atom exactly as
+   ;; before (absence-is-default). DERIVED from the carried target (EP-0002).
    (frame/call-with-frame-realm-registrar
      (frame/frame frame-id)
+     (fn []
+   (live-frame/call-with-frame-resolution
+     (frame-resolution-target frame-id)
      (fn []
    (or
      #?(:cljs
@@ -1061,7 +1093,7 @@
                (if (identical? reaction (get-in new [k :reaction]))
                  reaction
                  (compute-and-cache! frame-id query-v)))
-             (compute-and-cache! frame-id query-v)))))))))) ;; close fn + call-with-frame-realm-registrar (rf2-a15n62)
+             (compute-and-cache! frame-id query-v)))))))))))) ;; close fn + call-with-frame-resolution (rf2-uejnt3) + fn + call-with-frame-realm-registrar (rf2-a15n62)
 
 (defn subscribe-once
   "One-shot read of a sub's current value. Subscribes, derefs, then

--- a/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
@@ -1,0 +1,234 @@
+(ns re-frame.live-cascade-frame-resolution-cljs-test
+  "EP-0023 §Frame-derived live registration resolution — the OPERATIONAL
+  acceptance (rf2-uejnt3). Slice .9 (rf2-32siq3.9) landed the resolution SEAM
+  (`registrar/*generation*` + `live-frame/call-with-frame-resolution`) and proved
+  it routes `registrar/lookup` when bound MANUALLY. This suite proves the seam is
+  now invoked from the LIVE cascade: a REAL `(rf/dispatch [...] {:frame F})` (and
+  a real `(rf/subscribe F [...])`) resolves the event / sub handler through the
+  TARGET frame's resolved image generation END-TO-END — NOT through the global
+  registrar, and NOT via a manual `*generation*` binding.
+
+  > target frame -> resolved image generation -> registration resolution
+
+  The headline case: a globally-registered handler/sub for `[:counter/inc]` /
+  `[:counter/value]` writes/returns one value; the frame's IMAGE registers the
+  SAME ids with a DIFFERENT impl. A frame-targeted dispatch/subscribe must run
+  the IMAGE's impl, proving `router/process-event!` and `subs/subscribe` wrap the
+  cascade with `call-with-frame-resolution` (rf2-uejnt3). A realm-only / no-image
+  frame is unaffected (absence-is-default).
+
+  ## Why two registries, one id
+
+  The runnable frame RECORD (the EP-0013 substrate that owns app-db / queue /
+  sub-cache, created by `reg-frame`) and the EP-0023 live-frame OBJECT (which
+  carries the resolved image generation, created by `make-frame {:id …}`) are
+  DELIBERATELY SEPARATE registries (per `re-frame.live-frame` docstring). This
+  suite registers BOTH under the same id `:counter/main`: the router drains the
+  frame record; `process-event!` derives the generation from the live-frame
+  object of the same id. That is exactly the wiring rf2-uejnt3 ships — the .9/.10
+  unification of the two into one runnable image-loaded frame object is a later
+  slice; this slice only invokes the resolution seam at the live entry.
+
+  Fixtures snapshot/restore the registrar via `make-reset-runtime-fixture`
+  (NOT `registrar/clear-all!`, per the .9 isolation note) and clear the
+  process-local live-frame registry between cases. `.cljc` ending `-cljs-test`
+  rides `npm run test:cljs` AND `clojure -M:test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core           :as rf]
+            [re-frame.events         :as events]
+            [re-frame.image          :as image]
+            [re-frame.registrar      :as registrar]
+            [re-frame.live-frame     :as lf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support   :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture: install the plain-atom adapter (so frames are runnable), opt OUT of
+;; the ambient `:rf/default` scope (we drive explicit `{:frame …}` targets), and
+;; clear the live-frame registry between cases so an `:id` from one case does not
+;; collide with the next.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter        plain-atom/adapter
+                                            :ambient-frame  nil})
+  (fn [t]
+    (lf/clear-live-frames!)
+    (t)
+    (lf/clear-live-frames!)))
+
+;; ---------------------------------------------------------------------------
+;; Helpers — build a RUNNABLE event-handler descriptor for an image resolver.
+;;
+;; The descriptor the image's `:rf.gen/resolver` carries is the SAME shape
+;; `register!` stores — for an event that is `events/event-handler-meta` (carries
+;; `:handler-fn` + the wrapping `:interceptors`), merged with the provenance /
+;; kind / id keys image assembly groups + dedupes by. So a generation-routed
+;; `registrar/lookup :event` returns a descriptor the cascade can run directly.
+;; ---------------------------------------------------------------------------
+
+(defn- event-desc
+  "An image-resolver descriptor for an event id whose handler is `handler-fn` —
+  the runnable `events/event-handler-meta` shape merged with the provenance /
+  kind / id slots `image-assembly` keys by."
+  [provenance-ns id handler-fn]
+  (merge (events/event-handler-meta handler-fn)
+         {:rf.provenance/ns provenance-ns
+          :kind             :event
+          :id               id}))
+
+(defn- sub-desc
+  "An image-resolver descriptor for a sub id whose computation is `compute-fn`
+  (`(fn [db query-v] …)`). `reg-sub` stores the computation under `:handler-fn`,
+  so a generation-routed `registrar/lookup :sub` returns this verbatim."
+  [provenance-ns id compute-fn]
+  {:rf.provenance/ns provenance-ns
+   :kind             :sub
+   :id               id
+   :handler-fn       compute-fn})
+
+;; ===========================================================================
+;; 1. THE ACCEPTANCE — a REAL frame-targeted dispatch resolves the event
+;;    handler through the TARGET frame's image, not the global registrar.
+;; ===========================================================================
+
+(deftest real-dispatch-resolves-event-handler-through-frame-image
+  (testing "a globally-registered [:counter/inc] writes :global; the frame's
+            IMAGE registers the SAME id writing :image. A REAL
+            (rf/dispatch-sync [:counter/inc] {:frame :counter/main}) runs the
+            IMAGE handler END-TO-END — proving process-event! wraps the cascade
+            with call-with-frame-resolution (rf2-uejnt3), NOT a manual binding."
+    ;; A runnable frame RECORD under :counter/main (EP-0013 substrate).
+    (rf/reg-frame :counter/main {:doc "image-loaded counter frame"})
+    ;; The GLOBAL handler — the value the cascade would write if it (wrongly)
+    ;; resolved through the global registrar.
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (assoc db :written-by :global)}))
+    ;; The frame's IMAGE registers the SAME id with a DIFFERENT impl.
+    (let [pool  [(event-desc "examples.counter" :counter/inc
+                             (fn [{:keys [db]} _] {:db (assoc db :written-by :image)}))]
+          img   (image/image {:id :examples/counter :include-ns ["examples.counter"]})
+          ;; Register the live-frame OBJECT (carrying the image generation) under
+          ;; the SAME id as the runnable frame record.
+          _     (lf/make-frame {:id :counter/main :images [img]} pool)]
+      ;; A REAL frame-targeted dispatch — no manual *generation* binding.
+      (rf/dispatch-sync [:counter/inc] {:frame :counter/main})
+      (is (= :image (:written-by (rf/app-db-value :counter/main)))
+          "the IMAGE handler ran — the cascade resolved [:event :counter/inc]
+           through the target frame's resolved image generation, end-to-end")
+      (is (nil? registrar/*generation*)
+          "the generation binding did NOT leak past the cascade"))))
+
+;; ===========================================================================
+;; 2. THE ACCEPTANCE — a REAL frame-targeted subscribe resolves the sub
+;;    handler through the TARGET frame's image, not the global registrar.
+;; ===========================================================================
+
+(deftest real-subscribe-resolves-sub-handler-through-frame-image
+  (testing "a globally-registered [:counter/value] returns :global; the frame's
+            IMAGE registers the SAME id returning :image. A REAL
+            (rf/subscribe :counter/main [:counter/value]) builds the IMAGE sub
+            END-TO-END — proving subscribe wraps the build with
+            call-with-frame-resolution (rf2-uejnt3)."
+    (rf/reg-frame :counter/main {:doc "image-loaded counter frame"})
+    ;; GLOBAL sub.
+    (rf/reg-sub :counter/value (fn [_db _] :global))
+    ;; The frame's IMAGE registers the SAME sub id with a DIFFERENT computation.
+    (let [pool  [(sub-desc "examples.counter" :counter/value (fn [_db _] :image))]
+          img   (image/image {:id :examples/counter :include-ns ["examples.counter"]})
+          _     (lf/make-frame {:id :counter/main :images [img]} pool)]
+      (is (= :image @(rf/subscribe :counter/main [:counter/value]))
+          "the IMAGE sub computed — subscribe resolved [:sub :counter/value]
+           through the target frame's resolved image generation, end-to-end")
+      (is (nil? registrar/*generation*)
+          "the generation binding did NOT leak past the build"))))
+
+;; ===========================================================================
+;; 3. THE HEADLINE — two frames, two DIFFERENT images, SAME id, via REAL
+;;    dispatch: each resolves to its OWN image's handler (no global clobber).
+;; ===========================================================================
+
+(deftest two-frames-different-images-same-id-via-real-dispatch
+  (testing "two runnable frames each loaded with a DIFFERENT image both
+            handling [:boot/init] resolve that id to their OWN image's handler
+            under a REAL frame-targeted dispatch (EP-0023 §Independent Surfaces
+            On One Page — the heart of the same-id story, end-to-end)"
+    (rf/reg-frame :todo/main    {:doc "todo surface"})
+    (rf/reg-frame :counter/main {:doc "counter surface"})
+    ;; A GLOBAL [:boot/init] neither frame should ever run.
+    (rf/reg-event :boot/init
+      (fn [{:keys [db]} _] {:db (assoc db :booted-by :global)}))
+    (let [todo-pool    [(event-desc "examples.todo" :boot/init
+                                    (fn [{:keys [db]} _] {:db (assoc db :booted-by :todo)}))]
+          counter-pool [(event-desc "examples.counter" :boot/init
+                                    (fn [{:keys [db]} _] {:db (assoc db :booted-by :counter)}))]
+          todo-img     (image/image {:id :examples/todo    :include-ns ["examples.todo"]})
+          counter-img  (image/image {:id :examples/counter :include-ns ["examples.counter"]})
+          _ (lf/make-frame {:id :todo/main    :images [todo-img]}    todo-pool)
+          _ (lf/make-frame {:id :counter/main :images [counter-img]} counter-pool)]
+      (rf/dispatch-sync [:boot/init] {:frame :todo/main})
+      (rf/dispatch-sync [:boot/init] {:frame :counter/main})
+      (is (= :todo (:booted-by (rf/app-db-value :todo/main)))
+          "the todo frame ran the TODO image's handler")
+      (is (= :counter (:booted-by (rf/app-db-value :counter/main)))
+          "the counter frame ran the COUNTER image's handler")
+      (testing "neither image leaked into the other (no global clobber)"
+        (is (not= :global (:booted-by (rf/app-db-value :todo/main))))
+        (is (not= :global (:booted-by (rf/app-db-value :counter/main))))))))
+
+;; ===========================================================================
+;; 4. ABSENCE-IS-DEFAULT — a frame with NO image-loaded object resolves through
+;;    the global registrar EXACTLY as before (every realm-only / single-realm
+;;    frame is byte-identical).
+;; ===========================================================================
+
+(deftest no-image-frame-resolves-through-the-global-registrar
+  (testing "a runnable frame with NO live-frame image OBJECT (a realm-only /
+            EP-0013 frame) resolves a frame-targeted dispatch + subscribe through
+            the GLOBAL registrar unchanged — the load-bearing absence-is-default
+            fall-through that keeps every existing caller byte-identical"
+    (rf/reg-frame :plain/main {:doc "no image-loaded object for this frame"})
+    (rf/reg-event :plain/set
+      (fn [{:keys [db]} _] {:db (assoc db :written-by :global)}))
+    (rf/reg-sub :plain/value (fn [db _] (:written-by db)))
+    ;; NO `lf/make-frame` — the frame names no image-loaded object.
+    (rf/dispatch-sync [:plain/set] {:frame :plain/main})
+    (is (= :global (:written-by (rf/app-db-value :plain/main)))
+        "with no image generation, the dispatch resolved the GLOBAL handler")
+    (is (= :global @(rf/subscribe :plain/main [:plain/value]))
+        "with no image generation, the subscribe resolved the GLOBAL sub")
+    (is (nil? registrar/*generation*)
+        "no generation was ever bound for an image-less frame")))
+
+;; ===========================================================================
+;; 5. CHILD DISPATCH coherence — a child dispatch emitted from inside the
+;;    image handler's :fx re-enters process-event! for the SAME frame and
+;;    re-derives the generation, so it ALSO resolves through the frame's image.
+;; ===========================================================================
+
+(deftest child-dispatch-stays-in-the-frames-image
+  (testing "a child [:counter/step] dispatched via :fx from the image's
+            [:counter/inc] handler re-enters process-event! for :counter/main
+            and re-derives the generation — so it ALSO resolves through the
+            frame's image (the cascade stays coherent across child dispatches)"
+    (rf/reg-frame :counter/main {:doc "image-loaded counter frame"})
+    ;; GLOBAL versions both children should NEVER run.
+    (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (assoc db :inc :global)}))
+    (rf/reg-event :counter/step (fn [{:keys [db]} _] {:db (assoc db :step :global)}))
+    (let [pool [(event-desc "examples.counter" :counter/inc
+                            ;; image inc: write its own marker, then dispatch the
+                            ;; child step via :fx (the fx-walker threads the frame).
+                            (fn [{:keys [db]} _]
+                              {:db (assoc db :inc :image)
+                               :fx [[:dispatch [:counter/step]]]}))
+                (event-desc "examples.counter" :counter/step
+                            (fn [{:keys [db]} _] {:db (assoc db :step :image)}))]
+          img  (image/image {:id :examples/counter :include-ns ["examples.counter"]})
+          _    (lf/make-frame {:id :counter/main :images [img]} pool)]
+      (rf/dispatch-sync [:counter/inc] {:frame :counter/main})
+      (let [db (rf/app-db-value :counter/main)]
+        (is (= :image (:inc db))  "the parent resolved the image's inc handler")
+        (is (= :image (:step db))
+            "the CHILD dispatch re-derived the generation and resolved the
+             image's step handler too (coherent across the cascade)")))))


### PR DESCRIPTION
## What

Operationalises the EP-0023 frame-derived resolution seam (rf2-uejnt3, the .9-review graduation-blocker). Slice .9 (rf2-32siq3.9) landed the seam — `registrar/*generation*` + `re-frame.live-frame/call-with-frame-resolution` — and proved `registrar/lookup` routes through a frame's `:rf.gen/resolver` when `*generation*` is bound **manually**. But nothing in the live cascade invoked it, so `(rf/dispatch [:counter/inc] {:frame :counter/main})` ran with `*generation*` UNBOUND and resolved through the **global** registrar, not the frame's image. The EP-0023 headline (same-id / different-image on one page) did not work end-to-end. EP-0023 §Rationale marks the a15n62-equivalent live-resolution a **graduation blocker**.

## How

Invoke the existing seam at the two live entry points where a15n62's `call-with-frame-realm-registrar` already wraps the cascade — nesting `call-with-frame-resolution` **inside** the realm binding so the whole cascade resolves coherently (ALL-OR-NOTHING):

- **`router/process-event!`** (dispatch) — covers the event-handler lookup, every cofx injection, and the whole fx walk; child dispatches re-enter `process-event!` for their frame and re-derive the generation.
- **`subs/subscribe`** (subscribe build) — covers the sub-handler lookup and the recursive layer-2+ input `subscribe` calls inside `compute-and-cache!`.

The generation is **DERIVED from the carried frame target** (EP-0002): a direct frame OBJECT verbatim, a frame-id keyword through the process-local live-frame registry (a small private `frame-resolution-target` twin in each ns). A target naming no image-loaded frame — every EP-0013 realm-only frame and the single-realm default — derives no generation, so `call-with-frame-resolution` binds nothing and resolution falls through to the registrar-atom path, **byte-identical** (absence-is-default).

CALLS the existing `.9` seam only: no change to resolution semantics, no edit to `image_assembly` / `source_store` / `image` / `live_frame` core or the facade. Surface is `router.cljc` + `subs.cljc` + the new test — disjoint from the in-flight image/assembly/facade/live_frame slices.

## Entry points wired

| Path | Site | Wrap |
|------|------|------|
| dispatch | `re-frame.router/process-event!` | `call-with-frame-resolution` nested inside `call-with-frame-realm-registrar` |
| subscribe | `re-frame.subs/subscribe` (build path) | same |

## Acceptance test

`live_cascade_frame_resolution_cljs_test.cljc` — a REAL `(rf/dispatch-sync [...] {:frame F})` and `(rf/subscribe F [...])` (NOT a manual `*generation*` binding) resolve the event/sub handler through frame F's image end-to-end:

1. real frame-targeted dispatch resolves the event handler through the frame's image (global handler writes `:global`; image handler writes `:image`; the image one runs)
2. real frame-targeted subscribe resolves the sub through the frame's image
3. **the headline** — two runnable frames, two different images, same `[:boot/init]` id, via real dispatch → each resolves to its OWN image's handler (no global clobber)
4. **absence-is-default** — a frame with no image-loaded object resolves dispatch + subscribe through the global registrar unchanged
5. child-dispatch coherence — a child dispatched via `:fx` from the image handler re-derives the generation and also resolves through the frame's image

## Gates

- `npm run test:cljs` — 7419 tests / 30544 assertions, 0 failures (includes the new suite + the .9 `frame_resolution_cljs_test`)
- JVM core `clojure -M:test` — 1649 tests / 7188 assertions, 0 failures (the `.cljc` `:clj` arm)
- `scripts/test-fast-pr.sh` — PASS
- `npm run test:elision` — 43/43 absent in production (no leak on the hottest path)
- `npm run test:perf-bundle` — PASS (no budget regression)
- `npm run test:bundle-isolation` — PASS

## Notes

- `.15` conformance-suite coverage is a later slice, out of scope for this bead.
- Per-dispatch cost on the default path: one extra atom deref + map `get` on the (empty in single-realm apps) live-frame registry, returning nil → `call-with-frame-resolution` no-ops. Mirrors a15n62's per-dispatch realm lookup; perf-bundle gate confirms no budget regression.