### PR TITLE
fix(core): route clear-kind! through generation-bumping source-store API (rf2-32siq3.34)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -1124,6 +1124,15 @@
        ;; Live-store arity: the pool leg is the source-store generation. Read it
        ;; BEFORE selecting so the cached object is keyed to the store snapshot it
        ;; was assembled from.
+       ;;
+       ;; SINGLE-THREADED-REGISTRATION assumption (EP-0023 co-fix F3): the
+       ;; descriptor pool and the generation are read in two separate steps with
+       ;; no lock between them. This is sound only because registration mutations
+       ;; (`reg-*` / `forget-*` / `clear-*`) are single-threaded relative to
+       ;; assembly — they happen at load/hot-reload time, not concurrently with a
+       ;; live `assemble`. A concurrent mutation between these two reads could key
+       ;; a freshly-assembled pool to a stale generation; the framework does not
+       ;; defend against that because registration is not a concurrent surface.
        (assemble-cached images
                         (source-store-descriptors)
                         (source-store/store-generation)))))

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -649,8 +649,13 @@
         clear-kind   (fn [cache-set]
                        (into #{} (remove #(= kind (first %))) cache-set))]
     (swap! reg dissoc kind)
-    ;; EP-0023: drop the matching kind from the provenance source store too.
-    (swap! (source-store/active-source-store) dissoc kind)
+    ;; EP-0023: drop the matching kind from the provenance source store too, via
+    ;; the source-store API so the store GENERATION is bumped. A raw
+    ;; `(swap! (active-source-store) dissoc kind)` here would NOT bump the
+    ;; generation, leaving the resolved-image-generation cache (keyed on the
+    ;; source-store generation) to HIT and return a stale generation that still
+    ;; resolves the just-cleared `(kind, id)`s (rf2-32siq3.34).
+    (source-store/clear-kind! kind)
     (swap! missing-doc-warned clear-kind)
     (swap! collision-warned   clear-kind)
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared

--- a/implementation/core/src/re_frame/source_store.cljc
+++ b/implementation/core/src/re_frame/source_store.cljc
@@ -336,6 +336,26 @@
     (bump-generation!)
     nil))
 
+(defn clear-kind!
+  "Remove every `(id, provenance-ns)` slot for `kind` from the active source
+  store and BUMP the generation, mirroring `forget-id!`'s shell-cleanup + bump.
+  Backs `registrar/clear-kind!`, which drops a whole kind from the resolver map;
+  this keeps the provenance source store in step.
+
+  The generation bump is load-bearing: the resolved-image-generation cache
+  (`re-frame.image-assembly`) keys sealed generations on the source-store
+  generation, so without the bump a `clear-kind!` would leave the generation int
+  unchanged and a later `assemble` / `assemble-default` for the same image vector
+  would HIT the cache and return a stale generation that still resolves the
+  just-cleared `(kind, id)`s (EP-0023 §Image — resolved-generation cache). Honors
+  the `active-source-store` binding so a realm-bound store clears + bumps its OWN
+  state."
+  [kind]
+  (let [store (active-source-store)]
+    (swap! store dissoc kind)
+    (bump-generation!)
+    nil))
+
 (defn clear-all!
   "Reset the PROCESS-DEFAULT source store and the namespace-string pool. Test
   fixtures use this between cases, alongside `registrar/clear-all!`.
@@ -343,7 +363,16 @@
   Resets only the process-default store (not a bound realm store) — fixtures
   run against the default store. The ns-string pool is reset too so a fixture
   asserting pool behaviour starts clean; pool entries are harmless to retain in
-  production (the pool is never reset there)."
+  production (the pool is never reset there).
+
+  PROCESS-DEFAULT-ONLY BY CONTRACT (EP-0023 §Image co-fix F2): this always
+  targets `kind->id->ns->descriptor` and bumps that store's generation directly,
+  IGNORING any bound `*source-store*` — it is a fixture-reset surface that runs
+  against the default store. A realm-bound store is reset via its own seating
+  path, not here; the targeted-mutation surfaces (`record-descriptor!` /
+  `forget-*` / `clear-kind!`) all honor the `active-source-store` binding and bump
+  the bound store's generation, so a realm store's cache still invalidates on its
+  own mutations."
   []
   (reset! kind->id->ns->descriptor {})
   (reset! ns-string-pool {})

--- a/implementation/core/test/re_frame/source_store_cljs_test.cljc
+++ b/implementation/core/test/re_frame/source_store_cljs_test.cljc
@@ -363,3 +363,64 @@
           "no provenance stamped when no source namespace is available anywhere")
       (is (some? (get (ss/descriptors-for :event :prog/handler) nil))
           "recorded under the nil-provenance slot, not dropped"))))
