### PR TITLE
fix(xray): correct shifted (was N) index on scattered vector deletes (rf2-1njv97)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -276,6 +276,16 @@ first — reporting one before-value repeatedly and dropping the rest.
 The replay recovers the true before-index + before-value for every
 removed element regardless of contiguity or multiplicity.
 
+The `:same-shifted` **shift-suffix projection uses the same replay**
+(rf2-1njv97): the `(was N)` before-index of a surviving element is the
+original index left in the survivor list once the `:-` edits have been
+replayed (and the `:+` insert-markers spliced in), *not* an arithmetic
+`after-index − inserts + deletes` count. Treating the post-shift `:-`
+edit-indices as before-indices over-counted deletes for scattered /
+multi-element removals (`[:a :b :c :d] → [:a :c]` reported the surviving
+`:c` as `(was 3)` instead of `(was 2)`); the single-delete case lined up
+only by coincidence.
+
 > **Renderer note (rf2-vu42n, fixed).** The inline vector / list / seq
 > body renderer **consumes** this `:vector-removals` channel (plus the
 > `:same-shifted` shift projection) via `sequential-diff-children`,

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -399,70 +399,83 @@
   `{after-index was-before-index}` for every after-element whose
   identity moved positionally (op `:same-shifted`).
 
-  The logic walks the after-vector left→right, replaying each edit in
-  before-index order to maintain a running `(before-cursor, after-cursor)`
-  pair. Every after-position that the edit script LEFT ALONE moves by
-  exactly `(inserts-so-far - deletes-so-far)`; positions with edits
-  (`:+` / `:r`) are skipped because they classify under :added /
-  :modified, not :same-shifted."
-  [after-len edits-at-this-vector]
-  (let [;; Normalise edits to {idx, kind} sorted by idx ascending. We
-        ;; need the chronological order along the after-vector to
-        ;; compute the running shift offset. `:+` edits are keyed by
-        ;; their AFTER-index; `:-` edits are keyed by their BEFORE-
-        ;; index. `:r` edits sit at a shared index (same in both
-        ;; vectors) by Editscript's structure-preserving guarantee.
-        insert-idxs  (->> edits-at-this-vector
-                          (filter (fn [edit] (= :+ (second edit))))
-                          (map (fn [edit] (peek (first edit))))
-                          (sort)
-                          vec)
-        delete-idxs  (->> edits-at-this-vector
-                          (filter (fn [edit] (= :- (second edit))))
-                          (map (fn [edit] (peek (first edit))))
-                          (sort)
-                          vec)
-        replace-idxs (->> edits-at-this-vector
-                          (filter (fn [edit] (= :r (second edit))))
-                          (map (fn [edit] (peek (first edit))))
-                          (into #{}))
-        ;; Skip after-indices that ARE edits themselves.
-        skip-after?  (fn [after-idx]
-                       (or (contains? (set insert-idxs) after-idx)
-                           (contains? replace-idxs after-idx)))
-        ;; Count inserts ≤ after-idx.
-        inserts-at-or-before
-        (fn [after-idx] (count (filter (fn [i] (<= i after-idx)) insert-idxs)))]
-    (reduce
-      (fn [acc after-idx]
-        (if (skip-after? after-idx)
+  The logic REPLAYS the edit script against a live `survivors` list of
+  ORIGINAL before-indices — the same technique `resolve-vector-removals`
+  (rf2-yucxn) uses for the removals channel. This is mandatory because
+  Editscript emits `:-` edits at POST-shift indices applied SEQUENTIALLY
+  against a shrinking vector — they are NOT stable before-indices. The
+  pre-fix `delete-idxs ≤ cursor` fixed-point (rf2-1njv97) mis-read those
+  post-shift indices as before-indices and over-counted deletes for any
+  scattered/multi-element removal (`[:a :b :c :d] → [:a :c]` reported the
+  surviving `:c` as `(was 3)` instead of `(was 2)`; the single-delete case
+  worked only by coincidence).
+
+  Replay procedure:
+    1. `survivors` starts as `(range before-len)` — every before-index.
+    2. Apply each `:-` in Editscript order: edit-index `i` removes the
+       element CURRENTLY at `survivors[i]` (post-shift), shrinking the list.
+       What remains are the before-indices of all surviving elements, in
+       after-order.
+    3. Splice each `:+` (keyed by AFTER-index, ascending) into the survivor
+       list as a `nil` insert-marker, so the list aligns 1:1 with the
+       after-vector by index.
+  The resulting `slots` vector maps `after-index → original before-index`
+  (or `nil` for an inserted slot). Positions with edits (`:+` / `:r`) are
+  skipped from the output because they classify under :added / :modified,
+  not :same-shifted; an after-index whose before-index equals it (no move)
+  is likewise omitted."
+  [before-len edits-at-this-vector]
+  (let [;; `:+` edits are keyed by their AFTER-index; `:-` edits carry
+        ;; POST-shift edit-indices in Editscript order (NOT before-indices);
+        ;; `:r` edits sit at a shared, surviving index.
+        delete-edit-idxs (->> edits-at-this-vector
+                              (filter (fn [edit] (= :- (second edit))))
+                              (mapv (fn [edit] (peek (first edit)))))
+        insert-idxs      (->> edits-at-this-vector
+                              (filter (fn [edit] (= :+ (second edit))))
+                              (map (fn [edit] (peek (first edit))))
+                              (sort)
+                              vec)
+        replace-idxs     (->> edits-at-this-vector
+                              (filter (fn [edit] (= :r (second edit))))
+                              (map (fn [edit] (peek (first edit))))
+                              (into #{}))
+        ;; Step 1+2 — replay the `:-` deletes against the survivor list of
+        ;; original before-indices, removing the post-shift slot each time.
+        survivors-after-deletes
+        (loop [survivors  (vec (range before-len))
+               [i & more] delete-edit-idxs]
+          (if (nil? i)
+            survivors
+            (recur (if (and (>= i 0) (< i (count survivors)))
+                     (into (subvec survivors 0 i)
+                           (subvec survivors (inc i)))
+                     ;; Defensive: a malformed out-of-range edit-index is
+                     ;; skipped rather than crashing the projection.
+                     survivors)
+                   more)))
+        ;; Step 3 — splice insert-markers (nil) at each `:+` after-index so
+        ;; the slot vector aligns position-for-position with the after-vector.
+        slots
+        (reduce (fn [acc after-idx]
+                  (let [after-idx (min after-idx (count acc))]
+                    (into (conj (subvec acc 0 after-idx) nil)
+                          (subvec acc after-idx))))
+                survivors-after-deletes
+                insert-idxs)
+        insert-set (set insert-idxs)]
+    ;; Emit `{after-index before-index}` only for surviving (non-edit) slots
+    ;; whose position actually moved.
+    (reduce-kv
+      (fn [acc after-idx before-idx]
+        (if (or (nil? before-idx)                  ; inserted slot → :added
+                (contains? insert-set after-idx)
+                (contains? replace-idxs after-idx) ; replaced slot → :modified
+                (= after-idx before-idx))          ; unmoved → no suffix
           acc
-          (let [;; Each `:+` at index ≤ after-idx shifts the after-
-                ;; index up by 1 from the before-cursor. Each `:-`
-                ;; at index ≤ before-cursor shifts the before-cursor
-                ;; up. We solve by binary-friendly subtraction:
-                ;; before-idx ≈ after-idx - inserts-so-far + deletes-
-                ;; so-far. Compute fixed-point by walking deletes.
-                inserts-so-far (inserts-at-or-before after-idx)
-                ;; First-cut: ignore deletes (the simple insert case).
-                tentative-before (- after-idx inserts-so-far)
-                ;; Then add the count of deletes whose before-index is
-                ;; ≤ the inferred before-cursor — those slots were
-                ;; cleared out from the before-vector before this row.
-                deletes-shift
-                (loop [seen 0
-                       cursor tentative-before]
-                  (let [n (count (filter (fn [i] (<= i cursor)) delete-idxs))]
-                    (if (= n seen)
-                      seen
-                      (recur n (+ tentative-before n)))))
-                inferred-before (+ tentative-before deletes-shift)]
-            (if (and (>= inferred-before 0)
-                     (not= after-idx inferred-before))
-              (assoc acc after-idx inferred-before)
-              acc))))
+          (assoc acc after-idx before-idx)))
       {}
-      (range after-len))))
+      (vec slots))))
 
 (defn- group-edits-by-vector-parent
   "Group all edits by their parent path WHEN the parent is a vector.
@@ -960,12 +973,15 @@
           shift-suffix
           (reduce
             (fn [acc [parent-path edits]]
-              (let [parent-val (value-at after parent-path)
-                    n (cond
-                        (vector? parent-val)     (count parent-val)
-                        (sequential? parent-val) (count parent-val)
-                        :else 0)
-                    shifts (shift-suffixes-for-vector n edits)]
+              (let [;; The shift replay reconstructs survivor before-indices
+                    ;; from the BEFORE-side length (rf2-1njv97); the after
+                    ;; length is recoverable from the slot vector itself.
+                    before-val (value-at before parent-path)
+                    before-len (cond
+                                 (vector? before-val)     (count before-val)
+                                 (sequential? before-val) (count before-val)
+                                 :else 0)
+                    shifts (shift-suffixes-for-vector before-len edits)]
                 (reduce-kv
                   (fn [acc' after-idx before-idx]
                     (assoc acc' (conj (vec parent-path) after-idx) before-idx))

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -99,6 +99,26 @@
         (is (= 1 (count removals)))
         (is (= {:before-index 1 :before-value :b} (first removals)))))))
 
+(deftest r6-vector-scattered-remove-shifted-was-index
+  (testing "rf2-1njv97 — a SCATTERED (multi-element) removal must report the
+            TRUE before-index in the `(was N)` suffix. `[:a :b :c :d] →
+            [:a :c]` drops :b (before-idx 1) and :d (before-idx 3); the
+            surviving :c sits at after-index 1 and WAS at before-index 2.
+            The pre-fix deletes-shift fixed-point inferred before-idx 3 here
+            (counting both deletes as ≤-cursor) — the regression this guards."
+    (let [before [:a :b :c :d]
+          after  [:a :c]
+          p (engine/project before after)]
+      ;; After-index 0 = :a (unchanged at before-idx 0, no suffix).
+      ;; After-index 1 = :c, which was at before-index 2.
+      (is (= :same-shifted (engine/op-at p [1])))
+      (is (= 2 (engine/shifted-was-index p [1]))
+          "surviving :c must report `(was 2)`, not `(was 3)`")
+      ;; The :vector-removals channel stays correct (it already replayed).
+      (is (= [{:before-index 1 :before-value :b}
+              {:before-index 3 :before-value :d}]
+             (get-in p [:vector-removals []]))))))
+
 ;; ---- R7 type change -----------------------------------------------------
 
 (deftest r7-scalar-to-container


### PR DESCRIPTION
## rf2-1njv97 — diff/engine `shift-suffixes-for-vector` wrong "(was N)" on scattered deletes

### Defect (LOW, cosmetic)
`shift-suffixes-for-vector` inferred the `:same-shifted` "(was N)" before-index via a `delete-idxs <= cursor` fixed-point that treated Editscript `:-` edit indices as stable before-indices. Editscript actually emits `:-` at POST-shift indices applied sequentially against a shrinking vector, so for scattered / multi-element removals the delete count over-shifted. `[:a :b :c :d] -> [:a :c]` reported the surviving `:c` as "(was 3)" instead of "(was 2)". The single-delete case lined up only by coincidence; the impact is a misleading suffix only — no crash, no data corruption, and the `:vector-removals` channel itself was already correct.

### Fix
Reuse the replay technique `resolve-vector-removals` (rf2-yucxn) already uses for the removals channel:
1. Replay the `:-` deletes against a live survivor list of original before-indices, removing the post-shift slot each time.
2. Splice `:+` insert-markers (`nil`) in by after-index so the slot vector aligns 1:1 with the after-vector.
3. The slot vector maps `after-index -> true before-index`; emit a suffix only for surviving, moved (non-edit) slots.

The call site now passes the **before**-side parent length (the replay reconstructs survivor before-indices from it).

### Test (red-before-green)
`r6-vector-scattered-remove-shifted-was-index`: `[:a :b :c :d] -> [:a :c]` must report `op-at [1]` = `:same-shifted` with `shifted-was-index` = **2** (was failing as 3 pre-fix), plus the existing removals-channel assertion. Verified red before the fix (`(not (= 2 3))`), green after.

### Gates
- `tools/xray` JVM suite: 1218 tests / 5430 assertions, 0 failures.
- `scripts/test-fast-pr.sh`: PASS (7557 tests / 31068 assertions; markdown gates green; mkdocs soft-skip on Windows).

### Spec touch
Per the standing tools/xray rule, `tools/xray/spec/004-App-DB-Diff.md` updated: notes the `:same-shifted` shift-suffix projection shares the removals replay (true before-index, not arithmetic `after-index − inserts + deletes` counting), with the scattered-delete example.
