### PR TITLE
feat(core): EP-0023 collapse slice 1 — runnable object-returning make-frame (rf2-32siq3.32)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1579,9 +1579,13 @@
   "Return the current `app-db` VALUE (a plain map) for the named frame,
   or `nil` if not registered. Value-form accessor (no deref, no
   container) — pairs with `app-db-container` (the container accessor).
-  Per Spec 002 §The public registrar query API."
+  Per Spec 002 §The public registrar query API.
+
+  EP-0023 (rf2-32siq3.32): the argument may be a frame-id KEYWORD or a live
+  frame OBJECT (`rf/make-frame`'s return value); an object is normalized to its
+  runnable-id address via `frame/frame-target->id`."
   [frame-id]
-  (frame/frame-app-db-value frame-id))
+  (frame/frame-app-db-value (frame/frame-target->id frame-id)))
 
 (defn runtime-db-value
   "Return the current `runtime-db` partition VALUE for the named frame —
@@ -1592,9 +1596,11 @@
   EP-0001 (rf2-q4i9ko + rf2-adwcv6): the physical runtime-db partition is
   live. A fresh frame's runtime-db starts `{}`; reads return the current
   `:rf.db/runtime` projection off the one-container frame-state. Per Spec
-  002 §The two-partition frame contract and API.md `runtime-db-value`."
+  002 §The two-partition frame contract and API.md `runtime-db-value`.
+
+  EP-0023 (rf2-32siq3.32): accepts a frame-id keyword or a live frame object."
   [frame-id]
-  (frame/frame-runtime-db-value frame-id))
+  (frame/frame-runtime-db-value (frame/frame-target->id frame-id)))
 
 (defn frame-state-value
   "Return the coherent frame-state projection for the named frame —
@@ -1606,9 +1612,11 @@
   frame state off the one physical frame-state container. A fresh frame's
   state is `{:rf.db/app {} :rf.db/runtime {}}`; the `:rf.db/runtime` slot
   equals `runtime-db-value`. Per Spec 002 §The two-partition frame
-  contract and API.md `frame-state-value`."
+  contract and API.md `frame-state-value`.
+
+  EP-0023 (rf2-32siq3.32): accepts a frame-id keyword or a live frame object."
   [frame-id]
-  (frame/frame-state-value frame-id))
+  (frame/frame-state-value (frame/frame-target->id frame-id)))
 
 (defn snapshot-of
   "Return the value at `path` in a frame's app-db — convenience over
@@ -1621,9 +1629,10 @@
   Per Spec 002 §The public registrar query API."
   ([path] (snapshot-of path nil))
   ([path opts]
-   (let [frame-id (or (:frame opts)
-                      (frame/require-current-frame!
-                        :snapshot-of {:where 're-frame.core/snapshot-of}))]
+   (let [frame-id (frame/frame-target->id
+                    (or (:frame opts)
+                        (frame/require-current-frame!
+                          :snapshot-of {:where 're-frame.core/snapshot-of})))]
      (get-in (frame/frame-app-db-value frame-id) path))))
 
 ;; Per rf2-bmzq0: `sub-topology` and `sub-cache-snapshot` live in

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -82,6 +82,68 @@
   "Reserved frame-state key naming the runtime-db partition (`:rf.db/runtime`)."
   :rf.db/runtime)
 
+;; ---- EP-0023 runnable frame OBJECT marker + target normalization ----------
+;;
+;; EP-0023 collapse slice 1 (rf2-32siq3.32): `re-frame.live-frame/make-frame`
+;; returns a SINGLE runnable image-loaded frame OBJECT — a map carrying the
+;; resolved image generation AND a reference (`:rf.frame/runnable-id`) to the
+;; backing EP-0013 runnable RECORD this ns owns in `frames`. The object IS the
+;; public live frame; its runnable interior (app-db / runtime-db / queue /
+;; sub-cache / lifecycle) is the record reached by the runnable-id (EP-0023
+;; §Frame — "the live frame object owns app-db, runtime-db, event queue and
+;; drain state, subscription cache, ... a reference to the resolved image
+;; generation it is running").
+;;
+;; The PUBLIC target a dispatch / subscribe / destroy / app-db read addresses is
+;; a frame — usually a frame id KEYWORD, sometimes a direct frame OBJECT
+;; (EP-0023 §Frame). Every runnable subsystem resolves per-frame state through a
+;; frame-id ADDRESS keyed into `frames` (the universal chokepoint: the router
+;; queue/drain, `commit-frame-transition!`, the sub-cache, cofx, elision, …).
+;; So an OBJECT target is normalized to its runnable-id ADDRESS at the public
+;; entry, and every bare-`frame-id`-keyed operation downstream stays
+;; byte-identical. `live-frame` discriminates an object from a keyword
+;; STRUCTURALLY (the `:rf.frame/object` marker) so this ns needs no require on
+;; `live-frame` (which would cycle — `live-frame` requires THIS ns).
+
+(def ^:const object-marker
+  "Reserved frame-object marker key. A `true` value at this key on a map means
+  \"this is a live frame OBJECT\" (EP-0023 §Frame). Mirrors
+  `re-frame.live-frame/object-marker`; held here so the target normalizer can
+  recognize an object structurally without a (cyclic) `live-frame` require."
+  :rf.frame/object)
+
+(def ^:const runnable-id-key
+  "Reserved key on a runnable frame OBJECT naming the frame-id ADDRESS of its
+  backing runnable record in `frames` (EP-0023 collapse slice 1, rf2-32siq3.32).
+  For an `:id`-bearing object this equals the public `:rf.frame/id`; for a
+  no-id (direct) object it is a process-unique `:rf.frame/<gensym>` so the
+  object is still runnable (its record is addressable) while bypassing the
+  PUBLIC live-frame id space (EP-0023 §Frame — direct frame objects bypass the
+  registry)."
+  :rf.frame/runnable-id)
+
+(defn frame-target->id
+  "Normalize a public frame TARGET — a frame-id KEYWORD or a live frame OBJECT —
+  to the frame-id ADDRESS its runnable record is keyed by in `frames` (EP-0023
+  §Frame, rf2-32siq3.32). A frame OBJECT (carrying `:rf.frame/object true`)
+  yields its `:rf.frame/runnable-id`; any other target (a keyword id, or a nil /
+  malformed value) is returned UNCHANGED — so every existing keyword-target
+  caller is byte-identical. Pure. The single seam dispatch / subscribe / destroy
+  / app-db-read normalize a frame object through before keying `frames`."
+  [target]
+  (if (and (map? target) (get target object-marker))
+    (get target runnable-id-key)
+    target))
+
+(defn anon-frame-id
+  "Mint a process-unique anonymous frame-id under the reserved `:rf.frame/`
+  namespace — the address a no-id frame's runnable record is keyed by. Same
+  scheme as the EP-0013 `make-frame` anonymous instance id, so tooling that
+  filters `:rf.frame/*` ids sees runnable-object and EP-0013-anonymous frames
+  uniformly. INTERNAL — used by `re-frame.live-frame/make-frame`."
+  []
+  (keyword "rf.frame" (str (gensym ""))))
+
 (defonce
   ^{:doc "Map of frame-ADDRESS → frame-record. Per-process (one global frame
   registry). EP-0013 step 4 (rf2-a15n62): the key is a FRAME ADDRESS — the bare
@@ -1916,8 +1978,19 @@
   destroy is the existing pattern (a destroyed frame's `(frame id)`
   lookup already returns nil, so a *later* `destroy-frame!` short-
   circuits at the outer `when-let`); the in-flight guard closes the
-  RE-ENTRANT window before `mark-frame-destroyed!` flips the flag."
-  [id]
+  RE-ENTRANT window before `mark-frame-destroyed!` flips the flag.
+
+  EP-0023 (rf2-32siq3.32): the target may be a frame-id KEYWORD or a live frame
+  OBJECT (`re-frame.live-frame/make-frame`'s return value). An object is
+  normalized to its runnable-id ADDRESS via `frame-target->id` so the whole
+  recipe keys the backing record unchanged; after teardown the object's PUBLIC
+  live-frame registry entry is forgotten through the `:live-frame/forget!`
+  late-bind hook (a static `live-frame` require would cycle)."
+  [target]
+  ;; EP-0023 (rf2-32siq3.32): accept a frame OBJECT or a frame-id keyword.
+  ;; Normalize an object to its runnable-id address so every keyed teardown
+  ;; step below targets the backing record; a keyword passes through unchanged.
+  (let [id (frame-target->id target)]
   ;; Re-entrancy guard: short-circuit if we're already destroying this id.
   ;; Silent no-op (idempotent destroy is already a no-op pattern; no new
   ;; trace event needed per rf2-r1ciy decision).
@@ -2056,6 +2129,14 @@
         ;; still flows through the live stream cleanly. Routed via
         ;; late-bind so production CLJS bundles (no trace.tooling) no-op.
         (safe-call-hook! :trace.tooling/release-frame-ring! id)
+        ;; EP-0023 (rf2-32siq3.32): forget the PUBLIC live-frame registry entry
+        ;; for this frame so destroying an EP-0023 image-loaded frame frees its
+        ;; public id for re-use (the teardown counterpart of `make-frame`'s
+        ;; registration). Routed via late-bind (`live-frame` requires THIS ns, so
+        ;; a static back-require would cycle); the hook keys by the frame-id, and
+        ;; no-ops for an id that never entered the live-frame registry (every
+        ;; EP-0013 / no-id-object frame). Best-effort, like the cleanup hooks.
+        (safe-call-hook! :live-frame/forget! id)
         (dissoc-frame! fkey)
         (unregister-frame! frame-rid id)
         (notify-epoch-listeners! id cascade-fs-before fs-at-destroy cascade-time-ms)
@@ -2085,7 +2166,7 @@
           ;; Always clear the in-flight marker — even if a downstream step
           ;; throws unexpectedly, future `destroy-frame!` calls for `id`
           ;; (after a fresh `reg-frame`) must not see a stale entry.
-          (swap! destroying-frames disj fkey)))))))))))
+          (swap! destroying-frames disj fkey))))))))))))
 
 (defn reset-frame!
   "destroy-frame! followed by reg-frame with the same config. Per Spec 002

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1002,6 +1002,10 @@
     :producer-ns 're-frame.frame
     :design-bead "rf2-yueuvi"
     :description "EP-0013 realm-disposal counterpart of `:realm/frames-by-realm`. Destroys every frame OWNED by a realm — runs the full per-frame `destroy-frame!` recipe for each owned frame id (resolved from `frames-by-realm`, under `*current-realm*` bound to the realm so a non-default-realm frame is found by its `[realm-id frame-id]` address). `re-frame.realm/dispose-realm!` calls it FIRST (before its adapter + host-transient teardown) so disposing a realm ends its frames' lifecycle rather than leaving stale records addressable; routed late-bound because a static `realm` → `frame` require would cycle (`frame` requires `realm` for the record's default realm-id). No-op when the realm owns no frames."}
