### PR TITLE
docs(guide): EP-0023 images and frames model (rf2-32siq3.13)

### DIFF
--- a/docs/guide/concepts/frames.md
+++ b/docs/guide/concepts/frames.md
@@ -12,9 +12,9 @@ A frame is one running instance of your app. It owns the runtime state of that i
 - its **event queue** — the dispatches (requests to run an event) waiting to run against this instance,
 - its **subscription cache** — the memoised graph of derived values computed over this instance's state.
 
-A frame deliberately does *not* own the handlers — the functions you register to handle events and subscriptions. Every `reg-event`, `reg-sub`, and `reg-view` in your program goes into a single shared registry. So two frames running the `[:counter/inc]` event run the *same handler function* against *different app-dbs*. That's the whole trick.
+A frame deliberately does *not* own the handlers — the functions you register to handle events and subscriptions. The registrations live in an **image**: the set of `reg-event` / `reg-sub` / `reg-view` entries a frame resolves against, lifted into a value. A frame carries a reference to one resolved image; resolving `[:counter/inc]` means looking it up in *that frame's image*. By default every `reg-*` in your program projects into one shared image, so two frames running `[:counter/inc]` run the *same handler function* against *different app-dbs*. That's the whole trick. (When you need two frames to resolve the *same* id to *different* handlers — two examples on one page, a tool beside its target — you give them different images; [Images](images.md) is that story.)
 
-A frame isolates state, not behaviour. You write the app once, and the frame decides which copy of the state it runs against.
+A frame isolates state, not behaviour. You write the app once, and the frame decides which copy of the state it runs against — and which image supplies the behaviour.
 
 That division is why "show two of them side by side" never forces a rewrite. You mount the same app twice, each mount in its own frame, and isolation is total. One app, one frame — until the day you need two, and then nothing leaks.
 
@@ -206,13 +206,13 @@ If you feel the need for one, you've answered the discriminator question wrongly
 
 - **Not component-local state.** A frame carries a full app-db, queue, and sub cache; it is heavyweight by design. A dropdown's open flag or a form's draft text goes in the current frame's app-db like always — see [Where should this value live?](../where-state-lives.md).
 - **Not routing.** Navigating changes *which slice of app-db matters*, not which frame is running. One frame, many routes.
-- **Not micro-frontends.** Frames are N instances of *one* app sharing one handler registry. Genuinely different apps on one page want iframes — a wall, not a scalpel.
+- **Not micro-frontends.** Frames are N instances of *one* app, each resolving against its image. Two surfaces with disjoint images can share a page ([Images](images.md)), but genuinely different *apps* on one page want iframes — a wall, not a scalpel.
 
 ---
 
 **You can now:**
 
-- say what a frame owns (app-db, event queue, sub cache) and what it doesn't (handlers — registered once, shared by all frames),
+- say what a frame owns (app-db, event queue, sub cache) and what it doesn't (the registrations — those live in the frame's [image](images.md), one shared image by default),
 - register one frame and establish it at your root, and explain why `init!` doesn't do it for you,
 - mount one app N times — split panes, Story canvases, SSR requests, test fixtures — with `reg-frame` + `frame-provider`, nothing shared,
 - read `:rf.error/no-frame-context` as "this callback lost its frame" and fix it with `frame-handle` / `frame-bound-fn` — or with `:fx` when the work starts in a handler,

