### PR TITLE
fix(xray): strengthen EP-0023 self-image isolation proof to resolver-keyset + honest dogfood claims (rf2-32siq3.35)

### DIFF
--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -273,8 +273,21 @@ the target's registration set.
 > Xray runs in its own frame. Xray inspects the target frame. That keeps the
 > inspection tool from becoming part of the thing being inspected.
 
-Xray therefore models itself as a **separate image/frame**, NOT as shared
-registration state:
+**Scope (honest claim, rf2-32siq3.35).** What is realized today is the
+**CONSTRUCT-and-PROVE** half: Xray builds its OWN real `rf/image` (a separate
+registration-set value) and the implementation **proves** it
+registration-disjoint from a target frame's image. The running Xray shell is
+NOT yet SEATED in a frame built from that image via `rf/make-frame` — Xray
+still runs on the ambient registrar like any other surface. Actually seating
+Xray in its own frame is deferred follow-up (**rf2-32siq3.36**). So the claim is
+"Xray's instruction set is a separate image, provably non-overlapping with the
+target's" — the image VALUE plus the proven disjointness — not the full "Xray
+runs in its own frame" runtime. With the strengthened proof (below) the
+**isolation** claim is true; only the "runs-in-its-own-frame" claim is scoped
+down to construct-and-prove.
+
+Xray therefore models its registration set as a **separate image**, NOT as
+shared registration state:
 
 - `image_view_reads/xray-image` constructs Xray's OWN EP-0023 `rf/image` — an
   inert value selecting Xray's own source namespaces (`:include-ns
@@ -284,17 +297,32 @@ registration state:
 - Xray's `:rf.xray/*` registrations do NOT leak INTO a target frame's image:
   a target frame's image selects the TARGET's own namespaces, not Xray's.
 - A target frame's registrations do NOT leak INTO Xray's image: the two images
-  select disjoint source namespaces, so a frame built from one cannot resolve
+  resolve disjoint `[kind id]` sets, so a frame built from one cannot resolve
   the other's registrations.
 - Xray reads the target frame's **generation + state as DATA** through the
   live-read seam (`image_view_reads`), never by sharing the target's
   registrar. The target remains ordinary data from the tool's point of view.
 
 `image_view_reads/xray-image-isolated-from?` is the registration-disjointness
-predicate (compares the two images' `:include-ns` selectors); the
-`image_view_reads_cljs_test` asserts the isolation against a real target frame
-built via `re-frame.live-frame/make-frame` — the assertion the .29 dogfooding
-review verifies.
+predicate, and the proof is on the **REAL non-leakage invariant**, not a proxy:
+it **assembles BOTH images into sealed generations and compares their
+`:rf.gen/resolver` KEYSETS** (the `[kind id]` pairs each frame would resolve),
+returning true iff those keysets are DISJOINT. This is stronger than comparing
+the `:rf.image/include-ns` selector STRINGS (the prior proxy): different globs
+can select OVERLAPPING namespaces, and inline `:registrations` carry no
+`:include-ns` selector at all, yet either can introduce a shared `[kind id]` —
+the keyset comparison catches both, the string comparison neither. The
+predicate is fail-soft: a throw during assembly (a zero-match `:include-ns`, a
+collision, an old core) means isolation could not be assembled and proven, so it
+is CONSERVATIVE and returns `false` (not-proven-isolated) rather than a
+false-positive `true`. It offers a live-store arity (assemble both against the
+live source store — the production-runtime check) and an explicit-pool arity
+(assemble both against a supplied descriptor pool — the deterministic test
+form). The `image_view_reads_cljs_test` asserts the isolation **bidirectionally**
+against assembled generations — including the load-bearing case where two
+DIFFERENT globs select OVERLAPPING namespaces (a constructed overlap the string
+proxy would mislabel isolated, the keyset check correctly reports NOT isolated)
+— the assertion the .29 dogfooding review verifies.
 
 ### §8.2 Demand-gating & empty state
 
@@ -330,20 +358,29 @@ does not flip `:images?` (there is no image content to show).
   `project-frames` · `resolve-in-frame` · `project-image-view` ·
   `provenance-summary` · `image-row-summary` · `no-images-caption`);
   JVM-testable.
