### PR TITLE
fix(flows): preserve elision registry across durable runtime-db commits (rf2-gom797)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -114,6 +114,48 @@
     :else
     runtime-db))
 
+(defn ^:no-doc reconcile-runtime-db-effect
+  "Reconcile the durable elision registry across a whole-value
+  `:rf.db/runtime` partition commit (rf2-gom797).
+
+  A framework-authority event may return a `:rf.db/runtime` effect whose
+  value WHOLE-VALUE-REPLACES the runtime-db partition (Spec 002 §A runtime
+  effect replaces only runtime-db; router commit decision #5). But the
+  elision declaration registry at `[:rf.runtime/elision]` is a CROSS-CUTTING
+  durable subsystem child mutated OUT-OF-BAND by `reg-flow` / `add-marks` /
+  the frame-classification walker — NOT by the event returning the effect.
+  A whole-value runtime-db effect that seeds an UNRELATED subsystem (e.g.
+  `:rf.runtime/routing`) and does not itself carry `:rf.runtime/elision`
+  would otherwise DROP the registry on commit, silently losing every
+  flow-sourced / mark-sourced / frame-declared elision declaration — so the
+  post-commit frame would emit raw values that were correctly redacted
+  pre-commit (the durable privacy/trace contract breaks after any
+  runtime-db-writing event).
+
+  This preserves the existing `:rf.runtime/elision` sub-tree from
+  `prev-runtime-db` into `new-runtime-db` UNLESS the committing effect
+  ITSELF carries an `:rf.runtime/elision` key (an explicit full-frame
+  install — epoch-restore / SSR-hydration — legitimately replaces the
+  registry, so its decision is honoured verbatim, including an intentional
+  clear). When the effect omits the key, the prior registry is carried
+  forward; when there was no prior registry, nothing is added (a frame that
+  never used elision stays clean — `runtime-db-effect-whole-value-commit`).
+
+  Returns the reconciled runtime-db value. `new-runtime-db` is the
+  whole-value effect payload; `prev-runtime-db` is the pre-commit
+  runtime-db partition value (may be nil for a fresh frame)."
+  [new-runtime-db prev-runtime-db]
+  (let [new-runtime-db (or new-runtime-db {})]
+    (if (contains? new-runtime-db :rf.runtime/elision)
+      ;; The effect speaks about elision explicitly (full-frame install /
+      ;; deliberate clear) — honour it verbatim.
+      new-runtime-db
+      ;; The effect is silent about elision — carry the prior registry
+      ;; forward through the same prune logic so a frame that never used
+      ;; elision is left without a stray nil sub-tree.
+      (write-elision-slot new-runtime-db
+                          (get prev-runtime-db :rf.runtime/elision)))))
+
 (defn ^:no-doc swap-elision-slot!
   "Read-transform-write helper for the per-frame elision registry.
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -9,6 +9,7 @@
   any further external event is processed for that frame, and before any
   view re-renders."
   (:require [re-frame.frame :as frame]
+            [re-frame.elision :as elision]
             [re-frame.live-frame :as live-frame]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
@@ -1172,6 +1173,21 @@
                          "diagnostic).")}))
     (if (or app-effect? rt-effect?)
       (let [emit-event (privacy/redacted-event-from-ctx ctx)
+            ;; rf2-gom797: a whole-value `:rf.db/runtime` effect REPLACES the
+            ;; runtime-db partition (decision #5), but the elision declaration
+            ;; registry at `[:rf.runtime/elision]` is a CROSS-CUTTING durable
+            ;; subsystem child written OUT-OF-BAND by `reg-flow` / `add-marks` /
+            ;; frame-classification — not by the event returning the effect. An
+            ;; effect that seeds an unrelated subsystem (e.g.
+            ;; `:rf.runtime/routing`) and omits `:rf.runtime/elision` would
+            ;; otherwise drop the registry on commit, silently losing every
+            ;; declaration that correctly redacted PRE-commit. Reconcile the
+            ;; effect value against the pre-commit runtime-db so the registry
+            ;; survives unless the effect speaks about it explicitly (a
+            ;; full-frame install / deliberate clear is honoured verbatim).
+            new-runtime-db (when rt-effect?
+                             (elision/reconcile-runtime-db-effect
+                               (:rf.db/runtime effects) runtime-before))
             ;; Map the EFFECT keys (:db / :rf.db/runtime) to the frame-state
             ;; PARTITION keys (:rf.db/app / :rf.db/runtime). `:db` scopes to
             ;; the app-db partition; `:rf.db/runtime` to runtime-db. A
@@ -1179,8 +1195,7 @@
             ;; `commit-frame-transition!`. `new-db` is the nil-coerced value.
             partitions (cond-> {}
                          app-effect? (assoc frame/app-partition-key     new-db)
-                         rt-effect?  (assoc frame/runtime-partition-key (:rf.db/runtime effects)))
-            new-runtime-db (:rf.db/runtime effects)
+                         rt-effect?  (assoc frame/runtime-partition-key new-runtime-db))
             ;; ONE atomic frame-state install. Returns the set of partition
             ;; keys that actually changed by `=`.
             changed    (frame/commit-frame-transition! frame partitions)

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -599,6 +599,54 @@
     (is (= privacy/redacted-sentinel (computed-result :route-token-echo))
         "the output derived from a sensitive runtime-db slot is redacted")))
 
+(deftest runtime-db-whole-value-effect-preserves-flow-elision-declarations
+  ;; rf2-gom797 — a durable `:rf.db/runtime` whole-value effect must NOT clobber
+  ;; the elision declaration registry that lives in the SAME runtime-db
+  ;; partition at `[:rf.runtime/elision …]`. Pre-fix, `commit-frame-transition!`
+  ;; installed the effect's whole-value runtime-db verbatim, dropping every
+  ;; reserved `:rf.runtime/*` subsystem child (incl. `:rf.runtime/elision`) the
+  ;; effect did not itself carry — so a framework-authority event that seeded
+  ;; `:rf.runtime/routing` left the frame with NO flow-sourced elision
+  ;; declarations after commit, even though they were correctly read pre-commit
+  ;; (the existing `propagation-runtime-db-qualified-input` only asserts the
+  ;; SAME-event redaction, which reads the pre-commit registry). This regression
+  ;; pins POST-COMMIT declaration survival.
+  (testing "a durable `:rf.db/runtime` whole-value commit preserves the
+            flow-sourced elision declarations (the registry is a reserved
+            `:rf.runtime/elision` sibling, not application runtime-db)"
+    ;; Framework-authority handler that seeds the routing subsystem with a
+    ;; WHOLE-VALUE runtime-db effect carrying ONLY :rf.runtime/routing — the
+    ;; shape `partitioned_commit_test` / the bead repro use.
+    (reg-fw-runtime-handler! :seed-rt
+      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:token "RT-SECRET"}}}}))
+    (marks/add-marks :rf/default {[:rf.runtime/routing :current :token] :sensitive})
+    (rf/reg-flow {:id     :route-token-echo
+                  :inputs [[:rf.db/runtime :rf.runtime/routing :current :token]]
+                  :output (fn [t] {:echo t})
+                  :path   [:derived :route-token]})
+    ;; Pre-dispatch: BOTH the directly-marked runtime input slot and the
+    ;; propagated flow output declaration are present.
+    (is (contains? (sensitive-decls :rf/default) [:rf.runtime/routing :current :token])
+        "the directly-marked runtime-db input path is declared before dispatch")
+    (is (contains? (sensitive-decls :rf/default) [:derived :route-token])
+        "the propagated flow output declaration is present before dispatch")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:seed-rt])
+    ;; POST-COMMIT — the bug: a whole-value :rf.db/runtime commit must NOT have
+    ;; wiped the elision registry. Both declarations must survive.
+    (is (contains? (sensitive-decls :rf/default) [:rf.runtime/routing :current :token])
+        "the directly-marked runtime-db input declaration SURVIVES the durable runtime-db commit")
+    (is (contains? (sensitive-decls :rf/default) [:derived :route-token])
+        "the propagated flow output declaration SURVIVES the durable runtime-db commit")
+    ;; And the runtime-db seed actually committed (the effect's payload landed).
+    (is (= "RT-SECRET"
+           (get-in (frame/frame-runtime-db-value :rf/default)
+                   [:rf.runtime/routing :current :token]))
+        "the framework-authority runtime-db seed committed durably")
+    ;; The elision sub-tree coexists in the SAME committed runtime-db partition.
+    (is (some? (get (frame/frame-runtime-db-value :rf/default) :rf.runtime/elision))
+        "the :rf.runtime/elision subsystem child coexists with :rf.runtime/routing post-commit")))
+
 (deftest propagation-flow-dag-upstream-to-downstream
   (testing "flow→flow DAG propagation: flow B reading flow A's sensitive
             output :path inherits A's propagated mark. The topo-ordered drain


### PR DESCRIPTION
## Bug (rf2-gom797)

A flow output declaration refresh writes into the live runtime-db elision registry **before** the event commit, but a durable event returning a whole-value `:rf.db/runtime` effect overwrote that registry **during** commit. Same-event flow/computed and t2 pending-db traces redacted correctly (they read the pre-commit registry), but after commit the frame's runtime-db no longer carried the flow-sourced output declarations — so the post-commit frame emitted raw values that were correctly redacted pre-commit, breaking the durable privacy/trace contract after **any** runtime-db-writing event.

### Root cause

The elision declaration registry lives at `[:rf.runtime/elision]` *inside* the runtime-db partition (EP-0001 — durable, serializable framework state). `commit-frame-effects!` (router.cljc) installed a `:rf.db/runtime` effect's value as the whole runtime-db partition via `commit-frame-transition!` (whole-value replacement). An effect that seeded an unrelated reserved subsystem (e.g. `:rf.runtime/routing`) and did not itself carry `:rf.runtime/elision` therefore dropped the registry — even though `:rf.runtime/elision` is a cross-cutting subsystem child written out-of-band by `reg-flow` / `add-marks` / frame-classification, never by the committing event.

## Fix

Reconcile the runtime-db effect value against the pre-commit runtime-db at the commit boundary: carry the prior `:rf.runtime/elision` sub-tree forward **unless** the effect speaks about it explicitly (a full-frame install / deliberate clear — epoch-restore / SSR-hydration — is honoured verbatim, including an intentional clear). A frame that never used elision stays clean (no stray nil sub-tree).

The `:rf.runtime/elision` key knowledge stays in `re-frame.elision` (new `^:no-doc reconcile-runtime-db-effect`, the single source of truth alongside `write-elision-slot`); `re-frame.router` calls it on the forward-commit path.

**Atomicity preserved** — the rollback path still restores both partitions from the pre-commit snapshot (`runtime-before`), untouched by this change. `partitioned_commit_test` (incl. atomic cross-partition + whole-value-commit cases) stays green.

## Acceptance criteria
- [x] A runtime-db-writing event that triggers/considers flows preserves the flow-sourced elision declarations in the committed runtime-db.
- [x] Regression test added covering a flow with a runtime-db-qualified sensitive input where a durable `:rf.db/runtime` effect no longer clears the propagated output declaration after commit (`runtime-db-whole-value-effect-preserves-flow-elision-declarations`). **Red before, green after.**
- [x] Existing atomicity guarantees preserved (rollback restores both partitions).

## Surface / scope
- `implementation/core/src/re_frame/elision.cljc` — new reconciliation helper.
- `implementation/core/src/re_frame/router.cljc` — commit-path wiring (+ `elision` require).
- `implementation/flows/test/re_frame/flows_output_marks_test.clj` — regression test.

No hot-zone files touched. No new error ids (no spec/009 catalogue row needed). No spec change — this restores documented partition / atomicity semantics.

## Gates
- `implementation/flows` JVM: 206 tests / 4851 assertions, 0 failures.
- `implementation/core` JVM: 1759 tests / 7621 assertions, 0 failures.
- `npm run test:cljs`: 7551 tests / 31044 assertions, 0 failures.
- `npm run test:elision`: PASS (production 43/43 absent).
- `scripts/test-fast-pr.sh`: PASS fast PR spine.