+   {:key         :live-frame/forget!
+    :producer-ns 're-frame.live-frame
+    :design-bead "rf2-32siq3.32"
+    :description "EP-0023 collapse slice 1: forget a destroyed frame's PUBLIC live-frame registry entry (the teardown counterpart of `rf/make-frame`'s registration). `re-frame.frame/destroy-frame!` invokes it from the frame's destroy boundary, keyed by the frame id; routed late-bound because `re-frame.live-frame` requires `re-frame.frame` (for the backing runnable record), so a static back-require would cycle. No-op for a frame id that never entered the live-frame registry (every EP-0013 realm-only frame, and a no-id direct object keyed under its own gensym runnable-id)."}
    {:key         :app-value/project
     :producer-ns 're-frame.app-value
     :design-bead "rf2-yozjzo"

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -125,6 +125,8 @@
   spine."
   (:require [re-frame.image-assembly :as asm]
             [re-frame.registrar      :as registrar]
+            [re-frame.frame          :as frame]
+            [re-frame.late-bind      :as late-bind]
             [re-frame.error          :as error]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -142,41 +144,78 @@
 ;; the caller still believes points at the original — the realm-id-conflict
 ;; failure mode, here at the frame-id boundary).
 
-(defonce ^{:doc "Process-local live-frame registry: `{frame-id → frame-object}`.
-  An `:id`-bearing `make-frame` registers its object here; a duplicate live id
-  fails loud. Direct (no-id) frame objects never enter this map. INTERNAL — the
-  registry the public query/lookup helpers read."}
+(defonce ^{:doc "Process-local live-frame registry: `{runnable-id → frame-object}`.
+  EVERY runnable frame object `make-frame` produces is registered here keyed by
+  its `:rf.frame/runnable-id` ADDRESS (the same id its backing runnable record is
+  keyed by in `re-frame.frame/frames`) — both `:id`-bearing objects (runnable-id
+  = the public `:rf.frame/id`) AND no-id direct objects (runnable-id = a private
+  `:rf.frame/<gensym>`). Keying by the runnable-id is what lets a frame-targeted
+  dispatch / subscribe — including a CHILD dispatch that carries only the
+  runnable-id keyword on its envelope — re-derive the frame's resolved image
+  generation by id, so generation routing stays coherent across the whole
+  cascade for a no-id object too (EP-0023 §Frame-derived live registration
+  resolution).
+
+  The PUBLIC frame-id uniqueness contract (EP-0023 §Id Spaces) is enforced
+  SEPARATELY by `register-live-frame!` on the public `:rf.frame/id` BEFORE a slot
+  is taken, so two live frames may not both claim `:counter/main`; no-id objects
+  carry no public id and so bypass that contract (their gensym runnable-ids
+  never collide). `live-frame-ids` enumerates only the PUBLIC ids. INTERNAL — the
+  registry the query/lookup/reload helpers read."}
   live-frames
   (atom {}))
 
 (defn live-frame
-  "Return the live frame OBJECT registered under `frame-id`, or nil when no live
-  frame carries that id. The process-local frame-id lookup (EP-0023 §Frame — \"a
-  frame id names a running context in a registry\"). Pure read of the registry
-  snapshot."
+  "Return the live frame OBJECT registered under a frame target — its public
+  `frame-id` KEYWORD or its private runnable-id (the same `runnable-id → object`
+  key in either case), or nil when no live frame carries that id. The
+  process-local id lookup (EP-0023 §Frame — \"a frame id names a running context
+  in a registry\"). Pure read of the registry snapshot. The generation-resolution
+  seam reads through this so an `:id`-targeted dispatch and a no-id object's
+  child dispatch (carrying the runnable-id) BOTH resolve the frame's generation."
   [frame-id]
   (get @live-frames frame-id))
 
 (defn live-frame-ids
-  "The set of frame ids currently live in the process-local registry. Tools and
-  the later reload slice use this to enumerate the public frame-id space."
+  "The set of PUBLIC frame ids currently live in the process-local registry —
+  the public frame-id space tools and the reload slice enumerate. Only objects
+  created with an explicit `:id` contribute; no-id direct objects (keyed under a
+  private runnable-id) are deliberately excluded, so reprojection /
+  enumeration never touch a harness-local frame the spec says its owner reloads
+  explicitly (EP-0023 §Frame — direct objects bypass the registry)."
   []
-  (set (keys @live-frames)))
+  (into #{} (keep #(:rf.frame/id %)) (vals @live-frames)))
 
 (defn forget-live-frame!
-  "Remove `frame-id` from the live-frame registry, returning the registry's new
-  value. The teardown counterpart to `make-frame`'s registration; the later
-  frame-lifecycle slice fires this from the frame's destroy boundary. INTERNAL —
-  registry mutation only; it does not run any frame teardown of its own."
+  "Remove the frame keyed by `frame-id` (a public frame id or a runnable-id) from
+  the live-frame registry, returning the registry's new value. The teardown
+  counterpart to `make-frame`'s registration; `re-frame.frame/destroy-frame!`
+  fires this through the `:live-frame/forget!` late-bind hook from the frame's
+  destroy boundary. INTERNAL — registry mutation only; it does not run any frame
+  teardown of its own (the record teardown is `destroy-frame!`'s job)."
   [frame-id]
   (swap! live-frames dissoc frame-id))
 
 (defn clear-live-frames!
   "Reset the live-frame registry. Test fixtures use this between cases so a
-  registered `:id` from one case does not collide with the next."
+  registered `:id` from one case does not collide with the next.
+
+  EP-0023 (rf2-32siq3.32): this resets ONLY the live-frame registry index, not
+  the backing runnable RECORDS in `re-frame.frame/frames` (the runtime fixture's
+  registrar/`frames` reset owns those). The two are reset together by the test
+  fixtures."
   []
   (reset! live-frames {})
   nil)
+
+;; The destroy boundary (`re-frame.frame/destroy-frame!`) forgets a destroyed
+;; frame's live-frame entry through this hook — `re-frame.frame` cannot require
+;; THIS ns (it would cycle), so the forget is published as a late-bind hook
+;; keyed by the destroyed frame's id (the public id == the runnable-id for an
+;; id-bearing object; a no-id object's gensym runnable-id is keyed here too, so
+;; destroying a direct object by handle also forgets it). No-op for an id never
+;; registered (every EP-0013 realm-only frame).
+(late-bind/set-fn! :live-frame/forget! forget-live-frame!)
 
 ;; ===========================================================================
 ;; The frame OBJECT (EP-0023 §Frame)
@@ -448,10 +487,13 @@
                    LOCAL-ONLY: the caller keeps the returned object and passes it
                    directly to dispatch/subscribe/test helpers. The absence of
                    `:id` is NOT a default-id path (EP-0023 §Public API).
-    :initial-db    the frame's initial app-db value (optional). Carried on the
-                   object for the later state-container slice; frame STATE is a
-                   frame concern, image is a behaviour concern (EP-0023 §Image
-                   Patching And Overrides).
+    :initial-db    the frame's initial app-db value (optional). SEEDED into the
+                   runnable frame's app-db partition (EP-0023 §Frame — the live
+                   frame object owns app-db), so an immediate
+                   `(rf/subscribe frame [...])` / `(rf/app-db-value frame)` reads
+                   it; absent ⇒ the frame starts with app-db `{}` (the EP-0013
+                   fresh-frame default). Frame STATE is a frame concern, image is
+                   a behaviour concern (EP-0023 §Image Patching And Overrides).
     :capabilities  the host capability map the image's `:rf.image/requires` is
                    checked against (optional). The check runs UNCONDITIONALLY at
                    the frame boundary: any required capability the map does not
@@ -468,10 +510,26 @@
                    frame object, never the frame-state value (EP-0023 §Host
                    Boundary).
 
-  Returns the live frame OBJECT — a map carrying `:rf.frame/object true`, the
-  resolved `:rf.frame/generation`, the frame `:rf.frame/id` (when supplied), and
-  the creation inputs. The later slices wire frame-derived live resolution (.9)
-  against `:rf.frame/generation` and reload (.10) against the whole composition.
+  Returns the live frame OBJECT — a single RUNNABLE map carrying
+  `:rf.frame/object true`, the resolved `:rf.frame/generation`, the
+  `:rf.frame/runnable-id` ADDRESS of its backing runnable record, the public
+  frame `:rf.frame/id` (when supplied), and the creation inputs. The object is
+  fully runnable: `rf/dispatch` / `rf/subscribe` / `rf/destroy-frame!` /
+  `rf/app-db-value` accept it (or its id), and the cascade resolves through its
+  `:rf.frame/generation` (EP-0023 §Frame — the live frame object owns app-db,
+  runtime-db, queue, sub-cache, lifecycle, and a reference to the resolved image
+  generation it is running). `reload-images!` swaps the generation while
+  preserving the backing record's memory.
+
+  EP-0023 collapse slice 1 (rf2-32siq3.32): the object's runnable interior —
+  app-db / runtime-db container, projection reactions, router queue, drain-lock,
+  sub-cache, lifecycle — is an EP-0013 runnable RECORD created here via
+  `re-frame.frame/reg-frame` (the canonical create-and-register, idempotent on a
+  re-make of a live id) and keyed in `re-frame.frame/frames` by the
+  runnable-id. So one frame type carries BOTH the resolved image generation
+  (here, on the object) AND the runnable state (the record reached by the
+  runnable-id) — no separate `reg-frame` pairing is needed to run an event
+  stream against an image.
 
   Two arities:
     (make-frame opts)            — resolve `:images` against the LIVE source store.
@@ -480,21 +538,46 @@
                                    matching `image-assembly/assemble`'s 2-arity."
   ([opts] (make-frame opts nil))
   ([{:keys [images id initial-db capabilities adapter]} descriptors]
-   (let [generation (resolve-generation! images capabilities descriptors)
+   (let [generation  (resolve-generation! images capabilities descriptors)
+         ;; The runnable-id ADDRESS the backing record is keyed by: the public
+         ;; `:id` when supplied (so `(rf/dispatch [...] {:frame :counter/main})`
+         ;; finds the same record), else a process-unique anonymous id so a no-id
+         ;; (direct) object is still runnable while bypassing the PUBLIC frame-id
+         ;; space (EP-0023 §Frame).
+         runnable-id (if (some? id) id (frame/anon-frame-id))
          frame-object
-         (cond-> {object-marker  true
-                  generation-key generation}
+         (cond-> {object-marker          true
+                  generation-key         generation
+                  frame/runnable-id-key  runnable-id}
            (some? id)           (assoc :rf.frame/id id)
            (some? initial-db)   (assoc :rf.frame/initial-db initial-db)
            (some? capabilities) (assoc :rf.frame/capabilities capabilities)
            (some? adapter)      (assoc :rf.frame/adapter adapter))]
-     ;; An :id-bearing frame registers in the process-local live-frame
-     ;; registry (fail-loud on a duplicate). A direct (no-id) frame object
-     ;; BYPASSES the registry — the caller holds the returned object directly
-     ;; (EP-0023 §Frame / §Public API).
-     (if (some? id)
-       (register-live-frame! id frame-object)
-       frame-object))))
+     ;; Register the object in the process-local live-frame registry under the
+     ;; runnable-id FIRST. For an `:id`-bearing frame this is the PUBLIC-id
+     ;; uniqueness gate (fail-loud on a duplicate, BEFORE any record is created
+     ;; so a conflict leaves no half-created frame); a no-id frame's gensym
+     ;; runnable-id never conflicts. The keyword-target generation-resolution
+     ;; seam reads through this registry, so a child dispatch carrying only the
+     ;; runnable-id keyword still re-derives the frame's generation.
+     (register-live-frame! runnable-id frame-object)
+     ;; Create the backing runnable RECORD (app-db / runtime-db / queue /
+     ;; sub-cache / lifecycle) under the runnable-id via the canonical
+     ;; create-and-register. `reg-frame` is idempotent on an existing id
+     ;; (surgical update preserving runtime state), so pairing an EP-0023
+     ;; `make-frame {:id …}` with a pre-existing `reg-frame` of the same id just
+     ;; refreshes config. EP-0023 frames are default-realm (the collapse
+     ;; supersedes the public realm dimension), so the record is keyed by the
+     ;; bare runnable-id keyword. The config carries no `:on-create`, so no init
+     ;; cascade runs here.
+     (frame/reg-frame runnable-id {})
+     ;; Seed `:initial-db` into the app-db partition (EP-0023 §Frame — the live
+     ;; frame object owns app-db). A fresh record starts app-db `{}`; this writes
+     ;; ONLY the app-db partition (runtime-db untouched) through the canonical
+     ;; partition mutator, so an immediate subscribe/read observes the seed.
+     (when (some? initial-db)
+       (frame/replace-app-db! runnable-id initial-db))
+     frame-object)))
 
 ;; ===========================================================================
 ;; Image hot reload (EP-0023 §Hot Reload, rf2-32siq3.10)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -288,11 +288,24 @@
         ;; spelling into the error payload's `:event-id` slot when known,
         ;; so a frameless top-level dispatch's error is attributed to the
         ;; event it was carrying.
-        frame              (or (:frame opts)
-                               (frame/require-current-frame!
-                                 :dispatch
-                                 {:where    're-frame.router/build-envelope
-                                  :event-id (first event)}))
+        ;; EP-0023 (rf2-32siq3.32): the explicit `:frame` opt may be a frame-id
+        ;; KEYWORD or a live frame OBJECT (`rf/make-frame`'s return value —
+        ;; `(rf/dispatch-sync frame [...])`). Normalize an object to its
+        ;; runnable-id ADDRESS via `frame/frame-target->id` so the envelope
+        ;; carries a keyword `:frame` and every bare-`frame-id`-keyed cascade
+        ;; operation downstream (the router queue/drain, `frame-state-value`,
+        ;; the commit path, the sub-cache) stays byte-identical. The
+        ;; generation-resolution seam re-resolves the object from this id via the
+        ;; live-frame registry (`frame-resolution-target`), so an object target
+        ;; and a child dispatch carrying the same id BOTH route the frame's
+        ;; image. A keyword target (and the scope/hold-resolved frame) passes
+        ;; through `frame-target->id` unchanged.
+        frame              (frame/frame-target->id
+                             (or (:frame opts)
+                                 (frame/require-current-frame!
+                                   :dispatch
+                                   {:where    're-frame.router/build-envelope
+                                    :event-id (first event)})))
         ;; EP-0013 step 4 (rf2-a15n62): resolve the REALM half of the carried
         ;; (realm, frame) address — carried BESIDE `:frame`, never a
         ;; realm-qualified frame tuple (EP-0013 OI-2). An explicit `:realm`

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -945,6 +945,17 @@
                  :event-id (first query-v)})
               query-v))
   ([frame-id query-v]
+   ;; EP-0023 (rf2-32siq3.32): the 2-arity target may be a frame-id KEYWORD or a
+   ;; live frame OBJECT (`(rf/subscribe frame query-v)` — `rf/make-frame`'s
+   ;; return value). Normalize an object to its runnable-id ADDRESS so the
+   ;; sub-cache lookup (`(frame/frame frame-id)`), the realm-registrar binding,
+   ;; the override seam, and the error payloads all key the backing record
+   ;; unchanged; a keyword passes through. The generation-resolution seam
+   ;; (`frame-resolution-target`) then re-resolves the frame's image from this id
+   ;; via the live-frame registry — so an object target builds against its OWN
+   ;; image, byte-identical to the keyword form. Mirrors the dispatch-side
+   ;; normalization in `re-frame.router/build-envelope`.
+   (let [frame-id (frame/frame-target->id frame-id)]
    ;; rf2-9hoos (CLJS, dev-only): record the view→sub edge — push this
    ;; query-v into the in-flight render's deref sink so `:rf.view/rendered`
    ;; can carry the view's OWN read-set (`:deref-subs`). No-op outside a
@@ -1093,7 +1104,7 @@
                (if (identical? reaction (get-in new [k :reaction]))
                  reaction
                  (compute-and-cache! frame-id query-v)))
-             (compute-and-cache! frame-id query-v)))))))))))) ;; close fn + call-with-frame-resolution (rf2-uejnt3) + fn + call-with-frame-realm-registrar (rf2-a15n62)
+             (compute-and-cache! frame-id query-v))))))))))))) ;; close fn + call-with-frame-resolution (rf2-uejnt3) + fn + call-with-frame-realm-registrar (rf2-a15n62) + normalize-target let (rf2-32siq3.32)
 
 (defn subscribe-once
   "One-shot read of a sub's current value. Subscribes, derefs, then

--- a/implementation/core/test/re_frame/frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_resolution_cljs_test.cljc
@@ -30,6 +30,7 @@
             [re-frame.image-assembly :as asm]
             [re-frame.registrar      :as registrar]
             [re-frame.test-support   :as test-support]
+            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.live-frame     :as lf]))
 
 ;; ---------------------------------------------------------------------------
