### PR TITLE
feat(core): wire make-frame no-:images path to default-image projection (rf2-32siq3.33)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -391,7 +391,17 @@
   an absent map provides nothing, EP-0013 fail-loud parity). Returns the sealed
   generation. The shared resolution `make-frame` and `reload-images!` both use,
   so a reload resolves with byte-identical semantics to creation. Fail-loud on a
-  non-vector `:images`, an assembly error, or a missing capability."
+  non-vector `:images`, an assembly error, or a missing capability.
+
+  An ABSENT or EMPTY `:images` is the DEFAULT-IMAGE path (EP-0023 §Default Image
+  Semantics): nil `images` normalizes to `[]`, and `assemble` routes an empty
+  `:images` vector through `assemble-default` — the implicit selector over the
+  WHOLE source store (+ the framework standards), NOT the framework standards
+  alone. So a frame created with no explicit images runs every `reg-*`-authored
+  descriptor in the (live or supplied) source store, and a cross-namespace
+  same-`[kind id]` collision in that default projection FAILS LOUD here at
+  make-frame time (`:rf.error/image-duplicate-id`) exactly as an explicit
+  image's collision does — load order never silently decides the survivor."
   [images capabilities descriptors]
   (let [images     (if (some? images) (validate-images! images) [])
         generation (if (nil? descriptors)
@@ -422,8 +432,15 @@
                    image values are resolved into ONE sealed image generation via
                    `re-frame.image-assembly/assemble`; a non-vector `:images`
                    fails loud (`:rf.error/make-frame-bad-images`). Optional — a
-                   frame created with no `:images` resolves the framework
-                   standard set alone (the default-image path is a later slice).
+                   frame created with NO `:images` (absent or `[]`) runs the
+                   DEFAULT IMAGE (EP-0023 §Default Image Semantics): the implicit
+                   selector over the WHOLE source store (+ the framework
+                   standards), so it resolves every `reg-*`-authored registration,
+                   NOT the framework standards alone. The default projection
+                   FAILS LOUD on a cross-namespace same-`[kind id]` collision
+                   (`:rf.error/image-duplicate-id`) — load order never decides
+                   the survivor (a product wanting same ids with different
+                   meanings uses explicit images with disjoint selectors).
     :id            the frame id (optional). When supplied, the returned object is
                    registered in the PROCESS-LOCAL LIVE-FRAME REGISTRY under this
                    id; a duplicate live id fails loud

--- a/implementation/core/test/re_frame/live_frame_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_cljs_test.cljc
@@ -10,6 +10,13 @@
     * `:images` (a vector) resolves to a generation carried on the frame object;
     * the frame object holds a reference to its resolved generation
       (`:rf.frame/generation`);
+    * the NO-`:images` path (absent or `[]`) runs the DEFAULT IMAGE — the
+      implicit selector over the WHOLE source store (rf2-32siq3.33): the
+      generation includes the store's `reg-*` descriptors (+ standards), NOT the
+      framework standards alone, and a cross-namespace same-`[kind id]` collision
+      in that default projection FAILS LOUD at make-frame time
+      (`:rf.error/image-duplicate-id`). Covered for both the explicit-pool
+      2-arity and the bare live-store 1-arity;
     * an `:id` registers the object in the live-frame registry;
     * a duplicate live `:id` FAILS LOUD (`:rf.error/live-frame-id-conflict`);
     * a direct (no-id) frame object BYPASSES the registry;
@@ -23,29 +30,44 @@
   Each fail-loud assertion checks the `:rf.error/id` discriminator (NEVER the
   message bytes — Spec 009 §The thrown-error shape rule 3).
 
-  Resolution runs against an explicit synthetic descriptor pool (the
-  `make-frame` 2-arity), so there is no live source-store wiring — the same
-  decoupling idiom `image-assembly-cljs-test` uses. The live-frame registry IS
-  process state, so a fixture clears it per case. `.cljc` ends `-cljs-test` so
-  it rides `npm run test:cljs` AND `clojure -M:test`."
+  Most cases resolve against an explicit synthetic descriptor pool (the
+  `make-frame` 2-arity) — the same decoupling idiom `image-assembly-cljs-test`
+  uses. The default-image cases additionally exercise the BARE live-store 1-arity
+  (`make-frame {}`), which reads the live source store; those snapshot/restore
+  the store (never `clear-all!`, which would destroy real authored
+  registrations). The live-frame registry, the standard registry, the generation
+  cache, and the source store are all process state, so the fixture
+  snapshot/restores or clears them per case. `.cljc` ends `-cljs-test` so it
+  rides `npm run test:cljs` AND `clojure -M:test`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.image       :as image]
             [re-frame.image-assembly :as asm]
-            [re-frame.live-frame  :as lf]))
+            [re-frame.live-frame  :as lf]
+            [re-frame.source-store   :as ss]))
 
 ;; ---------------------------------------------------------------------------
