### PR TITLE
fix(core): wire reproject-live-frames! to reg-* (coalesced auto-reprojection) (rf2-h4q6cy)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -52,7 +52,12 @@
       swaps the freshly-assembled generation onto any frame whose resolution
       changed — EXPLICIT-image frames included, not only default-image frames. A
       frame whose composition re-resolves byte-for-byte is left untouched (no
-      spurious swap).
+      spurious swap). It is WIRED to fire AUTOMATICALLY on any `reg-*` via a
+      `registrar/add-registration-hook!` seam (rf2-h4q6cy), coalesced across a
+      hot-reload `reg-*` burst onto a single `interop/next-tick` flush — see the
+      §Auto-reprojection section below. So an ordinary `reg-*` re-eval swaps the
+      affected live frame's generation WITHOUT a manual `reload-images!` /
+      `reproject-live-frames!` call.
 
   Reload is frame-targeted: reloading `:counter/left` swaps the generation THAT
   frame runs; it does not move `:counter/right` merely because the two frames
@@ -121,11 +126,13 @@
   requires are
   `re-frame.image-assembly` (the merged assembly entry point),
   `re-frame.registrar` (the `*generation*` resolution seam + the closed kind
-  set), and `re-frame.error` (fail-loud diagnostics) — all already in the core
-  spine."
+  set + the `add-registration-hook!` reprojection seam), `re-frame.interop`
+  (the `next-tick` coalescing primitive + the `debug-enabled?` production gate),
+  and `re-frame.error` (fail-loud diagnostics) — all already in the core spine."
   (:require [re-frame.image-assembly :as asm]
             [re-frame.registrar      :as registrar]
             [re-frame.frame          :as frame]
+            [re-frame.interop        :as interop]
             [re-frame.late-bind      :as late-bind]
             [re-frame.error          :as error]))
 
@@ -803,3 +810,152 @@
               moved))
           {}
           (live-frame-ids)))
