### PR TITLE
fix(core): distinguish source-store identity in image-assembly cache key (rf2-1x2zuc)

### DIFF
--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -983,28 +983,36 @@
 ;; values, so they occupy different cache slots and can never cache-collide on
 ;; a shared resolver shape.
 ;;
-;; The two store-side legs are the monotonic generations:
+;; The store-side legs are the live store IDENTITY + its monotonic generation,
+;; plus the framework-standard generation:
 ;;
-;;   * single-arity (live store): `source-store/store-generation` —
-;;     the registered descriptor pool's generation; ANY reg-*/forget-*/clear
-;;     bumps it.
+;;   * single-arity (live store): `[source-store/store-identity
+;;     source-store/store-generation]` — the active store atom paired with its
+;;     monotonic generation. The generation alone is NOT enough: it is keyed
+;;     PER store (see source-store), so two DISTINCT stores (a realm-bound
+;;     `*source-store*` vs the process-default) can each sit at the same
+;;     generation integer over DIFFERENT descriptor pools. The store identity
+;;     disambiguates them so a sealed generation assembled from one store is
+;;     never handed back for another (rf2-1x2zuc). ANY reg-*/forget-*/clear on
+;;     the active store bumps its generation leg.
 ;;   * the framework-standard generation: `standard-generation` — ANY
 ;;     register-standard!/forget-standard!/clear bumps it.
 ;;
 ;; For the EXPLICIT-POOL arity `(assemble images descriptors)` the registered
 ;; pool is supplied directly (tests / a pre-snapshotted store), NOT read from
-;; the live store — so the store generation is NOT a faithful invalidation
-;; signal there. The honest pool leg in that arity is the descriptor pool
-;; itself (a value), so the explicit-pool key folds in the descriptors rather
-;; than the store generation. The standard generation still applies (standards
-;; are always read live).
+;; the live store — so neither the store identity nor its generation is a
+;; faithful invalidation signal there. The honest pool leg in that arity is the
+;; descriptor pool itself (a value), so the explicit-pool key folds in the
+;; descriptors rather than a store identity/generation: two distinct pools are
+;; distinct VALUES and so already distinct keys. The standard generation still
+;; applies (standards are always read live).
 ;;
 ;; This is a FINER key than the EP minimum (the EP permits a finer
 ;; descriptor-set fingerprint so unrelated store changes need not invalidate)
 ;; only in that two distinct stores at the same generation integer never alias
