### PR TITLE
feat(resources): EP-0019 slice 1 — :revision durable-entry substrate (rf2-byl7bk.1)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -808,10 +808,17 @@
         (match-invalidation-keys entries cscope cross-scope? tag-set exempt)
         ;; mark each matched entry stale (durable :invalidated-at fact). Keyed
         ;; on the byte key-id — write straight to the entries-path slot.
+        ;; EP-0019 / byl7bk: marking an entry stale is an authoritative durable
+        ;; write a later optimistic rollback could clobber (it moves the entry's
+        ;; freshness), so bump the per-entry :revision write identity in the
+        ;; SAME swap — biasing to over-bump (a false conflict costs one refetch;
+        ;; a missed one is silent corruption).
         rdb'       (reduce
                      (fn [db k-id]
                        (update-in db (state/entry-path-by-id k-id)
-                                  (fn [e] (when e (assoc e :invalidated-at invalidated-at)))))
+                                  (fn [e] (when e
+                                            (state/bump-revision
+                                              (assoc e :invalidated-at invalidated-at))))))
                      runtime-db matched-ids)
         ;; per-entry decision: active-owner entries refetch (Spec 016
         ;; §Invalidation 3); ownerless entries are left stale / GC-eligible

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -249,13 +249,20 @@
           patched  (patch-fn old mutation-result)
           ;; structural sharing — keep the old value when nothing changed
           shared   (if (= old patched) old patched)]
