### PR TITLE
fix(ssr): duplicate-suspense-id + inert-template fallbacks + client trace suspense-id decode (rf2-8en9mu rf2-xzhf2a rf2-m96yhw)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -98,8 +98,21 @@
        "</template>"))
 
 (defn fallback-template
-  "The fallback chunk shape — emitted inline in the shell HTML so the
-  browser paints a placeholder immediately."
+  "The fallback chunk shape — the boundary's fallback markup wrapped in an
+  inline `<template data-rf2-suspense-fallback>` placeholder in the shell
+  HTML.
+
+  rf2-xzhf2a — a `<template>`'s content is INERT by the HTML spec (its
+  `.content` is a detached `DocumentFragment`, never painted), so this is
+  NOT first-byte-visible content: nothing paints until the client runtime
+  (`re-frame.ssr.streaming.client/install!`) materialises each inert
+  fallback into a live, visible `<rf-suspense data-rf2-suspense-mount>`
+  mount. This is the deliberate streaming model (Spec 011 §Client-side
+  hydration semantics — the same visible-fallback-plus-stable-mount shape
+  React 18 / Solid use): the inert `<template>` is the wire-carrier for the
+  fallback markup, the client owns the painted mount. A streaming page
+  therefore requires the client runtime to show fallbacks — non-JS clients
+  see the shell structure without painted skeletons until the final payload."
   [id fallback-html]
   (suspense-template id (str wire/attr-suspense-fallback "=\"1\"") fallback-html))
 

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -23,11 +23,15 @@
        type=\"application/edn\">…full-payload…</script>`.
     4. The closing `</body></html>`.
 
-  WITHOUT a client consuming chunks (2), the deltas stream over the
-  wire but are inert: the browser paints skeleton fallbacks until the
-  final `__rf_payload` lands, then `:rf/hydrate` re-renders everything
-  — identical UX to non-streaming, defeating the speed prop of
-  suspense boundaries. This namespace is that consumer.
+  WITHOUT a client consuming these chunks, the whole protocol is inert:
+  the fallback `<template>`s never paint (a `<template>`'s content is a
+  detached `DocumentFragment` by the HTML spec — see chunk (1) / rf2-xzhf2a),
+  the resolved `<template>`s never swap in, and the deltas never merge — the
+  browser shows blank boundary regions until the final `__rf_payload` lands,
+  then `:rf/hydrate` renders everything at once. Identical UX to
+  non-streaming, defeating the speed prop of suspense boundaries. This
+  namespace is that consumer: it materialises the inert fallbacks into
+  visible mounts AND swaps in resolved chunks progressively.
 
   `install!` performs progressive per-subtree hydration: as each
   resolved chunk's nodes parse into the DOM, the runtime
@@ -136,15 +140,32 @@
   "Parse a boundary-id attribute string back into the id value the
   hiccup author wrote. The server stamps `(html/escape-attr (str id))`;
   for a keyword id that is the keyword's printed form (`:card.revenue`),
-  for a string id the raw string. `cljs.reader/read-string` recovers a
-  keyword id as a keyword and any other token as itself; on a parse
-  failure (an exotic string id with reader-significant chars) we fall
-  back to the raw string so matching still works structurally — the id
-  is only ever used as a map/DOM-attribute key, never evaluated."
+  for a string id the raw string (`card-revenue`).
+
+  `cljs.reader/read-string` recovers a keyword id as a keyword. But a bare
+  string id (`(str \"card-revenue\")` → `card-revenue`) parses to an EDN
+  SYMBOL, not a string — `(str id)` erased the string vs symbol distinction
+  on the wire (a hiccup id is only ever a keyword or a string, never a
+  symbol). So a SYMBOL parse is always a string id that lost its quotes in
+  transit: coerce it back to its printed string, preserving the documented
+  contract that a string id stays a string in trace payloads (rf2-m96yhw).
+  `(str sym)` faithfully reconstructs the original string for both a bare
+  (`card-revenue`) and a slash-bearing (`card/revenue`) string id — `name`
+  would drop the namespace segment. Keyword ids (and any other non-symbol
+  parse) keep their parsed type. On a parse FAILURE (an exotic string id with
+  reader-significant chars) we fall back to the raw attribute string. The id
+  is only ever used as a map/DOM-attribute key or a trace payload, never
+  evaluated."
   [s]
