### PR TITLE
ci: wire tenant-switcher testbed smoke into CI routing (rf2-h5e3v7)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -41,6 +41,7 @@ template_expensive=false
 mcp_conformance=false
 mcp_live=false
 story_xray_browser=false
+tenant_switcher_smoke=false
 skills_structural=false
 playground=false
 
@@ -58,6 +59,7 @@ mark_all() {
   mcp_conformance=true
   mcp_live=true
   story_xray_browser=true
+  tenant_switcher_smoke=true
   skills_structural=true
   playground=true
 }
@@ -436,6 +438,29 @@ else
         reagent_slim_bundle=true
         story_xray_browser=true
         ;;
+      implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs)
+        # rf2-h5e3v7 — false-green fix, mirroring the xray-feature-gate +
+        # reagent-slim-smoke launcher cases above. This launcher IS the
+        # executable orchestration for `npm run test:testbed-tenant-switcher`,
+        # the command the tenant-switcher-testbed-smoke PR job runs
+        # (.github/workflows/test.yml). It is the ONLY Playwright smoke that
+        # exercises the tenant-switcher browser scenario (compile / index.html
+        # staging / ownership-token server readiness / pageerror handling). A
+        # break in this launcher — or in the colocated testbed it drives —
+        # could ship green, since the generic implementation/scripts/* case
+        # below routes only to the always-on JS/CLJS surfaces and never to
+        # tenant_switcher_smoke. Fire tenant_switcher_smoke so editing the
+        # launcher runs the gate it orchestrates. The remaining static-script
+        # surfaces this file shares with the generic case (cljs_node_test /
+        # cljs_browser / cljs_prod / bundle_isolation / reagent_slim_bundle)
+        # stay armed too — this case widens coverage, it does not narrow it.
+        cljs_node_test=true
+        cljs_browser=true
+        cljs_prod=true
+        bundle_isolation=true
+        reagent_slim_bundle=true
+        tenant_switcher_smoke=true
+        ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
         # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i + rf2-k9ekz + rf2-t5slp —
         # adapter_testbed_smokes and story_xray_browser are NOT fired
@@ -481,6 +506,21 @@ else
         # (matched above) fire it. The cljs_browser gate covers
         # CLJS-source regressions touched by examples/.
         cljs_browser=true
