### PR TITLE
fix(mcp-base): reject trailing-form ]-injection in read-edn-no-tags via EOF exhaustion (rf2-rtg9t1)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -160,6 +160,15 @@
                    :recovery    :no-recovery
                    :reason      "EDN cursor decoded to more than one form — a cursor is one opaque payload map"})))
 
+(def ^:private eof-sentinel
+  "A sentinel keyword appended after the decoded cursor text to assert
+  the reader consumed the ENTIRE wrapped string (the string-host analog
+  of an `:eof` read sentinel — see `read-edn-no-tags`). Qualified +
+  unguessable so that even attacker-supplied text reproducing this exact
+  literal cannot pass the exhaustion check (a cursor must still be a
+  single payload map FOLLOWED by the sentinel — two forms, no more)."
+  ::cursor-eof-sentinel)
+
 (defn- read-edn-no-tags
   "Read a cursor's decoded EDN string as EXACTLY ONE form, with EVERY
   tagged literal rejected — built-in (`#inst` / `#uuid`) AND custom
@@ -169,7 +178,7 @@
   `:rf.error/mcp-cursor-bad-edn-tag` on every remaining unregistered
   tag.
 
-  ## One form, EOF-exhausted (rf2-ykv9a0)
+  ## One form, EOF-exhausted (rf2-ykv9a0, hardened rf2-rtg9t1)
 
   A cursor is ONE opaque payload map; a token whose decoded text is a
   valid map FOLLOWED by a second form — e.g.
@@ -179,24 +188,39 @@
   trailing object and weaken the opacity / corruption guard). A plain
   `read-string` reads only the FIRST form and never checks exhaustion.
 
-  We close that by wrapping the decoded text in `[ … ]` and reading the
-  WHOLE thing as one vector: a single clean form yields a one-element
-  vector (trailing whitespace / comments are absorbed), while ANY
-  trailing form yields a 2+-element vector → `bad-trailing!`. This is a
-  pure-`read-string` technique that behaves identically on the JVM
+  The earlier fix wrapped the text in `[ … ]` and accepted a
+  ONE-element vector. That guard was bypassable by `]`-INJECTION
+  (rf2-rtg9t1): attacker text `{…valid map…}] <junk>` wraps to
+  `[{…}] <junk>]`, where the injected `]` closes the wrapper early —
+  `read-string` reads the clean 1-element vector `[{…}]`, returns the
+  inner map, and SILENTLY DISCARDS everything after the injected `]`.
+
+  We close that by asserting reader EXHAUSTION via an appended sentinel:
+  wrap as `[ <text> <eof-sentinel> ]` and require the read to yield
+  EXACTLY `[<one-form> <eof-sentinel>]` — a 2-element vector whose
+  SECOND element is the sentinel. The sentinel can only land as the
+  trailing element if the reader consumed the WHOLE wrapped string
+  (no early-`]` truncation): an injected `]` truncates the read before
+  the sentinel (vector does NOT end with it ⇒ `bad-trailing!`), and any
+  genuine trailing form pushes the count past 2 (also `bad-trailing!`).
+  Trailing whitespace / comments are absorbed. This is a pure
+  `read-string` technique that behaves identically on the JVM
   (`clojure.edn`) and CLJS (`cljs.reader`) without reaching into either
   host's pushback-reader internals. Tagged literals anywhere inside the
   wrapped text still throw via the readers above. Returns the sole
-  decoded form (so the caller's `map?` / `valid?` checks are unchanged).
-  Caught by the surrounding try in `decode-cursor` → `::malformed`."
+  decoded payload form (so the caller's `map?` / `valid?` checks are
+  unchanged). Caught by the surrounding try in `decode-cursor` →
+  `::malformed`."
   [s]
   (let [opts    {:readers no-tag-readers
                  :default (fn [tag _val] (bad-tag! tag))}
-        wrapped (str "[" s "]")
+        wrapped (str "[" s " " (pr-str eof-sentinel) "]")
         forms   #?(:clj  (edn/read-string opts wrapped)
                    :cljs (cljs.reader/read-string opts wrapped))]
-    (if (and (vector? forms) (= 1 (count forms)))
-      (first forms)
+    (if (and (vector? forms)
+             (= 2 (count forms))
+             (= eof-sentinel (nth forms 1)))
+      (nth forms 0)
       (bad-trailing!))))
 
 (defn decode-cursor

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -298,6 +298,23 @@
              (cursor/decode-cursor
                (cursor/b64-encode "{:v 1 :after-id 1} 42")
                pair?))))
