### PR TITLE
test(core): install substrate adapter in live_frame_reload fixture (rf2-32siq3.43)

### DIFF
--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -36,16 +36,26 @@
             [re-frame.image        :as image]
             [re-frame.image-assembly :as asm]
             [re-frame.source-store :as source-store]
-            [re-frame.live-frame   :as lf]))
+            [re-frame.live-frame   :as lf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixture — clear the EP-0023 process-state atoms (the live-frame registry and
 ;; the framework-standard registry) per case. Does NOT touch the shared
 ;; registrar (slice .9 note); the source-store reprojection test snapshots +
 ;; restores the source store itself, locally.
+;;
+;; EP-0023 collapse slice 1 (rf2-32siq3.32): `make-frame` now creates a RUNNABLE
+;; backing record (app-db / queue / sub-cache) via `reg-frame`, which needs a
+;; substrate adapter — so the plain-atom adapter is installed (and the registrar
+;; snapshot/restored) via `make-reset-runtime-fixture`. These cases still assert
+;; the reload/diff/reproject contract; the backing record is an allocation side
+;; effect they do not otherwise inspect.
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
     (lf/clear-live-frames!)
     (asm/clear-standards!)


### PR DESCRIPTION
## What

Adds the plain-atom substrate adapter to the `live_frame_reload_cljs_test.cljc` `use-fixtures` block, composed with the existing `clear-live-frames!`/`clear-standards!` wrapper — matching the pattern the three sibling live-frame tests already use.

## Why

A collapse slice-1 (rf2-32siq3.32) regression. Slice 1 made `lf/make-frame` allocate a runnable backing record (app-db / queue / sub-cache) via `reg-frame`, which fails loud with `:rf.error/no-adapter-installed` when no substrate adapter is installed. The slice-1 worker updated the fixtures of `frame_resolution_cljs_test`, `live_cascade_frame_resolution_cljs_test`, and `live_frame_cljs_test` — but missed this file.

Standalone, the ns 11-errored (`rf/make-state-container` called before init!). It passed #4418 CI only because the consolidated suite ordering left a prior test's adapter installed (shared-bundle pollution) — latent and fragile.

## Verify

- `clojure -M:test -n re-frame.live-frame-reload-cljs-test` standalone: **13 tests, 58 assertions, 0 failures, 0 errors** (was 11 errors).
- `npm run test:cljs`: 7583 tests, 0 failures, 0 errors.
- `sh scripts/test-fast-pr.sh`: PASS fast PR spine.

## Surface lane

One test file only. No production source or other tests touched.