-;; — the store-generation is keyed per active store (see source-store). It is
-;; never COARSER: any change to a selected, standard, inline, OR replacement
-;; input changes a key leg and forces a re-seal.
+;; — the live-store leg carries the store identity alongside the per-store
+;; generation. It is never COARSER: any change to a selected, standard, inline,
+;; OR replacement input changes a key leg and forces a re-seal.
 
 (defonce ^{:doc "cache-key → sealed generation. The resolved-generation cache
   (EP-0023 §Image). A plain map atom: an SSR request assembling an unchanged
@@ -1029,17 +1037,28 @@
 
 (defn- cache-key
   "Build the resolved-generation cache key for a normalized image vector under
-  a descriptor `pool-leg` (the store-generation integer for the live-store
-  arity, or the explicit descriptor pool value for the explicit-pool arity).
+  a descriptor `pool-leg`. The `pool-leg` is the store-side identity leg:
+
+    * live-store arity — `[store-identity store-generation]`: the active store
+      atom (identity, so distinct stores never alias) paired with its monotonic
+      per-store generation (so a mutation re-seals). The identity is REQUIRED
+      because the generation is keyed per store: two distinct stores at the
+      same generation integer would otherwise collide (rf2-1x2zuc);
+    * explicit-pool arity — the explicit descriptor pool VALUE itself (distinct
+      pools are distinct values, so distinct keys without a separate identity).
+
   The image vector carries the inline fingerprints + replacement maps by value;
   `pool-leg` + the standard generation are the store-side legs. A vector so it
-  hashes + compares as a value."
+  hashes + compares as a value (the live-store `pool-leg`'s embedded store atom
+  is an opaque, reference-identity key leg — never dereferenced)."
   [images pool-leg]
   [images pool-leg (standard-generation)])
 
 (defn- assemble-cached
   "Look the normalized `images` up in the resolved-generation cache under
-  `[images pool-leg standard-generation]`; on a MISS compute the sealed
+  `[images pool-leg (standard-generation)]` (the live-store `pool-leg` is the
+  `[store-identity store-generation]` pair, so distinct stores at the same
+  generation never alias — rf2-1x2zuc); on a MISS compute the sealed
   generation via `assemble*` (against `descriptors`), cache it, and return it.
   A cache HIT returns the SAME sealed object — this is the SSR no-re-seal
   guarantee. A throwing `assemble*` (a fail-loud validation) is NOT cached: the
@@ -1100,12 +1119,15 @@
   Two arities:
     (assemble images)            — select against the live source store; the
                                    key's pool leg is the live source-store
-                                   generation.
+                                   IDENTITY + its generation (the identity stops
+                                   two distinct stores at the same generation
+                                   from aliasing — rf2-1x2zuc).
     (assemble images descriptors)— select against an explicit descriptor pool
                                    (tests / harnesses / a pre-snapshotted
                                    store); the key's pool leg is the descriptor
-                                   pool value itself (the live store generation
-                                   does not describe an explicit pool).
+                                   pool value itself (distinct pools are
+                                   distinct values, so the live store
+                                   identity/generation does not apply).
 
   `images` is ALWAYS a seq/vector of image values — never a single image map
   (the EP is emphatic that `:images` is vector-only; `live-frame/validate-images!`
@@ -1137,9 +1159,15 @@
        ;; live `assemble`. A concurrent mutation between these two reads could key
        ;; a freshly-assembled pool to a stale generation; the framework does not
        ;; defend against that because registration is not a concurrent surface.
+       ;;
+       ;; The pool leg pairs the active store IDENTITY with its generation: the
+       ;; generation is keyed per store, so the identity is what stops two
+       ;; distinct stores at the same generation from aliasing one sealed
+       ;; generation (rf2-1x2zuc).
        (assemble-cached images
                         (source-store-descriptors)
-                        (source-store/store-generation)))))
+                        [(source-store/store-identity)
+                         (source-store/store-generation)]))))
   ([images descriptors]
    (let [images (vec images)]
      (if (empty? images)
@@ -1174,11 +1202,13 @@
   Two arities mirror `assemble`:
     (assemble-default)            — select against the LIVE source store; the
                                    cache key's pool leg is the source-store
-                                   generation, so the default generation is
-                                   cached and invalidated the instant any
-                                   `reg-*` / `forget-*` / `clear-*` bumps it
-                                   (EP-0023 §Image — the default generation is
-                                   cached keyed on the source-store generation).
+                                   IDENTITY + its generation, so the default
+                                   generation is cached, invalidated the instant
+                                   any `reg-*` / `forget-*` / `clear-*` bumps it,
+                                   and never aliased across two distinct stores
+                                   at the same generation (rf2-1x2zuc; EP-0023
+                                   §Image — the default generation is cached
+                                   keyed on the source-store generation).
     (assemble-default descriptors)— select against an explicit descriptor pool
                                    (tests / harnesses / a pre-snapshotted store);
                                    the pool leg is the descriptor pool value
@@ -1189,9 +1219,13 @@
   standards) and no inline / replacement declarations. Returns the sealed
   generation (the same shape `assemble` returns)."
   ([]
+   ;; Live-store default: pair the active store identity with its generation so
+   ;; the default generation of two distinct stores at the same generation never
+   ;; aliases (rf2-1x2zuc).
    (assemble-cached [default-image]
                     (source-store-descriptors)
-                    (source-store/store-generation)))
+                    [(source-store/store-identity)
+                     (source-store/store-generation)]))
   ([descriptors]
    (assemble-cached [default-image] descriptors descriptors)))
 

--- a/implementation/core/src/re_frame/source_store.cljc
+++ b/implementation/core/src/re_frame/source_store.cljc
@@ -156,6 +156,28 @@
   []
   (get @store->generation (active-source-store) 0))
 
