### PR TITLE
ci: route missing resources/conformance/ssr-ring tiers + test-quiet gate (rf2-am7grp rf2-dxndhc rf2-qmhysc)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -255,7 +255,7 @@ else
         mcp_conformance=true
         mcp_live=true
         ;;
-      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/security/*|implementation/deps.edn)
+      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/security/*|implementation/deps.edn)
         # rf2-8jz9t — adapter_testbed_smokes NOT fired here. Per-feature
         # artefact changes are covered by their own JVM + CLJS unit
         # suites (implementation_jvm, cljs_browser, cljs_prod) and by
@@ -263,6 +263,18 @@ else
         # adapter-testbed-smokes only catch adapter-mount-specific bugs
         # (createRoot lifecycle, hydration, real concurrent scheduling).
         # Nightly + post-merge gate runs the full matrix.
+        #
+        # rf2-dxndhc — implementation/resources/* (the EP-0003
+        # day8/re-frame2-resources artefact, on the root CLJS/test
+        # classpath via implementation/deps.edn + shadow-cljs.edn) was
+        # NOT routed here before: a PR touching only resources/* left
+        # every output false, so the aggregator could pass with the
+        # jvm-resources suite + the consolidated :node-test resources
+        # surface both skipped. It is a published, src-carrying
+        # per-feature artefact exactly like schemas/ssr/…, so it gets the
+        # full per-feature treatment (implementation_jvm fires the
+        # jvm-resources job added in test.yml; cljs_node_test/cljs_browser/
+        # cljs_prod/bundle_isolation cover its CLJS surface + isolation).
         implementation_jvm=true
         cljs_node_test=true
         cljs_browser=true
@@ -306,6 +318,54 @@ else
         case "$file" in
           implementation/machines/*) playground=true ;;
         esac
+        ;;
+      implementation/reply-conformance/*|implementation/derivation-conformance/*|implementation/event-conformance/*)
+        # rf2-dxndhc — the three EP cross-conformance tiers
+        # (reply-conformance / derivation-conformance / event-conformance)
+        # are src-less `.cljc` TEST surfaces on the root test classpath
+        # (implementation/deps.edn + shadow-cljs.edn list them). They run
+        # in BOTH runtimes: the always-on consolidated `:node-test` gate
+        # (the `cljs` job, gated on cljs_node_test) runs the `:cljs` arms,
+        # and each tier's own `:test` alias runs the SAME `.cljc`
+        # namespaces under the JVM to exercise the `:clj` reader-conditional
+        # arms (the JVM jobs added in test.yml, gated on implementation_jvm;
+        # mirrors the security tier). Before rf2-dxndhc a PR touching only
+        # one of these tiers left every output false, so the aggregator
+        # could pass with both the JVM `:clj`-arm job AND the consolidated
+        # node-test surface skipped. They ship NO production src (no Maven
+        # artefact), so they do NOT widen any production bundle — hence no
+        # cljs_browser / cljs_prod / bundle_isolation here (the security
+        # tier, the precedent, is likewise off those).
+        implementation_jvm=true
+        cljs_node_test=true
+        ;;
+      implementation/test-quiet/src/*|implementation/test-quiet/test/*|implementation/test-quiet/deps.edn)
+        # rf2-am7grp — implementation/test-quiet is the test-runtime
+        # quiet-reporter artefact (day8/re-frame2-test-quiet, rf2-try1x):
+        # the JVM runner (re-frame.test-quiet.runner, runner.clj — the
+        # `:main-opts` of EVERY per-artefact `:test` alias) AND the CLJS
+        # shadow-node runner (re-frame.test-quiet.shadow-node, the
+        # `:node-test` build's `:main` in implementation/shadow-cljs.edn).
+        # Before this case the classifier had NO rule for test-quiet/**,
+        # so a PR changing the quiet reporter implementation, its runners,
+        # its deps.edn, or its contract tests left every output false — the
+        # JVM quiet-runner contract (test_quiet_runner_contract_test.clj,
+        # test_quiet_pin*_test.clj) and the CLJS node-test quiet reporter
+        # contract (test_quiet_shadow_node_cljs_test.cljs, the green/red
+        # fixture cljs tests) BOTH skipped, leaving js-harness-self-tests
+        # (which only runs the JS script policy/helper tests, never the
+        # quiet reporter's own :test or the consolidated :node-test pins)
+        # as the sole — insufficient — verifier.
+        #
+        # Fire implementation_jvm so the per-artefact JVM `:test` aliases
+        # (which route through the quiet runner) re-run the runner contract
+        # at PR time, and cljs_node_test so the consolidated `:node-test`
+        # build (whose `:main` IS the CLJS quiet runner) exercises the
+        # shadow-node reporter + its contract tests. Scoped to src/test/
+        # deps.edn only; no broadening onto unrelated docs/spec paths and
+        # no reliance on js-harness-self-tests as the sole verifier.
+        implementation_jvm=true
+        cljs_node_test=true
         ;;
       spec/conformance/fixtures/*)
         # rf2-qmiiz — Fixtures under spec/conformance/fixtures/*.edn

--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -87,14 +87,25 @@ declare -A ARTEFACT_PATHS=(
   [flows]="flows"
   [http]="http"
   [ssr]="ssr"
+  [ssr-ring]="ssr-ring"
+  [resources]="resources"
   [epoch]="epoch"
 )
 
-ARTEFACTS=(core schemas reagent reagent-slim uix helix machines routing flows http ssr epoch)
+# rf2-qmhysc — resources + ssr-ring both declare publishable
+# :clein/build artefacts (day8/re-frame2-resources, day8/re-frame2-ssr-ring)
+# and ship in the release/deploy matrix, so they MUST participate in the
+# lockstep contract. They were previously omitted: version/local-root
+# drift in those two publishable artefacts was unguarded, and the summary
+# under-counted (it said "all 15"). The fail-on-drift inventory check
+# below now also asserts that EVERY implementation/*/deps.edn carrying a
+# :clein/build alias appears in this list, so a future publishable
+# artefact cannot be omitted unnoticed.
+ARTEFACTS=(core schemas reagent reagent-slim uix helix machines routing flows http ssr ssr-ring resources epoch)
 
 # core is the lockstep root: it does not depend on any other re-frame2
 # artefact, so the :local/root core-reference check below skips it.
