### PR TITLE
feat(xray): EP-0019 optimistic-mutation lifecycle view (rf2-byl7bk.1)

### DIFF
--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -285,6 +285,45 @@ stacked sections:
      row here is positive evidence the accepted reply continued into app
      workflow; a stale/superseded reply never fires one (it appears as
      `:rf.mutation/stale-suppressed` instead).
+6d. **Optimistic mutations** (EP-0019) — the optimistic-mutation lifecycle,
+   surfacing the parity surface re-frame2 had deferred against TanStack
+   Query / RTK Query / SWR. Each `:rf.mutation/optimistic-applied` (a
+   forward optimistic patch applied to the cache BEFORE the request settles,
+   phase 1.5) is **paired by `:snapshot-id`** with its terminal settle and
+   rendered as one row carrying the bug-class answer "I saw an optimistic
+   apply — did it COMMIT or ROLL BACK, and was there a conflict?":
+   - the **`:outcome` chip** — `:pending` (still in flight; the optimistic
+     value is live on the cache), `:reconciled` (the mutation SUCCEEDED and
+     the authoritative `:populates` / `:patches` COMMITTED over the
+     optimistic value — the recorded inverse was discarded), or
+     `:rolled-back` (the mutation FAILED / was cancelled / restore-dangled
+     and the recorded inverse was replayed, conflict-aware);
+   - the apply facts — the mutation id, instance, work id, generation, the
+     **snapshot id**, the optimistically-patched **affected keys**
+     (summarized — scope/params carry PII), the `:optimistic-tags`
+     tag-matched keys, and the **fail-closed `:target-unresolved`**
+     `{:from-db …}` ids (a tag/target reference that resolved nil and
+     touched NO entry, never an implicit global apply);
+   - **on reconcile** — the count of **committed** keys (the authoritative
+     write owned them) + the `:reconciliation-refetches` (optimistic keys
+     this mutation's invalidation marked stale → the read path refetches);
+   - **on rollback** — the resolved **`:on-conflict`** rule
+     (`:invalidate` default / `:force`) + the per-key **restored-vs-conflict
+     disposition** (an UNMOVED `:revision` `· restored` the recorded
+     `:before` verbatim; a MOVED one `· refetch` deferred to the read path
+     under `:invalidate`, or `· conflict (:force)` restored the stale
+     inverse anyway), the restored / conflicted / refetched key counts.
+
+   Beneath the lifecycle rows, the **`:rf.warning/optimistic-force-clobber`**
+   warnings render loud (red): an `:on-conflict :force` rollback restored a
+   now-stale inverse OVER a concurrent authoritative write — the deliberate
+   single-writer last-write-wins escape, surfaced so an unexpected clobber is
+   visible (the forced keys + the recovery hint `:review-on-conflict`). A
+   STALE / superseded mutation reply produces NEITHER op (the inverse is
+   discarded, never replayed — it appears as `:rf.mutation/stale-suppressed`
+   instead), so an apply with no terminal settle stays `:pending`. The
+   distinction mirrors slice-4a's `:optimistic?` derived sub at the lifecycle
+   level (Spec 016 §Optimistic mutations / §Surfacing to tooling).
 7. **Cache growth** — per-resource aggregate of entry count, owned
    count, and GC-eligible count, plus the totals + live-work count.
    Surfaces unbounded list-param growth (many entries, few owners).
@@ -391,6 +430,30 @@ live-owner ensure resolves it), so the main Trace panel surfaces them
 under its cross-cutting `WARNING` badge while the Resources lifecycle
 timeline colours them `:hydration`.
 
+### The `:rf.mutation/optimistic-*` lifecycle ops (EP-0019)
+
+The optimistic-mutation surface rides on three `:rf.mutation/*` ops the
+framework emits from `re-frame.resources.mutation-events` (NOT members of
+the `:rf.resource/*` `trace-ops` family — they are mutation ops, recognised
+here by their literal op keys via `optimistic-mutation-op?` in
+`panels/resources_helpers.cljc`):
+
+| Operation | Emit site | Carries |
+|---|---|---|
+| `:rf.mutation/optimistic-applied` | `mutation-events.cljc` (phase 1.5, before the request lowers) | `:mutation` `:instance` `:work/id` `:generation` `:scope` `:snapshot-id` `:affected-keys` `:revisions` (per-key `{:resource/key :revision :forward}` at apply time — the conflict-check basis) `:tag-matched-keys` `:target-unresolved` `:cause` |
+| `:rf.mutation/optimistic-reconciled` | `mutation-events.cljc` (mutation SUCCESS — commit) | `:instance` `:mutation` `:work/id` `:generation` `:snapshot-id` `:optimistic-keys` `:committed` `:reconciliation-refetches` `:cause` |
+| `:rf.mutation/optimistic-rolled-back` | `mutation-events.cljc` (mutation FAILURE / cancel / restore-dangle) | `:instance` `:mutation` `:work/id` `:generation` `:snapshot-id` `:on-conflict` `:dispositions` (per-key `{:resource/key :restored :conflict :on-conflict}`) `:restored` `:conflicted` `:refetched` `:cause` |
+
+plus the `:warning`-level `:rf.warning/optimistic-force-clobber` (emitted
+alongside a `:force` rollback that clobbered a concurrent write — carries
+`:mutation` `:instance` `:forced-keys` `:recovery :review-on-conflict`
+`:reason`). The consumer (`optimistic-lifecycle` / `optimistic-force-clobbers`)
+pairs each `:applied` with its terminal settle by `:snapshot-id` to drive the
+§6d **Optimistic mutations** section above. The settle is keyed on the
+recorded `:revision` + the work-id/generation acceptance verdict, never a
+wall-clock race; a STALE / superseded reply emits NEITHER terminal op (the
+inverse is discarded, the apply row stays `:pending`).
+
 `:rf.resource/ensure` / `:rf.resource/refetch` / `:rf.resource/remove` /
 `:rf.resource/window-focused` / `:rf.resource/network-reconnected` /
 `:rf.resource/invalidate-tags` / `:rf.resource/release-owner` are
@@ -461,7 +524,7 @@ override input layered on top; see §Events below.
 | `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db` | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
 | `:rf.xray/resource-sub-reads` | (none) | observed live subscription reads backing the scope-mismatch lint (empty by default). |
 | `:rf.xray/resource-routing-slice` | `:rf.xray/target-frame-runtime-db` | the live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. |
