### PR TITLE
test(reply-conformance): point HTTP stale row at real http-reply/suppress (rf2-fkdyhl)

### DIFF
--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -189,16 +189,14 @@
     :success   #(http-reply/success-reply http-ctx {:title "Welcome"})
     :error     #(http-reply/failure-reply http-ctx a-failure)
     :cancel    #(http-reply/aborted-reply http-ctx an-abort)
-    ;; HTTP supersession is the stale path (a same-:request-id supersede)
-    ;; lowered through the shared substrate `suppress`; pin the canonical
-    ;; stale shape via the substrate directly with the HTTP work-id.
-    :stale     #(:reply (reply/suppress nil
-                                        {:work/id (http-reply/work-id http-ctx)}
-                                        {:work/id [:rf.work/http :article/by-id 2]}
-                                        {:work/id      (http-reply/work-id http-ctx)
-                                         :work/kind    :http
-                                         :rf.frame/id  :app/main
-                                         :stale/reason :rf.http/superseded}))}
+    ;; HTTP supersession is the stale path (a same-:request-id supersede).
+    ;; Pin the canonical stale shape via the REAL production helper
+    ;; `re-frame.http-reply/suppress` (NOT the substrate directly with a
+    ;; synthetic extra) so this row would go red if the HTTP helper drifts in
+    ;; its :stale/reason, carried/current facts, frame threading, or work-id
+    ;; shape (rf2-fkdyhl). `current-work-id` is the superseding attempt's
+    ;; work-id (issuance 2), =-distinct from the carried one (issuance 1).
+    :stale     #(:reply (http-reply/suppress http-ctx [:rf.work/http :article/by-id 2 1]))}
 
    {:family    :resource
     :work-head :rf.work/resource
@@ -431,16 +429,14 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- http-stale-out []
-  ;; HTTP supersession lowered through the shared substrate `suppress`, with a
-  ;; carried-vs-current HTTP work-id gate (the same shape the :http row's
-  ;; :stale builder uses — Managed-Effects §Stale suppression).
-  (reply/suppress nil
-                  {:work/id (http-reply/work-id http-ctx)}
-                  {:work/id [:rf.work/http :article/by-id 2]}
-                  {:work/id      (http-reply/work-id http-ctx)
-                   :work/kind    :http
-                   :rf.frame/id  :app/main
-                   :stale/reason :rf.http/superseded}))
+  ;; HTTP supersession lowered through the REAL production helper
+  ;; `re-frame.http-reply/suppress` (rf2-fkdyhl — NOT the substrate directly
+  ;; with a synthetic extra), with a carried-vs-current HTTP work-id gate
+  ;; (the same call the :http row's :stale builder uses — Managed-Effects
+  ;; §Stale suppression). This makes the cross-family correlation gate fail
+  ;; closed on a real HTTP-helper drift (a dropped :rf.reply/carried /
+  ;; :rf.reply/current trace fact).
+  (http-reply/suppress http-ctx [:rf.work/http :article/by-id 2 1]))
 
 (defn- mutation-stale-out []
   (rreply/stale-reply


### PR DESCRIPTION
## Gap (rf2-fkdyhl)

Surfaced by review wave rf2-ks67un. The cross-family reply-vocabulary conformance suite (`implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc`) claims to verify each managed-async family's stale lowering, but the **HTTP** stale descriptor and the `http-stale-out` correlation-gate helper constructed the stale outcome **directly** via `re-frame.reply/suppress` plus a synthetic `extra` map (`:stale/reason :rf.http/superseded`) — instead of calling the production `re-frame.http-reply/suppress`.

That meant the conformance surface could stay green even if the real HTTP stale helper drifted in its `:stale/reason`, carried/current trace facts, `completed-at`/frame threading, or work-id shape — a conformance-surface false-positive gap (the per-family HTTP suite still covered `http-reply/suppress`, so no observed runtime failure).

Confirmed still present on current `origin/main` (rebased; rf2-hbus90 touched `http_transport.cljc` but not `http_reply.cljc`, so the helper + `stale-reason` are unchanged).

## Fix

Both the `:http` family row's `:stale` builder **and** the `http-stale-out` helper now call the real production path:

```clojure
(http-reply/suppress http-ctx [:rf.work/http :article/by-id 2 1])
```

using the real superseding work-id shape (4-tuple, issuance 2 — `=`-distinct from the carried issuance-1 attempt). This matches the per-family HTTP suite's `suppress` call.

- Expected HTTP stale reason now flows from the helper's own `stale-reason` (`:rf.http/request-id-superseded`), not the synthetic `:rf.http/superseded`.
- The cross-family stale correlation gate (`stale-replies-carry-a-carried-and-current-correlation-gate`) and its adversarial fail-closed control now exercise the genuine HTTP outcome, so it would go red if `http-reply/suppress` dropped `:rf.reply/carried` or `:rf.reply/current`.

No production source touched — test-surface only.

## Gates
- `implementation/reply-conformance` JVM (`clojure -M:test`): **16 tests / 287 assertions / 0 failures** (re-verified post-rebase)
- `implementation` `npm run test:cljs`: **7567 tests / 31102 assertions / 0 failures** (suite discovered)
- `implementation` `npm run test:elision`: **PASS** (43/43 absent)
- repo-root `scripts/test-fast-pr.sh`: **PASS fast PR spine**

(rf2-fkdyhl)