-- `panels/image_view_reads.cljs` — the fail-soft live read seam (`live-frames`
-  · `resolve-descriptor` · `image-view-data`) over the EP-0023 core surfaces
-  (`re-frame.live-frame` / `re-frame.image` / `re-frame.image-assembly`), PLUS
-  the Xray-as-its-own-image constructor (`xray-image` · `xray-image-id` ·
-  `xray-source-glob` · `xray-image-isolated-from?`). Xray may require these core
+- `panels/image_view_reads.cljs` — the READ-TIME fail-soft live read seam
+  (`live-frames` · `resolve-descriptor` · `image-view-data`) over the EP-0023
+  core surfaces (`re-frame.live-frame` / `re-frame.image` /
+  `re-frame.image-assembly`), PLUS the Xray-as-its-own-image constructor
+  (`xray-image` · `xray-image-id` · `xray-source-glob` · `resolver-keyset` ·
+  `xray-image-isolated-from?`). `resolver-keyset` is the `[kind id]`-keyset
+  reader the strengthened predicate compares; `xray-image-isolated-from?`
+  assembles both images and compares those keysets (live-store + explicit-pool
+  arities, fail-soft to a conservative `false`). Xray may require these core
   namespaces directly — bundle isolation forbids `implementation/` requiring
   from `tools/`, not the reverse, the same pattern Xray uses for
-  `re-frame.frame` / `re-frame.registrar`.
+  `re-frame.frame` / `re-frame.registrar`. (The read seam's fail-soft is
+  READ-TIME robustness, not absent-core-surface tolerance: the core EP-0023
+  namespaces are hard-`:require`d, so an old core fails at LOAD before the
+  try/catch.)
 - `panels/module_view.cljs` — extended with the FRAMES section (`frame-row` ·
   `descriptor-rows` · `frames-section-body`) + the `:rf.xray/image-view` sub.
 - Tests: `panels/image_view_helpers_cljs_test.cljc` (the generation/image
   projection, the frame-row shape, the frame-derived resolution — same id /
   different image → different descriptor, the demand-gated `:images?`
   decision, the display strings) + `panels/image_view_reads_cljs_test.cljs`
-  (the Xray-as-its-own-image isolation against a real target frame, the
-  fail-soft live-read seam end-to-end, frame-derived resolution through a real
+  (the Xray-as-its-own-image isolation proven on assembled resolver KEYSETS —
+  bidirectional disjointness, the constructed overlapping-glob case the string
+  proxy would miss, and the negative leaky-image case — plus the fail-soft
+  live-read seam end-to-end and frame-derived resolution through a real
   generation).

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc
@@ -75,19 +75,27 @@
       {:kind :rf.prov/standard}
       {:kind :rf.prov/unknown}
 
-  Pure `data -> data`; JVM-testable."
+  The three provenance slots are MUTUALLY EXCLUSIVE on a well-formed
+  descriptor, so this `cond`'s branch order tracks core's
+  `re-frame.image-assembly/descriptor-coordinate` (the ground-truth
+  source-coordinate fn) — `:standard` first, then the inline image coordinate,
+  then the registered `:rf.provenance/ns` — rather than introducing a different
+  precedence the projection would have to defend. (`descriptor-coordinate`'s
+  final `:else` is the registered-ns case; here that leg is explicit so an
+  unrecognized descriptor falls through to `:rf.prov/unknown` instead of
+  `{:ns nil}`.) Pure `data -> data`; JVM-testable."
   [descriptor]
   (cond
-    (:rf.provenance/ns descriptor)
-    {:kind :rf.prov/ns :ns (:rf.provenance/ns descriptor)}
+    (:standard descriptor)
+    {:kind :rf.prov/standard}
 
     (:rf.provenance/image descriptor)
     {:kind   :rf.prov/inline
      :image  (:rf.provenance/image descriptor)
      :inline (:rf.provenance/inline descriptor)}
 
-    (:standard descriptor)
-    {:kind :rf.prov/standard}
+    (:rf.provenance/ns descriptor)
+    {:kind :rf.prov/ns :ns (:rf.provenance/ns descriptor)}
 
     :else
     {:kind :rf.prov/unknown}))

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
@@ -4,23 +4,38 @@
 
   ## The two jobs
 
