### PR TITLE
fix(machines): parallel region cache must not leak stale :rf/cofx (rf2-gqr4vs)

### DIFF
--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -131,12 +131,16 @@
         (assoc :rf/parent-id      (:rf/parent-id parent-machine))
         (assoc :rf/platform       (:rf/platform parent-machine))
         (assoc :rf/frame          (:rf/frame parent-machine))
-        ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): inherit the causal
-        ;; recordable-coeffect token so a region's guard / action reads
-        ;; `:rf.cofx` causally too. The cached spec's value is overlaid live in
-        ;; `region-spec-overlaid` (the token is dynamic, stamped per dispatch by
-        ;; `prepare-machine-ctx`).
-        (assoc :rf/cofx           (:rf/cofx parent-machine))
+        ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): the causal
+        ;; recordable-coeffect token is transition-local, NOT registration-time
+        ;; data — `prepare-machine-ctx` stamps `:rf/cofx` per dispatch. The cache
+        ;; is populated at registration time, so we must NOT bake a value (or even
+        ;; the key) in here: a stale `:rf/cofx` cached from the priming dispatch
+        ;; would otherwise leak into a later transition whose parent carries none
+        ;; (rf2-gqr4vs). `region-spec-overlaid` is the single choke-point that
+        ;; overlays the LIVE `:rf/cofx` onto the cached spec — present iff the
+        ;; current parent carries it, dissoc'd otherwise — so the absent path
+        ;; leaves no stale slot for `callback-ctx`'s presence check to read.
         (assoc :rf/region         region-name))))
 
 (defn region-machine
@@ -357,12 +361,19 @@
                   :rf/frame    (:rf/frame parent-machine))
       ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): overlay the live causal
       ;; recordable-coeffect token so a region guard / action reads the CURRENT
-      ;; dispatch's `:rf.cofx` (the cache was populated at registration time,
-      ;; before the token was stamped). Only when present so the absent path
-      ;; leaves the cached spec free of a stale slot — `callback-ctx` keys off
-      ;; presence.
+      ;; dispatch's `:rf.cofx`. `:rf/cofx` is transition-local — `callback-ctx`
+      ;; keys off its PRESENCE — so the overlay must MATCH the live parent
+      ;; exactly: assoc when the parent carries it, DISSOC otherwise. A bare
+      ;; `(contains? parent-machine ...)`-gated assoc left a stale slot intact
+      ;; when the live parent carried none, leaking a cached coeffect into a
+      ;; later transition (rf2-gqr4vs). Dissoc on the absent path guarantees the
+      ;; cached spec can never surface a coeffect the current caller did not
+      ;; carry — even if the cache faulted in under a coeffect-carrying parent.
       (contains? parent-machine :rf/cofx)
-      (assoc :rf/cofx (:rf/cofx parent-machine)))))
+      (assoc :rf/cofx (:rf/cofx parent-machine))
+
+      (not (contains? parent-machine :rf/cofx))
+      (dissoc :rf/cofx))))
 
 (defn- reduce-regions
   "Apply `step-fn` to each region of `parent-machine` in declaration

--- a/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
+++ b/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
@@ -149,3 +149,71 @@
             "client run scheduled — the cache was NOT poisoned by the prior server overlay")
         (is (empty? (of-op cli-tr :rf.machine.timer/skipped-on-server))
             "no stale server-skip leaked from the prior run")))))