--- a/docs/guide/concepts/images.md
+++ b/docs/guide/concepts/images.md
@@ -1,0 +1,198 @@
+# Images: which registrations a frame runs
+
+You've registered a dozen events and subscriptions and your app works — and you've never had to think about *which* of them a given frame can see. That's the default path, and it's deliberately invisible. This page is for the day it stops being enough: two examples on one page that both want a `:counter/inc` event, an inspection tool mounted beside the app it inspects, a test that needs a fake HTTP effect instead of the real one, a docs page showing four versions of the same counter. Each of those is the same question — *which registrations does this frame resolve against?* — and the answer is the **image**.
+
+> **Coming from Redux?** An image is the set of reducers/selectors a store runs, lifted into a value you can name and compose — `combineReducers` if it returned data instead of a function, and could be assembled per-store. The divergence: registration *names* are scoped to the image, so two stores can each define `:cart/add` meaning different things without a global collision.
+
+If you quote one sentence from this page, quote this one:
+
+> **An image is which registrations are loaded; a frame is the live run that resolves against them.**
+
+## The model in one line
+
+```text
+image  →  frame  →  event stream
+```
+
+Read left to right. An **image** selects a set of registrations. A **frame** is the isolated execution context that runs one resolved image — its app-db, its queue, its subscription cache, all the live memory ([Frames](frames.md) is the full tour). The **event stream** is the ordered sequence of events that frame processes over its lifetime. The image says what the frame *can* do; the frame accumulates what *has* happened; the events are the program.
+
+That split is the whole point. Two frames running the same image share behaviour but not state — the same handlers, two independent app-dbs. Two frames running *different* images can reuse the same registration ids for different meanings, because each id is scoped to its image, not to one global registry.
+
+## You already use an image — the default one
+
+Here is ordinary re-frame2. No image in sight:
+
+```clojure
+(rf/reg-event :counter/inc
+  (fn [{:keys [db]} _event]
+    {:db (update db :count (fnil inc 0))}))
+
+(rf/reg-sub :counter/value
+  (fn [db _] (:count db 0)))
+```
+
+Those `reg-*` forms don't run anything. They write entries into a **registration source store** — a record of every registration, tagged with the namespace it was authored in. When a frame is created without naming an image, the runtime projects *the whole source store* into one sealed set and hands it to the frame. That projection is the **default image**: the implicit selector over everything you've registered.
+
+```text
+reg-*  writes the source store
+default image  =  the implicit selector over that source
+frame creation  resolves the selector into one sealed image
+```
+
+So the common case stays boring. You never name an image, additions show up as you register them, and hot reload keeps working — the runtime just re-projects the source store into a fresh sealed image and swaps it under the live frame, preserving the frame's memory. You meet the image concept explicitly only when the default — *everything that's loaded, ids assumed globally unique* — stops being the boundary you want.
+
+> **Heads-up.** "Default image" is a runtime projection, not a value you author. Don't reach for `rf/image` to get the default behaviour — plain `reg-*` already gives it to you.
+
+## The default image fails loud on a collision
+
+The default image works only while ids are globally unique across everything loaded. The moment two loaded namespaces register the same `(kind, id)` with different implementations — two surfaces that both define `:counter/inc`, say — the default image **fails to assemble**, with an error that names the colliding kind/id and the two source namespaces.
+
+This is a deliberate hardening over the old last-write-wins registrar, where the second registration silently clobbered the first and you found out weeks later when the wrong handler ran. The source store keeps *both* descriptors; assembly refuses to guess which one wins. Your three options are all explicit: rename one id, narrow the selector with explicit images so each frame sees only one, or declare an exact replacement winner. Silence is the one thing it won't do.
+
+## Naming an image: `rf/image`
+
+When you do need to be explicit, `rf/image` builds an image value. It's pure data — no registrar, no side effect — and you hand it to a frame through `:images`:
+
+```clojure
+(def counter-image
+  (rf/image {:include-ns ["docs.quickstart.counter.basic"]}))
+
+(rf/make-frame {:id :counter/main
+                :images [counter-image]})
+```
+
+Two ways to put registrations into an image:
+
+**Select by source namespace with `:include-ns`.** The selector is a *query over the source store*, choosing registrations by the namespace they were authored in (their recorded provenance) — not by the keyword namespace of their id. A registration with id `:counter/inc` authored in `docs.quickstart.counter.basic` is selected because of *where it was written*, not because the keyword starts with `counter`.
+
+```clojure
+(def page-image
+  (rf/image {:include-ns ["docs.*.counter.*"
+                          "docs.shared.widgets.*"]}))
+```
+
+The glob grammar is small and case-sensitive: a literal segment matches itself, `*` matches exactly one dot-free segment, and `**` matches zero or more segments. So `docs.shared.widgets.*` matches `docs.shared.widgets.button` but not `docs.shared.widgets` or `docs.shared.widgets.forms.input`; `docs.shared.**` matches all three. The selector does **not** load code — namespaces must already be required through normal `ns` dependencies; the glob only chooses from what the runtime already knows. And a pattern that matches *nothing* is an assembly error, not an empty image: that turns a typo, a forgotten `require`, or a dead-code-eliminated namespace into a loud failure at assembly time instead of a silently incomplete frame.
+
+**Or supply registrations inline with `:registrations`.** Useful for generated code, tests, or library packaging where authoring a whole namespace is overkill. The sections mirror the `reg-*` names, and entries are call-shaped tuples:
+
+```clojure
+(def small-image
+  (rf/image
+    {:id :test/small
+     :registrations
+     {:reg-event [[:counter/inc
+                   {:doc "Increment."}
+                   (fn [{:keys [db]} _] {:db (update db :count (fnil inc 0))})]]
+      :reg-sub   [[:counter/value
+                   {:doc "Current value."}
+                   (fn [db _] (:count db 0))]]}}))
+```
+
+Most human-authored code should stay with ordinary `reg-*` forms and select by provenance. Inline descriptors are an option, not the main road — and they're descriptions of registrations, never `reg-*` calls smuggled into a map.
+
+Whatever the inputs, an image is always resolved into one **sealed image generation** before the frame runs — framework standard registrations added, collisions and references validated, capabilities checked, the result frozen. The frame resolves every lookup against that one sealed generation. Assembly is where a bad image fails: a duplicate id, a zero-match glob, a stale replacement, a missing capability — all caught *before any event touches state*, which is the payoff of making the registration set a value the framework can inspect up front.
+
+## The id story: reuse registration ids, never frame ids
+
+This is the rule that makes same-on-one-page examples work, so it's worth stating sharply. There are two id spaces with different scopes:
+
+| Id space | Example | Scope | Rule |
+|---|---|---|---|
+| **Registration ids** | `:counter/inc`, `:counter/value` | the resolved image | reusable across images; must be unambiguous *within* one sealed image |
+| **Frame ids** | `:counter/left`, `:counter/right` | the process-local frame registry | must be unique among live frames |
+
+Two images may both contain a `:counter/inc` event. Two live frames may not both register as `:counter/main`. So a docs page can reuse one teaching vocabulary across every example, while each mounted example still gets a distinct frame id.
+
+```clojure
+(def counter-basic  (rf/image {:include-ns ["docs.quickstart.counter.basic"]}))
+(def counter-parity (rf/image {:include-ns ["docs.quickstart.counter.parity"]}))
+
+;; Same ids inside each image (:counter/inc, :counter/value), different meaning.
+;; Distinct frame ids, because frame ids are globally unique.
+(rf/make-frame {:id :docs.counter/basic-frame  :images [counter-basic]  :initial-db {:count 0}})
+(rf/make-frame {:id :docs.counter/parity-frame :images [counter-parity] :initial-db {:count 0}})
+```
+
+The reader sees one small vocabulary evolve across lessons instead of `:counter-v1/inc`, `:counter-v2/inc`, `:counter-v3/inc`. The image supplies the meaning; the frame ids keep the live instances apart.
+
+## When you reach for an explicit image
+
+The recurring shapes, all the same move — *different behaviour ⇒ different image; same behaviour, different history ⇒ same image, different frames*:
+
+- **Two surfaces on one page.** A todo surface and a counter surface that both want simple local ids (`:boot/init`, `:item/add`). Give each its own image with disjoint `:include-ns` selectors; each frame resolves only its own.
+- **An inspection tool beside its target.** Xray is itself a running surface with its own events, subs, and app-db paths. Run it in its own image and frame, and let it inspect the target frame as data — the tool never has to coordinate ids with the thing it inspects.
+- **Progressive docs examples.** Four versions of a counter, each a lesson, each its own image, all reusing `:counter/inc` / `:counter/value` / `:counter/view`.
+- **A library slice you compose in.** Eventually a library ships an image value; you build a frame from your image plus theirs. `:images` is the assembly input; the frame still runs one sealed generation:
+
+```clojure
+(rf/make-frame {:id :docs/main
+                :images [widgets-image routing-image product-image]})
+```
+
+  Composition is deterministic and collision-checked: if two input images provide the same `(kind, id)` with different implementations, assembly fails unless the composing image declares an explicit winner. Order never silently decides.
+
+## Tests and stories: behaviour is an image change, state is a frame change
+
+Tests and stories want controlled behaviour *and* controlled state. The image gives you the behaviour side; the frame gives you the state side. To swap in a fake HTTP effect or a story-recording navigation, you don't mutate a process-global registrar under the running frame — you build a different image:
+
+```clojure
+(def checkout-test-image
+  (rf/image {:include-ns ["checkout.core.**"
+                          "checkout.test-doubles.**"]}))
+
+(let [frame (rf/make-frame {:images [checkout-test-image]
+                            :initial-db {:cart/items []}})]
+  (rf/dispatch-sync frame [:cart/add "SKU-1"])
+  @(rf/subscribe frame [:cart/items]))
+```
+
+State setup stays a frame concern — `:initial-db`, a restored frame-state value, or setup events. Behaviour setup is an image concern — select or override registrations before the frame runs. (Targeting the frame *object* directly, as above, is the test/harness path; mounted product code targets a frame *id*. Both are in [Frames](frames.md).)
+
+### Overriding a registration is explicit
+
+If an image replaces an existing `(kind, id)`, assembly makes you say so — a bare collision is still an error, because silent last-writer-wins is exactly the failure mode the source store exists to prevent. The override names the surviving descriptor:
+
+```clojure
+(rf/image
+  {:include-ns ["checkout.core.**"
+                "checkout.story.**"]
+   :replace {[:fx :checkout.http/post] {:ns "checkout.story.http"}}})
+```
+
+Application-owned registrations replace through `:replace`. Framework-standard registrations are louder: they're non-replaceable by default, and an invariant-coupled standard stays non-replaceable outright — an image cannot replace *how the frame executes*, only *what it executes*. Replacing one needs `:replace-standard` against a standard that has opted in. The boundary is simple:
+
+> If it's application-owned and has a registered `(kind, id)`, an image may replace it — explicitly. If it's framework-standard, the standard must opt into replacement. If it's how the frame executes registered entries — queue ordering, the interceptor algorithm, app-db commit semantics — it's the processing contract, and no image touches it.
+
+## Capabilities: an image can require, a frame supplies
+
+An image can declare the host capabilities its registrations need — DOM rendering, an HTTP transport, a schema validator. The frame supplies the matching capability map. If a required capability is missing, frame creation fails *before* the image becomes runnable — the same fail-loud check, moved to the image/frame boundary:
+
+```clojure
+(def articles-image
+  (rf/image {:include-ns ["articles.core.**" "articles.browser.**"]
+             :rf.image/requires #{:rf.capability/http
+                                  :rf.capability/schemas}}))
+
+(rf/make-frame {:id :articles/main
+                :images [articles-image]
+                :capabilities {:rf.capability/http    browser-http
+                               :rf.capability/schemas malli-schemas}})
+```
+
+That keeps "this image needs HTTP" a declared fact you can read off the value, rather than a runtime surprise three events into a cascade.
+
+## Hot reload swaps the image, keeps the memory
+
+During development the source store changes as you save files. A `reg-*` re-eval doesn't mutate any running sealed generation — it marks every image that selects the changed namespace dirty, resolves fresh sealed generations, and swaps them into the affected frames. Existing app-db, runtime-db, queues, and still-valid subscription caches continue. The code changed; the VM kept its memory. That automatic path is the one you lean on day to day; you save a file and the live frames pick up the change without losing their state.
+
+When you want to change a frame's image *composition* outright — swap one whole `:images` vector for another — that's a frame-targeted reload: it replaces the target frame's whole image composition and returns a diff (what was added, changed, removed, retained) so the runtime invalidates only what actually moved. Reloading one frame never drags a sibling that happened to share a generation along with it.
+
+---
+
+**You can now:**
+
+- state the model — `image → frame → event stream` — and say which part holds behaviour (the image), which holds live state (the frame), and which is the program (the events),
+- explain the default image as the implicit projection over everything you've registered, and why a cross-namespace id collision now fails loud instead of clobbering,
+- build an explicit image with `rf/image` — `:include-ns` glob selection by source provenance, or inline `:registrations` — and supply it to a frame via `:images`,
+- reuse registration ids across images while keeping frame ids unique, and pick "same image, new frame" vs "new image" for tests, stories, multi-surface pages, and Xray,
+- override a registration explicitly with `:replace`, declare needed `:rf.image/requires` capabilities, and hot-reload a frame's image while preserving its memory.