-  1. **Live reads (fail-soft).** The EP-0023 public model — the live-frame
-     registry + sealed image generations — is read here, kept OUT of the pure
-     `image_view_helpers.cljc` algebra so that algebra stays JVM-testable
-     `data -> data`. Every read is `try`-guarded and degrades to the empty
-     value, so an image/frame browse never throws on a core too old to expose
-     the EP-0023 surfaces (the same fail-soft discipline as
-     `static/shared/realm.cljs`).
+  1. **Live reads (READ-TIME fail-soft).** The EP-0023 public model — the
+     live-frame registry + sealed image generations — is read here, kept OUT of
+     the pure `image_view_helpers.cljc` algebra so that algebra stays
+     JVM-testable `data -> data`. Every read is `try`-guarded and degrades to
+     the empty value, so an image/frame browse never throws AT READ TIME on a
+     malformed/absent runtime value or any read-path throw. (This is read-time
+     robustness, NOT an absent-core-surface tolerance: the EP-0023 core
+     namespaces are hard `:require`d below, so a core too old to expose them
+     fails at LOAD, before any try/catch here runs — unlike a surface that
+     reflectively probes for an optional API.)
 
   2. **Xray-as-its-own-image (the dogfooding — EP-0023 §Xray Beside The
      Target).** Xray is itself a running surface with registrations, state,
      views, subscriptions, and effects. EP-0023's headline isolation case is
-     that the inspector MUST NOT share the target's registration set: Xray
-     runs in its OWN image/frame and inspects the target frame as DATA.
+     that the inspector MUST NOT share the target's registration set. This ns
+     realizes the CONSTRUCT-and-PROVE half of that case: Xray builds its OWN
+     real `rf/image` (a separate registration-set value) and PROVES it
+     registration-disjoint from the target frame's image, inspecting the target
+     frame as DATA.
 
          > Xray runs in its own frame. Xray inspects the target frame.
          > That keeps the inspection tool from becoming part of the thing
          > being inspected. (EP-0023 §Xray Beside The Target)
+
+     SCOPE NOTE (honest claim): this ns CONSTRUCTS Xray's own image and proves
+     the isolation invariant; it does NOT yet SEAT the running Xray shell in a
+     frame built from that image via `rf/make-frame`. Xray today still runs on
+     the ambient registrar like any other surface; actually seating Xray in its
+     own frame is deferred follow-up (rf2-32siq3.36). What is realized here is
+     the image VALUE + the proven disjointness — Xray's instruction set is a
+     separate image, provably non-overlapping with the target's — not the
+     full Xray-runs-in-its-own-frame runtime.
 
      This ns constructs Xray's own registration set as an EP-0023 `rf/image`
      — selected by the `:include-ns` glob over Xray's OWN source namespaces
@@ -111,13 +126,17 @@
   PURE: `rf/image` is data, not registration (no realm, no registrar, no side
   effect).
 
