### PR TITLE
fix(http): accept-domain failure emits accept-failure trace + decoded-body privacy (rf2-ltaihw)

### DIFF
--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -520,10 +520,31 @@
           (dispatch-success! ctx (:ok accepted))
 
           (contains? accepted :failure)
-          (dispatch-failure! ctx {:kind       :rf.http/accept-failure
-                                  :detail     (:failure accepted)
-                                  :decoded    (:decoded ctx)
-                                  :request-id (:request-id ctx)}))))))
+          ;; rf2-ltaihw — a domain `:accept` failure (`{:failure user-map}` on a
+          ;; successful 2xx decode) is an `:rf.http/accept-failure`, exactly like
+          ;; the throw / malformed-return accept-failure branches in
+          ;; `handle-response!`. It MUST route through `emit-and-dispatch-failure!`
+          ;; (NOT `dispatch-failure!` directly): that is the shared tail which
+          ;;   - emits the `:rf.http/accept-failure` failure-CATEGORY trace via
+          ;;     `trace/emit-error!` (the rf2-bma05 redaction + Managed-Effects
+          ;;     §Tracing structured-failure-coverage contract), and
+          ;;   - stamps `:rf.http/off-box-body` for the `:decoded` slot
+          ;;     (rf2-t55hxg.6 fail-closed disposition).
+          ;; The earlier `dispatch-failure!` shortcut emitted ONLY the canonical
+          ;; `:rf.http/replied` envelope, so the failure-category event was missed
+          ;; and the decoded body rode unclassified off-box. The `:decoded` slot
+          ;; carries the schema-classified body (`privacy-body/classify-decoded`)
+          ;; so a `:decode`-schema sensitive slot redacts on the on-box trace —
+          ;; the same on-box projection the `handle-response!` accept-failure
+          ;; branches apply. We already hold the once-only `:finalised?` token and
+          ;; cleared the registry above, satisfying `emit-and-dispatch-failure!`'s
+          ;; precondition (the abort/natural-completion sample-(2) path next door
+          ;; relies on the same).
+          (emit-and-dispatch-failure!
+            ctx {:kind       :rf.http/accept-failure
+                 :detail     (:failure accepted)
+                 :decoded    (privacy-body/classify-decoded (:decoded ctx) (:decode ctx))
+                 :request-id (:request-id ctx)}))))))
 
 (defn- finalise-failure!
   "Final-failure dispatch (after retries exhausted or non-retriable).

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -676,3 +676,114 @@
               "on-box :body-text rides raw — the local operator inspects it"))
         (finally
           (stop-server! srv))))))