-;; Fixture — both the live-frame registry and the framework-standard registry
-;; are process-state defonce atoms; clear per case.
+;; Fixture — the live-frame registry, the framework-standard registry, and the
+;; resolved-generation cache are process-state defonce atoms; clear them per
+;; case. The source store is ALSO process state (the DEFAULT-image path reads it
+;; live), so SNAPSHOT/RESTORE it — do NOT `clear-all!`, which would destroy real
+;; authored registrations (per the bead). The live-store default-image tests
+;; mutate the store inside their own snapshot/restore body too.
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
   (fn [t]
-    (lf/clear-live-frames!)
-    (asm/clear-standards!)
-    (t)
-    (lf/clear-live-frames!)
-    (asm/clear-standards!)))
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (lf/clear-live-frames!)
+      (asm/clear-standards!)
+      (asm/clear-generation-cache!)
+      (try
+        (t)
+        (finally
+          (lf/clear-live-frames!)
+          (asm/clear-standards!)
+          (asm/clear-generation-cache!)
+          (reset! ss/kind->id->ns->descriptor store-before))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -70,6 +92,14 @@
 (def ^:private counter-pool
   [(reg-desc "examples.counter" :event :counter/inc ::inc)
    (reg-desc "examples.counter" :sub   :counter/value ::value)])
+
+(defn- record!
+  "Record one registered descriptor into the LIVE source store (the same path a
+  `reg-*` walks) so the DEFAULT image — the implicit whole-store selector — can
+  project it. The fixture snapshot/restores the store around the case."
+  [provenance-ns kind id impl]
+  (ss/record-descriptor! kind id {:ns provenance-ns :kind kind :id id
+                                  :handler-fn impl}))
 
 ;; ===========================================================================
 ;; 1. :images (a vector) resolves to a generation carried on the frame object
@@ -105,12 +135,93 @@
       (is (some? (asm/resolve-descriptor gen :event :widgets/init)))
       (is (some? (asm/resolve-descriptor gen :event :counter/inc))))))
 