-  (try
-    (reader/read-string s)
-    (catch :default _ s)))
+  (let [parsed (try
+                 (reader/read-string s)
+                 (catch :default _ ::fail))]
+    (cond
+      (= ::fail parsed) s
+      ;; A bare-token parse is a symbol — the server emitted a STRING id via
+      ;; `(str id)`, dropping the quotes; recover the string (rf2-m96yhw).
+      (symbol? parsed)  (str parsed)
+      :else             parsed)))
 
 ;; ---- DOM helpers -----------------------------------------------------------
 
@@ -162,15 +183,28 @@
   [tmpl]
   (.cloneNode (.-content tmpl) true))
 
-(defn- mount-for
-  "Find the live `<rf-suspense data-rf2-suspense-mount=\"<id>\">` wrapper
-  for boundary `id-str` under `root`, or nil. This is the swap target
-  the resolved chunk replaces. Matching is by the id attribute so the
-  swap is exact even across nested boundaries."
+(defn- mounts-for
+  "Every live `<rf-suspense data-rf2-suspense-mount=\"<id>\">` wrapper for
+  boundary `id-str` under `root`, in document order. A well-formed page has
+  exactly one per id; a DUPLICATE-id boundary (a programmer error the server
+  surfaces with `:rf.error/suspense-boundary-duplicate-id`, fail-soft
+  last-write-wins) yields more than one — one live mount per declared
+  boundary, all carrying the same id."
   [root id-str]
   (->> (query-by-attr root attr-suspense-mount)
-       (filter #(= id-str (.getAttribute % attr-suspense-mount)))
-       first))
+       (filter #(= id-str (.getAttribute % attr-suspense-mount)))))
+
+(defn- mount-for
+  "The swap-target live mount for boundary `id-str` under `root`, or nil.
+  Matching is by the id attribute so the swap is exact even across nested
+  boundaries. For a DUPLICATE-id boundary the target is the LAST mount in
+  document order — the server keeps the LAST registration (last-write-wins,
+  Spec 011 §Boundary nesting and recursion) and ships only that
+  continuation's resolved chunk, so the resolved content must land in the
+  last boundary's position; the earlier mounts keep showing their fallback
+  (rf2-8en9mu). For the common single-id case this is just that one mount."
+  [root id-str]
+  (last (mounts-for root id-str)))
 
 (defn- materialise-fallback!
   "Turn one inert `data-rf2-suspense-fallback` `<template>` into a LIVE
@@ -178,22 +212,28 @@
   wrapper carrying the boundary id, fills it with the template's parsed
   fallback content (so the user sees the skeleton), and removes the
   template (its job — carrying the fallback markup across the wire — is
-  done). Idempotent: skips a template whose mount already exists.
+  done).
 
-  Returns the mount element (new or pre-existing), or nil if the
-  template carried no id."
+  Per-template idempotent by construction: a materialised template is
+  REMOVED from the DOM, so a later sweep's `materialise-fallbacks!` query
+  cannot re-encounter it. We therefore do NOT short-circuit on an existing
+  same-id mount — doing so would collapse a DUPLICATE-id boundary's second
+  fallback `<template>` into the first boundary's mount, leaving the second
+  template stranded inert in the DOM (rf2-8en9mu). Each declared boundary
+  gets its OWN visible mount; the resolved chunk later targets the LAST one
+  (`mount-for`).
+
+  Returns the new mount element, or nil if the template carried no id."
   [fb-tmpl]
   (when-let [id-str (.getAttribute fb-tmpl attr-suspense-id)]
-    (let [root (or (.-parentNode fb-tmpl) fb-tmpl)]
-      (or (mount-for root id-str)
-          (let [parent (.-parentNode fb-tmpl)
-                mount  (.createElement js/document mount-tag)]
-            (.setAttribute mount attr-suspense-mount id-str)
-            (.appendChild mount (template-content-fragment fb-tmpl))
-            (when parent
-              (.insertBefore parent mount fb-tmpl)
-              (.removeChild parent fb-tmpl))
-            mount)))))
+    (let [parent (.-parentNode fb-tmpl)
+          mount  (.createElement js/document mount-tag)]
+      (.setAttribute mount attr-suspense-mount id-str)
+      (.appendChild mount (template-content-fragment fb-tmpl))
+      (when parent
+        (.insertBefore parent mount fb-tmpl)
+        (.removeChild parent fb-tmpl))
+      mount)))
 
 (defn- materialise-fallbacks!
   "Materialise every un-mounted fallback `<template>` under `root` into a
@@ -205,12 +245,14 @@
 
 (defn- replace-mount-content!
   "Replace the live mount's children for `id-str` with the resolved
-  `<template>`'s parsed content, in-place. Returns true if a mount was
-  found + swapped, false otherwise (e.g. duplicate-id: the resolved
-  chunk for an id whose mount was already consumed, or a resolved chunk
-  with no matching fallback). The mount wrapper itself stays in the DOM
-  carrying its id — harmless, and it keeps the swap target stable if a
-  later (duplicate) chunk arrives."
+  `<template>`'s parsed content, in-place. Targets `mount-for` — the LAST
+  mount for the id, so a DUPLICATE-id boundary's single resolved chunk
+  (the server's last-write-wins registration) lands in the LAST boundary's
+  position while earlier mounts keep their fallback (rf2-8en9mu). Returns
+  true if a mount was found + swapped, false otherwise (a resolved chunk
+  with no matching fallback mount yet — e.g. a nested inner chunk racing
+  ahead of its mount). The mount wrapper itself stays in the DOM carrying
+  its id — harmless, and it keeps the swap target stable."
   [root id-str resolved-tmpl]
   (if-let [mount (mount-for root id-str)]
     (do

--- a/implementation/ssr/src/re_frame/ssr/streaming/constants.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming/constants.cljc
@@ -39,8 +39,11 @@
 
 (def ^:const attr-suspense-fallback
   "Marker on the inline fallback `<template>` the shell walk emits, so the
-  browser paints a placeholder immediately and the client knows which
-  templates to materialise into live mounts."
+  client knows which templates to materialise into live, visible mounts.
+  rf2-xzhf2a — the `<template>` content is INERT (never painted) until the
+  client runtime runs; the marked template is the wire-carrier, the painted
+  fallback is the client-materialised `<rf-suspense>` mount, NOT first-byte
+  content."
   "data-rf2-suspense-fallback")
 
 (def ^:const attr-suspense-resolved

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -512,6 +512,164 @@
               (finally (stop!))))
           (finally (remove-root! host)))))))
 