-| `:rf.xray/resources-tab-data` | the six above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :scope-resolvers :instances :work :live-work :stale-races :stale-tally :route-graph :timeline :invalidations :scope-resolutions :mutation-invalidations :continuations :cache-growth :audit}`. Its `:scope-resolvers` is the projected named-scope-resolver registry (id + declared inputs + whole-db cost flag, paths summarized, NO resolved value); `:scope-resolutions` is the `:rf.resource/scope-resolved` resolution timeline (resolver id + resolved scope summarized + fail-closed nil evidence — EP-0016 D3); `:mutation-invalidations` is the descriptor-level invalidation evidence off the mutation settlement traces (per-descriptor resolved scope + fail-closed `:unresolved` + Rider-1 `:populate-exempt` — EP-0016 D2); `:continuations` is the `:rf.mutation/replied` call-site `:reply-to` dispatch evidence (EP-0016 D1). `:route-graph` joins the static route plan against the live instance/work rows + routing slice. The `:live-work` / `:stale-races` / `:stale-tally` slots are the UNIFORM reply-envelope reads (see below). |
+| `:rf.xray/resources-tab-data` | the six above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :scope-resolvers :instances :work :live-work :stale-races :stale-tally :route-graph :timeline :invalidations :scope-resolutions :mutation-invalidations :continuations :optimistic-mutations :optimistic-force-clobbers :cache-growth :audit}`. Its `:scope-resolvers` is the projected named-scope-resolver registry (id + declared inputs + whole-db cost flag, paths summarized, NO resolved value); `:scope-resolutions` is the `:rf.resource/scope-resolved` resolution timeline (resolver id + resolved scope summarized + fail-closed nil evidence — EP-0016 D3); `:mutation-invalidations` is the descriptor-level invalidation evidence off the mutation settlement traces (per-descriptor resolved scope + fail-closed `:unresolved` + Rider-1 `:populate-exempt` — EP-0016 D2); `:continuations` is the `:rf.mutation/replied` call-site `:reply-to` dispatch evidence (EP-0016 D1); `:optimistic-mutations` is the EP-0019 optimistic-mutation lifecycle (each `:rf.mutation/optimistic-applied` paired by `:snapshot-id` with its terminal `:reconciled` / `:rolled-back` settle, carrying the per-key restored-vs-conflict disposition); `:optimistic-force-clobbers` is the `:rf.warning/optimistic-force-clobber` rows (a `:force` rollback over a concurrent write). `:route-graph` joins the static route plan against the live instance/work rows + routing slice. The `:live-work` / `:stale-races` / `:stale-tally` slots are the UNIFORM reply-envelope reads (see below). |
 
 ### Events (test-only override seam — rf2-e8330v / xxo3zz F3)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -603,6 +603,143 @@
        (empty-caption "No :reply-to continuations dispatched in this epoch."
                       "rf-xray-resources-continuations-empty"))]))
 