+(defn store-identity
+  "The IDENTITY of the active source store — the active store atom itself
+  (EP-0023 §Image — the resolved-generation cache's source-store-identity key
+  leg). The generation counter is monotonic but keyed PER store
+  (`store->generation` is an atom-identity → counter map), so the generation
+  integer ALONE is ambiguous across stores: two distinct stores (e.g. a
+  realm-bound `*source-store*` vs the process-default) can each sit at the same
+  generation integer while holding DIFFERENT descriptor pools. The
+  resolved-generation cache folds this identity alongside `store-generation` so
+  two distinct stores at the same generation never alias each other's sealed
+  generation (rf2-1x2zuc).
+
+  The active store atom is the right identity: atoms compare and hash by
+  reference identity, so the same store yields the same key leg (a HIT for an
+  unchanged store) and distinct stores yield distinct key legs (a MISS — no
+  cross-store aliasing). A bare integer or symbol would NOT do: integers alias
+  across stores (the bug), and there is no stable per-store name. The atom never
+  escapes the cache key — the cache map holds it as an opaque key leg, never
+  dereferences it, and the public boundary never exposes it."
+  []
+  (active-source-store))
+
 ;; ---- canonical namespace-string pooling -----------------------------------
 ;;
 ;; One string instance per source namespace per store (the EP's anti-tax

--- a/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_assembly_cache_cljs_test.cljc
@@ -288,6 +288,69 @@
           "the throwing composition left nothing cached"))))
 
 ;; ===========================================================================