--- a/docs/guide/concepts/index.md
+++ b/docs/guide/concepts/index.md
@@ -64,7 +64,7 @@ One form, one map: a db update is the effect `{:db …}`, and everything else ri
 
 ## A small virtual machine
 
-Structurally, a re-frame2 app is a small virtual machine. The handlers you register are its instruction set. The events you dispatch are instructions. The stream of events the app sees over its lifetime is the program, and app-db is the machine's memory. Growing the app means registering more instructions, which means the machine itself never gets more complicated. So the cost of adding a feature is bounded by the size of the feature, not the size of the app — there's simply nowhere else for the relevant logic to hide.
+Structurally, a re-frame2 app is a small virtual machine. The handlers you register are its instruction set — and the selected set a given machine loads is its **image**. The events you dispatch are instructions. The stream of events the app sees over its lifetime is the program, and app-db is the machine's memory. Growing the app means registering more instructions, which means the machine itself never gets more complicated. So the cost of adding a feature is bounded by the size of the feature, not the size of the app — there's simply nowhere else for the relevant logic to hide. (Most apps load one implicit image and never name it; [Images](images.md) is for the day you want two machines on one page running different instruction sets.)
 
 ??? note "When the loop is overkill"
 
@@ -106,6 +106,7 @@ And everything else is built *on* the loop, never beside it:
 | The URL as just another input | [Routing: the URL is a sub](routing.md) |
 | Rendering on the server | [Server-side rendering](ssr.md) |
 | Cross-cutting behaviour around handlers | [Interceptors](interceptors.md) |
