### PR TITLE
test(core): EP-0023 elision probe + frame-object + reproject coverage gaps (rf2-32siq3.40)

### DIFF
--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -60,7 +60,15 @@
             [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.http-managed :as http-managed]
             [re-frame.views        :as views]
-            [re-frame.machines]))
+            [re-frame.machines]
+            ;; rf2-32siq3.40 — EP-0023 image-loaded frames. The probe roots the
+            ;; registration SOURCE STORE so `:rf.provenance/ns` is in the
+            ;; :advanced reachability graph (it must SURVIVE DCE — a production
+            ;; descriptor field, not a dev-only sentinel). It does NOT root the
+            ;; image-loading path (make-frame / assemble / check-capabilities!),
+            ;; so those image-assembly fns DCE when unused.
+            [re-frame.source-store :as source-store]
+            [re-frame.source-coords :as source-coords]))
 
 ;; ---- trace listener API ---------------------------------------------------
 
@@ -569,6 +577,64 @@
                      {:rf.probe/override-summary-removed-ic  nil
                       :rf.probe/override-summary-replaced-ic :rf.probe/override-summary-stub-ic}}))
 
+;; ---- rf2-32siq3.40: EP-0023 image-loaded frames — provenance survives, ----
+;;       image-assembly fns elide when unused
+;;
+;; EP-0023 §Namespace-Selected Images: every `reg-*` descriptor carries
+;; `:rf.provenance/ns` as a CANONICAL STRING — a PRODUCTION descriptor field,
+;; not optional debug metadata. `:include-ns` image assembly reads it, so it
+;; MUST SURVIVE `:advanced` + goog.DEBUG=false or namespace-selected images
+;; cannot work. Before this probe touch the survival was only HAND-MODELED
+;; (source_store_cljs_test/provenance-from-pending-coords-when-ns-stripped binds
+;; `*pending-coords*` and hand-strips `:ns`); it was never run under a real
+;; elision gate.
+;;
+;; This is the OPPOSITE direction from the dev-only sentinels above: the
+;; `rf.provenance/ns` keyword's string fragment must be PRESENT in the
+;; production bundle (it is asserted under PROD_SURVIVING_SENTINELS in
+;; check-elision.cjs, not DEV_ONLY_SENTINELS). The probe roots it by recording a
+;; descriptor through the SAME `record-descriptor!` path `reg-*` walks — under
+;; `:advanced` the descriptor's `:ns` slot is stripped (merge-coords returns the
+;; user metadata unchanged) but `record-descriptor!` derives the canonical
+;; provenance string from the surviving `*pending-coords*` binding and stamps
+;; `:rf.provenance/ns`, exactly the production path. The probe also asserts the
+;; survival at RUNTIME (the build's init-fn would throw if the keyword DCE'd and
+;; the read-back returned nil), making the methodology assertion belt-and-braces.
+;;
+;; Conversely, the EP-0023 image-ASSEMBLY fns (make-frame / assemble /
+;; check-capabilities!) carry NO debug gate and ride the runtime/SSR
+;; image-loading path; image_assembly.cljc's own docstring states "an app that
+;; never assembles an image never reaches these fns (Closure DCE removes them)."
+;; The probe deliberately does NOT root that path, so the distinctive
+;; assembly-only string `check-capabilities!` mints
+;; ("rf/make-frame: the image requires capabilities the frame does not supply")
+;; must be ABSENT from the production bundle — asserted under
+;; PROD_ABSENT_WHEN_UNUSED_SENTINELS in check-elision.cjs.
+
+(defn ^:export touch-image-frame-provenance! []
+  ;; Model the production descriptor shape: the macro path's `:ns` slot is
+  ;; stripped under :advanced, but the reg-* macro's `*pending-coords*` binding
+  ;; survives (prod-coords-form keeps `:ns`). record-descriptor! derives
+  ;; `:rf.provenance/ns` from the live binding — the production-surviving path.
+  (binding [source-coords/*pending-coords* {:ns "re-frame.elision-probe.image"}]
+    (let [stored (source-store/record-descriptor!
+                   :event :rf.probe/image-frame-provenance
+                   {:handler-fn (fn [{:keys [db]} _] {:db db})})]
+      ;; Runtime assertion: provenance MUST survive :advanced. If the
+      ;; `:rf.provenance/ns` keyword were DCE'd, this read returns nil and the
+      ;; init-fn throws, failing the build run.
+      (when-not (string? (:rf.provenance/ns stored))
+        (throw (ex-info "elision-probe: :rf.provenance/ns did not survive :advanced"
+                        {:stored stored})))))
+  ;; Touch the public read API so the provenance keyword stays in the
+  ;; reachability graph through a documented entry point too.
+  (let [_d (source-store/descriptor-for :event :rf.probe/image-frame-provenance
+                                        "re-frame.elision-probe.image")]
+    nil)
+  ;; Clean up the probe's source-store slot so it does not perturb other touches.
+  (source-store/forget-descriptor! :event :rf.probe/image-frame-provenance
+                                   "re-frame.elision-probe.image"))
+
 ;; ---- entry point ----------------------------------------------------------
 
 (defn ^:export run []
@@ -584,6 +650,7 @@
   (touch-teardown!)
   (touch-doc-metadata!)
   (touch-interceptor-override-summary!)
+  (touch-image-frame-provenance!)
   ;; Reference trace/emit! directly through the trace ns alias so its
   ;; body, not just the public re-frame.core re-export, is reachable.
   (trace/emit! :event :rf.probe/direct-touch {:source :probe}))

--- a/implementation/core/test/re_frame/live_frame_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_cljs_test.cljc
@@ -89,6 +89,15 @@
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
          (:rf.error/id (ex-data e)))))
 
+(defn- err-data
+  "The full `ex-data` of a thrown re-frame2 error, or nil. The `:extra` slots
+  (`:missing-capabilities` / `:supplied-capabilities`) are merged at the top
+  level of the ex-data — see `re-frame.error/throw-error!`."
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (ex-data e))))
+
 (def ^:private counter-pool
   [(reg-desc "examples.counter" :event :counter/inc ::inc)
    (reg-desc "examples.counter" :sub   :counter/value ::value)])
@@ -403,3 +412,98 @@
           (is (lf/frame-object? frame))
           (is (= #{:rf.capability/http :rf.capability/schemas}
                  (:rf.gen/requires (lf/frame-generation frame)))))))))
+
+;; ---- capability-union BOUNDARY diagnostic is structured (rf2-32siq3.40
+;;      minor c) -------------------------------------------------------------
+;;
+;; The .31 review found the make-frame BOUNDARY capability failures asserted
+;; only the `:rf.error/id` discriminator, while the bare `check-capabilities!`
+;; unit test (image_assembly_cljs_test/partial-capabilities-fail-on-the-unmet-
+;; subset) asserts the structured `:missing-capabilities` / `:supplied-
+;; capabilities` slots. The frame-boundary failure rides the SAME error helper,
+;; so the boundary diagnostic must carry the SAME structured slots — pinning
+;; that the union check at the frame boundary names the unmet subset and the
+;; supplied set, not just the error id.
+
+(deftest capability-boundary-diagnostic-carries-structured-slots
+  (testing "the make-frame frame-boundary capability failure carries the SAME
+            structured :missing-capabilities / :supplied-capabilities slots as
+            the bare check-capabilities! unit test — the diagnostic names the
+            unmet subset (sorted) and what the frame DID supply, at the boundary"
+    (let [pool  [(reg-desc "examples.counter" :event :counter/inc ::inc)
+                 (reg-desc "examples.cart"    :event :cart/add    ::add)]
+          ;; Two images → a UNION requires of {http schemas}; the frame supplies
+          ;; only http, so the boundary check fails on the unmet schemas subset.
+          img-a (image/image {:id :counter/img :include-ns ["examples.counter"]
+                              :rf.image/requires #{:rf.capability/http}})
+          img-b (image/image {:id :cart/img :include-ns ["examples.cart"]
+                              :rf.image/requires #{:rf.capability/schemas
+                                                   :rf.capability/storage}})
+          d (err-data #(lf/make-frame {:id :articles/main
+                                       :images [img-a img-b]
+                                       :capabilities {:rf.capability/http ::http-impl}}
+                                      pool))]
+      (is (= :rf.error/image-missing-capability (:rf.error/id d))
+          "the boundary union failure is :rf.error/image-missing-capability")
+      (testing ":missing-capabilities names exactly the unmet union subset, sorted"
+        (is (= [:rf.capability/schemas :rf.capability/storage]
+               (:missing-capabilities d))))
+      (testing ":supplied-capabilities names what the frame DID provide (a
+                CAPABILITY gap, not a registration gap)"
+        (is (= [:rf.capability/http]
+               (:supplied-capabilities d))))
+      (testing "the conflicting frame id was NOT registered (creation aborted)"
+        (is (not (contains? (lf/live-frame-ids) :articles/main)))))))
+
+;; ===========================================================================
+;; 7. Host-handle exclusion — the EP-0023 §Host Boundary two-boundaries
+;;    invariant at the OBJECT boundary (rf2-32siq3.40 MAJOR-2)
+;; ===========================================================================
+;;
+;; The .31 review found the EP two-boundaries invariant (host handles / adapter
+;; binding NEVER enter the frame-state value) untested at the EP-0023 OBJECT
+;; boundary. make-frame stores :rf.frame/adapter + :rf.frame/capabilities on the
+;; frame object (the host-handle slots); existing tests assert they are
+;; PRESERVED across reload, but none asserts they are EXCLUDED from the
+;; serializable frame-state projection.
+;;
+;; The runnable state container (the app-db/cache atoms) is deferred to .32, so
+;; the serializable frame-state SEED available at this slice is :rf.frame/
+;; initial-db. The invariant tested here: the adapter binding and the capability
+;; map handed to make-frame are confined to their OWN object slots and never
+;; bleed into :rf.frame/initial-db (the serializable state), and the host-handle
+;; slots are a distinct, non-serializable concern from the state slot.
+
+(deftest host-handles-excluded-from-serializable-frame-state
+  (testing "the adapter binding + capability map ride DEDICATED object slots
+            (:rf.frame/adapter, :rf.frame/capabilities) and are EXCLUDED from the
+            serializable frame-state seed (:rf.frame/initial-db) — the EP-0023
+            §Host Boundary two-boundaries invariant: host handles never enter the
+            frame-state value (MAJOR-2)"
+    (let [img        (image/image {:include-ns ["examples.counter"]
+                                   :rf.image/requires #{:rf.capability/http}})
+          adapter    {:rf.adapter/kind :reagent :rf.adapter/render-root ::host-handle}
+          caps       {:rf.capability/http ::http-impl}
+          state-seed {:count 7 :user/name "ada"}
+          frame      (lf/make-frame {:images     [img]
+                                     :initial-db state-seed
+                                     :adapter    adapter
+                                     :capabilities caps}
+                                    counter-pool)]
+      (testing "the host handles ride their OWN object slots (preserved)"
+        (is (= adapter (:rf.frame/adapter frame)))
+        (is (= caps    (:rf.frame/capabilities frame))))
+      (testing "the serializable frame-state seed is EXACTLY :initial-db — no
+                adapter binding, no capability map bled into it"
+        (is (= state-seed (:rf.frame/initial-db frame)))
+        (let [serializable (:rf.frame/initial-db frame)]
+          (is (not (contains? serializable :rf.frame/adapter))
+              "the adapter binding is NOT in the serializable state value")
+          (is (not (contains? serializable :rf.frame/capabilities))
+              "the capability map is NOT in the serializable state value")
+          (is (not-any? #{::host-handle ::http-impl} (vals serializable))
+              "no host-handle VALUE leaked into the serializable state value")))
+      (testing "the host-handle slots are a DISTINCT concern from the state slot
+                (object slots ≠ the serializable frame-state seed)"
+        (is (not= (:rf.frame/adapter frame)      (:rf.frame/initial-db frame)))
+        (is (not= (:rf.frame/capabilities frame) (:rf.frame/initial-db frame)))))))

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -321,3 +321,118 @@
             (is (identical? gen-before (lf/frame-generation (lf/live-frame :stable/main))))))
         (finally
           (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ---- the REMOVED leg (rf2-32siq3.40 minor a) ------------------------------
+;;
+;; The .31 review found reproject coverage exercised only the impl-CHANGED
+;; leg (source-store-change-reprojects-an-explicit-image-frame) and the
+;; UNCHANGED leg (reproject-leaves-unchanged-frames-untouched). The REMOVED
+;; leg — a descriptor the frame's image SELECTED is FORGOTTEN from the source
+;; store (the `forget-descriptor!` path) — was untested. After the forget,
+;; reproject must re-resolve the frame to a NARROWER generation, report the
+;; dropped id under the diff's `:removed`, and the swapped generation must no
+;; longer resolve it.
+
+(deftest reproject-removed-leg-forgets-a-selected-descriptor
+  (testing "reproject-live-frames! after a SELECTED descriptor is forgotten from
+            the source store re-resolves the frame to a narrower generation and
+            names the dropped id under :removed (EP-0023 §Default Image Semantics
+            — a source-store change reprojects affected frames; the removed leg).
+            Uses the LIVE source store; snapshot + restore (NOT clear-all!)."
+    (let [snapshot @source-store/kind->id->ns->descriptor]
+      (try
+        ;; Two registrations the explicit image selects: one will be forgotten.
+        (source-store/record-descriptor!
+          :event :rm/inc
+          {:rf.provenance/ns "removal.feature" :kind :event :id :rm/inc
+           :handler-fn ::rm-inc})
+        (source-store/record-descriptor!
+          :sub :rm/value
+          {:rf.provenance/ns "removal.feature" :kind :sub :id :rm/value
+           :handler-fn ::rm-value})
+        (let [img   (image/image {:id :rm/img :include-ns ["removal.feature"]})
+              frame (lf/make-frame {:id :rm/main :images [img]})
+              gen-before (lf/frame-generation frame)]
+          (testing "both selected ids resolve before the forget (control)"
+            (is (some? (asm/resolve-descriptor gen-before :event :rm/inc)))
+            (is (some? (asm/resolve-descriptor gen-before :sub :rm/value))))
+          ;; Forget exactly the selected :sub slot (targeted removal, mirrors a
+          ;; registrar/unregister! of a registration the image was selecting).
+          (source-store/forget-descriptor! :sub :rm/value "removal.feature")
+          (let [moved (lf/reproject-live-frames!)]
+            (testing "reproject reports the frame as moved, naming the dropped id
+                      under :removed (the removed leg — not :changed/:added)"
+              (is (contains? moved :rm/main))
+              (let [diff (get moved :rm/main)]
+                (is (contains? (:removed diff) [:sub :rm/value])
+                    "the forgotten selected id appears under :removed")
+                (is (not (contains? (:changed diff) [:sub :rm/value])))
+                (is (not (contains? (:added diff)   [:sub :rm/value])))
+                (is (contains? (:retained diff) [:event :rm/inc])
+                    ":rm/inc was untouched → retained, not removed")))
+            (testing "the swapped generation no longer resolves the forgotten id"
+              (let [gen-after (lf/frame-generation (lf/live-frame :rm/main))]
+                (is (nil? (asm/resolve-descriptor gen-after :sub :rm/value))
+                    "the forgotten descriptor is gone from the reprojected generation")
+                (is (some? (asm/resolve-descriptor gen-after :event :rm/inc))
+                    ":rm/inc still resolves — the frame narrowed, it did not empty")))))
+        (finally
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ---- composed multi-image reproject, one member ns changes (minor b) ------
+;;
+;; The .31 review found the reproject coverage used only a SINGLE-image frame.
+;; A COMPOSED frame (two images, each selecting a DIFFERENT member namespace)
+;; must reproject when ONLY ONE member ns changes: the changed member's id is
+;; :changed in the diff, the untouched member's id stays :retained, and both
+;; resolve in the swapped generation (the composition is preserved, only the
+;; changed slice moves).
+
+(deftest reproject-composed-frame-on-one-member-ns-change
+  (testing "a frame composed of TWO images (each over a distinct member ns)
+            reprojects when ONLY ONE member ns's source changes: the changed
+            member's id is :changed, the untouched member's id is :retained, and
+            both still resolve in the swapped generation (EP-0023 §Default Image
+            Semantics — composed images containing the changed slot reproject).
+            Uses the LIVE source store; snapshot + restore (NOT clear-all!)."
+    (let [snapshot @source-store/kind->id->ns->descriptor]
+      (try
+        ;; Member A and member B live in DIFFERENT namespaces; the composed
+        ;; frame selects both via two images.
+        (source-store/record-descriptor!
+          :event :compose.a/go
+          {:rf.provenance/ns "compose.member-a" :kind :event :id :compose.a/go
+           :handler-fn ::a-original})
+        (source-store/record-descriptor!
+          :event :compose.b/go
+          {:rf.provenance/ns "compose.member-b" :kind :event :id :compose.b/go
+           :handler-fn ::b-stable})
+        (let [img-a (image/image {:id :compose/a :include-ns ["compose.member-a"]})
+              img-b (image/image {:id :compose/b :include-ns ["compose.member-b"]})
+              frame (lf/make-frame {:id :compose/main :images [img-a img-b]})
+              gen-before (lf/frame-generation frame)]
+          (testing "both members resolve in the composed generation (control)"
+            (is (= ::a-original (:handler-fn (asm/resolve-descriptor gen-before :event :compose.a/go))))
+            (is (= ::b-stable   (:handler-fn (asm/resolve-descriptor gen-before :event :compose.b/go)))))
+          ;; Re-eval ONLY member A's namespace (the same (kind,id,ns) slot, new impl).
+          ;; Member B's source slot is untouched.
+          (source-store/record-descriptor!
+            :event :compose.a/go
+            {:rf.provenance/ns "compose.member-a" :kind :event :id :compose.a/go
+             :handler-fn ::a-reloaded})
+          (let [moved (lf/reproject-live-frames!)]
+            (testing "the composed frame is reported as moved"
+              (is (contains? moved :compose/main)))
+            (let [diff (get moved :compose/main)]
+              (testing "only the changed member's id is :changed"
+                (is (contains? (:changed diff) [:event :compose.a/go])))
+              (testing "the untouched member's id is :retained (not :changed)"
+                (is (contains? (:retained diff) [:event :compose.b/go]))
+                (is (not (contains? (:changed diff) [:event :compose.b/go])))))
+            (testing "the swapped generation resolves BOTH members — A reloaded,
+                      B preserved (composition kept, only the changed slice moved)"
+              (let [gen-after (lf/frame-generation (lf/live-frame :compose/main))]
+                (is (= ::a-reloaded (:handler-fn (asm/resolve-descriptor gen-after :event :compose.a/go))))
+                (is (= ::b-stable   (:handler-fn (asm/resolve-descriptor gen-after :event :compose.b/go))))))))
+        (finally
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -504,6 +504,62 @@ const DEV_ONLY_SENTINELS = [
   // pins the replacement no-frame-context contract.
 ];
 
+// ----- EP-0023 image-loaded frames (rf2-32siq3.40) ---------------------------
+//
+// EP-0023 introduces TWO elision contracts that run in the OPPOSITE direction
+// from the dev-only sentinels above (which must be ABSENT in production):
+//
+//   1. PROD_SURVIVING_SENTINELS — strings that MUST be PRESENT in the
+//      production bundle. `:rf.provenance/ns` is a PRODUCTION descriptor field,
+//      not optional debug metadata (EP-0023 §Namespace-Selected Images):
+//      `:include-ns` image assembly reads it, so it MUST survive :advanced +
+//      goog.DEBUG=false or namespace-selected images cannot work. Before the
+//      `re-frame.elision-probe/touch-image-frame-provenance!` touch this was
+//      only HAND-MODELED (source_store_cljs_test binds *pending-coords* and
+//      hand-strips :ns); now it runs under a real elision gate. The probe roots
+//      the keyword through the same `record-descriptor!` path `reg-*` walks.
+//
+//   2. PROD_ABSENT_WHEN_UNUSED_SENTINELS — strings inside EP-0023 image-ASSEMBLY
+//      fns (make-frame / assemble / check-capabilities!) that MUST be ABSENT in
+//      production WHEN THE PROBE DOES NOT ROOT THE IMAGE-LOADING PATH. These fns
+//      carry NO debug gate; image_assembly.cljc's own docstring states "an app
+//      that never assembles an image never reaches these fns (Closure DCE
+//      removes them)." This is a REACHABILITY-DCE contract (not a goog.DEBUG
+//      one): the probe touches `reg-*` (the source store) but never calls
+//      make-frame/assemble, so the assembly-only literals DCE. A regression that
+//      wired image assembly into an always-reachable boot path would surface the
+//      string and fail this assertion. (No control-build check: with no debug
+//      gate the string is reachability-absent in BOTH builds, so a mustContain
+//      control assertion would be vacuous — the teeth are the prod-absence plus
+//      the PROD_SURVIVING provenance counterpart proving the bundle is non-empty
+//      and the EP-0023 source-store surface IS compiled in.)
+
+const PROD_SURVIVING_SENTINELS = [
+  // re-frame.source-store/record-descriptor! + canonical-ns — the
+  // `:rf.provenance/ns` descriptor field (EP-0023 §Namespace-Selected Images).
+  // A PRODUCTION field every `reg-*` descriptor carries as a canonical string;
+  // `:include-ns` selection reads it, so it MUST survive :advanced. The probe's
+  // touch-image-frame-provenance! records a descriptor through the production
+  // provenance-derivation path (*pending-coords* fallback) and reads the
+  // keyword back, rooting the literal in the reachability graph. If this is
+  // ABSENT in production, namespace-selected image assembly is broken.
+  { source: 're-frame.source-store/record-descriptor! (rf.provenance/ns survives :advanced)',
+    sentinel: 'rf.provenance/ns' },
+];
+
+const PROD_ABSENT_WHEN_UNUSED_SENTINELS = [
+  // re-frame.image-assembly/check-capabilities! — the fail-loud diagnostic
+  // string (EP-0023 §Public API / §Image — the frame-boundary capability
+  // check). The probe records into the source store but NEVER calls
+  // make-frame/assemble/check-capabilities!, so this assembly-only literal must
+  // DCE from the production bundle (reachability DCE — image_assembly.cljc
+  // docstring: "an app that never assembles an image never reaches these fns").
+  // The fragment is the distinctive head of the error message, unambiguous
+  // under a global grep.
+  { source: 're-frame.image-assembly/check-capabilities! (assembly-only, DCE when unused)',
+    sentinel: 'rf/make-frame: the image requires capabilities the frame does not' },
+];
+
 // ----- helpers ---------------------------------------------------------------
 
 // Bundle reading is shared with the sibling check-* scripts via
@@ -530,26 +586,36 @@ function checkBundle(label, bundlePath, mustContain) {
   report.detail(`[elision] ${label}: ${bundlePath}`);
   report.detail(`          bundle size: ${blob.length} chars`);
 
-  let ok = true;
-  let passedCount = 0;
-  for (const { source, sentinel } of DEV_ONLY_SENTINELS) {
-    const present = blob.includes(sentinel);
-    const expected = mustContain ? 'PRESENT' : 'ABSENT';
-    const actual   = present     ? 'PRESENT' : 'ABSENT';
-    const passed   = present === mustContain;
-    const tag      = passed ? 'OK' : 'FAIL';
-    report.detail(`          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
-    if (passed) passedCount += 1;
-    if (!passed) ok = false;
-  }
+  const { ok, passed } = assertSentinels(blob, DEV_ONLY_SENTINELS, mustContain);
   return {
     ok,
     checked: DEV_ONLY_SENTINELS.length,
-    passed: passedCount,
+    passed,
     bytes: blob.length,
     bundlePath,
     missing: false,
   };
+}
+
+// Assert a sentinel set against an already-read bundle blob. `mustContain`
+// true ⇒ every sentinel must be PRESENT; false ⇒ every sentinel must be
+// ABSENT. Returns { ok, passed, checked }. Shared by the dev-only ABSENT
+// check and the EP-0023 PROD-SURVIVING (present) / PROD-ABSENT-WHEN-UNUSED
+// (absent) checks (rf2-32siq3.40).
+function assertSentinels(blob, sentinels, mustContain) {
+  let ok = true;
+  let passed = 0;
+  for (const { source, sentinel } of sentinels) {
+    const present  = blob.includes(sentinel);
+    const expected = mustContain ? 'PRESENT' : 'ABSENT';
+    const actual   = present     ? 'PRESENT' : 'ABSENT';
+    const ok1      = present === mustContain;
+    const tag      = ok1 ? 'OK' : 'FAIL';
+    report.detail(`          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (ok1) passed += 1;
+    else ok = false;
+  }
+  return { ok, passed, checked: sentinels.length };
 }
 
 // ----- main ------------------------------------------------------------------
@@ -560,10 +626,23 @@ function main() {
   const probeDir   = path.join(ROOT, 'out', 'elision-probe');
   const controlDir = path.join(ROOT, 'out', 'elision-probe-control');
 
-  // Production bundle: sentinels MUST be absent.
+  // Production bundle: dev-only sentinels MUST be absent.
   const prod = checkBundle('production (goog.DEBUG=false)', probeDir, false);
 
-  // Control bundle: sentinels MUST be present (if compiled).
+  // EP-0023 image-loaded frames (rf2-32siq3.40) — the two OPPOSITE-direction
+  // contracts, asserted against the SAME production bundle blob.
+  let ep23 = { ok: true, surviving: { passed: 0, checked: 0 }, absent: { passed: 0, checked: 0 } };
+  if (!prod.missing && !prod.empty) {
+    const { blob } = classifyReleaseBundle(probeDir);
+    report.detail('[elision] EP-0023 image-loaded frames (rf2-32siq3.40):');
+    report.detail('          PROD_SURVIVING — :rf.provenance/ns must be PRESENT (survives :advanced):');
+    const surviving = assertSentinels(blob, PROD_SURVIVING_SENTINELS, true);
+    report.detail('          PROD_ABSENT_WHEN_UNUSED — image-assembly fns must DCE when unused:');
+    const absent = assertSentinels(blob, PROD_ABSENT_WHEN_UNUSED_SENTINELS, false);
+    ep23 = { ok: surviving.ok && absent.ok, surviving, absent };
+  }
+
+  // Control bundle: dev-only sentinels MUST be present (if compiled).
   let control = { ok: true, skipped: true };
   if (fs.existsSync(controlDir)) {
     control = checkBundle('control    (goog.DEBUG=true) ', controlDir, true);
@@ -573,13 +652,16 @@ function main() {
     report.detail('          to enable the methodology assertion.');
   }
 
-  if (prod.ok && control.ok) {
+  if (prod.ok && ep23.ok && control.ok) {
     const controlSummary = control.skipped
       ? 'control skipped'
       : `control ${control.passed}/${control.checked} present (${control.bytes} chars)`;
     report.pass(
       'elision',
-      `production ${prod.passed}/${prod.checked} absent (${prod.bytes} chars); ${controlSummary}; bundle=${probeDir}`
+      `production ${prod.passed}/${prod.checked} absent (${prod.bytes} chars); ` +
+      `EP-0023 ${ep23.surviving.passed}/${ep23.surviving.checked} provenance-survives + ` +
+      `${ep23.absent.passed}/${ep23.absent.checked} assembly-DCE; ` +
+      `${controlSummary}; bundle=${probeDir}`
     );
     process.exit(0);
   } else {
@@ -591,6 +673,16 @@ function main() {
       console.error('Per Spec 009 §Production builds, every emit / schema / ');
       console.error('registrar dev-only branch must be gated on');
       console.error('re-frame.interop/debug-enabled? so DCE removes it.');
+    }
+    if (!ep23.ok) {
+      console.error('EP-0023 elision contract broke (rf2-32siq3.40):');
+      console.error('  - PROD_SURVIVING: :rf.provenance/ns MUST survive :advanced —');
+      console.error('    it is a production descriptor field :include-ns assembly reads');
+      console.error('    (EP-0023 §Namespace-Selected Images). If absent, namespace-');
+      console.error('    selected images cannot work.');
+      console.error('  - PROD_ABSENT_WHEN_UNUSED: image-assembly fns MUST DCE when the');
+      console.error('    probe does not root make-frame/assemble. If present, an');
+      console.error('    assembly fn became reachable from an always-run path.');
     }
     if (!control.ok) {
       console.error('Control bundle missing dev-only sentinels — the grep test');


### PR DESCRIPTION
Closes the EP-0023 .31-review test-coverage gaps that do **not** need the deferred runnable frame object (rf2-32siq3.40).

## MAJOR-1 — elision probe (provenance survives + assembly DCE)
Provenance survival was only **hand-modeled** (`source_store_cljs_test/provenance-from-pending-coords-when-ns-stripped` binds `*pending-coords*` + hand-strips `:ns`); it was never run under a real elision gate. This roots the EP-0023 source-store provenance surface in `re-frame.elision-probe` (`touch-image-frame-provenance!`) and adds two opposite-direction sentinel categories to `scripts/check-elision.cjs`:

- **PROD_SURVIVING_SENTINELS** — `:rf.provenance/ns` MUST be **present** in the `:advanced` bundle (a production descriptor field `:include-ns` assembly reads, EP-0023 §Namespace-Selected Images).
- **PROD_ABSENT_WHEN_UNUSED_SENTINELS** — the `check-capabilities!` assembly diagnostic MUST **DCE** when the probe does not root `make-frame`/`assemble` (image_assembly's own reachability-DCE contract, documented in its docstring).

The probe also asserts survival at runtime (the build init-fn throws if the keyword DCE'd).

## MAJOR-2 — host-handle exclusion
Asserts the EP-0023 object boundary excludes host handles / adapter binding from the serializable frame-state seed (`:rf.frame/initial-db`): the adapter + capability map ride their own object slots and never bleed into the state value (§Host Boundary two-boundaries invariant).

## Minors
- **(a)** reproject **"removed"** leg — a *selected* descriptor forgotten from the source store reprojects the frame to a narrower generation, naming the dropped id under `:removed`.
- **(b)** **composed** multi-image frame reprojecting on a change to only **one** member ns — the changed member is `:changed`, the untouched member `:retained`, both resolve in the swapped generation.
- **(c)** capability-union **boundary** diagnostic carries the same structured `:missing-capabilities` / `:supplied-capabilities` slots as the bare `check-capabilities!` unit test.

## Scope
Surface lane respected: only `live_frame` / `live_frame_reload` tests + the elision-probe surface + its verifier script. **No** `image_assembly`/`source_store` tests (the .39 worker owns those), **no** production source edits. Snapshot/restore fixtures (no `clear-all!`). The two-frames-one-image independent-state isolation test is out of scope (needs the .32 runnable object).

## Gates
- `npm run test:cljs` — 7548 tests, 0 failures, 0 errors
- `npm run test:elision` — PASS (`EP-0023 1/1 provenance-survives + 1/1 assembly-DCE`)
- `sh scripts/test-fast-pr.sh` — exit 0