+
+;; ===========================================================================
+;; 8. clear-kind! bumps the store generation (rf2-32siq3.34) — the
+;;    resolved-image-generation cache MUST invalidate after a clear-kind!
+;; ===========================================================================
+
+(deftest clear-kind-bumps-generation
+  (testing "source-store/clear-kind! bumps the active store's generation, like
+            every other mutation, so a generation read after the clear differs
+            (rf2-32siq3.34)"
+    (ss/record-descriptor! :event :a/x {:ns 'n.s :handler-fn :f})
+    (let [before (ss/store-generation)]
+      (ss/clear-kind! :event)
+      (is (not= before (ss/store-generation))
+          "clear-kind! bumped the source-store generation")
+      (is (empty? (ss/descriptors-for :event :a/x))
+          "the kind's slots were dropped from the store"))))
+
+(deftest registrar-clear-kind-invalidates-resolved-generation-cache
+  (testing "registrar/clear-kind! routes through source-store/clear-kind!, which
+            bumps the store generation, so a re-`assemble` after the clear is a
+            cache MISS that returns a FRESH generation no longer resolving the
+            cleared id. On the unfixed path (raw `dissoc kind`, no bump) the
+            store had fewer descriptors but the SAME generation int, so the
+            re-`assemble` HIT the resolved-image-generation cache and returned a
+            stale generation that still resolved the cleared (kind, id)
+            (rf2-32siq3.34, EP-0023 §Image — resolved-generation cache).
+
+            Fixtures: this case relies ONLY on the :each fixture's snapshot/
+            restore (ss/clear-all! + clear-generation-cache! at the boundaries);
+            it does NOT call registrar/clear-all! between the two assembles —
+            doing so would reset the generation cache and mask the very stale-hit
+            path under test."
+    (registrar/register! :event :counter/inc
+                         {:ns 'docs.counter.v2 :handler-fn (fn [_ _] {})})
+    ;; First assembly fills the resolved-image-generation cache, keyed on the
+    ;; current source-store generation. Default image (empty :images) projects
+    ;; the whole live store and keys on (source-store/store-generation).
+    (let [gen-before (assembly/assemble [])
+          size-before (assembly/cache-size)]
+      (is (some? (assembly/resolve-descriptor gen-before :event :counter/inc))
+          "the registered descriptor resolves in the first sealed generation")
+      ;; Clear the whole :event kind via the PUBLIC registrar path (this backs
+      ;; clear-handlers / resources teardown).
+      (registrar/clear-kind! :event)
+      (is (empty? (ss/descriptors-for :event :counter/inc))
+          "the source store no longer holds the cleared descriptor")
+      ;; Re-assemble the SAME (empty) image vector. With the generation bump this
+      ;; is a cache MISS → a fresh generation; without it, a stale cache HIT.
+      (let [gen-after (assembly/assemble [])]
+        (is (not (identical? gen-before gen-after))
+            "re-assemble after clear-kind! returns a FRESH, non-identical
+             generation (a cache MISS) — NOT the stale cached object")
+        (is (nil? (assembly/resolve-descriptor gen-after :event :counter/inc))
+            "the cleared (kind, id) no longer resolves in the fresh generation —
+             the cache invalidation hole is closed")
+        (is (not (contains? (assembly/generation-kinds gen-after) :event))
+            "no :event kind survives the clear in the fresh generation")
+        (is (> (assembly/cache-size) size-before)
+            "a new cache entry was sealed (the post-clear generation), not a
+             reuse of the stale one")))))


### PR DESCRIPTION
## Summary

EP-0023 correctness fix. `registrar/clear-kind!` mutated the provenance source store with a raw `(swap! (source-store/active-source-store) dissoc kind)` — bypassing the source-store API and **not** bumping `store->generation`. Every other source-store mutation (`record-descriptor!`/`forget-descriptor!`/`forget-id!`/`clear-all!`) bumps the generation.

The resolved-image-generation cache (`re-frame.image-assembly`) is keyed `[images store-generation standard-generation]`. After a `clear-kind!` the store held fewer descriptors but the **same** generation int, so a later `assemble` / `assemble-default` for the same image vector was a **cache HIT returning a stale sealed generation that still resolved the just-cleared `(kind, id)`s**. `clear-kind!` backs the public `clear-handlers` (events/subs/fx) and resources teardown; the generation cache is never cleared in production, so the stale entry persisted.

## Changes

- **`source-store/clear-kind!`** (new) — drops the kind subtree and `bump-generation!`s, mirroring `forget-id!`'s shell-cleanup + bump; honors the `active-source-store` binding so a realm-bound store clears + bumps its own state.
- **`registrar/clear-kind!`** now routes through `source-store/clear-kind!` instead of the raw `dissoc`.
- **Regression test** (`source_store_cljs_test.cljc`): register → `assemble` (fills cache) → `registrar/clear-kind!` → re-`assemble` asserts a FRESH, non-`identical?` generation that no longer resolves the cleared id and grew the cache. Relies only on the `:each` snapshot/restore fixture (not `registrar/clear-all!` between the two assembles, which would mask the stale-hit path). Plus a direct `clear-kind-bumps-generation` unit test.
- **Co-fix F2**: louder "process-default-only by contract" comment on `clear-all!`.
- **Co-fix F3**: comment on the live-store `assemble` arity noting the single-threaded-registration assumption its two-step pool+generation read relies on.

## Red-before-green

With `registrar/clear-kind!` reverted to the raw `dissoc` (no bump), the regression test failed exactly the 4 stale-cache assertions (`identical?` to the stale gen, cleared id still resolves, `:event` kind still present, no new cache entry): `4 failures, 0 errors`. With the fix: `0 failures, 0 errors`.

## Gates

- `npm run test:cljs` — 7487 tests / 30820 assertions, 0 failures 0 errors
- `npm run test:elision` — PASS (production 43/43 absent; control 43/43 present)
- `sh scripts/test-fast-pr.sh` — PASS fast PR spine

Disjoint from the in-flight .33 worker — `live_frame.cljc` untouched.