-NON_CORE=(schemas reagent reagent-slim uix helix machines routing flows http ssr epoch)
+NON_CORE=(schemas reagent reagent-slim uix helix machines routing flows http ssr ssr-ring resources epoch)
 
 # Adapters (substrate adapters) are one directory deeper than per-feature
 # artefacts.
@@ -181,11 +192,68 @@ for artefact in "${NON_CORE[@]}"; do
   else
     expected_local_root='day8/re-frame2 {:local/root "../core"}'
   fi
-  if ! grep -qF "${expected_local_root}" "${deps_file}"; then
+  # rf2-qmhysc — collapse runs of whitespace before matching. ssr-ring's
+  # deps.edn (newly in NON_CORE) column-aligns its dep map
+  # (`day8/re-frame2     {:local/root …}`), so a single-space literal
+  # grep -qF would spuriously report drift. Mirrors the tools/* loop's
+  # `tr -s` normalisation below; the rewrite step in release.yml keys off
+  # the `:local/root "<path>"` substring, which the normalisation
+  # preserves.
+  normalised_core="$(tr -s '[:space:]' ' ' < "${deps_file}")"
+  if ! grep -qF "${expected_local_root}" <<< "${normalised_core}"; then
     echo "::error file=${rel_label}::expected '${expected_local_root}' (lockstep contract; the release workflow rewrites this to :mvn/version at deploy time)"
     errors=$((errors + 1))
   fi
 done
