### PR TITLE
feat(core): EP-0023 default-image projection over source store (rf2-32siq3.24)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -42,6 +42,23 @@
       6. seal the result into an immutable [kind id] resolver;
       7. give the frame that sealed generation (frame loading is slice .7).
 
+  ## The DEFAULT image (rf2-32siq3.24)
+
+  The DEFAULT image (EP-0023 §Default Image Semantics) is the implicit selector
+  over the WHOLE default source store: `reg-*` mutates the source store, and the
+  default image projects ALL of its descriptors (+ the framework standards) into
+  a sealed generation. It is the no-explicit-`:images` frame path. `default-image`
+  is a marker image value (`:rf.image/default? true`) that rides the SAME
+  `assemble*` pipeline + the SAME resolved-generation cache as an explicit image
+  — the only difference is selection (the whole pool rather than an `:include-ns`
+  glob match). Crucially, the default projection FAILS LOUD on a cross-namespace
+  same-`[kind id]` collision via the same `resolve-collision` /
+  `:rf.error/image-duplicate-id` path (no last-write-wins on the default path).
+  Entry points: `assemble-default` (both arities), and `assemble` routes its
+  empty-`:images` case to it. The default generation is cached keyed on the
+  source-store generation (+ standard generation), so it invalidates the instant
+  any `reg-*` / `forget-*` / `clear-*` bumps the store.
+
   ## Validation is FAIL-LOUD (the central guarantee)
 
   Every validation failure throws via the central `re-frame.error/throw-error!`
@@ -279,6 +296,57 @@
         (mapcat source-store/all-descriptors)
         (source-store/kinds-present)))
 
+;; ---- the DEFAULT image (EP-0023 §Default Image Semantics / §Namespace-Selected
+;;      Images) — the implicit selector over the WHOLE default source store ------
+;;
+;; > the default image is the implicit selector over [the default registration]
+;; > source [store] … The default image is the implicit selector over all
+;; > descriptors in the default source store. It works only while selected ids
+;; > are globally unique across the loaded namespaces. If two loaded namespaces
+;; > both register the same `(kind, id)`, the default image does not guess and
+;; > does not let load order win; default image assembly fails with a collision
+;; > error.
+;;
+;; The default image is NOT an `:include-ns` glob image: it selects EVERY
+;; descriptor in the source store, not a namespace-matched subset, so there is
+;; no zero-match concern (an empty store projects an empty generation, which is
+;; valid — a frame with no app registrations resolving only framework
+;; standards). It is a marker image value (`:rf.image/default? true`) so it
+;; flows through the SAME `assemble*` pipeline + the SAME resolved-generation
+;; cache as an explicit image — the only difference is selection: the whole pool
+;; rather than a glob match. Validation + sealing (collision detection via
+;; `resolve-collision` → `:rf.error/image-duplicate-id`, standard union,
+;; reference checks) are byte-identical to the explicit path, so a
+;; cross-namespace same-`[kind id]` collision in the default projection FAILS
+;; LOUD exactly as an explicit image's collision does — load order never decides
+;; the survivor on the default path either.
+
+(def default-image
+  "The DEFAULT image VALUE — the implicit selector over the WHOLE source-store
+  pool (EP-0023 §Default Image Semantics). A normalized image value marked
+  `:rf.image/default? true` (rather than carrying `:include-ns` globs) so it
+  rides the same `assemble*` pipeline + resolved-generation cache as an explicit
+  image; `select-for-images` recognizes the marker and selects every descriptor
+  in the pool. It declares no inline descriptors, no `:include-ns`, no
+  `:rf.image/requires`, and no `:replace` / `:replace-standard` — the default
+  path assumes globally-unique ids and fails loud (`:rf.error/image-duplicate-id`)
+  on any cross-namespace `(kind, id)` collision rather than declaring a winner.
+  A constant value: the default selection is fully described by the marker, so
+  the cache key's image-vector leg is constant and the store-generation +
+  standard-generation legs are the only invalidation signals (EP-0023 §Image —
+  the default generation is cached keyed on the source-store generation)."
+  {:rf.image/default?   true
+   :rf.image/include-ns []
+   :rf.image/inline     []
+   :rf.image/requires   #{}})
+
+(defn default-image?
+  "True when `image` is the DEFAULT image value — the implicit whole-store
+  selector (`:rf.image/default? true`), as opposed to an explicit `rf/image`
+  value. Pure."
+  [image]
+  (boolean (:rf.image/default? image)))
+
 (defn select-for-images
   "Run slice-.3's `image/select-descriptors` for EACH image value in `images`
   against `descriptors` (the source-store pool), returning the concatenated
@@ -286,10 +354,20 @@
   descriptors). Order is image order then selector order; collision validation
   (which makes order irrelevant to the WINNER) runs downstream. Any zero-match
   `:include-ns` pattern fails loud inside `select-descriptors` (slice .3).
+
+  The DEFAULT image (`default-image?`) is the implicit whole-store selector
+  (EP-0023 §Default Image Semantics): it selects EVERY descriptor in
+  `descriptors` rather than running a glob, with no zero-match fail-loud (an
+  empty store is a valid empty default projection). Every other case routes
+  through the pure `:include-ns`/inline selector unchanged.
+
   Pure — a function of the image values and the candidate pool."
   [images descriptors]
   (into []
-        (mapcat #(image/select-descriptors % descriptors))
+        (mapcat (fn [image]
+                  (if (default-image? image)
+                    descriptors
+                    (image/select-descriptors image descriptors))))
         images))
 
 ;; ===========================================================================
@@ -978,6 +1056,12 @@
         (swap! generation-cache assoc k gen)
         gen))))
 