+        ;;
+      testbeds/tenant_switcher/*)
+        # rf2-h5e3v7 — the tenant-switcher testbed is the ONE top-level
+        # testbed that legitimately keeps its own colocated Playwright
+        # spec.cjs (a cross-cutting framework smoke per CLAUDE.md
+        # "framework testbeds carry their own non-adapter spec.cjs"). Its
+        # runner serve-and-run-tenant-switcher-testbed.cjs drives
+        # testbeds/tenant_switcher/spec.cjs against the compiled
+        # :testbeds/tenant-switcher build + staged index.html. So a change
+        # to the testbed's core.cljs / spec.cjs / index.html must fire the
+        # tenant-switcher-testbed-smoke gate (else the runner's only live
+        # browser coverage can be avoided). cljs_browser stays lit too for
+        # the transitive CLJS-source coverage every other testbed gets.
+        cljs_browser=true
+        tenant_switcher_smoke=true
         ;;
       testbeds/*)
         # rf2-7vsfm + rf2-t5slp — Top-level testbeds/* surfaces are
@@ -659,5 +699,6 @@ emit template_expensive "$template_expensive"
 emit mcp_conformance "$mcp_conformance"
 emit mcp_live "$mcp_live"
 emit story_xray_browser "$story_xray_browser"
+emit tenant_switcher_smoke "$tenant_switcher_smoke"
 emit skills_structural "$skills_structural"
 emit playground "$playground"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
       mcp_conformance: ${{ steps.detect.outputs.mcp_conformance }}
       mcp_live: ${{ steps.detect.outputs.mcp_live }}
       story_xray_browser: ${{ steps.detect.outputs.story_xray_browser }}
+      tenant_switcher_smoke: ${{ steps.detect.outputs.tenant_switcher_smoke }}
       skills_structural: ${{ steps.detect.outputs.skills_structural }}
       playground: ${{ steps.detect.outputs.playground }}
     steps:
@@ -1975,6 +1976,88 @@ jobs:
       - name: Run Reagent Slim client-runtime browser smoke
         run: npm run test:reagent-slim:smoke
 
+  tenant-switcher-testbed-smoke:
+    name: Tenant-switcher testbed browser smoke (rf2-h5e3v7)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.tenant_switcher_smoke == 'true'
+    runs-on: ubuntu-latest
+    # rf2-h5e3v7 — job-level backstop to the step-level Playwright cap below,
+    # mirroring the cljs-reagent-slim-bundle-isolation job. A wedged
+    # `--with-deps` apt/dpkg-lock would otherwise leave this job — and the
+    # required all-required-passed aggregator that `needs:` it — open-ended
+    # pending and block the merge. 20 min gives a cold-Maven-cache testbed
+    # compile generous headroom while making any genuine hang a fast,
+    # re-runnable FAILURE.
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-tenant-switcher-smoke-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-tenant-switcher-smoke-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      # rf2-f79t8 — cache the Playwright browser binary (see cljs-browser).
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      # rf2-e6enf — cap the `--with-deps` Playwright install (see the slim
+      # job for the dpkg/apt-lock-wedge rationale). A healthy install is
+      # ~20s; 5 min covers a slow apt + cold download while turning a lock
+      # wait into a re-runnable FAILURE instead of an open-ended block.
+      - name: Install Playwright (Chromium + system deps)
+        timeout-minutes: 5
+        run: npx playwright install --with-deps chromium
+
+      # rf2-h5e3v7 — ARM the tenant-switcher testbed browser smoke in PR CI.
+      # The dedicated runner (serve-and-run-tenant-switcher-testbed.cjs)
+      # compiles the :testbeds/tenant-switcher shadow build, stages the
+      # hand-written index.html, serves it under the ownership-token
+      # handshake, and drives the colocated testbeds/tenant_switcher/spec.cjs
+      # in headless Chromium (failing on any uncaught pageerror). It is the
+      # ONLY Playwright smoke that exercises this browser scenario; before
+      # this job `npm run test:testbed-tenant-switcher` was defined in
+      # package.json but invoked by no workflow, so a regression in the
+      # runner / colocated spec / testbed could ship green.
+      - name: Run tenant-switcher testbed browser smoke
+        run: npm run test:testbed-tenant-switcher
+
   # ---------------------------------------------------------------------------
   # Per-tool CI jobs (rf2-qq70f).
   #
@@ -3018,6 +3101,7 @@ jobs:
       - adapter-testbed-smokes
       - story-xray-browser
       - cljs-reagent-slim-bundle-isolation
+      - tenant-switcher-testbed-smoke
       - jvm-tools-xray
       - jvm-tools-story
       - jvm-tools-story-mcp

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -818,6 +818,101 @@ test('test-quiet routing does NOT broaden docs/spec-only or unrelated surfaces (
   assert.equal(result.cljs_node_test, 'false');
 });
 
+// rf2-h5e3v7 — tenant-switcher testbed smoke routing. The runner
+// serve-and-run-tenant-switcher-testbed.cjs IS the executable
+// orchestration for `npm run test:testbed-tenant-switcher`, the command
+// the new tenant-switcher-testbed-smoke PR job runs (test.yml). It is the
+// ONLY Playwright smoke that exercises the tenant-switcher browser
+// scenario. Before this bead the npm script was defined in package.json
+// but invoked by NO workflow, and the classifier routed both the runner
+// (generic implementation/scripts/*) and the testbed (generic testbeds/*)
+// only to always-on CLJS surfaces — so a regression in the runner, its
+// colocated spec, or the testbed could ship green. These assertions lock
+// the new tenant_switcher_smoke routing onto the runner + the testbed,
+// while keeping unrelated implementation/scripts/* + testbeds/* off it.
+
+test('serve-and-run-tenant-switcher-testbed.cjs fires tenant_switcher_smoke (rf2-h5e3v7)', () => {
+  const result = classify(
+    'implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs',
+  );
+  assert.equal(
+    result.tenant_switcher_smoke,
+    'true',
+    'editing the tenant-switcher smoke launcher must run the gate it drives',
+  );
+});
+
+test('serve-and-run-tenant-switcher-testbed.cjs still arms the generic static-script gates (regression) (rf2-h5e3v7)', () => {
+  const result = classify(
+    'implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs',
+  );
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.cljs_prod, 'true');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
+const TENANT_SWITCHER_TESTBED_FILES = [
+  'testbeds/tenant_switcher/spec.cjs',
+  'testbeds/tenant_switcher/core.cljs',
+  'testbeds/tenant_switcher/index.html',
+];
+for (const file of TENANT_SWITCHER_TESTBED_FILES) {
+  test(`${file} fires tenant_switcher_smoke + cljs_browser (rf2-h5e3v7)`, () => {
+    const result = classify(file);
+    assert.equal(
+      result.tenant_switcher_smoke,
+      'true',
+      'a tenant-switcher testbed change must run its colocated browser smoke',
+    );
+    assert.equal(result.cljs_browser, 'true');
+  });
+}
+
+test('an UNRELATED implementation/scripts/* file does NOT fire tenant_switcher_smoke (scope discipline) (rf2-h5e3v7)', () => {
+  const result = classify('implementation/scripts/build-foo.cjs');
+  assert.equal(
+    result.tenant_switcher_smoke,
+    'false',
+    'a generic implementation/scripts/* edit drives no tenant-switcher gate',
+  );
+});
+
+test('an UNRELATED top-level testbed does NOT fire tenant_switcher_smoke (scope discipline) (rf2-h5e3v7)', () => {
+  const result = classify('testbeds/ssr_basic/core.cljs');
+  assert.equal(
+    result.tenant_switcher_smoke,
+    'false',
+    'only the tenant-switcher testbed carries a colocated Playwright smoke',
+  );
+  // It still gets the always-on transitive CLJS coverage.
+  assert.equal(result.cljs_browser, 'true');
+});
+
+test('tenant-switcher-testbed-smoke job is job-level gated on tenant_switcher_smoke (rf2-h5e3v7)', () => {
+  const block = jobBlock(
+    fs.readFileSync(WORKFLOW, 'utf8'),
+    'tenant-switcher-testbed-smoke',
+  );
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.tenant_switcher_smoke == 'true'/,
+  );
+  // The job must actually RUN the npm script the gate exists to drive —
+  // pinning the wiring so the script cannot drift out of CI again.
+  assert.match(block, /npm run test:testbed-tenant-switcher/);
+});
+
+test('all-required-passed aggregator needs tenant-switcher-testbed-smoke (rf2-h5e3v7)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'all-required-passed');
+  assert.match(
+    block,
+    /- tenant-switcher-testbed-smoke\r?\n/,
+    'aggregator must list tenant-switcher-testbed-smoke in needs:',
+  );
+});
+
 let failed = 0;
 for (const { name, fn } of tests) {
   try {

--- a/implementation/scripts/_impl-browser-runners-pageerror-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-pageerror-policy.test.cjs
@@ -3,9 +3,9 @@
 'use strict';
 
 /*
- * Policy gate for the THREE implementation-side browser runners that
- * could previously ship green while Chromium observed an uncaught
- * `pageerror` (rf2-mwx08). Same correctness class rf2-wf5al fixed for the
+ * Policy gate for the implementation-side browser runners that could
+ * previously ship green while Chromium observed an uncaught `pageerror`
+ * (rf2-mwx08). Same correctness class rf2-wf5al fixed for the
  * examples/scripts Story play runner, here applied to:
  *
  *   - run-browser-tests.cjs           (a green cljs.test summary ignored
@@ -15,6 +15,8 @@
  *                                      pageerror was captured)
  *   - check-story-static.cjs          (static smoke passed on visible
  *                                      assertions, ignoring pageerrors)
+ *   - serve-and-run-tenant-switcher-testbed.cjs (rf2-h5e3v7 — joined the
+ *                                      pinned set when CI-wired)
  *
  * These runners drive a headless Chromium end-to-end, so their verdict
  * paths are not cleanly unit-testable without launching a browser.
@@ -125,6 +127,44 @@ test('check-story-static: the smoke throws on a captured pageerror even when ass
     src,
     /if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,300}?throw\s+new\s+Error/,
     'must throw when pageErrors is non-empty so the smoke fails (exit 1)',
+  );
+});
+
+// ---- serve-and-run-tenant-switcher-testbed.cjs (rf2-h5e3v7) ----
+// The tenant-switcher testbed smoke is now CI-wired
+// (tenant-switcher-testbed-smoke job), so its verdict path joins the
+// pinned set: the bead explicitly called out pageerror handling specific
+// to this runner as a maskable failure. Same discipline as the siblings —
+// pageerrors go into a dedicated array and flip the verdict to fail before
+// `passed = true`.
+
+test('tenant-switcher-testbed: pageerrors are tracked in a dedicated array, not just diagnostics (rf2-h5e3v7)', () => {
+  const src = read('serve-and-run-tenant-switcher-testbed.cjs');
+  assert.match(
+    src,
+    /const\s+pageErrors\s*=\s*\[\]/,
+    'must declare a dedicated pageErrors array',
+  );
+  assert.match(
+    src,
+    /page\.on\(\s*['"]pageerror['"][\s\S]{0,160}?pageErrors\.push\(/,
+    'the pageerror handler must push into the dedicated pageErrors array',
+  );
+});
+
+test('tenant-switcher-testbed: a captured pageerror fails the spec even when assertions passed (rf2-h5e3v7)', () => {
+  const src = read('serve-and-run-tenant-switcher-testbed.cjs');
+  assert.match(
+    src,
+    /if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,300}?throw\s+new\s+Error/,
+    'must throw when pageErrors is non-empty so the spec fails',
+  );
+  const throwIdx = src.search(/pageErrors\.length\s*>\s*0/);
+  const passedIdx = src.search(/\bpassed\s*=\s*true\s*;/);
+  assert.ok(throwIdx > -1 && passedIdx > -1, 'both call-sites must exist');
+  assert.ok(
+    throwIdx < passedIdx,
+    'the pageerror fatal check must precede `passed = true`',
   );
 });
 


### PR DESCRIPTION
## Problem (rf2-h5e3v7)

`implementation/package.json` defines `test:testbed-tenant-switcher` → `node scripts/serve-and-run-tenant-switcher-testbed.cjs`, the dedicated Playwright browser smoke for the top-level `testbeds/tenant_switcher/` framework testbed (the one top-level testbed that legitimately carries its own colocated `spec.cjs`). But that npm script was invoked by **no workflow**, and `report-changed-surfaces.sh` routed both the runner (via the generic `implementation/scripts/*` case) and the testbed (via the generic `testbeds/*` case) only to the always-on CLJS surfaces.

Net: a regression in the runner, its colocated `spec.cjs`, or the testbed — including the compile / `index.html` staging / ownership-token server readiness / pageerror handling **specific to this runner** — could ship green.

## Fix

- **`test.yml`** — add a `tenant-switcher-testbed-smoke` job that runs `npm run test:testbed-tenant-switcher`. It mirrors the `cljs-reagent-slim-bundle-isolation` Playwright-smoke shape (checkout + JDK 21 + Node 24 + Clojure + Maven/Playwright caches + `npm ci` + capped `--with-deps` install + 20-min job timeout). Gated on a new `tenant_switcher_smoke` surface output; wired into the `all-required-passed` aggregator.
- **`report-changed-surfaces.sh`** — declare + `mark_all` + `emit` the new flag; route `serve-and-run-tenant-switcher-testbed.cjs` and `testbeds/tenant_switcher/**` to `tenant_switcher_smoke` (mirrors the xray-feature-gate / reagent-slim-smoke launcher cases). Unrelated `implementation/scripts/*` and other `testbeds/*` stay off it.
- **`_changed-surfaces.test.cjs`** — pin the routing for the runner + testbed paths, scope-discipline negatives, and the workflow shape (job gated on the output + runs the npm script + aggregator membership), satisfying the AC "the npm script cannot drift out of CI again".
- **`_impl-browser-runners-pageerror-policy.test.cjs`** — the runner joins the pinned browser-runner set: its pageerror discipline must flip the verdict to fail.

`shadow-cljs.edn` is **unchanged** — the `:testbeds/tenant-switcher` build-id and `:dev-http 8060` were already present (rf2-5e22yc).

## Acceptance criteria

- [x] CI has an explicit job/step for `npm run test:testbed-tenant-switcher` (`tenant-switcher-testbed-smoke`).
- [x] `report-changed-surfaces.sh` routes representative tenant-switcher runner/spec/testbed paths to that job.
- [x] `_changed-surfaces.test.cjs` pins the routing for the runner + `testbeds/tenant_switcher/**`.
- [x] The workflow shape is covered by a policy test (job gate + npm-script invocation + aggregator membership) so the script cannot drift out of CI again.

## Gates

- `scripts/test-fast-pr.sh` green (7568 tests / 31105 assertions, 0 failures) — includes the edited `test:script-policy` suite and the consolidated CLJS node-test build.
- `report-changed-surfaces.sh` manually verified for runner / spec.cjs / core.cljs / index.html (→ true) and unrelated script / testbed (→ false) and `--all` (→ true).
- `test.yml` validated as parsing YAML; new job structure confirmed via parse.
- This PR's own CI is the live check that the smoke runs green in the routed job.