### PR TITLE
docs(guide): correct optimistic-rollback-deferred caveats now that EP-0019 shipped (rf2-tideyl)

### DIFF
--- a/docs/guide/AUTHORING.md
+++ b/docs/guide/AUTHORING.md
@@ -135,7 +135,7 @@ The `cljs-rf2` rules, each of which bites the first time:
 - **"For the categorically curious."** re-frame2's category-theory grounding is a design tool, not teaching vocabulary — *translate, don't transplant*. The deeper frame goes only in a collapsed `<details markdown="1"><summary>For the categorically curious</summary>…</details>` block: always skippable, never load-bearing, at most one per concept, ~6 lines, every term glossed in the same breath.
 - **Asides are bold-lead blockquotes** (`> **Heads-up.** …`), not `!!!` admonitions — match the corpus.
 - **No bead references in prose.** Pages state current truth, not the decision trail; `(rf2-xxx)` citations belong in the tracker. Spec section anchors and migration-rule ids are fine — those are normative, not historical.
-- **Honesty.** Say when *not* to use a feature; mark deferred things (optimistic rollback) and CLIENT-ONLY paths; no marketing voice. The test for every paragraph: could a tired engineer act on it at 11pm mid-incident?
+- **Honesty.** Say when *not* to use a feature; mark deferred things (timed polling, infinite feeds) and CLIENT-ONLY paths; no marketing voice. The test for every paragraph: could a tired engineer act on it at 11pm mid-incident?
 
 ## The gates
 

--- a/docs/guide/concepts/server-state.md
+++ b/docs/guide/concepts/server-state.md
@@ -180,6 +180,44 @@ In TanStack Query, keeping reads honest after a write is a call you remember to 
 
 Entries with live owners refetch; unowned entries are marked stale and refetch when next ensured. Invalidation is **scoped by default**, so a write can't accidentally stale another tenant's cache. The operational details — instance-keyed pending state, `:reply-to` continuations, seeding the cache from the reply — live in [Part 4](../tutorial/04-mutations-and-invalidation.md) and [Invalidate after a mutation](../how-to/invalidate-after-a-mutation.md).
 