+(defn- mounts-for
+  "Every live `<rf-suspense data-rf2-suspense-mount=\"<id>\">` wrapper for
+  boundary `id` under `host`, in document order. Duplicate-id boundaries
+  produce more than one — the placement-coherence assertions (rf2-8en9mu)
+  read both."
+  [host id]
+  (array-seq
+    (.querySelectorAll host (str "[" wire/attr-suspense-mount "=\"" (pr-str id) "\"]"))))
+
+(defn- inert-fallback-template-count
+  "Count of un-materialised fallback `<template>`s still in the DOM. After a
+  sweep this MUST be zero — every fallback template is consumed into a live
+  mount (rf2-8en9mu: a duplicate-id boundary must not leave a stray inert
+  template)."
+  [host]
+  (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-fallback "]")))))
+
+(deftest fallback-is-inert-template-before-js-then-painted-on-install
+  (testing "rf2-xzhf2a — the no-JS / first-byte contract. The shell's
+            fallback markup is delivered ONLY inside an inert
+            `<template data-rf2-suspense-fallback>` — its content is NOT
+            painted DOM until the client runtime runs. We distinguish the two:
+            before install, the skeleton lives inside a `<template>` (its
+            `.content` is a detached DocumentFragment — `querySelector` on the
+            live tree does NOT find it) and there is NO live `<rf-suspense>`
+            mount; after install, the same markup is materialised into a live,
+            paintable `<rf-suspense data-rf2-suspense-mount>` mount."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (let [fid  (make-client-frame!)
+            host (make-root! [:card.revenue])]
+        (try
+          ;; BEFORE install (the no-JS / first-byte state): the fallback skeleton
+          ;; is inert template content — NOT in the live painted DOM.
+          (is (some? (.querySelector host (str "[" wire/attr-suspense-fallback "]")))
+              "the inert fallback <template> is present in the shell")
+          (is (nil? (.querySelector host ".skeleton"))
+              "the skeleton is INERT template content — not painted live DOM before JS")
+          (is (nil? (mount-for host :card.revenue))
+              "no live <rf-suspense> mount exists before the client runs")
+          ;; AFTER install: the runtime materialises the inert template into a
+          ;; live, painted mount — the skeleton is now real DOM.
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (try
+              (is (zero? (inert-fallback-template-count host))
+                  "the inert fallback <template> is consumed on install")
+              (is (some? (mount-for host :card.revenue))
+                  "a live <rf-suspense> mount now exists")
+              (is (some? (.querySelector host ".skeleton"))
+                  "the skeleton is now PAINTED live DOM (inside the live mount)")
+              (is (true? (showing-fallback? host :card.revenue))
+                  "the boundary shows its (now live, visible) fallback")
+              (finally (stop!))))
+          (finally (remove-root! host)))))))
+
+(deftest duplicate-id-resolves-into-last-boundary
+  (testing "rf2-8en9mu — two suspense boundaries declared with the SAME id.
+            The server's `dedupe-continuations` keeps the LAST registration
+            (last-write-wins, Spec 011 §Boundary nesting and recursion), so
+            exactly ONE resolved chunk for that id streams in. The shell still
+            carries TWO fallback `<template>`s (one per boundary). The client
+            must (a) materialise BOTH fallbacks into visible live mounts (no
+            stray inert template stranded), and (b) swap the single resolved
+            chunk into the LAST boundary's mount — the registration that won —
+            leaving the EARLIER mount showing its fallback. Before the fix the
+            resolved content landed in the FIRST mount (querySelectorAll
+            document order) and the second fallback template was left inert."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (let [fid  (make-client-frame!)
+            ;; Two boundaries, SAME id — make-root! emits a fallback template
+            ;; per id, so [:card.dupe :card.dupe] yields two same-id templates.
+            host (make-root! [:card.dupe :card.dupe])]
+        (try
+          ;; The server emitted only the LAST continuation's resolved chunk
+          ;; (dedupe keeps last). It arrives before install (initial sweep).
+          (append-chunk!
+            host
+            (resolved-chunk-html :card.dupe
+                                 "<div class=\"card resolved-dupe\">resolved 7</div>"
+                                 {:cards {:dupe {:value 7}}}))
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (try
+              ;; (a) BOTH fallbacks materialised — no stray inert template.
+              (is (zero? (inert-fallback-template-count host))
+                  "no inert fallback <template> left behind for the duplicate id")
+              (let [ms (mounts-for host :card.dupe)]
+                (is (= 2 (count ms)) "two live mounts — one per boundary")
+                ;; (b) the resolved content is in the LAST mount; the first
+                ;; mount still shows its skeleton fallback.
+                (let [first-mount (first ms)
+                      last-mount  (last ms)]
+                  (is (some? (.querySelector first-mount ".skeleton"))
+                      "earlier boundary still shows its fallback skeleton")
+                  (is (nil? (.querySelector first-mount ".resolved-dupe"))
+                      "earlier boundary did NOT receive the resolved content")
+                  (is (some? (.querySelector last-mount ".resolved-dupe"))
+                      "the LAST boundary (the won registration) received the resolved content")
+                  (is (nil? (.querySelector last-mount ".skeleton"))
+                      "the last boundary no longer shows its fallback")))
+              ;; exactly one resolved-dupe node total — not duplicated.
+              (is (= 1 (card-count host "resolved-dupe"))
+                  "the single resolved chunk is placed exactly once")
+              ;; delta still merged (placement bug must not regress hydration).
+              (is (= 7 (:value @(rf/subscribe fid [:sct/card :dupe])))
+                  "the resolved chunk's delta merged")
+              (finally (stop!))))
+          (finally (remove-root! host)))))))
+
+(deftest string-boundary-id-preserves-type-in-trace
+  (testing "rf2-m96yhw — a STRING suspense id must keep its string type in
+            client-side trace payloads, while a KEYWORD id parses back to a
+            keyword. The malformed-delta + failed-boundary trace paths decode
+            the id via `read-boundary-id`; before the fix a bare string id
+            (`card-revenue`, emitted via `(str id)`) parsed to an EDN SYMBOL,
+            so the trace `:id` carried the wrong type."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      ;; Drive a STRING id and a KEYWORD id through the failed-boundary path
+      ;; (which decodes the attribute via read-boundary-id for its :id).
+      (doseq [[id expected-pred shape]
+              [["card-revenue" string? "string id"]
+               [:card/revenue  keyword? "keyword id"]]]
+        (let [fid      (make-client-frame!)
+              host     (.createElement js/document "div")
+              captured (atom [])
+              k        (str (gensym "stream-idtype-cb"))]
+          (set! (.-innerHTML host) "<div id=\"app\"><main></main></div>")
+          (.appendChild (.-body js/document) host)
+          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (try
+            ;; A failed-boundary chunk → process-resolved-template! emits
+            ;; :rf.ssr/suspense-boundary-failed with :id (read-boundary-id …).
+            ;; No prior fallback mount is needed: the failed branch still
+            ;; emits the trace even when the swap finds no mount.
+            (append-chunk!
+              host
+              (failed-chunk-html id "<div class=\"card card-failed\">unavailable</div>"))
+            (let [stop! (streaming-client/install! {:frame fid :root host})]
+              (try
+                ;; The boundary id lands in the trace envelope's PAYLOAD —
+                ;; `[:tags :id]` — not the top-level `:id` (a trace-sequence
+                ;; counter). `emit-error!` stamps caller payload under `:tags`.
+                (let [ev     (some #(when (= :rf.ssr/suspense-boundary-failed (:operation %)) %)
+                                   @captured)
+                      ev-id  (get-in ev [:tags :id])]
+                  (is (some? ev) (str shape ": failed-boundary trace emitted"))
+                  (is (= id ev-id)
+                      (str shape ": trace :id round-trips to the authored id; got "
+                           (pr-str ev-id)))
+                  (is (expected-pred ev-id)
+                      (str shape ": trace :id has the right type; got "
+                           (pr-str (type ev-id)))))
+                (finally (stop!))))
+            (finally
+              (trace-tooling/unregister-listener! k)
+              (remove-root! host))))))))
+
 (deftest async-observer-applies-late-chunk
   (testing "A resolved chunk that arrives AFTER install (the observer-driven
             path) is swapped + merged too. Proves the MutationObserver

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -69,6 +69,39 @@
       (is (str/includes? shell-html "data-rf2-suspense-fallback=\"1\"") "fallback marker stamped")
       (is (str/includes? shell-html "<p>Loading…</p>") "fallback hiccup rendered inline"))))
 