+;; ---- §6d OPTIMISTIC MUTATIONS (EP-0019) ---------------------------------
+;;
+;; The optimistic-mutation lifecycle: each `:rf.mutation/optimistic-applied`
+;; paired by `:snapshot-id` with its terminal settle. The bug-class question
+;; "I saw an optimistic apply — did it COMMIT or ROLL BACK, and was there a
+;; conflict?" answered in one row: the apply (its snapshot + affected keys),
+;; the `:outcome` chip (`:pending` in flight / `:reconciled` committed /
+;; `:rolled-back`), and on rollback the per-key restored-vs-conflict
+;; disposition + the resolved `:on-conflict` rule. The force-clobber warnings
+;; (an `:on-conflict :force` restore OVER a concurrent authoritative write)
+;; render loud beneath. Per Spec 016 §Optimistic mutations / §Surfacing to
+;; tooling + Xray spec 024 §The optimistic-mutation lifecycle.
+
+(defn- optimistic-outcome-colour
+  "Outcome → token for an optimistic-apply row. `:reconciled` (committed —
+  the happy path) green, `:rolled-back` amber (the inverse won), `:pending`
+  (still in flight, optimistic value live on the cache) accent."
+  [outcome]
+  (case outcome
+    :reconciled  (:green tokens)
+    :rolled-back (:warning tokens)
+    :pending     mode-accent
+    (:text-tertiary tokens)))
+
+(defn- optimistic-outcome-label
+  [outcome]
+  (case outcome
+    :reconciled  "reconciled (committed)"
+    :rolled-back "rolled back"
+    :pending     "pending (optimistic)"
+    (str (some-> outcome name))))
+
+(defn- optimistic-mutation-row-view [row]
+  (let [testid (str "rf-xray-resources-optimistic-row-" (:id row))]
+    [:div {:data-testid testid
+           :data-mutation (str (:mutation row))
+           :data-outcome (str (some-> (:outcome row) name))
+           :style {:display "flex" :flex-direction "column" :gap "2px"
+                   :padding "3px 0" :font-family mono-stack :font-size "11px"}}
+     [:div {:style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"}}
+      [:span {:data-testid (str testid "-outcome")
+              :style {:color       (optimistic-outcome-colour (:outcome row))
+                      :font-weight 600 :min-width "9rem"}}
+       (optimistic-outcome-label (:outcome row))]
+      [:span {:style {:color mode-accent}} (str (:mutation row))]
+      (when (:instance row)
+        [:span {:style {:color (:text-tertiary tokens)}} (pr-str (:instance row))])
+      (when (:generation row)
+        [:span {:style {:color (:text-tertiary tokens)}} "gen " (:generation row)])
+      [:span {:style {:color (:text-tertiary tokens)}}
+       (count (:affected-keys row)) " key(s)"]
+      (when (seq (:target-unresolved row))
+        [:span {:data-testid (str testid "-unresolved")
+                :style {:color (:warning tokens)}}
+         "unresolved (fail-closed): "
+         (str/join " " (map str (:target-unresolved row)))])]
+     ;; the optimistically-patched scoped keys (the snapshot's affected set)
+     (when (seq (:affected-keys row))
+       (into [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
+                            :padding-left "12px"}}
+              [:span {:style {:color (:text-tertiary tokens)}} "affected"]]
+             (for [k (:affected-keys row)]
+               ^{:key (str (:resource-id k) (get-in k [:params :preview]))}
+               (summary-chip (:scope k) nil))))
+     ;; ON RECONCILE — the committed keys (authoritative write owned them)
+     (when (= :reconciled (:outcome row))
+       [:div {:data-testid (str testid "-committed")
+              :style {:padding-left "12px" :color (:green tokens)}}
+        (count (:committed row)) " committed"
+        (when (seq (:reconciliation-refetches row))
+          [:span {:style {:color (:info tokens) :margin-left "6px"}}
+           (count (:reconciliation-refetches row)) " refetched"])])
+     ;; ON ROLLBACK — the conflict-aware per-key disposition + on-conflict rule
+     (when (= :rolled-back (:outcome row))
+       [:div {:data-testid (str testid "-rollback")
+              :style {:display "flex" :flex-direction "column" :gap "1px"
+                      :padding-left "12px"}}
+        [:div {:style {:display "flex" :gap "8px" :flex-wrap "wrap"}}
+         [:span {:style {:color (:text-tertiary tokens)}}
+          "on-conflict " (str (some-> (:on-conflict row) name))]
+         [:span {:style {:color (:green tokens)}}
+          (count (:restored row)) " restored"]
+         (when (seq (:conflicted row))
+           [:span {:data-testid (str testid "-conflicted")
+                   :style {:color (:error tokens)}}
+            (count (:conflicted row)) " conflicted"])
+         (when (seq (:refetched row))
+           [:span {:style {:color (:info tokens)}}
+            (count (:refetched row)) " refetched"])]
+        ;; per-key restored-vs-conflict disposition (the truthful evidence)
+        (into [:div {:style {:display "flex" :flex-direction "column" :gap "1px"}}]
+              (for [d (:dispositions row)]
+                ^{:key (str (get-in d [:resource/key :resource-id])
+                            (get-in d [:resource/key :params :preview]))}
+                [:span {:style {:color (if (:conflict d)
+                                         (:warning tokens)
+                                         (:text-tertiary tokens))}}
+                 (str (get-in d [:resource/key :resource-id]))
+                 (if (:restored d) " · restored" " · refetch")
+                 (when (:conflict d)
+                   (str " · conflict (" (some-> (:on-conflict d) name) ")"))]))])]))
+
+(defn- optimistic-force-clobber-row-view [row]
+  [:div {:data-testid (str "rf-xray-resources-optimistic-clobber-row-" (:id row))
+         :data-mutation (str (:mutation row))
+         :style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"
+                 :padding "2px 0" :font-family mono-stack :font-size "11px"
+                 :color (:error tokens)}}
+   [:span {:style {:font-weight 600 :min-width "9rem"}} "⚠ force clobber"]
+   [:span {:style {:color mode-accent}} (str (:mutation row))]
+   (when (:instance row)
+     [:span {:style {:color (:text-tertiary tokens)}} (pr-str (:instance row))])
+   [:span {:style {:color (:warning tokens)}}
+    (count (:forced-keys row)) " key(s) clobbered"]
+   (when (:recovery row)
+     [:span {:style {:color (:text-tertiary tokens)}}
+      "recovery " (str (some-> (:recovery row) name))])])
+
+(defn- optimistic-mutations-section [{:keys [optimistic-mutations optimistic-force-clobbers]}]
+  (section
+    {:first? false :testid "rf-xray-resources-optimistic"}
+    (section-caption "Optimistic mutations" "rf-xray-resources-optimistic-caption")
+    [:div {:style {:display "flex" :flex-direction "column" :gap "6px"}}
+     (if (seq optimistic-mutations)
+       (into [:div {:data-testid "rf-xray-resources-optimistic-body"
+                    :style {:display "flex" :flex-direction "column" :gap "3px"}}]
+             (for [row optimistic-mutations]
+               ^{:key (str (:id row))} (optimistic-mutation-row-view row)))
+       (empty-caption "No optimistic mutations in this epoch."
+                      "rf-xray-resources-optimistic-empty"))
+     ;; the loud :force-over-a-concurrent-write clobber warnings
+     (when (seq optimistic-force-clobbers)
+       (into [:div {:data-testid "rf-xray-resources-optimistic-clobber-body"
+                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+             (for [row optimistic-force-clobbers]
+               ^{:key (str (:id row))} (optimistic-force-clobber-row-view row))))]))
+
 ;; ---- §7 CACHE GROWTH ----------------------------------------------------
 
 (defn- cache-growth-section [growth]
@@ -700,13 +837,15 @@
   top → bottom: static registry, named scope resolvers (EP-0016 D3), live
   instances, work ledger, route/resource graph, lifecycle timeline,
   invalidation graph, scope resolution timeline (EP-0016 D3), mutation
-  continuations + scoped invalidation (EP-0016 D1/D2), cache growth, scope
+  continuations + scoped invalidation (EP-0016 D1/D2), optimistic mutations
+  (EP-0019 — the apply→reconcile/rollback lifecycle), cache growth, scope
   audit + lints. When the host has no resources registered AND no live
   instances, renders the silent-by-default caption."
   []
   (let [{:keys [silent? registry scope-resolvers instances work route-graph
                 timeline invalidations scope-resolutions mutation-invalidations
-                continuations cache-growth audit]}
+                continuations optimistic-mutations optimistic-force-clobbers
+                cache-growth audit]}
         @(rf/subscribe [:rf.xray/resources-tab-data])]
     [:section {:data-testid "rf-xray-resources"
                :style {:height         "100%"
@@ -730,6 +869,9 @@
         (scope-resolution-section scope-resolutions)
         (continuations-section {:continuations continuations
                                 :mutation-invalidations mutation-invalidations})
+        (optimistic-mutations-section
+          {:optimistic-mutations optimistic-mutations
+           :optimistic-force-clobbers optimistic-force-clobbers})
         (cache-growth-section cache-growth)
         (audit-section audit)])]))
 
@@ -910,6 +1052,15 @@
          ;; dispatch evidence (`:rf.mutation/replied` — phase 6, after cache
          ;; consequences + instance settlement).
          :continuations (h/mutation-continuations trace-buffer)