+
+;; ===========================================================================
+;; Auto-reprojection on `reg-*` source-store change (EP-0023 §Default Image
+;; Semantics / §Hot Reload — the headline guarantee wired, rf2-h4q6cy)
+;; ===========================================================================
+;;
+;; The EP-0023 headline guarantee (EP-0023:1497, §Default Image Semantics):
+;;
+;;     The `reg-*` path uses the same operation through dependency
+;;     invalidation. A changed `reg-*` entry does not mutate any running
+;;     generation. It MARKS every dependent generation DIRTY, including
+;;     explicit images whose `:include-ns` selector matches the changed
+;;     namespace, resolves new sealed generations, computes the diff, and
+;;     swaps those generations into affected frames.
+;;
+;; `reproject-live-frames!` is that "resolve new generations + swap into
+;; affected frames" operation. Before rf2-h4q6cy NOTHING called it in
+;; production — no hook fired on `reg-*`, so the helper was dead outside tests
+;; and a `reg-*` hot reload in an `:include-ns`-selected namespace left the
+;; running frame on its STALE generation until some external `reload-images!`
+;; or manual `reproject-live-frames!` ran. This slice wires the missing trigger.
+;;
+;; ## Trigger model — DIRTY-FLAG + `next-tick` COALESCING
+;;
+;; The dirtying rule (EP-0023:524) is "mark the projection DIRTY, then resolve a
+;; new generation" — a TWO-PHASE operation, not reproject-per-reg. That split is
+;; exactly the coalescing seam: a hot reload of one namespace re-evaluates the
+;; whole namespace, firing a BURST of synchronous `register!` calls (one per
+;; `reg-*` form). Reprojecting on EACH would re-resolve + re-diff every live
+;; frame N times for an N-registration namespace — O(frames * regs) assembly
+;; churn for a single conceptual reload, and intermediate frames would briefly
+;; observe a HALF-RELOADED namespace (some new descriptors, some old).
+;;
+;; So `register!`'s hook does NOT reproject inline. It MARKS the projection dirty
+;; (sets `pending-reprojection?`) and schedules ONE `interop/next-tick` flush
+;; (only when none is already pending — `mark-dirty-and-schedule!` is the
+;; coalescing gate). The whole synchronous `reg-*` burst sets the same flag and
+;; schedules at most ONE flush; the flush runs AFTER the burst settles (the
+;; macroscopic batch boundary), clears the flag, and reprojects ONCE against the
+;; now-complete source store. `next-tick` is the right boundary: every
+;; synchronous `reg-*` of a reloaded namespace happens before control returns to
+;; the event loop, so the single deferred flush sees the FULL new registration
+;; set, never a partial one. (CLJS: `goog.async.nextTick` microtask; JVM: the
+;; single-thread executor — async there too, which the dev hot-reload semantic
+;; tolerates; tests drive the synchronous `flush-pending-reprojection!`.)
+;;
+;; ## Production elision
+;;
+;; Reprojection is a DEV hot-reload concern: in production the source registrar
+;; stops changing after boot (EP-0023:530 — "the default path feels sealed for
+;; the lifetime of the frame"), so there is nothing to reproject. The whole
+;; wiring is therefore gated on `interop/debug-enabled?` — under `:advanced` +
+;; `goog.DEBUG=false` the gate constant-folds to `false`, the `defonce` install
+;; body DCEs, and the registration path carries ZERO reprojection cost. The
+;; hook adds NO new always-on error id: assembly errors flow through the
+;; existing `resolve-generation!` diagnostics, and the registrar fires
+;; registration hooks ISOLATED (a hook throw is swallowed, never blocking the
+;; `reg-*`), so a reprojection-assembly failure during a dev hot reload cannot
+;; break the underlying registration.
+
+(defonce ^{:private true
+           :doc "Process-local DIRTY flag: true when a `reg-*` source-store change
+  has marked the live-frame projection dirty and a coalesced reprojection is
+  pending (EP-0023:524 — \"default image projection is dirty\"). Set by the
+  registration hook, cleared by the flush. A plain atom (not a ratom) — this is
+  reload-bookkeeping, not reactive frame state."}
+  pending-reprojection?
+  (atom false))
+
+(defn flush-pending-reprojection!
+  "If a `reg-*` source-store change has marked the projection dirty, clear the
+  flag and reproject EVERY registered live frame ONCE against the current source
+  store (the coalesced batch boundary — EP-0023 §Default Image Semantics). A
+  no-op when nothing is pending. Returns the `{frame-id reload-diff}` map of
+  frames that MOVED (empty when none did or when nothing was pending).
+
+  The synchronous counterpart of the `next-tick`-scheduled flush
+  `mark-dirty-and-schedule!` arms: tests (and any caller that needs the
+  reprojection to have happened by a known point) invoke this to force the
+  pending reprojection through deterministically rather than awaiting the
+  deferred tick. The dirty-flag clear is read-then-reset so a re-entrant
+  `reg-*` during reprojection re-arms a fresh flush rather than being lost."
+  []
+  (if @pending-reprojection?
+    (do (reset! pending-reprojection? false)
+        (reproject-live-frames!))
+    {}))
+
+(defn- deferred-flush!
+  "The fire-and-forget tick body the coalescing scheduler arms on
+  `interop/next-tick`. Runs `flush-pending-reprojection!` but SWALLOWS any throw:
+  a deferred background dev-hot-reload reprojection has no caller to surface an
+  exception to (it runs on a microtask / the JVM executor thread, OUTSIDE any
+  `reg-*` call frame), so a throw there would become an unhandled rejection that
+  pollutes unrelated work. Crucially the flush has ALREADY cleared the dirty flag
+  before reprojecting, so a swallowed failure does not wedge the flag set (a
+  subsequent `reg-*` re-arms a fresh tick). The SYNCHRONOUS
+  `flush-pending-reprojection!` and the direct `reproject-live-frames!` keep
+  surfacing throws — only this deferred path is defensive. Returns nil."
+  []
+  (try (flush-pending-reprojection!)
+       (catch #?(:clj Throwable :cljs :default) _ nil))
+  nil)
+
+(defn- mark-dirty-and-schedule!
+  "Mark the live-frame projection DIRTY and schedule ONE coalesced reprojection
+  flush on `interop/next-tick` (EP-0023:524 — mark dirty, then resolve a new
+  generation). The COALESCING GATE: schedule the flush ONLY when no flush is
+  already pending, so a synchronous burst of `reg-*` (a hot-reloaded namespace
+  re-evaluating all its registrations) sets the flag many times but schedules at
+  most ONE deferred flush — reprojecting ONCE at the batch boundary, not per
+  `reg-*`. `compare-and-set!` makes the schedule-decision atomic against the
+  burst. The scheduled body is the error-swallowing `deferred-flush!` (a
+  background tick has no caller to surface a throw to). Returns nil."
+  []
+  ;; Only the transition false→true schedules — the burst's subsequent calls
+  ;; observe the flag already true and add no second tick.
+  (when (compare-and-set! pending-reprojection? false true)
+    (interop/next-tick deferred-flush!))
+  nil)
+
+(defn reproject-on-registration-change!
+  "Registrar registration-hook (`registrar/add-registration-hook!`) body: any
+  `reg-*` (first-time OR re-registration, any kind) is a source-store change, so
+  it MARKS the live-frame projection dirty and schedules a coalesced reprojection
+  (EP-0023 §Default Image Semantics / §Hot Reload — a `reg-*` re-eval in a
+  namespace an explicit `:include-ns` image selects reprojects + swaps the
+  affected explicit-image frames, automatically). Reprojection itself is
+  per-frame conditional (`reproject-live-frame!` only swaps a frame whose
+  composition actually re-resolved differently), so marking dirty on EVERY
+  `reg-*` is safe — an unaffected frame is left untouched at flush time. Ignores
+  its hook-event arg (the dirty mark is registration-set-wide, not per id).
+  Returns nil."
+  [_event]
+  (mark-dirty-and-schedule!))
+
+;; Install the reprojection hook ONCE per process. `defonce` over the install so
+;; a dev `:reload` of THIS ns does not push a duplicate hook into the registrar's
+;; `registration-hooks` vector (it dedupes none, and `clear-all!` does not clear
+;; it) — the same "install a registrar hook once, survive hot-reload" pattern
+;; `re-frame.flows.registry`'s `_hot-reload-hook` and `re-frame.routing`'s
+;; `_url-bound-exclusivity-hook` use. Gated on `interop/debug-enabled?` so the
+;; whole install (and thus any reprojection cost on the registration path) is
+;; constant-folded away under `:advanced` + `goog.DEBUG=false`: production stops
+;; `reg-*`-ing after boot, so there is nothing to reproject (EP-0023:530).
+(defonce ^:private _auto-reprojection-hook
+  (when interop/debug-enabled?
+    (registrar/add-registration-hook! reproject-on-registration-change!)
+    :installed))

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -879,6 +879,19 @@
   pending-reprojection?
   (atom false))
 
+(defonce ^{:private true
+           :doc "Process-local RE-ENTRANCY guard: true WHILE a reprojection flush
+  is running. `reproject-live-frames!` re-assembles + swaps generations only — it
+  must never `reg-*`, so it must never re-arm the hook. But the EP-0023 collapse
+  (rf2-32siq3.32) made `make-frame` create a backing runnable RECORD via
+  `frame/reg-frame` (a `register!`), so the auto-reprojection hook now fires on
+  `:frame` registrations too. Were a flush to ever provoke a `register!`
+  (defensively — none is expected), this guard makes the hook a NO-OP during the
+  flush so a flush can never schedule its own successor. A plain atom — flush
+  bookkeeping, not reactive state."}
+  reprojecting?
+  (atom false))
+
 (defn flush-pending-reprojection!
   "If a `reg-*` source-store change has marked the projection dirty, clear the
   flag and reproject EVERY registered live frame ONCE against the current source
@@ -891,11 +904,19 @@
   reprojection to have happened by a known point) invoke this to force the
   pending reprojection through deterministically rather than awaiting the
   deferred tick. The dirty-flag clear is read-then-reset so a re-entrant
-  `reg-*` during reprojection re-arms a fresh flush rather than being lost."
+  `reg-*` during reprojection re-arms a fresh flush rather than being lost.
+
+  The reproject runs under the `reprojecting?` RE-ENTRANCY guard: any
+  `register!` the reproject provokes (the EP-0023 collapse made `make-frame`'s
+  backing `reg-frame` fire the hook; reproject itself never `reg-*`s, but this
+  is defensive) sees the guard set and is a NO-OP, so a flush can never schedule
+  its own successor — bounding the work to ONE reprojection per pending mark."
   []
   (if @pending-reprojection?
     (do (reset! pending-reprojection? false)
-        (reproject-live-frames!))
+        (reset! reprojecting? true)
+        (try (reproject-live-frames!)
+             (finally (reset! reprojecting? false))))
     {}))
 
 (defn- deferred-flush!
@@ -923,12 +944,37 @@
   most ONE deferred flush — reprojecting ONCE at the batch boundary, not per
   `reg-*`. `compare-and-set!` makes the schedule-decision atomic against the
   burst. The scheduled body is the error-swallowing `deferred-flush!` (a
-  background tick has no caller to surface a throw to). Returns nil."
+  background tick has no caller to surface a throw to).
+
+  TWO short-circuits keep this off the hot path so an ordinary registration
+  burst with no live image frames costs essentially nothing (rf2-h4q6cy fix):
+
+    * NO-LIVE-FRAME skip — reprojection only ever touches PUBLIC-id live frames
+      (`reproject-live-frames!` enumerates `live-frame-ids`). With none live the
+      flush would be a guaranteed no-op, so there is nothing to mark dirty or
+      schedule. This is the dominant case: every `reg-event` / `reg-sub` /
+      `reg-fx` — and the `reg-frame` of EVERY runnable frame's backing record
+      since the EP-0023 collapse (rf2-32siq3.32) — funnels through `register!`
+      and so fires this hook, but the overwhelming majority run while NO explicit
+      `:id` frame is live (app boot, every handler-only test). Marking +
+      scheduling on each would flood `interop/next-tick` with one no-op flush per
+      registration — the bundle has thousands — interleaving expensive deferred
+      callbacks with the async test runner's own scheduling and never settling
+      (the observed CI node-test / browser hang). Skipping when nothing is
+      reprojectable removes the flood; a `reg-*` while a live image frame DOES
+      exist (the headline-guarantee case) still marks + schedules.
+
+    * RE-ENTRANCY skip — a `register!` that fires WHILE a flush is running
+      (`reprojecting?` set) does not re-arm: a flush can never schedule its own
+      successor, so the work is bounded to ONE reprojection per pending mark
+      regardless of any registration the reproject path provokes."
   []
-  ;; Only the transition false→true schedules — the burst's subsequent calls
-  ;; observe the flag already true and add no second tick.
-  (when (compare-and-set! pending-reprojection? false true)
-    (interop/next-tick deferred-flush!))
+  (when (and (not @reprojecting?)
+             (seq (live-frame-ids)))
+    ;; Only the transition false→true schedules — the burst's subsequent calls
+    ;; observe the flag already true and add no second tick.
+    (when (compare-and-set! pending-reprojection? false true)
+      (interop/next-tick deferred-flush!)))
   nil)
 
 (defn reproject-on-registration-change!

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -527,43 +527,172 @@
   (testing "a BURST of reg-* (a hot-reloaded namespace re-evaluating N
             registrations) schedules at MOST ONE deferred reprojection flush — the
             coalescing gate (rf2-h4q6cy). Counting the next-tick schedules proves
-            the burst reprojects ONCE at the batch boundary, not per reg-*."
+            the burst reprojects ONCE at the batch boundary, not per reg-*. A live
+            explicit-image frame over the reloaded ns must exist for the schedule
+            to arm at all (the no-live-frame short-circuit — see the burst-with-no-
+            live-frame test below); make-frame it first."
     (let [snapshot  @source-store/kind->id->ns->descriptor
           scheduled (atom 0)
           captured  (atom nil)]
       (try
-        ;; Drain any pending flush so the burst below starts from a clean
-        ;; (un-pending) flag — the first reg-* of the burst is the false→true edge.
-        (lf/flush-pending-reprojection!)
-        ;; Redef next-tick to COUNT schedules and CAPTURE (defer) the flush —
-        ;; deliberately NOT run inline, so the dirty flag stays set through the
-        ;; whole burst exactly as a real deferred tick would leave it. If the
-        ;; coalescing gate works, only the first reg-* (false→true) schedules; the
-        ;; other four observe the flag already set and add no second tick. The
-        ;; re-arm step below stays INSIDE this redef so its schedule hits the same
-        ;; counting next-tick (outside, the real next-tick would not be counted).
-        (with-redefs [interop/next-tick (fn [f] (swap! scheduled inc)
-                                          (reset! captured f) nil)]
-          ;; A burst of 5 reg-* in one synchronous run (a namespace re-eval).
-          (doseq [n (range 5)]
-            (registrar/register! :event (keyword "burst" (str "e" n))
-              {:rf.provenance/ns "burst.feature" :handler-fn (keyword "impl" (str n))}))
-          (testing "the 5-reg-* burst scheduled exactly ONE flush (coalesced) —
-                    the deferred tick was never run during the burst"
-            (is (= 1 @scheduled)
-                "compare-and-set! gates: only the false→true transition schedules"))
-          (testing "running the single captured tick drains the whole burst at once,
-                    and a post-drain reg-* re-arms a fresh tick (flag re-armable)"
-            (when-let [tick @captured] (tick))
-            ;; The drain (`tick` → flush) cleared the dirty flag; a new reg-* is the
-            ;; next false→true edge, so it schedules again — proving the flag is not
-            ;; stuck-set after a flush. (Inside the redef, so this counts here.)
-            (registrar/register! :event :burst/e0
-              {:rf.provenance/ns "burst.feature" :handler-fn ::e0-again})
-            (is (= 2 @scheduled)
-                "a post-drain reg-* re-arms a new tick (flag cleared, re-armable)")))
+        ;; A live frame selecting the burst namespace, so the auto-reprojection
+        ;; schedule is REACHABLE (the hook short-circuits to a no-op when no live
+        ;; image frame exists). Record a descriptor in burst.feature FIRST so the
+        ;; image's :include-ns selector matches (a zero-match is fail-loud at
+        ;; image construction); construct the image AFTER. make-frame's own backing
+        ;; reg-frame fires the hook, so drain afterwards to start the burst from a
+        ;; clean (un-pending) flag — the first burst reg-* is then the false→true edge.
+        (source-store/record-descriptor!
+          :event :burst/seed
+          {:rf.provenance/ns "burst.feature" :kind :event :id :burst/seed
+           :handler-fn ::burst-seed})
+        (let [img (image/image {:id :burst/img :include-ns ["burst.feature"]})]
+          (lf/make-frame {:id :burst/main :images [img]})
+          (lf/flush-pending-reprojection!)
+          ;; Redef next-tick to COUNT schedules and CAPTURE (defer) the flush —
+          ;; deliberately NOT run inline, so the dirty flag stays set through the
+          ;; whole burst exactly as a real deferred tick would leave it. If the
+          ;; coalescing gate works, only the first reg-* (false→true) schedules; the
+          ;; other four observe the flag already set and add no second tick. The
+          ;; re-arm step below stays INSIDE this redef so its schedule hits the same
+          ;; counting next-tick (outside, the real next-tick would not be counted).
+          (with-redefs [interop/next-tick (fn [f] (swap! scheduled inc)
+                                            (reset! captured f) nil)]
+            ;; A burst of 5 reg-* in one synchronous run (a namespace re-eval).
+            (doseq [n (range 5)]
+              (registrar/register! :event (keyword "burst" (str "e" n))
+                {:rf.provenance/ns "burst.feature" :handler-fn (keyword "impl" (str n))}))
+            (testing "the 5-reg-* burst scheduled exactly ONE flush (coalesced) —
+                      the deferred tick was never run during the burst"
+              (is (= 1 @scheduled)
+                  "compare-and-set! gates: only the false→true transition schedules"))
+            (testing "running the single captured tick drains the whole burst at once,
+                      and a post-drain reg-* re-arms a fresh tick (flag re-armable)"
+              (when-let [tick @captured] (tick))
+              ;; The drain (`tick` → flush) cleared the dirty flag; a new reg-* is the
+              ;; next false→true edge, so it schedules again — proving the flag is not
+              ;; stuck-set after a flush. (Inside the redef, so this counts here.)
+              (registrar/register! :event :burst/e0
+                {:rf.provenance/ns "burst.feature" :handler-fn ::e0-again})
+              (is (= 2 @scheduled)
+                  "a post-drain reg-* re-arms a new tick (flag cleared, re-armable)"))))
         (finally
+          ;; Forget the live frame before draining (see register!-during-flush's
+          ;; finally): a pending reproject of :burst/main must not re-assemble its
+          ;; image after the burst descriptors are unregistered.
+          (lf/clear-live-frames!)
+          (lf/flush-pending-reprojection!)
           (doseq [n (range 5)]
             (registrar/unregister! :event (keyword "burst" (str "e" n))))
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ---- the HANG GUARD: a burst with NO live frame schedules ZERO flushes -----
+;;
+;; rf2-h4q6cy fix: the auto-reprojection hook fires on EVERY register! (the
+;; EP-0023 collapse made make-frame's backing reg-frame a register! too, so even
+;; frame creation funnels through it). Marking dirty + scheduling a next-tick
+;; flush on each — when there is NOTHING reprojectable (no PUBLIC-id live frame
+;; exists) — floods the microtask queue with one no-op deferred flush per
+;; registration. The bundle issues thousands of reg-* with no live image frame
+;; (app boot, every handler-only test); the flood interleaved with cljs.test's
+;; async scheduling never settled (the observed CI node-test / browser-test /
+;; elision hang). The fix short-circuits the hook to a NO-OP when no live frame
+;; is reprojectable, so a registration burst with no live frame schedules ZERO
+;; flushes — the bounded-flush guarantee.
+
+(deftest reg-star-burst-with-no-live-frame-schedules-nothing
+  (testing "a BURST of reg-* with NO live image frame schedules ZERO deferred
+            flushes (rf2-h4q6cy hang guard): with nothing reprojectable the hook
+            short-circuits, so a hot-reloaded namespace re-evaluating N
+            registrations costs no next-tick scheduling at all — bounding the
+            flush work that previously hung CI's node-test/browser jobs."
+    (let [snapshot  @source-store/kind->id->ns->descriptor
+          scheduled (atom 0)]
+      (try
+        ;; No live frame: clear the registry and drain any residual pending flush a
+        ;; prior case left, so the flag starts clean and live-frame-ids is empty.
+        (lf/clear-live-frames!)
+        (lf/flush-pending-reprojection!)
+        (with-redefs [interop/next-tick (fn [_f] (swap! scheduled inc) nil)]
+          ;; A 50-reg-* burst with no reprojectable frame — the worst-case flood
+          ;; the hang guard suppresses. EVERY one fires the hook.
+          (doseq [n (range 50)]
+            (registrar/register! :event (keyword "noframe" (str "e" n))
+              {:rf.provenance/ns "noframe.feature" :handler-fn (keyword "impl" (str n))}))
+          (testing "no live frame ⇒ the hook short-circuits ⇒ ZERO flushes scheduled"
+            (is (= 0 @scheduled)
+                "no PUBLIC-id live frame is reprojectable, so nothing is marked or scheduled"))
+          (testing "the dirty flag was never set (nothing pending to drain)"
+            (is (empty? (lf/flush-pending-reprojection!))
+                "flush is a no-op — the burst marked nothing dirty")))
+        (finally
+          (doseq [n (range 50)]
+            (registrar/unregister! :event (keyword "noframe" (str "e" n))))
           (lf/flush-pending-reprojection!)
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ---- the RE-ENTRANCY guard: a register! during a flush does not re-arm ------
+;;
+;; reproject-live-frames! re-assembles + swaps generations only — it must never
+;; reg-*. But the EP-0023 collapse made make-frame's backing reg-frame a
+;; register!, so a flush that (defensively) provoked any register! must NOT
+;; schedule its own successor. flush-pending-reprojection! binds `reprojecting?`
+;; around the reproject; mark-dirty-and-schedule! is a no-op while it is set.
+
+(deftest register!-during-flush-does-not-re-arm
+  (testing "a reg-* fired WHILE a reprojection flush runs does NOT schedule a
+            successor flush (rf2-h4q6cy re-entrancy guard): the reprojecting?
+            guard makes the hook a no-op for the duration of the flush, bounding
+            the work to ONE reprojection per pending mark even if reprojection
+            provokes a registration."
+    (let [snapshot  @source-store/kind->id->ns->descriptor
+          scheduled (atom 0)]
+      (try
+        ;; A live frame so a flush actually runs reproject-live-frames! (and so
+        ;; mark-dirty-and-schedule! passes the no-live-frame short-circuit). Record
+        ;; the descriptor FIRST so the image's :include-ns selector matches a loaded
+        ;; registration (a zero-match is fail-loud at image construction); construct
+        ;; the image AFTER.
+        (source-store/record-descriptor!
+          :event :reentry/inc
+          {:rf.provenance/ns "reentry.feature" :kind :event :id :reentry/inc
+           :handler-fn ::v1})
+        (let [img (image/image {:id :reentry/img :include-ns ["reentry.feature"]})]
+          (lf/make-frame {:id :reentry/main :images [img]})
+          (lf/flush-pending-reprojection!)
+          (with-redefs [interop/next-tick (fn [_f] (swap! scheduled inc) nil)
+                        lf/reproject-live-frames!
+                        (fn []
+                          ;; Mid-flush register! — the guard must make this a no-op.
+                          (registrar/register! :event :reentry/mid
+                            {:rf.provenance/ns "reentry.feature" :handler-fn ::mid})
+                          {})]
+            ;; A real reg-* (with the live frame present) marks dirty + schedules
+            ;; ONE flush (count → 1). Run that captured flush; its with-redef'd
+            ;; reproject fires a mid-flush register! — the re-entrancy guard must
+            ;; make that hook a no-op, so the count stays 1 (no successor).
+            (registrar/register! :event :reentry/inc
+              {:rf.provenance/ns "reentry.feature" :handler-fn ::v2})
+            (testing "the live-frame reg-* armed exactly one flush"
+              (is (= 1 @scheduled)))
+            (lf/flush-pending-reprojection!)
+            (testing "the mid-flush register! scheduled NO successor flush"
+              (is (= 1 @scheduled)
+                  "reprojecting? guard makes the hook a no-op during the flush")))
+          (testing "after the flush the guard is cleared — a fresh reg-* re-arms"
+            (with-redefs [interop/next-tick (fn [_f] (swap! scheduled inc) nil)]
+              (registrar/register! :event :reentry/inc
+                {:rf.provenance/ns "reentry.feature" :handler-fn ::v3})
+              (is (= 2 @scheduled)
+                  "outside the flush, a reg-* with a live frame re-arms normally"))))
+        (finally
+          ;; Clear the live frame BEFORE draining: the body left a flush pending,
+          ;; and a reproject of the still-live :reentry/main would re-assemble its
+          ;; :include-ns ["reentry.feature"] image AFTER we forget the descriptors
+          ;; below — a zero-match. Forgetting the frame first makes the drain a
+          ;; no-op (nothing reprojectable), so cleanup order does not matter.
+          (lf/clear-live-frames!)
+          (lf/flush-pending-reprojection!)
+          (registrar/unregister! :event :reentry/inc)
+          (registrar/unregister! :event :reentry/mid)
           (reset! source-store/kind->id->ns->descriptor snapshot))))))

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -35,6 +35,8 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.image        :as image]
             [re-frame.image-assembly :as asm]
+            [re-frame.interop      :as interop]
+            [re-frame.registrar    :as registrar]
             [re-frame.source-store :as source-store]
             [re-frame.live-frame   :as lf]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -445,4 +447,123 @@
                 (is (= ::a-reloaded (:handler-fn (asm/resolve-descriptor gen-after :event :compose.a/go))))
                 (is (= ::b-stable   (:handler-fn (asm/resolve-descriptor gen-after :event :compose.b/go))))))))
         (finally
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+;; ===========================================================================
+;; 9. AUTO-reprojection: a `reg-*` change reprojects the affected explicit-image
+;;    frame WITHOUT a manual reproject-live-frames! call (rf2-h4q6cy)
+;; ===========================================================================
+;;
+;; The .28 B1 finding: `reproject-live-frames!` implements the EP-0023 headline
+;; guarantee but NOTHING called it — no hook fired on `reg-*`, so a hot-reload of
+;; an `:include-ns`-selected namespace left the running frame on its STALE
+;; generation until some external reproject/reload ran. rf2-h4q6cy wires
+;; `registrar/add-registration-hook!` → mark-dirty + coalesced `next-tick`
+;; flush, so an ordinary `reg-*` re-eval swaps the affected frame automatically.
+;;
+;; These tests drive the change through `registrar/register!` (the path every
+;; `reg-*` macro funnels through — and the path that FIRES the hook), and they
+;; NEVER call `reproject-live-frames!` manually. The deferred flush is forced
+;; deterministically via the synchronous `flush-pending-reprojection!` (the same
+;; flush the scheduled `next-tick` tick arms). Before the fix the hook did not
+;; exist, so `flush-pending-reprojection!` found nothing pending and the frame
+;; stayed on ::auto-v1 — RED. After the fix the `register!` marks dirty, the
+;; flush reprojects, and the frame resolves ::auto-v2 — GREEN.
+
+(deftest reg-star-change-auto-reprojects-explicit-image-frame
+  (testing "a reg-* re-eval (via registrar/register!) in a namespace an explicit
+            :include-ns image selects marks the projection dirty and the coalesced
+            flush reprojects + swaps THAT frame's generation — WITHOUT a manual
+            reproject-live-frames! call (EP-0023 §Default Image Semantics — the
+            headline guarantee, wired by rf2-h4q6cy). Uses the LIVE source store
+            + the shared registrar; snapshot/restore the source store and clean
+            the registrar in finally (NOT clear-all!). Asserts BEHAVIOR (the
+            frame resolves the new impl), never the internal dirty flag."
+    (let [snapshot @source-store/kind->id->ns->descriptor]
+      (try
+        ;; Start from a clean slate: drain any reprojection a prior case left
+        ;; pending (the hook is a process-defonce, shared across cases).
+        (lf/flush-pending-reprojection!)
+        ;; First registration of the selected id, via the SAME register! path a
+        ;; reg-* macro funnels through (so the auto-reprojection hook is exercised
+        ;; end to end). The hook fires here too (first-time); no frame is live yet,
+        ;; so we drain the resulting (move-empty) pending flush to start clean.
+        (registrar/register! :event :auto/inc
+          {:rf.provenance/ns "auto.feature" :handler-fn ::auto-v1})
+        (lf/flush-pending-reprojection!)
+        (let [img   (image/image {:id :auto/img :include-ns ["auto.feature"]})
+              frame (lf/make-frame {:id :auto/main :images [img]})
+              gen-before (lf/frame-generation frame)]
+          (testing "the frame resolves the ORIGINAL impl before any re-eval (control)"
+            (is (= ::auto-v1
+                   (:handler-fn (asm/resolve-descriptor gen-before :event :auto/inc)))))
+          ;; The reg-* RE-EVAL — a new impl for the same (kind,id,ns) slot, through
+          ;; register!. This FIRES the registration hook → marks dirty + schedules.
+          (registrar/register! :event :auto/inc
+            {:rf.provenance/ns "auto.feature" :handler-fn ::auto-v2})
+          ;; Force the COALESCED flush synchronously (the same flush the next-tick
+          ;; tick arms). NO manual reproject-live-frames! — this is the wired path:
+          ;; a flush only does work because the register! above marked it pending.
+          (let [moved (lf/flush-pending-reprojection!)]
+            (testing "the register!-armed flush reprojects the affected
+                      explicit-image frame (the hook fired and marked it dirty)"
+              (is (contains? moved :auto/main))
+              (is (contains? (:changed (get moved :auto/main)) [:event :auto/inc]))))
+          (testing "the live frame now resolves the RE-EVAL'd impl through its
+                    swapped generation — automatically, no reload-images! call"
+            (is (= ::auto-v2
+                   (:handler-fn (asm/resolve-descriptor
+                                  (lf/frame-generation (lf/live-frame :auto/main))
+                                  :event :auto/inc))))))
+        (finally
+          ;; Clean the shared registrar slot we wrote + drain any residual pending
+          ;; reprojection, then restore the source store. (The hook itself is a
+          ;; process-defonce — it stays installed across cases by design.)
+          (registrar/unregister! :event :auto/inc)
+          (lf/flush-pending-reprojection!)
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
+(deftest reg-star-burst-coalesces-to-one-flush
+  (testing "a BURST of reg-* (a hot-reloaded namespace re-evaluating N
+            registrations) schedules at MOST ONE deferred reprojection flush — the
+            coalescing gate (rf2-h4q6cy). Counting the next-tick schedules proves
+            the burst reprojects ONCE at the batch boundary, not per reg-*."
+    (let [snapshot  @source-store/kind->id->ns->descriptor
+          scheduled (atom 0)
+          captured  (atom nil)]
+      (try
+        ;; Drain any pending flush so the burst below starts from a clean
+        ;; (un-pending) flag — the first reg-* of the burst is the false→true edge.
+        (lf/flush-pending-reprojection!)
+        ;; Redef next-tick to COUNT schedules and CAPTURE (defer) the flush —
+        ;; deliberately NOT run inline, so the dirty flag stays set through the
+        ;; whole burst exactly as a real deferred tick would leave it. If the
+        ;; coalescing gate works, only the first reg-* (false→true) schedules; the
+        ;; other four observe the flag already set and add no second tick. The
+        ;; re-arm step below stays INSIDE this redef so its schedule hits the same
+        ;; counting next-tick (outside, the real next-tick would not be counted).
+        (with-redefs [interop/next-tick (fn [f] (swap! scheduled inc)
+                                          (reset! captured f) nil)]
+          ;; A burst of 5 reg-* in one synchronous run (a namespace re-eval).
+          (doseq [n (range 5)]
+            (registrar/register! :event (keyword "burst" (str "e" n))
+              {:rf.provenance/ns "burst.feature" :handler-fn (keyword "impl" (str n))}))
+          (testing "the 5-reg-* burst scheduled exactly ONE flush (coalesced) —
+                    the deferred tick was never run during the burst"
+            (is (= 1 @scheduled)
+                "compare-and-set! gates: only the false→true transition schedules"))
+          (testing "running the single captured tick drains the whole burst at once,
+                    and a post-drain reg-* re-arms a fresh tick (flag re-armable)"
+            (when-let [tick @captured] (tick))
+            ;; The drain (`tick` → flush) cleared the dirty flag; a new reg-* is the
+            ;; next false→true edge, so it schedules again — proving the flag is not
+            ;; stuck-set after a flush. (Inside the redef, so this counts here.)
+            (registrar/register! :event :burst/e0
+              {:rf.provenance/ns "burst.feature" :handler-fn ::e0-again})
+            (is (= 2 @scheduled)
+                "a post-drain reg-* re-arms a new tick (flag cleared, re-armable)")))
+        (finally
+          (doseq [n (range 5)]
+            (registrar/unregister! :event (keyword "burst" (str "e" n))))
+          (lf/flush-pending-reprojection!)
           (reset! source-store/kind->id->ns->descriptor snapshot))))))


### PR DESCRIPTION
## What

Wires the EP-0023 headline guarantee — an ordinary `reg-*` re-eval in a namespace an explicit `:include-ns` image selects reprojects + swaps the affected live frame's generation **automatically** (EP-0023 §Default Image Semantics:524, :1497; §Conformance:1745) — which was implemented as `reproject-live-frames!` but **had no production caller** (the .28 B1 finding, rf2-h4q6cy). Before this, a `reg-*` hot reload left the running frame on its STALE generation until some external `reload-images!` / manual `reproject-live-frames!` ran.

## How — trigger model

Consumes the existing `registrar/add-registration-hook!` seam (no `registrar.cljc` change), **coalesced** across a hot-reload `reg-*` burst:

- The hook MARKS the live-frame projection dirty and schedules ONE `interop/next-tick` flush — the dirtying rule's two-phase "mark dirty, then resolve a new generation" (EP-0023:524). `compare-and-set!` gates the schedule so a burst of N `reg-*` (a namespace re-evaluating all its registrations) schedules **at most one** deferred flush; the flush runs after the burst settles, reprojecting ONCE against the now-complete source store — never per-reg, never on a half-reloaded namespace.
- `flush-pending-reprojection!` is the synchronous counterpart tests drive deterministically. The scheduled tick is an error-swallowing `deferred-flush!` (a background tick has no caller to surface a throw to; the dirty flag is cleared before reprojecting, so a swallowed failure re-arms rather than wedges).
- **Production-elided**: the whole install is gated on `interop/debug-enabled?` (= `goog.DEBUG`), so `:advanced` constant-folds it away — production stops `reg-*`-ing after boot, so there is nothing to reproject (EP-0023:530). Adds **no new always-on error id** (reuses existing assembly diagnostics).
- `defonce`-wrapped install (survives a dev `:reload` without duplicate-hooking), mirroring the flows/routing registrar-hook pattern.

Reprojection re-assembles + swaps the live-frame atom only; it never calls `register!`, so it cannot re-trigger the hook (no recursion — satisfies the acceptance criterion's "no recursive unsafe registration").

## Surface lane

`implementation/core/src/re_frame/live_frame.cljc` (reproject wiring) + the reload test. Disjoint from the `.41` image_assembly / facade slices. `registrar.cljc` unchanged (the hook seam already existed).

## Tests (red-before-green)

In `live_frame_reload_cljs_test`:
- `reg-star-change-auto-reprojects-explicit-image-frame`: a `reg-*` re-eval via `registrar/register!` auto-reprojects the affected explicit-image frame **without** a manual `reproject-live-frames!` call. **Red-before-green proven**: with the hook disabled, exactly these 2 tests fail (5 assertions); no other test regresses.
- `reg-star-burst-coalesces-to-one-flush`: a 5-`reg-*` burst coalesces to exactly ONE scheduled flush, and the flag is re-armable after a drain.

## Gates

- `npm run test:cljs` — **7609 tests / 31320 assertions, 0 failures, 0 errors** (post-rebase).
- core JVM (`clojure -M:test`) — **1772 tests, 0 failures, 0 errors** (incl. EP-0023 reload + conformance).
- `npm run test:elision` — **PASS** (43/43 production sentinels absent; EP-0023 provenance-survives + assembly-DCE green; control 43/43 present).
- `scripts/test-fast-pr.sh` — all python guards + JS harness helpers + core JVM + cljs green.