+(deftest render-shell-fallback-is-inert-template-not-painted-dom
+  (testing "rf2-xzhf2a — the streaming first shell chunk carries each
+            boundary's fallback markup ONLY inside an inert
+            `<template data-rf2-suspense-fallback>` — NOT as painted
+            (template-free) DOM. This is the no-JS / first-byte contract:
+            a `<template>`'s content is inert by the HTML spec (it does not
+            paint until the client runtime materialises it into a live
+            `<rf-suspense>` mount), so the server emit is intentionally a
+            wrapped placeholder, NOT first-byte visible content. The fallback
+            text appears EXACTLY once, and exactly once inside the template —
+            i.e. there is no second, painted copy outside the `<template>`."
+    (let [tree   [:main
+                  [:rf/suspense-boundary
+                   {:id :news/comments :fallback [:p.skeleton "Loading comments…"]}
+                   [:section.comments "Body"]]]
+          {:keys [shell-html]} (streaming/render-shell tree)
+          ;; Strip every <template …>…</template> block; whatever fallback
+          ;; markup the server painted OUTSIDE a template survives.
+          painted (str/replace shell-html
+                               #"(?s)<template[^>]*>.*?</template>"
+                               "")]
+      (is (str/includes? shell-html "data-rf2-suspense-fallback=\"1\"")
+          "the fallback is emitted as a marked <template> placeholder")
+      (is (str/includes? shell-html "<p class=\"skeleton\">Loading comments…</p>")
+          "the fallback markup is present (inside the template)")
+      ;; The fallback markup must NOT survive template-stripping — i.e. there
+      ;; is NO painted (template-free) copy. The shell, sans templates, is just
+      ;; the surrounding structure with NO fallback content.
+      (is (not (str/includes? painted "Loading comments…"))
+          "no painted (template-free) fallback copy — fallback content is ONLY inside the inert <template>")
+      (is (not (str/includes? painted "skeleton"))
+          "no painted fallback element outside the inert <template>"))))
+
 (deftest render-shell-handles-multiple-boundaries
   (testing "Multiple boundaries register multiple continuations in document order"
     (let [tree [:main


### PR DESCRIPTION
Closes three related SSR streaming/suspense beads on the `implementation/ssr` surface (one coordinated toucher to avoid inter-conflict). Rebased off latest `origin/main`; each bead confirmed against current main.

## rf2-8en9mu (P2) — duplicate suspense ids resolved into the FIRST DOM mount
The server keeps the LAST registration (last-write-wins, `dedupe-continuations`) and ships one resolved chunk, but the client materialised the second fallback `<template>` into the first boundary's existing mount (leaving the second template inert) and swapped the resolved content into the first mount — moving resolved content to the wrong location.

Fix: each declared boundary now gets its own visible mount (`materialise-fallback!` no longer short-circuits on an existing same-id mount — per-template idempotency is preserved because a materialised template is removed from the DOM), and the resolved chunk targets the LAST mount (`mount-for` → `last` of `mounts-for`). Matches Spec 011 §Boundary nesting and recursion / §1019: resolved content lands in the won (last) boundary, earlier placeholders keep their fallback, no stray inert template remains.

## rf2-xzhf2a (P2) — streaming fallbacks emitted inside inert `<template>`s
This is the **deliberate, spec'd** streaming model (Spec 011 §958: the client materialises inert fallbacks into visible `<rf-suspense>` mounts; a `<template>`'s content never paints). The drift was misleading **server docstrings/commentary** claiming "the browser paints a placeholder immediately." Resolved as the spec-consistent option (B): corrected `fallback-template` / `attr-suspense-fallback` docstrings and the client-ns commentary to the shipped contract — no first-byte visible fallback without JS. Spec 011 already documents this correctly (no spec change).

## rf2-m96yhw (P3) — client traces coerced STRING suspense ids to EDN symbols
The server emits `(str id)`, so a string id (`card-revenue`) arrives as a bare token that `cljs.reader/read-string` parses to a **symbol**, not a string. `read-boundary-id` now coerces a symbol parse back to its printed string (`(str sym)` — faithfully reconstructs both bare and slash-bearing string ids), so a string id stays a string in trace `:id` payloads while a keyword id still parses to a keyword. (Matching always used the raw string, so this is observability/parity only — no DOM-placement change.)

## Tests
- `ssr_streaming_test.clj`: `render-shell-fallback-is-inert-template-not-painted-dom` (xzhf2a — no painted, template-free fallback copy at first byte).
- `streaming_client_dom_cljs_test.cljs`:
  - `fallback-is-inert-template-before-js-then-painted-on-install` (xzhf2a)
  - `duplicate-id-resolves-into-last-boundary` (rf2-8en9mu)
  - `string-boundary-id-preserves-type-in-trace` (rf2-m96yhw)

No new always-on error id (all three reuse existing catalogued traces), so no Spec 009 row.

## Gates (all green)
- `npm run test:cljs` — 7571 tests / 31108 assertions, 0 failures
- `npm run test:browser` — 218 tests / 688 assertions, 0 failures
- `npm run test:elision` — 43/43 absent in production, clean
- ssr JVM suite — 344 tests, 0 failures; ssr-ring JVM suite — 166 tests, 0 failures
- `scripts/test-fast-pr.sh` — PASS