+         ;; EP-0019 (slice 4b): the optimistic-mutation lifecycle — each
+         ;; `:rf.mutation/optimistic-applied` paired by `:snapshot-id` with its
+         ;; terminal settle (`:reconciled` commit / `:rolled-back`), so a
+         ;; developer SEES an optimistic apply, its snapshot, and whether it
+         ;; committed or rolled back (with the conflict outcome). The
+         ;; `:optimistic-force-clobbers` are the loud `:force`-restored-over-a-
+         ;; concurrent-write warnings.
+         :optimistic-mutations (h/optimistic-lifecycle trace-buffer)
+         :optimistic-force-clobbers (h/optimistic-force-clobbers trace-buffer)
          :cache-growth  (h/cache-growth instance-rows work-rows)
          :audit         {:global-audit (h/global-scope-audit registry-rows)
                          :suspicious   (h/suspicious-global-warnings registry-rows)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -1181,6 +1181,230 @@
                   :target   (:target tags)
                   :cause    (when (contains? tags :cause) (summarize (:cause tags)))})))))
 
+;; ---------------------------------------------------------------------------
+;; EP-0019 — optimistic mutation lifecycle (apply / rolled-back / reconciled).
+;; Spec 016 §Optimistic mutations / §Surfacing to tooling; Xray spec 024
+;; §The optimistic-mutation lifecycle. The runtime (mutation_events.cljc)
+;; applies a FORWARD optimistic patch BEFORE the request settles (phase 1.5)
+;; and records the truthful per-entry INVERSE (snapshot + observed `:revision`)
+;; on the mutation instance row. On reply settlement the recorded inverse is
+;; deterministically disposed:
+;;
+;;   - SUCCESS    -> `:rf.mutation/optimistic-reconciled` — the authoritative
+;;     `:populates` / `:patches` COMMITTED over the optimistic value; the
+;;     recorded inverse was discarded (the commit superseded it).
+;;   - FAILURE / accepted cancel / restore-DANGLE
+;;     -> `:rf.mutation/optimistic-rolled-back` — conflict-aware per-key
+;;     rollback: an UNMOVED `:revision` restores the recorded `:before`
+;;     verbatim (`:restored true`); a MOVED `:revision` defers to
+;;     `:on-conflict` (`:invalidate` default — mark stale + refetch, so
+;;     `:restored false`; `:force` — restore the stale inverse anyway, the
+;;     single-writer last-write-wins escape that also fires
+;;     `:rf.warning/optimistic-force-clobber`).
+;;   - STALE / superseded reply -> NEITHER (the inverse is discarded; never
+;;     replayed — handled by the stale-suppression branch, no op here).
+;;
+;; The developer's bug-class question is "I saw an optimistic apply — did it
+;; COMMIT or ROLL BACK, and was there a conflict?" The projections below pair
+;; each `:applied` with its terminal disposition (by `:snapshot-id`) so an
+;; apply still in flight reads `:pending`, a committed one `:reconciled`, and a
+;; rolled-back one `:rolled-back` (with per-key restored-vs-conflict evidence +
+;; the resolved `:on-conflict` rule). PRIVACY: a `:cause` may carry mutation
+;; data → summarized; the scoped keys carry PII in scope/params → summarized;
+;; the metadata (mutation id, instance, work id, generation, snapshot id,
+;; on-conflict rule, restored/conflict booleans) is framework bookkeeping and
+;; never egressed.
+;; ---------------------------------------------------------------------------
+
+(def optimistic-apply-op
+  "The op the runtime emits for a forward optimistic apply (phase 1.5), BEFORE
+  the request settles. Per Spec 016 §Optimistic mutations."
+  :rf.mutation/optimistic-applied)
+
+(def optimistic-reconcile-op
+  "The op the runtime emits when a mutation SUCCEEDS and the authoritative
+  write COMMITTED over the optimistic value (the recorded inverse discarded).
+  Per Spec 016 §Optimistic settle."
+  :rf.mutation/optimistic-reconciled)
+
+(def optimistic-rollback-op
+  "The op the runtime emits when a mutation FAILS / is cancelled / restore-
+  dangles and the recorded inverse is rolled back (conflict-aware). Per Spec
+  016 §Optimistic settle."
+  :rf.mutation/optimistic-rolled-back)
+
+(def optimistic-force-clobber-op
+  "The `:warning`-level op the runtime emits when an `:on-conflict :force`
+  rollback restored a now-stale inverse OVER a concurrent authoritative write
+  (the deliberate single-writer last-write-wins escape — loud so an unexpected
+  clobber is visible). Per Spec 016 §Optimistic settle / §On-conflict."
+  :rf.warning/optimistic-force-clobber)
+
+(def ^:private optimistic-ops
+  "The closed `:rf.mutation/optimistic-*` lifecycle op set (apply + the two
+  terminal settle dispositions). The force-clobber WARNING is surfaced
+  separately (it rides a rollback) — it is not a lifecycle op."
+  #{optimistic-apply-op optimistic-reconcile-op optimistic-rollback-op})
+
+(defn optimistic-mutation-op?
+  "True iff `operation` is a member of the EP-0019 optimistic-mutation
+  lifecycle op set (`:applied` / `:reconciled` / `:rolled-back`)."
+  [operation]
+  (contains? optimistic-ops operation))
+
+(defn- optimistic-settlement-index
+  "PURE: index the terminal settle dispositions (`:reconciled` / `:rolled-back`)
+  by `:snapshot-id`, so an `:applied` row can be paired with its outcome. Each
+  value is `{:outcome (:reconciled|:rolled-back) :id <trace-id>}` (the LAST
+  terminal seen for a snapshot-id wins, though a snapshot settles exactly once
+  in practice). Apply rows with no terminal settle are left `:pending`."
+  [trace-buffer]
+  (reduce (fn [acc ev]
+            (let [op (trace-op ev)]
+              (if (or (= op optimistic-reconcile-op) (= op optimistic-rollback-op))
+                (let [sid (:snapshot-id (trace-tags ev))]
+                  (cond-> acc
+                    (some? sid)
+                    (assoc sid {:outcome (if (= op optimistic-reconcile-op)
+                                           :reconciled :rolled-back)
+                                :id      (:id ev)})))
+                acc)))
+          {} (or trace-buffer [])))
+
+(defn- rollback-disposition-summary
+  "Summarize ONE `:rf.mutation/optimistic-rolled-back` per-key disposition
+  `{:resource/key … :restored (bool) :conflict (bool) :on-conflict …}` for a
+  render-safe row. PRIVACY: the scoped key carries PII in scope/params →
+  summarized; `:restored` / `:conflict` / `:on-conflict` are bookkeeping."
+  [{scoped-key :resource/key :keys [restored conflict on-conflict]}]
+  (cond-> {:resource/key (scoped-key-summary scoped-key)
+           :restored     (boolean restored)
+           :conflict     (boolean conflict)}
+    (some? on-conflict) (assoc :on-conflict on-conflict)))
+
+(defn optimistic-lifecycle
+  "Project the EP-0019 optimistic-mutation lifecycle from the trace buffer
+  (Spec 016 §Optimistic mutations / §Surfacing to tooling). One row per
+  `:rf.mutation/optimistic-applied`, PAIRED with its terminal settle
+  disposition by `:snapshot-id`:
+
+      {:id              <trace-id>      ; the :applied event's id
+       :snapshot-id     <id>            ; the apply/settle correlation key
+       :mutation        :realworld/favorite-article
+       :instance        [:favorite \"welcome\"]
+       :work-id         <work-id>
+       :generation      8
+       :scope           <summary>       ; PRIVACY — the mutation's resolved scope
+       :affected-keys   [<scoped-key-summary> …]   ; the optimistically-patched keys
+       :forward         [{:resource/key <summary> :revision N :forward :patch} …]
+       :tag-matched-keys [<scoped-key-summary> …]  ; keys reached via :optimistic-tags
+       :target-unresolved [:realworld/tenant]      ; fail-closed {:from-db …} ids
+       :cause           <summary>
+       :outcome         :pending         ; :pending / :reconciled / :rolled-back
+       :settled-id      <trace-id>        ; the terminal settle event's id (when settled)
+       ;; ON RECONCILE (commit):
+       :committed       [<scoped-key-summary> …]   ; keys the authoritative write owned
+       :reconciliation-refetches [<scoped-key-summary> …]
+       ;; ON ROLLBACK:
+       :on-conflict     :invalidate       ; the resolved conflict rule
+       :restored        [<scoped-key-summary> …]   ; keys restored verbatim
+       :conflicted      [<scoped-key-summary> …]   ; keys whose :revision MOVED
+       :refetched       [<scoped-key-summary> …]   ; keys deferred to the read path
+       :dispositions    [{:resource/key <summary> :restored true :conflict false} …]}
+
+  `:outcome` is the headline: an apply with no matching terminal settle is
+  `:pending` (still in flight — the optimistic value is live on the cache); a
+  COMMITTED one is `:reconciled`; a rolled-back one is `:rolled-back` (carrying
+  the per-key restored-vs-conflict evidence + the resolved `:on-conflict`
+  rule). The settle facets (`:committed` / `:restored` / `:conflicted` / …)
+  are read off the terminal event's tags and attached to the apply row, so a
+  developer reads the WHOLE lifecycle of one optimistic apply in a single row.
+  Pure over the trace vector; preserves apply order (oldest-first). Per Spec
+  016."
+  [trace-buffer]
+  (let [buffer    (or trace-buffer [])
+        settle-ix (optimistic-settlement-index buffer)
+        ;; index the terminal settle EVENTS by snapshot-id so the apply row can
+        ;; pull the matching facets (committed / restored / conflicted / …).
+        terminal-by-sid
+        (reduce (fn [acc ev]
+                  (let [op (trace-op ev)]
+                    (if (or (= op optimistic-reconcile-op) (= op optimistic-rollback-op))
+                      (let [sid (:snapshot-id (trace-tags ev))]
+                        (cond-> acc (some? sid) (assoc sid ev)))
+                      acc)))
+                {} buffer)]
+    (->> buffer
+         (filter #(= optimistic-apply-op (trace-op %)))
+         (mapv (fn [ev]
+                 (let [tags     (trace-tags ev)
+                       sid      (:snapshot-id tags)
+                       settled  (get settle-ix sid)
+                       outcome  (:outcome settled :pending)
+                       term-ev  (get terminal-by-sid sid)
+                       term     (trace-tags term-ev)]
+                   (cond-> {:id                (:id ev)
+                            :snapshot-id       sid
+                            :mutation          (:mutation tags)
+                            :instance          (:instance tags)
+                            :work-id           (:work/id tags)
+                            :generation        (:generation tags)
+                            :scope             (summarize (:scope tags))
+                            :affected-keys     (mapv scoped-key-summary (:affected-keys tags))
+                            :forward           (mapv (fn [{scoped-key :resource/key :keys [revision forward]}]
+                                                       {:resource/key (scoped-key-summary scoped-key)
+                                                        :revision     revision
+                                                        :forward      forward})
+                                                     (:revisions tags))
+                            :tag-matched-keys  (mapv scoped-key-summary (:tag-matched-keys tags))
+                            :target-unresolved (vec (:target-unresolved tags))
+                            :cause             (when (contains? tags :cause)
+                                                 (summarize (:cause tags)))
+                            :outcome           outcome}
+                     (some? settled)
+                     (assoc :settled-id (:id settled))
+                     (= :reconciled outcome)
+                     (assoc :committed (mapv scoped-key-summary (:committed term))
+                            :reconciliation-refetches
+                            (mapv scoped-key-summary (:reconciliation-refetches term)))
+                     (= :rolled-back outcome)
+                     (assoc :on-conflict  (:on-conflict term)
+                            :restored     (mapv scoped-key-summary (:restored term))
+                            :conflicted   (mapv scoped-key-summary (:conflicted term))
+                            :refetched    (mapv scoped-key-summary (:refetched term))
+                            :dispositions (mapv rollback-disposition-summary
+                                                (:dispositions term)))))))
+         vec)))
+
+(defn optimistic-force-clobbers
+  "Project the `:rf.warning/optimistic-force-clobber` trace rows (EP-0019
+  §On-conflict). The runtime emits ONE per rollback where `:on-conflict :force`
+  restored a now-stale inverse OVER a concurrent authoritative write (the
+  deliberate single-writer last-write-wins escape — surfaced LOUD so an
+  unexpected clobber is visible). One row per warning:
+
+      {:id          <trace-id>
+       :mutation    :realworld/favorite-article
+       :instance    [:favorite \"welcome\"]
+       :forced-keys [<scoped-key-summary> …]   ; the conflicted keys force-clobbered
+       :recovery    :review-on-conflict
+       :reason      \"mutation … rolled back with :on-conflict :force …\"}
+
+  PRIVACY: the forced scoped keys carry PII in scope/params → summarized; the
+  mutation/instance/recovery/reason are bookkeeping. Pure over the trace
+  vector; preserves order. Per Spec 016."
+  [trace-buffer]
+  (->> (or trace-buffer [])
+       (filter #(= optimistic-force-clobber-op (trace-op %)))
+       (mapv (fn [ev]
+               (let [tags (trace-tags ev)]
+                 {:id          (:id ev)
+                  :mutation    (:mutation tags)
+                  :instance    (:instance tags)
+                  :forced-keys (mapv scoped-key-summary (:forced-keys tags))
+                  :recovery    (:recovery tags)
+                  :reason      (:reason tags)})))))
+
 (defn cache-growth
   "Project the live instance rows + the work ledger into the cache-growth
   view (Spec 016 §Paginated and previous data / §Xray — the cache-growth

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -305,6 +305,87 @@
           (is (re-find #":realworld/save-article" (node-text row))
               "the mutation id surfaced"))))))
 
+;; ---- (3b) EP-0019 optimistic mutation lifecycle render ------------------
+
+(def ep0019-buffer
+  [;; an optimistic apply that SUCCEEDED → reconciled (committed)
+   {:id 60 :op-type :rf.event :operation :rf.mutation/optimistic-applied
+    :tags {:mutation :realworld/favorite-article :instance [:favorite "welcome"]
+           :work/id [:rf.work/resource [:rf.mutation [:favorite "welcome"]] 5]
+           :generation 5 :scope session-scope :snapshot-id "snap-1"
+           :affected-keys [[session-scope :article/by-slug {:slug "welcome"}]]
+           :revisions [{:resource/key [session-scope :article/by-slug {:slug "welcome"}]
+                        :revision 3 :forward :patch}]
+           :tag-matched-keys [] :target-unresolved []
+           :cause [:mutation :realworld/favorite-article [:favorite "welcome"]]}}
+   {:id 61 :op-type :rf.event :operation :rf.mutation/optimistic-reconciled
+    :tags {:mutation :realworld/favorite-article :instance [:favorite "welcome"]
+           :work/id [:rf.work/resource [:rf.mutation [:favorite "welcome"]] 5]
+           :generation 5 :snapshot-id "snap-1"
+           :optimistic-keys [[session-scope :article/by-slug {:slug "welcome"}]]
+           :committed [[session-scope :article/by-slug {:slug "welcome"}]]
+           :reconciliation-refetches []
+           :cause [:mutation :realworld/favorite-article [:favorite "welcome"]]}}
+   ;; an optimistic apply that FAILED → rolled back, with a :force clobber
+   {:id 62 :op-type :rf.event :operation :rf.mutation/optimistic-applied
+    :tags {:mutation :realworld/rename :instance [:rename 7]
+           :work/id [:rf.work/resource [:rf.mutation [:rename 7]] 9]
+           :generation 9 :scope :rf.scope/global :snapshot-id "snap-2"
+           :affected-keys [[:rf.scope/global :realworld/feed {}]]
+           :revisions [{:resource/key [:rf.scope/global :realworld/feed {}]
+                        :revision 2 :forward :seed}]
+           :tag-matched-keys [] :target-unresolved []
+           :cause [:mutation :realworld/rename [:rename 7]]}}
+   {:id 63 :op-type :rf.event :operation :rf.mutation/optimistic-rolled-back
+    :tags {:mutation :realworld/rename :instance [:rename 7]
+           :work/id [:rf.work/resource [:rf.mutation [:rename 7]] 9]
+           :generation 9 :snapshot-id "snap-2" :on-conflict :force
+           :dispositions [{:resource/key [:rf.scope/global :realworld/feed {}]
+                           :restored true :conflict true :on-conflict :force}]
+           :restored [[:rf.scope/global :realworld/feed {}]]
+           :conflicted [[:rf.scope/global :realworld/feed {}]]
+           :refetched []
+           :cause [:rf.mutation/failed :realworld/rename]}}
+   {:id 64 :op-type :warning :operation :rf.warning/optimistic-force-clobber
+    :tags {:mutation :realworld/rename :instance [:rename 7]
+           :forced-keys [[:rf.scope/global :realworld/feed {}]]
+           :recovery :review-on-conflict
+           :reason "mutation :realworld/rename rolled back with :on-conflict :force"}}])
+
+(deftest ep0019-optimistic-surfaces-render
+  (testing "the optimistic-mutation lifecycle renders the apply→settle pairing
+            (reconciled commit + rolled-back conflict) + the force-clobber
+            warning from the trace buffer (EP-0019 slice 4b)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides!)
+      (rf/dispatch-sync [:rf.xray/sync-trace-buffer ep0019-buffer] {:frame :rf/xray})
+      (let [tree (resources/Panel)]
+        ;; the section renders
+        (is (some? (find-by-testid tree "rf-xray-resources-optimistic"))
+            "optimistic-mutations section rendered")
+        ;; the SUCCEEDED apply paired with its reconcile → :reconciled outcome
+        (let [row (find-by-testid tree "rf-xray-resources-optimistic-row-60")]
+          (is (some? row) "the optimistic apply row rendered")
+          (is (re-find #"reconciled" (node-text row))
+              "the committed apply reads reconciled")
+          (is (re-find #":realworld/favorite-article" (node-text row))
+              "the mutation id surfaced")
+          (is (some? (find-by-testid tree "rf-xray-resources-optimistic-row-60-committed"))
+              "the committed keys surfaced"))
+        ;; the FAILED apply paired with its rollback → :rolled-back + conflict
+        (let [row (find-by-testid tree "rf-xray-resources-optimistic-row-62")]
+          (is (some? row) "the rolled-back apply row rendered")
+          (is (re-find #"rolled back" (node-text row))
+              "the failed apply reads rolled back")
+          (is (some? (find-by-testid tree "rf-xray-resources-optimistic-row-62-rollback"))
+              "the rollback disposition surfaced")
+          (is (some? (find-by-testid tree "rf-xray-resources-optimistic-row-62-conflicted"))
+              "the conflicted key surfaced"))
+        ;; the :force clobber warning renders loud
+        (is (some? (find-by-testid tree "rf-xray-resources-optimistic-clobber-row-64"))
+            "the :force-clobber warning row rendered")))))
+
 (deftest instance-row-shows-status-and-owners
   (testing "the instance row surfaces status + owner-count, derived not stored"
     (setup-xray-frame!)

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -28,6 +28,11 @@
     6. **project-route-graph** — routes with `:resources` → graph nodes;
        blocking = SSR wait point.
     7. **lifecycle-timeline / invalidation-graph / cache-growth**.
+    7c. **optimistic mutation lifecycle (EP-0019)** —
+       `optimistic-lifecycle` pairs each `:rf.mutation/optimistic-applied`
+       with its terminal `:reconciled` / `:rolled-back` settle by
+       `:snapshot-id` (or `:pending` when unsettled);
+       `optimistic-force-clobbers` projects the `:force`-clobber warnings.
     8. **lints** — global-scope audit, suspicious-global, scope-mismatch,
        orphaned-owner.
     9. **filters** — instance / work / history filter axes; bounded
@@ -731,6 +736,145 @@
                (:work-id r)))
         ;; the cause is summarized (may carry data)
         (is (map? (:cause r)))))))
