### PR TITLE
feat(core): EP-0023 collapse slice 2 — non-breaking public reachability (rf/reload-images! + object-target sugar) (rf2-32siq3.32)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -123,6 +123,26 @@
             ;; constructs an image leaves the constructor as Closure-DCE dead
             ;; code.
             [re-frame.image :as image]
+            ;; EP-0023 collapse slice 2 (rf2-32siq3.32): the runnable-object
+            ;; live-frame ns. Required for its PUBLIC hot-reload export
+            ;; `reload-images!` (re-exported below as `rf/reload-images!`) — the
+            ;; frame-targeted, composition-replacing image reload that preserves
+            ;; frame memory (EP-0023 §Hot Reload / §Public API). The ns is
+            ;; ALREADY in the core spine transitively (router / subs / frame /
+            ;; registrar require it for the `{:frame object}` resolution seam), so
+            ;; this adds no new load edge; it pulls only `re-frame.image-assembly`
+            ;; + `re-frame.registrar` + `re-frame.frame` + `re-frame.late-bind` +
+            ;; `re-frame.error` (the core spine), so it is bundle-isolation
+            ;; neutral. An app that never hot-reloads leaves `rf/reload-images!`
+            ;; (and the live-frame reload fns) as Closure-DCE dead code — the
+            ;; elision probe deliberately does NOT root the image-loading path
+            ;; (see elision_probe.cljs). NOTE: the EP-0023 OBJECT-returning
+            ;; `live-frame/make-frame` is NOT re-pointed onto `rf/make-frame` in
+            ;; this slice — `rf/make-frame` stays the EP-0013 RECORD constructor
+            ;; during the migration window (the `assert-no-dual-make-frame!` guard
+            ;; keeps both off one name); the repoint rides the later caller-
+            ;; migration slice.
+            [re-frame.live-frame :as live-frame]
             ;; EP-0023 (rf2-32siq3.11): the EP-0013 -> EP-0023 migration shims +
             ;; diagnostics ns. Carries the surface dispositions as inspectable
             ;; data plus the fail-loud migration diagnostics (cross-realm
@@ -784,6 +804,24 @@
   exported under one name. See EP-0023 §Backwards Compatibility."}
   make-frame    frame/make-frame)
 
