### PR TITLE
docs(skills): fix EP-0023 dispatch-sync frame-arg shape + frame-handle naming (rf2-32siq3.37)

### DIFF
--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -48,7 +48,7 @@ A test that needs a *different instruction set* (a fake HTTP fx, a swapped coeff
                 {:images     [(rf/image {:include-ns ["shop.cart.**"
                                                       "shop.test-doubles.**"]})]
                  :initial-db {:cart/items []}})]
-    (rf/dispatch-sync frame [:cart/add "SKU-1"])
+    (rf/dispatch-sync [:cart/add "SKU-1"] {:frame frame})
     (is (= ["SKU-1"] @(rf/subscribe frame [:cart/items])))))
 ```
 

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -125,7 +125,7 @@ Per-test isolated frame, from `examples/reagent/login/core.cljs`:
   (assert (= :authed (rf/compute-sub [:auth.login/state] (rf/app-db-value f)))))
 ```
 
-Each test gets its own frame with its own app-db and its own fx-override map — concurrent tests can run with no cross-contamination. Holding the frame as a value and passing it directly (`{:frame f}`, `(rf/app-db-value f)`) is the EP-0023 **direct frame object** pattern: the frame is born in the test scope and dies with it, with no entry in any process-local frame-id registry. That is the right shape for tests and harnesses — reach for an `:id`-registered frame only when mounted code must address it by id.
+Each test gets its own frame with its own app-db and its own fx-override map — concurrent tests can run with no cross-contamination. Holding the frame handle/id as a value and passing it directly (`{:frame f}`, `(rf/app-db-value f)`) is the EP-0023 anonymous-frame test pattern: the frame is born in the test scope and dies with it, with no entry in any process-local frame-id registry. On the landed API `f` is a gensym frame-id (a keyword), not an object — "direct frame object" is reserved for the (unlanded) object-API section. That is the right shape for tests and harnesses — reach for an `:id`-registered frame only when mounted code must address it by id.
 
 And establishing the app frame at boot (the runtime infers no frame, so you register it explicitly and scope it at the root):
 


### PR DESCRIPTION
EP-0023 skills follow-up from the read-only review (.30) of the merged .14 skills slice. Two small docs fixes; surface is `skills/` only.

## F1 — testing.md dispatch-sync frame-arg shape (minor)
`references/cross-cutting/testing.md` behaviour-isolation example passed the frame as a **leading positional** arg to `dispatch-sync`, contradicting the call-site contract taught in `references/fundamentals/frames.md` (lines 81–89): `dispatch`/`dispatch-sync` take a **trailing `{:frame …}`** opt; only `subscribe` takes a leading frame-id.

- Before: `(rf/dispatch-sync frame [:cart/add "SKU-1"])`
- After:  `(rf/dispatch-sync [:cart/add "SKU-1"] {:frame frame})`

(The `(rf/subscribe frame [:cart/items])` line on the next line already matches `subscribe`'s leading-frame form and is left unchanged.)

## F2 — frames.md frame-handle naming (nit)
`references/fundamentals/frames.md` landed `with-new-frame` mini-example caption called holding `f` + passing `{:frame f}` the "direct frame object" pattern, but on the **landed** API `f` is a gensym frame-**id** (a keyword), not an object. The code was already correct; this was naming imprecision.

- Renamed to "anonymous-frame test pattern" and added a clause: on the landed API `f` is a gensym frame-id (a keyword), not an object — "direct frame object" is reserved for the (unlanded) object-API section.

The `testing.md` behaviour-isolation block (which IS the unlanded object-API `make-frame`/`:images` facade wave) keeps its "direct-frame-object" naming — correct there because `frame` is bound to a literal `make-frame` object.

## Out of scope (left untouched per brief)
- `skills/re-frame2/spec/design.md` `rf/realm` references (excluded skill-internal authoring meta-doc)
- everything outside `skills/`

## Gates
`sh scripts/test-fast-pr.sh` → PASS fast PR spine (CLJS 7511 tests / 0 failures; skill structural + MCP-drift + implementor-order + eval-docs + markdown link/anchor + bead-id gates all green).