+## Optimistic writes commit, roll back, or reconcile
+
+The pattern above settles the cache only when the server replies. For a write that should *feel* instant — the favorite heart flips on click, the count ticks up — a mutation may declare an **optimistic plan** that patches the cache *before* the request is sent, then commits, rolls back, or reconciles when the reply settles. This is the re-frame2 counterpart of TanStack Query's `onMutate`/`onError` rollback (and SWR's `optimisticData` + `rollbackOnError`).
+
+You declare the forward change; the runtime records the inverse for you, so a rollback restores exactly the entry that existed — never an author-written inverse that can drift from the forward patch:
+
+```clojure
+(rf/reg-mutation :realworld/favorite
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :request       (fn [{:keys [slug]} _ctx]
+                    {:request {:method :post
+                               :url    (str "/api/articles/" slug "/favorite")}
+                     :decode  :json})
+   ;; Patch every cached entry carrying these tags, in its scope, before the
+   ;; request leaves — the detail, every list, and the session feed flip at once.
+   :optimistic-tags (fn [{:keys [slug]}]
+                      [{:scope :rf.scope/global
+                        :tags  #{[:article slug]}
+                        :patch (fn [article] (update-favorite article true))}])
+   ;; The accepted reply still seeds the authoritative value and invalidates.
+   :populates     (fn [{:keys [slug]} result]
+                    {{:resource :realworld/article :params {:slug slug}} result})
+   :invalidates   (fn [{:keys [slug]} _result]
+                    [{:scope :rf.scope/global :tags #{[:article slug] [:article-list]}}
+                     {:scope {:from-db :realworld/session} :tags #{[:feed]}}])})
+```
+
+Two forward forms exist: `:optimistic` patches **exact** cache targets (the twin of `:populates`/`:patches`), and `:optimistic-tags` patches **every** entry carrying a tag in its scope (the twin of tag-addressed `:invalidates`) — the cross-view-consistency case the author can't enumerate by key. Both are exact-key or tag-within-named-scope only, and **fail closed**: a `{:from-db …}` scope that resolves to `nil` drops that target rather than writing globally, so an optimistic write can never leak across viewers.
+
+Settle is deterministic, decided on recorded facts (the generation acceptance verdict and a per-entry `:revision`), so there's no wall-clock race:
+
+- an accepted **`:ok`** reply **commits** — the authoritative `:populates`/`:patches` overwrite the optimistic value with the server's, then `:invalidates` runs.
+- an accepted **`:error`**/`:cancelled` reply **rolls back** — the recorded inverse is restored.
+- a **stale/superseded** reply rolls back nothing; the current generation already owns the entry.
+
+The one wrinkle is a *contested* rollback — a concurrent write landed on the entry between your apply and the failure. `:on-conflict` governs it: the default **`:invalidate`** declines to restore a now-stale inverse and instead marks the entry stale so the read path refetches the authoritative value (re-frame2's deliberate divergence from the query libraries' unconditional context-restore); `:force` restores the inverse anyway (the single-writer escape, with a tooling warning). A view renders the in-flight optimistic state from the instance sub's derived **`:optimistic?`** flag. The normative contract is [Spec 016 §Optimistic mutations](../../../spec/016-Resources.md#optimistic-mutations).
+
 ## Logout is one causal event
 
 The cross-session leak — user B sees user A's dashboard — has a structural fix here. Every session-scoped entry lives under A's scope, and logout clears that scope. There's one subtlety worth pausing on: resolve the *old* scope from the handler's coeffect db (the read-only inputs handed to the handler), which still carries the logging-out user, *before* you remove the auth slice:
@@ -208,8 +246,9 @@ On the server, each request renders in its own frame, which matters because a pr
 
     - **A handful of reads, no caching story.** A [managed HTTP request](http.md) plus a small app-db slice is less machinery and entirely idiomatic.
     - **Login and other commands.** Auth is a state machine driving a write — don't contort it into a cached read.
-    - **Optimistic UI with rollback.** A write that flips the UI immediately and reverts on server rejection isn't expressible as a mutation today; rollback is deferred. Use a managed HTTP write whose failure handler restores the prior app-db value.
     - **GraphQL.** The transport is HTTP-only for now; GraphQL is a planned later phase.
+
+A mutation *can* now flip the UI immediately and reconcile when the server replies: an **optimistic mutation** patches the cache before the request is sent and commits, rolls back, or reconciles on settle. That's a property of the mutation, not a reason to avoid resources — see [Optimistic writes commit, roll back, or reconcile](#optimistic-writes-commit-roll-back-or-reconcile) below.
 
 ---
 