+| Which registrations a frame runs | [Images](images.md) |
 | Failures as structured data | [Errors: dossiers, not log lines](errors.md) |
 | Watching the loop run | [Observability: one wire, every tool](observability.md) |
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -167,7 +167,7 @@ The snippets above are the whole app *except* for boot. Boot is the one place yo
                [counter/counter-app]]))
 ```
 
-A **frame** is one isolated world — its own app-db, registrations, and subscriptions, all sealed off from any other frame. `frame-provider` scopes the mounted views to it, so every `subscribe` and `dispatch` inside resolves there. This app has one app, one frame, and you'll rarely think about frames again until the day you want two ([Frames](concepts/frames.md)).
+A **frame** is one isolated world — its own app-db and subscription state, sealed off from any other frame. The registrations it runs come from an [image](concepts/images.md); by default that's the one implicit image projected from everything you've registered, so you don't name it. `frame-provider` scopes the mounted views to the frame, so every `subscribe` and `dispatch` inside resolves there. This app has one app, one frame, and you'll rarely think about frames again until the day you want two ([Frames](concepts/frames.md)).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
     - "More concepts":
       - "Interceptors": guide/concepts/interceptors.md
       - "Frames": guide/concepts/frames.md
+      - "Images": guide/concepts/images.md
       - "Flows": guide/concepts/flows.md
       - "Machines": guide/concepts/machines.md
       - "HTTP": guide/concepts/http.md


### PR DESCRIPTION
Teaches the EP-0023 public model in the human guide: **image -> frame -> event stream**. Conceptual + worked-example oriented; the spec/EP stay normative, this is the on-ramp.

## What changed

**New page — `docs/guide/concepts/images.md`** (Core concepts shelf, beside Frames):
- What an **image** is — a selected registration set, built with `rf/image` via `:include-ns` source-provenance globs (the small `*` / `**` grammar, selection by authoring namespace not id namespace, zero-match fails loud) or inline `:registrations`.
- The **default image** — the implicit projection over the whole registration source store; the common `reg-*` path stays boring and never names an image.
- **Cross-namespace collision fails loud** — the source store retains both descriptors; default-image assembly refuses to guess (the hardening over last-write-wins).
- The **two id spaces** — registration ids reusable across images, frame ids unique in the process-local registry (the same-ids-on-one-page story).
- When to reach for an explicit image — two surfaces on one page, an inspection tool beside its target, progressive docs examples, tests/stories (behaviour is an image change, state is a frame change).
- `:replace` / `:replace-standard` overrides at a guide level, `:rf.image/requires` capabilities, and hot reload preserving frame memory.

**Light updates** weaving images into existing pages:
- `frames.md` — the frame carries a resolved image; registrations live in the image (one shared default image), with forward links.
- `concepts/index.md` — name the image as the loaded instruction set in the VM section; add an Images row to the concepts map.
- `quickstart.md` — a frame's registrations come from its image (the implicit default).
- `mkdocs.yml` — nav entry under "More concepts".

## Gates
- `mkdocs build --strict` (with `spec/` + `migration/` staged): GREEN, no warnings/errors; `images.md` renders.
- `check_doc_slugs.py` link/anchor validator: GREEN (no broken links).
- `doc-guide-check` manifest-projection drift gate: GREEN (491 `(rf/<var>` references resolve).
- CLJS node integration (`npm run test:cljs`): 7485 tests, 0 failures, 0 errors.
- No `rf2-` bead ids in prose; no hot-zone files touched.

## Notes
- The explicit `reload-images!` worked example is written as prose, not a `(rf/reload-images! ...)` call-position fence: that facade export is a tracked EP-0023 follow-up and is not yet a `re-frame.core` manifest row, so a `(rf/...` form would trip the doc-guide drift gate and mislead a reader who tried it today. The automatic `reg-*` re-eval hot-reload path (which works now) is taught with a worked shape.
- The hot-zone `migration/from-re-frame-v1/README.md` was **not** touched: EP-0023's image/realm surface is v2-internal evolution (EP-0013 -> EP-0023), not a v1->v2 delta — v1 had no realm/image concept — so there is nothing v1-specific to migrate. The guide concepts page is the right home.