+;; `assemble` routes its empty-`:images` case to `assemble-default` (the
+;; dedicated default-projection entry, defined just below). Forward-declared so
+;; the narrative order — the general `assemble`, then its default sibling — reads
+;; top-down.
+(declare assemble-default)
+
 (defn assemble
   "Resolve `images` (a seq of normalized `rf/image` values) into a SEALED,
   VALIDATED image generation (EP-0023 §Image Validation). The integration of
@@ -1023,8 +1107,10 @@
                                    pool value itself (the live store generation
                                    does not describe an explicit pool).
 
-  `images` may be a single image value (wrapped) or a seq. Returns the sealed
-  generation:
+  `images` may be a single image value (wrapped) or a seq. An EMPTY (or nil)
+  `images` is the DEFAULT-image case — it projects `default-image`, the implicit
+  selector over the WHOLE source store (EP-0023 §Default Image Semantics; see
+  `assemble-default`). Returns the sealed generation:
 
     {:rf.gen/resolver {[kind id] descriptor …}
      :rf.gen/images   [<image value> …]
@@ -1032,17 +1118,69 @@
      :rf.gen/kinds    #{kind …}}"
   ([images]
    (let [images (if (map? images) [images] (vec images))]
-     ;; Live-store arity: the pool leg is the source-store generation. Read it
-     ;; BEFORE selecting so the cached object is keyed to the store snapshot it
-     ;; was assembled from.
-     (assemble-cached images
-                      (source-store-descriptors)
-                      (source-store/store-generation))))
+     (if (empty? images)
+       ;; No explicit image ⇒ the DEFAULT image projection over the live store.
+       (assemble-default)
+       ;; Live-store arity: the pool leg is the source-store generation. Read it
+       ;; BEFORE selecting so the cached object is keyed to the store snapshot it
+       ;; was assembled from.
+       (assemble-cached images
+                        (source-store-descriptors)
+                        (source-store/store-generation)))))
   ([images descriptors]
    (let [images (if (map? images) [images] (vec images))]
-     ;; Explicit-pool arity: the pool leg is the descriptor pool value itself —
-     ;; the live store generation does not describe a supplied pool.
-     (assemble-cached images descriptors descriptors))))
+     (if (empty? images)
+       ;; No explicit image ⇒ the DEFAULT image projection over the supplied
+       ;; pool (the deterministic explicit-pool form for tests/harnesses).
+       (assemble-default descriptors)
+       ;; Explicit-pool arity: the pool leg is the descriptor pool value itself —
+       ;; the live store generation does not describe a supplied pool.
+       (assemble-cached images descriptors descriptors)))))
+
+(defn assemble-default
+  "Resolve the DEFAULT image — the implicit selector over the WHOLE registration
+  source store + the framework standards — into a SEALED, VALIDATED image
+  generation (EP-0023 §Default Image Semantics / Bead Plan item 6). The default
+  path projects ALL default-source `reg-*` descriptors into the default image
+  generation, FAILING LOUD if that projection contains same-kind same-id
+  collisions.
+
+  This is the no-explicit-`:images` frame path: `reg-*` mutates the default
+  source store, and the default image is the implicit selector over that store.
+  It runs through the SAME `assemble*` pipeline + the SAME resolved-generation
+  cache as an explicit image — selection (the whole pool, via the `default-image`
+  marker), the framework-standard union, collision validation, reference checks,
+  and sealing are byte-identical. So a cross-namespace same-`(kind, id)`
+  collision in the default projection FAILS LOUD with
+  `:rf.error/image-duplicate-id` (via `resolve-collision`) exactly as an explicit
+  image's collision does — load order NEVER silently decides the survivor on the
+  default path; there is no last-write-wins. A product that intentionally wants
+  same ids with different meanings must use explicit images with disjoint
+  selectors (EP-0023 §Default Image Semantics).
+
+  Two arities mirror `assemble`:
+    (assemble-default)            — select against the LIVE source store; the
+                                   cache key's pool leg is the source-store
+                                   generation, so the default generation is
+                                   cached and invalidated the instant any
+                                   `reg-*` / `forget-*` / `clear-*` bumps it
+                                   (EP-0023 §Image — the default generation is
+                                   cached keyed on the source-store generation).
+    (assemble-default descriptors)— select against an explicit descriptor pool
+                                   (tests / harnesses / a pre-snapshotted store);
+                                   the pool leg is the descriptor pool value
+                                   itself (the deterministic test form).
+
+  The default image carries no `:include-ns` (so no zero-match fail-loud — an
+  empty store is a valid empty default projection resolving only the framework
+  standards) and no inline / replacement declarations. Returns the sealed
+  generation (the same shape `assemble` returns)."
+  ([]
+   (assemble-cached [default-image]
+                    (source-store-descriptors)
+                    (source-store/store-generation)))
+  ([descriptors]
+   (assemble-cached [default-image] descriptors descriptors)))
 
 ;; ===========================================================================
 ;; The resolver READ API — the surface slices .7 / .8 (frame loading,

--- a/implementation/core/test/re_frame/image_assembly_default_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_default_cljs_test.cljc
@@ -1,0 +1,284 @@
+(ns re-frame.image-assembly-default-cljs-test
+  "EP-0023 §Default Image Semantics / Bead Plan item 6 — the DEFAULT image
+  projection over the source store (rf2-32siq3.24).
+
+  > the default image is the implicit selector over [the default registration]
+  > source [store] … The default image is the implicit selector over all
+  > descriptors in the default source store. It works only while selected ids
+  > are globally unique across the loaded namespaces. If two loaded namespaces
+  > both register the same `(kind, id)`, the default image does not guess and
+  > does not let load order win; default image assembly fails with a collision
+  > error.
+
+  Pins the bead's enumerated coverage:
+
+    * the default projection includes ALL source-store descriptors + the
+      framework standards;
+    * a cross-namespace same-`(kind, id)` collision in the default projection
+      FAILS LOUD (`:rf.error/image-duplicate-id`) — no clobber, no
+      last-write-wins on the default path;
+    * the default generation is CACHED and INVALIDATES on a source-store change
+      (the .7 cache, keyed on the source-store generation);
+    * a single-namespace default projects cleanly;
+    * `assemble` with NO / empty `:images` routes to the default projection
+      (the empty-images entry).
+
+  Each fail-loud assertion checks the `:rf.error/id` discriminator, never the
+  message bytes (Spec 009 §The thrown-error shape rule 3).
+
+  The deterministic projection cases use the EXPLICIT-POOL form
+  `(assemble-default descriptors)` — no live source-store mutation. The
+  cache-invalidation case needs the LIVE store, so it SNAPSHOTS the source-store
+  atom and RESTORES it (per the bead — no `clear-all!` that would destroy
+  authored registrations) and clears only the derived standard registry +
+  generation cache. `.cljc` ending `-cljs-test` rides `npm run test:cljs` AND
+  `clojure -M:test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.image-assembly :as asm]
+            [re-frame.source-store   :as ss]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture — SNAPSHOT/RESTORE the live source store (do NOT clear-all! — that
+;; would destroy real authored registrations). The standard registry + the
+;; generation cache are DERIVED process state, safe to reset per case so a stale
+;; generation never leaks across a case that mutated the store.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (fn [t]
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (asm/clear-standards!)
+      (asm/clear-generation-cache!)
+      (try
+        (t)
+        (finally
+          ;; Restore the source store to exactly its pre-case contents.
+          (reset! ss/kind->id->ns->descriptor store-before)
+          (asm/clear-standards!)
+          (asm/clear-generation-cache!))))))
+
+;; ---------------------------------------------------------------------------
+;; Synthetic registered descriptors — same shape the selector consumes. The
+;; load-bearing field for collision detection is :rf.provenance/ns (the source
+;; coordinate) + :handler-fn (the impl that distinguishes a real collision from
+;; a dedupe).
+;; ---------------------------------------------------------------------------
+
+(defn- reg-desc
+  "A synthetic REGISTERED descriptor authored in `provenance-ns`."
+  [provenance-ns kind id impl]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :handler-fn       impl})
+
+(defn- assembly-error-id
+  "Run `thunk`; return the `:rf.error/id` of the thrown ex-info (or nil if it did
+  not throw). Branches on the discriminator, never the message."
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+(defn- record! [provenance-ns kind id impl]
+  (ss/record-descriptor! kind id {:ns provenance-ns :kind kind :id id
+                                  :handler-fn impl}))
+
+;; ===========================================================================
+;; 1. The default projection includes ALL source-store descriptors + standards
+;; ===========================================================================
+
+(deftest default-projection-includes-the-whole-pool-plus-standards
+  (testing "the default image is the implicit selector over the WHOLE source
+            store: it projects EVERY descriptor across every namespace + the
+            framework standards into a sealed [kind id] resolver"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+    (let [pool [(reg-desc "shop.cart"    :event :cart/add   ::cart-add)
+                (reg-desc "shop.cart"    :sub   :cart/items ::cart-items)
+                (reg-desc "shop.auth"    :event :auth/login ::auth-login)
+                (reg-desc "shop.catalog" :view  :catalog/grid ::grid)]
+          gen  (asm/assemble-default pool)]
+      (testing "every namespace's descriptors are selected (no glob — the whole
+                store)"
+        (is (contains? (:rf.gen/resolver gen) [:event :cart/add]))
+        (is (contains? (:rf.gen/resolver gen) [:sub   :cart/items]))
+        (is (contains? (:rf.gen/resolver gen) [:event :auth/login]))
+        (is (contains? (:rf.gen/resolver gen) [:view  :catalog/grid])))
+      (testing "the framework standard is unioned in, exactly as the explicit
+                path"
+        (is (contains? (:rf.gen/resolver gen) [:fx :rf.nav/push-url]))
+        (is (= ::std-nav (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))))
+      (testing "resolve-descriptor reads one descriptor per (kind, id)"
+        (is (= ::cart-add (:handler-fn (asm/resolve-descriptor gen :event :cart/add))))
+        (is (= ::grid (:handler-fn (asm/resolve-descriptor gen :view :catalog/grid)))))
+      (testing "the generation carries the kinds present"
+        (is (= #{:event :sub :view :fx} (asm/generation-kinds gen)))))))
+
+(deftest empty-store-default-projects-an-empty-generation
+  (testing "the default image over an EMPTY source store is a VALID empty
+            projection (resolving only framework standards) — no zero-match
+            fail-loud, unlike an :include-ns glob"
+    (let [gen (asm/assemble-default [])]
+      (is (map? gen))
+      (is (= {} (:rf.gen/resolver gen)))
+      (is (= #{} (asm/generation-kinds gen)))
+      (testing "with only a framework standard present, the default projects it"
+        (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std})
+        (asm/clear-generation-cache!) ;; the standard generation also invalidates
+        (let [gen2 (asm/assemble-default [])]
+          (is (contains? (:rf.gen/resolver gen2) [:fx :rf.nav/push-url])))))))
+
+;; ===========================================================================
+;; 2. Cross-namespace same-(kind, id) collision FAILS LOUD — no clobber, no
+;;    last-write-wins on the default path (the central rule).
+;; ===========================================================================
+
+(deftest default-projection-cross-namespace-collision-fails-loud
+  (testing "two namespaces registering the same (kind, id) with different impls,
+            both in the source store, with NO explicit image to disambiguate →
+            :rf.error/image-duplicate-id (the default image does NOT guess and
+            does NOT let load order win)"
+    (let [pool [(reg-desc "examples.todo.boot"    :event :boot/init ::todo-boot)
+                (reg-desc "examples.counter.boot" :event :boot/init ::counter-boot)]]
+      (is (= :rf.error/image-duplicate-id
+             (assembly-error-id #(asm/assemble-default pool)))))))
+
+(deftest default-projection-collision-order-independent
+  (testing "the default-projection duplicate-id error fires regardless of pool
+            order — there is no last-write that 'wins' on the default path"
+    (let [a (reg-desc "examples.todo.boot"    :event :boot/init ::a)
+          b (reg-desc "examples.counter.boot" :event :boot/init ::b)]
+      (is (= :rf.error/image-duplicate-id
+             (assembly-error-id #(asm/assemble-default [a b]))))
+      (is (= :rf.error/image-duplicate-id
+             (assembly-error-id #(asm/assemble-default [b a])))))))
+
+(deftest default-projection-same-namespace-replacement-is-not-a-collision
+  (testing "the same (kind, id) in the SAME namespace is the hot-reload
+            replacement path — the source store keeps ONE slot, so the default
+            projection sees ONE descriptor and seals cleanly (no spurious
+            collision)"
+    ;; A genuine same-ns replacement: the store keeps one slot per
+    ;; [kind id provenance-ns], so two records for the same ns leave ONE.
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (try
+        (reset! ss/kind->id->ns->descriptor {})
+        (record! "counter.core" :event :counter/inc ::v1)
+        (record! "counter.core" :event :counter/inc ::v2) ;; replaces ::v1
+        (let [gen (asm/assemble-default
+                    (into [] (mapcat ss/all-descriptors) (ss/kinds-present)))]
+          (is (= ::v2 (:handler-fn (asm/resolve-descriptor gen :event :counter/inc)))
+              "the same-namespace re-register replaced the slot; one descriptor seals"))
+        (finally (reset! ss/kind->id->ns->descriptor store-before))))))
+
+;; ===========================================================================
+;; 3. Single-namespace default projects cleanly
+;; ===========================================================================
+
+(deftest single-namespace-default-projects-cleanly
+  (testing "the ordinary single-surface case: one namespace's globally-unique
+            registrations project into a clean default generation"
+    (let [pool [(reg-desc "app.core" :event :counter/inc   ::inc)
+                (reg-desc "app.core" :sub   :counter/value ::value)
+                (reg-desc "app.core" :view  :counter/view  ::view)]
+          gen  (asm/assemble-default pool)]
+      (is (= ::inc   (:handler-fn (asm/resolve-descriptor gen :event :counter/inc))))
+      (is (= ::value (:handler-fn (asm/resolve-descriptor gen :sub :counter/value))))
+      (is (= ::view  (:handler-fn (asm/resolve-descriptor gen :view :counter/view))))
+      (is (= #{:event :sub :view} (asm/generation-kinds gen))))))
+
+;; ===========================================================================
+;; 4. `assemble` with NO / empty :images routes to the default projection
+;; ===========================================================================
+
+(deftest assemble-empty-images-is-the-default-projection
+  (testing "`assemble` with an empty :images vector projects the DEFAULT image
+            (the implicit whole-store selector) — the no-explicit-image frame
+            path produces the same generation as `assemble-default`"
+    (let [pool [(reg-desc "app.core" :event :counter/inc ::inc)]
+          via-empty   (asm/assemble [] pool)
+          via-default (asm/assemble-default pool)]
+      (is (contains? (:rf.gen/resolver via-empty) [:event :counter/inc]))
+      (is (= via-default via-empty)
+          "the empty-:images path equals the explicit default projection")
+      (is (identical? via-default via-empty)
+          "and shares the one cached default generation object"))))
+
+(deftest assemble-empty-images-collision-fails-loud
+  (testing "the empty-:images default path fails loud on a cross-namespace
+            collision exactly as `assemble-default` does"
+    (let [pool [(reg-desc "todo.boot"    :event :boot/init ::a)
+                (reg-desc "counter.boot" :event :boot/init ::b)]]
+      (is (= :rf.error/image-duplicate-id
+             (assembly-error-id #(asm/assemble [] pool)))))))
+
+;; ===========================================================================
+;; 5. The default generation is CACHED + invalidates on a source-store change
+;;    (the .7 cache, keyed on the source-store generation). Uses the LIVE store
+;;    so the store-generation invalidation fires for real; snapshot/restore in
+;;    the body keeps the live store clean.
+;; ===========================================================================
+
+(deftest default-generation-is-cached-and-invalidates-on-store-change
+  (testing "the LIVE-store default projection is cached (the SAME sealed object
+            on a repeat) and INVALIDATES the instant a `reg-*` bumps the
+            source-store generation (EP-0023 §Image — the default generation is
+            cached keyed on the source-store generation)"
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (try
+        ;; Start from a known clean live store for a deterministic generation.
+        (reset! ss/kind->id->ns->descriptor {})
+        (asm/clear-generation-cache!)
+        (record! "shop.cart" :event :cart/add ::add)
+        (let [gen1 (asm/assemble-default)
+              gen1b (asm/assemble-default)]
+          (testing "a repeat assembly over the UNCHANGED live store reuses the
+                    SAME sealed object (the cache HIT)"
+            (is (identical? gen1 gen1b))
+            (is (= 1 (asm/cache-size))))
+          (is (not (contains? (:rf.gen/resolver gen1) [:sub :cart/items])))
+          ;; A new registration bumps the source-store generation.
+          (record! "shop.cart" :sub :cart/items ::items)
+          (let [gen2 (asm/assemble-default)]
+            (testing "the store changed → a re-seal, NOT the stale cached object"
+              (is (not (identical? gen1 gen2)))
+              (is (contains? (:rf.gen/resolver gen2) [:sub :cart/items])
+                  "the re-sealed default generation reflects the new registration")
+              (is (= 2 (asm/cache-size))
+                  "both the pre- and post-change default generations are cached"))))
+        (finally
+          (reset! ss/kind->id->ns->descriptor store-before)
+          (asm/clear-generation-cache!))))))
+
+(deftest default-generation-invalidates-on-standard-change
+  (testing "registering a NEW framework standard bumps the standard generation,
+            so a re-assembly of the default image over the same store is a MISS
+            — the standard set is part of the default generation too"
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (try
+        (reset! ss/kind->id->ns->descriptor {})
+        (asm/clear-generation-cache!)
+        (record! "app.core" :event :app/boot ::boot)
+        (let [gen1 (asm/assemble-default)]
+          (is (not (contains? (:rf.gen/resolver gen1) [:fx :rf.nav/push-url])))
+          (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+          (let [gen2 (asm/assemble-default)]
+            (is (not (identical? gen1 gen2))
+                "the standard set changed → a re-seal of the default generation")
+            (is (contains? (:rf.gen/resolver gen2) [:fx :rf.nav/push-url]))))
+        (finally
+          (reset! ss/kind->id->ns->descriptor store-before)
+          (asm/clear-generation-cache!))))))
+
+;; ===========================================================================
+;; 6. `default-image?` predicate + the default-image marker value
+;; ===========================================================================
+
+(deftest default-image-marker-and-predicate
+  (testing "`default-image` is the marker value; `default-image?` recognizes it
+            and rejects an ordinary explicit image value"
+    (is (asm/default-image? asm/default-image))
+    (is (true? (:rf.image/default? asm/default-image)))
+    (is (not (asm/default-image? {:rf.image/include-ns ["a.b"]})))
+    (is (not (asm/default-image? {})))))


### PR DESCRIPTION
## What

Implements the **default-image projection** over the registration source store (EP-0023 §Default Image Semantics / Bead Plan item 6) — the last EP-0023 assembly slice. Builds on merged .2–.10, .17–.22, .25, .26, uejnt3.

The default image is the **implicit selector over the WHOLE default registration source store**. This adds it to `image_assembly.cljc`:

- **`default-image`** — a marker image value (`:rf.image/default? true`) that rides the **same** `assemble*` pipeline + resolved-generation cache as an explicit image. The only difference is selection: the whole pool rather than an `:include-ns` glob match.
- **`select-for-images`** recognizes the marker and selects every descriptor in the pool. No zero-match fail-loud (an empty store is a valid empty default projection resolving only the framework standards).
- **`assemble-default`** (live-store + explicit-pool arities) is the dedicated entry point; **`assemble` routes its empty-`:images` case** to it (so the no-explicit-image frame path projects the default image).

## Fail-loud on cross-namespace collisions (the .4 acceptance)

A cross-namespace same-`[kind id]` collision in the default projection **FAILS LOUD** with `:rf.error/image-duplicate-id` via the existing `resolve-collision` path — load order never silently decides the survivor on the default path; there is **no last-write-wins**. The default path is byte-identical to the explicit path through validation + sealing, so it reuses the existing assembly error catalogue. **spec/009 unchanged** (no new error category).

## Caching (.7)

The default generation is cached keyed on the **source-store generation** (+ standard generation), reusing the existing resolved-generation cache machinery (the `default-image` value is constant, so its image-vector key leg is constant and the store/standard generations are the only invalidation signals). It invalidates the instant any `reg-*` / `forget-*` / `clear-*` bumps the store.

## Tests

`image_assembly_default_cljs_test.cljc`:
- default projection includes ALL source-store descriptors + framework standards;
- cross-namespace same-`[kind id]` collision fails loud (order-independent — no clobber);
- single-namespace default projects cleanly; same-namespace re-register is hot-reload replacement, not a collision;
- the default generation is cached (identical object on a repeat) and invalidates on a source-store / standard change;
- `assemble` with empty `:images` equals + shares the cached default projection.

Source-store fixtures **snapshot/restore** the live store (no `clear-all!`).

## Surface lane

Edits confined to `image_assembly.cljc` + its test. **`live_frame.cljc` untouched** (the in-flight .11 migration owns it). See the note below — a small make-frame wiring follow-on is needed.

## Gates
- `npm run test:cljs` — 7477 tests / 30759 assertions, 0 failures, 0 errors ✅
- `npm run test:elision` — production 43/43 absent, control 43/43 present ✅
- `scripts/test-fast-pr.sh` — PASS ✅

## Follow-on needed (do NOT do here — sequence after .11)
`make-frame`'s no-`:images` path should call `assemble-default` (or `assemble` with empty images) so a frame created without explicit images runs the default image generation. That wiring lives in `live_frame.cljc`, which slice .11 is restructuring in parallel — left for a sequenced follow-on per the bead brief.