@@ -41,8 +42,14 @@
 ;; CLJS has no `(require … :reload)` to reinstate them — see
 ;; `re-frame.test-support`). Snapshot/restore rolls back THIS test's
 ;; registrations (`:app/boot`, `:global/only`, …) while leaving framework state
-;; intact, run-order-independently. No adapter is installed — these tests never
-;; render; they exercise pure `(kind, id)` resolution.
+;; intact, run-order-independently.
+;;
+;; EP-0023 collapse slice 1 (rf2-32siq3.32): `make-frame` now returns a RUNNABLE
+;; image-loaded frame OBJECT — it creates its backing runnable record (app-db /
+;; queue / sub-cache) via `reg-frame`, which needs a substrate adapter — so the
+;; plain-atom adapter is installed. These cases still exercise pure `(kind, id)`
+;; resolution through the manual `call-with-frame-resolution` seam (they do not
+;; run a cascade), but constructing the frame now allocates a state container.
 ;;
 ;; The EP-0023 framework-standard registry and the live-frame registry are this
 ;; wave's OWN process-state defonce atoms (not framework ns-load state a sibling
@@ -51,7 +58,7 @@
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {})
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
     (asm/clear-standards!)
     (lf/clear-live-frames!)

--- a/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
@@ -17,17 +17,19 @@
   cascade with `call-with-frame-resolution` (rf2-uejnt3). A realm-only / no-image
   frame is unaffected (absence-is-default).
 