+
+;; ---- rf2-gqr4vs: transition-local `:rf/cofx` must not survive the cache ----
+
+;; A parallel machine whose region action captures the causal `:rf.cofx`
+;; coeffect threaded onto the action ctx. The `:capture` action records what it
+;; saw so the test can assert presence / absence per transition. `(:type
+;; :parallel)` exercises the same `region-machine` cache + `region-spec-overlaid`
+;; choke-point as the platform/frame overlay above.
+(def cofx-capture-spec
+  {:type    :parallel
+   :data    {}
+   :regions {:a {:initial :one
+                 :states  {:one {:on {:go {:action :capture}}}}}
+             :b {:initial :rest
+                 :states  {:rest {}}}}})
+
+(deftest region-cofx-does-not-leak-from-cache-into-later-transition
+  (testing "rf2-gqr4vs: priming the region cache from a parent carrying
+   `:rf/cofx`, then running a LATER transition whose parent carries NO
+   `:rf/cofx`, must surface NO `:rf.cofx` on the region action ctx — the
+   transition-local coeffect cannot survive on the cached region spec."
+    (let [seen      (atom [])
+          ;; A shared `:capture` action recording the cofx slot it observed.
+          spec      (assoc-in cofx-capture-spec [:actions :capture]
+                              (fn [{cofx :rf.cofx :as ctx}]
+                                (swap! seen conj {:has? (contains? ctx :rf.cofx)
+                                                  :cofx cofx})
+                                {:data (:data ctx)}))
+          installed (parallel/install-region-cache spec)]
+      ;; 1. PRIME the cache from a parent carrying a causal coeffect token —
+      ;;    reproducing the bug origin: the cached region spec captures the
+      ;;    coeffect-carrying parent.
+      (parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :a)
+      (parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :b)
+      ;; 2. The LIVE transition's parent carries NO `:rf/cofx` (a pure-fn / no-
+      ;;    router caller, or a dispatch that simply did not thread the token).
+      (let [snap (parallel-snapshot installed)]
+        (parallel/machine-transition installed snap [:go]))
+      (is (= 1 (count @seen)) "the region :capture action ran exactly once")
+      (is (false? (:has? (first @seen)))
+          "the action ctx carried NO :rf.cofx — the cached coeffect did not leak
+           (callback-ctx keys off presence; the overlay dissoc'd the stale slot)")
+      (is (nil? (:cofx (first @seen)))
+          "and the destructured value is nil, never the primed {:rf/time-ms 1}"))))
+
+(deftest region-cofx-overlays-live-value-when-parent-carries-it
+  (testing "rf2-gqr4vs (symmetric): when the LIVE parent DOES carry `:rf/cofx`,
+   the region action ctx surfaces THAT value — the overlay threads the current
+   dispatch's coeffect through region pure logic, even when the cache was primed
+   under a DIFFERENT coeffect."
+    (let [seen      (atom [])
+          spec      (assoc-in cofx-capture-spec [:actions :capture]
+                              (fn [{cofx :rf.cofx :as ctx}]
+                                (swap! seen conj {:has? (contains? ctx :rf.cofx)
+                                                  :cofx cofx})
+                                {:data (:data ctx)}))
+          installed (parallel/install-region-cache spec)]
+      ;; Prime under one coeffect …
+      (parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :a)
+      ;; … then transition under a DIFFERENT live coeffect.
+      (let [live (assoc installed :rf/cofx {:rf/time-ms 99})
+            snap (parallel-snapshot live)]
+        (parallel/machine-transition live snap [:go]))
+      (is (= 1 (count @seen)) "the region :capture action ran exactly once")
+      (is (true? (:has? (first @seen)))
+          "the action ctx carried :rf.cofx (the live parent supplied it)")
+      (is (= {:rf/time-ms 99} (:cofx (first @seen)))
+          "and it was the LIVE value, not the primed {:rf/time-ms 1}"))))


### PR DESCRIPTION
## Bug (rf2-gqr4vs)

`re-frame.machines.parallel/region-machine` memoises a synthetic single-machine spec per region at registration time. `build-region-machine` baked the parent's `:rf/cofx` (a **transition-local** causal coeffect token, stamped per dispatch by `prepare-machine-ctx`) into that cached spec. `region-spec-overlaid` then only re-overlaid `:rf/cofx` when the *current* parent carried it, leaving any stale baked-in value intact otherwise.

So priming the cache from a parent carrying `:rf/cofx`, then running a later transition whose parent carried none, fed the stale coeffect into the region action/guard ctx (`callback-ctx` keys off `:rf/cofx` *presence*). This violates the carried-frame/coeffect transition semantics — coeffects must be absent when the caller did not carry them.

### Repro (from `implementation/machines`, evidence command from the bead)
- Before: observed `[#:rf{:time-ms 1}]` — stale coeffect leaked.
- After: observed `[nil]` — no coeffect surfaces.

## Fix

- **`build-region-machine`** no longer bakes `:rf/cofx` into the cache — it is transition-local, not registration-time data (the same treatment the existing comment already documents for `:rf/parent-id` / `:rf/platform` / `:rf/frame`, which are overlaid live).
- **`region-spec-overlaid`** now overlays `:rf/cofx` to **match the live parent exactly**: assoc when present, **dissoc when absent**. The dissoc guarantees a cached spec can never surface a coeffect the current caller did not carry, even if the cache faulted in under a coeffect-carrying parent.

Both edits stay inside `implementation/machines` (no shared-core / hot-zone file, no new always-on error id).

## Tests (acceptance criteria)

Added two regression tests to `parallel_region_runtime_overlay_test` — same bug class as the rf2-z522n platform/frame overlay tests already living there:
- `region-cofx-does-not-leak-from-cache-into-later-transition` — primes the cache under a `:rf/cofx`-carrying parent, then transitions without; asserts the action ctx has **no** `:rf.cofx`. **Confirmed red on origin/main** (observed `{:rf/time-ms 1}`), green with the fix.
- `region-cofx-overlays-live-value-when-parent-carries-it` — symmetric: when the live parent *does* carry `:rf/cofx`, the action ctx surfaces the **live** value (not the primed one).

The 3 existing overlay tests continue to pass.

## Gates
- `npm run test:cljs` — 7565 tests / 31096 assertions, 0 failures
- `npm run test:elision` — clean
- `scripts/test-fast-pr.sh` — PASS