-(deftest no-images-resolves-the-standard-set-alone
-  (testing "make-frame with no :images resolves the framework standard set alone
-            — a valid (empty-app) generation, still returning a frame object"
-    (let [frame (lf/make-frame {} [])]
+;; ===========================================================================
+;; 1b. The no-`:images` path runs the DEFAULT IMAGE — the implicit whole-store
+;;     projection (EP-0023 §Default Image Semantics, rf2-32siq3.33), NOT the
+;;     framework standard set alone. Both the explicit-pool 2-arity and the bare
+;;     live-store 1-arity are covered; a cross-namespace collision in the default
+;;     fails loud at make-frame time.
+;; ===========================================================================
+
+(deftest no-images-runs-the-default-image-over-the-explicit-pool
+  (testing "make-frame with NO :images (and an explicit descriptor pool) runs the
+            DEFAULT image — the implicit selector over the WHOLE pool — so the
+            frame's generation INCLUDES a reg-*'d descriptor from the store, not
+            just the framework standards"
+    (asm/register-standard! :fx :rf.nav/push-url {:handler-fn ::std-nav})
+    (let [frame (lf/make-frame {} counter-pool)
+          gen   (lf/frame-generation frame)]
       (is (lf/frame-object? frame))
-      (is (some? (lf/frame-generation frame))))))
+      (is (some? gen))
+      (testing "the whole-pool reg-* descriptors are projected (default image,
+                NOT standards-only)"
+        (is (some? (asm/resolve-descriptor gen :event :counter/inc))
+            "a reg-*'d descriptor from the source pool is in the default generation")
+        (is (= ::inc (:handler-fn (asm/resolve-descriptor gen :event :counter/inc))))
+        (is (some? (asm/resolve-descriptor gen :sub :counter/value))))
+      (testing "the framework standard is also unioned in (default = pool + standards)"
+        (is (some? (asm/resolve-descriptor gen :fx :rf.nav/push-url)))))))
+
+(deftest empty-images-vector-is-the-default-image-path
+  (testing "make-frame with :images [] is the SAME default-image path as no
+            :images at all (an empty vector ⇒ the implicit whole-store selector)"
+    (let [frame (lf/make-frame {:images []} counter-pool)
+          gen   (lf/frame-generation frame)]
+      (is (lf/frame-object? frame))
+      (is (some? (asm/resolve-descriptor gen :event :counter/inc))
+          "an empty :images vector projects the whole-store default, not standards-only"))))
+
+(deftest no-images-default-cross-namespace-collision-fails-loud
+  (testing "a cross-namespace same-(kind, id) collision in the DEFAULT projection
+            makes make-frame FAIL LOUD (:rf.error/image-duplicate-id) — the
+            no-:images default does not guess and does not let load order win"
+    (let [colliding-pool
+          [(reg-desc "examples.todo.boot"    :event :boot/init ::todo-boot)
+           (reg-desc "examples.counter.boot" :event :boot/init ::counter-boot)]]
+      (is (= :rf.error/image-duplicate-id
+             (err-id #(lf/make-frame {} colliding-pool))))
+      (testing "the collision fires regardless of pool order (no last-write-wins)"
+        (is (= :rf.error/image-duplicate-id
+               (err-id #(lf/make-frame {} (vec (reverse colliding-pool))))))))))
+
+(deftest bare-make-frame-runs-the-default-image-over-the-live-store
+  (testing "the BARE 1-arity make-frame (no descriptor pool) resolves the DEFAULT
+            image against the LIVE source store, so a frame created with no
+            :images runs every reg-*-authored registration in the store"
+    ;; Drive from a known-clean live store inside a snapshot/restore body so the
+    ;; default projection is deterministic; the fixture also restores the store.
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (try
+        (reset! ss/kind->id->ns->descriptor {})
+        (asm/clear-generation-cache!)
+        (record! "shop.cart" :event :cart/add   ::cart-add)
+        (record! "shop.cart" :sub   :cart/items ::cart-items)
+        (let [frame (lf/make-frame {})
+              gen   (lf/frame-generation frame)]
+          (is (lf/frame-object? frame))
+          (is (some? (asm/resolve-descriptor gen :event :cart/add))
+              "the bare make-frame default projection includes the live-store reg-*")
+          (is (= ::cart-add (:handler-fn (asm/resolve-descriptor gen :event :cart/add))))
+          (is (some? (asm/resolve-descriptor gen :sub :cart/items))))
+        (finally
+          (reset! ss/kind->id->ns->descriptor store-before)
+          (asm/clear-generation-cache!))))))
+
+(deftest bare-make-frame-default-live-store-collision-fails-loud
+  (testing "the BARE 1-arity make-frame fails loud (:rf.error/image-duplicate-id)
+            when the LIVE source store carries a cross-namespace same-(kind, id)
+            collision in the default projection"
+    (let [store-before @ss/kind->id->ns->descriptor]
+      (try
+        (reset! ss/kind->id->ns->descriptor {})
+        (asm/clear-generation-cache!)
+        (record! "examples.todo.boot"    :event :boot/init ::todo-boot)
+        (record! "examples.counter.boot" :event :boot/init ::counter-boot)
+        (is (= :rf.error/image-duplicate-id
+               (err-id #(lf/make-frame {}))))
+        (finally
+          (reset! ss/kind->id->ns->descriptor store-before)
+          (asm/clear-generation-cache!))))))
 
 ;; ===========================================================================
 ;; 2. :id registers the object in the process-local live-frame registry


### PR DESCRIPTION
## What

Wire `rf/make-frame`'s no-`:images` path (absent or `[]`) to the **default-image projection** — the implicit selector over the WHOLE source store (+ framework standards) — instead of the prior framework-standards-set-only behaviour (EP-0023 §Default Image Semantics, rf2-32siq3.33).

## How

The behaviour rides .24's `assemble` / `assemble-default` routing: `resolve-generation!` normalizes an absent `:images` to `[]`, and `assemble` routes the empty-`:images` case through `assemble-default` (the whole-store selector). This commit makes the path explicit and correct:

- **`live_frame.cljc`** — updated the `make-frame` and `resolve-generation!` docs, which still described the stale "framework standards alone / default-image path is a later slice" behaviour. No new facade export; `image_assembly.cljc` untouched (its API is complete — `make-frame` just calls it).
- A frame with no explicit images now resolves every `reg-*`-authored descriptor in the (live or supplied) source store, and a **cross-namespace same-`[kind id]` collision in the default projection FAILS LOUD at make-frame time** (`:rf.error/image-duplicate-id`, via the existing collision path) — load order never silently decides the survivor.

## Tests

Replaced the stale `no-images-resolves-the-standard-set-alone` test with default-image coverage at the `make-frame` boundary:

- the default generation **includes a `reg-*`'d source-store descriptor** (not just standards) — covered for the explicit-pool 2-arity AND the bare live-store 1-arity (`make-frame {}`);
- `:images []` is the same default path as no `:images`;
- a default-projection cross-namespace collision makes `make-frame` fail loud (order-independent), both for the explicit-pool and the live-store arity.

The fixture now **snapshot/restores the live source store** (and clears the standard registry + generation cache) — no `clear-all!`.

## Gates (all green)

- `implementation/`: `npm run test:cljs` — 7489 tests / 30825 assertions, 0 failures; `npm run test:elision` — clean (43/43 production-absent).
- repo root: `sh scripts/test-fast-pr.sh` — PASS.
- targeted JVM `re-frame.live-frame-cljs-test` — 19 tests / 56 assertions, 0 failures.

Surface lane: `live_frame.cljc` + its test only. No facade/api-manifest change, no `image_assembly.cljc` change, no `re-frame.migration` change.