### PR TITLE
refactor(core): EP-0023 collapse migration — core callers to runnable make-frame object (rf2-32siq3.45)

### DIFF
--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1225,7 +1225,7 @@
   resolve; :on-match dispatches; fresh nav-token per navigation."
   [{:keys [substrate-kw name]}]
   (testing (str name " — routing: :rf.route/transitioned drives the slice")
-    (let [f          (rf/make-frame {:doc "isolated frame for this test"})
+    (let [f          (frame/make-frame {:doc "isolated frame for this test"})
           home       (route-kw substrate-kw "home")
           article    (route-kw substrate-kw "article")
           load-ev    (mint-kw substrate-kw "article-load")
@@ -1273,8 +1273,8 @@
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
       (subs/reg-runtime-sub route-sub (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
 
-      (let [left  (rf/make-frame {:doc "left tab frame"})
-            right (rf/make-frame {:doc "right tab frame"})]
+      (let [left  (frame/make-frame {:doc "left tab frame"})
+            right (frame/make-frame {:doc "right tab frame"})]
         (rf/dispatch-sync [:rf.route/transitioned (route-path sk2 "/articles")] {:frame left})
         (rf/dispatch-sync [:rf.route/transitioned (route-path sk2 "/articles/intro")] {:frame right})
 
@@ -2053,9 +2053,9 @@
         (if-let [reply (:rf/reply msg)]
           {:db {:article (:value reply)}}
           {:fx [[:rf.http/managed {:request {:method :get :url "/articles/hello"} :decode :json}]]})))
-    (let [left  (rf/make-frame {:doc "left"
+    (let [left  (frame/make-frame {:doc "left"
                                 :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
-          right (rf/make-frame {:doc "right"
+          right (frame/make-frame {:doc "right"
                                 :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})]
       (rf/dispatch-sync [:article/load] {:frame left})
       (rf/dispatch-sync [:article/load] {:frame right})

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -103,7 +103,7 @@
   (testing "(with-new-frame [f (make-frame opts)] body) creates, binds, destroys"
     (let [captured-id (atom nil)
           observed-current (atom nil)]
-      (rf/with-new-frame [f (rf/make-frame {:doc "ephemeral"})]
+      (rf/with-new-frame [f (frame/make-frame {:doc "ephemeral"})]
         (reset! captured-id f)
         (reset! observed-current (rf/current-frame-id))
         (is (= f (rf/current-frame-id))
@@ -128,7 +128,7 @@
   (testing "(with-new-frame [f ...] body) destroys the frame even when body throws"
     (let [captured-id (atom nil)]
       (try
-        (rf/with-new-frame [f (rf/make-frame {:doc "ephemeral-throw"})]
+        (rf/with-new-frame [f (frame/make-frame {:doc "ephemeral-throw"})]
           (reset! captured-id f)
           (throw (ex-info "boom" {:kind ::boom})))
         (catch Exception e
@@ -144,7 +144,7 @@
             destroy runs after"
     (rf/reg-event :wf/initialise (fn [{:keys [db]} _] {:db {:counter 42}}))
     (let [captured-db (atom nil)]
-      (rf/with-new-frame [f (rf/make-frame {:on-create [:wf/initialise]})]
+      (rf/with-new-frame [f (frame/make-frame {:on-create [:wf/initialise]})]
         (reset! captured-db (rf/app-db-value f)))
       (is (= {:counter 42} @captured-db)
           "the body observed the on-create-seeded app-db"))))

--- a/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
@@ -176,7 +176,7 @@
   `:rf.cofx` token under `:rf.cofx/mint-policy :strict`. Returns the durable
   item id the handler folded in."
   [recorded]
-  (let [f (rf/make-frame {:doc          "nine-states replay frame"
+  (let [f (frame/make-frame {:doc          "nine-states replay frame"
                           :fx-overrides {:rf.http/managed
                                          :nine-states.http/managed-demo}})]
     ;; `:initialise` seeds the form slice + resets/spawns the :ui/nine-states
@@ -223,7 +223,7 @@
   the success path fires is stubbed to a no-op so no backend is needed.
   Returns the durable optimistic card id the handler folded in."
   [recorded]
-  (let [f (rf/make-frame {:doc "realworld replay frame"})]
+  (let [f (frame/make-frame {:doc "realworld replay frame"})]
     ;; Stub the managed-HTTP fx so the optimistic-post fx fires harmlessly
     ;; (the durable write under test is the temp card conj'd into
     ;; [:comments :data]; the request itself is irrelevant here).

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -385,7 +385,7 @@
             with the :rf/app-db slice"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (rf/make-frame {:doc "ssr-example client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-example client frame"
                                        :platform :client})
           payload      {:rf/version     1
                         :rf/render-hash "abc12345"
@@ -407,7 +407,7 @@
             payload's :rf/render-hash emits NO :rf.ssr/hydration-mismatch"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (rf/make-frame {:doc "ssr-example verify-match frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-example verify-match frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           client-tree  [:div.page [:h1 "Recent articles"]]
@@ -429,7 +429,7 @@
             (the verify step the example's `run` wires via :render-tree-fn)"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (rf/make-frame {:doc "ssr-example verify-divergent frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-example verify-divergent frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           payload      {:rf/version 1
@@ -452,7 +452,7 @@
             validate fail-closed before installation)"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (rf/make-frame {:doc "ssr-example fail-closed frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-example fail-closed frame"
                                        :platform :client})]
       ;; Seed a known app-db value first so we can prove it survives.
       (rf/dispatch-sync [:articles/loaded {:value [{:id "keep" :title "Keep" :body "b"}]}]
@@ -734,7 +734,7 @@
       ;; Full drain: registers the machine, dispatches into it, asserts the
       ;; app-db landed at :authed. Uses the `:fx-overrides` seam to swap
       ;; `:rf.http/managed` for the per-test canned-success stub.
-      (let [f (rf/make-frame {:fx-overrides {:rf.http/managed :auth.login/canned-success}})]
+      (let [f (frame/make-frame {:fx-overrides {:rf.http/managed :auth.login/canned-success}})]
         (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                               {:email "a@b.com"
                                                :password "secret"}]]
@@ -747,7 +747,7 @@
       ;; a fourth :submit fails the guard and lands at :locked-out. Uses
       ;; `rf/with-fx-overrides` — the lexical-scope counterpart to the
       ;; per-frame `:fx-overrides` opt on `make-frame`.
-      (let [f (rf/make-frame {})]
+      (let [f (frame/make-frame {})]
         (rf/with-fx-overrides {:rf.http/managed :auth.login/canned-failure}
           (dotimes [_ 3]
             (rf/dispatch-sync [:auth.login/flow [:auth.login/submit

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -328,8 +328,8 @@
         (fn [_ [_ payload]]
           {:fx [[:http payload]]}))
 
-      (let [a (rf/make-frame {:fx-overrides {:http :http.stub-A}})
-            b (rf/make-frame {:fx-overrides {:http :http.stub-B}})]
+      (let [a (frame/make-frame {:fx-overrides {:http :http.stub-A}})
+            b (frame/make-frame {:fx-overrides {:http :http.stub-B}})]
         ;; Gensym contract: id is a keyword in the :rf.frame namespace,
         ;; the two ids differ, and neither collides with :rf/default.
         (is (keyword? a))
@@ -668,7 +668,7 @@
       (rf/reg-event :parent/spawn-sub-actor
         (fn [_ _]
           (swap! order conj :parent/before-make-frame)
-          (reset! child-id (rf/make-frame {:on-create [:sub-actor/boot]}))
+          (reset! child-id (frame/make-frame {:on-create [:sub-actor/boot]}))
           (swap! order conj :parent/after-make-frame)
           {}))
       (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -163,20 +163,20 @@
 
       (testing "no overrides — registered fx fires"
         (reset! fired [])
-        (let [f (rf/make-frame {})]
+        (let [f (frame/make-frame {})]
           (rf/dispatch-sync [:fx-test/send] {:frame f})
           (is (= [:registered] @fired))))
 
       (testing "per-frame override applied"
         (reset! fired [])
-        (let [f (rf/make-frame
+        (let [f (frame/make-frame
                   {:fx-overrides {:fx-test/email :fx-test/email.frame}})]
           (rf/dispatch-sync [:fx-test/send] {:frame f})
           (is (= [:per-frame] @fired))))
 
       (testing "per-call override beats per-frame"
         (reset! fired [])
-        (let [f (rf/make-frame
+        (let [f (frame/make-frame
                   {:fx-overrides {:fx-test/email :fx-test/email.frame}})]
           (rf/dispatch-sync
             [:fx-test/send]
@@ -224,7 +224,7 @@
 
       (testing "per-call opt > lexical with-fx-overrides > per-frame"
         (reset! fired [])
-        (let [f (rf/make-frame
+        (let [f (frame/make-frame
                   {:fx-overrides {:fx-test/wo-email :fx-test/wo-email.stub}})]
           (rf/with-fx-overrides {:fx-test/wo-email :fx-test/wo-email.stub}
             ;; Per-call wins over both lexical and per-frame

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -19,6 +19,7 @@
   contract under `:advanced` + `goog.DEBUG=false`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.error-emit :as error-emit]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -405,7 +406,7 @@
                        (fn [_ _] {:fx [[:goum9x/real-fx]]}))
       ;; Per-call override redirects :goum9x/real-fx to an id that is NOT
       ;; registered → override-fallthrough; runtime uses :goum9x/real-fx.
-      (let [f (rf/make-frame {})]
+      (let [f (frame/make-frame {})]
         (rf/dispatch-sync [:goum9x/run-bad-override]
                           {:frame f
                            :fx-overrides {:goum9x/real-fx :goum9x/not-registered}})

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -120,7 +120,7 @@
                             :fx [[:dispatch [:app/ready]]]}))
     (rf/reg-event :app/ready
       (fn [{:keys [db]} _] {:db (assoc db :app/booted? true)}))
-    (let [f (rf/make-frame {:on-create [:app/init]})
+    (let [f (frame/make-frame {:on-create [:app/init]})
           db (rf/app-db-value f)]
       (is (true? (:app/booted? db)) "chained-events boot reached :app/ready")
       (is (= {:loaded? true} (:config db)))))
@@ -138,7 +138,7 @@
           :ready       {}}}))
     ;; :on-create kicks the boot machine; subsequent dispatched lifecycle
     ;; events drive the documented progression to :ready.
-    (let [f (rf/make-frame {:on-create [:app/boot [:configured {:url "/api"}]]})]
+    (let [f (frame/make-frame {:on-create [:app/boot [:configured {:url "/api"}]]})]
       (is (= :loading (get-in (rf/runtime-db-value f) [:rf.runtime/machines :snapshots :app/boot :state]))
           ":on-create transitioned :configuring → :loading")
       (rf/dispatch-sync [:app/boot [:loaded]] {:frame f})

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -350,7 +350,7 @@
       :<- [:diamond/a]
       :<- [:diamond/b]
       (fn [[a b] _] {:a a :b b}))
-    (let [f (rf/make-frame {})]
+    (let [f (frame/make-frame {})]
       (rf/dispatch-sync [:diamond/init] {:frame f})
       (is (= {:a 1 :b 2} (rf/compute-sub [:diamond/c] (rf/app-db-value f)))
           "initial state is fully consistent")
@@ -365,7 +365,7 @@
     (rf/reg-sub :chain/a (fn [db _] (:n db)))
     (rf/reg-sub :chain/b :<- [:chain/a] (fn [a _] (* a 2)))
     (rf/reg-sub :chain/c :<- [:chain/b] (fn [b _] (inc b)))
-    (let [f (rf/make-frame {})]
+    (let [f (frame/make-frame {})]
       (rf/dispatch-sync [:chain/init] {:frame f})
       (is (= 21 (rf/compute-sub [:chain/c] (rf/app-db-value f)))
           "initial: n=10 → b=20 → c=21")
@@ -380,7 +380,7 @@
                      (fn [{:keys [db]} _] {:db (assoc db :unrelated "z")}))   ;; same value
     (rf/reg-sub :stable/a (fn [db _] (:n db)))
     (rf/reg-sub :stable/squared :<- [:stable/a] (fn [a _] (* a a)))
-    (let [f (rf/make-frame {})]
+    (let [f (frame/make-frame {})]
       (rf/dispatch-sync [:stable/init] {:frame f})
       (is (= 25 (rf/compute-sub [:stable/squared] (rf/app-db-value f)))
           "initial value correct: 5*5 = 25")
@@ -774,7 +774,7 @@
 
       (testing "happy path: idle → submitting → authed; session token stored"
         (reset! stored nil)
-        (let [f (rf/make-frame {:fx-overrides {:http :http.canned-success}})]
+        (let [f (frame/make-frame {:fx-overrides {:http :http.canned-success}})]
           (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                                {:email "a@b.c" :password "secret"}]]
                             {:frame f})
@@ -785,7 +785,7 @@
 
       (testing "retry-then-lockout: 3 failures land in :error-shown, 4th in :locked-out"
         (reset! stored nil)
-        (let [f (rf/make-frame {:fx-overrides {:http :http.canned-failure}})]
+        (let [f (frame/make-frame {:fx-overrides {:http :http.canned-failure}})]
           (dotimes [_ 3]
             (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                                  {:email "x@y.z" :password "wrong"}]]
@@ -806,7 +806,7 @@
        :data    {:n 0}
        :actions {:bump (fn [{data :data}] {:data (update data :n inc)})}
        :states  {:idle {:on {:tick {:target :idle :action :bump}}}}})
-    (let [f (rf/make-frame {})]
+    (let [f (frame/make-frame {})]
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
       ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.


### PR DESCRIPTION
## EP-0023 collapse wave — slice 3a (rf2-32siq3.45): CORE-surface caller migration

First caller-migration slice of the collapse chain (.45 core → .46 ssr → .47 adapters → repoint). Migrates the CORE-surface callers off the facade `rf/make-frame` so the eventual repoint slice (where `rf/make-frame` flips to the EP-0023 object constructor) is a **clean flip** with no stranded record-contract callers.

### What changed

32 `rf/make-frame` call sites across 9 core test files → `re-frame.frame/make-frame` (the EP-0013 record constructor, reached directly).

### Why the record constructor, not the object constructor

The bead allows two targets: the object constructor *"where they need the object"*, OR *"the keyword form that survives the eventual repoint."* Every migrated call site depends on the EP-0013 record contract, so the keyword form is the behaviour-preserving target:

- **Keyword-id return** — `with-new-frame [f …]` binds an id and asserts `(= f (rf/current-frame-id))` / `(rf/frame-meta f)`; `frame_lifecycle_test` asserts `(keyword? id)` + `"rf.frame"` namespace; `on_error_test` asserts the frame-attributed error record's `:frame` equals the handle.
- **Record-config keys the object constructor does not consume** — `:fx-overrides`, `:on-create`, `:platform`, `:ssr`, `:doc`. The object constructor (`live-frame/make-frame`) destructures only `:images`/`:id`/`:initial-db`/`:capabilities`/`:adapter` and calls `(reg-frame runnable-id {})`, so it would **silently drop** that config and change behaviour the tests assert against.

`re-frame.frame/make-frame` does **not** move in the repoint slice (only the facade var does), so these calls are byte-identical today and after the flip. The 82 core callers that genuinely want the OBJECT already use `live-frame/make-frame` (untouched).

### Window pins left untouched (they flip at the repoint slice)

- `ep0023_conformance_cljs_test` — `s8-dual-make-frame-export-fails-loud` (asserts the live facade `rf/make-frame` returns a keyword **during the window**)
- `migration_cljs_test` — `facade-make-frame-is-the-ep-0013-record-constructor-only`

No `rf/make-frame` repoint, no retirement of `re-frame.migration/assert-no-dual-make-frame!` — those are the repoint slice. No new always-on ids → no spec/009 change.

### Files (all `implementation/core/test/`)

`adapter/react_shared_suite.cljs`, `core_api_additions_test.clj`, `example_frame_scoping_cljs_test.cljs`, `examples_test.clj`, `frame_lifecycle_test.clj`, `fx_test.clj`, `on_error_test.cljc` (+ `re-frame.frame` require), `pattern_smoke_test.clj`, `smoke_test.clj`.

### Coordination

Did not touch `live_frame.cljc`; no collision with the concurrent `rf2-h4q6cy` reproject worker. Rebased onto latest origin/main (clean).

### Gates

- `npm run test:cljs` — 7611 tests / 31372 assertions / 0 failures (post-rebase)
- core JVM (`clojure -M:test`) — 1770 tests / 7679 assertions / 0 failures
- `npm run test:elision` — PASS (production 43/43 absent; EP-0023 provenance + assembly-DCE)
- `scripts/test-fast-pr.sh` — PASS