### PR TITLE
docs(guide): post-merge guide-v2 hardening (rf2-0kyck2)

### DIFF
--- a/docs/guide/concepts/flows.md
+++ b/docs/guide/concepts/flows.md
@@ -133,7 +133,7 @@ Flows are registered against the runtime, not compiled into event chains. So you
 
     A subscription and a flow are the *same node* in one derivation graph — the same pure function of the same inputs — differing only in policy: a sub stores nothing and evaluates on demand; a flow stores into app-db and evaluates after each event (the algebra names that policy `:after-event`). [One graph: derivations and their algebra views](../derivations-and-algebra-views.md) draws the whole picture.
 
-## You can now
+**You can now:**
 
 - re-express a subscription as a flow — and say which of the two a given value deserves
 - materialise a derived value into app-db so event handlers, other flows, and registered schemas read it as plain data, and it survives SSR and time travel

--- a/docs/guide/tutorial/index.md
+++ b/docs/guide/tutorial/index.md
@@ -227,7 +227,7 @@ Xray auto-opened with the app, and `Ctrl+Shift+C` toggles it. Take a moment to l
 
 One event, one state, nothing else. **Keep Xray open for the whole tutorial.** Every part runs the rhythm *do → observe → explain*, and Xray is the observe step — so when something misbehaves, you won't reach for print statements, you'll just read what the app actually did. [Debug with Xray](../how-to/debug-with-xray.md) is the deeper tour when you want it.
 
-## You can now
+**You can now:**
 
 - Scaffold a re-frame2 project on the real toolchain: `deps.edn`, `package.json`, `shadow-cljs.edn`, a host page.
 - Boot an app honestly, and say what each move does: `init!` (substrate), `reg-frame` (the app's frame), `with-frame` + `dispatch-sync` (seed before first render), `frame-provider` (carry the frame down the tree).


### PR DESCRIPTION
## What

Post-merge guide-v2 hardening (rf2-0kyck2). Independent API-correctness audit of the guide against the actual landed facade + a footer-contract drift sweep.

### Footer-contract drift (fixed)
Two content pages ended with a `## You can now` **heading** (no colon) instead of the codified bold inline `**You can now:**` checklist (AUTHORING.md footer section) used by the other 43 content pages:

- `docs/guide/concepts/flows.md`
- `docs/guide/tutorial/index.md`

Same drift class as the ellipsis footers fixed in #4362, different malformation. Normalized to the dominant `**You can now:**` form.

### API correctness (verified clean — no fix needed)
Extracted every `rf/*` call the guide makes and checked each against `implementation/core/src/re_frame/core.cljc`:

- Every live `rf/*` call resolves to a real facade export.
- The removed/renamed forms (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `inject-cofx`, `on-changes`) appear **only** as labelled v1 migration prose (the `25-from-re-frame-v1.md` before/after pairs and codemod mappings) or as explicit negative examples (`rf/runtime` / `rf/path` "there is no such thing" notes) — never as live v2 API.
- No EP-0007 retired spellings (`:frame` event-context read, `:url`/`:to` redirect target) in the guide.

This independently confirms the prior audit's "API-clean" verdict.

## Deferred (already tracked in the bead's NOTES, not duplicated)
- (a) Snippet-source backfill (~185 uncited fences) — **operator-gated** on aggressiveness; guide is API-clean so no urgency.
- (b) Cold-start buildability test + time-to-pixels — needs a runnable shadow-cljs env, out of scope for a docs-only worktree.

## Gates
- `mkdocs build --strict` — green (built in ~34s; remaining lines are INFO-level external-link notes, pre-existing).
- README link/anchor validator — green.
- docs corpus anchor (slug) validator — green.
- `scripts/test-fast-pr.sh` — all gates green except the final `CLJS node integration` step, which fails only because this fresh worktree has no `implementation/node_modules` (shadow-cljs not installed). A 2-char markdown edit cannot affect CLJS compilation; CI runs it provisioned.