+;; 6b. rf2-1x2zuc — two DISTINCT live source stores at the SAME generation
+;;     integer must NOT alias one cached generation. The store-generation
+;;     counter is keyed PER store, so the integer alone is ambiguous across
+;;     stores; the cache key folds the store IDENTITY alongside the generation
+;;     so a realm-bound store never reuses the process-default store's sealed
+;;     generation (or vice versa).
+;; ===========================================================================
+
+(deftest distinct-stores-same-generation-do-not-alias
+  (testing "two DIFFERENT source-store atoms, each at generation 1 with the SAME
+            image selector but DIFFERENT registered handlers, assemble DISTINCT
+            sealed generations — the second store resolves its OWN handler, NOT
+            the first store's cached handler (rf2-1x2zuc). On current main this
+            FAILS: the live-store cache key carried only the generation integer,
+            so the second store (also generation 1) hit the first store's slot."
+    (let [store-a (atom {})
+          store-b (atom {})
+          img     (image/image {:id :shared/main :include-ns ["shared.core"]})
+          ;; Store A: register ::a-handler under the same (kind, id) the image
+          ;; selects; assemble against store A (its generation becomes 1).
+          gen-a   (binding [ss/*source-store* store-a]
+                    (record! "shared.core" :event :shared/boot ::a-handler)
+                    {:store-gen (ss/store-generation)
+                     :gen       (asm/assemble [img])})
+          ;; Store B: a DISTINCT atom; register a DIFFERENT handler ::b-handler
+          ;; under the SAME (kind, id); assemble against store B (its generation
+          ;; ALSO becomes 1 — the counter is keyed per store).
+          gen-b   (binding [ss/*source-store* store-b]
+                    (record! "shared.core" :event :shared/boot ::b-handler)
+                    {:store-gen (ss/store-generation)
+                     :gen       (asm/assemble [img])})
+          a-impl  (:handler-fn (asm/resolve-descriptor (:gen gen-a) :event :shared/boot))
+          b-impl  (:handler-fn (asm/resolve-descriptor (:gen gen-b) :event :shared/boot))]
+      (is (= (:store-gen gen-a) (:store-gen gen-b) 1)
+          "both stores sit at the SAME generation integer (1) — the per-store
+           counter does not distinguish them; the identity must")
+      (is (not (identical? (:gen gen-a) (:gen gen-b)))
+          "distinct stores at the same generation → DISTINCT sealed generations,
+           NOT the first store's cached object")
+      (is (= ::a-handler a-impl)
+          "store A's generation resolves store A's handler")
+      (is (= ::b-handler b-impl)
+          "store B's generation resolves store B's OWN handler — NOT store A's
+           cached handler (the cross-store alias bug)")
+      (is (= 2 (asm/cache-size))
+          "two distinct stores at the same generation occupy two cache slots"))))
+
+(deftest same-store-still-hits-after-identity-leg
+  (testing "the complement: the SAME source store assembling the SAME unchanged
+            composition twice STILL returns the one cached object — folding the
+            store identity into the key did not break the HIT path (rf2-1x2zuc)"
+    (let [store (atom {})
+          img   (image/image {:id :realm/main :include-ns ["realm.core"]})]
+      (binding [ss/*source-store* store]
+        (record! "realm.core" :event :realm/boot ::impl)
+        (let [gen1 (asm/assemble [img])
+              gen2 (asm/assemble [img])]
+          (is (identical? gen1 gen2)
+              "an unchanged store re-assembling the same image reuses the cached
+               object — the identity leg is stable per store")
+          (is (= 1 (asm/cache-size))))))))
+
+;; ===========================================================================
 ;; 7. Explicit-pool arity caches on the POOL value (tests / harnesses)
 ;; ===========================================================================
 


### PR DESCRIPTION
## Bug (rf2-1x2zuc)

EP-0023's resolved-generation cache aliased distinct live source stores that happened to sit at the same generation integer.

`re-frame.source-store/store-generation` is keyed PER store (`store->generation` is an atom-identity -> counter map), so a realm-bound `*source-store*` and the process-default store each carry their OWN generation. But the live-store cache pool leg was just that bare integer (`image_assembly.cljc` `assemble` / `assemble-default`). With only the integer in the key, two distinct stores both at generation 1 with the same image selector collided: the second store hit the first store's cached sealed generation and ran the **wrong** registration impl while every image input appeared valid.

This is distinct from rf2-32siq3.34 (`clear-kind!` failing to bump a generation) — it reproduces even when both stores bump correctly.

### Repro confirmed red on `851efec5` (base)

Two distinct store atoms, each at generation 1, same `:include-ns` selector, different handlers:
- `same-generation? true`
- store B resolved store A's handler (`B-handler-is-A? true`, `gen identical? true`)

## Fix

- Add `source-store/store-identity` — returns the active store **atom** (reference-identity keyed: distinct stores never alias, the same store still hits; an integer/symbol cannot do this).
- Fold it into the **live-store** cache pool leg as `[store-identity store-generation]` in both `assemble` and `assemble-default`.
- The **explicit-pool** arity is unchanged: its pool leg is the descriptor pool VALUE, which is already store-distinct by value.

After the fix the repro goes green: distinct stores assemble distinct generations and each resolves its OWN handler (`gen identical? false`).

## Regression tests (red-before-green)

`image_assembly_cache_cljs_test.cljc` §6b:
- `distinct-stores-same-generation-do-not-alias` — two distinct stores at the same generation + same selector assemble distinct generations; B resolves `::b-handler`, not A's cached `::a-handler`; 2 cache slots.
- `same-store-still-hits-after-identity-leg` — the complement: the same store re-assembling an unchanged composition still returns the one cached object (the identity leg did not break the HIT path).

## Scope

- Stayed entirely in the `image_assembly.cljc` cache-key surface + the supporting `source_store.cljc` identity accessor. Did NOT touch `live_frame.cljc` (the concurrent EP-0023 collapse wave).
- No new error id introduced (pure cache-key disambiguation, no new fail-loud path) -> no spec/009 row needed. EP-0023's "minimum cache key" floor is unchanged; the per-store identity is the soundness mechanism for the existing per-store generation.

## Gates (all green)

- `npm run test:cljs` — 7570 tests / 31112 assertions, 0 failures, 0 errors (incl. the 2 new tests; re-run green post-rebase)
- `npm run test:elision` — PASS (EP-0023 provenance-survives + assembly-DCE clean)
- `scripts/test-fast-pr.sh` — PASS

(rf2-1x2zuc)