+
+;; ---- (7c) EP-0019 optimistic mutation lifecycle -------------------------
+;; each :rf.mutation/optimistic-applied paired by :snapshot-id with its
+;; terminal :reconciled / :rolled-back settle (+ the :force-clobber warning).
+
+(def ^:private opt-scope-a [:rf.scope/session {:user-id "u-1"}])
+(def ^:private opt-key-a [opt-scope-a :realworld/article {:slug "welcome"}])
+(def ^:private opt-key-b [:rf.scope/global :realworld/feed {}])
+
+(def ^:private ep0019-trace-buffer
+  [;; (1) an optimistic apply that SUCCEEDED → reconciled (committed)
+   {:id 20 :operation :rf.mutation/optimistic-applied
+    :tags {:mutation :realworld/favorite-article :instance [:favorite "welcome"]
+           :work/id [:rf.work/resource [:rf.mutation [:favorite "welcome"]] 5]
+           :generation 5 :scope opt-scope-a :snapshot-id "snap-1"
+           :affected-keys [opt-key-a]
+           :revisions [{:resource/key opt-key-a :revision 3 :forward :patch}]
+           :tag-matched-keys [] :target-unresolved []
+           :cause [:mutation :realworld/favorite-article [:favorite "welcome"]]}}
+   {:id 21 :operation :rf.mutation/optimistic-reconciled
+    :tags {:mutation :realworld/favorite-article :instance [:favorite "welcome"]
+           :work/id [:rf.work/resource [:rf.mutation [:favorite "welcome"]] 5]
+           :generation 5 :snapshot-id "snap-1"
+           :optimistic-keys [opt-key-a] :committed [opt-key-a]
+           :reconciliation-refetches [opt-key-b]
+           :cause [:mutation :realworld/favorite-article [:favorite "welcome"]]}}
+   ;; (2) an optimistic apply that FAILED → rolled back, conflict-aware
+   ;;     (one key restored verbatim, one key conflicted & invalidated)
+   {:id 22 :operation :rf.mutation/optimistic-applied
+    :tags {:mutation :realworld/rename :instance [:rename 7]
+           :work/id [:rf.work/resource [:rf.mutation [:rename 7]] 9]
+           :generation 9 :scope :rf.scope/global :snapshot-id "snap-2"
+           :affected-keys [opt-key-a opt-key-b]
+           :revisions [{:resource/key opt-key-a :revision 1 :forward :patch}
+                       {:resource/key opt-key-b :revision 2 :forward :seed}]
+           :tag-matched-keys [opt-key-b]
+           :target-unresolved [:realworld/tenant]
+           :cause [:mutation :realworld/rename [:rename 7]]}}
+   {:id 23 :operation :rf.mutation/optimistic-rolled-back
+    :tags {:mutation :realworld/rename :instance [:rename 7]
+           :work/id [:rf.work/resource [:rf.mutation [:rename 7]] 9]
+           :generation 9 :snapshot-id "snap-2" :on-conflict :invalidate
+           :dispositions [{:resource/key opt-key-a :restored true :conflict false}
+                          {:resource/key opt-key-b :restored false :conflict true
+                           :on-conflict :invalidate}]
+           :restored [opt-key-a] :conflicted [opt-key-b] :refetched [opt-key-b]
+           :cause [:rf.mutation/failed :realworld/rename]}}
+   ;; (3) an optimistic apply with NO terminal settle → :pending (in flight)
+   {:id 24 :operation :rf.mutation/optimistic-applied
+    :tags {:mutation :realworld/toggle :instance [:toggle 1]
+           :work/id [:rf.work/resource [:rf.mutation [:toggle 1]] 11]
+           :generation 11 :scope opt-scope-a :snapshot-id "snap-3"
+           :affected-keys [opt-key-a]
+           :revisions [{:resource/key opt-key-a :revision 0 :forward :seed}]
+           :tag-matched-keys [] :target-unresolved []
+           :cause [:mutation :realworld/toggle [:toggle 1]]}}
+   ;; (4) a :force clobber WARNING (rode a :force rollback over a concurrent write)
+   {:id 25 :operation :rf.warning/optimistic-force-clobber
+    :tags {:mutation :realworld/rename :instance [:rename 7]
+           :forced-keys [opt-key-b] :recovery :review-on-conflict
+           :reason "mutation :realworld/rename rolled back with :on-conflict :force"}}])
+
+(deftest optimistic-mutation-op?-test
+  (testing "the three optimistic lifecycle ops are family members"
+    (is (true? (h/optimistic-mutation-op? :rf.mutation/optimistic-applied)))
+    (is (true? (h/optimistic-mutation-op? :rf.mutation/optimistic-reconciled)))
+    (is (true? (h/optimistic-mutation-op? :rf.mutation/optimistic-rolled-back))))
+  (testing "the force-clobber warning + non-members reject"
+    (is (false? (h/optimistic-mutation-op? :rf.warning/optimistic-force-clobber)))
+    (is (false? (h/optimistic-mutation-op? :rf.mutation/succeeded)))
+    (is (false? (h/optimistic-mutation-op? :rf.resource/succeeded)))))
+
+(deftest optimistic-lifecycle-test
+  (let [rows (h/optimistic-lifecycle ep0019-trace-buffer)]
+    (testing "one row per :rf.mutation/optimistic-applied, in apply order"
+      (is (= 3 (count rows)))
+      (is (= [20 22 24] (mapv :id rows))))
+    (testing "a SUCCEEDED apply pairs with its reconcile by snapshot-id"
+      (let [r (first rows)]
+        (is (= "snap-1" (:snapshot-id r)))
+        (is (= :reconciled (:outcome r)))
+        (is (= 21 (:settled-id r)))
+        (is (= :realworld/favorite-article (:mutation r)))
+        ;; the affected + committed keys are PRIVACY-summarized scoped keys
+        (is (= 1 (count (:affected-keys r))))
+        (is (= :realworld/article (get-in r [:affected-keys 0 :resource-id])))
+        (is (= 1 (count (:committed r))))
+        (is (= :realworld/feed (get-in r [:reconciliation-refetches 0 :resource-id])))
+        ;; the forward op shape rides the row (revision + :patch/:seed)
+        (is (= 3 (get-in r [:forward 0 :revision])))
+        (is (= :patch (get-in r [:forward 0 :forward])))
+        ;; reconciled rows carry NO rollback facets
+        (is (nil? (:on-conflict r)))
+        (is (nil? (:dispositions r)))))
+    (testing "a FAILED apply pairs with its rollback (conflict-aware per-key)"
+      (let [r (second rows)]
+        (is (= "snap-2" (:snapshot-id r)))
+        (is (= :rolled-back (:outcome r)))
+        (is (= 23 (:settled-id r)))
+        (is (= :invalidate (:on-conflict r)))
+        (is (= 1 (count (:restored r))))
+        (is (= 1 (count (:conflicted r))))
+        (is (= 1 (count (:refetched r))))
+        ;; the fail-closed unresolved {:from-db …} ids ride the apply row
+        (is (= [:realworld/tenant] (:target-unresolved r)))
+        ;; per-key disposition: one restored verbatim, one conflicted+refetch
+        (let [restored-d (first (filter :restored (:dispositions r)))
+              conflict-d (first (filter :conflict (:dispositions r)))]
+          (is (= :realworld/article (get-in restored-d [:resource/key :resource-id])))
+          (is (false? (:conflict restored-d)))
+          (is (= :realworld/feed (get-in conflict-d [:resource/key :resource-id])))
+          (is (= :invalidate (:on-conflict conflict-d))))
+        ;; rolled-back rows carry NO reconcile facets
+        (is (nil? (:committed r)))))
+    (testing "an apply with NO terminal settle stays :pending (in flight)"
+      (let [r (nth rows 2)]
+        (is (= "snap-3" (:snapshot-id r)))
+        (is (= :pending (:outcome r)))
+        (is (nil? (:settled-id r)))
+        (is (nil? (:committed r)))
+        (is (nil? (:on-conflict r)))))
+    (testing "PRIVACY — the resolved scope + cause are summarized, never raw"
+      (let [r (first rows)]
+        (is (map? (:scope r)))
+        (is (contains? (:scope r) :preview))
+        (is (map? (:cause r)))))))
+
+(deftest optimistic-force-clobbers-test
+  (let [rows (h/optimistic-force-clobbers ep0019-trace-buffer)]
+    (testing "one row per :rf.warning/optimistic-force-clobber"
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= 25 (:id r)))
+        (is (= :realworld/rename (:mutation r)))
+        (is (= :review-on-conflict (:recovery r)))
+        ;; the forced (clobbered) keys are summarized scoped keys
+        (is (= 1 (count (:forced-keys r))))
+        (is (= :realworld/feed (get-in r [:forced-keys 0 :resource-id])))
+        (is (string? (:reason r)))))))
 
 ;; ---- (8) lints ----------------------------------------------------------
 