+(def ^{:doc "Hot-reload ONE frame's whole image composition, PRESERVING FRAME
+  MEMORY (EP-0023 §Hot Reload / §Public API). `target` is EITHER a frame id
+  (looked up in the process-local live-frame registry) OR a direct live frame
+  OBJECT (`re-frame.live-frame/make-frame`'s return value); `opts` takes the same
+  `:images` VECTOR shape as the object constructor. Reload is composition-
+  REPLACING (it replaces the whole `:images` vector, not one member) and frame-
+  targeted: it re-assembles `:images` into a fresh sealed generation
+  (capability-checked against the frame's own `:rf.frame/capabilities`) and SWAPS
+  only `:rf.frame/generation` onto the frame — app-db, runtime-db, caches,
+  lifecycle, and every other frame slot continue unchanged (\"hot reload must not
+  be implemented by tearing down and recreating the frame\"). It does NOT move
+  sibling frames that previously shared the generation. Returns the reload REPORT
+  `{:rf.frame/frame <reloaded object> :rf.reload/diff {:added … :changed …
+  :removed … :retained …}}`. For an `:id`-bearing frame the registry slot is
+  updated in place. A NEW export (non-breaking); the EP-0023 hot-reload public
+  path. See `re-frame.live-frame/reload-images!`."}
+  reload-images! live-frame/reload-images!)
+
 (def ^{:doc "Atomic `destroy-frame!` + `reg-frame` with the same config —
   full replace (opt-in). Per Spec 002 §reset-frame!. Use sparingly:
   destroy is the normative teardown boundary, so per-feature artefacts
@@ -854,17 +892,95 @@
 ;; `re-frame.core/dispatch*` / `subscribe*` etc., so those defs must
 ;; live here.
 
-(def ^{:doc "Fn-form of `dispatch` for HoF / programmatic dispatch — no
-  call-site source-coord capture. Append `event` to the target frame's
-  router queue; returns nil. Per spec/API.md §Dispatch and subscribe
-  (rf2-ts1a)."}
-  dispatch*       router/dispatch!)
+;; EP-0023 collapse slice 2 (rf2-32siq3.32): the `*`-fns gain a frame-FIRST
+;; positional 2-arity — `(dispatch* frame event-vec)` — beside the established
+;; event-first `(dispatch* event-vec opts)`, so the public macro forms
+;; `(rf/dispatch-sync frame [...])` / `(rf/dispatch frame [...])` (EP-0023
+;; §Public API) route the carried frame TARGET (a frame-id keyword OR a live
+;; frame OBJECT) exactly like the 2-arity `(rf/subscribe frame [...])` already
+;; does. The discriminator is the FIRST arg's shape: an event-vec is ALWAYS a
+;; vector, a frame target NEVER is (a keyword id or a `:rf.frame/object`-marked
+;; object map), so `vector?` on arg-1 cleanly separates the two 2-arg forms —
+;; every existing `(dispatch* [..] opts)` caller (the frame-handle closures, the
+;; macro expansion, programmatic HoF callers) stays byte-identical. The
+;; frame-first form lowers to the established `{:frame target}` opt, which
+;; `re-frame.router/build-envelope` normalizes through `frame/frame-target->id`
+;; (object → runnable-id, keyword unchanged) — no new internal seam, the slice-1
+;; wiring carries it. The optional THIRD positional arg is the call-site coord
+;; the `dispatch` / `dispatch-sync` macro splices in under the OUTERMOST
+;; debug-gate (so it DCEs in `:advanced` + `goog.DEBUG=false`); it is stamped
+;; onto whichever opts map the discriminated form builds.
 
-(def ^{:doc "Fn-form of `dispatch-sync` for HoF / programmatic sync
-  dispatch — no call-site source-coord capture. Process `event`
-  end-to-end synchronously, then drain to fixed point. For tests / REPL
-  / bootstrap only. Per spec/API.md §Dispatch and subscribe (rf2-ts1a)."}
-  dispatch-sync*  router/dispatch-sync!)
+;; The discriminating bodies live in `-impl` fns, and `dispatch*` /
+;; `dispatch-sync*` are `def` ALIASES to them. The alias-`def` (not a direct
+;; `defn`) is DELIBERATE: it keeps the public `*`-fns RE-DEFINABLE under
+;; `with-redefs` from the tools tests (Xray/Story stub `rf/dispatch*`). A direct
+;; `defn` here would let the CLJS compiler attach inline fixed-arity metadata to
+;; `re-frame.core/dispatch*`, so the macro call sites would emit a STATIC
+;; `.cljs$core$IFn$_invoke$arity$N` dispatch that a `with-redefs`'d fn whose arity
+;; set differs cannot satisfy ("arity$N is not a function"); the alias-`def`
+;; preserves the same general-application indirection the previous `(def
+;; dispatch* router/dispatch!)` cross-var alias gave.
+;;
+;; The `*`-fns are 1-or-2-arity ONLY (no call-site arity). The 2-arity
+;; discriminates the frame-first `(dispatch* frame event-vec)` sugar from the
+;; event-first `(dispatch* event-vec opts)` on the FIRST arg's shape (an event-vec
+;; is ALWAYS a vector; a frame target — a keyword id or a `:rf.frame/object`
+;; object map — never is), lowering frame-first to the established `{:frame …}`
+;; opt. Call-site stamping is the MACRO's job (debug-gated, DCE'd in prod) and
+;; reaches these via the 2-arity opts map, so NO `:rf.trace/call-site` literal
+;; lives in these production-reachable bodies (the elision probe asserts the
+;; keyword is ABSENT from the prod bundle).
+
+(defn- dispatch*-impl
+  ([event-vec] (router/dispatch! event-vec))
+  ([a b]
+   (if (vector? a)
+     (router/dispatch! a b)
+     (router/dispatch! b {:frame a}))))
+
+(defn- dispatch-sync*-impl
+  ([event-vec] (router/dispatch-sync! event-vec))
+  ([a b]
+   (if (vector? a)
+     (router/dispatch-sync! a b)
+     (router/dispatch-sync! b {:frame a}))))
+
+(def ^{:doc "Fn-form of `dispatch` for HoF / programmatic dispatch — no
+  call-site source-coord capture. Two 2-arity forms, discriminated by the
+  FIRST arg's shape (EP-0023 §Public API, rf2-32siq3.32):
+
+    (dispatch* event-vec)              — ambient frame (carried scope).
+    (dispatch* event-vec opts)         — event-first; `opts` may carry
+                                         `:frame` (a frame-id keyword OR a
+                                         live frame object), plus the other
+                                         dispatch opts.
+    (dispatch* frame event-vec)        — frame-first; `frame` is a frame-id
+                                         keyword OR a live frame OBJECT
+                                         (`rf/make-frame`'s return value),
+                                         lowered to `{:frame frame}`.
+
+  An event-vec is always a VECTOR; a frame target never is — so `vector?`
+  on the first arg separates the forms. Appends `event` to the target
+  frame's router queue; returns nil. Per spec/API.md §Dispatch and
+  subscribe (rf2-ts1a)."
+       :arglists '([event-vec] [event-vec opts] [frame event-vec])}
+  dispatch*       dispatch*-impl)
+
+(def ^{:doc "Fn-form of `dispatch-sync` for HoF / programmatic sync dispatch — no
+  call-site source-coord capture. Mirrors `dispatch*`'s forms, discriminated by
+  the FIRST arg's shape (EP-0023 §Public API, rf2-32siq3.32):
+
+    (dispatch-sync* event-vec)         — ambient frame.
+    (dispatch-sync* event-vec opts)    — event-first; `opts` may carry `:frame`.
+    (dispatch-sync* frame event-vec)   — frame-first; `frame` is a frame-id
+                                         keyword OR a live frame OBJECT.
+
+  An event-vec is always a VECTOR; a frame target never is. Processes `event`
+  end-to-end synchronously, then drains to fixed point. For tests / REPL /
+  bootstrap only. Per spec/API.md §Dispatch and subscribe (rf2-ts1a)."
+       :arglists '([event-vec] [event-vec opts] [frame event-vec])}
+  dispatch-sync*  dispatch-sync*-impl)
 
 (def ^{:doc "One-shot read of a sub's current value — subscribes, derefs,
   then unsubscribes. Does NOT retain a cache reference. Use in handler
@@ -920,19 +1036,34 @@
      (rf2-ts1a) for error-trace attribution. For HoF / programmatic use
      call `dispatch*`. Per Spec 002 §Routing.
 
-     Canonical `event-vec` shape (best practice — not enforced):
+     Two public 2-arities, discriminated at runtime by the FIRST arg's
+     shape (EP-0023 §Public API, rf2-32siq3.32):
+
+       (dispatch event-vec)             ;; ambient frame (carried scope)
+       (dispatch event-vec opts)        ;; event-first; `opts` may carry
+                                        ;; `:frame` (a frame-id keyword OR a
+                                        ;; live frame object) + other opts
+       (dispatch frame event-vec)       ;; frame-first; `frame` is a frame-id
+                                        ;; keyword OR a live frame OBJECT
+                                        ;; (`rf/make-frame`'s return value)
+
+     An `event-vec` is ALWAYS a vector and a frame target NEVER is, so the
+     two 2-arg forms are unambiguous; the frame-first form mirrors the
+     2-arity `(subscribe frame query-v)` and lowers to the `{:frame frame}`
+     opt. Canonical `event-vec` shape (best practice — not enforced):
        [<event-id>]                   ;; trivial
        [<event-id> <single-scalar>]   ;; single-argument
        [<event-id> {<k> <v>}]         ;; multi-argument — single map payload
      Variadic `[<id> a b c]` is accepted by the runtime for v1-migration
      and caller convenience; the linter nudges new code toward the map
      form. See spec/Conventions.md §Canonical event-vector shape."
-     ([event-vec]
+     {:arglists '([event-vec] [event-vec opts] [frame event-vec])}
+     ([arg1]
       (csm/build-dispatch-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                               event-vec nil))
-     ([event-vec opts]
+                               arg1 nil))
+     ([arg1 arg2]
       (csm/build-dispatch-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                               event-vec opts))))
+                               arg1 arg2))))
 
 #?(:clj
    (defmacro dispatch-sync
@@ -942,15 +1073,26 @@
      in-handler`). Captures call-site coords (rf2-ts1a). For HoF /
      programmatic use call `dispatch-sync*`. Per Spec 002 §dispatch-sync.
 
-     Canonical `event-vec` shape — see `dispatch` docstring above; same
-     best-practice convention applies (id-first, with at most one
+     Two public 2-arities, discriminated at runtime by the FIRST arg's
+     shape (EP-0023 §Public API, rf2-32siq3.32):
+
+       (dispatch-sync event-vec)        ;; ambient frame
+       (dispatch-sync event-vec opts)   ;; event-first; `opts` may carry `:frame`
+       (dispatch-sync frame event-vec)  ;; frame-first; `frame` is a frame-id
+                                        ;; keyword OR a live frame OBJECT
+
+     The frame-first form is the `(rf/dispatch-sync frame [...])` shape a
+     local test harness uses on a `rf/make-frame` object (EP-0023 §Public
+     API). Canonical `event-vec` shape — see `dispatch` docstring above;
+     same best-practice convention applies (id-first, with at most one
      trailing map; variadic tolerated, linter nudges)."
-     ([event-vec]
+     {:arglists '([event-vec] [event-vec opts] [frame event-vec])}
+     ([arg1]
       (csm/build-dispatch-sync-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                    event-vec nil))
-     ([event-vec opts]
+                                    arg1 nil))
+     ([arg1 arg2]
       (csm/build-dispatch-sync-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                    event-vec opts))))
+                                    arg1 arg2))))
 
 #?(:clj
    (defmacro subscribe

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -57,30 +57,62 @@
 ;; / `*ns*` / `*file*` through; we emit the same gated expansion the
 ;; original inlined `defmacro` body produced.
 
+;; EP-0023 collapse slice 2 (rf2-32siq3.32): the 2-arity dispatch surface is now
+;; SHAPE-DISCRIMINATED at runtime by `dispatch*` / `dispatch-sync*` — the first
+;; arg is EITHER an event-vec (event-first `(dispatch [..] opts)`) or a frame
+;; target (frame-first `(dispatch frame [..])`). The call-site delivery is
+;; preserved BACKWARD-COMPATIBLY: the EVENT-FIRST stamped path keeps the historic
+;; 2-arity `(dispatch* event-vec (assoc opts :rf.trace/call-site cs))` shape (so
+;; every existing `(with-redefs [rf/dispatch* (fn [ev _opts] …)])` tools-test stub
+;; that matches the 2-arity contract keeps working), while the NEW FRAME-FIRST
+;; path uses the 3-arity `(dispatch* frame event-vec cs)` (it CANNOT `assoc` the
+;; call-site onto the event VECTOR). The stamped branch therefore discriminates
+;; at RUNTIME on the first arg's shape — `vector?` ⇒ event-first 2-arity, else ⇒
+;; frame-first 3-arity. The PLAIN (production) branch needs no call-site, so it
+;; just calls the 2-arity `dispatch*`, whose OWN `vector?` discrimination routes a
+;; frame-first call. The debug-gate stays OUTERMOST so the whole stamped branch
+;; (the `cs` literal + the discrimination) DCEs under `:advanced` +
+;; `goog.DEBUG=false`. `arg1`/`arg2` are the user's two forms verbatim.
+
+#?(:clj
+   (defn- build-stamped-2
+     "Emit the STAMPED dispatch-family call — ALWAYS a 2-arity `disp` call so the
+     `:rf.trace/call-site` keyword literal lives ONLY in THIS debug-gated macro
+     expansion (DCE'd in production), never in the production-reachable `*`-fn
+     body. `disp-sym` is the fully-qualified `*`-fn (`dispatch*` /
+     `dispatch-sync*`). When the user wrote two args, discriminate at runtime on
+     the first arg's shape: event-first (`arg1` a vector) keeps the historic
+     `(disp event-vec (assoc opts :rf.trace/call-site cs))`; frame-first builds
+     the event-first opts shape `(disp event-vec {:frame frame :rf.trace/call-site
+     cs})` (the call-site keyword stays a macro-literal — no `*`-fn 3-arity, so no
+     keyword leaks into the prod bundle). The 1-arg case is the ambient-frame
+     form, stamped via the 2-arity opts map."
+     [disp-sym arg1 arg2 cs-form]
+     (if arg2
+       `(let [a# ~arg1 b# ~arg2]
+          (if (vector? a#)
+            (~disp-sym a# (assoc b# :rf.trace/call-site ~cs-form))
+            (~disp-sym b# {:frame a# :rf.trace/call-site ~cs-form})))
+       `(~disp-sym ~arg1 {:rf.trace/call-site ~cs-form}))))
+
 #?(:clj
    (defn build-dispatch-form
-     [form-meta ns-sym file event-vec opts-form]
+     [form-meta ns-sym file arg1 arg2]
      (let [cs-form (call-site-form form-meta ns-sym file)
-           stamped (if opts-form
-                     `(re-frame.core/dispatch* ~event-vec
-                                               (assoc ~opts-form :rf.trace/call-site ~cs-form))
-                     `(re-frame.core/dispatch* ~event-vec {:rf.trace/call-site ~cs-form}))
-           plain   (if opts-form
-                     `(re-frame.core/dispatch* ~event-vec ~opts-form)
-                     `(re-frame.core/dispatch* ~event-vec))]
+           stamped (build-stamped-2 're-frame.core/dispatch* arg1 arg2 cs-form)
+           plain   (if arg2
+                     `(re-frame.core/dispatch* ~arg1 ~arg2)
+                     `(re-frame.core/dispatch* ~arg1))]
        (gate stamped plain))))
 
 #?(:clj
    (defn build-dispatch-sync-form
-     [form-meta ns-sym file event-vec opts-form]
+     [form-meta ns-sym file arg1 arg2]
      (let [cs-form (call-site-form form-meta ns-sym file)
-           stamped (if opts-form
-                     `(re-frame.core/dispatch-sync* ~event-vec
-                                                    (assoc ~opts-form :rf.trace/call-site ~cs-form))
-                     `(re-frame.core/dispatch-sync* ~event-vec {:rf.trace/call-site ~cs-form}))
-           plain   (if opts-form
-                     `(re-frame.core/dispatch-sync* ~event-vec ~opts-form)
-                     `(re-frame.core/dispatch-sync* ~event-vec))]
+           stamped (build-stamped-2 're-frame.core/dispatch-sync* arg1 arg2 cs-form)
+           plain   (if arg2
+                     `(re-frame.core/dispatch-sync* ~arg1 ~arg2)
+                     `(re-frame.core/dispatch-sync* ~arg1))]
        (gate stamped plain))))
 
 #?(:clj

--- a/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
@@ -279,8 +279,9 @@
       ;; Independent app-db: divergent event streams over divergent seeds. The
       ;; frame OBJECT is the dispatch target via the `{:frame …}` opt (the
       ;; canonical object-accepting form — build-envelope normalizes the object
-      ;; to its runnable-id; the positional `(dispatch frame event)` sugar is
-      ;; slice-2 facade work).
+      ;; to its runnable-id). The positional `(rf/dispatch frame event)` sugar is
+      ;; also exposed on the facade (slice 2, rf2-32siq3.32) — exercised in the
+      ;; `frame-first-positional-dispatch-forms` test below.
       (rf/dispatch-sync [:counter/inc] {:frame fa})
       (rf/dispatch-sync [:counter/inc] {:frame fa})
       (rf/dispatch-sync [:counter/inc] {:frame fb})
@@ -329,3 +330,105 @@
         (rf/destroy-frame! frame)
         (is (nil? (rf/app-db-value frame))
             "after destroy the object's backing record is gone")))))
+
+;; ===========================================================================
+;; 8. FRAME-FIRST POSITIONAL DISPATCH (EP-0023 collapse slice 2, rf2-32siq3.32)
+;;    — the public-facade `(rf/dispatch-sync frame [...])` / `(rf/dispatch frame
+;;    [...])` sugar routes the carried frame TARGET (a frame-id keyword OR a live
+;;    frame OBJECT), discriminated from the event-first `(dispatch [...] opts)`
+;;    form purely by the FIRST arg's shape (an event-vec is always a vector; a
+;;    frame target never is). Mirrors the 2-arity `(rf/subscribe frame [...])`.
+;; ===========================================================================
+
+(deftest frame-first-positional-dispatch-forms
+  (testing "EP-0023 §Public API: (rf/dispatch-sync frame [event]) and
+            (rf/dispatch frame [event]) target the carried frame — for BOTH a
+            live frame OBJECT and a frame-id keyword — END-TO-END through the
+            target frame's image, identically to the {:frame …} opt form"
+    (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (assoc db :n :global)}))
+    (rf/reg-sub   :counter/value (fn [_db _] :global))
+    (let [pool [(event-desc "ex.counter" :counter/inc
+                            (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+                (sub-desc   "ex.counter" :counter/value (fn [db _] (:n db)))]
+          img  (image/image {:id :ex/counter :include-ns ["ex.counter"]})]
+      (testing "frame OBJECT as the FIRST positional dispatch arg"
+        (let [obj (lf/make-frame {:images [img] :initial-db {:n 0}} pool)]
+          ;; frame-first: object is arg-1, event-vec is arg-2.
+          (rf/dispatch-sync obj [:counter/inc])
+          (rf/dispatch-sync obj [:counter/inc])
+          (is (= 2 (:n (rf/app-db-value obj)))
+              "the IMAGE inc ran twice on the object's OWN app-db (not the global)")
+          (is (= 2 @(rf/subscribe obj [:counter/value]))
+              "the 2-arity object-target subscribe reads the same app-db")))
+      (testing "frame-id KEYWORD as the FIRST positional dispatch arg"
+        (let [_ (lf/make-frame {:id :counter/main :images [img] :initial-db {:n 10}}
+                               pool)]
+          (rf/dispatch-sync :counter/main [:counter/inc])
+          (is (= 11 (:n (rf/app-db-value :counter/main)))
+              "the keyword frame-first form routes to the registered live frame")))
+      (testing "the async (queued) (rf/dispatch frame [event]) form also routes"
+        (let [obj (lf/make-frame {:images [img] :initial-db {:n 0}} pool)]
+          ;; `dispatch` enqueues; drain synchronously via a frame-first sync follow-up
+          (rf/dispatch obj [:counter/inc])
+          (rf/dispatch-sync obj [:counter/inc])   ;; drains the queue + runs once more
+          (is (= 2 (:n (rf/app-db-value obj)))
+              "both the queued and the sync frame-first dispatches ran the image inc")))
+      (testing "the event-first (dispatch [event] {:frame …}) form is unaffected"
+        (let [obj (lf/make-frame {:images [img] :initial-db {:n 0}} pool)]
+          (rf/dispatch-sync [:counter/inc] {:frame obj})
+          (is (= 1 (:n (rf/app-db-value obj)))
+              "event-first opts form still routes the object target byte-identically"))))))
+
+;; ===========================================================================
+;; 9. rf/reload-images! ON THE FACADE (EP-0023 collapse slice 2, rf2-32siq3.32)
+;;    — the public hot-reload export swaps a frame's whole image composition
+;;    while PRESERVING FRAME MEMORY (app-db continues; only the generation moves)
+;;    and returns the reload report. Reachable as `rf/reload-images!`.
+;; ===========================================================================
+
+(deftest reload-images-on-the-facade-swaps-generation-preserving-memory
+  (testing "EP-0023 §Hot Reload / §Public API: rf/reload-images! re-assembles the
+            new :images into a fresh generation and swaps it onto the live frame
+            WITHOUT tearing it down — app-db (frame memory) continues, and the
+            target frame's subsequent dispatch resolves through the NEW image"
+    (let [;; v1 image: inc by 1. v2 image: inc by 10 (same id, different impl).
+          pool-v1 [(event-desc "ex.counter.v1" :counter/inc
+                               (fn [{:keys [db]} _] {:db (update db :n (fnil + 0) 1)}))
+                   (sub-desc   "ex.counter.v1" :counter/value (fn [db _] (:n db)))]
+          pool-v2 [(event-desc "ex.counter.v2" :counter/inc
+                               (fn [{:keys [db]} _] {:db (update db :n (fnil + 0) 10)}))
+                   (sub-desc   "ex.counter.v2" :counter/value (fn [db _] (:n db)))]
+          img-v1 (image/image {:id :ex/counter-v1 :include-ns ["ex.counter.v1"]})
+          img-v2 (image/image {:id :ex/counter-v2 :include-ns ["ex.counter.v2"]})
+          frame  (lf/make-frame {:id :counter/main :images [img-v1] :initial-db {:n 0}}
+                                pool-v1)]
+      ;; Run the v1 image once: n 0 -> 1.
+      (rf/dispatch-sync frame [:counter/inc])
+      (is (= 1 (:n (rf/app-db-value :counter/main))) "v1 inc by 1")
+      ;; HOT RELOAD via the FACADE export — swap the whole composition to v2.
+      (let [report (rf/reload-images! :counter/main {:images [img-v2]} pool-v2)]
+        (is (map? report) "reload-images! returns a report map")
+        (is (contains? report :rf.frame/frame) "report carries the reloaded object")
+        (is (contains? report :rf.reload/diff) "report carries the generation diff")
+        (is (lf/frame-object? (:rf.frame/frame report))))
+      ;; FRAME MEMORY PRESERVED: app-db still holds the v1-computed value.
+      (is (= 1 (:n (rf/app-db-value :counter/main)))
+          "app-db (frame memory) survived the reload — not torn down + recreated")
+      ;; The frame now runs the v2 image: inc by 10.
+      (rf/dispatch-sync :counter/main [:counter/inc])
+      (is (= 11 (:n (rf/app-db-value :counter/main)))
+          "after reload the SAME live frame runs the v2 image's inc (1 + 10)")))
+  (testing "rf/reload-images! also targets a direct frame OBJECT and a bad target
+            fails loud"
+    (let [pool [(event-desc "ex.r" :r/noop (fn [{:keys [db]} _] {:db db}))]
+          img  (image/image {:include-ns ["ex.r"]})
+          obj  (lf/make-frame {:images [img] :initial-db {:n 7}} pool)
+          report (rf/reload-images! obj {:images [img]} pool)]
+      (is (lf/frame-object? (:rf.frame/frame report))
+          "a direct (no-id) object's reloaded copy is returned in the report")
+      (is (= :rf.error/reload-no-such-frame
+             (try (rf/reload-images! :no/such-live-frame {:images [img]} pool)
+                  nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+                    (:rf.error/id (ex-data e)))))
+          "an unknown frame id fails loud through the facade export"))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -377,6 +377,26 @@
   ["re-frame.core" "reg-interceptor*"]    {:tier :advanced    :owner "001" :status "EP-0022"}
   ["re-frame.core" "reg-frame"]           {:tier :front-porch :owner "002" :status "v1"}
   ["re-frame.core" "make-frame"]          {:tier :advanced    :owner "002" :status "v1"}
+  ;; EP-0023 collapse slice 2 (rf2-32siq3.32): `reload-images!` is the public
+  ;; `rf/reload-images!` — the frame-targeted, composition-REPLACING image hot
+  ;; reload that swaps a frame's whole `:images` composition while PRESERVING
+  ;; FRAME MEMORY (app-db / runtime-db / caches / lifecycle continue; only
+  ;; `:rf.frame/generation` moves — EP-0023 §Hot Reload / §Public API).
+  ;; CLASSIFICATION (EP-0015 facade-export diff-time rule): a NEW, deliberate
+  ;; public hot-reload constructor-sibling. Tier `:advanced`, not `:front-porch`
+  ;; — same posture as its siblings `image` / `make-frame`: ordinary apps reach
+  ;; hot reload through the implicit `reg-*` re-eval + source-store reprojection
+  ;; path (`reproject-live-frames!`, an internal hook), so an EXPLICIT
+  ;; composition-replacing reload is the advanced surface for the cases that name
+  ;; their images (multiple surfaces on one page, docs/story/test image
+  ;; overrides). Owned by 002 (Frames — EP-0023's frame/image normative home, the
+  ;; sibling of `image` / `make-frame`). Status `EP-0023` (proposal-stage; the
+  ;; row exists ahead of the spec/API.md projection, which EP-0023 graduates
+  ;; separately — same posture as `image`). NON-BREAKING addition: it is a new
+  ;; name, no existing surface changes; the `rf/make-frame` repoint onto the
+  ;; OBJECT constructor + the `assert-no-dual-make-frame!` retirement are the
+  ;; later caller-migration slice, NOT this one.
+  ["re-frame.core" "reload-images!"]      {:tier :advanced    :owner "002" :status "EP-0023"}
   ;; EP-0023 (rf2-32siq3.17 — image-loaded frames): `image` is the public
   ;; `rf/image` CONSTRUCTOR — it builds an IMAGE value, the selected
   ;; registration-set value a frame resolves against (EP-0023 §Image, §Public

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 509,
+ :var-count 510,
  :tier-vocab
  [:front-porch
   :advanced
@@ -186,6 +186,7 @@
   {:namespace "re-frame.core", :var "register-observability-sink!", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "registrations", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reinstall!", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "reload-images!", :tier :advanced, :kind :fn, :owner "002", :status "EP-0023", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "remove-history-listener!", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "remove-revalidation-listeners!", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "render-head", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
## EP-0023 collapse wave — slice 2 (non-breaking public reachability)

Exposes the EP-0023 runnable-object surface on the public `re-frame.core` facade **non-breakingly**, WITHOUT repointing `rf/make-frame` (it stays the EP-0013 record constructor during the migration window) and WITHOUT retiring `assert-no-dual-make-frame!`. The reachability layer only — the repoint + ~234-caller migration ride later sequenced slices.

### What's exported / classified
- **`rf/reload-images!`** — new facade export aliasing `re-frame.live-frame/reload-images!` (frame-targeted, composition-replacing image hot reload; preserves frame memory; returns the reload report). Classified per the EP-0015 facade-export diff-time rule: manifest sidecar row (`{:tier :advanced :owner \"002\" :status \"EP-0023\"}`, same posture as `image`) + regenerated `spec/api-manifest.edn` (509 → 510 vars), `gen --check` green.

### Object-target sugar on the facade
- Frame-FIRST positional dispatch: **`(rf/dispatch-sync frame [...])`** / **`(rf/dispatch frame [...])`**, mirroring the existing 2-arity `(rf/subscribe frame [...])`. The frame target is a frame-id keyword OR a live frame OBJECT.
- `dispatch*`/`dispatch-sync*` discriminate event-first vs frame-first by the **first arg's shape** (an event-vec is always a vector; a frame target never is), lowering frame-first to the established `{:frame target}` opt — which slice 1's `build-envelope` already normalizes via `frame/frame-target->id`. The event-first `(rf/dispatch [...] {:frame obj})` form (object via opt) is unchanged.

### How the non-breaking constraint is held
- `rf/make-frame` is **not** repointed; `assert-no-dual-make-frame!` is **not** retired. The s8 conformance assertion (`rf/make-frame` returns a keyword during the window) still passes.
- The `*`-fns stay `def`-aliases to private `-impl` fns so they remain `with-redefs`-able from the tools tests (a direct `defn` would force static-arity dispatch at macro call sites and break the Xray/Story stubs).
- Call-site stamping stays in the debug-gated macro: event-first keeps the historic 2-arity `(dispatch* event-vec (assoc opts :rf.trace/call-site cs))` shape (so every existing fixed-arity tools-test stub keeps working); frame-first builds the same event-first opts shape. **No `:rf.trace/call-site` keyword leaks into the production bundle** — elision stays clean.

### Follow-up slices filed (sequenced core → ssr → adapters → repoint)
- rf2-32siq3.45 (core callers) → .46 (ssr, ~150 test callers) → .47 (adapters, ~48) → .48 (REPOINT `rf/make-frame` to the object + retire the dual-export guard).

### Gates
- `npm run test:cljs`: 7585 tests / 31186 assertions, 0 failures, 0 errors (incl. new tests for `rf/reload-images!` + the frame-first dispatch sugar).
- `npm run test:elision`: PASS (43/43 absent in prod; EP-0023 provenance-survives + assembly-DCE).
- `api-manifest gen --check` + all 5 projections (api-md / story / xray / skills / doc-guide) in sync.
- JVM implementation + JVM tools sweeps green; `mkdocs build --strict`; fast-pr spine green.