### PR TITLE
feat(xray): EP-0023 image/frame support + Xray-beside-target as its own image (rf2-32siq3.12)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -563,6 +563,25 @@ remain deferred.)
 | `:rf.xray/set-registered-machines-override-for-test` | `[_ ov]` | Test-only override hook. |
 | `:rf.xray/set-machine-snapshots-override-for-test` | `[_ ov]` | Test-only override hook. |
 
+## Module-view tab (EP-0013 substrate + EP-0023 image/frame model)
+
+Spec: [`026-Module-View-Panel.md`](./026-Module-View-Panel.md). The cohesive
+home for runtime-structure inspection: the EP-0023 `image -> frame` PUBLIC
+model (the FRAMES/IMAGES section, §8) plus the retained EP-0013 `(realm,
+frame)` / module substrate (the REALMS + MODULES sections, §3/§4). A BROWSE
+surface (registry-wide, not event-coupled) — read-only, dispatches nothing.
+
+### Subscriptions
+
+| Sub | Returns |
+|---|---|
+| `:rf.xray/module-view` | Composite — the EP-0013 `(realm, frame)` address space + per-module provenance. Reads the public `rf/realm-ids` · `rf/frame-ids` · `rf/frame-realm` · `rf/installed-app` seams at recompute; projects via `module_view_helpers/project-module-view`. (rf2-wtg9z4 / rf2-at0oen.) |
+| `:rf.xray/image-view` | Composite — the EP-0023 `image -> frame` model (rf2-32siq3.12). `{:frames [<frame-row> …] :frame-count :images?}` over the live-frame registry: each live image-loaded frame as an execution context carrying its resolved image (the generation's `[kind id]` descriptors + per-descriptor provenance). Reads the EP-0023 live-frame registry (`re-frame.live-frame/live-frames`) + sealed generations (`re-frame.image-assembly/resolve-descriptor`) via the fail-soft `image_view_reads` seam; projects via `image_view_helpers/project-image-view`. `:images?` false → the no-image caption (EP-0023's public model is opt-in over the retained substrate). Xray inspects the target frame as DATA here; Xray's OWN image (`image_view_reads/xray-image`) is a separate registration set that never mixes with a target frame's image (EP-0023 §Xray Beside The Target). |
+
+Both subs are L4-tab-internal — `module_view.cljs` registers no panel-internal
+events (a browse surface). The tab is registered via `reg-l4-tab!` (id
+`:module-view`, label **"Modules"**), so it is NOT in `panel_enum.cljc`.
+
 ## Static mode
 
 Spec: [`007-UX-IA.md`](./007-UX-IA.md) §Static mode +

--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -1,16 +1,39 @@
 # 026 — Module-view Panel
 