+
+# rf2-qmhysc — ssr-ring is the one implementation artefact whose
+# PUBLISHED :deps reference a SECOND in-repo framework artefact besides
+# core: it depends on both day8/re-frame2 {:local/root "../core"} (checked
+# in the NON_CORE loop above) AND day8/re-frame2-ssr {:local/root "../ssr"}
+# (the Ring/Pedestal host adapter sits on top of the ssr renderer). The
+# release workflow must rewrite BOTH :local/root coordinates to
+# :mvn/version at deploy time, so the in-repo source must declare both —
+# assert the ssr reference here.
+SSR_RING_DEPS="${REPO_ROOT}/implementation/ssr-ring/deps.edn"
+if [[ -f "${SSR_RING_DEPS}" ]]; then
+  normalised_ssr_ring="$(tr -s '[:space:]' ' ' < "${SSR_RING_DEPS}")"
+  if ! grep -qF 'day8/re-frame2-ssr {:local/root "../ssr"}' <<< "${normalised_ssr_ring}"; then
+    echo "::error file=implementation/ssr-ring/deps.edn::expected 'day8/re-frame2-ssr {:local/root \"../ssr\"}' (lockstep contract; ssr-ring depends on ssr and the release workflow rewrites this to :mvn/version at deploy time)"
+    errors=$((errors + 1))
+  fi
+fi
+
+# rf2-qmhysc — inventory drift guard. The whole risk this script exists
+# to close is "a publishable artefact ships at a stale version / broken
+# :local/root because it was never wired into the lockstep inventory" —
+# exactly how resources + ssr-ring slipped through before. Make that
+# class of omission impossible to reintroduce silently: every
+# implementation/*/deps.edn carrying a :clein/build alias MUST appear in
+# the ARTEFACT_PATHS list above. A new publishable artefact added without
+# a matching ARTEFACTS entry fails the build here.
+declare -A KNOWN_IMPL_PATHS=()
+for artefact in "${ARTEFACTS[@]}"; do
+  KNOWN_IMPL_PATHS["${ARTEFACT_PATHS[$artefact]}"]=1
+done
+# Adapters live under implementation/adapters/<name>/; their subpaths are
+# already registered (adapters/reagent, …). Walk both the flat
+# per-feature dirs and the adapters/ dir for :clein/build.
+while IFS= read -r deps_file; do
+  [[ -f "${deps_file}" ]] || continue
+  # Strip `;;` line comments before matching so a deps.edn that only
+  # MENTIONS :clein/build in prose (e.g. implementation/adapters/test-react/
+  # whose header documents that it deliberately carries NO :clein/build) is
+  # not mis-detected as publishable.
+  sed 's/;;.*$//' "${deps_file}" | grep -qF ':clein/build' || continue
+  # Derive the subpath relative to implementation/ (e.g. "resources" or
+  # "adapters/reagent").
+  subpath="${deps_file#"${REPO_ROOT}/implementation/"}"
+  subpath="${subpath%/deps.edn}"
+  if [[ -z "${KNOWN_IMPL_PATHS[$subpath]:-}" ]]; then
+    echo "::error file=implementation/${subpath}/deps.edn::implementation/${subpath} declares a :clein/build (publishable) artefact but is NOT in the lockstep ARTEFACTS inventory — add it to ARTEFACT_PATHS / ARTEFACTS / NON_CORE in this script AND to the release.yml deploy matrix + release notes (rf2-qmhysc)"
+    errors=$((errors + 1))
+  fi
+done < <(find "${REPO_ROOT}/implementation" -mindepth 2 -maxdepth 3 -name deps.edn)
 
 # Tools/* deployable jars (rf2-lwtke). Each tools/<name>/deps.edn that
 # carries a :clein/build alias publishes to Clojars at the same lockstep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@
 #                                         ├── deploy-flows
 #                                         ├── deploy-http
 #                                         ├── deploy-ssr
+#                                         ├── deploy-ssr-ring (also deps ssr)
+#                                         ├── deploy-resources
 #                                         └── deploy-epoch
 #                                                  │
 #                                                  ▼
@@ -221,6 +223,21 @@ jobs:
         working-directory: implementation/ssr
         run: clojure -M:test
 
+      # rf2-qmhysc — ssr-ring + resources are publishable :clein/build
+      # artefacts deployed by the matrix below, so their JVM suites MUST
+      # gate the release alongside the other per-feature artefacts.
+      # ssr-ring is the Ring/Pedestal host adapter (spins up a real Jetty
+      # host on an ephemeral port in its e2e validator); resources is the
+      # EP-0003 declarative server-state runtime (FSM + work-ledger +
+      # managed-HTTP + invalidation/GC + routing/SSR integrations).
+      - name: JVM tests (ssr-ring artefact)
+        working-directory: implementation/ssr-ring
+        run: clojure -M:test
+
+      - name: JVM tests (resources artefact)
+        working-directory: implementation/resources
+        run: clojure -M:test
+
       - name: JVM tests (epoch artefact)
         working-directory: implementation/epoch
         run: clojure -M:test
@@ -374,6 +391,24 @@ jobs:
             artefact: day8/re-frame2-ssr
             directory: implementation/ssr
             local-root: ../core
+          # rf2-qmhysc — ssr-ring is the one leaf whose published :deps
+          # reference a SECOND in-repo framework artefact besides core: it
+          # depends on both day8/re-frame2 (../core) AND day8/re-frame2-ssr
+          # (../ssr). The Rewrite step below handles the extra-local-root
+          # axis so BOTH :local/root coords become :mvn/version at deploy
+          # time. (Its sibling day8/re-frame2-ssr is published by the `ssr`
+          # leaf above; deploy-leaf values do not depend on each other —
+          # the published pom resolves ssr from Clojars at the lockstep
+          # version, same as every leaf's core dep.)
+          - leaf: ssr-ring
+            artefact: day8/re-frame2-ssr-ring
+            directory: implementation/ssr-ring
+            local-root: ../core
+            extra-local-root: ../ssr
+          - leaf: resources
+            artefact: day8/re-frame2-resources
+            directory: implementation/resources
+            local-root: ../core
           - leaf: epoch
             artefact: day8/re-frame2-epoch
             directory: implementation/epoch