+
+;; ---- 12. :accept {:failure ...} emits the accept-failure category trace ----
+;;   + applies decoded-body privacy / off-box disposition (rf2-ltaihw)
+;;
+;; A successful 2xx decode whose `:accept` projects the decoded value to
+;; `{:failure user-map}` is an `:rf.http/accept-failure` domain failure. The
+;; bug: `finalise-success!`'s accept-`{:failure}` branch dispatched through
+;; `dispatch-failure!` directly, which emits ONLY the canonical
+;; `:rf.http/replied` envelope and bypasses `emit-and-dispatch-failure!` — so
+;; the `:rf.http/accept-failure` failure-category trace (via `emit-error!`) was
+;; NEVER emitted, and the decoded body in the trace payload missed the
+;; schema-classification + `:rf.http/off-box-body` disposition that the
+;; throw / malformed-return accept-failure branches already apply. This is the
+;; structural parity with those branches (they route through
+;; `finalise-failure!` → `emit-and-dispatch-failure!`).
+
+(deftest accept-failure-emits-category-trace-with-schema-classified-decoded
+  (testing "rf2-ltaihw — an :accept returning {:failure ...} on a 2xx decode
+            emits the :rf.http/accept-failure failure-category trace, the
+            decoded body's schema-sensitive slot is redacted on-box, and the
+            off-box disposition is stamped :classify for the schema body"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 200 "application/json"
+                                   "{\"token\":\"bearer-secret\",\"status\":\"rejected\"}")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-listener! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+        (rf/reg-event :api/login
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/login")}
+                    ;; Schema decode marks :token sensitive — the per-slot mark
+                    ;; must redact the decoded body on the accept-failure trace.
+                    :decode     [:map
+                                 [:token {:sensitive? true} :string]
+                                 [:status :string]]
+                    ;; Domain accept failure: a structurally-valid 200 the app
+                    ;; classifies as a failure.
+                    :accept     (fn [decoded]
+                                  (if (= "rejected" (:status decoded))
+                                    {:failure {:reason :domain-rejected}}
+                                    {:ok decoded}))
+                    :on-failure [:api/failed]}]]}))
+        (rf/reg-event :api/failed (fn [_ _] {}))
+
+        (rf/dispatch-sync [:api/login])
+
+        (let [_  (wait-for!
+                   (fn [] (some #(= :rf.http/accept-failure (:operation %)) @captured))
+                   3000)
+              ev (first (filter #(= :rf.http/accept-failure (:operation %)) @captured))]
+          ;; The failure-category trace MUST be emitted (the bypassed path).
+          (is (some? ev)
+              "the :rf.http/accept-failure failure-category trace is emitted
+               (was bypassed: finalise-success! routed through dispatch-failure!
+               which only emits :rf.http/replied)")
+          ;; The off-box disposition is stamped forward for the decoded slot.
+          (is (= :classify (get-in ev [:tags :rf.http/off-box-body]))
+              "schema decoded body stamped :classify for the off-box projector")
+          ;; The decoded body's schema-sensitive slot is redacted ON-BOX, matching
+          ;; the throw / malformed-return accept-failure branches.
+          (is (= :rf/redacted (get-in ev [:tags :decoded :token]))
+              "the :token slot the :decode schema marks sensitive is redacted on
+               the accept-failure trace's :decoded payload")
+          (is (= "rejected" (get-in ev [:tags :decoded :status]))
+              "the non-sensitive sibling slot rides verbatim"))
+        (finally
+          (stop-server! srv))))))
+
+(deftest accept-failure-unschematized-decoded-stamps-off-box-omit
+  (testing "rf2-ltaihw — an :accept {:failure ...} whose decoded body is
+            UNSCHEMATIZED (:auto / :json decode) stamps :rf.http/off-box-body
+            :omit (fail-closed), matching the throw / malformed accept-failure
+            branches; the on-box :decoded still rides raw for the local operator"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 200 "application/json"
+                                   "{\"echoed-token\":\"bearer-abc123\"}")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-listener! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+        (rf/reg-event :api/login
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/login")}
+                    ;; Unschematized decode → off-box must fail closed (:omit).
+                    :decode     :json
+                    :accept     (fn [_decoded] {:failure {:reason :domain-rejected}})
+                    :on-failure [:api/failed]}]]}))
+        (rf/reg-event :api/failed (fn [_ _] {}))
+
+        (rf/dispatch-sync [:api/login])
+
+        (let [_  (wait-for!
+                   (fn [] (some #(= :rf.http/accept-failure (:operation %)) @captured))
+                   3000)
+              ev (first (filter #(= :rf.http/accept-failure (:operation %)) @captured))]
+          (is (some? ev)
+              "the :rf.http/accept-failure failure-category trace is emitted")
+          (is (= :omit (get-in ev [:tags :rf.http/off-box-body]))
+              "unschematized decoded body stamped :omit for the off-box projector
+               (fail-closed) — the off-box projector omits :decoded"))
+        (finally
+          (stop-server! srv))))))


### PR DESCRIPTION
## Summary

Fixes **rf2-ltaihw** — HTTP accept-domain failures bypassed the failure trace and decoded-body privacy. (**rf2-ved68e is an exact duplicate** and is resolved by this same fix.)

A successful 2xx decode whose `:accept` projects the decoded value to `{:failure user-map}` is an `:rf.http/accept-failure` domain failure. `finalise-success!`'s accept-`{:failure}` branch routed through `dispatch-failure!` **directly**, which emits ONLY the canonical `:rf.http/replied` envelope and bypasses `emit-and-dispatch-failure!`. As a result:

- the `:rf.http/accept-failure` failure-**category** trace (via `trace/emit-error!`) was **never emitted** — a structured-failure-coverage gap (Managed-Effects §Tracing), and
- the decoded body in the trace payload missed the schema-classification + `:rf.http/off-box-body` disposition that the throw / malformed-return accept-failure branches already apply (rf2-t55hxg.6 / rf2-bma05).

## Fix

Route the branch through `emit-and-dispatch-failure!` (the shared failure tail `finalise-failure!` already uses) and carry the schema-classified `:decoded` value, restoring structural parity with the throw / malformed-return accept-failure branches in `handle-response!`:

- emits the `:rf.http/accept-failure` failure-category trace with the rf2-bma05 redaction shape;
- stamps `:rf.http/off-box-body` for the `:decoded` slot (`:classify` for a schema decode, `:omit` fail-closed for an unschematized one);
- redacts a `:decode`-schema sensitive slot on the on-box trace.

The public `{:kind :failure :failure ...}` reply envelope is **unchanged**.

**Spec unchanged** — Spec 014 already documents all three accept-failure cases uniformly (§`:accept`, §Classification order, §Failure tags) requiring the `:rf.http/accept-failure` trace + off-box treatment. Only the implementation bypassed it; this aligns it with the documented contract. No new always-on error id is introduced (the category already exists).

## Tests (red-before-green)

Two regression tests added to the privacy integration suite:
- `accept-failure-emits-category-trace-with-schema-classified-decoded` — asserts the `:rf.http/accept-failure` trace IS emitted, `:rf.http/off-box-body :classify` is stamped, and the schema-sensitive `:token` slot redacts on-box (sibling slot rides verbatim). Confirmed RED before the fix (the `:rf.http/accept-failure` op never arrived → `poll-until-timeout`).
- `accept-failure-unschematized-decoded-stamps-off-box-omit` — asserts the fail-closed `:omit` off-box stamp for an unschematized (`:json`) decode.

## Gates

- `implementation/`: `npm run test:cljs` green (7551 tests, 31044 assertions, 0/0); `npm run test:elision` clean (43/43 absent, EP-0023 provenance + assembly-DCE pass).
- repo root: `sh scripts/test-fast-pr.sh` → `PASS fast PR spine`.
- http JVM suites (privacy-integration / managed / reply-lowering / abort-precedence / swallowed-failure) green.