--- a/docs/guide/explanation/resources-vs-query-libraries.md
+++ b/docs/guide/explanation/resources-vs-query-libraries.md
@@ -10,7 +10,7 @@ If you want the design rationale rather than the comparison, read [Inside out: w
 
 !!! note "Resources are an optional artefact, and pre-alpha"
 
-    Server state in re-frame2 is the optional `day8/re-frame2-resources` artefact, and it is **pre-alpha**: the read path and the mutation path have landed, but three parity-relevant features (optimistic rollback, polling, infinite feeds) are not built yet and are tracked as design proposals. Every "proposed" row below names its tracking proposal so you can see exactly where the edge is. Nothing here is back-compat-frozen.
+    Server state in re-frame2 is the optional `day8/re-frame2-resources` artefact, and it is **pre-alpha**: the read path, the mutation path, and optimistic mutation rollback have all landed. Two parity-relevant features (polling, infinite feeds) are not built yet and are tracked as design proposals. Every "proposed" row below names its tracking proposal so you can see exactly where the edge is. Nothing here is back-compat-frozen.
 
 ## How to read the status column
 
@@ -20,7 +20,7 @@ Each row carries a status. They mean precisely:
 |---|---|
 | **Landed** | Shipped in the reference implementation (`re-frame.resources`) and pinned by tests. |
 | **Different by design** | A capability the query libraries have, expressed differently here on purpose — usually because re-frame2 already has a more general mechanism (the subscription graph, the event loop) that subsumes it. |
-| **Proposed (EP-00NN)** | A real parity gap, *deferred*, with an open enhancement-proposal PR working out the design. Not in the shipped contract. The proposal numbers below — EP-0019 (optimistic rollback), EP-0020 (active-owner polling), EP-0021 (infinite resources) — are landing as proposal PRs and are tracked under the [pre-alpha resource parity tranche] beads `rf2-byl7bk.1` / `.2` / `.3`. |
+| **Proposed (EP-00NN)** | A real parity gap, *deferred*, with an open enhancement-proposal PR working out the design. Not in the shipped contract. The proposal numbers below — EP-0020 (active-owner polling), EP-0021 (infinite resources) — are landing as proposal PRs and are tracked under the [pre-alpha resource parity tranche]. Optimistic rollback (EP-0019) has since *landed* and moved out of this column. |
 | **Out of scope** | Deliberately not a resources concern — a different artefact, a different phase, or a non-goal. |
 
 ## The parity matrix
@@ -39,7 +39,7 @@ Each row carries a status. They mean precisely:
 | **Mutation consequences (patch/populate/seed)** | `setQueryData` in `onSuccess` | `onQueryStarted` + `updateQueryData` | `mutate` with `optimisticData`/`populateCache` | declarative `:patches` / `:populates` / `:removes` from the reply, then tag invalidation, with explicit timing | **Landed** |
 | **Mutation completion continuation** | `onSuccess` / `onError` callbacks | lifecycle callbacks | promise resolution | call-site `:reply-to` **event** (not a callback); fires only for the accepted terminal reply | **Landed** |
 | **Projection / `select`** | `select` option | `selectFromResult` | derived in component | no `:select` key — projections are ordinary subscriptions layered over `[:rf.resource/data …]` | **Different by design** |
-| **Optimistic updates + rollback** | `onMutate` snapshot + `onError` rollback | `updateQueryData` + `undo` patch | `optimisticData` + `rollbackOnError` | **not built** — write a managed-HTTP write whose failure handler restores prior app-db | **Proposed (EP-0019)** |
+| **Optimistic updates + rollback** | `onMutate` snapshot + `onError` rollback | `updateQueryData` + `undo` patch | `optimisticData` + `rollbackOnError` | `:optimistic` (exact-target) / `:optimistic-tags` (tag-addressed) plan applied pre-request; runtime records the inverse; deterministic commit / rollback / reconcile on settle, with `:on-conflict` governing a contested rollback | **Landed** |
 | **Polling / refetch interval** | `refetchInterval` | `pollingInterval` | `refreshInterval` | **not built** — focus/reconnect revalidation has landed; *timed* polling has not | **Proposed (EP-0020)** |
 | **Refetch on window focus / reconnect** | `refetchOnWindowFocus` / `refetchOnReconnect` | `refetchOnFocus` / `refetchOnReconnect` | `revalidateOnFocus` / `revalidateOnReconnect` | `install-revalidation-listeners!` per frame; refetches only entries that are *stale AND owned* | **Landed** |
 | **Infinite / load-more** | `useInfiniteQuery` | `infiniteQuery` (recent) | `useSWRInfinite` | **not built** — numbered/cursor pages are ordinary resources with `:keep-previous?`; a canonical accumulating-feed model is deferred | **Proposed (EP-0021)** |
@@ -152,15 +152,42 @@ In TanStack and SWR, keeping reads honest after a write is an imperative call yo
 
 The fail-closed floor matters: a bare `:rf.resource/invalidate-tags` with no scope is a loud error, not a silent global blast across every tenant. "Invalidate this tag wherever it lives" is possible — `:cross-scope? true` — but it is an *audited* operation that must carry a `:cause` and is a privacy-relevant trace event. See [Writes invalidate by tag — causally](../concepts/server-state.md#writes-invalidate-by-tag--causally) and [Spec 016 §Scoped invalidation descriptors](../../../spec/016-Resources.md#scoped-invalidation-descriptors-per-target).
 
+## Optimistic updates with rollback — landed
+
+The query libraries all ship optimistic UI: flip the cache immediately, snapshot the prior value, revert on server rejection (`onMutate`/`onError` rollback in TanStack, `updateQueryData` + undo patch in RTK, `optimisticData` + `rollbackOnError` in SWR). re-frame2 now matches this on the mutation path, with one deliberate divergence on contested rollback.
+
+A mutation declares an **optimistic plan** applied *before* the request leaves, in one of two forward forms — the twins of the success-time consequence keys:
+
+- **`:optimistic`** — `(fn [params] -> {target patch-fn})`, the exact-target twin of `:patches`. A `nil` patch-fn removes the entry optimistically; a patch over an absent key seeds it.
+- **`:optimistic-tags`** — `(fn [params] -> [{:scope … :tags #{…} :patch (fn [old] new)}])`, the tag-addressed twin of `:invalidates`. It patches every cached entry carrying the tag in its scope — the cross-view-consistency case (flip a favorite and have it flip on the detail, every list, and the session feed at once) you can't enumerate by exact key.
+
+```clojure
+(rf/reg-mutation :realworld/favorite
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :request       (fn [{:keys [slug]} _ctx] ...)
+   :optimistic-tags (fn [{:keys [slug]}]
+                      [{:scope :rf.scope/global
+                        :tags  #{[:article slug]}
+                        :patch (fn [article] (update-favorite article true))}])
+   :populates     (fn [{:keys [slug]} result]
+                    {{:resource :realworld/article :params {:slug slug}} result})
+   :invalidates   (fn [{:keys [slug]} _result]
+                    [{:scope :rf.scope/global :tags #{[:article slug] [:article-list]}}
+                     {:scope {:from-db :realworld/session} :tags #{[:feed]}}])})
+```
+
+Three properties are worth holding onto, because they are where re-frame2 differs from a hand-rolled `onMutate` snapshot:
+
+- **The runtime records the inverse — you don't.** It snapshots each touched entry verbatim before patching, so a rollback restores exactly what existed, never an author-written undo patch that can drift from the forward change.
+- **Settle is deterministic, with no wall-clock race.** It is decided on recorded facts — the generation acceptance verdict and a per-entry `:revision`. An accepted `:ok` reply commits (the authoritative `:populates`/`:patches` overwrite the optimistic value, then `:invalidates` runs); an accepted `:error`/`:cancelled` rolls back; a stale/superseded reply rolls back nothing.
+- **Contested rollback is governed by `:on-conflict`, and the default diverges from the query libraries.** When a concurrent write landed on the entry between the apply and a failure, the recorded inverse is a stale "before." The default `:invalidate` declines to restore it and marks the entry stale so the read path refetches the authoritative value — the read path is the recovery authority, re-frame2's deliberate divergence from TanStack/SWR's unconditional context restore. `:force` restores the inverse anyway (the single-writer escape, with a tooling warning).
+
+A view renders the in-flight optimistic state from the instance sub's derived **`:optimistic?`** flag (true between the pre-request apply and settle). The optimistic surface is exact-key or tag-within-named-scope only, both **fail-closed** on a nil-resolving `{:from-db …}` scope — there is no scope-agnostic optimistic write, so it cannot leak across viewers, tenants, or SSR requests. The normative contract is [Spec 016 §Optimistic mutations](../../../spec/016-Resources.md#optimistic-mutations); the worked write is in [Part 4 of the tutorial](../tutorial/04-mutations-and-invalidation.md).
+
 ## The honest gaps
 
 These are real parity gaps. They are deferred, tracked, and have open design proposals. Do not let the rest of this page's confidence obscure them.
-
-### Optimistic updates with rollback — proposed (EP-0019)
-
-The query libraries all ship optimistic UI: flip the cache immediately, snapshot the prior value, revert on server rejection (`onMutate`/`onError` rollback in TanStack, `updateQueryData` + undo patch in RTK, `optimisticData` + `rollbackOnError` in SWR). re-frame2's mutation path is **not** optimistic today — a mutation settles its instance state and applies cache consequences only on the accepted reply, and the success trace *reserves* the rollback shape (`:affected-keys`, patch/snapshot/reconciliation slots) but rollback itself is deferred ([Spec 016 §Mutations](../../../spec/016-Resources.md#mutations-first-public-beta-gate), [§Deferred slices](../../../spec/016-Resources.md#deferred-slices)).
-
-**Until it lands:** use a managed-HTTP write whose failure handler restores the prior app-db value (the optimistic flip lives in your app-db, not the cache). This is the [When resources are the wrong tool](../concepts/server-state.md#when-resources-are-the-wrong-tool) guidance. The design is being worked under EP-0019 / bead `rf2-byl7bk.1`; getting deterministic rollback right under overlapping mutations, stale/superseded replies, and scoped invalidation is exactly why it is a proposal rather than a quick add.
 
 ### Polling / refetch-interval — proposed (EP-0020)
 
@@ -187,7 +214,6 @@ A query library is the obvious default in React because it is the *only* server-
 
     - **A handful of reads, no caching story.** A [managed HTTP request](../concepts/http.md) plus a small app-db slice is less machinery and entirely idiomatic.
     - **Login and other commands.** Auth is a state machine driving a write — model it as a [machine](../concepts/machines.md), not a cached read.
-    - **Optimistic UI with rollback.** Not expressible as a mutation today (above) — use a managed HTTP write with a restoring failure handler.
 
 Reach for resources when cached server reads start multiplying and the per-read bookkeeping — scope, staleness, dedupe, invalidation, GC, SSR — is worth moving into the framework. [Where should this value live?](../where-state-lives.md) has the decision table.
 
@@ -195,9 +221,9 @@ Reach for resources when cached server reads start multiplying and the per-read 
 
 **The summary, one more time:**
 
-- **Matched:** keyed cache, staleness, dedupe, GC, tag invalidation, mutations + consequences, focus/reconnect revalidation, keep-previous paging, SSR/hydration, devtools — all **landed**.
-- **Different by design:** per-frame cache, required structural scope, owners-vs-observers, passive views, subscriptions-instead-of-`select`, declarative causal invalidation.
-- **Not built yet:** optimistic rollback (EP-0019), polling (EP-0020), infinite feeds (EP-0021).
+- **Matched:** keyed cache, staleness, dedupe, GC, tag invalidation, mutations + consequences, optimistic updates with rollback, focus/reconnect revalidation, keep-previous paging, SSR/hydration, devtools — all **landed**.
+- **Different by design:** per-frame cache, required structural scope, owners-vs-observers, passive views, subscriptions-instead-of-`select`, declarative causal invalidation, `:on-conflict :invalidate` as the contested-rollback default.
+- **Not built yet:** polling (EP-0020), infinite feeds (EP-0021).
 - **Out of scope:** normalized/GraphQL caches, offline/cross-tab.
 
 ---

--- a/docs/guide/how-to/invalidate-after-a-mutation.md
+++ b/docs/guide/how-to/invalidate-after-a-mutation.md
@@ -99,9 +99,9 @@ Sometimes the write's reply carries the updated data back to you. `:populates` p
 
 A populated key counts as an **authoritative load**, which means it's exempt from this same mutation's invalidation pass. So invalidating broad tags doesn't immediately re-fetch the entry you just seeded from the reply — the framework trusts the value you handed it.
 
-!!! note "Populate is forward-only"
+!!! note "Populate runs on success — reach for `:optimistic` to flip before the reply"
 
-    There's no automatic revert on failure here — optimistic rollback is deferred. If a write must flip the UI and then roll back on rejection, keep it a plain managed [HTTP](../concepts/http.md) write with an `:on-failure` handler instead.
+    `:populates` seeds the cache from the *accepted reply*, so it runs only after the server confirms. If a write must flip the UI immediately and revert on rejection, declare an **optimistic plan** instead: `:optimistic` (exact target) or `:optimistic-tags` (tag-addressed) patches the cache *before* the request is sent, and the runtime commits, rolls back, or reconciles it deterministically on settle — `:on-conflict` (default `:invalidate`) governs a contested rollback. See [Spec 016 §Optimistic mutations](../../../spec/016-Resources.md#optimistic-mutations) and the worked write in [Part 4 of the tutorial](../tutorial/04-mutations-and-invalidation.md).
 
 !!! warning "A bare tag set matches only in the mutation's resolved scope"
 


### PR DESCRIPTION
## What

Part of **rf2-tideyl** — the **guide-caveat-sweep** portion only. EP-0019 (optimistic mutation rollback) has landed (`:optimistic` / `:optimistic-tags` forward plans, runtime-recorded snapshot inverse, deterministic commit/rollback/reconcile on settle, `:on-conflict` with default `:invalidate`, and the derived `:optimistic?` instance flag — all merged and pinned by tests under `implementation/resources/`). Several guide pages still said optimistic rollback was deferred / forward-only / not expressible as a mutation. This corrects them to teach the landed feature, linking [Spec 016 §Optimistic mutations](../spec/016-Resources.md).

## Docs swept

- **`concepts/server-state.md`** — removed the "rollback is deferred" wrong-tool bullet; added an **Optimistic writes commit, roll back, or reconcile** section teaching `:optimistic` / `:optimistic-tags`, the runtime-recorded inverse, deterministic settle (commit/rollback/reconcile), `:on-conflict :invalidate` default, and the `:optimistic?` flag.
- **`explanation/resources-vs-query-libraries.md`** — flipped the parity-matrix **Optimistic updates + rollback** row and the status-column note to **Landed**; replaced the "honest gap" EP-0019 subsection with an **Optimistic updates with rollback — landed** explainer; updated the pre-alpha admonition (now lists only polling + infinite feeds as not-built), the "wrong tool" list, and the summary.
- **`how-to/invalidate-after-a-mutation.md`** — rewrote the *"Populate is forward-only"* note to point at `:optimistic` / `:optimistic-tags` for immediate-flip-then-revert writes (keeping the still-true point that `:populates` itself runs on success).
- **`AUTHORING.md`** — swapped the "deferred things" honesty example off optimistic rollback onto still-deferred timed polling / infinite feeds.

The three unrelated "rollback" usages in the guide (schema-validation rollback, drain-depth rollback, effects-don't-roll-back) were verified out of scope and left untouched.

## Out of scope (remainder of rf2-tideyl)

The **Linearlite-class optimistic driver** (a new example surface that deterministically fails/contends a write to exercise the rollback + `:on-conflict :invalidate` paths live on screen) is the other half of rf2-tideyl and remains pending — the bead stays open for it.

## Gates

- `mkdocs build --strict` → exit 0
- `check_readme_links.py` → exit 0
- `check_doc_slugs.py` (anchor/slug + bead-id drift) → exit 0
- `scripts/test-fast-pr.sh` markdown spine green; its CLJS step fails only because `shadow-cljs` isn't installed in this fresh worktree (docs-only change, no CLJS touched).