### PR DESCRIPTION
## EP-0019 slice 4b — Xray optimistic-mutation lifecycle view

Surfaces the EP-0019 optimistic-mutation lifecycle in Xray's Resources tab. Slices 1-3 (merged) emit the trace ops `:rf.mutation/optimistic-applied` / `:rf.mutation/optimistic-reconciled` / `:rf.mutation/optimistic-rolled-back` + the `:rf.warning/optimistic-force-clobber` warning; this slice extends the Xray **consumer** to render them. No `implementation/` change (the ops already emit; Xray consumes them — bundle isolation preserved).

### What Xray now shows (Resources tab §6d "Optimistic mutations")
Each `:rf.mutation/optimistic-applied` is **paired by `:snapshot-id`** with its terminal settle and rendered as one row answering "I saw an optimistic apply — did it COMMIT or ROLL BACK, and was there a conflict?":
- **`:outcome` chip** — `:pending` (still in flight, optimistic value live on the cache), `:reconciled` (mutation succeeded, authoritative write committed over the optimistic value), or `:rolled-back`.
- apply facts — mutation id, instance, work id, generation, snapshot id, the optimistically-patched affected keys (summarized), and the fail-closed `:target-unresolved` `{:from-db …}` ids.
- **on reconcile** — committed key count + reconciliation-refetches.
- **on rollback** — the resolved `:on-conflict` rule + the per-key restored-vs-conflict disposition (restored / refetch / conflict).
- beneath, the loud (red) `:rf.warning/optimistic-force-clobber` rows (a `:force` rollback that restored a stale inverse over a concurrent authoritative write).

A stale/superseded reply emits neither terminal op, so its apply row stays `:pending`.

### Files
- `tools/xray/src/.../panels/resources_helpers.cljc` — `optimistic-lifecycle`, `optimistic-force-clobbers`, `optimistic-mutation-op?` + op constants (pure, JVM-portable).
- `tools/xray/src/.../panels/resources.cljs` — §6d render section + composite-sub keys.
- `tools/xray/spec/024-Resources-Panel.md` — **spec updated in the same PR** (surface-lane rule): §6d section, the `:rf.mutation/optimistic-*` op table, composite-sub returns.
- tests — helper (`resources_helpers_cljs_test`) + view (`resources_cljs_test`) coverage: reconcile, rollback+conflict, pending, force-clobber.

### Gates
- xray JVM `clojure -M:test`: 1221 tests / 5478 assertions, 0 failures.
- `npm run test:cljs` (node-test): 7609 tests / 31358 assertions, 0 failures.
- `scripts/test-fast-pr.sh`: PASS (incl. markdown link/anchor gates).