-  ## Why two registries, one id
+  ## One runnable image-loaded frame (EP-0023 collapse slice 1, rf2-32siq3.32)
 
-  The runnable frame RECORD (the EP-0013 substrate that owns app-db / queue /
-  sub-cache, created by `reg-frame`) and the EP-0023 live-frame OBJECT (which
-  carries the resolved image generation, created by `make-frame {:id …}`) are
-  DELIBERATELY SEPARATE registries (per `re-frame.live-frame` docstring). This
-  suite registers BOTH under the same id `:counter/main`: the router drains the
-  frame record; `process-event!` derives the generation from the live-frame
-  object of the same id. That is exactly the wiring rf2-uejnt3 ships — the .9/.10
-  unification of the two into one runnable image-loaded frame object is a later
-  slice; this slice only invokes the resolution seam at the live entry.
+  `make-frame` now returns a SINGLE runnable image-loaded frame OBJECT: it
+  creates its own backing runnable record (app-db / queue / sub-cache /
+  lifecycle, via `reg-frame`) keyed by the frame's runnable-id AND carries the
+  resolved image generation, so an event stream runs against an image with no
+  separate `reg-frame` pairing. The cases below still call `reg-frame` first
+  (harmless — `make-frame {:id :counter/main}` surgical-updates the same record);
+  the router drains that record and `process-event!` derives the generation from
+  the live-frame object of the same id. The `two-frames-from-one-image-keep-…`
+  test exercises the collapse directly — two RUNNABLE objects built from ONE
+  image keep INDEPENDENT app-db + sub-cache (the previously-impossible proof, no
+  `reg-frame` in sight).
 
   Fixtures snapshot/restore the registrar via `make-reset-runtime-fixture`
   (NOT `registrar/clear-all!`, per the .9 isolation note) and clear the