-      (assoc entry
-             :data           shared
-             :status         :loaded
-             :loaded-at      clock-ms
-             :stale-at       stale-at
-             :invalidated-at nil
-             :refresh-error  nil))
+      (-> entry
+          (assoc
+            :data           shared
+            :status         :loaded
+            :loaded-at      clock-ms
+            :stale-at       stale-at
+            :invalidated-at nil
+            :refresh-error  nil)
+          ;; EP-0019 / byl7bk: a patch is an authoritative durable write
+          ;; (re-stamps :loaded-at / :stale-at, clears :invalidated-at), so it
+          ;; bumps the per-entry :revision write identity UNCONDITIONALLY —
+          ;; even on the `=`-shared structural-sharing branch. The no-usable-
+          ;; data no-op branch below makes no write and does not bump.
+          state/bump-revision))
     entry))
 
 (defn populate-entry
@@ -278,17 +285,23 @@
   (let [base   (or entry (state/empty-entry resource-id scoped-key))
         old    (:data base)
         shared (if (and (some? old) (= old populate-value)) old populate-value)]
-    (assoc base
-           :resource/id    (:resource/id base resource-id)
-           :resource/key   (or (:resource/key base) scoped-key)
-           :data           shared
-           :status         :loaded
-           :error          nil
-           :refresh-error  nil
-           :loaded-at      clock-ms
-           :stale-at       stale-at
-           :invalidated-at nil
-           :tags           (or tags (:tags base) #{}))))
+    (-> base
+        (assoc
+          :resource/id    (:resource/id base resource-id)
+          :resource/key   (or (:resource/key base) scoped-key)
+          :data           shared
+          :status         :loaded
+          :error          nil
+          :refresh-error  nil
+          :loaded-at      clock-ms
+          :stale-at       stale-at
+          :invalidated-at nil
+          :tags           (or tags (:tags base) #{}))
+        ;; EP-0019 / byl7bk: a populate is an authoritative durable write (it
+        ;; seeds / re-stamps :loaded-at / :stale-at / :tags), so it bumps the
+        ;; per-entry :revision write identity UNCONDITIONALLY — including the
+        ;; `=`-shared branch and a freshly-seeded entry (base revision 0 -> 1).
+        state/bump-revision)))
 
 ;; ---- fail-closed boundary validation (Spec 016 §Resource identity / -------
 ;;       EP-0003 §Mutations)

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -196,6 +196,20 @@
    :invalidated-at nil
    :attempt        0
    :generation     0
+   ;; `:revision` is the per-entry WRITE identity (EP-0019 / byl7bk Open
+   ;; Issue 5 ruling) — a monotone counter bumped on EVERY authoritative
+   ;; durable entry write a rollback could clobber (load success, populate,
+   ;; patch, invalidation-driven settle, and the later optimistic apply),
+   ;; UNCONDITIONALLY (never gated on `(= old new)` of `:data`). It is DISTINCT
+   ;; from `:generation`: `:generation` bumps at load START (`entry-start-load`)
+   ;; — the work / stale-suppression identity — so reusing it would
+   ;; false-conflict on every in-flight refetch, before any authoritative write
+   ;; lands. `:revision` moves only when an authoritative write actually
+   ;; SETTLES the entry. It is the substrate the EP-0019 optimistic-rollback
+   ;; settle protocol compares against (`revision-conflict?`) to decide whether
+   ;; a recorded inverse is still a truthful "before" or has been overtaken.
+   ;; Base value 0. Per Spec 016 §Status semantics / EP-0019 §Decision 2.
+   :revision       0
    :request-id     nil
    :current-work   nil
    :tags           #{}
@@ -635,15 +649,79 @@
          (or (some? (:invalidated-at entry))
              (when-let [sa (:stale-at entry)] (>= clock-ms sa))))))
 
+;; ---- per-entry revision (EP-0019 §Decision 2 / byl7bk Open Issue 5) --------
+;;
+;; `:revision` is the per-entry WRITE identity the optimistic-rollback settle
+;; protocol compares against. The EP-0019 conflict check at settle is a
+;; CANONICAL-IDENTITY comparison of the recorded revision against the entry's
+;; current revision — NOT a value diff — answering "did an authoritative write
+;; land on this entry between my optimistic apply and my reply settling?". If
+;; it did, the recorded inverse is a stale "before" and a blind restore would
+;; clobber newer truth; the settle reconciles by invalidation instead.
+;;
+;; The bump rule (byl7bk ruling, load-bearing): bump on EVERY authoritative
+;; durable entry write a rollback could clobber — UNCONDITIONALLY, never gated
+;; on `(= old new)` of `:data`. `entry-succeeded` / `patch-entry` /
+;; `populate-entry` re-stamp `:loaded-at` / `:stale-at` / `:tags` even when the
+;; new `:data` is `=`-shared, so a value-gated token would MISS that freshness
+;; settle and let a later rollback silently clobber newer freshness with a
+;; stale snapshot — a real cache-coherence bug. Bias to OVER-bump: a false
+;; conflict costs one refetch (made safe by the `:on-conflict :invalidate`
+;; default — the read path recovers truth); a MISSED conflict means silent
+;; corruption. The asymmetry favours over-bumping.
+
+(defn bump-revision
+  "Pure: increment the entry's monotone per-entry `:revision` write identity
+  (EP-0019 §Decision 2 / byl7bk Open Issue 5). The SINGLE home for the bump so
+  every authoritative durable entry write (`entry-succeeded`, `patch-entry`,
+  `populate-entry`, the invalidation-driven settle, the later optimistic apply)
+  advances it the same way — UNCONDITIONALLY, never gated on whether `:data`
+  changed. Treats an absent / nil `:revision` as 0 (a pre-EP-0019 entry or a
+  freshly-seeded one), so the bump is total over any entry shape. Returns the
+  entry with `:revision` incremented; a nil entry is returned unchanged (there
+  is nothing to bump — a missing entry carries no revision)."
+  [entry]
+  (if entry
+    (update entry :revision (fnil inc 0))
+    entry))
+
+(defn entry-revision
+  "Pure: read an entry's per-entry `:revision` write identity, defaulting to 0
+  for an absent / nil entry or a pre-EP-0019 entry that predates the fact. The
+  value the optimistic-rollback settle protocol records at apply time and
+  compares at settle time (`revision-conflict?`). Per EP-0019 §Decision 2."
+  [entry]
+  (if entry (:revision entry 0) 0))
+
+(defn revision-conflict?
+  "Pure: the EP-0019 settle-time conflict check (Decision 3). True iff the
+  entry's CURRENT revision has MOVED away from the `recorded-revision` an
+  optimistic apply observed — i.e. an authoritative durable write landed on the
+  entry between the apply and the reply settling, so the recorded inverse is a
+  stale \"before\" a blind rollback must NOT restore. A canonical-identity
+  comparison (`not=` over the monotone counter), never a value diff.
+
+  Conflict-positive (`true`) is the BIAS-SAFE answer: on a true conflict the
+  settle reconciles by invalidation (the read path recovers authoritative
+  truth); a false positive costs only a refetch, while a false negative would
+  let a stale inverse clobber newer truth. The recorded revision is read
+  through `entry-revision` semantics (an absent recorded value, e.g. an apply
+  against a then-missing entry whose revision was 0, compares against the
+  current entry's revision the same way). Per EP-0019 §Decision 3."
+  [entry recorded-revision]
+  (not= (entry-revision entry) (or recorded-revision 0)))
+
 ;; ---- entry transitions (Spec 016 §Status semantics / §Structural sharing) -
 ;;
 ;; Pure functions `(entry, …) -> entry`. They transition through
 ;; `next-status` so the five-state semantics stay in one place, write the
 ;; durable FACTS (status / data / errors / timestamps / generation /
-;; current-work / tags), and NEVER store the derived booleans. Structural
-;; sharing preserves the old `:data` value when the newly-decoded value
-;; equals the previous (identity-preserving — downstream subs stay quiet on
-;; a background refresh that returns identical EDN).
+;; revision / current-work / tags), and NEVER store the derived booleans.
+;; Structural sharing preserves the old `:data` value when the newly-decoded
+;; value equals the previous (identity-preserving — downstream subs stay quiet
+;; on a background refresh that returns identical EDN), but the `:revision`
+;; bump is UNCONDITIONAL (a value-gated bump would miss a freshness-only
+;; settle — byl7bk ruling).
 
 (defn entry-start-load
   "Transition an entry to its in-flight status for a fresh load attempt:
@@ -675,26 +753,38 @@
   stay quiet. Sets `:loaded-at` / `:stale-at` from the supplied clock +
   stale policy, clears `:error` / `:refresh-error` / `:current-work`, and
   records the produced `:tags`. Per Spec 016 §Status semantics /
-  §Structural sharing."
+  §Structural sharing.
+
+  Bumps the per-entry `:revision` UNCONDITIONALLY (EP-0019 / byl7bk Open Issue
+  5) — even when `:data` is `=`-shared. A success re-stamps `:loaded-at` /
+  `:stale-at` / `:tags` on the structural-sharing branch too, so this IS an
+  authoritative durable write a later optimistic rollback could clobber; a
+  value-gated bump would miss it. The `:revision` bump is therefore orthogonal
+  to the `:data` structural sharing."
   [entry {:keys [data loaded-at stale-at tags]}]
   (let [prev      (:data entry)
         ;; Structural sharing: keep the OLD value when the decoded value is
         ;; equal, so `(identical? old new-data)` holds for quiet downstream
         ;; reactions. Per Spec 016 §Structural sharing.
         shared    (if (and (some? prev) (= prev data)) prev data)]
-    (assoc entry
-           :status        :loaded
-           :data          shared
-           :error         nil
-           :refresh-error nil
-           :loaded-at     loaded-at
-           :stale-at      stale-at
-           :invalidated-at nil
-           :current-work  nil
-           ;; the new key now has its OWN data — drop the previous-key
-           ;; projection pointer (Spec 016 §Paginated and previous data).
-           :previous-key  nil
-           :tags          (or tags (:tags entry) #{}))))
+    (-> entry
+        (assoc
+          :status        :loaded
+          :data          shared
+          :error         nil
+          :refresh-error nil
+          :loaded-at     loaded-at
+          :stale-at      stale-at
+          :invalidated-at nil
+          :current-work  nil
+          ;; the new key now has its OWN data — drop the previous-key
+          ;; projection pointer (Spec 016 §Paginated and previous data).
+          :previous-key  nil
+          :tags          (or tags (:tags entry) #{}))
+        ;; EP-0019 / byl7bk: every authoritative durable write bumps the
+        ;; per-entry write identity, unconditionally — including the
+        ;; freshness-only (`=`-shared `:data`) settle the ruling names.
+        bump-revision)))
 
 (defn entry-failed
   "Transition an entry on a failed load/refresh (Spec 016 §Status

--- a/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
@@ -1,0 +1,170 @@
+(ns re-frame.resources-revision-substrate-cljs-test
+  "EP-0019 slice 1 — the per-entry `:revision` durable-entry substrate the
+  optimistic-mutation-rollback settle protocol builds on (rf2-byl7bk.1, Open
+  Issue 5 ruling 2026-06-15).
+
+  `:revision` is the per-entry WRITE identity: a monotone counter bumped on
+  EVERY authoritative durable entry write a rollback could clobber, and the
+  basis of the settle-time conflict check (`state/revision-conflict?`). These
+  JVM+CLJS unit tests pin the substrate contract the later slices depend on:
+
+    1. SHAPE — `empty-entry` carries `:revision 0`, DISTINCT from `:generation`;
+    2. DISTINCT FROM `:generation` — `entry-start-load` bumps `:generation`
+       (load START) and leaves `:revision` UNMOVED (no false-conflict on an
+       in-flight refetch); `entry-succeeded` bumps `:revision`;
+    3. UNCONDITIONAL BUMP — `entry-succeeded` / `patch-entry` / `populate-entry`
+       bump `:revision` even when `:data` is `=`-shared (the freshness-only
+       settle the ruling names — a value-gated token would MISS it);
+    4. CONFLICT COMPARISON — `revision-conflict?` is false when the recorded
+       revision matches and TRUE when a competing authoritative write moved it.
+
+  PURE — the substrate is the pure transition functions in `re-frame.resources
+  .state` + `re-frame.resources.mutation-runtime`; CLJC so the load-bearing JVM
+  run (`clojure -M:test`) exercises it alongside the CLJS node runtime."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])
+   [re-frame.resources.state :as state]
+   [re-frame.resources.mutation-runtime :as mut-rt]))
+
+;; ---- shape: base value, distinct from :generation -------------------------
+
+(deftest empty-entry-carries-revision-zero
+  (testing "the base empty entry carries :revision 0, alongside :generation 0"
+    (let [e (state/empty-entry :conduit/article)]
+      (is (= 0 (:revision e)) ":revision base value is 0")
+      (is (= 0 (:generation e)) ":generation base value is 0")
+      (is (contains? e :revision)
+          ":revision is a present durable entry fact, not absent")))
+  (testing "the 2-arity (with scoped-key) also carries :revision 0"
+    (let [sk (state/scoped-resource-key :rf.scope/global :conduit/article {:slug "a"})
+          e  (state/empty-entry :conduit/article sk)]
+      (is (= 0 (:revision e)))
+      (is (= sk (:resource/key e))))))
+
+(deftest revision-is-distinct-from-generation
+  (testing ":revision and :generation are independent facts; entry-start-load
+            bumps :generation (load START) but NOT :revision — so an in-flight
+            refetch never false-conflicts"
+    (let [e0 (state/empty-entry :conduit/article)
+          e1 (state/entry-start-load
+               e0 {:generation 7 :work-id [:w 1] :request-id "r1" :owner :o})]
+      (is (= 7 (:generation e1)) ":generation moves to the allocated value at load start")
+      (is (= 0 (:revision e1))
+          ":revision is UNMOVED by entry-start-load — load START is the work
+           identity (:generation), not an authoritative durable write"))))
+
+;; ---- unconditional bump on an authoritative durable write -----------------
+
+(deftest entry-succeeded-bumps-revision-even-on-equal-data
+  (testing "a load success bumps :revision; and a freshness-only settle
+            (re-stamping :loaded-at / :stale-at while :data is `=`-shared) STILL
+            bumps :revision — the byl7bk ruling's load-bearing case"
+    (let [loaded (-> (state/empty-entry :conduit/article)
+                     (state/entry-succeeded {:data {:n 1} :loaded-at 100
+                                             :stale-at 200 :tags #{[:a]}}))]
+      (is (= 1 (:revision loaded)) "first load success bumps 0 -> 1")
+      (is (= 100 (:loaded-at loaded)))
+      ;; a refetch returning EQUAL data: structural sharing keeps the old :data
+      ;; identity, but :loaded-at / :stale-at are re-stamped — an authoritative
+      ;; freshness settle a rollback could clobber.
+      (let [resettled (state/entry-succeeded
+                        loaded {:data {:n 1} :loaded-at 999 :stale-at 1200
+                                :tags #{[:a]}})]
+        (is (identical? (:data loaded) (:data resettled))
+            "structural sharing: equal :data keeps the SAME value identity")
+        (is (= 999 (:loaded-at resettled))
+            "freshness IS re-stamped even though :data is `=`-shared")
+        (is (= 2 (:revision resettled))
+            ":revision bumps UNCONDITIONALLY on the equal-data freshness settle
+             — NOT gated on `(= old new)` of :data (the cache-coherence fix)")))))
+
+(deftest patch-entry-bumps-revision-even-on-equal-data
+  (testing "a controlled patch bumps :revision, including the `=`-shared branch"
+    (let [base   (-> (state/empty-entry :conduit/article)
+                     (state/entry-succeeded {:data {:count 0} :loaded-at 10
+                                             :stale-at 20 :tags #{}}))
+          rev0   (:revision base)
+          ;; identity patch (returns `=` data) — structural-shared but a
+          ;; re-stamp of :loaded-at / :stale-at, an authoritative durable write.
+          patched (mut-rt/patch-entry base (fn [d _r] d) :ignored-result
+                                      {:clock-ms 50 :stale-at 60})]
+      (is (= (inc rev0) (:revision patched))
+          "patch bumps :revision even when the patch-fn returns `=` data")
+      (is (identical? (:data base) (:data patched))
+          "structural sharing still holds for `=` patched data")
+      (is (= 50 (:loaded-at patched)) "freshness IS re-stamped")))
+  (testing "a patch of an entry with NO usable data is a no-op — no bump"
+    (let [empty   (state/empty-entry :conduit/article)
+          patched (mut-rt/patch-entry empty (fn [d _r] {:x 1}) :r
+                                      {:clock-ms 1 :stale-at 2})]
+      (is (= empty patched) "no-data patch returns the entry unchanged")
+      (is (= 0 (:revision patched)) "the no-op path makes no write and no bump"))))
+
+(deftest populate-entry-bumps-revision
+  (testing "populate-of-fresh seeds :revision 1 (base 0 -> bump); populate-over-
+            existing bumps including the `=`-shared branch"
+    (let [sk    (state/scoped-resource-key :rf.scope/global :conduit/article {})
+          fresh (mut-rt/populate-entry nil :conduit/article {:v 1}
+                                       {:clock-ms 5 :stale-at 9 :tags #{[:t]}
+                                        :scoped-key sk})]
+      (is (= 1 (:revision fresh)) "a freshly-seeded populate bumps 0 -> 1")
+      (is (= {:v 1} (:data fresh)))
+      ;; populate over the existing entry with EQUAL value — structural-shared,
+      ;; but re-stamps freshness: an authoritative write.
+      (let [re (mut-rt/populate-entry fresh :conduit/article {:v 1}
+                                      {:clock-ms 77 :stale-at 88 :tags #{[:t]}})]
+        (is (identical? (:data fresh) (:data re))
+            "equal populate value keeps the SAME :data identity")
+        (is (= 77 (:loaded-at re)) "freshness IS re-stamped")
+        (is (= 2 (:revision re))
+            ":revision bumps unconditionally on the equal-value populate")))))
+
+;; ---- the bump helper itself -----------------------------------------------
+
+(deftest bump-revision-helper-is-total-and-monotone
+  (testing "bump-revision increments, treats absent/nil :revision as 0, and
+            leaves a nil entry unchanged"
+    (is (= 1 (:revision (state/bump-revision {:revision 0}))))
+    (is (= 6 (:revision (state/bump-revision {:revision 5}))))
+    (is (= 1 (:revision (state/bump-revision {})))
+        "absent :revision is treated as 0 (a pre-EP-0019 entry)")
+    (is (= 1 (:revision (state/bump-revision {:revision nil})))
+        "nil :revision is treated as 0")
+    (is (nil? (state/bump-revision nil))
+        "a nil entry has nothing to bump — returned unchanged"))
+  (testing "entry-revision reads the fact, defaulting to 0"
+    (is (= 0 (state/entry-revision nil)))
+    (is (= 0 (state/entry-revision {})))
+    (is (= 3 (state/entry-revision {:revision 3})))))
+
+;; ---- the canonical-identity conflict comparison ---------------------------
+
+(deftest revision-conflict-detects-a-competing-authoritative-write
+  (testing "no conflict when the recorded revision matches the current one"
+    (let [loaded (-> (state/empty-entry :conduit/article)
+                     (state/entry-succeeded {:data {:n 1} :loaded-at 1
+                                             :stale-at 2 :tags #{}}))
+          rec    (state/entry-revision loaded)]
+      (is (false? (state/revision-conflict? loaded rec))
+          "an entry that has NOT been written since the apply is conflict-free")))
+  (testing "CONFLICT when a competing authoritative write moved the revision
+            between the recorded apply and the settle"
+    (let [loaded   (-> (state/empty-entry :conduit/article)
+                       (state/entry-succeeded {:data {:n 1} :loaded-at 1
+                                               :stale-at 2 :tags #{}}))
+          recorded (state/entry-revision loaded)         ;; observed at apply time
+          ;; a competing write lands (a refetch returning equal data — still an
+          ;; authoritative freshness settle that bumps :revision):
+          competed (state/entry-succeeded
+                     loaded {:data {:n 1} :loaded-at 500 :stale-at 600 :tags #{}})]
+      (is (= (inc recorded) (state/entry-revision competed)))
+      (is (true? (state/revision-conflict? competed recorded))
+          "the moved revision is detected as a conflict — the recorded inverse
+           is now a stale `before` the settle must NOT blindly restore")))
+  (testing "the comparison is canonical-identity over the counter, not a value
+            diff: a recorded nil compares as 0"
+    (is (false? (state/revision-conflict? {:revision 0} nil))
+        "recorded nil ~ 0 vs current 0 — no conflict")
+    (is (true? (state/revision-conflict? {:revision 1} nil))
+        "recorded nil ~ 0 vs current 1 — conflict")))

--- a/spec/016-Resources.md
+++ b/spec/016-Resources.md
@@ -380,6 +380,7 @@ Resource state uses [Pattern-RemoteData](Pattern-RemoteData.md) semantics, but d
  :invalidated-at <ms-or-nil>
  :attempt        <int>
  :generation     <int>
+ :revision        <int>
  :request-id     <request-id-or-nil>
  :current-work   <work-id-or-nil>
  :tags           <set>
@@ -387,6 +388,8 @@ Resource state uses [Pattern-RemoteData](Pattern-RemoteData.md) semantics, but d
 ```
 
 `:resource/id` is the registered resource id (a bare keyword); `:resource/key` is the entry's own scoped resource key (the `[scope resource-id params]` tuple, [§Resource identity](#resource-identity)); `:current-work` points at the in-flight attempt's `:work/id` (the join to the [work ledger](#frame-work-ledger), cleared when no attempt is live — [§Restore and replay](#restore-and-replay)). The `:keep-previous?` projection pointer `:previous-key` rides the entry too ([§Paginated and previous data](#paginated-and-previous-data)). The durable entry stores **facts**; `:loading?` / `:fetching?` / `:stale?` / `:has-data?` are derived, never stored.
+
+`:revision` (base `0`) is the per-entry **write identity** — a monotone counter bumped on **every authoritative durable entry write** (load success, controlled patch, populate, and an invalidation-driven freshness settle), **unconditionally** and never gated on whether `:data` changed. It is **distinct** from `:generation`: `:generation` is the work / stale-suppression identity bumped at load **start**, whereas `:revision` moves only when an authoritative write actually **settles** the entry. The distinction is load-bearing for [EP-0019](../docs/EP/EP-0019-optimistic-mutation-rollback.md) optimistic-mutation rollback, whose settle-time conflict check compares a recorded `:revision` (observed at optimistic-apply time) against the entry's current `:revision` to decide whether a recorded inverse is still a truthful "before" — a value-gated token would miss a freshness-only settle (`:loaded-at` / `:stale-at` re-stamped while `:data` is `=`-shared, [§Structural sharing](#structural-sharing)) and let a later rollback silently clobber newer freshness with a stale snapshot.
 
 This deliberately **refines** Pattern-RemoteData's broad `:error` state. The load-bearing invariants (MUST):
 


### PR DESCRIPTION
## EP-0019 slice 1 — the `:revision` durable-entry substrate

First slice of the EP-0019 optimistic-mutation-rollback wave (bead **rf2-byl7bk.1**). Adds the per-entry `:revision` write-identity the later rollback **settle protocol** compares against. **Substrate only** — no optimistic apply / snapshot / rollback / `:on-conflict` / `:optimistic` API (those are later slices).

Implements the **byl7bk Open Issue 5 ruling** (2026-06-15, the load-bearing amendment that gates the settle-protocol slice).

### What changed

- **`state.cljc`** — added `:revision` (base `0`) to `empty-entry*`, **distinct from `:generation`**. Added `bump-revision` (the single bump home, total over any entry shape, nil-entry-safe), `entry-revision` (read with default 0), and **`revision-conflict?`** — the canonical-identity conflict comparison (`not=` over the monotone counter, never a value diff) the settle protocol will use. `entry-succeeded` now bumps `:revision` **unconditionally** — including the `=`-shared structural-sharing branch.
- **`mutation_runtime.cljc`** — `patch-entry` and `populate-entry` bump `:revision` unconditionally on every write (incl. the `=`-shared branch and a freshly-seeded populate). The no-usable-data `patch-entry` no-op path makes no write and does **not** bump.
- **`events.cljc`** — the invalidation handler bumps `:revision` in the same swap that marks each matched entry stale (`:invalidated-at`) — biasing to over-bump.
- **`spec/016-Resources.md`** (hot-zone, sole toucher this wave) — added `:revision` to the durable entry shape + a minimal substrate note. The Q5 prose is already in EP-0019.

### Why distinct from `:generation`, why unconditional

`:generation` bumps at load **start** (the work / stale-suppression identity) → reusing it would false-conflict on every in-flight refetch. `:revision` moves only when an authoritative write **settles** the entry. The bump is **never gated on `(= old new)` of `:data`** because `entry-succeeded` / `patch-entry` / `populate-entry` re-stamp `:loaded-at` / `:stale-at` / `:tags` even on the `=`-shared branch — a value-gated token would miss that freshness settle and let a later rollback silently clobber newer freshness with a stale snapshot (the cache-coherence bug the ruling fixes). Bias to over-bump: a false conflict costs one refetch (made safe by the `:on-conflict :invalidate` default); a missed conflict is silent corruption.

### Tests

New CLJC unit suite `resources_revision_substrate_cljs_test.cljc`: base value + distinctness from `:generation`; `entry-start-load` bumps `:generation` not `:revision`; the **unconditional bump on an equal-data freshness settle** (`entry-succeeded` / `patch-entry` / `populate-entry`); the no-op patch no-bump path; the `bump-revision` helper totality; and `revision-conflict?` detecting a competing authoritative write.

### Gates

- `implementation/resources` JVM: **426 tests / 1698 assertions, 0 failures**
- `npm run test:cljs`: **7575 tests / 31140 assertions, 0 failures**
- `npm run test:elision`: **PASS** (43/43 absent, control 43/43 present)
- `mkdocs build --strict`: built clean (new EP-0019 link resolves)
- `scripts/test-fast-pr.sh`: **PASS** (incl. markdown link/anchor + EP status-sync gates)

### Follow-up slices (per EP-0019 bead plan)

3. Optimistic apply (phase 1.5) — `:optimistic` resolution + snapshot-inverse recording on the instance row.
4. Settle protocol — commit/rollback/reconcile + the conflict rule + `:on-conflict`.
5. Tag-addressed optimistic (`:optimistic-tags`).
6. Subs + tooling — `:optimistic?` flag, fill `:patch-summary` slots, Xray rows, egress projection.