### PR TITLE
fix(core): EP-0023 populate framework-standard registry so :replace-standard + standard-interceptor refs resolve under a generation (rf2-32siq3.41)

### DIFF
--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -44,6 +44,7 @@
   consumer) is the one path surface and is the carrier of that no-op."
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
+            [re-frame.image-assembly :as image-assembly]
             [re-frame.error :as error]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -247,21 +248,85 @@
                      "the path argument of [:rf.interceptor/path <path-vector>] must be a vector"))
   (standard-path-interceptor path-vector))
 
+(def path-interceptor-descriptor
+  "The `{:factory path-factory}` descriptor the `:rf.interceptor/path` standard
+  registers under (the `reg-interceptor*` authoring input). A def so BOTH the
+  regular-registrar registration AND the EP-0023 framework-standard registry
+  registration carry the SAME factory object — so a generation-routed
+  `registrar/lookup` and a registrar-atom `lookup` resolve the standard path
+  interceptor identically (rf2-32siq3.41)."
+  {:factory path-factory})
+
+(def path-interceptor-metadata
+  "The Spec 001 registration metadata the `:rf.interceptor/path` standard ships.
+  Shared by the regular-registrar `reg-interceptor*` and the EP-0023
+  framework-standard registry descriptor so both surfaces carry identical
+  `:rf/interceptor-descriptor` slots (rf2-32siq3.41)."
+  {:doc "Framework-standard path interceptor (EP-0022). Focuses an event
+        handler on an app-db sub-slice at the given path-vector; the handler
+        sees/returns only the slice, spliced back into full app-db.
+        Referenced as `[:rf.interceptor/path <path-vector>]`."})
+
+;; EP-0023 framework-standard registry — the named invariant the
+;; `:rf.interceptor/path` standard is coupled to (Spec 002 §Standard
+;; `:rf.interceptor/path` rule 4 / rf2-ekq28v): an unchanged focused slice
+;; widens back to the ORIGINAL full app-db OBJECT so the frame-commit
+;; `identical?` no-op is preserved. The invariant-coupled lock keeps the
+;; standard non-replaceable until a conformance profile proves a replacement
+;; preserves it (`image-assembly/standard-replaceable?`); see EP-0023 §Image
+;; Patching And Overrides and `image_assembly.cljc`'s `:rf.standard/*` keys.
+(def ^:private path-conformance-invariant
+  :rf.interceptor.path/commit-identical-no-op)
+
 (defn register-standard-interceptors!
   "Register the framework-standard interceptors (currently only
-  `:rf.interceptor/path`) into the active registrar. Idempotent — called at
-  namespace load AND from `re-frame.core/init!` so the standard refs survive a
-  test fixture's `registrar/clear-all!` (which wipes the `:interceptor` kind
-  along with everything else). Mirrors how the reserved fx survive via
-  defmethod — the standard interceptors re-seed here on every boot."
+  `:rf.interceptor/path`) into the active registrar AND the EP-0023
+  framework-standard registry. Idempotent — called at namespace load AND from
+  `re-frame.core/init!` so the standard refs survive a test fixture's
+  `registrar/clear-all!` (which wipes the `:interceptor` kind along with
+  everything else). Mirrors how the reserved fx survive via defmethod — the
+  standard interceptors re-seed here on every boot.
+
+  TWO surfaces, ONE descriptor (rf2-32siq3.41):
+
+    * the REGULAR registrar (`reg-interceptor*`) — the default-image /
+      no-generation resolution path, where `registrar/lookup` reads the
+      registrar atom directly;
+
+    * the EP-0023 FRAMEWORK-STANDARD registry (`image-assembly/register-standard!`)
+      — so the standard descriptor is unioned into EVERY resolved image
+      generation. Without this, an image-loaded frame whose event references
+      `[:rf.interceptor/path …]` under a bound `*generation*` could not resolve
+      it (generation-routed `lookup` reads ONLY the generation's resolver — no
+      fallback to the registrar atom), and the `:replace-standard` /
+      invariant-coupled-standard machinery would be dead code (no standard would
+      ever sit in a generation to protect). The standard descriptor carries the
+      SAME `:rf/interceptor-descriptor` slot the regular registrar stores, so a
+      generation-routed resolution returns a byte-shape-identical value.
+
+  The standard is marked NON-replaceable and INVARIANT-COUPLED via
+  `:rf.standard/requires-conformance #{:rf.interceptor.path/commit-identical-no-op}`
+  (the rule-4 frame-commit `identical?` no-op, rf2-ekq28v): an image MUST NOT
+  silently shadow it, and `:replace-standard` against it FAILS LOUD
+  (`:rf.error/image-standard-replacement-forbidden`) until a conformance profile
+  proves a replacement preserves the invariant (EP-0023 §Image Patching And
+  Overrides; `image-assembly/standard-replaceable?`)."
   []
   (icpt-reg/reg-interceptor*
     :rf.interceptor/path
-    {:doc "Framework-standard path interceptor (EP-0022). Focuses an event
-          handler on an app-db sub-slice at the given path-vector; the handler
-          sees/returns only the slice, spliced back into full app-db.
-          Referenced as `[:rf.interceptor/path <path-vector>]`."}
-    {:factory path-factory})
+    path-interceptor-metadata
+    path-interceptor-descriptor)
+  ;; EP-0023: contribute the SAME standard descriptor into the framework-standard
+  ;; registry so it is unioned into every resolved image generation. The
+  ;; descriptor carries `:rf/interceptor-descriptor` (the factory) so a
+  ;; generation-routed `interceptor-registry/resolve-ref` reads it identically to
+  ;; the registrar path. Marked invariant-coupled (non-replaceable until a
+  ;; conformance profile exists — rf2-32siq3.41).
+  (image-assembly/register-standard!
+    :interceptor :rf.interceptor/path
+    (assoc path-interceptor-metadata
+           :rf/interceptor-descriptor path-interceptor-descriptor
+           :rf.standard/requires-conformance #{path-conformance-invariant}))
   nil)
 
 ;; Register at namespace load so standalone require'rs (no init!) get the

--- a/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
@@ -70,6 +70,8 @@
             [re-frame.migration      :as migration]
             [re-frame.realm          :as realm]
             [re-frame.core           :as rf]
+            [re-frame.std-interceptors    :as std]
+            [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support   :as ts]))
 
