### PR TITLE
fix(story): re-check settle deadline after terminal flush (rf2-65bnwl)

### DIFF
--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -308,11 +308,18 @@
            ;; rather than reporting a settled pass it did not earn.
            (loop [[level & more] levels]
              (cond
-               (nil? level)
-               {:status :settled :boundary required}
-
+               ;; The deadline is re-checked BEFORE this branch returns so it
+               ;; also covers the TERMINAL flush: the last (richest) flush can
+               ;; run within budget on entry yet blow the wall-clock budget as
+               ;; it returns. Checking here — not only at the top of the next
+               ;; iteration — means an over-budget terminal flush refuses with
+               ;; a fail-closed `:flush-timeout` instead of a settled pass it
+               ;; did not earn (rf2-65bnwl).
                (and deadline (> (interop/now-ms) deadline))
                (flush-timeout-result required provided step)
+
+               (nil? level)
+               {:status :settled :boundary required}
 
                :else
                (do (when-let [f (get flushes level)]

--- a/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
+++ b/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
@@ -14,6 +14,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core   :as rf]
             [re-frame.frame  :as frame]
+            [re-frame.interop :as interop]
             [re-frame.story.play.settled-boundary :as boundary]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.registrar :as registrar]))
@@ -217,6 +218,49 @@
         (is (not= :settled (:status res)) "a flush timeout is never a settled pass")
         (is (empty? @ran)
             "the over-budget flush phase ran no flush fn (deadline already past)")
+        (is (true? (:fired (rf/app-db-value bf)))
+            "the event was dispatched before the bounded flush phase refused")))))
+
+(deftest timeout-ms-terminal-flush-over-budget-refuses
+  (testing "when the TERMINAL (richest) flush itself blows the wall-clock
+            budget, the settle is refused with :cannot-run/:flush-timeout —
+            never a silent :settled pass. The deadline check after each
+            flush MUST also cover the last flush in the ladder (rf2-65bnwl):
+            the top-of-loop check passes for the terminal :dom level (budget
+            not yet spent), the :dom flush then runs over budget, and the
+            settle must NOT report :settled."
+    (let [ran    (atom [])
+          ;; A small positive budget: the :cljs-reactive flush stays within
+          ;; it, then the terminal :dom flush deterministically pushes the
+          ;; wall clock past the deadline by busy-spinning on now-ms (no
+          ;; platform sleep — works on JVM + CLJS). This is the ONLY level
+          ;; whose post-flush deadline check the buggy code skipped.
+          budget 30
+          hooks  {:provides   :dom
+                  :timeout-ms budget
+                  :dispatch!  (fn [frame-id evec]
+                                (boundary/drain-sync! frame-id evec))
+                  :flush!     {:cljs-reactive (fn [_] (swap! ran conj :reactive))
+                               :dom           (fn [_]
+                                                (swap! ran conj :dom)
+                                                ;; burn well past the deadline
+                                                ;; so the post-flush check is
+                                                ;; unambiguously over budget
+                                                (let [stop (+ (interop/now-ms)
+                                                              (* 4 budget))]
+                                                  (while (< (interop/now-ms) stop) nil)))}}]
+      (rf/reg-event :timeout/terminal (fn [{:keys [db]} _] {:db (assoc db :fired true)}))
+      (let [res (boundary/dispatch-and-settle! bf [:timeout/terminal] hooks :dom [:click "b"])]
+        (is (not= :settled (:status res))
+            "an over-budget TERMINAL flush is never a settled pass")
+        (is (= :cannot-run    (:status res)))
+        (is (= :flush-timeout (:reason res)))
+        (is (= :dom           (:required-boundary res)))
+        (is (= :dom           (:provided-boundary res)))
+        (is (= [:click "b"]   (:step res)))
+        (is (= [:reactive :dom] @ran)
+            "the terminal flush DID run (it was within budget on entry); the
+             refusal is detected by the post-flush deadline re-check")
         (is (true? (:fired (rf/app-db-value bf)))
             "the event was dispatched before the bounded flush phase refused")))))
 


### PR DESCRIPTION
## What

`tools/story` `dispatch-and-settle!` (`settled_boundary.cljc`) checked the `:timeout-ms` deadline only at the **top** of each flush-loop iteration, then returned `{:status :settled}` from the `(nil? level)` branch **without re-checking**. So the terminal (richest, e.g. `:dom`/`:browser`) flush could blow the wall-clock budget and still report `:settled` instead of the documented fail-closed `:flush-timeout`/`:cannot-run`.

The ns docstring (:41-44), the fn docstring, and the inline comment (:305-308) all claimed the deadline is checked "after EACH flush fn returns" — which the code did NOT do for the terminal flush.

## Fix

Reorder the loop `cond` so the deadline check precedes the terminal `:settled` branch. The deadline is now re-checked at the top of every iteration **and** after the terminal flush (the `recur` after the last flush re-enters the loop and hits the deadline check before `(nil? level)`). The existing docs become accurate with no wording change.

## Test

Added `timeout-ms-terminal-flush-over-budget-refuses`: a richer-runner (`:provides :dom`) hooks map with a positive `:timeout-ms` whose terminal `:dom` flush deterministically busy-spins past the deadline (no platform sleep; runs on JVM + node). It now asserts `:cannot-run`/`:flush-timeout` — previously it returned `:settled`. Red-before-green confirmed (6 assertions failed pre-fix). The existing `timeout-ms-bounds-flush-phase-and-refuses` (deadline-already-past-on-entry) and `timeout-ms-generous-budget-settles-normally` cases still cover the top-of-loop check and the happy path.

## Gates

- `tools/story` JVM suite: 1686 tests / 6247 assertions, 0 failures.
- `npm run test:cljs` (node host, exercises the `.cljc` test): 7556 tests / 31065 assertions, 0 failures.
- `scripts/test-fast-pr.sh`: PASS.

Surface lane: `tools/story/` only (`settled_boundary.cljc` + its test). No `implementation/` changes.