-  This is the dogfooding the EP names: Xray models itself as a SEPARATE
-  image/frame, not as shared registration state. The returned image value is
-  Xray's instruction set; it never mixes with a target frame's image, and the
-  target frame is inspected as DATA through the live-read fns. Construct an
-  Xray frame with this image (`(rf/make-frame {:id :rf.xray/main :images
-  [(xray-image)] :initial-db {:rf.xray/target <target-frame-id>}})`) to run
-  Xray beside the target without the two sharing a registration set.
+  This is the CONSTRUCT-and-PROVE half of the dogfooding the EP names: Xray
+  builds its OWN registration-set value (a SEPARATE image, not shared
+  registration state) and `xray-image-isolated-from?` proves it
+  registration-disjoint from a target frame's image. The returned image value
+  is Xray's instruction set; it never mixes with a target frame's image, and
+  the target frame is inspected as DATA through the live-read fns. To SEAT a
+  running Xray in a frame built from this image one would construct
+  `(rf/make-frame {:id :rf.xray/main :images [(xray-image)] :initial-db
+  {:rf.xray/target <target-frame-id>}})` — that seating is deferred follow-up
+  (rf2-32siq3.36); what this fn realizes is the image VALUE and (via the
+  isolation predicate) the proven disjointness, not the seated runtime.
 
   Returns the normalized inert image value (`:rf.image/id` /
   `:rf.image/include-ns` / …)."
@@ -125,21 +144,65 @@
   (image/image {:id         xray-image-id
                 :include-ns [xray-source-glob]}))
 
+(defn resolver-keyset
+  "The set of `[kind id]` resolver keys a sealed image `generation` carries
+  (`(keys (:rf.gen/resolver generation))` as a set) — the registration set a
+  frame running that generation actually resolves (EP-0023 §Specification
+  Summary). A nil generation has the empty keyset. Pure `data -> #{[kind id]}`."
+  [generation]
+  (set (keys (:rf.gen/resolver generation))))
+
 (defn xray-image-isolated-from?
   "True iff XRAY'S OWN image and a `target-image` are REGISTRATION-DISJOINT —
   the EP-0023 §Xray Beside The Target invariant that the inspector's
-  registrations do not leak into / from the target frame's image. Compares the
-  `:rf.image/include-ns` selectors: Xray selects `day8.re-frame2-xray.**`; a
-  target frame's image selects the target's OWN namespaces. Isolation holds
-  when no selector is shared (the two images select disjoint source
-  namespaces). Pure `data -> bool`; the assertion the .29 dogfooding review
-  verifies.
+  registrations do not leak into / from the target frame's image — that keeps
+  the inspection tool from becoming part of the thing being inspected.
 
-  `target-image` is a normalized image value (`rf/image`'s return). Returns
-  true when the two images share no `:include-ns` selector — i.e. neither
-  selects the other's source namespaces — so a frame built from one cannot see
-  the other's registrations."
-  [target-image]
-  (let [xray-sel   (set (:rf.image/include-ns (xray-image)))
-        target-sel (set (:rf.image/include-ns target-image))]
-    (empty? (set/intersection xray-sel target-sel))))
+  The check is on the REAL non-leakage invariant, not a proxy: ASSEMBLE both
+  images into sealed generations and compare their `:rf.gen/resolver` KEYSETS
+  (the `[kind id]` pairs each frame would resolve). Isolation holds iff the two
+  keysets are DISJOINT — no `[kind id]` is resolved by BOTH a frame built from
+  Xray's image and a frame built from the target's image, so neither frame can
+  see the other's registrations. This is stronger than comparing the
+  `:rf.image/include-ns` selector strings (the prior proxy): different globs can
+  select OVERLAPPING namespaces, and inline `:registrations` carry no
+  `:include-ns` selector at all, yet either can introduce a shared `[kind id]` —
+  the keyset comparison catches both, the string comparison neither.
+
+  Two arities:
+
+    (xray-image-isolated-from? target-image)
+      assemble BOTH images against the LIVE registration source store (the real
+      runtime: where Xray's `:rf.xray/*` registrations and the target's
+      registrations both live). The honest production-runtime check.
+
+    (xray-image-isolated-from? target-image pool)
+      assemble BOTH images against an EXPLICIT descriptor `pool` (a flat seq of
+      descriptor maps, the source store's output shape) — the deterministic
+      test/harness form that does not depend on what the live store carries.
+      Both images select from the SAME pool, so a `[kind id]` authored under a
+      namespace BOTH images select surfaces as a shared resolver key (the
+      check FAILS, correctly), proving the predicate is a real disjointness
+      test and not a constant true.
+
+  Fail-soft: assembly is fail-loud (a zero-match `:include-ns`, a collision),
+  and a core too old to expose the EP-0023 assembly surfaces would throw. A
+  throw means isolation could NOT be assembled and PROVEN, so the predicate is
+  CONSERVATIVE and returns `false` (not-proven-isolated) rather than a
+  false-positive `true`. `target-image` is a normalized image value
+  (`rf/image`'s return). Pure `data -> bool` (modulo the read of the live store
+  in the single-arity form)."
+  ([target-image]
+   (try
+     (let [xray-gen   (image-assembly/assemble [(xray-image)])
+           target-gen (image-assembly/assemble [target-image])]
+       (empty? (set/intersection (resolver-keyset xray-gen)
+                                 (resolver-keyset target-gen))))
+     (catch :default _ false)))
+  ([target-image pool]
+   (try
+     (let [xray-gen   (image-assembly/assemble [(xray-image)] pool)
+           target-gen (image-assembly/assemble [target-image] pool)]
+       (empty? (set/intersection (resolver-keyset xray-gen)
+                                 (resolver-keyset target-gen))))
+     (catch :default _ false))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
@@ -19,6 +19,7 @@
   sealed generations (the fail-soft seam) so the projection runs end-to-end on
   the values `make-frame` / `assemble` actually produce."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.set :as set]
             [re-frame.image :as image]
             [re-frame.live-frame :as live-frame]
             [re-frame.image-assembly :as image-assembly]
@@ -58,35 +59,87 @@
       ;; yields equal values and touches no registry.
       (is (= img (reads/xray-image)) "rf/image is pure — equal values"))))
 