@@ -79,13 +81,18 @@
           :id               id}))
 
 (defn- sub-desc
-  "An image-resolver descriptor for a sub id whose computation is `compute-fn`
-  (`(fn [db query-v] …)`). `reg-sub` stores the computation under `:handler-fn`,
-  so a generation-routed `registrar/lookup :sub` returns this verbatim."
+  "An image-resolver descriptor for a LAYER-1 (app-db reader) sub id whose
+  computation is `compute-fn` (`(fn [db query-v] …)`). `reg-sub` stores the
+  computation under `:handler-fn` and stamps `:input-kind :db` so the sub-cache
+  feeds it the frame's app-db projection as the single signal; a generation-
+  routed `registrar/lookup :sub` returns this verbatim, so the descriptor must
+  carry `:input-kind` to be recognized as a layer-1 reader (a sub that ignores
+  `db` works without it, but one that READS app-db needs the discriminator)."
   [provenance-ns id compute-fn]
   {:rf.provenance/ns provenance-ns
    :kind             :sub
    :id               id
+   :input-kind       :db
    :handler-fn       compute-fn})
 
 ;; ===========================================================================
@@ -232,3 +239,93 @@
         (is (= :image (:step db))
             "the CHILD dispatch re-derived the generation and resolved the
              image's step handler too (coherent across the cascade)")))))
+
+;; ===========================================================================
+;; 6. THE COLLAPSE HEADLINE (EP-0023 collapse slice 1, rf2-32siq3.32) — two
+;;    RUNNABLE objects built from ONE image keep INDEPENDENT app-db + sub-cache.
+;;    This is the previously-impossible `.31 blocker-1` proof: before the
+;;    collapse a `make-frame` object had NO runnable state, so it could not run
+;;    an event stream at all without a paired `reg-frame` record. Now ONE object
+;;    carries both the image generation AND its own runnable record.
+;; ===========================================================================
+
+(deftest two-frames-from-one-image-keep-independent-state
+  (testing "two runnable frames built from the SAME image — NO reg-frame, NO
+            shared id — maintain INDEPENDENT app-db and sub-cache: each frame's
+            event stream mutates only its own state, and each frame's subscribe
+            builds its own reaction (EP-0023 §Frame — the live frame object owns
+            app-db + subscription cache; two frames that run the same generation
+            still have independent state)"
+    ;; ONE image carries the runnable inc handler + the value sub. A GLOBAL
+    ;; version of each exists only so we can prove the image's impl ran (not the
+    ;; global) — neither frame is paired with a reg-frame.
+    (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (assoc db :n :global)}))
+    (rf/reg-sub   :counter/value (fn [_db _] :global))
+    (let [pool [(event-desc "ex.counter" :counter/inc
+                            (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+                (sub-desc   "ex.counter" :counter/value (fn [db _] (:n db)))]
+          img  (image/image {:id :ex/counter :include-ns ["ex.counter"]})
+          ;; TWO direct (no-id) runnable objects from the SAME image, seeded with
+          ;; DIFFERENT initial-db. No reg-frame, no shared frame id.
+          fa   (lf/make-frame {:images [img] :initial-db {:n 0}}   pool)
+          fb   (lf/make-frame {:images [img] :initial-db {:n 100}} pool)]
+      ;; The objects are distinct runnable frames sharing one image generation.
+      (is (lf/frame-object? fa))
+      (is (lf/frame-object? fb))
+      (is (= (lf/frame-generation fa) (lf/frame-generation fb))
+          "both frames run the SAME resolved image generation (shared value)")
+      (is (not= (:rf.frame/runnable-id fa) (:rf.frame/runnable-id fb))
+          "yet they are distinct runnable frames (distinct backing records)")
+      ;; Independent app-db: divergent event streams over divergent seeds. The
+      ;; frame OBJECT is the dispatch target via the `{:frame …}` opt (the
+      ;; canonical object-accepting form — build-envelope normalizes the object
+      ;; to its runnable-id; the positional `(dispatch frame event)` sugar is
+      ;; slice-2 facade work).
+      (rf/dispatch-sync [:counter/inc] {:frame fa})
+      (rf/dispatch-sync [:counter/inc] {:frame fa})
+      (rf/dispatch-sync [:counter/inc] {:frame fb})
+      (is (= 2 (:n (rf/app-db-value fa)))
+          "frame A: seeded 0, inc'd twice — the IMAGE handler ran on A's OWN app-db")
+      (is (= 101 (:n (rf/app-db-value fb)))
+          "frame B: seeded 100, inc'd once — fully isolated from A")
+      (is (not= :global (:n (rf/app-db-value fa)))
+          "the IMAGE inc ran, not the global (generation routed to the frame's image)")
+      ;; Independent subscribe: each frame builds its OWN reaction over its OWN
+      ;; app-db, and the two reactions are NOT the same cached object.
+      (let [ra  (rf/subscribe fa [:counter/value])
+            ra2 (rf/subscribe fa [:counter/value])
+            rb  (rf/subscribe fb [:counter/value])]
+        (is (= 2 @ra)   "frame A's sub reads A's own app-db")
+        (is (= 101 @rb) "frame B's sub reads B's own app-db")
+        (is (identical? ra ra2)
+            "A's repeat subscribe HITS A's own sub-cache (same reaction)")
+        (is (not (identical? ra rb))
+            "A and B build DISTINCT reactions — independent sub-caches")))))
+
+;; ===========================================================================
+;; 7. DIRECT-OBJECT RUNNABILITY (the spec harness form) — a no-id object is
+;;    runnable end-to-end without any reg-frame pairing (EP-0023 §Frame).
+;; ===========================================================================
+
+(deftest direct-no-id-object-is-runnable-end-to-end
+  (testing "the spec's local-harness form: a no-id frame OBJECT is dispatched +
+            subscribed directly (object via the `{:frame …}` opt for dispatch and
+            as the 2-arity subscribe target) and runs the image's handlers
+            against the object's OWN runnable state — NO reg-frame, NO frame id
+            (EP-0023 §Frame — a direct object is a local reference a harness uses
+            directly)"
+    (let [pool  [(event-desc "ex.counter" :counter/inc
+                             (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+                 (sub-desc   "ex.counter" :counter/value (fn [db _] (:n db)))]
+          img   (image/image {:include-ns ["ex.counter"]})
+          frame (lf/make-frame {:images [img] :initial-db {:n 0}} pool)]
+      (rf/dispatch-sync [:counter/inc] {:frame frame})
+      (is (= 1 @(rf/subscribe frame [:counter/value]))
+          "the direct object ran the image's inc and read its own seeded app-db")
+      (testing "app-db-value + frame-state-value accept the object directly"
+        (is (= 1 (:n (rf/app-db-value frame))))
+        (is (= {:n 1} (:rf.db/app (rf/frame-state-value frame)))))
+      (testing "destroy-frame! accepts the object and tears its record down"
+        (rf/destroy-frame! frame)
+        (is (nil? (rf/app-db-value frame))
+            "after destroy the object's backing record is gone")))))

--- a/implementation/core/test/re_frame/live_frame_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_cljs_test.cljc
@@ -44,6 +44,8 @@
             [re-frame.image       :as image]
             [re-frame.image-assembly :as asm]
             [re-frame.live-frame  :as lf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.source-store   :as ss]))
 
 ;; ---------------------------------------------------------------------------