@@ -417,24 +452,48 @@ jobs:
         working-directory: implementation/core
         run: clojure -M:clein install
 
+      # rf2-qmhysc — ssr-ring's published pom additionally depends on
+      # day8/re-frame2-ssr ${{ version }}. The sibling `ssr` leaf publishes
+      # it in parallel, so we install ssr into the runner's local
+      # ~/.m2/repository here (same rationale as the core install above):
+      # the runner resolves ssr-ring's ssr dep locally without racing the
+      # `ssr` leaf's deploy or waiting on Clojars' index. Installing ssr
+      # transitively re-resolves core, which the step above already placed
+      # in ~/.m2. Scoped to the ssr-ring leaf via `if:`.
+      - name: Install ssr to runner ~/.m2 (ssr-ring only)
+        if: matrix.leaf == 'ssr-ring'
+        working-directory: implementation/ssr
+        run: clojure -M:clein install
+
       - name: Rewrite ${{ matrix.leaf }} :local/root → :mvn/version
         working-directory: ${{ matrix.directory }}
         env:
           VERSION: ${{ needs.deploy-core.outputs.version }}
           LOCAL_ROOT: ${{ matrix.local-root }}
+          EXTRA_LOCAL_ROOT: ${{ matrix.extra-local-root }}
           LEAF_DIR: ${{ matrix.directory }}
         run: |
           set -euo pipefail
-          BEFORE=":local/root \"${LOCAL_ROOT}\""
-          if ! grep -qF "${BEFORE}" deps.edn; then
-            echo "::error::expected '${BEFORE}' substring not found in ${LEAF_DIR}/deps.edn"
-            exit 1
+          rewrite_one() {
+            local local_root="$1"
+            local before=":local/root \"${local_root}\""
+            if ! grep -qF "${before}" deps.edn; then
+              echo "::error::expected '${before}' substring not found in ${LEAF_DIR}/deps.edn"
+              exit 1
+            fi
+            BEFORE="${before}" \
+            AFTER=":mvn/version \"${VERSION}\"" \
+            python3 -c 'import os, pathlib; p = pathlib.Path("deps.edn"); src = p.read_text(); before = os.environ["BEFORE"]; after = os.environ["AFTER"]; assert src.count(before) == 1, f"expected exactly one occurrence of {before!r}"; p.write_text(src.replace(before, after))'
+            echo "Rewrote ${before} → :mvn/version $VERSION"
+          }
+          rewrite_one "${LOCAL_ROOT}"
+          # rf2-qmhysc — ssr-ring carries a second in-repo dep (../ssr);
+          # the matrix sets EXTRA_LOCAL_ROOT for it (empty for every other
+          # leaf, so the conditional is a no-op there).
+          if [ -n "${EXTRA_LOCAL_ROOT:-}" ]; then
+            rewrite_one "${EXTRA_LOCAL_ROOT}"
           fi
-          BEFORE="${BEFORE}" \
-          AFTER=":mvn/version \"${VERSION}\"" \
-          python3 -c 'import os, pathlib; p = pathlib.Path("deps.edn"); src = p.read_text(); before = os.environ["BEFORE"]; after = os.environ["AFTER"]; assert src.count(before) == 1, f"expected exactly one occurrence of {before!r}"; p.write_text(src.replace(before, after))'
-          echo "Rewrote :local/root → :mvn/version $VERSION"
-          grep "day8/re-frame2 " deps.edn
+          grep "day8/re-frame2" deps.edn
 
       # ─────────────────────────────────────────────────────────────
       # reagent-slim publication-time ns rename (rf2-zvjme; extracted to