@@ -793,3 +795,117 @@
         (let [created (rf/make-frame {})]
           (is (keyword? created))
           (rf/destroy-frame! created))))))
+
+;; ===========================================================================
+;; SECTION 9 — Framework-standard registry populated
+;; (EP-0023 §Image — "+ framework standard registrations"; rf2-32siq3.41)
+;; ===========================================================================
+;;
+;; The framework-standard interceptor (`:rf.interceptor/path`) is contributed
+;; into the EP-0023 framework-standard registry at boot, not ONLY into the
+;; regular registrar. Without this (rf2-32siq3.41, .27 Finding 2) the standard
+;; registry shipped EMPTY, so an image-loaded frame whose event references a
+;; standard interceptor BY REFERENCE under a bound `*generation*` could not
+;; resolve it (generation-routed `lookup` reads ONLY the generation's resolver,
+;; no registrar fallback), and the `:replace-standard` / invariant-coupled
+;; machinery was dead code (no standard ever sat in a generation to protect).
+;;
+;; The fixture clears the standard registry per case (it is this wave's own
+;; process state), so these cases RE-SEED via the boot fn `register-standard-
+;; interceptors!` — exactly what `re-frame.core/init!` does — then assert the
+;; standard rides into a generation and resolves under it.
+
+(defn- with-standard-interceptors-seeded
+  "Re-seed the framework-standard interceptors (the boot path
+  `register-standard-interceptors!` runs at ns-load + from `init!`) after the
+  fixture's `clear-standards!`, run `thunk`, returning its value."
+  [thunk]
+  (std/register-standard-interceptors!)
+  (thunk))
+
+(deftest s9-standard-interceptor-is-in-the-framework-standard-registry
+  (testing "EP-0023 §Image: register-standard-interceptors! contributes
+            :rf.interceptor/path into the framework-standard registry, marked
+            invariant-coupled (non-replaceable) — NOT only into the regular
+            registrar (rf2-32siq3.41)"
+    (with-standard-interceptors-seeded
+      (fn []
+        (let [by-kid (into {} (map (juxt (juxt :kind :id) identity))
+                           (asm/standard-descriptors))
+              std-desc (get by-kid [:interceptor :rf.interceptor/path])]
+          (is (some? std-desc)
+              "the standard registry is NO LONGER empty — it carries :rf.interceptor/path")
+          (is (true? (:standard std-desc)) "stamped :standard true")
+          (is (seq (:rf.standard/requires-conformance std-desc))
+              "invariant-coupled — a non-empty :rf.standard/requires-conformance")
+          (is (false? (asm/standard-replaceable? std-desc))
+              "an invariant-coupled standard is NOT replaceable (the rule-4 commit no-op lock)")
+          (is (contains? std-desc :rf/interceptor-descriptor)
+              "carries the SAME interceptor descriptor the regular registrar stores"))))))
+
+(deftest s9-standard-interceptor-ref-resolves-under-a-generation
+  (testing "EP-0023 §Frame-derived live registration resolution: an image-loaded
+            frame whose event references [:rf.interceptor/path …] resolves the
+            standard UNDER the frame's generation — no
+            :rf.error/unregistered-interceptor (rf2-32siq3.41). Before the fix the
+            generation lacked the standard and resolution under *generation* threw."
+    (with-standard-interceptors-seeded
+      (fn []
+        (let [pool  [(reg-desc "shop.cart" :event :cart/add ::cart-add)]
+              img   (rf/image {:include-ns ["shop.cart"]})
+              frame (lf/make-frame {:images [img]} pool)
+              gen   (lf/frame-generation frame)]
+          (testing "the standard rides into the resolved generation"
+            (is (contains? (:rf.gen/resolver gen) [:interceptor :rf.interceptor/path])
+                "the framework standard is unioned into the frame's generation"))
+          (testing "the standard interceptor REF resolves under the frame's generation"
+            (lf/call-with-frame-resolution frame
+              (fn []
+                (is (some? registrar/*generation*) "a generation is bound")
+                ;; The bug: generation-routed lookup of a standard ref threw
+                ;; :rf.error/unregistered-interceptor because the generation
+                ;; lacked the standard. Now it resolves the factory-built path.
+                (let [resolved (icpt-reg/resolve-ref [:rf.interceptor/path [:cart :items]])]
+                  (is (= :rf.interceptor/path (:id resolved))
+                      "the standard path interceptor is built from the generation's descriptor")
+                  (is (fn? (:before resolved)) "an executable path interceptor")))))
+          (testing "absent the fix, a bare missing ref under a generation DOES throw
+                    — proving the resolution path is genuinely generation-routed"
+            (lf/call-with-frame-resolution frame
+              (fn []
+                (is (= :rf.error/unregistered-interceptor
+                       (err-id #(icpt-reg/resolve-ref :app/never-registered))))))))))))
+
+(deftest s9-replace-standard-of-the-path-interceptor-is-invariant-locked
+  (testing "EP-0023 §Image Patching And Overrides: the framework-standard
+            :rf.interceptor/path is invariant-coupled, so an image declaring
+            :replace-standard against it FAILS LOUD
+            (:rf.error/image-standard-replacement-forbidden) until a conformance
+            profile exists — the .5 machinery is now EXERCISED in production, not
+            dead code (rf2-32siq3.41)"
+    (with-standard-interceptors-seeded
+      (fn []
+        (let [pool [(reg-desc "naive.override" :interceptor :rf.interceptor/path ::naive)]
+              img  (rf/image {:id :i
+                              :include-ns ["naive.override"]
+                              :replace-standard {[:interceptor :rf.interceptor/path]
+                                                 {:ns "naive.override"}}})]
+          (is (= :rf.error/image-standard-replacement-forbidden
+                 (err-id #(asm/assemble [img] pool)))))))))
+
+(deftest s9-replace-standard-of-a-replaceable-standard-takes-effect
+  (testing "EP-0023 §Image Patching And Overrides: a replaceable standard +
+            :replace-standard naming the app survivor actually TAKES EFFECT — the
+            replacement winner resolves through the generation, proving the
+            :replace-standard machinery is live (rf2-32siq3.41)"
+    ;; The fixture cleared the registry; register a REPLACEABLE standard directly
+    ;; (no conformance lock) to prove a declared :replace-standard winner wins.
+    (asm/register-standard! :fx :rf.nav/push-url
+                            {:handler-fn ::std-nav :rf.standard/replaceable? true})
+    (let [pool [(reg-desc "product.story" :fx :rf.nav/push-url ::app-nav)]
+          img  (rf/image {:id :i
+                          :include-ns ["product.story"]
+                          :replace-standard {[:fx :rf.nav/push-url] {:ns "product.story"}}})
+          gen  (asm/assemble [img] pool)]
+      (is (= ::app-nav (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))
+          "the declared :replace-standard winner replaces the standard in the generation"))))

--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -306,9 +306,18 @@ shared registration state:
 `image_view_reads/xray-image-isolated-from?` is the registration-disjointness
 predicate, and the proof is on the **REAL non-leakage invariant**, not a proxy:
 it **assembles BOTH images into sealed generations and compares their
-`:rf.gen/resolver` KEYSETS** (the `[kind id]` pairs each frame would resolve),
-returning true iff those keysets are DISJOINT. This is stronger than comparing
-the `:rf.image/include-ns` selector STRINGS (the prior proxy): different globs
+APPLICATION-OWNED `:rf.gen/resolver` KEYSETS** (the `[kind id]` pairs each frame
+would resolve, EXCLUDING the framework-standard registrations), returning true
+iff those application-owned keysets are DISJOINT. The exclusion is load-bearing
+(rf2-32siq3.41): EP-0023 assembly unions the framework standards (e.g.
+`[:interceptor :rf.interceptor/path]`, stamped `:standard true`) into **every**
+resolved generation, so a framework standard is shared by every frame *by
+construction* — it is the framework, not a leak between two application images.
+Comparing the full keysets would therefore report a false-positive overlap on
+the shared standard; `application_resolver_keyset` filters the `:standard true`
+descriptors out before the comparison, so the predicate measures the genuine
+application-registration leak. This is stronger than comparing the
+`:rf.image/include-ns` selector STRINGS (the prior proxy): different globs
 can select OVERLAPPING namespaces, and inline `:registrations` carry no
 `:include-ns` selector at all, yet either can introduce a shared `[kind id]` —
 the keyset comparison catches both, the string comparison neither. The
@@ -321,8 +330,9 @@ live source store — the production-runtime check) and an explicit-pool arity
 form). The `image_view_reads_cljs_test` asserts the isolation **bidirectionally**
 against assembled generations — including the load-bearing case where two
 DIFFERENT globs select OVERLAPPING namespaces (a constructed overlap the string
-proxy would mislabel isolated, the keyset check correctly reports NOT isolated)
-— the assertion the .29 dogfooding review verifies.
+proxy would mislabel isolated, the keyset check correctly reports NOT isolated),
+and that the framework standard rides into BOTH generations yet is excluded from
+the leak comparison — the assertion the .29 dogfooding review verifies.
 
 ### §8.2 Demand-gating & empty state
 
@@ -363,10 +373,15 @@ does not flip `:images?` (there is no image content to show).
   core surfaces (`re-frame.live-frame` / `re-frame.image` /
   `re-frame.image-assembly`), PLUS the Xray-as-its-own-image constructor
   (`xray-image` · `xray-image-id` · `xray-source-glob` · `resolver-keyset` ·
-  `xray-image-isolated-from?`). `resolver-keyset` is the `[kind id]`-keyset
-  reader the strengthened predicate compares; `xray-image-isolated-from?`
-  assembles both images and compares those keysets (live-store + explicit-pool
-  arities, fail-soft to a conservative `false`). Xray may require these core
+  `application-resolver-keyset` · `xray-image-isolated-from?`).
+  `resolver-keyset` is the full `[kind id]`-keyset reader (every resolved
+  registration, framework standards included — what the FRAMES section
+  displays); `application-resolver-keyset` is the application-owned subset
+  (excluding the `:standard true` framework standards the assembly unions into
+  every generation — rf2-32siq3.41) that the disjointness predicate compares;
+  `xray-image-isolated-from?` assembles both images and compares those
+  application-owned keysets (live-store + explicit-pool arities, fail-soft to a
+  conservative `false`). Xray may require these core
   namespaces directly — bundle isolation forbids `implementation/` requiring
   from `tools/`, not the reverse, the same pattern Xray uses for
   `re-frame.frame` / `re-frame.registrar`. (The read seam's fail-soft is

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
@@ -152,6 +152,22 @@
   [generation]
   (set (keys (:rf.gen/resolver generation))))
 
+(defn application-resolver-keyset
+  "The set of `[kind id]` resolver keys a sealed `generation` carries that are
+  APPLICATION-owned — i.e. excluding the FRAMEWORK-STANDARD registrations
+  (descriptors stamped `:standard true`) the EP-0023 assembly unions into EVERY
+  generation (EP-0023 §Image — \"+ framework standard registrations\", e.g.
+  `[:interceptor :rf.interceptor/path]`; rf2-32siq3.41). A framework standard is
+  present in every frame BY DEFINITION — it is the framework, not a leak between
+  two application images — so the registration-isolation invariant
+  (`xray-image-isolated-from?`) compares only the application-owned keysets. A
+  nil generation has the empty keyset. Pure `data -> #{[kind id]}`."
+  [generation]
+  (into #{}
+        (comp (remove (fn [[_kid descriptor]] (:standard descriptor)))
+              (map key))
+        (:rf.gen/resolver generation)))
+
 (defn xray-image-isolated-from?
   "True iff XRAY'S OWN image and a `target-image` are REGISTRATION-DISJOINT —
   the EP-0023 §Xray Beside The Target invariant that the inspector's
@@ -159,11 +175,18 @@
   the inspection tool from becoming part of the thing being inspected.
 
   The check is on the REAL non-leakage invariant, not a proxy: ASSEMBLE both
-  images into sealed generations and compare their `:rf.gen/resolver` KEYSETS
-  (the `[kind id]` pairs each frame would resolve). Isolation holds iff the two
-  keysets are DISJOINT — no `[kind id]` is resolved by BOTH a frame built from
-  Xray's image and a frame built from the target's image, so neither frame can
-  see the other's registrations. This is stronger than comparing the
+  images into sealed generations and compare their APPLICATION-OWNED
+  `:rf.gen/resolver` KEYSETS (the `[kind id]` pairs each frame would resolve,
+  EXCLUDING the framework-standard registrations the EP-0023 assembly unions
+  into every generation — `[:interceptor :rf.interceptor/path]` et al, stamped
+  `:standard true`; rf2-32siq3.41). Isolation holds iff the two
+  application-owned keysets are DISJOINT — no APPLICATION `[kind id]` is resolved
+  by BOTH a frame built from Xray's image and a frame built from the target's
+  image, so neither frame can see the other's APPLICATION registrations. A
+  framework standard is shared by every frame by construction (it is the
+  framework, not a leak between two images), so it is excluded from the
+  comparison rather than reported as a false-positive overlap. This is stronger
+  than comparing the
   `:rf.image/include-ns` selector strings (the prior proxy): different globs can
   select OVERLAPPING namespaces, and inline `:registrations` carry no
   `:include-ns` selector at all, yet either can introduce a shared `[kind id]` —
@@ -196,13 +219,13 @@
    (try
      (let [xray-gen   (image-assembly/assemble [(xray-image)])
            target-gen (image-assembly/assemble [target-image])]
-       (empty? (set/intersection (resolver-keyset xray-gen)
-                                 (resolver-keyset target-gen))))
+       (empty? (set/intersection (application-resolver-keyset xray-gen)
+                                 (application-resolver-keyset target-gen))))
      (catch :default _ false)))
   ([target-image pool]
    (try
      (let [xray-gen   (image-assembly/assemble [(xray-image)] pool)
            target-gen (image-assembly/assemble [target-image] pool)]
-       (empty? (set/intersection (resolver-keyset xray-gen)
-                                 (resolver-keyset target-gen))))
+       (empty? (set/intersection (application-resolver-keyset xray-gen)
+                                 (application-resolver-keyset target-gen))))
      (catch :default _ false))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
@@ -126,20 +126,33 @@
     (let [xray-gen    (image-assembly/assemble [(reads/xray-image)] combined-pool)
           target-gen  (image-assembly/assemble [target-image] combined-pool)
           xray-keys   (reads/resolver-keyset xray-gen)
-          target-keys (reads/resolver-keyset target-gen)]
+          target-keys (reads/resolver-keyset target-gen)
+          ;; The APPLICATION-owned keysets exclude the framework standard the
+          ;; assembly unions into EVERY generation (`:rf.interceptor/path`,
+          ;; stamped :standard true; rf2-32siq3.41) — a framework standard is
+          ;; shared by every frame by construction, NOT a leak between images.
+          xray-app    (reads/application-resolver-keyset xray-gen)
+          target-app  (reads/application-resolver-keyset target-gen)]
       ;; Each frame resolves ITS own ids.
       (is (contains? xray-keys [:event :rf.xray/refresh])
           "Xray's frame resolves Xray's own [kind id]")
       (is (contains? target-keys [:event :counter/inc])
           "the target's frame resolves the target's own [kind id]")
-      ;; Bidirectional non-leakage: no Xray id in the target's keyset, and no
-      ;; target id in Xray's keyset.
-      (is (empty? (set/intersection xray-keys target-keys))
-          "the two resolver keysets are disjoint")
-      (is (every? (fn [[_ id]] (not= "rf.xray" (namespace id))) target-keys)
+      ;; The framework standard rides into BOTH generations (the rf2-32siq3.41
+      ;; fix: the standard registry is no longer empty) — shared by construction,
+      ;; so it is excluded from the leak comparison rather than flagged.
+      (is (contains? xray-keys [:interceptor :rf.interceptor/path])
+          "the framework standard is unioned into Xray's generation")
+      (is (contains? target-keys [:interceptor :rf.interceptor/path])
+          "the framework standard is unioned into the target's generation too")
+      ;; Bidirectional non-leakage on the APPLICATION-owned keysets: no Xray app
+      ;; id in the target's app keyset, and no target app id in Xray's.
+      (is (empty? (set/intersection xray-app target-app))
+          "the two APPLICATION-owned resolver keysets are disjoint")
+      (is (every? (fn [[_ id]] (not= "rf.xray" (namespace id))) target-app)
           "no :rf.xray/* id leaked INTO the target frame's image")
-      (is (every? (fn [[_ id]] (= "rf.xray" (namespace id))) xray-keys)
-          "no target id leaked INTO Xray's image"))))
+      (is (every? (fn [[_ id]] (= "rf.xray" (namespace id))) xray-app)
+          "no target id leaked INTO Xray's image (app-owned ids are all :rf.xray/*)"))))
 
 ;; ---- live reads of the real registry (fail-soft seam) --------------------
 
@@ -150,14 +163,26 @@
     ;; registered under an :id so it enters the live-frame registry.
     (live-frame/make-frame {:id :app/main :images [target-image]} target-pool)
     (let [data (reads/image-view-data)
-          row  (first (filter #(= :app/main (:frame-id %)) (:frames data)))]
+          row  (first (filter #(= :app/main (:frame-id %)) (:frames data)))
+          kids (set (map (juxt :kind :id) (:descriptors (:image row))))]
       (is (true? (:images? data)) "a live image-loaded frame → :images? true")
       (is (some? row) "the registered frame is projected")
-      (is (= 2 (:descriptor-count (:image row)))
-          "the frame's resolved image carries its [kind id] descriptors")
-      (is (contains? (set (map (juxt :kind :id) (:descriptors (:image row))))
-                     [:event :counter/inc])
-          "the resolved descriptor set is the frame's image as a value"))))
+      ;; EP-0023 §Image: the resolved generation = the 2 selected application
+      ;; descriptors + the framework-standard registrations the assembly unions
+      ;; into EVERY generation (`:rf.interceptor/path`, stamped :standard true;
+      ;; rf2-32siq3.41) — so the frame resolves 3 [kind id] entries, not 2.
+      (is (= 3 (:descriptor-count (:image row)))
+          "the frame's resolved image carries its 2 app descriptors + the
+           framework standard the assembly unions in")
+      (is (contains? kids [:event :counter/inc])
+          "the resolved descriptor set is the frame's image as a value")
+      (is (contains? kids [:interceptor :rf.interceptor/path])
+          "the framework standard :rf.interceptor/path rides into the generation")
+      (let [std-row (first (filter #(= [:interceptor :rf.interceptor/path]
+                                       [(:kind %) (:id %)])
+                                   (:descriptors (:image row))))]
+        (is (= :rf.prov/standard (:kind (:provenance std-row)))
+            "the standard is surfaced with the framework-standard provenance marker")))))
 
 (deftest live-reads-fail-soft-empty-registry
   (testing "an empty live-frame registry projects to the honest no-image state"


### PR DESCRIPTION
## Bug (rf2-32siq3.41 — EP-0023 .27 Finding 2)

`image_assembly/standard-registry` shipped **EMPTY**.
`std_interceptors/register-standard-interceptors!` registered
`:rf.interceptor/path` only into the **regular** registrar, never into the
EP-0023 framework-standard registry. Under a bound `*generation*`,
`registrar/lookup` consults **only** the generation's resolver with no
fallback to the registrar atom, so:

- an image-loaded frame whose event referenced `[:rf.interceptor/path …]`
  under a generation threw `:rf.error/unregistered-interceptor` at runtime —
  even though `check-references!` deliberately skips `:rf.interceptor/*` refs
  at assembly as framework-provided (assembly promised it; runtime could not
  find it);
- the `:replace-standard` / `standard-replaceable?` / `resolve-collision`
  machinery was **dead code** — no standard ever sat in a generation to
  protect.

## Fix — option (a)

`register-standard-interceptors!` now **also** calls
`image-assembly/register-standard!` for `:rf.interceptor/path`, carrying the
**same** `:rf/interceptor-descriptor` (the `{:factory path-factory}`) the
regular registrar stores — so a generation-routed resolution is
byte-shape-identical to the registrar path. The standard is marked
invariant-coupled (`:rf.standard/requires-conformance
#{:rf.interceptor.path/commit-identical-no-op}`), so it is non-replaceable
until a conformance profile proves a replacement preserves the rule-4
frame-commit `identical?` no-op (rf2-ekq28v). No new always-on error id; the
existing `:rf.error/image-standard-replacement-forbidden` (already in spec/009)
is now genuinely exercised. spec/002 + spec/009 untouched.

## Tests (EP-0023 conformance §9 — red-before-green verified)

- `s9-standard-interceptor-is-in-the-framework-standard-registry` — the
  registry is no longer empty; the standard is invariant-coupled +
  non-replaceable + carries the interceptor descriptor.
- `s9-standard-interceptor-ref-resolves-under-a-generation` — an image-loaded
  frame resolves `[:rf.interceptor/path …]` under its generation (no throw);
  a genuinely-missing ref under the same generation still throws (proves the
  path is generation-routed).
- `s9-replace-standard-of-the-path-interceptor-is-invariant-locked` —
  `:replace-standard` of the path interceptor fails loud.
- `s9-replace-standard-of-a-replaceable-standard-takes-effect` — a declared
  `:replace-standard` winner actually replaces the standard in the generation.

## Xray image-view follow-on

The standard now rides into **every** generation, so the registration-
isolation predicate `xray-image-isolated-from?` compares **application-owned**
keysets (new `application-resolver-keyset`, excluding `:standard true`) — a
framework standard is shared by every frame by construction, not a leak.
`tools/xray/spec/026-Module-View-Panel.md` §8.1/§8.4 updated to match.

## Gates

- `npm run test:cljs` — 7587 tests / 31188 assertions, 0 failures (incl. the
  new §9 + updated Xray assertions; red-before-green confirmed).
- `npm run test:elision` — clean (EP-0023 assembly-DCE + provenance-survives
  probes pass).
- core JVM `clojure -M:test` — 1768 tests, 0 failures (conformance .cljc runs
  here too).
- xray JVM `clojure -M:test` — 1218 tests, 0 failures.
- `scripts/test-fast-pr.sh` — PASS (all policy/drift guards + markdown anchor
  gates; mkdocs soft-skipped locally, CI runs it).