@@ -53,9 +55,17 @@
 ;; live), so SNAPSHOT/RESTORE it — do NOT `clear-all!`, which would destroy real
 ;; authored registrations (per the bead). The live-store default-image tests
 ;; mutate the store inside their own snapshot/restore body too.
+;;
+;; EP-0023 collapse slice 1 (rf2-32siq3.32): `make-frame` now creates a RUNNABLE
+;; backing record (app-db / queue / sub-cache) via `reg-frame`, which needs a
+;; substrate adapter — so the plain-atom adapter is installed (and the registrar
+;; snapshot/restored) via `make-reset-runtime-fixture`. These cases still assert
+;; the pure image-resolution / id-conflict / capability-check contract; the
+;; backing record is an allocation side effect they do not otherwise inspect.
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
     (let [store-before @ss/kind->id->ns->descriptor]
       (lf/clear-live-frames!)


### PR DESCRIPTION
## EP-0023 collapse wave — slice 1: the runnable object-returning make-frame (rf2-32siq3.32)

Makes `re-frame.live-frame/make-frame` return a **single RUNNABLE image-loaded frame OBJECT**, unifying the EP-0013 frame RECORD's runnable state into the EP-0023 live-frame object per Mike's ruling (object-returning). One frame type now carries **both** the resolved image generation **and** the runnable state (app-db / runtime-db / queue / sub-cache / lifecycle), so an event stream runs against an image with **no separate `reg-frame` pairing**.

### Unification approach
The live-frame object is backed by an EP-0013 runnable record created via `frame/reg-frame` and keyed in `frame/frames` by the object's new `:rf.frame/runnable-id`:
- `:id`-bearing object → runnable-id is the public `:rf.frame/id` (so `{:frame :counter/main}` finds the same record).
- no-id (direct) object → runnable-id is a process-unique `:rf.frame/<gensym>`, so a harness-local object is runnable while bypassing the PUBLIC frame-id space (EP-0023 §Frame).

`:initial-db` is now seeded into the app-db partition. The object is registered in the live-frame registry under the runnable-id so generation routing stays coherent across **child** dispatches for no-id frames too.

The central seam, `frame/frame-target->id`, normalizes a frame OBJECT-or-keyword to its runnable-id address. This keeps blast radius minimal: every bare-`frame-id`-keyed cascade operation downstream is byte-identical, and absence-is-default is preserved.

### What dispatch / subscribe / destroy / app-db now accept
- `dispatch`/`dispatch-sync` — a frame OBJECT via the `{:frame obj}` opt (normalized in `build-envelope`). (The positional `(dispatch frame event)` sugar is slice-2 facade work.)
- `subscribe` (2-arity) — a frame OBJECT as the target (`(rf/subscribe frame query-v)`).
- `destroy-frame!` — a frame OBJECT (extracts the runnable-id; also forgets the object's live-frame entry via the new `:live-frame/forget!` late-bind hook to avoid the live-frame→frame cycle).
- `app-db-value` / `runtime-db-value` / `frame-state-value` / `snapshot-of` — a frame OBJECT.

### The independent-state proof (`.31 blocker-1`, previously impossible)
`two-frames-from-one-image-keep-independent-state`: two RUNNABLE frames built from **one** image maintain **independent app-db + sub-cache** (divergent event streams over divergent `:initial-db`; distinct cached reactions). Plus `direct-no-id-object-is-runnable-end-to-end` exercises the spec's local-harness form (dispatch + subscribe + destroy on a no-id object).

### Gates (all green)
- `npm run test:cljs` — 7570 tests, 0 failures (incl. the independence test)
- `npm run test:elision` — clean (EP-0023 provenance-survives + assembly-DCE)
- core JVM — 1761 tests, 0 failures
- EP-0023 conformance + reload + live-frame + resolution — 72 tests, 0 failures
- `scripts/test-fast-pr.sh` — PASS; `test:bundle-isolation` — PASS; `migration-cljs-test` — PASS

### Out of scope (sequenced later)
- Slice 2 (HOT-ZONE): `rf/make-frame` facade export + `rf/reload-images!` + api-manifest; retire `assert-no-dual-make-frame!` (kept here).
- Slice 3+: the ~234-caller migration (core → ssr → adapters).
- No new error ids → no spec/009 row; no numbered-spec / hot-zone files touched.