### PR TITLE
fix(ssr-ring): project resource payload inside request frame scope (rf2-p026f5)

### DIFF
--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -67,6 +67,13 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
+                       ;; rf2-p026f5 — the non-streaming resource-projection
+                       ;; regression seeds a frame-sensitive `{:from-db}`
+                       ;; resource and asserts the emitted `__rf_payload`
+                       ;; redacts it (the projection MUST run INSIDE the
+                       ;; request frame scope). Resources is a test-only dep
+                       ;; here, as in the sibling `implementation/ssr/deps.edn`.
+                       day8/re-frame2-resources  {:local/root "../resources"}
                        ;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        ;; rf2-to8pm — JVM-side e2e validator coverage spins

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -330,24 +330,24 @@
   ;; §SSR and hydration steps 3-4). A no-op when the resources artefact is
   ;; absent (the `:resources/drain-blocking-ssr!` hook is nil).
   (ssr/drain-blocking-resources! frame-id opts)
-  (let [;; Single `with-frame` block covers the three frame-aware
-        ;; stages: root-view resolution (a 0-arity fn may close over
-        ;; subscribe-time reads), the render walk (subs on registered
-        ;; views), and head resolution (`rf/active-head` reads the
-        ;; frame's route registry). One push/pop per request.
+  (let [;; Single `with-frame` block covers the frame-aware stages:
+        ;; root-view resolution (a 0-arity fn may close over subscribe-time
+        ;; reads), the render walk (subs on registered views), head
+        ;; resolution (`rf/active-head` reads the frame's route registry),
+        ;; AND the hydration-payload build. One push/pop per request.
         explicit-head (:head opts)
-        {:keys [hash-str body-html head-html html-attrs body-attrs]}
+        {:keys [head-html html-attrs body-attrs body-html rf-payload]}
         ;; rf2-bzw8gd / EP-0013 §Realm Conformance: route the render walk's
         ;; registered-view + head/route registry lookups through the request
         ;; frame's OWN realm registrar, so a non-default-realm frame renders
         ;; its realm's views/heads — not the process-global default's. The
         ;; binding is established ONCE per request (covers resolve-root-view,
-        ;; render-to-string's `:view` lookups, and resolve-head's `:head` /
-        ;; `:route` lookups); a default-realm frame binds nothing (the
-        ;; byte-identical single-realm path). `with-frame` only binds
-        ;; `*current-frame*` (core_reg_view_macro.cljc), not the realm
-        ;; registrar — so the realm registrar is bound here, at the host
-        ;; adapter that holds the frame.
+        ;; render-to-string's `:view` lookups, resolve-head's `:head` /
+        ;; `:route` lookups, AND the payload's resource-runtime projection);
+        ;; a default-realm frame binds nothing (the byte-identical
+        ;; single-realm path). `with-frame` only binds `*current-frame*`
+        ;; (core_reg_view_macro.cljc), not the realm registrar — so the realm
+        ;; registrar is bound here, at the host adapter that holds the frame.
         (frame/call-with-frame-realm-registrar
          (frame/frame frame-id)
          (fn []
@@ -388,25 +388,37 @@
                             hiccup
                             {:doctype?    false
                              :emit-hash?  emit-hash?
-                             :render-hash (when emit-hash? hash-str)})]
+                             :render-hash (when emit-hash? hash-str)})
+                ;; rf2-p026f5 — build the hydration payload INSIDE the same
+                ;; `with-frame` + realm-registrar scope. app-db-value /
+                ;; runtime-db-value read the named frame explicitly, but the
+                ;; runtime-db PROJECTION is NOT frame-blind: the resources SSR
+                ;; hook (`:ssr/extend-runtime-db-projection` →
+                ;; `re-frame.resources.ssr/project-resources-runtime-db`)
+                ;; resolves the CURRENT frame (`frame/resolve-current-frame`,
+                ;; the `*current-frame*` dynamic var) to apply frame-owned
+                ;; egress classification + named-scope DERIVED sensitivity
+                ;; (Spec 015 §Derived sensitivity / Spec 016 clause 4). Built
+                ;; OUTSIDE this scope (the prior shape) it ran FRAMELESS, so a
+                ;; resource under a frame-sensitive `{:from-db}` scope leaked
+                ;; its raw scope identity + data into the payload. Reading the
+                ;; snapshot here — AFTER the render walk, INSIDE the block — is
+                ;; load-bearing in BOTH dimensions: the post-walk value (a
+                ;; continuation drain may have mutated the frame-state) AND the
+                ;; frame scope the projection needs. This mirrors the streaming
+                ;; path, where `build-final-payload` runs inside the same
+                ;; `call-with-realm` + `with-frame` rebinding (rf2-tbr67x).
+                ;; EP-0001 (rf2-30kzz2): the runtime-db rides as the
+                ;; serializable `:rf/runtime-db` slice.
+                app-db     (rf/app-db-value frame-id)
+                runtime-db (rf/runtime-db-value frame-id)
+                rf-payload (payload/build-payload frame-id app-db runtime-db hash-str
+                                                  {:version       version
+                                                   :schema-digest schema-digest
+                                                   :payload       payload})]
             (assoc head-bag
-                   :hash-str  hash-str
-                   :body-html body-html)))))
-        ;; app-db-value / runtime-db-value read the named frame explicitly; no
-        ;; with-frame needed. Kept outside the block so the explicit frame-id
-        ;; read is visible — pulling the snapshot AFTER the render walk is
-        ;; load-bearing (a continuation drain inside the walker may mutate
-        ;; the frame-state; the payload must reflect the post-walk value).
-        ;; EP-0001 (rf2-30kzz2): the runtime-db value rides the payload as the
-        ;; serializable `:rf/runtime-db` slice (machine snapshots, route slice,
-        ;; elision declarations, SSR metadata) so the client hydrates a
-        ;; coherent frame-state — `build-payload` projects it.
-        app-db      (rf/app-db-value frame-id)
-        runtime-db  (rf/runtime-db-value frame-id)
-        rf-payload  (payload/build-payload frame-id app-db runtime-db hash-str
-                                           {:version       version
-                                            :schema-digest schema-digest
-                                            :payload       payload})
+                   :body-html  body-html
+                   :rf-payload rf-payload)))))
         payload-edn (pr-str rf-payload)
         shell-opts  (assoc opts
                            :head        head-html

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
@@ -1,0 +1,241 @@
+(ns re-frame.ssr.ring.resource-payload-projection-test
+  "rf2-p026f5 — the NON-streaming Ring hydration payload projects the
+  resource-runtime slice INSIDE the request frame scope, so a frame-owned
+  egress classification (and named-scope derived sensitivity) governs the
+  emitted `__rf_payload`.
+
+  THE BUG: `pipeline/build-full-response*` bound `rf/with-frame` around the
+  root-view resolution / render walk / head resolution, then EXITED that
+  scope before reading app-db / runtime-db and calling `payload/build-payload`.
+  The resources SSR projection hook
+  (`:ssr/extend-runtime-db-projection` → `re-frame.resources.ssr/`
+  `project-resources-runtime-db`) resolves the current frame with
+  `frame/resolve-current-frame` so it can apply the frame-owned egress
+  classification + named-scope derived sensitivity. With NO current frame the
+  projection ran FRAMELESS, so a resource under a frame-sensitive `{:from-db}`
+  scope serialized its raw scope identity + data into the payload instead of
+  redacting them — leaking resource data/scope/params to every visitor of
+  every SSR page.
+
+  THE CONTRACT (Spec 016 clause 4 / Spec 015 §Derived sensitivity): the
+  emitted `__rf_payload` `:rf/runtime-db` resource entry under a frame-sensitive
+  `{:from-db}` scope MUST redact its data + scoped-key components exactly as the
+  resources SSR projection does INSIDE `rf/with-frame` — the raw scope identity
+  and the resource data must never ride.
+
+  This mirrors `re-frame.resources-derived-scope-sensitivity-cljs-test`'s
+  end-to-end projection assertion (same `\"jake\"` viewer + `{:articles …}`
+  data the bead's review eval reproduced) but drives it through the actual
+  non-streaming Ring render path (`build-full-response*`), where the payload
+  build had escaped the frame scope. The realm sibling that fixed the
+  STREAMING path is `re-frame.ssr.ring.realm-routing-test`
+  (rf2-tbr67x — daemon-writer realm rebinding)."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.resources.state :as state]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]
+            [re-frame.ssr.ring.pipeline :as pipeline]
+            [re-frame.ssr.ring.shell :as shell]
+            [re-frame.ssr.ring.test-support :as ts]
+            ;; load-bearing side-effecting requires: register the :resource +
+            ;; :resource-scope registrar kinds, the schemas walker hooks, and
+            ;; (crucially) the `:ssr/extend-runtime-db-projection` late-bind
+            ;; hook resources publishes — the body under test.
+            [re-frame.resources]
+            [re-frame.resources.ssr]
+            [re-frame.schemas]))
+
+(use-fixtures :each ts/reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; App: a frame-sensitive `{:from-db}` session-scoped feed resource.
+;;
+;; Mirrors the resources derived-scope-sensitivity test's `init!`: the frame
+;; declares the viewer-identity path sensitive, a named scope resolver reads
+;; it (default :inherit, so it derives sensitive), and a session-scoped feed
+;; resource references it via `{:from-db}` WITHOUT itself being declared
+;; `:sensitive?`. The derivation inherits → the entry must redact on the wire.
+;; ---------------------------------------------------------------------------
+
+(defn- register-sensitive-feed-app!
+  "Register the resource-scope resolver + the `{:from-db}` feed resource into
+  the active registrar. The FRAME `:sensitive` declaration is supplied per
+  frame at `reg-frame` time by the caller (the gensym handler frame can't
+  carry it, so the regression registers its OWN frame — see the test)."
+  []
+  (registrar/clear-kind! :resource-scope)
+  (registrar/clear-kind! :resource)
+  ;; resolver reading the FRAME-SENSITIVE viewer-identity path (default
+  ;; :inherit → propagates sensitivity from the input).
+  (rf/reg-resource-scope :p026f5/session
+    {:inputs  {:username [:db [:auth :user :username]]}
+     :resolve (fn [{:keys [username]} _ctx]
+                (when username [:rf.scope/session {:username username}]))})
+  ;; a session-scoped feed resource — NOT itself declared :sensitive?.
+  (rf/reg-resource :p026f5/feed
+    {:scope         {:from-db :p026f5/session}
+     :params-schema [:map [:page :int]]
+     :request       (fn [{:keys [page]} _ctx]
+                      {:request {:method :get :url "/feed" :params {:page page}}})})
+  (rf/reg-view* :p026f5/root
+    (fn [] [:main [:h1 "Feed"]])))
+
+(defn- loaded-feed-entry
+  "A `:loaded` durable feed entry under the session scope for `username`,
+  carrying `data` and its own scoped key (the runtime keys `:entries` on the
+  byte `key-id`; the kind-preserving scoped-key vector rides inside the
+  entry per rf2-9e0tyq)."
+  [username page data]
+  (let [sk (state/scoped-resource-key [:rf.scope/session {:username username}]
+                                      :p026f5/feed {:page page})]
+    [sk (merge (state/empty-entry :p026f5/feed sk)
+               {:status :loaded :data data :loaded-at 1000 :stale-at 9.0e15})]))
+
+(defn- seed-feed-runtime-db!
+  "Install a single loaded feed entry into `frame-id`'s runtime-db resource
+  cache (byte-key-id `:entries` shape). `swap-runtime-db!` (NOT
+  `replace-runtime-db!`) so the frame's elision registry at
+  `[:rf.runtime/elision]` — where `reg-frame`'s `:sensitive` declaration is
+  installed — is PRESERVED; a wholesale replace would clobber it and the
+  derived-sensitivity classification would silently see no frame-sensitive
+  paths."
+  [frame-id username page data]
+  (let [[sk entry] (loaded-feed-entry username page data)]
+    (frame/swap-runtime-db!
+      frame-id
+      assoc state/resources-key {:entries     {(state/key-id sk) entry}
+                                 :tag-index   {}
+                                 :owner-index {}})))
+
+(defn- payload-edn
+  "Parse the `__rf_payload` EDN out of a rendered (non-streaming) SSR document
+  body. The payload is a `#:rf{…}` namespace-map; `clojure.edn/read-string`
+  reads it (the namespaced keys round-trip)."
+  [body]
+  (some-> (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>" body)
+          second
+          edn/read-string))
+
+;; ===========================================================================
+;; THE regression — the non-streaming payload redacts the frame-sensitive
+;; resource (data + scoped-key) because the projection runs INSIDE the frame.
+;; ===========================================================================
+
+(deftest non-streaming-payload-redacts-frame-sensitive-resource
+  (testing "rf2-p026f5: the non-streaming Ring `__rf_payload` projects the
+            resource-runtime slice INSIDE the request frame scope, so a
+            frame-sensitive `{:from-db}` feed entry (NOT declared :sensitive?)
+            ships METADATA ONLY — data redacted + scope/params in the wire key
+            redacted to opaque digests. Before the fix the payload build ran
+            OUTSIDE `rf/with-frame`, so the projection was FRAMELESS and the
+            raw viewer identity (\"jake\") + data ({:articles …}) leaked."
+    (register-sensitive-feed-app!)
+    (let [fid :p026f5/req-frame]
+      (rf/reg-frame fid
+        {:platform  :server
+         :doc       "rf2-p026f5 per-request frame"
+         ;; FRAME classification: the viewer-identity path is sensitive.
+         :sensitive {:app-db [[:auth :user :username]]}})
+      (try
+        ;; Seed a loaded feed entry whose derived session scope embeds the
+        ;; sensitive viewer identity ("jake"), with article data.
+        (seed-feed-runtime-db! fid "jake" 1 {:articles [:a :b]})
+        (let [opts     {:on-create  nil
+                        :root-view  [:p026f5/root]
+                        :emit-hash? true
+                        :html-shell shell/default-html-shell
+                        ;; whole-app-db so the test isolates the runtime-db
+                        ;; resource projection (the bug surface), not the
+                        ;; app-db allowlist.
+                        :payload    :rf.ssr.payload/whole-app-db}
+              resp     (#'pipeline/build-full-response* fid {:status 200} opts)
+              body     (:body resp)
+              payload  (payload-edn body)
+              entries  (get-in payload [:rf/runtime-db
+                                        :rf.runtime/resources :entries])]
+          (is (= 200 (:status resp)) "happy-path render emitted a 200")
+          (is (some? payload) "the __rf_payload parsed")
+          (is (= 1 (count entries))
+              "the single feed entry rides in the runtime-db slice")
+          (let [we (val (first entries))
+                wk (:resource/key we)]
+            ;; THE bug assertions — data + scope/params REDACTED.
+            (is (= privacy/redacted-sentinel (:data we))
+                "rf2-p026f5: the derived-sensitive entry's DATA is redacted in
+                 the non-streaming payload (the projection saw the frame)")
+            (is (= :loaded (:status we)) "metadata (status) still rides")
+            (is (= :p026f5/feed (nth wk 1))
+                "the resource-id rides at position 1 (never sensitive)")
+            (is (contains? (nth wk 0) :rf/redacted)
+                "the derived sensitive SCOPE is redacted in the wire key")
+            (is (contains? (nth wk 2) :rf/redacted)
+                "the PARAMS are redacted in the wire key"))
+          ;; The raw viewer identity + article data must not ride ANYWHERE in
+          ;; the payload — the load-bearing leak check (the bead's review eval
+          ;; observed raw "jake" + {:articles [:a :b]} before the fix).
+          (is (not (str/includes? (pr-str payload) "jake"))
+              "rf2-p026f5: the raw sensitive viewer identity does NOT ride")
+          (is (not (str/includes? (pr-str payload) ":articles"))
+              "rf2-p026f5: the redacted resource DATA does NOT ride"))
+        (finally
+          (lifecycle/destroy-frame-quietly! fid))))))
+
+;; ===========================================================================
+;; A NON-sensitive resource still serializes verbatim — the in-frame
+;; projection does not over-redact (the fix is scoped to the frame-classified
+;; case; existing non-resource / non-sensitive payload behavior is unchanged).
+;; ===========================================================================
+
+(deftest non-streaming-payload-serializes-non-sensitive-resource
+  (testing "rf2-p026f5: a resource whose `{:from-db}` resolver reads a
+            NON-sensitive input serializes its data + scope verbatim in the
+            non-streaming payload — the in-frame projection does not
+            over-redact (the inheritance arm only fires for sensitive inputs)."
+    (registrar/clear-kind! :resource-scope)
+    (registrar/clear-kind! :resource)
+    (rf/reg-resource-scope :p026f5/locale
+      {:inputs  {:locale [:db [:i18n :locale]]}
+       :resolve (fn [{:keys [locale]} _]
+                  (when locale [:rf.scope/locale {:locale locale}]))})
+    (rf/reg-resource :p026f5/prefs
+      {:scope         {:from-db :p026f5/locale}
+       :params-schema [:map]
+       :request       (fn [_ _] {:request {:method :get :url "/prefs"}})})
+    (rf/reg-view* :p026f5/root2 (fn [] [:main [:h1 "Prefs"]]))
+    (let [fid :p026f5/req-frame-2]
+      ;; frame declares a DIFFERENT path sensitive — the locale input does NOT
+      ;; overlap, so no inheritance.
+      (rf/reg-frame fid
+        {:platform  :server
+         :sensitive {:app-db [[:auth :user :username]]}})
+      (try
+        (let [sk    (state/scoped-resource-key [:rf.scope/locale {:locale :en}]
+                                               :p026f5/prefs {})
+              entry (merge (state/empty-entry :p026f5/prefs sk)
+                           {:status :loaded :data {:theme "dark"}
+                            :loaded-at 1000 :stale-at 9.0e15})]
+          ;; swap (not replace) to preserve the frame's elision registry.
+          (frame/swap-runtime-db!
+            fid assoc state/resources-key {:entries     {(state/key-id sk) entry}
+                                           :tag-index   {} :owner-index {}})
+          (let [opts    {:on-create  nil
+                         :root-view  [:p026f5/root2]
+                         :emit-hash? true
+                         :html-shell shell/default-html-shell
+                         :payload    :rf.ssr.payload/whole-app-db}
+                resp    (#'pipeline/build-full-response* fid {:status 200} opts)
+                payload (payload-edn (:body resp))
+                we      (val (first (get-in payload [:rf/runtime-db
+                                                     :rf.runtime/resources
+                                                     :entries])))]
+            (is (= {:theme "dark"} (:data we))
+                "rf2-p026f5: the non-derived-sensitive data rides verbatim")
+            (is (= sk (:resource/key we))
+                "rf2-p026f5: the wire key rides verbatim (no redaction)")))
+        (finally
+          (lifecycle/destroy-frame-quietly! fid))))))


### PR DESCRIPTION
## Summary

Fixes **rf2-p026f5** — the non-streaming Ring hydration payload lost the request frame's classification, leaking resource data/scope/params for frame-sensitive resources.

`build-full-response*` (the non-streaming render path) bound the request frame's `rf/with-frame` scope (and realm registrar) around root-view resolution, the render walk, and head resolution — then **exited that scope** before reading app-db/runtime-db and calling `payload/build-payload`.

The resources SSR projection hook (`:ssr/extend-runtime-db-projection` → `re-frame.resources.ssr/project-resources-runtime-db`) resolves the current frame via `frame/resolve-current-frame` so it can apply frame-owned egress classification and **named-scope derived sensitivity**. With no current frame it ran a **frameless** projection, so a resource under a frame-sensitive `{:from-db}` scope serialized its raw scope identity + data into `__rf_payload` — exposing it to every visitor of every SSR page.

## Fix

Move the `app-db` / `runtime-db` read + `payload/build-payload` call **inside** the existing `call-with-frame-realm-registrar` + `with-frame` block (the same scope the render walk uses). This mirrors the streaming path, where `build-final-payload` runs inside the carried-realm + `with-frame` rebinding (rf2-tbr67x — the streaming sibling of this bug). The load-bearing "read the snapshot AFTER the render walk" ordering is preserved — the reads still follow `render-to-string` within the block.

Pure structural change: no new error ids, no new trace ops, so no spec/009 row is needed.

## Regression (red-before-green)

New `re-frame.ssr.ring.resource-payload-projection-test`:

- a frame-sensitive `{:from-db}` feed resource (NOT declared `:sensitive?`) → the emitted non-streaming `__rf_payload` must **redact** its data + scoped-key scope/params (matching the in-`with-frame` projection); the raw viewer identity (`"jake"`) + data (`:articles`) must not ride. **Fails on `origin/main` (5 assertions red), passes with the fix.**
- a non-sensitive `{:from-db}` resource → still serializes verbatim (the fix does not over-redact).

Adds the test-only `day8/re-frame2-resources` dep to the ssr-ring `:test` alias (as in the sibling `implementation/ssr/deps.edn`).

## Gates

- `implementation/ssr-ring`: `clojure -M:test` → 166 tests / 753 assertions, 0F/0E
- `implementation/ssr`: `clojure -M:test` → 343 tests / 1378 assertions, 0F/0E
- `implementation`: `npm run test:cljs` → 7556 tests / 31065 assertions, 0F/0E
- `implementation`: `npm run test:elision` → clean (production 43/43 absent)
- repo root: `sh scripts/test-fast-pr.sh` → PASS