+;; A descriptor authored under XRAY's OWN source namespace (the shape the live
+;; source store stamps for every :rf.xray/* registration). Used to give Xray's
+;; `day8.re-frame2-xray.**` glob something to select from an EXPLICIT pool, so
+;; the resolver-keyset comparison can be exercised deterministically without
+;; depending on what the live store carries in the test JVM.
+(def ^:private xray-pool
+  [{:kind :event :id :rf.xray/refresh :rf.provenance/ns "day8.re-frame2-xray.panels.foo" :impl :refresh}
+   {:kind :sub   :id :rf.xray/tab     :rf.provenance/ns "day8.re-frame2-xray.panels.bar" :impl :tab}])
+
+;; The combined pool both images select from in the explicit-pool arity. Xray's
+;; glob selects the xray-authored descriptors; the target's glob selects the
+;; app.counter ones. Disjoint by construction.
+(def ^:private combined-pool (into target-pool xray-pool))
+
 (deftest xray-image-isolated-from-target-image
   (testing "Xray's image and the target frame's image are REGISTRATION-DISJOINT
-            — Xray's registrations do not leak into / from the target's image
-            (the .29-review invariant)"
-    (is (true? (reads/xray-image-isolated-from? target-image))
-        "Xray (day8.re-frame2-xray.**) and the target (app.counter) select
-         disjoint source namespaces → isolated")
-    ;; The negative: an image that DID select Xray's namespaces would NOT be
-    ;; isolated — the predicate is a real check, not a constant true.
+            — assemble BOTH and compare resolver keysets; Xray's [kind id]s do
+            not leak into / from the target's image (the strengthened
+            .29-review invariant)"
+    ;; Explicit-pool arity: both images select from `combined-pool`. Xray
+    ;; resolves its own :rf.xray/* ids; the target resolves :counter/* — the two
+    ;; resolver keysets are disjoint → isolated.
+    (is (true? (reads/xray-image-isolated-from? target-image combined-pool))
+        "Xray (day8.re-frame2-xray.**) and the target (app.counter) resolve
+         disjoint [kind id] sets → isolated")
+    ;; The negative: an image that DID select Xray's namespaces resolves Xray's
+    ;; OWN ids, so the keysets OVERLAP → NOT isolated. The predicate is a real
+    ;; keyset-disjointness check, not a constant true.
     (let [leaky (image/image {:id :leaky/img
                               :include-ns ["day8.re-frame2-xray.**" "app.counter"]})]
-      (is (false? (reads/xray-image-isolated-from? leaky))
-          "an image selecting Xray's namespaces is NOT isolated from Xray"))))
+      (is (false? (reads/xray-image-isolated-from? leaky combined-pool))
+          "an image selecting Xray's namespaces shares Xray's [kind id]s → NOT
+           isolated"))))
+
+(deftest xray-isolation-is-keyset-not-selector-string
+  (testing "the predicate compares RESOLVER KEYSETS, not :include-ns selector
+            STRINGS — two DIFFERENT globs that select OVERLAPPING namespaces are
+            correctly reported NOT isolated (the proxy a string comparison would
+            miss)"
+    ;; `day8.re-frame2-xray.**` (Xray's glob) and `day8.re-frame2-xray.panels.*`
+    ;; (this target's glob) are DIFFERENT strings — a string-intersection check
+    ;; would wrongly call them isolated. But BOTH select the xray-authored
+    ;; descriptor under `day8.re-frame2-xray.panels.foo`, so their resolver
+    ;; keysets SHARE [:event :rf.xray/refresh] → the keyset check correctly
+    ;; reports NOT isolated.
+    (let [overlap-target (image/image {:id :overlap/img
+                                       :include-ns ["day8.re-frame2-xray.panels.*"]})
+          xray-sel       (set (:rf.image/include-ns (reads/xray-image)))
+          target-sel     (set (:rf.image/include-ns overlap-target))]
+      (is (empty? (set/intersection xray-sel target-sel))
+          "the two :include-ns selector STRINGS are disjoint (the old proxy
+           would call this isolated)")
+      (is (false? (reads/xray-image-isolated-from? overlap-target xray-pool))
+          "but the two RESOLVER KEYSETS overlap → the strengthened predicate
+           correctly reports NOT isolated"))))
 
 (deftest xray-and-target-resolvers-do-not-share-registrations
   (testing "a frame built from Xray's image and a frame built from the target's
-            image have DISJOINT resolver keysets — neither sees the other's
-            registrations (Xray is NOT part of the thing being inspected)"
-    ;; Assemble the target generation against its explicit pool. (Xray's image
-    ;; selects the LIVE source store, where Xray's own :rf.xray/* regs live;
-    ;; the target pool is explicit + carries no :rf.xray/* descriptor, so the
-    ;; two resolver keysets cannot overlap regardless of what is loaded.)
-    (let [target-gen (image-assembly/assemble [target-image] target-pool)
-          target-keys (set (keys (:rf.gen/resolver target-gen)))]
-      ;; The target frame resolves ITS ids; none are :rf.xray/* and none come
-      ;; from Xray's source namespaces.
-      (is (contains? target-keys [:event :counter/inc]))
+            image have DISJOINT resolver keysets BIDIRECTIONALLY — neither sees
+            the other's registrations (Xray is NOT part of the thing being
+            inspected)"
+    ;; Assemble BOTH generations against the same combined pool, then compare
+    ;; their resolver keysets directly (the invariant `xray-image-isolated-from?`
+    ;; encodes), in BOTH directions.
+    (let [xray-gen    (image-assembly/assemble [(reads/xray-image)] combined-pool)
+          target-gen  (image-assembly/assemble [target-image] combined-pool)
+          xray-keys   (reads/resolver-keyset xray-gen)
+          target-keys (reads/resolver-keyset target-gen)]
+      ;; Each frame resolves ITS own ids.
+      (is (contains? xray-keys [:event :rf.xray/refresh])
+          "Xray's frame resolves Xray's own [kind id]")
+      (is (contains? target-keys [:event :counter/inc])
+          "the target's frame resolves the target's own [kind id]")
+      ;; Bidirectional non-leakage: no Xray id in the target's keyset, and no
+      ;; target id in Xray's keyset.
+      (is (empty? (set/intersection xray-keys target-keys))
+          "the two resolver keysets are disjoint")
       (is (every? (fn [[_ id]] (not= "rf.xray" (namespace id))) target-keys)
-          "no :rf.xray/* id leaked into the target frame's image"))))
+          "no :rf.xray/* id leaked INTO the target frame's image")
+      (is (every? (fn [[_ id]] (= "rf.xray" (namespace id))) xray-keys)
+          "no target id leaked INTO Xray's image"))))
 
 ;; ---- live reads of the real registry (fail-soft seam) --------------------
 


### PR DESCRIPTION
EP-0023 (rf2-32siq3.35): harden the Xray self-image isolation proof and make the dogfood claims honest. Found by the .29 read-only review of the merged .12 Xray slice. Surface: **tools/xray only**.

## F2 (the real fix) — resolver-keyset isolation proof
`xray-image-isolated-from?` previously compared the two images' `:rf.image/include-ns` selector STRINGS for empty intersection — a sufficient-but-not-necessary proxy (different globs can select overlapping namespaces; inline `:registrations` carry no `:include-ns` selector at all). It now ASSEMBLES both images into sealed generations and compares their `:rf.gen/resolver` KEYSETS for empty intersection — the real non-leakage invariant (no shared `[kind id]`).

- Added `resolver-keyset` (the `[kind id]`-keyset reader).
- Two arities: live-store (`assemble` single-arity — the production-runtime check) and explicit-pool (deterministic test form).
- Fail-soft: a throw during assembly (zero-match `:include-ns`, collision, old core) returns a CONSERVATIVE `false` (not-proven-isolated), never a false-positive `true`.
- The test exercises the predicate **BIDIRECTIONALLY** and adds the load-bearing constructed-overlap case: two DIFFERENT globs (`day8.re-frame2-xray.**` vs `day8.re-frame2-xray.panels.*`) that select OVERLAPPING namespaces — the string proxy would mislabel isolated; the keyset check correctly reports NOT isolated. Plus the negative leaky-image case.

## F1a — honest "runs in its own frame" claim
Scoped the headline wording down to the realized **CONSTRUCT-and-PROVE** half: Xray constructs its own real `rf/image` and proves it registration-disjoint from the target. Actually SEATING the running Xray shell in that frame via `rf/make-frame` is deferred follow-up (rf2-32siq3.36). With F2 done the ISOLATION claim is true; only the "runs-in-its-own-frame" claim is softened. (docstrings + spec 026 §8.1)

## F3 — fail-soft scoping
Reworded the read seam's fail-soft to READ-TIME robustness and dropped the `realm.cljs` absent-surface equivalence: the hard `:require`s of `re-frame.live-frame`/`image`/`image-assembly` mean an old core fails at LOAD before the try/catch, unlike a reflective optional-API probe.

## F4 — descriptor-provenance ordering
`descriptor-provenance` now orders `:standard` → inline → `:rf.provenance/ns`, matching core's `descriptor-coordinate` (the slots are mutually exclusive); the explicit `:else → :rf.prov/unknown` leg is documented (core's `:else` is the ns case).

Spec `tools/xray/spec/026` §8/§8.1/§8.4 updated in the same PR (Xray-spec-currency rule).

## Gates
- `tools/xray` JVM `clojure -M:test`: 1217 tests / 5427 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 7512 tests / 30897 assertions, 0 failures, 0 errors.
- `sh scripts/test-fast-pr.sh`: PASS (incl. markdown link/anchor gates; mkdocs soft-skip — not on local PATH, CI runs it).