+    ;; rf2-rtg9t1 — `]`-injection runs identically on cljs.reader. The
+    ;; injected `]` closes the wrap-in-`[…]` early; the EOF-sentinel
+    ;; exhaustion check rejects because the truncated read no longer ends
+    ;; with the appended sentinel.
+    (testing "valid map + injected ] + trailing junk ⇒ ::malformed"
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor
+               (cursor/b64-encode "{:v 1 :after-id 1}] {:junk 1}")
+               pair?)))
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor
+               (cursor/b64-encode "{:v 1 :after-id 1}] 42")
+               pair?)))
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor
+               (cursor/b64-encode "{:v 1 :after-id 1}]")
+               pair?))))
     (testing "a single clean cursor still round-trips"
       (is (= {:v 1 :after-id "ev-9"}
              (cursor/decode-cursor (cursor/encode-cursor {:v 1 :after-id "ev-9"}) pair?))))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -201,6 +201,31 @@
   (testing "valid map + trailing scalar ⇒ ::malformed"
     (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} 42")]
       (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  ;; rf2-rtg9t1 — `]`-injection. The earlier wrap-in-`[…]` guard accepted
+  ;; a ONE-element vector; attacker text `{…}] <junk>` wraps to
+  ;; `[{…}] <junk>]` where the injected `]` closes the wrapper EARLY, so
+  ;; `read-string` reads the clean 1-element vector `[{…}]` and silently
+  ;; discards the trailing junk → the cursor was ACCEPTED. The
+  ;; EOF-sentinel exhaustion check rejects it: the injected `]` truncates
+  ;; the read before the appended sentinel, so the result no longer ends
+  ;; with the sentinel ⇒ ::malformed.
+  (testing "valid map + injected ] + trailing map ⇒ ::malformed (not silently accepted)"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"}] {:junk 1}")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "valid map + injected ] + trailing scalar ⇒ ::malformed"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"}] 42")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "valid map + injected ] + trailing tagged literal ⇒ ::malformed"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"}] #foo/bar 1")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "valid map + injected ] alone (no trailing form) ⇒ ::malformed"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"}]")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "attacker reproduces the eof sentinel keyword as a trailing form ⇒ ::malformed"
+    (let [evil (cursor/b64-encode
+                 (str "{:v 1 :offset 0 :total 1 :sig \"s\"} "
+                      (pr-str :re-frame.mcp-base.cursor/cursor-eof-sentinel)))]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
   (testing "a single clean cursor (incl. trailing whitespace) still round-trips"
     (let [clean (cursor/encode-cursor {:v 1 :offset 0 :total 1 :sig "s"})]
       (is (= {:v 1 :offset 0 :total 1 :sig "s"}


### PR DESCRIPTION
## Summary

Closes **rf2-rtg9t1** (LOW, robustness/opacity guard). The `read-edn-no-tags` "exactly one EDN form" check in `tools/mcp-base/src/re_frame/mcp_base/cursor.cljc` was bypassable by `]`-injection.

## The defect

The guard wrapped decoded cursor text as `[ <text> ]` and accepted a one-element vector. Attacker text shaped `{...valid map...}] <trailing junk>` wraps to `[{...}] <trailing junk>]` — the injected `]` closes the wrapper early, so `read-string` reads the clean one-element vector `[{...}]`, returns the inner map, and **silently discards everything after the injected `]`**. The cursor was ACCEPTED instead of rejected `::malformed` — the exact trailing-form smuggling the rf2-ykv9a0 fix intended to close.

Repro confirmed: `[{...}] {:junk 1}]` → `read-string` → `[{...}]` (trailing junk dropped).

Why only LOW: the trailing bytes are never parsed (no tag reader fires), the returned value is still a `valid?`-validated payload map, and cursors are opaque + server-generated — only a weakened opacity/corruption guard, no leak/crash/corruption.

## The fix

Assert reader **exhaustion** via an appended EOF sentinel: wrap as `[ <text> <eof-sentinel> ]` and require the read to yield exactly `[<one-form> <eof-sentinel>]` (a two-element vector whose second element is the sentinel). The sentinel can only land as the trailing element if the reader consumed the whole wrapped string without early-`]` truncation:
- injected `]` truncates the read before the sentinel → vector doesn't end with it → `bad-trailing!`
- any genuine trailing form pushes the count past two → `bad-trailing!`

Pure-`read-string` technique, identical on JVM (`clojure.edn`) and CLJS (`cljs.reader`); no pushback-reader internals. Tagged-literal rejection unchanged. The sentinel keyword is qualified + unguessable, and attacker text reproducing it as a trailing form is still rejected (two-form count check).

## Tests

Added `]`-injection cases to both trailing-form suites:
- JVM `cursor_test.clj`: injected `]` + trailing map / scalar / tagged literal / bare `]`, plus a sentinel-reproduction guard.
- CLJS `cljs_branches_cljs_test.cljs`: injected `]` + trailing junk / scalar / bare `]`.

Confirmed **red-before-green** on both hosts (old src returned the silently-accepted inner map; new src returns `::malformed`).

## Gates

- `tools/mcp-base` JVM: 236 tests, 785 assertions, 0 failures.
- `tools/mcp-base` CLJS branches: 15 tests, 95 assertions, 0 failures.
- `scripts/test-fast-pr.sh`: all gates green incl. core JVM + implementation CLJS node-integration (7556 tests, 31065 assertions, 0 failures).

Surface lane: `tools/mcp-base/` only.