-> The Xray-side consumer contract for EP-0013 app values + runtime realms:
-> the **(realm, frame) address space** of the running process and the
-> **disposition-6 demand-trigger** for per-module descriptor provenance.
+> The Xray-side consumer contract for **two** runtime-structure models, side
+> by side: the EP-0023 **`image -> frame -> event stream`** public model
+> (images as registration-set values, frames as execution contexts,
+> frame-derived resolution as the lookup path), and the retained EP-0013
+> internal substrate (the **(realm, frame) address space** + the
+> **disposition-6 demand-trigger** for per-module descriptor provenance).
 
 Status: **shipped** — rf2-wtg9z4 (address space) + rf2-at0oen (per-module
-provenance). The realm/frame address space renders from public seams, and the
-MODULES section reads real per-module provenance off each realm's installed app
-value via the public `rf/installed-app` read seam (EP-0013 disposition 6,
-PR #4061). A process running entirely on the `reg-*` sugar / load-order path
-carries no constructed app value, so its MODULES section shows the honest
-no-module caption.
+provenance) + **rf2-32siq3.12** (the EP-0023 image/frame model). The realm/frame
+address space renders from public seams, the MODULES section reads real
+per-module provenance off each realm's installed app value via the public
+`rf/installed-app` read seam (EP-0013 disposition 6, PR #4061), and the FRAMES
+section presents each EP-0023 live image-loaded frame as an execution context
+carrying its resolved image (the generation's `[kind id]` descriptors). A
+process running entirely on the `reg-*` sugar / load-order path carries no
+constructed app value, so its MODULES section shows the honest no-module
+caption; a process not using `rf/make-frame` image-loaded frames shows the
+honest no-image caption in the FRAMES section.
+
+## EP-0023 partial supersession (rf2-32siq3.12)
+
+[EP-0023](../../../docs/EP/EP-0023-image-loaded-frames.md) makes the PUBLIC
+architecture `image -> frame -> event stream`, **partially superseding** the
+EP-0013 app/realm surface while RETAINING the realm machinery as the internal
+installation substrate. This tab is the cohesive home for BOTH:
+
+- the EP-0023 PUBLIC model (the FRAMES/IMAGES section, §8) — rendered FIRST,
+  because it is the public model the operator reasons in;
+- the EP-0013 internal substrate (the REALMS + MODULES sections, §3/§4) —
+  retained below as the implementation structure the public model rides on.
+
+The two read DIFFERENT surfaces and are each demand-gated: a process using one
+and not the other renders only the section it has. §8 is the normative contract
+for the EP-0023 model on this tab.
 
 ## §1 Purpose & scope
 
@@ -35,9 +58,18 @@ Xray module-view demands it*. This is that view (see §4).
 
 ## §2 Layout
 
-Two stacked sections (the shared `theme/section` rhythm):
+Three stacked sections (the shared `theme/section` rhythm) — the EP-0023
+public model FIRST (§8), then the retained EP-0013 substrate (§3/§4):
 
 ```
+│ ▼ FRAMES  (N)                                                   │
+│   :counter/main                                                 │
+│     image     12 descriptors · 6 kinds  :docs.counter/v2        │
+│     caps      :rf.capability/http                               │
+│     resolves  this frame resolves (kind id) through its image   │
+│       event :counter/inc    docs.counter.v2                     │
+│       sub   :counter/value  docs.counter.v2                     │
+│ ─────────────────────────────────────────────────────────────  │
 │ ▼ REALMS  (N)                                                   │
 │   :rf.realm/default  · 2 frames                                 │
 │     frames: :app/main  :app/cart                                │
@@ -50,9 +82,11 @@ Two stacked sections (the shared `theme/section` rhythm):
 │     source    shop.cart:12                                      │
 ```
 
-(In a single-realm process the modules list with the realm dimension
-implicit; with more than one realm each realm's modules sit under an uppercase
-realm header — zero-ceremony.)
+The FRAMES section presents the EP-0023 `image -> frame` model (an image as
+its `[kind id]` descriptor set, a frame as the execution context running it);
+see §8. In a single-realm process the modules list renders with the realm
+dimension implicit; with more than one realm each realm's modules sit under an
+uppercase realm header — zero-ceremony.
 
 ## §3 REALMS section — the (realm, frame) address space
 
@@ -200,3 +234,116 @@ Cmd-K palette picks it up automatically (the palette reads
   zero-module-app caption / no-provenance caption via
   `any-provenance?` / `any-modules?`, incl. the explicit `:modules {}`
   constructed app — rf2-e0mq7a).
+
+## §8 FRAMES / IMAGES section — the EP-0023 public model (rf2-32siq3.12)
+
+The EP-0023 `image -> frame -> event stream` public model on this tab. It
+presents the three load-bearing nouns
+([EP-0023 §Specification Summary](../../../docs/EP/EP-0023-image-loaded-frames.md)):
+
+- **image** — the selected registration-set VALUE a frame resolves against.
+  The inspectable, sealed form is the *resolved image generation*: a
+  `{[kind id] descriptor}` resolver plus the union capability requirements and
+  the kinds present. An image is presented AS THAT SET OF `[kind id]`
+  descriptors — *"which registrations are visible to this frame?"*. Each
+  descriptor carries its **provenance**: a source namespace (`:rf.provenance/ns`
+  string), an inline coordinate (`:rf.provenance/image` / `:rf.provenance/inline`),
+  or the framework-standard marker (`:standard true`). An image is data, not
+  state, and not the running object (EP-0023 §Image).
+- **frame** — the live EXECUTION CONTEXT that POINTS AT the ONE resolved image
+  generation it runs (EP-0023 §Frame). Presented as a frame-row: the frame id
+  (or `<anonymous>` for a direct, no-id frame object), the image summary
+  (`N descriptors · K kinds`), the host capability keys, the active-substrate
+  adapter binding presence, and the resolved descriptor set. The frame is
+  *"what has happened in this run?"*; the image is *"what can this frame
+  run?"* (EP-0023 §Two Boundaries).
+- **frame-derived RESOLUTION** — the lookup path
+  `target frame -> resolved image generation -> registration resolution`
+  (EP-0023 §Specification). The SAME `(kind, id)` resolves to DIFFERENT
+  descriptors in frames running different images, because each frame resolves
+  through its own generation. The section makes this visible: every frame-row's
+  descriptor set is *that frame's* resolution, not a global registry.
+
+### §8.1 Xray-beside-the-target as its OWN image (EP-0023 §Xray Beside The Target)
+
+The load-bearing dogfooding the EP names: Xray is itself a running surface with
+registrations, state, views, subscriptions, and effects, and it MUST NOT share
+the target's registration set.
+
+> Xray runs in its own frame. Xray inspects the target frame. That keeps the
+> inspection tool from becoming part of the thing being inspected.
+
+Xray therefore models itself as a **separate image/frame**, NOT as shared
+registration state:
+
+- `image_view_reads/xray-image` constructs Xray's OWN EP-0023 `rf/image` — an
+  inert value selecting Xray's own source namespaces (`:include-ns
+  ["day8.re-frame2-xray.**"]`, under which every `:rf.xray/*` registration is
+  authored and stamped `:rf.provenance/ns`, which survives production elision).
+  It is Xray's instruction set as data.
+- Xray's `:rf.xray/*` registrations do NOT leak INTO a target frame's image:
+  a target frame's image selects the TARGET's own namespaces, not Xray's.
+- A target frame's registrations do NOT leak INTO Xray's image: the two images
+  select disjoint source namespaces, so a frame built from one cannot resolve
+  the other's registrations.
+- Xray reads the target frame's **generation + state as DATA** through the
+  live-read seam (`image_view_reads`), never by sharing the target's
+  registrar. The target remains ordinary data from the tool's point of view.
+
+`image_view_reads/xray-image-isolated-from?` is the registration-disjointness
+predicate (compares the two images' `:include-ns` selectors); the
+`image_view_reads_cljs_test` asserts the isolation against a real target frame
+built via `re-frame.live-frame/make-frame` — the assertion the .29 dogfooding
+review verifies.
+
+### §8.2 Demand-gating & empty state
+
+The EP-0023 sections are demand-gated like the realm dimension. EP-0023's
+public model is OPT-IN over the retained EP-0013 substrate: a process that
+never calls `rf/make-frame` with `:images` has an empty live-frame registry, so
+`project-image-view` reports `:images?` false and the FRAMES section renders
+the calm **no-image caption** (`image_view_helpers/no-images-caption`) naming
+the `rf/image` / `rf/make-frame` remedy — the honest *not-using-images-yet*
+state, not a broken surface. A frame whose generation resolves zero descriptors
+does not flip `:images?` (there is no image content to show).
+
+### §8.3 Data sources & privacy
+
+- `:rf.xray/image-view` — the FRAMES/IMAGES composite; reads the EP-0023
+  live-frame registry (`re-frame.live-frame/live-frames`) + each frame's sealed
+  generation (`re-frame.image-assembly/resolve-descriptor`) at recompute time
+  via the fail-soft `image_view_reads` seam, and projects via the pure
+  `image_view_helpers/project-image-view`. **Read-only** — enumerating live
+  frames and reading sealed generations pins nothing and dispatches nothing (a
+  sealed generation is an immutable VALUE, not a routing path).
+- The surface carries frame/image **ids and structural descriptors** — frame
+  ids, image ids, `[kind id]` pairs, provenance namespace strings / inline
+  coordinates, and capability keywords. These are **structural descriptors**,
+  not app-db values. No handler values or app-db data egress through this
+  surface (frame STATE — app-db / runtime-db — is the App-db tab's concern; this
+  tab shows the IMAGE, the instruction set).
+
+### §8.4 Implementation & tests
+
+- `panels/image_view_helpers.cljc` — the pure `data → data` projection
+  (`descriptor-provenance` · `project-generation` · `project-frame-row` ·
+  `project-frames` · `resolve-in-frame` · `project-image-view` ·
+  `provenance-summary` · `image-row-summary` · `no-images-caption`);
+  JVM-testable.
+- `panels/image_view_reads.cljs` — the fail-soft live read seam (`live-frames`
+  · `resolve-descriptor` · `image-view-data`) over the EP-0023 core surfaces
+  (`re-frame.live-frame` / `re-frame.image` / `re-frame.image-assembly`), PLUS
+  the Xray-as-its-own-image constructor (`xray-image` · `xray-image-id` ·
+  `xray-source-glob` · `xray-image-isolated-from?`). Xray may require these core
+  namespaces directly — bundle isolation forbids `implementation/` requiring
+  from `tools/`, not the reverse, the same pattern Xray uses for
+  `re-frame.frame` / `re-frame.registrar`.
+- `panels/module_view.cljs` — extended with the FRAMES section (`frame-row` ·
+  `descriptor-rows` · `frames-section-body`) + the `:rf.xray/image-view` sub.
+- Tests: `panels/image_view_helpers_cljs_test.cljc` (the generation/image
+  projection, the frame-row shape, the frame-derived resolution — same id /
+  different image → different descriptor, the demand-gated `:images?`
+  decision, the display strings) + `panels/image_view_reads_cljs_test.cljs`
+  (the Xray-as-its-own-image isolation against a real target frame, the
+  fail-soft live-read seam end-to-end, frame-derived resolution through a real
+  generation).

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc
@@ -1,0 +1,268 @@
+(ns day8.re-frame2-xray.panels.image-view-helpers
+  "Pure-data helpers for Xray's EP-0023 IMAGE / FRAME inspection — the
+  `image -> frame -> event stream` public model (rf2-32siq3.12).
+
+  ## The EP-0023 model this surface presents
+
+  EP-0023 makes the public architecture `image -> frame -> event stream`
+  (docs/EP/EP-0023-image-loaded-frames.md). This helper projects the three
+  load-bearing nouns the operator inspects:
+
+    - **image** — the SELECTED REGISTRATION-SET VALUE a frame resolves
+      against. The inspectable, sealed form is the *resolved image
+      generation*: a `{[kind id] descriptor}` resolver plus the union
+      capability requirements and the kinds present (EP-0023 §Image /
+      §Specification Summary). Tools present an image as that set of
+      `[kind id]` descriptors — \"which registrations are visible to this
+      frame?\". An image is NOT state; it is the instruction set.
+
+    - **frame** — the live EXECUTION CONTEXT (EP-0023 §Frame). It owns
+      app-db / runtime-db / queue / caches / traces / lifecycle and carries a
+      reference to the ONE resolved image generation it runs. The frame is
+      \"what has happened in this run?\"; the image is \"what can this frame
+      run?\" (EP-0023 §Two Boundaries). A frame is presented as an execution
+      context that points at its generation, not as registration state.
+
+    - **frame-derived resolution** — the LOOKUP PATH
+      `target frame -> resolved image generation -> registration resolution`
+      (EP-0023 §Specification). What a given frame actually resolves a
+      `(kind, id)` to depends on its generation, so two frames running
+      DIFFERENT images resolve the same id to their OWN descriptor. This
+      helper surfaces the resolution AS a path: given a frame and a
+      `[kind id]`, what descriptor (and its provenance) does that frame's
+      generation resolve it to?
+
+  ## Why this lives beside the Module-view (EP-0013 substrate) tab
+
+  EP-0023 partially supersedes EP-0013's public app/realm surface while
+  RETAINING the realm machinery as an internal installation substrate
+  (EP-0023 §Backwards Compatibility). The Module-view tab is already the
+  cohesive home for the EP-0013 `(realm, frame)` / module inspection; this
+  helper extends that same tab with the EP-0023 PUBLIC model. The two read
+  DIFFERENT surfaces: the realm/module projection reads `rf/realm-ids` /
+  `rf/installed-app` (the retained internal substrate); this image/frame
+  projection reads the EP-0023 live-frame registry + sealed generations (the
+  public model). A process using one and not the other renders only the
+  section it has (each is fail-soft and demand-gated, like the realm
+  dimension).
+
+  ## Inert-data, fail-soft, JVM-testable
+
+  Every fn here is pure `data -> data`. The live reads (the EP-0023
+  registry/generation touches) live in `image_view_reads.cljs` and are
+  passed IN as already-projected values, so this algebra runs under the JVM
+  unit-test target (`clojure -M:test`) exactly like every other Xray panel
+  helper. A frame object / generation / image is presented as the inert data
+  it already is — `make-frame` returns an inert map and `assemble` seals an
+  inert generation (EP-0023 §Image — \"an image is data, not registration\")."
+  (:require [clojure.string :as str]))
+
+;; ===========================================================================
+;; Generation projection — an image as its `[kind id]` descriptor set
+;; (EP-0023 §Image / §Specification Summary)
+;; ===========================================================================
+
+(defn descriptor-provenance
+  "Project a resolved descriptor's PROVENANCE into a compact display value
+  (EP-0023 §Namespace-Selected Images / §Image Fragments). A registered
+  descriptor is identified by its source namespace string
+  (`:rf.provenance/ns`); an inline descriptor by its containing image id +
+  inline coordinate (`:rf.provenance/image` / `:rf.provenance/inline`); a
+  framework standard by its `:standard true` marker. Returns
+
+      {:kind :rf.prov/ns        :ns \"docs.counter.v2\"}
+      {:kind :rf.prov/inline    :image :test/small :inline [:reg-event :counter/inc]}
+      {:kind :rf.prov/standard}
+      {:kind :rf.prov/unknown}
+
+  Pure `data -> data`; JVM-testable."
+  [descriptor]
+  (cond
+    (:rf.provenance/ns descriptor)
+    {:kind :rf.prov/ns :ns (:rf.provenance/ns descriptor)}
+
+    (:rf.provenance/image descriptor)
+    {:kind   :rf.prov/inline
+     :image  (:rf.provenance/image descriptor)
+     :inline (:rf.provenance/inline descriptor)}
+
+    (:standard descriptor)
+    {:kind :rf.prov/standard}
+
+    :else
+    {:kind :rf.prov/unknown}))
+
+(defn project-generation
+  "Project a sealed image GENERATION into the image-view's image-row shape —
+  an image presented as its set of `[kind id]` descriptors (EP-0023 §Image —
+  \"which registrations are visible to this frame?\"). Returns
+
+      {:images          [<:rf.image/id> …]   ;; the image ids composed (nil entry
+                                              ;; for an anonymous image)
+       :requires        #{:rf.capability/* …};; the union :rf.gen/requires
+       :kinds           [<kind> …]            ;; sorted kinds present
+       :descriptor-count <int>                ;; total [kind id] entries resolved
+       :descriptors     [{:kind … :id … :provenance {…}} …]}
+                                              ;; one row per resolved [kind id],
+                                              ;; sorted by (kind id) str
+
+  `generation` is the inert sealed value `assemble` returns
+  (`:rf.gen/resolver` / `:rf.gen/images` / `:rf.gen/requires` /
+  `:rf.gen/kinds`). A nil generation projects to the empty image-row (no
+  descriptors). Pure `data -> data`; JVM-testable."
+  [generation]
+  (let [resolver (:rf.gen/resolver generation)
+        descs    (->> resolver
+                      (sort-by (fn [[[kind id] _]] (str kind " " id)))
+                      (mapv (fn [[[kind id] descriptor]]
+                              {:kind       kind
+                               :id         id
+                               :provenance (descriptor-provenance descriptor)})))]
+    {:images           (mapv :rf.image/id (:rf.gen/images generation))
+     :requires         (set (:rf.gen/requires generation))
+     :kinds            (vec (sort-by str (:rf.gen/kinds generation)))
+     :descriptor-count (count resolver)
+     :descriptors      descs}))
+
+;; ===========================================================================
+;; Frame projection — a frame as an execution context (EP-0023 §Frame)
+;; ===========================================================================
+
+(defn project-frame-row
+  "Project ONE live frame OBJECT into the image-view's frame-row shape — a
+  frame presented as an EXECUTION CONTEXT that POINTS AT its generation
+  (EP-0023 §Frame). Returns
+
+      {:frame-id     <:rf.frame/id> | nil    ;; nil for a direct (no-id) frame
+       :anonymous?   <bool>                  ;; true iff no public frame id
+       :has-adapter? <bool>                  ;; carries an active-substrate binding?
+       :capabilities #{:rf.capability/* …}   ;; the host capability map's keys
+       :image        {<project-generation> …}};; the resolved image this frame runs
+
+  `frame-id` is the registry key (or nil for a direct frame object);
+  `frame-object` is the inert map `make-frame` returns
+  (`:rf.frame/object` / `:rf.frame/generation` / `:rf.frame/id` / …). The
+  frame's IMAGE is its resolved generation projected via `project-generation`
+  — that is the `frame -> resolved image generation` half of the EP-0023
+  resolution path. Pure `data -> data`; JVM-testable."
+  [frame-id frame-object]
+  (let [gen (:rf.frame/generation frame-object)]
+    {:frame-id     frame-id
+     :anonymous?   (nil? frame-id)
+     :has-adapter? (boolean (:rf.frame/adapter frame-object))
+     :capabilities (set (keys (:rf.frame/capabilities frame-object)))
+     :image        (project-generation gen)}))
+
+(defn project-frames
+  "Project the live-frame registry `{frame-id frame-object}` into sorted
+  frame-rows (EP-0023 §Frame / §Id Spaces — the process-local live-frame
+  registry). Returns a vector of frame-rows sorted by frame-id str. Only
+  `:id`-bearing frames are in the registry; direct (no-id) frame objects
+  bypass it (EP-0023 §Public API — \"the absence of `:id` is not a default-id
+  path\"). Pure `data -> data`; JVM-testable."
+  [live-frames]
+  (->> live-frames
+       (sort-by (comp str key))
+       (mapv (fn [[fid fobj]] (project-frame-row fid fobj)))))
+
+;; ===========================================================================
+;; Frame-derived resolution — the lookup path (EP-0023 §Specification)
+;; ===========================================================================
+
+(defn resolve-in-frame
+  "Project the FRAME-DERIVED RESOLUTION of one `[kind id]` through `frame`'s
+  generation (EP-0023 §Specification — `target frame -> resolved image
+  generation -> registration resolution`). `resolve-fn` is the
+  generation-level resolver (`re-frame.image-assembly/resolve-descriptor`,
+  passed in so this stays pure). Returns
+
+      {:kind kind :id id
+       :resolved? <bool>                    ;; did the frame's generation resolve it?
+       :provenance {…}}                     ;; the resolving descriptor's provenance,
+                                            ;; nil when unresolved
+
+  This is what makes the image/frame split visible: the SAME `[kind id]`
+  resolves to DIFFERENT descriptors (or to nothing) depending on which frame
+  asks, because each frame runs its own image generation. Pure `data -> data`
+  (given a pure `resolve-fn`); JVM-testable."
+  [resolve-fn frame kind id]
+  (let [gen        (:rf.frame/generation frame)
+        descriptor (when gen (resolve-fn gen kind id))]
+    {:kind       kind
+     :id         id
+     :resolved?  (some? descriptor)
+     :provenance (when descriptor (descriptor-provenance descriptor))}))
+
+;; ===========================================================================
+;; Top-level projection
+;; ===========================================================================
+
+(defn project-image-view
+  "Top-level EP-0023 image/frame projection — produce every slot the
+  image/frame sections of the Module-view tab need (rf2-32siq3.12). Pure
+  `data -> data`; JVM-testable.
+
+  `live-frames` is the live-frame registry snapshot `{frame-id frame-object}`
+  (from `re-frame.live-frame/live-frames`, read in `image_view_reads.cljs`).
+  Returns
+
+      {:frames        [<frame-row> …]   ;; per live frame, each carrying its
+                                        ;; resolved image (its generation's
+                                        ;; [kind id] descriptors)
+       :frame-count   <int>
+       :images?       <bool>}           ;; true iff ANY live frame runs a
+                                        ;; generation — i.e. the EP-0023 public
+                                        ;; image/frame model is in use. Drives
+                                        ;; whether the image/frame sections
+                                        ;; materialise (demand-gated, like the
+                                        ;; realm dimension).
+
+  A process that never calls `rf/make-frame` with `:images` has an empty
+  registry → `:images?` false → the sections render the calm no-image
+  caption. EP-0023's public model is OPT-IN over the retained EP-0013
+  substrate, so this is the honest \"not using the image/frame model yet\"
+  state, not a broken surface."
+  [live-frames]
+  (let [frames (project-frames live-frames)]
+    {:frames      frames
+     :frame-count (count frames)
+     :images?     (boolean (some (comp pos? :descriptor-count :image) frames))}))
+
+;; ===========================================================================
+;; Display strings
+;; ===========================================================================
+
+(defn provenance-summary
+  "A compact one-line rendering of a descriptor's provenance (from
+  `descriptor-provenance`): the source namespace, the inline coordinate, or
+  the standard/unknown marker. Pure `data -> string`; JVM-testable."
+  [{:keys [kind ns image inline] :as _provenance}]
+  (case kind
+    :rf.prov/ns       (str ns)
+    :rf.prov/inline   (str "inline " (pr-str image) " " (pr-str inline))
+    :rf.prov/standard "framework standard"
+    "—"))
+
+(defn image-row-summary
+  "A one-line plain-language summary for an image (a frame's resolved
+  generation): `N descriptors · K kinds`. Pure `data -> string`;
+  JVM-testable."
+  [{:keys [descriptor-count kinds] :as _image}]
+  (str descriptor-count " descriptor" (when (not= 1 descriptor-count) "s")
+       " · " (count kinds) " kind" (when (not= 1 (count kinds)) "s")))
+
+(def no-images-caption
+  "The calm empty-state caption the image/frame sections render when NO live
+  frame runs a resolved image generation (rf2-32siq3.12). EP-0023's public
+  `image -> frame -> event stream` model is OPT-IN: a process using only the
+  retained EP-0013 realm substrate (or the bare `reg-*` default path) creates
+  no `rf/make-frame` image-loaded frames, so there is no image/frame model to
+  show here yet. Names why the section is empty so the operator understands
+  it is the honest not-using-images state, not a broken surface. Pure
+  `data -> string`."
+  (str "No image-loaded frames — this process is not using the EP-0023 "
+       "image/frame model yet. Construct an image (rf/image {:include-ns [...]}) "
+       "and load it into a frame (rf/make-frame {:images [...]}) to surface the "
+       "resolved registration set (the [kind id] descriptors a frame sees) and "
+       "each frame's execution context here. The image/frame model runs beside "
+       "the retained EP-0013 realm substrate shown above."))

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
@@ -1,0 +1,145 @@
+(ns day8.re-frame2-xray.panels.image-view-reads
+  "Live read seam + Xray-as-its-own-image constructor for the EP-0023
+  IMAGE / FRAME inspection (rf2-32siq3.12).
+
+  ## The two jobs
+
+  1. **Live reads (fail-soft).** The EP-0023 public model — the live-frame
+     registry + sealed image generations — is read here, kept OUT of the pure
+     `image_view_helpers.cljc` algebra so that algebra stays JVM-testable
+     `data -> data`. Every read is `try`-guarded and degrades to the empty
+     value, so an image/frame browse never throws on a core too old to expose
+     the EP-0023 surfaces (the same fail-soft discipline as
+     `static/shared/realm.cljs`).
+
+  2. **Xray-as-its-own-image (the dogfooding — EP-0023 §Xray Beside The
+     Target).** Xray is itself a running surface with registrations, state,
+     views, subscriptions, and effects. EP-0023's headline isolation case is
+     that the inspector MUST NOT share the target's registration set: Xray
+     runs in its OWN image/frame and inspects the target frame as DATA.
+
+         > Xray runs in its own frame. Xray inspects the target frame.
+         > That keeps the inspection tool from becoming part of the thing
+         > being inspected. (EP-0023 §Xray Beside The Target)
+
+     This ns constructs Xray's own registration set as an EP-0023 `rf/image`
+     — selected by the `:include-ns` glob over Xray's OWN source namespaces
+     (`day8.re-frame2-xray.**`), under which every `:rf.xray/*` registration
+     is authored (and stamped `:rf.provenance/ns` in the source store, which
+     survives production elision). The result is an inert image VALUE: Xray's
+     instruction set, separate from any target frame's image. The target
+     frame is read as data through the live-read fns above; its generation
+     and state never mix with Xray's image, and Xray's `:rf.xray/*`
+     registrations never leak INTO the target frame's image (a target image
+     selects the target's own namespaces, not Xray's).
+
+  ## Why Xray may require the EP-0023 core surfaces directly
+
+  Xray is a TOOL that consumes the framework's instrumentation + introspection
+  surfaces; it already requires internal core namespaces (`re-frame.frame`,
+  `re-frame.registrar`, `re-frame.machines`, …). Bundle isolation forbids
+  `implementation/` requiring from `tools/`, NOT the reverse, so requiring
+  `re-frame.live-frame` / `re-frame.image` / `re-frame.image-assembly` here is
+  consistent with the established pattern. These EP-0023 read seams are not on
+  the `re-frame.core` facade, so the tool reads the owning namespaces directly,
+  exactly as it does for the realm substrate."
+  (:require [clojure.set :as set]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.image :as image]
+            [re-frame.image-assembly :as image-assembly]
+            [day8.re-frame2-xray.panels.image-view-helpers :as h]))
+
+;; ===========================================================================
+;; Live reads of the EP-0023 public model (fail-soft)
+;; ===========================================================================
+
+(defn live-frames
+  "The EP-0023 process-local live-frame registry snapshot
+  `{frame-id frame-object}` (EP-0023 §Frame / §Id Spaces), read via
+  `re-frame.live-frame/live-frames`. Fail-soft: a core too old to expose the
+  EP-0023 registry (or any throw) degrades to `{}`, so an image/frame browse
+  always has a value. Pure-read."
+  []
+  (try
+    (let [reg @live-frame/live-frames]
+      (if (map? reg) reg {}))
+    (catch :default _ {})))
+
+(defn resolve-descriptor
+  "Resolve `(kind, id)` against a sealed `generation` via
+  `re-frame.image-assembly/resolve-descriptor` (the runtime registration-
+  resolution read — EP-0023 §Specification). Fail-soft: a nil generation or
+  any throw yields nil (unresolved). Pure-read."
+  [generation kind id]
+  (try
+    (image-assembly/resolve-descriptor generation kind id)
+    (catch :default _ nil)))
+
+(defn image-view-data
+  "Project the live EP-0023 image/frame model into the view-facing data
+  (rf2-32siq3.12): the live-frame registry → frame-rows, each carrying its
+  resolved image (its generation's `[kind id]` descriptors). Fail-soft
+  composition of `live-frames` + the pure `h/project-image-view`. Pure-read
+  `() -> data`."
+  []
+  (h/project-image-view (live-frames)))
+
+;; ===========================================================================
+;; Xray-as-its-own-image — the dogfooding (EP-0023 §Xray Beside The Target)
+;; ===========================================================================
+
+(def xray-image-id
+  "The id of Xray's OWN image — the inspector's instruction set, separate from
+  any target frame's image (EP-0023 §Xray Beside The Target). Namespaced under
+  `:rf.xray/*` for the same isolation discipline as the rest of the Xray
+  registry."
+  :rf.xray/image)
+
+(def xray-source-glob
+  "The `:include-ns` glob selecting Xray's OWN registrations by their source
+  namespace (EP-0023 §Namespace-Selected Images). Every `:rf.xray/*`
+  registration is authored under `day8.re-frame2-xray.*` and stamped
+  `:rf.provenance/ns` in the source store (which survives production elision),
+  so this glob selects Xray's instruction set and ONLY Xray's — a target
+  frame's image selects the target's own namespaces, never this one."
+  "day8.re-frame2-xray.**")
+
+(defn xray-image
+  "Construct XRAY'S OWN EP-0023 image VALUE — the inspector's registration set
+  as inert data, selected by the `:include-ns` glob over Xray's own source
+  namespaces (EP-0023 §Xray Beside The Target / §Namespace-Selected Images).
+  PURE: `rf/image` is data, not registration (no realm, no registrar, no side
+  effect).
+
+  This is the dogfooding the EP names: Xray models itself as a SEPARATE
+  image/frame, not as shared registration state. The returned image value is
+  Xray's instruction set; it never mixes with a target frame's image, and the
+  target frame is inspected as DATA through the live-read fns. Construct an
+  Xray frame with this image (`(rf/make-frame {:id :rf.xray/main :images
+  [(xray-image)] :initial-db {:rf.xray/target <target-frame-id>}})`) to run
+  Xray beside the target without the two sharing a registration set.
+
+  Returns the normalized inert image value (`:rf.image/id` /
+  `:rf.image/include-ns` / …)."
+  []
+  (image/image {:id         xray-image-id
+                :include-ns [xray-source-glob]}))
+
+(defn xray-image-isolated-from?
+  "True iff XRAY'S OWN image and a `target-image` are REGISTRATION-DISJOINT —
+  the EP-0023 §Xray Beside The Target invariant that the inspector's
+  registrations do not leak into / from the target frame's image. Compares the
+  `:rf.image/include-ns` selectors: Xray selects `day8.re-frame2-xray.**`; a
+  target frame's image selects the target's OWN namespaces. Isolation holds
+  when no selector is shared (the two images select disjoint source
+  namespaces). Pure `data -> bool`; the assertion the .29 dogfooding review
+  verifies.
+
+  `target-image` is a normalized image value (`rf/image`'s return). Returns
+  true when the two images share no `:include-ns` selector — i.e. neither
+  selects the other's source namespaces — so a frame built from one cannot see
+  the other's registrations."
+  [target-image]
+  (let [xray-sel   (set (:rf.image/include-ns (xray-image)))
+        target-sel (set (:rf.image/include-ns target-image))]
+    (empty? (set/intersection xray-sel target-sel))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -1,16 +1,44 @@
 (ns day8.re-frame2-xray.panels.module-view
   "Module-view tab — the EP-0013 disposition-6 demand-trigger surface
-  (rf2-wtg9z4).
+  (rf2-wtg9z4) PLUS the EP-0023 `image -> frame` public model (rf2-32siq3.12).
 
   ## What this tab shows
 
+  TWO models, side by side — the cohesive home for runtime-structure
+  inspection (per Mike's 'cohesive sub-domains get their own tab' ruling). It
+  is a BROWSE surface (Static-style — registry-wide, not event-coupled).
+
+  ### EP-0013 substrate (retained internally)
+
   The (realm, frame) ADDRESS SPACE of the running process (EP-0013
-  disposition 3): every installed runtime realm, and the frames each
-  realm holds. It is a BROWSE surface (Static-style — registry-wide, not
-  event-coupled), the cohesive home for app-value / realm / module
-  inspection (per Mike's 'cohesive sub-domains get their own tab' ruling —
-  realm/module structure earns its own L4 tab rather than piling into
-  App-db).
+  disposition 3): every installed runtime realm, and the frames each realm
+  holds, plus the per-module ownership / capability / descriptor provenance.
+
+  ### EP-0023 public model (rf2-32siq3.12)
+
+  EP-0023 makes the PUBLIC architecture `image -> frame -> event stream`,
+  partially superseding the EP-0013 app/realm surface while RETAINING the
+  realm machinery as the internal substrate above. This tab surfaces the
+  public nouns:
+
+    - **IMAGES** — an image presented as a registration-set VALUE: the
+      resolved generation's `[kind id]` descriptors (\"which registrations are
+      visible to this frame?\"), with each descriptor's provenance (source
+      namespace / inline / framework standard).
+    - **FRAMES** — a frame presented as an EXECUTION CONTEXT that points at
+      the ONE resolved image generation it runs.
+    - **frame-derived RESOLUTION** — the lookup path `target frame -> resolved
+      image generation -> registration resolution`: what a given frame
+      resolves a `(kind, id)` to, via its generation. The same id resolves to
+      DIFFERENT descriptors in frames running different images.
+
+  Xray itself runs in its OWN image/frame and inspects the target frame as
+  DATA (EP-0023 §Xray Beside The Target) — `image_view_reads/xray-image` is
+  Xray's separate registration set; the inspector never shares the target's.
+
+  The EP-0023 sections are DEMAND-GATED (like the realm dimension): a process
+  not using `rf/make-frame` image-loaded frames renders the calm no-image
+  caption — the honest not-using-images state.
 
       │ REALMS                                                          │
       │   :rf.realm/default  · 2 frames                                 │
@@ -66,6 +94,8 @@
             [re-frame.frame :as frame]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.module-view-helpers :as h]
+            [day8.re-frame2-xray.panels.image-view-helpers :as ih]
+            [day8.re-frame2-xray.panels.image-view-reads :as image-reads]
             [day8.re-frame2-xray.theme.section :as section]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -134,6 +164,31 @@
    :letter-spacing "0.4px"
    :text-transform "uppercase"
    :padding        "6px 0 2px 0"})
+
+(def ^:private frame-id-style
+  {:color       (:accent tokens)
+   :font-weight 600
+   :font-family mono-stack
+   :font-size   "12px"
+   :padding     "4px 0 1px 0"})
+
+(def ^:private frame-fact-style
+  {:color       (:text-secondary tokens)
+   :font-family mono-stack
+   :font-size   "11px"
+   :padding     "0 0 0 18px"})
+
+(def ^:private frame-fact-label-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private descriptor-row-style
+  {:color       (:text-secondary tokens)
+   :font-family mono-stack
+   :font-size   "11px"
+   :padding     "0 0 0 36px"})
+
+(def ^:private descriptor-prov-style
+  {:color (:text-tertiary tokens)})
 
 ;; ---- module row ----------------------------------------------------------
 
@@ -206,6 +261,74 @@
               :style       realm-frames-style}
         (str "frames: " (str/join "  " (map str frames)))])]))
 
+;; ---- EP-0023 image/frame row (rf2-32siq3.12) -----------------------------
+
+(defn- descriptor-rows
+  "Render a frame's resolved image as its `[kind id]` descriptor list —
+  the image presented as a registration-set VALUE (EP-0023 §Image). Each row
+  is `kind/id   <provenance>`. Capped to keep the browse calm; the count line
+  carries the full total. Pure hiccup."
+  [{:keys [descriptors descriptor-count] :as _image}]
+  (let [shown (take 24 descriptors)]
+    (into [:div]
+          (concat
+            (for [{:keys [kind id provenance]} shown]
+              [:div {:style descriptor-row-style}
+               (str kind " " id)
+               " "
+               [:span {:style descriptor-prov-style}
+                (ih/provenance-summary provenance)]])
+            (when (> descriptor-count (count shown))
+              [[:div {:style descriptor-prov-style}
+                (str "… " (- descriptor-count (count shown)) " more")]])))))
+
+(defn- frame-row
+  "Render one live frame as an EXECUTION CONTEXT pointing at its resolved
+  image generation (EP-0023 §Frame). Shows the frame id, the image summary (N
+  descriptors · K kinds), capability requirements, and the resolved `[kind
+  id]` descriptor set (the image as a value). Pure hiccup."
+  [{:keys [frame-id image capabilities has-adapter?] :as _frame-row}]
+  (let [fid-name (if frame-id (str frame-id) "<anonymous>")]
+    [:div {:data-testid (str "rf-xray-module-view-frame-" fid-name)}
+     [:div {:data-testid (str "rf-xray-module-view-frame-" fid-name "-id")
+            :style       frame-id-style}
+      fid-name]
+     [:div {:style frame-fact-style}
+      [:span {:style frame-fact-label-style} "image     "]
+      (ih/image-row-summary image)
+      ;; Name the composed image ids when present (an anonymous image carries
+      ;; no `:rf.image/id` → a nil entry; drop it rather than print "nil").
+      (when-let [named (seq (remove nil? (:images image)))]
+        (str "  " (str/join " " (map pr-str named))))]
+     (when (seq capabilities)
+       [:div {:style frame-fact-style}
+        [:span {:style frame-fact-label-style} "caps      "]
+        (str/join "  " (sort-by str capabilities))])
+     (when has-adapter?
+       [:div {:style frame-fact-style}
+        [:span {:style frame-fact-label-style} "adapter   "]
+        "active-substrate binding"])
+     [:div {:style frame-fact-style}
+      [:span {:style frame-fact-label-style} "resolves  "]
+      "this frame resolves (kind id) through its image generation"]
+     (descriptor-rows image)]))
+
+(defn- frames-section-body
+  "The FRAMES / IMAGES section body — every live image-loaded frame, each as
+  an execution context carrying its resolved image (its generation's `[kind
+  id]` descriptors). When NO live frame runs a generation, the calm no-image
+  caption (EP-0023's public model is opt-in over the retained substrate).
+  Pure hiccup."
+  [{:keys [frames images?] :as _image-view}]
+  (if images?
+    (into [:div {:data-testid "rf-xray-module-view-frames-list"}]
+          (for [{:keys [frame-id] :as fr} frames]
+            (with-meta (frame-row fr)
+              {:key (str (or frame-id "<anonymous>"))})))
+    [:div {:data-testid "rf-xray-module-view-frames-empty"
+           :style       awaiting-caption-style}
+     ih/no-images-caption]))
+
 ;; ---- public view ---------------------------------------------------------
 
 (defn- modules-section-body
@@ -268,11 +391,25 @@
   caption."
   []
   (let [{:keys [realms multi-realm?] :as _data}
-        @(rf/subscribe [:rf.xray/module-view])]
+        @(rf/subscribe [:rf.xray/module-view])
+        {:keys [frame-count] :as image-view}
+        @(rf/subscribe [:rf.xray/image-view])]
     [:section {:data-testid "rf-xray-module-view"
                :style       panel-root-style}
      [:div {:style panel-scroll-container-style}
-      ;; REALMS — the installed realms and each realm's frames.
+      ;; FRAMES / IMAGES — the EP-0023 PUBLIC model: every live image-loaded
+      ;; frame as an execution context carrying its resolved image (the
+      ;; generation's [kind id] descriptors), plus the frame-derived
+      ;; resolution path. Rendered FIRST — EP-0023 is the public model; the
+      ;; EP-0013 realm/module sections below are the retained internal
+      ;; substrate (rf2-32siq3.12).
+      (section/section-row
+        {:label  "Frames"
+         :testid "rf-xray-module-view-frames"
+         :count* frame-count}
+        (frames-section-body image-view))
+      ;; REALMS — the installed realms and each realm's frames (EP-0013
+      ;; substrate, retained internally).
       (section/section-row
         {:label  "Realms"
          :testid "rf-xray-module-view-realms"
@@ -319,6 +456,26 @@
                              (rf/frame-ids)
                              frame/frame-realm
                              rf/installed-app)))
+
+  ;; `:rf.xray/image-view` — the EP-0023 PUBLIC `image -> frame` model
+  ;; (rf2-32siq3.12). Reads the EP-0023 live-frame registry + sealed image
+  ;; generations via the fail-soft `image-view-reads` seam and projects via
+  ;; the pure `image-view-helpers/project-image-view`: every live
+  ;; image-loaded frame as an execution context carrying its resolved image
+  ;; (the generation's [kind id] descriptors). Read-only — enumerating live
+  ;; frames + reading sealed generations pins nothing and dispatches nothing
+  ;; (a sealed generation is an immutable VALUE, not a routing path). Like
+  ;; `:rf.xray/module-view` it does NOT compose off an `:rf.xray/*` app-db
+  ;; slot: the live-frame registry is a process-global fact (it lives in
+  ;; `re-frame.live-frame`, not Xray's app-db); the sub reads it directly at
+  ;; recompute time and a tab activation re-renders the panel which
+  ;; re-derefs. Xray inspects the target frame as DATA here; Xray's OWN
+  ;; image (`image-view-reads/xray-image`) is a separate registration set
+  ;; that never mixes with a target frame's image (EP-0023 §Xray Beside The
+  ;; Target).
+  (rf/reg-sub :rf.xray/image-view
+    (fn [_db _query]
+      (image-reads/image-view-data)))
 
   ;; Register the Dynamic Module-view tab with the internal L4 tab
   ;; registry. Order 9 — after the Derivation-Graph (order 8), keeping the

--- a/tools/xray/test/day8/re_frame2_xray/panels/image_view_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/image_view_helpers_cljs_test.cljc
@@ -1,0 +1,223 @@
+(ns day8.re-frame2-xray.panels.image-view-helpers-cljs-test
+  "JVM + CLJS coverage for the EP-0023 image/frame pure-data helpers
+  (rf2-32siq3.12 — the `image -> frame -> event stream` public model on the
+  Module-view tab).
+
+  Verifies the three EP-0023 nouns the surface presents:
+
+    - **image** as a registration-set VALUE — a sealed generation projected
+      into its `[kind id]` descriptor set with per-descriptor provenance
+      (`project-generation` / `descriptor-provenance`);
+    - **frame** as an EXECUTION CONTEXT pointing at its generation
+      (`project-frame-row` / `project-frames`);
+    - **frame-derived RESOLUTION** — the same `[kind id]` resolving to
+      DIFFERENT descriptors in frames running different images
+      (`resolve-in-frame`).
+
+  Plus the demand-gated top-level projection (`project-image-view` →
+  `:images?`) and the display strings. All algebra is pure `data -> data`, so
+  this runs under the JVM test target with hand-built generation/frame fixtures
+  (the inert shapes `assemble` / `make-frame` produce)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [day8.re-frame2-xray.panels.image-view-helpers :as h]))
+
+;; ---- fixtures: the inert shapes the EP-0023 core surfaces produce -------
+
+;; A resolved descriptor as the source store / image stamps it: :kind / :id /
+;; :rf.provenance/ns (a canonical source-namespace STRING — EP-0023
+;; §Namespace-Selected Images).
+(def ^:private inc-desc
+  {:kind :event :id :counter/inc :rf.provenance/ns "docs.counter.v2"})
+
+(def ^:private value-desc
+  {:kind :sub :id :counter/value :rf.provenance/ns "docs.counter.v2"})
+
+;; An inline descriptor — identified by its containing image id + inline coord
+;; (EP-0023 §Image Fragments), not a source namespace.
+(def ^:private inline-desc
+  {:kind :event :id :counter/inc
+   :rf.provenance/image :test/small
+   :rf.provenance/inline [:reg-event :counter/inc]})
+
+;; A framework STANDARD descriptor — tagged `:standard true` by assembly.
+(def ^:private standard-desc
+  {:kind :interceptor :id :rf.interceptor/path :standard true})
+
+;; A sealed image generation — the inert value `image-assembly/assemble`
+;; returns (`:rf.gen/resolver` / `:rf.gen/images` / `:rf.gen/requires` /
+;; `:rf.gen/kinds`).
+(def ^:private counter-generation
+  {:rf.gen/resolver {[:event :counter/inc]   inc-desc
+                     [:sub   :counter/value] value-desc}
+   :rf.gen/images   [{:rf.image/id :docs.counter/v2 :rf.image/include-ns ["docs.counter.v2"]}]
+   :rf.gen/requires #{:rf.capability/http}
+   :rf.gen/kinds    #{:event :sub}})
+
+;; A SECOND generation where the SAME id (:counter/inc) resolves to a
+;; DIFFERENT descriptor (an inline one) — the same-id / different-image story.
+(def ^:private other-generation
+  {:rf.gen/resolver {[:event :counter/inc] inline-desc}
+   :rf.gen/images   [{:rf.image/id :test/small}]
+   :rf.gen/requires #{}
+   :rf.gen/kinds    #{:event}})
+
+;; A live frame OBJECT — the inert map `make-frame` returns.
+(def ^:private counter-frame
+  {:rf.frame/object       true
+   :rf.frame/generation   counter-generation
+   :rf.frame/id           :counter/main
+   :rf.frame/capabilities {:rf.capability/http :some-http}})
+
+(def ^:private other-frame
+  {:rf.frame/object     true
+   :rf.frame/generation other-generation
+   :rf.frame/id         :counter/alt})
+
+;; A pure resolver fn (the role `image-assembly/resolve-descriptor` plays).
+(defn- resolve-fn [generation kind id]
+  (get (:rf.gen/resolver generation) [kind id]))
+
+;; ---- descriptor-provenance ----------------------------------------------
+
+(deftest descriptor-provenance-source-ns
+  (testing "a registered descriptor projects to its source-namespace provenance"
+    (is (= {:kind :rf.prov/ns :ns "docs.counter.v2"}
+           (h/descriptor-provenance inc-desc)))))
+
+(deftest descriptor-provenance-inline
+  (testing "an inline descriptor projects to its image id + inline coordinate"
+    (is (= {:kind :rf.prov/inline :image :test/small :inline [:reg-event :counter/inc]}
+           (h/descriptor-provenance inline-desc)))))
+
+(deftest descriptor-provenance-standard
+  (testing "a framework standard descriptor projects to the standard marker"
+    (is (= {:kind :rf.prov/standard} (h/descriptor-provenance standard-desc)))))
+
+(deftest descriptor-provenance-unknown
+  (testing "a descriptor with no recognizable provenance projects to :unknown"
+    (is (= {:kind :rf.prov/unknown} (h/descriptor-provenance {:kind :event :id :x})))))
+
+;; ---- project-generation: image as a [kind id] descriptor set -------------
+
+(deftest project-generation-shape
+  (testing "a sealed generation projects to the image-row: composed image ids,
+            union requires, sorted kinds, descriptor count, and one descriptor
+            row per [kind id] (sorted, each with provenance)"
+    (let [img (h/project-generation counter-generation)]
+      (is (= [:docs.counter/v2] (:images img)))
+      (is (= #{:rf.capability/http} (:requires img)))
+      (is (= [:event :sub] (:kinds img)) "kinds sorted by str")
+      (is (= 2 (:descriptor-count img)))
+      (is (= [{:kind :event :id :counter/inc
+               :provenance {:kind :rf.prov/ns :ns "docs.counter.v2"}}
+              {:kind :sub :id :counter/value
+               :provenance {:kind :rf.prov/ns :ns "docs.counter.v2"}}]
+             (:descriptors img))
+          "one row per resolved [kind id], sorted by (kind id) str"))))
+
+(deftest project-generation-nil-is-empty
+  (testing "a nil generation projects to the empty image-row (no descriptors)"
+    (let [img (h/project-generation nil)]
+      (is (= [] (:images img)))
+      (is (= #{} (:requires img)))
+      (is (= [] (:kinds img)))
+      (is (= 0 (:descriptor-count img)))
+      (is (= [] (:descriptors img))))))
+
+;; ---- project-frame-row: frame as an execution context -------------------
+
+(deftest project-frame-row-shape
+  (testing "a live frame projects to the frame-row: id, not-anonymous, capability
+            keys, and the resolved IMAGE it runs (its generation's descriptors)"
+    (let [row (h/project-frame-row :counter/main counter-frame)]
+      (is (= :counter/main (:frame-id row)))
+      (is (false? (:anonymous? row)))
+      (is (false? (:has-adapter? row)))
+      (is (= #{:rf.capability/http} (:capabilities row)))
+      (is (= 2 (:descriptor-count (:image row)))
+          "the frame POINTS AT its generation — projected as the image"))))
+
+(deftest project-frame-row-anonymous
+  (testing "a direct (no-id) frame object projects as anonymous"
+    (let [row (h/project-frame-row nil (dissoc counter-frame :rf.frame/id))]
+      (is (nil? (:frame-id row)))
+      (is (true? (:anonymous? row))))))
+
+(deftest project-frames-sorted
+  (testing "the live-frame registry projects to frame-rows sorted by frame-id str"
+    (let [rows (h/project-frames {:counter/main counter-frame
+                                  :counter/alt  other-frame})]
+      (is (= [:counter/alt :counter/main] (mapv :frame-id rows))))))
+
+;; ---- resolve-in-frame: frame-derived resolution path --------------------
+
+(deftest resolve-in-frame-same-id-different-image
+  (testing "the SAME [kind id] resolves to DIFFERENT descriptors in frames
+            running different images — the frame-derived resolution path
+            (EP-0023 §Specification)"
+    (let [in-counter (h/resolve-in-frame resolve-fn counter-frame :event :counter/inc)
+          in-other   (h/resolve-in-frame resolve-fn other-frame   :event :counter/inc)]
+      (is (true? (:resolved? in-counter)))
+      (is (= {:kind :rf.prov/ns :ns "docs.counter.v2"} (:provenance in-counter))
+          "counter-frame resolves :counter/inc to its source-ns descriptor")
+      (is (true? (:resolved? in-other)))
+      (is (= {:kind :rf.prov/inline :image :test/small :inline [:reg-event :counter/inc]}
+             (:provenance in-other))
+          "other-frame resolves the SAME id to ITS image's inline descriptor")
+      (is (not= (:provenance in-counter) (:provenance in-other))
+          "same id, different image → different resolution"))))
+
+(deftest resolve-in-frame-unresolved
+  (testing "a [kind id] not in the frame's generation resolves to nothing"
+    (let [r (h/resolve-in-frame resolve-fn counter-frame :event :nope/missing)]
+      (is (false? (:resolved? r)))
+      (is (nil? (:provenance r))))))
+
+;; ---- project-image-view: demand-gated top-level -------------------------
+
+(deftest project-image-view-with-frames
+  (testing "the live registry projects to frame-rows + :images? true when at
+            least one frame runs a generation with descriptors"
+    (let [data (h/project-image-view {:counter/main counter-frame})]
+      (is (= 1 (:frame-count data)))
+      (is (true? (:images? data)))
+      (is (= :counter/main (:frame-id (first (:frames data))))))))
+
+(deftest project-image-view-empty-is-no-images
+  (testing "an empty registry → :images? false (the honest not-using-images
+            state — EP-0023's public model is opt-in)"
+    (let [data (h/project-image-view {})]
+      (is (= 0 (:frame-count data)))
+      (is (false? (:images? data)))
+      (is (= [] (:frames data))))))
+
+(deftest project-image-view-frameless-generation-is-no-images
+  (testing "a frame whose generation resolves ZERO descriptors does not flip
+            :images? — there is no image content to show"
+    (let [empty-frame {:rf.frame/object true
+                       :rf.frame/id :empty/main
+                       :rf.frame/generation {:rf.gen/resolver {}}}
+          data        (h/project-image-view {:empty/main empty-frame})]
+      (is (= 1 (:frame-count data)))
+      (is (false? (:images? data))))))
+
+;; ---- display strings -----------------------------------------------------
+
+(deftest provenance-summary-strings
+  (testing "provenance summaries read cleanly per kind"
+    (is (= "docs.counter.v2"
+           (h/provenance-summary {:kind :rf.prov/ns :ns "docs.counter.v2"})))
+    (is (= "inline :test/small [:reg-event :counter/inc]"
+           (h/provenance-summary {:kind :rf.prov/inline :image :test/small
+                                  :inline [:reg-event :counter/inc]})))
+    (is (= "framework standard"
+           (h/provenance-summary {:kind :rf.prov/standard})))
+    (is (= "—" (h/provenance-summary {:kind :rf.prov/unknown})))))
+
+(deftest image-row-summary-string
+  (testing "the image summary reads N descriptors · K kinds with correct plurals"
+    (is (= "2 descriptors · 2 kinds"
+           (h/image-row-summary (h/project-generation counter-generation))))
+    (is (= "1 descriptor · 1 kind"
+           (h/image-row-summary (h/project-generation other-generation))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
@@ -1,0 +1,125 @@
+(ns day8.re-frame2-xray.panels.image-view-reads-cljs-test
+  "CLJS coverage for the EP-0023 live image/frame read seam + the
+  Xray-as-its-own-image DOGFOODING (rf2-32siq3.12 — EP-0023 §Xray Beside The
+  Target).
+
+  This is the test the .29 dogfooding review verifies: Xray models itself as a
+  SEPARATE image/frame that inspects the target frame as DATA — NOT as shared
+  registration state. Concretely:
+
+    - Xray constructs its OWN `rf/image` (`image-view-reads/xray-image`),
+      selecting its own source namespaces (`day8.re-frame2-xray.**`);
+    - Xray's `:rf.xray/*` registrations do not leak INTO a target frame's
+      image (a target image selects the target's own namespaces, not Xray's);
+    - a target frame's registrations do not leak INTO Xray's image;
+    - Xray reads the target frame's generation + state as DATA through the
+      live-read fns, with the two images registration-disjoint.
+
+  The reads are also exercised against the real EP-0023 live-frame registry +
+  sealed generations (the fail-soft seam) so the projection runs end-to-end on
+  the values `make-frame` / `assemble` actually produce."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.image :as image]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.image-assembly :as image-assembly]
+            [day8.re-frame2-xray.panels.image-view-reads :as reads]))
+
+;; Each case starts from a clean live-frame registry so an `:id` from one case
+;; never collides with the next (EP-0023 §Id Spaces — a frame id is unique in
+;; the process-local registry).
+(use-fixtures :each
+  {:before #(live-frame/clear-live-frames!)
+   :after  #(live-frame/clear-live-frames!)})
+
+;; A target image + a target frame, built against an EXPLICIT descriptor pool
+;; (so the test does not depend on the live source store carrying any host
+;; registrations). The target image selects the target's OWN namespaces.
+(def ^:private target-pool
+  ;; The explicit descriptor pool `assemble`'s 2-arity selects from: a FLAT seq
+  ;; of descriptor maps (each carrying :kind / :id / :rf.provenance/ns — the
+  ;; source store's output shape), matching `image/select-descriptors`'s input.
+  [{:kind :event :id :counter/inc   :rf.provenance/ns "app.counter" :impl :inc}
+   {:kind :sub   :id :counter/value :rf.provenance/ns "app.counter" :impl :val}])
+
+(def ^:private target-image
+  (image/image {:id :app/counter :include-ns ["app.counter"]}))
+
+;; ---- Xray's own image (the dogfooding) -----------------------------------
+
+(deftest xray-image-is-its-own-value
+  (testing "Xray constructs its OWN inert image VALUE selecting its own source
+            namespaces — the inspector's instruction set as data (EP-0023
+            §Xray Beside The Target)"
+    (let [img (reads/xray-image)]
+      (is (= :rf.xray/image (:rf.image/id img)))
+      (is (= ["day8.re-frame2-xray.**"] (:rf.image/include-ns img))
+          "Xray selects ONLY its own source namespaces")
+      ;; PURE — an image is data, not registration: constructing it twice
+      ;; yields equal values and touches no registry.
+      (is (= img (reads/xray-image)) "rf/image is pure — equal values"))))
+
+(deftest xray-image-isolated-from-target-image
+  (testing "Xray's image and the target frame's image are REGISTRATION-DISJOINT
+            — Xray's registrations do not leak into / from the target's image
+            (the .29-review invariant)"
+    (is (true? (reads/xray-image-isolated-from? target-image))
+        "Xray (day8.re-frame2-xray.**) and the target (app.counter) select
+         disjoint source namespaces → isolated")
+    ;; The negative: an image that DID select Xray's namespaces would NOT be
+    ;; isolated — the predicate is a real check, not a constant true.
+    (let [leaky (image/image {:id :leaky/img
+                              :include-ns ["day8.re-frame2-xray.**" "app.counter"]})]
+      (is (false? (reads/xray-image-isolated-from? leaky))
+          "an image selecting Xray's namespaces is NOT isolated from Xray"))))
+
+(deftest xray-and-target-resolvers-do-not-share-registrations
+  (testing "a frame built from Xray's image and a frame built from the target's
+            image have DISJOINT resolver keysets — neither sees the other's
+            registrations (Xray is NOT part of the thing being inspected)"
+    ;; Assemble the target generation against its explicit pool. (Xray's image
+    ;; selects the LIVE source store, where Xray's own :rf.xray/* regs live;
+    ;; the target pool is explicit + carries no :rf.xray/* descriptor, so the
+    ;; two resolver keysets cannot overlap regardless of what is loaded.)
+    (let [target-gen (image-assembly/assemble [target-image] target-pool)
+          target-keys (set (keys (:rf.gen/resolver target-gen)))]
+      ;; The target frame resolves ITS ids; none are :rf.xray/* and none come
+      ;; from Xray's source namespaces.
+      (is (contains? target-keys [:event :counter/inc]))
+      (is (every? (fn [[_ id]] (not= "rf.xray" (namespace id))) target-keys)
+          "no :rf.xray/* id leaked into the target frame's image"))))
+
+;; ---- live reads of the real registry (fail-soft seam) --------------------
+
+(deftest live-reads-project-real-frames
+  (testing "the live-read seam projects the REAL EP-0023 live-frame registry +
+            sealed generations end-to-end"
+    ;; A target frame loaded with the target image against its explicit pool,
+    ;; registered under an :id so it enters the live-frame registry.
+    (live-frame/make-frame {:id :app/main :images [target-image]} target-pool)
+    (let [data (reads/image-view-data)
+          row  (first (filter #(= :app/main (:frame-id %)) (:frames data)))]
+      (is (true? (:images? data)) "a live image-loaded frame → :images? true")
+      (is (some? row) "the registered frame is projected")
+      (is (= 2 (:descriptor-count (:image row)))
+          "the frame's resolved image carries its [kind id] descriptors")
+      (is (contains? (set (map (juxt :kind :id) (:descriptors (:image row))))
+                     [:event :counter/inc])
+          "the resolved descriptor set is the frame's image as a value"))))
+
+(deftest live-reads-fail-soft-empty-registry
+  (testing "an empty live-frame registry projects to the honest no-image state"
+    (let [data (reads/image-view-data)]
+      (is (= 0 (:frame-count data)))
+      (is (false? (:images? data))))))
+
+(deftest resolve-descriptor-is-frame-derived
+  (testing "resolving a [kind id] through a real frame's generation yields the
+            frame's OWN descriptor (the frame-derived resolution path)"
+    (let [frame (live-frame/make-frame {:images [target-image]} target-pool)
+          gen   (:rf.frame/generation frame)
+          desc  (reads/resolve-descriptor gen :event :counter/inc)]
+      (is (= :counter/inc (:id desc)))
+      (is (= "app.counter" (:rf.provenance/ns desc))
+          "resolves to the target image's descriptor, not Xray's"))
+    (testing "a nil generation is fail-soft → nil (no throw)"
+      (is (nil? (reads/resolve-descriptor nil :event :counter/inc))))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -324,6 +324,13 @@
    ;; The disposition-6 demand-trigger surface; the per-module provenance
    ;; section is scaffolded behind the awaiting-seam caption.
    :rf.xray/module-view
+   ;; rf2-32siq3.12 — EP-0023 image/frame model on the Module-view tab: the
+   ;; live image-loaded frames as execution contexts, each carrying its
+   ;; resolved image (the generation's [kind id] descriptors). Reads the
+   ;; EP-0023 live-frame registry + sealed generations via the fail-soft
+   ;; `image-view-reads` seam; presents Xray itself as its OWN image
+   ;; inspecting the target frame as data (EP-0023 §Xray Beside The Target).
+   :rf.xray/image-view
    ;; rf2-o5f5f.3 — Routes browse + Simulate-URL state lives under
    ;; the Static Routes panel (promoted from `:rf.xray.routing/*` per
    ;; the two-verbs-two-homes split). The Dynamic Routing lens narrows


### PR DESCRIPTION
## Summary

EP-0023 bead **rf2-32siq3.12** — teach Xray + dev tooling to understand image-loaded frames (`image -> frame -> event stream`).

Extends the **Module-view tab** (the existing EP-0013 realm/module consumer) into the cohesive home for BOTH runtime-structure models, side by side:

- **EP-0023 public model** (FRAMES/IMAGES section, rendered first) — the new surface.
- **EP-0013 internal substrate** (REALMS + MODULES sections) — retained below, unchanged.

### What the EP-0023 surface presents

- **images as registration-set VALUES** — the resolved generation's `[kind id]` descriptors ("which registrations are visible to this frame?"), each with its provenance (source namespace / inline coordinate / framework-standard marker).
- **frames as EXECUTION CONTEXTS** — each live image-loaded frame pointing at the ONE resolved image generation it runs (id, image summary, capability keys, adapter binding).
- **frame-derived RESOLUTION** — the lookup path `target frame -> resolved image generation -> registration resolution`. The SAME `(kind id)` resolves to DIFFERENT descriptors in frames running different images.

### Xray-beside-target as its OWN image (the dogfooding — EP-0023 §Xray Beside The Target)

Xray models itself as a **separate image/frame inspecting the target frame as DATA**, NOT as shared registration state:

- `image_view_reads/xray-image` constructs Xray's own `rf/image` selecting its own source namespaces (`day8.re-frame2-xray.**`, under which every `:rf.xray/*` registration is authored + stamped `:rf.provenance/ns`).
- Xray's registrations don't leak INTO a target frame's image; a target's registrations don't leak INTO Xray's image (registration-disjoint `:include-ns` selectors).
- `xray-image-isolated-from?` is the disjointness predicate; `image_view_reads_cljs_test` asserts isolation against a **real** target frame built via `re-frame.live-frame/make-frame` — the assertion the .29 dogfooding review verifies.

## Files

- **New** `panels/image_view_helpers.cljc` — pure `data → data` projection (generation → `[kind id]` descriptors, frame-row, frame-derived resolution, demand-gated `:images?`, display strings). JVM-testable.
- **New** `panels/image_view_reads.cljs` — fail-soft live read seam over `re-frame.live-frame` / `re-frame.image` / `re-frame.image-assembly` + the Xray-as-its-own-image constructor.
- **New** `panels/image_view_helpers_cljs_test.cljc` + `panels/image_view_reads_cljs_test.cljs` — pure-projection coverage + the dogfooding isolation / fail-soft live-read tests.
- `panels/module_view.cljs` — FRAMES section render + `:rf.xray/image-view` sub.
- `tools/xray/spec/026-Module-View-Panel.md` — new §8 (EP-0023 model + §8.1 dogfooding); header/layout updated.
- `tools/xray/spec/014-Registry-Catalogue.md` — new Module-view section documenting both subs.
- `registry_cljs_test.cljs` — `:rf.xray/image-view` added to the authoritative `all-sub-names`.

## Constructs itself as an EP-0023 image?

**Yes** — `image_view_reads/xray-image` is Xray's own `rf/image` value, tested isolated from a target frame's image.

## shadow-cljs.edn

**Not touched** — no testbed build-id or `:dev-http` port change.

## Gates

- `tools/xray` JVM tests: **green** (1217 tests / 5427 assertions).
- `npm run test:cljs`: **green** (7496 tests / 30841 assertions) — incl. the new `.cljc`/`.cljs` tests + the registry enumeration.
- `scripts/test-fast-pr.sh`: **green** (incl. markdown link/anchor gates; mkdocs `--strict` soft-skips locally on Windows, CI runs it — xray spec docs are contributor-facing, not in the mkdocs corpus).

Bundle isolation is unaffected: the new requires reach only core-spine namespaces (`re-frame.live-frame` / `image` / `image-assembly`) from within Xray's dev-only tree.