@@ -548,6 +607,8 @@ jobs:
             - `day8/re-frame2-flows` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-http` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-ssr` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame2-ssr-ring` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame2-resources` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-epoch` ${{ needs.deploy-core.outputs.version }}
           draft: false
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1038,6 +1038,191 @@ jobs:
       - name: Run JVM tests (epoch artefact)
         run: clojure -M:test
 
+  jvm-resources:
+    name: JVM resources (clojure -M:test)
+    # rf2-dxndhc — closes the gap surfaced by the rf2-ks67un review. The
+    # resources artefact (day8/re-frame2-resources, EP-0003) is on the
+    # root CLJS/test classpath (implementation/deps.edn +
+    # shadow-cljs.edn) and ships its own JVM `:test` alias (414 tests:
+    # the resource lifecycle FSM, work-ledger substrate, managed-HTTP
+    # lowering, invalidation/GC/owners, mutations, and the routing +
+    # SSR/hydration integrations), yet no PR-CI job ran it on the JVM and
+    # scripts/test-jvm-implementation.sh omitted it. A resources-only PR
+    # could pass with this suite skipped. Gated on implementation_jvm
+    # (now armed for implementation/resources/* by report-changed-
+    # surfaces.sh), mirroring every sibling per-feature jvm-* job.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/resources
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-resources-${{ hashFiles('implementation/resources/deps.edn', 'implementation/core/deps.edn', 'implementation/schemas/deps.edn', 'implementation/routing/deps.edn', 'implementation/ssr/deps.edn', 'implementation/http/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-resources-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (resources artefact)
+        run: clojure -M:test
+
+  jvm-reply-conformance:
+    name: JVM reply-conformance (clojure -M:test)
+    # rf2-dxndhc — the EP-0011 cross-family reply-VOCABULARY-consistency
+    # tier is a src-less `.cljc` test surface on the root test classpath.
+    # Its own `:test` alias runs the SAME `.cljc` namespaces under the JVM
+    # so the `:clj` reader-conditional arms (the EDN round-trip
+    # `read-string`) are exercised — previously only the always-on
+    # `:node-test` gate ran the `:cljs` side, and no PR job armed the JVM
+    # `:clj` arm on a tier-only change. Mirrors the security tier.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/reply-conformance
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-reply-conformance-${{ hashFiles('implementation/reply-conformance/deps.edn', 'implementation/core/deps.edn', 'implementation/http/deps.edn', 'implementation/resources/deps.edn', 'implementation/machines/deps.edn', 'implementation/routing/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-reply-conformance-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (reply-conformance tier)
+        run: clojure -M:test
+
+  jvm-derivation-conformance:
+    name: JVM derivation-conformance (clojure -M:test)
+    # rf2-dxndhc — the EP-0014 derivation/process-ALGEBRA conformance tier
+    # is a src-less `.cljc` test surface on the root test classpath. Its
+    # own `:test` alias runs the SAME `.cljc` namespaces under the JVM so
+    # the `:clj`-side composition (JVM default-contributors auto-resolution,
+    # the pure-data algebra views, the whole-value law over JVM data) is
+    # exercised — previously only the always-on `:node-test` gate ran the
+    # `:cljs` side. Mirrors the security tier.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/derivation-conformance
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-derivation-conformance-${{ hashFiles('implementation/derivation-conformance/deps.edn', 'implementation/core/deps.edn', 'implementation/flows/deps.edn', 'implementation/resources/deps.edn', 'implementation/routing/deps.edn', 'implementation/machines/deps.edn', 'implementation/schemas/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-derivation-conformance-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (derivation-conformance tier)
+        run: clojure -M:test
+
+  jvm-event-conformance:
+    name: JVM event-conformance (clojure -M:test)
+    # rf2-dxndhc — the EP-0018 one-form event-MODEL conformance tier is a
+    # src-less `.cljc` test surface on the root test classpath. Its own
+    # `:test` alias runs the SAME `.cljc` namespaces under the JVM so the
+    # `:clj`-only arms are exercised: the `^:no-doc`-meta facade probe
+    # (reads `(meta (var …))` over the public re-frame.core vars — JVM-only)
+    # and the `:clj` host throw type (clojure.lang.ExceptionInfo) for the
+    # retired-name removal errors — previously only the always-on
+    # `:node-test` gate ran the `:cljs` side. Mirrors the security tier.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/event-conformance
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-event-conformance-${{ hashFiles('implementation/event-conformance/deps.edn', 'implementation/core/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-event-conformance-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (event-conformance tier)
+        run: clojure -M:test
+
   cljs:
     name: CLJS (shadow-cljs :node-test)
     # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:
@@ -2819,6 +3004,10 @@ jobs:
       - jvm-security
       - jvm-ssr-ring
       - jvm-epoch
+      - jvm-resources
+      - jvm-reply-conformance
+      - jvm-derivation-conformance
+      - jvm-event-conformance
       - cljs
       - js-harness-self-tests
       - cljs-browser

--- a/TESTING.md
+++ b/TESTING.md
@@ -469,9 +469,11 @@ must re-run the matrix).
 | S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |
 | S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent-slim/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |   |   |
 | S4 | `implementation/adapters/*` (other) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |
-| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` (note: `schemas/*` also fires `template_expensive`; `machines/*` also fires `playground` — see S5a) | ✓ |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
+| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,resources,epoch}/*`, `implementation/deps.edn` (note: `schemas/*` also fires `template_expensive`; `machines/*` also fires `playground` — see S5a; `resources/*` added rf2-dxndhc) | ✓ |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
 | S5a | `implementation/machines/*` (rf2-2h1yhk — the SCI bundle bakes in the machines artefact + its reserved `:rf.machine/*` lifecycle keywords, so a keyword rename can stale the committed `playground-rf2.js`; in ADDITION to the S5 columns it fires `playground`) | ✓ |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   | ✓ |
 | S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |
+| S6a | `implementation/{reply-conformance,derivation-conformance,event-conformance}/*` (rf2-dxndhc — src-less `.cljc` cross-conformance tiers; the JVM `:clj`-arm jobs fire on `implementation_jvm`, the always-on `:node-test` `:cljs` arm on `cljs_node_test`; no production src so no bundle/browser/prod columns — mirrors the `security` tier) | ✓ |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |   |
+| S6b | `implementation/test-quiet/{src,test}/**`, `implementation/test-quiet/deps.edn` (rf2-am7grp — the quiet-reporter artefact: the JVM runner is the `:main-opts` of every per-artefact `:test` alias, the CLJS shadow-node runner is the `:node-test` build's `:main`; fires both so the JVM + CLJS quiet-reporter contracts run) | ✓ |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |   |
 | S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | S8 | `examples/*` (excluding the orchestrator scripts called out in S8a) |   |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |
 | S8a | `examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers,examples-filter}.cjs` (orchestrator + runner + helpers + shared example-set manifest — rf2-bxdk8 + rf2-cjp0i + rf2-l72e2) |   |   |   |   |   |   |   | ✓ |   |   |   |   |   |   |   |
@@ -492,7 +494,7 @@ PR time; one row per output here so the table stays scannable).
 
 | Output | Jobs |
 |---|---|
-| `implementation_jvm` | JVM artefact unit suites ×9 (`jvm-core`, `jvm-flows`, `jvm-schemas`, `jvm-machines`, `jvm-routing`, `jvm-http`, `jvm-ssr`, `jvm-ssr-ring`, `jvm-epoch`) |
+| `implementation_jvm` | JVM artefact unit suites ×13 (`jvm-core`, `jvm-flows`, `jvm-schemas`, `jvm-machines`, `jvm-routing`, `jvm-http`, `jvm-ssr`, `jvm-ssr-ring`, `jvm-resources`, `jvm-epoch`, plus the src-less cross-conformance tiers `jvm-reply-conformance`, `jvm-derivation-conformance`, `jvm-event-conformance` — rf2-dxndhc; note `jvm-security` is also armed by `implementation_jvm` but is listed under [Diagnostic / skip-ok gates]) |
 | `adapter_diagnostic` | Adapter classpath probes ×4 (`jvm-reagent`, `jvm-reagent-slim`, `jvm-uix`, `jvm-helix`) |
 | `cljs_node_test` | `cljs` (the `CLJS (shadow-cljs :node-test)` job — consolidated CLJS unit suite: `shadow-cljs compile node-test` + `node out/node-test.js`, covering core + every adapter + every feature artefact + the `tools/{story,xray}/{src,test}` source paths). |
 | `cljs_browser` | `cljs-browser` (the `CLJS (shadow-cljs :browser-test, headless Chromium)` job — DOM `:browser-test` build served + driven by the Playwright runner; a distinct job from `cljs`, split off node-test gating in rf2-f79t8). |

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -677,6 +677,147 @@ test('adapter-testbed-smokes workflow remains scoped to EXAMPLES_FILTER=adapters
   );
 });
 
+// rf2-dxndhc — resources + cross-conformance tier routing false-green
+// fix (review wave rf2-ks67un). The resources artefact and the three
+// EP cross-conformance tiers (reply / derivation / event) are live
+// implementation test surfaces on the root CLJS/test classpath
+// (implementation/deps.edn + shadow-cljs.edn), but the classifier had
+// NO case for them — a PR touching only one left every output false, so
+// the aggregator could pass with the relevant JVM + consolidated
+// node-test gates skipped. These assertions lock the new routing.
+
+test('implementation/resources/* arms implementation_jvm + the CLJS surfaces (rf2-dxndhc)', () => {
+  const result = classify('implementation/resources/src/re_frame/resources.cljc');
+  assert.equal(
+    result.implementation_jvm,
+    'true',
+    'a resources source change must run the jvm-resources suite (its own :test alias)',
+  );
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.cljs_prod, 'true');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
+test('implementation/resources/deps.edn arms implementation_jvm + cljs_node_test (rf2-dxndhc)', () => {
+  const result = classify('implementation/resources/deps.edn');
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+const CONFORMANCE_TIERS = [
+  'implementation/reply-conformance/test/re_frame/reply_vocabulary_conformance_cljs_test.cljc',
+  'implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc',
+  'implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc',
+];
+for (const file of CONFORMANCE_TIERS) {
+  test(`${file} arms implementation_jvm + cljs_node_test (cross-conformance tier, rf2-dxndhc)`, () => {
+    const result = classify(file);
+    assert.equal(
+      result.implementation_jvm,
+      'true',
+      'a conformance-tier change must run the JVM :clj-arm job for that tier',
+    );
+    assert.equal(
+      result.cljs_node_test,
+      'true',
+      'a conformance-tier change must run the consolidated :node-test :cljs arm',
+    );
+  });
+}
+
+test('a src-less conformance tier does NOT widen production bundles (no bundle_isolation/cljs_browser) (rf2-dxndhc scope)', () => {
+  // The tiers ship no production src (no Maven artefact), so — like the
+  // security tier — they must NOT fire the bundle/browser/prod gates.
+  const result = classify('implementation/reply-conformance/test/foo.cljc');
+  assert.equal(result.bundle_isolation, 'false');
+  assert.equal(result.cljs_browser, 'false');
+  assert.equal(result.cljs_prod, 'false');
+});
+
+test('jvm-resources is job-level gated on implementation_jvm (rf2-dxndhc)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'jvm-resources');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.implementation_jvm == 'true'/,
+  );
+});
+
+for (const job of [
+  'jvm-reply-conformance',
+  'jvm-derivation-conformance',
+  'jvm-event-conformance',
+]) {
+  test(`${job} is job-level gated on implementation_jvm (rf2-dxndhc)`, () => {
+    const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), job);
+    assert.match(block, /needs: detect_changed_surfaces/);
+    assert.match(
+      block,
+      /if: needs\.detect_changed_surfaces\.outputs\.implementation_jvm == 'true'/,
+    );
+  });
+}
+
+test('all-required-passed aggregator needs the four new implementation_jvm jobs (rf2-dxndhc)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'all-required-passed');
+  for (const job of [
+    'jvm-resources',
+    'jvm-reply-conformance',
+    'jvm-derivation-conformance',
+    'jvm-event-conformance',
+  ]) {
+    assert.match(
+      block,
+      new RegExp(`- ${job}\\r?\\n`),
+      `aggregator must list ${job} in needs:`,
+    );
+  }
+});
+
+// rf2-am7grp — quiet-reporter routing false-green fix (review wave
+// rf2-ks67un). implementation/test-quiet is the test-runtime
+// quiet-reporter artefact: the JVM runner (runner.clj, the :main-opts of
+// every per-artefact :test alias) AND the CLJS shadow-node runner (the
+// :node-test build's :main). The classifier had NO test-quiet/** case,
+// so a PR changing the reporter implementation, its runners, its
+// deps.edn, or its contract tests left every output false — both the JVM
+// quiet-runner contract and the CLJS node-test quiet reporter contract
+// skipped, with js-harness-self-tests (JS script policy/helper tests
+// only) the sole insufficient verifier. These assertions lock the new
+// routing onto implementation_jvm + cljs_node_test.
+
+const TEST_QUIET_FILES = [
+  'implementation/test-quiet/src/re_frame/test_quiet/runner.clj',
+  'implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs',
+  'implementation/test-quiet/deps.edn',
+  'implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj',
+  'implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs',
+];
+for (const file of TEST_QUIET_FILES) {
+  test(`${file} arms implementation_jvm + cljs_node_test (quiet reporter, rf2-am7grp)`, () => {
+    const result = classify(file);
+    assert.equal(
+      result.implementation_jvm,
+      'true',
+      'a quiet-reporter change must re-run the per-artefact :test aliases (which route through the JVM quiet runner)',
+    );
+    assert.equal(
+      result.cljs_node_test,
+      'true',
+      'a quiet-reporter change must run the consolidated :node-test build (whose :main is the CLJS quiet runner)',
+    );
+  });
+}
+
+test('test-quiet routing does NOT broaden docs/spec-only or unrelated surfaces (rf2-am7grp scope)', () => {
+  // Scoped to src/test/deps.edn under test-quiet; a generic spec/docs
+  // change stays off the implementation gates entirely.
+  const result = classify('spec/006-ReactiveSubstrate.md');
+  assert.equal(result.implementation_jvm, 'false');
+  assert.equal(result.cljs_node_test, 'false');
+});
+
 let failed = 0;
 for (const { name, fn } of tests) {
   try {

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -18,6 +18,15 @@ artefacts=(
   implementation/ssr
   implementation/ssr-ring
   implementation/epoch
+  # rf2-dxndhc — the resources artefact (day8/re-frame2-resources,
+  # EP-0003) ships its own JVM `:test` alias (the resource lifecycle FSM,
+  # the work-ledger substrate, managed-HTTP lowering, invalidation/GC/
+  # owners, mutations, and the routing + SSR/hydration integrations under
+  # test-only :local/root deps). It was omitted from this local rigorous
+  # sweep even though every sibling per-feature artefact is listed; a
+  # resources-only change therefore skipped the JVM tier locally. Added
+  # here alongside the matching jvm-resources PR-CI job (test.yml).
+  implementation/resources
   # rf2-gj2ae — the adversarial-property security tier is `.cljc` and
   # advertises a cross-runtime contract (e.g. `re-frame.security.gen`'s
   # JVM `:clj` `long`-multiply vs the CLJS `Math.imul` arm, pinned by


### PR DESCRIPTION
Three CI-coverage-gap fixes from the **rf2-ks67un** review wave, all touching `.github/workflows/*` (hot-zone), coordinated in one PR.

## rf2-am7grp — quiet-reporter gate routing
`report-changed-surfaces.sh` had no case for `implementation/test-quiet/**`, so a PR changing the quiet reporter implementation, its JVM/CLJS runners, deps.edn, or contract tests left every output false — the JVM runner contract and the CLJS node-test quiet reporter contract both skipped, with `js-harness-self-tests` (JS script policy only) the sole insufficient verifier. Now routes `test-quiet/{src,test}/**` + `deps.edn` → `implementation_jvm` + `cljs_node_test`. Scoped (no docs/spec broadening).

## rf2-dxndhc — resources + cross-conformance tier routing
- `implementation/resources/*` folded into the per-feature case (`implementation_jvm` + the CLJS surfaces).
- The three src-less `.cljc` tiers (`reply/derivation/event-conformance`) → `implementation_jvm` + `cljs_node_test` only (off bundle/browser/prod, mirroring the `security` tier).
- New `jvm-resources` + `jvm-{reply,derivation,event}-conformance` jobs in `test.yml` (gated on `implementation_jvm`), added to the `all-required-passed` aggregator.
- `scripts/test-jvm-implementation.sh` now includes `implementation/resources` (the three tiers + ssr-ring were already present).
- **All four tiers verified green on JVM locally** — the wiring is purely additive, no pre-existing failures surfaced.

## rf2-qmhysc — release lockstep + deploy for resources/ssr-ring
- `verify-version-lockstep.sh` now covers all publishable artefacts (14 implementation + 3 tools = 17), including `day8/re-frame2-resources` + `day8/re-frame2-ssr-ring`. ssr-ring's dual `:local/root` (core + ssr) handled with whitespace-normalised matching.
- New **fail-on-drift inventory guard**: any future `implementation/*/deps.edn` carrying `:clein/build` that is not in the inventory fails the build (comment-stripped so it ignores `test-react`'s documented no-`:clein/build` header). Verified to fire on a planted un-inventoried artefact.
- `release.yml`: preflight JVM tests for both, deploy-leaf matrix entries (ssr-ring carries `extra-local-root: ../ssr` + an `ssr` local-install so both coords rewrite to `:mvn/version`), and release-notes lines.

## Sync + gates
- `TESTING.md` surface→output (S5 + new S6a/S6b) + output→jobs (`implementation_jvm` ×9 → ×13) matrices synced.
- Regression coverage in `_changed-surfaces.test.cjs` — **95 tests pass**.
- Gates: lockstep PASS, full `test:script-policy` PASS, README inventory ratchet PASS, both workflow YAMLs parse, all shell scripts `bash -n` clean.