### PR TITLE
refactor(ssr): EP-0023 collapse migration — ssr callers (rf2-32siq3.46)

### DIFF
--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -12,6 +12,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.error-emit :as error-emit]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
@@ -1896,7 +1897,7 @@
             tag, yielding two."
     (let [;; The head fragment as the pipeline produces it for a route
           ;; with no declared :head — default-head rendered to HTML.
-          f          (rf/make-frame {:doc "Charset probe" :platform :server})
+          f          (frame/make-frame {:doc "Charset probe" :platform :server})
           head-model (rf/active-head f)
           head-html  (rf/head-model->html head-model)
           html       (ssr-ring/default-html-shell "body" "{}" {:head head-html})

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -12,6 +12,7 @@
       mismatch trace fires with :expected + :actual + :recovery shape."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr.test-fixture :as tf]))
 
@@ -55,7 +56,7 @@
         ;; check-version probes compare integers, not semver strings.
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 1}]]}))
 
-    (let [f      (rf/make-frame {:platform :client})
+    (let [f      (frame/make-frame {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-version-match]
@@ -72,7 +73,7 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 2}]]}))
 
-    (let [f      (rf/make-frame {:platform :client})
+    (let [f      (frame/make-frame {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-version-mismatch]
@@ -110,7 +111,7 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:deadbeefcafef00d"}]]}))
 
-    (let [f      (rf/make-frame {:platform :client})
+    (let [f      (frame/make-frame {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-digest-match]
@@ -129,7 +130,7 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:0000000000000000"}]]}))
 
-    (let [f      (rf/make-frame {:platform :client})
+    (let [f      (frame/make-frame {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-digest-mismatch]
@@ -166,7 +167,7 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version 1]]}))
 
-    (let [f      (rf/make-frame {:platform :client})
+    (let [f      (frame/make-frame {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-version-scalar-no-hook]
@@ -195,7 +196,7 @@
         (fn [_ _]
           {:fx [[:rf.ssr/check-version 1]]}))
 
-      (let [f      (rf/make-frame {:platform :client})
+      (let [f      (frame/make-frame {:platform :client})
             traces (capture-traces!
                      (fn []
                        (rf/dispatch-sync [::probe-check-version-scalar-with-hook]
@@ -228,7 +229,7 @@
           (fn [_ _]
             {:fx [[:rf.ssr/check-schema-digest "sha256:deadbeefcafef00d"]]}))
 
-        (let [f      (rf/make-frame {:platform :client})
+        (let [f      (frame/make-frame {:platform :client})
               traces (capture-traces!
                        (fn []
                          (rf/dispatch-sync [::probe-check-digest-scalar-no-hook]

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -33,6 +33,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.trace :as trace]))
@@ -119,7 +120,7 @@
               ^{:key id} [:li [:h3 title] [:p body]])]])))
 
     ;; ---- (1) per-request server frame -------------------------------------
-    (let [server-frame (rf/make-frame
+    (let [server-frame (frame/make-frame
                          {:doc          "SSR request frame"
                           :platform     :server
                           :on-create    [:rf/server-init {:uri "/articles"}]
@@ -166,7 +167,7 @@
               "payload carries the resolved render-tree hash")
 
           ;; ---- (6) hydration on a separate "client" frame ---------------
-          (let [client-frame (rf/make-frame
+          (let [client-frame (frame/make-frame
                                {:doc      "Hydrated client frame"
                                 :platform :client})
                 ;; rf2-nv3mua: in a real SSR deployment the server and client
@@ -263,7 +264,7 @@
           {:fx [[:rf.server/set-status 401]
                 [:rf.server/set-status 403]]}))                          ;; second write replaces
 
-      (let [f (rf/make-frame {:platform :server})]
+      (let [f (frame/make-frame {:platform :server})]
         (rf/register-listener! ::status (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:auth/forbid] {:frame f})
         (rf/unregister-listener! ::status)
@@ -302,7 +303,7 @@
                                       :value   "off"
                                       :max-age 0}]]}))
 
-    (let [f (rf/make-frame {:platform :server})]
+    (let [f (frame/make-frame {:platform :server})]
       (rf/dispatch-sync [:auth/establish] {:frame f})
 
       (let [cookies (:cookies (get-response f))]
@@ -336,7 +337,7 @@
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie {:name "session" :path "/"}]]}))
 
-    (let [f (rf/make-frame {:platform :server})]
+    (let [f (frame/make-frame {:platform :server})]
       (rf/dispatch-sync [:auth/logout] {:frame f})
       (let [[c] (:cookies (get-response f))]
         (is (= "session" (:name c)))
@@ -362,7 +363,7 @@
         {:fx [[:rf.server/append-header {:name "Set-Cookie" :value "a=1"}]
               [:rf.server/append-header {:name "Set-Cookie" :value "b=2"}]]}))
 
-    (let [f (rf/make-frame {:platform :server})]
+    (let [f (frame/make-frame {:platform :server})]
       (rf/dispatch-sync [:hdr/set-then-replace] {:frame f})
       (rf/dispatch-sync [:hdr/append-twice]     {:frame f})
       (let [hdrs  (:headers (get-response f))
@@ -439,7 +440,7 @@
                {:name  "X-Forwarded-For"
                 :value "1.2.3.4\r\nSet-Cookie: admin=1"}]]}))
 
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/inject-crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -451,7 +452,7 @@
       (rf/reg-event :hdr/probe-injection
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name "X-Probe" :value hostile}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:hdr/probe-injection] {:frame f})))]
         (expect-fx-error-keyword!
@@ -466,7 +467,7 @@
         {:fx [[:rf.server/append-header
                {:name  "X-Audit"
                 :value "ok\r\nSet-Cookie: forged=1"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/append-crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -482,7 +483,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect
                {:location "https://example.com\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:redirect/crlf-in-location] {:frame f})))]
       (expect-fx-error-keyword!
@@ -502,7 +503,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/ok"}]]}))
     (doseq [ev [:redirect/via-url :redirect/via-to]]
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [ev] {:frame f})))]
         (expect-fx-error-keyword!
@@ -518,7 +519,7 @@
     (rf/reg-event :redirect/retired-spelling
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/login"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:redirect/retired-spelling] {:frame f})))
           ex     (some (fn [ev]
@@ -554,7 +555,7 @@
       (rf/reg-event :redirect/malformed
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:redirect/malformed] {:frame f})))]
         (expect-fx-error-keyword!
@@ -577,7 +578,7 @@
       (rf/reg-event :redirect/well-formed
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f    (rf/make-frame {:platform :server :on-create [:redirect/well-formed]})
+      (let [f    (frame/make-frame {:platform :server :on-create [:redirect/well-formed]})
             resp (get-response f)]
         (is (= loc (-> resp :redirect :location))
             (str "well-formed redirect :location survives the structural gate: " loc))))))
@@ -593,7 +594,7 @@
               [:rf.server/set-header {:name "X-Whitespace"
                                       :value "tab\there space"}]
               [:rf.server/redirect    {:location "https://example.com/path?q=1&r=2"}]]}))
-    (let [f (rf/make-frame {:platform :server :on-create [:hdr/clean]})
+    (let [f (frame/make-frame {:platform :server :on-create [:hdr/clean]})
           resp (get-response f)
           hdrs (:headers resp)]
       (is (some (fn [[k v]]
@@ -615,7 +616,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
 
-    (let [f (rf/make-frame {:platform     :server
+    (let [f (frame/make-frame {:platform     :server
                             :on-create    [:auth/check-session]})]
       (let [resp     (get-response f)
             redirect (:redirect resp)]
@@ -644,7 +645,7 @@
     (rf/reg-event :auth/check-no-status
       (fn [_ _]
         {:fx [[:rf.server/redirect {:location "/login"}]]}))
-    (let [f (rf/make-frame {:platform  :server
+    (let [f (frame/make-frame {:platform  :server
                             :on-create [:auth/check-no-status]})]
       (is (= 302 (-> (get-response f) :redirect :status))
           ":rf.server/redirect defaults :status to 302 per Spec 011 §Redirect"))))
@@ -664,7 +665,7 @@
   (testing "routing's :rf.error/no-such-handler → default projector → 404"
     (rf/reg-route :route/home {:path "/"})
     (let [project-error  ssr/project-error
-          f              (rf/make-frame
+          f              (frame/make-frame
                            {:platform :server
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
                                   :dev-error-detail? false}})
@@ -704,7 +705,7 @@
     (let [project-error  ssr/project-error
           traces         (atom [])
           _              (rf/register-listener! ::he (fn [ev] (swap! traces conj ev)))
-          f              (rf/make-frame
+          f              (frame/make-frame
                            {:platform :server
                             :on-create [:rf/server-init]
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
@@ -729,7 +730,7 @@
 (deftest ssr-error-projector-dev-mode-includes-details
   (testing ":dev-error-detail? true puts the raw trace under :details"
     (let [project-error ssr/project-error
-          f             (rf/make-frame
+          f             (frame/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :rf.ssr/default-error-projector
                                  :dev-error-detail? true}})
@@ -766,7 +767,7 @@
            :retryable? false})))
 
     (let [project-error ssr/project-error
-          f             (rf/make-frame
+          f             (frame/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :myapp/public-error
                                  :dev-error-detail? false}})]
@@ -793,7 +794,7 @@
         (throw (ex-info "projector bug" {}))))
 
     (let [project-error ssr/project-error
-          f             (rf/make-frame
+          f             (frame/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :myapp/buggy-projector
                                  :dev-error-detail? false}})
@@ -816,7 +817,7 @@
       (fn [_trace-event] {:wrong :shape}))
 
     (let [project-error ssr/project-error
-          f             (rf/make-frame
+          f             (frame/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :myapp/bad-shape}})
           traces        (atom [])
@@ -880,7 +881,7 @@
             peek-response (pure read) and only stamps :status when
             flush-response! / get-response drains it."
     (rf/reg-route :route/home {:path "/"})
-    (let [f (rf/make-frame
+    (let [f (frame/make-frame
               {:platform :server
                :ssr {:public-error-id   :rf.ssr/default-error-projector
                      :dev-error-detail? false}})]
@@ -916,7 +917,7 @@
       (fn [_ _]
         {:fx [[:rf.server/set-status 201]
               [:rf.server/set-status 202]]}))
-    (let [f (rf/make-frame {:platform :server})]
+    (let [f (frame/make-frame {:platform :server})]
       (rf/dispatch-sync [:resp/multi-status] {:frame f})
       (doseq [[label resp] [["peek-response"  (ssr/peek-response f)]
                             ["get-response"   (ssr/get-response f)]]]
@@ -934,7 +935,7 @@
     ;; project. (The trace still fires; the projector just isn't called
     ;; for a client frame's response slot.)
     (rf/reg-route :route/home {:path "/"})
-    (let [client-f (rf/make-frame {:platform :client})]
+    (let [client-f (frame/make-frame {:platform :client})]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"]
                         {:frame client-f})
       (let [resp (get-response client-f)]
@@ -955,7 +956,7 @@
           {:fx [[:rf.server/redirect {:status 302 :location "/login"}]
                 [:rf.server/redirect {:status 301 :location "/canonical"}]]}))
 
-      (let [f (rf/make-frame {:platform :server})]
+      (let [f (frame/make-frame {:platform :server})]
         (rf/register-listener! ::redir (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:auth/double-redirect] {:frame f})
         (rf/unregister-listener! ::redir)
@@ -1008,7 +1009,7 @@
                      :rf/runtime-db  {:rf.runtime/routing {:current {:route-id :route/article :params {:id "123"}}}}
                      :rf/render-hash "head-hash-server-A"}
           traces    (atom [])
-          f         (rf/make-frame {:platform :client})]
+          f         (frame/make-frame {:platform :client})]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame f})
       (is (= "head-hash-server-A"
              (get-in (rf/runtime-db-value f) [:rf.runtime/ssr :hydration :server-hash]))
@@ -1148,7 +1149,7 @@
   (testing "rf2-dl9yg TC9: a synthetic error trace tagged with a server frame
             → error-projection-listener buffers → get-response flushes → response
             :status carries the default projector's 500"
-    (let [f (rf/make-frame
+    (let [f (frame/make-frame
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]
@@ -1242,7 +1243,7 @@
     (rf/reg-event :retired/url-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/dashboard"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:retired/url-redirect] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1258,7 +1259,7 @@
     (rf/reg-event :retired/to-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/welcome" :status 301}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:retired/to-redirect] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1291,7 +1292,7 @@
 
     (let [traces (atom [])
           _      (rf/register-listener! ::rpe (fn [ev] (swap! traces conj ev)))
-          f      (rf/make-frame
+          f      (frame/make-frame
                    {:platform  :server
                     :on-create [:redirect-then-error]
                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -1363,7 +1364,7 @@
         ;; not a legal scheme-specific character).
         {:fx [[:rf.server/safe-redirect
                {:location "https://example.com/path with space"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/unparseable] {:frame f})))
           resp   (get-response f)]
@@ -1382,7 +1383,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "javascript:alert(1)"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/javascript] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-scheme-rejected
@@ -1401,7 +1402,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "data:text/html,<script>alert(1)</script>"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/data] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1415,7 +1416,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "vbscript:msgbox(\"x\")"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/vbscript] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1430,7 +1431,7 @@
       (rf/reg-event :sr/probe-case
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect {:location hostile}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/probe-case] {:frame f})))]
         (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1447,7 +1448,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location       "https://evil.example.com/phish"
                 :relative-only? true}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/abs-with-relative-only] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1471,7 +1472,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location       "/dashboard"
                 :relative-only? true}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/relative-ok] {:frame f})))
           resp   (get-response f)]
@@ -1492,7 +1493,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://evil.example.com/phish"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/not-in-allow] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1518,7 +1519,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/in-allow] {:frame f})))
           resp   (get-response f)]
@@ -1537,7 +1538,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://APP.Example.COM/dashboard"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/in-allow-mixed-case] {:frame f})))
           resp   (get-response f)]
@@ -1559,7 +1560,7 @@
         ;; parser-fail must fire FIRST because step 1 runs before step 2.
         {:fx [[:rf.server/safe-redirect
                {:location "javascript: not a real url "}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/order-parse-first] {:frame f})))
           ops    (mapv :operation traces)]
@@ -1577,7 +1578,7 @@
     (rf/reg-event :sr/empty
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location ""}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/empty] {:frame f})))]
       (is (some #(= :rf.error/safe-redirect-invalid-url (:operation %))
@@ -1611,7 +1612,7 @@
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "http:evil.example.com"} policy)]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/opaque-http] {:frame f})))]
         (is (seq traces)
@@ -1628,7 +1629,7 @@
     (rf/reg-event :sr/opaque-https
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "https:evil.example.com"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/opaque-https] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-invalid-url (:operation %))
@@ -1645,7 +1646,7 @@
     (rf/reg-event :sr/mailto
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "mailto:user@example.com"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/mailto] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1662,7 +1663,7 @@
     (rf/reg-event :sr/ftp
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "ftp:example.com"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/ftp] {:frame f})))]
       (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1682,7 +1683,7 @@
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "//evil.example.com/path"} policy)]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/protocol-relative] {:frame f})))]
         (is (some #(and (= :rf.error/safe-redirect-host-disallowed (:operation %))
@@ -1701,7 +1702,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/account/settings" :relative-only? true}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/relative-control] {:frame f})))
           resp   (get-response f)]
@@ -1721,7 +1722,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
                 :allow    ["app.example.com"]}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/abs-control] {:frame f})))
           resp   (get-response f)]
@@ -1741,7 +1742,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/path\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:sr/crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1845,7 +1846,7 @@
         {:fx [[:rf.server/set-header
                {:name  "X-Test\r\nSet-Cookie: evil=1"
                 :value "ok"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/crlf-in-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1858,7 +1859,7 @@
       (rf/reg-event :hdr/probe-name
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name hostile :value "ok"}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:hdr/probe-name] {:frame f})))]
         (expect-fx-error-keyword!
@@ -1873,7 +1874,7 @@
         {:fx [[:rf.server/append-header
                {:name  "X-Audit\r\nSet-Cookie: forged=1"
                 :value "ok"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/append-crlf-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1888,7 +1889,7 @@
         {:fx [[:rf.server/set-cookie
                {:name  "session\r\nSet-Cookie: stolen=1"
                 :value "abc"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1902,7 +1903,7 @@
         {:fx [[:rf.server/set-cookie
                {:name  "session"
                 :value "abc\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-value] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1917,7 +1918,7 @@
                {:name  "session"
                 :value "abc"
                 :path  "/\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-path] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1932,7 +1933,7 @@
                {:name   "session"
                 :value  "abc"
                 :domain "example.com\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-domain] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1946,7 +1947,7 @@
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie
                {:name "session" :path "/admin\r\nbad"}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/del-crlf-path] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1969,7 +1970,7 @@
                  {:name    "session"
                   :value   "x"
                   :max-age "3600\r\nSet-Cookie: admin=1; Path=/"}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-max-age] {:frame f})))]
         (expect-fx-error-keyword!
@@ -1985,7 +1986,7 @@
                  {:name      "session"
                   :value     "x"
                   :same-site "Lax\r\nSet-Cookie: admin=1"}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-same-site] {:frame f})))]
         (expect-fx-error-keyword!
@@ -1999,7 +2000,7 @@
                  {:name    "session"
                   :value   "x"
                   :expires "Wed, 09 Jun 2027 10:18:14 GMT\r\nSet-Cookie: admin=1"}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-expires] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2012,7 +2013,7 @@
           (fn [_ _]
             {:fx [[:rf.server/set-cookie
                    {:name "s" :value "x" :max-age hostile}]]}))
-        (let [f      (rf/make-frame {:platform :server})
+        (let [f      (frame/make-frame {:platform :server})
               traces (capture-fx-traces!
                        (fn [] (rf/dispatch-sync [:ck/probe-max-age] {:frame f})))]
           (expect-fx-error-keyword!
@@ -2033,7 +2034,7 @@
                 :same-site "Strict"
                 :path      "/"
                 :expires   "Wed, 09 Jun 2027 10:18:14 GMT"}]]}))
-    (let [f       (rf/make-frame {:platform :server :on-create [:ck/clean-attrs]})
+    (let [f       (frame/make-frame {:platform :server :on-create [:ck/clean-attrs]})
           cookies (:cookies (get-response f))]
       (is (= 1 (count cookies))
           "the clean cookie lands on the accumulator")
@@ -2056,7 +2057,7 @@
                                        :path    "/"
                                        :domain  "example.com"}]
               [:rf.server/delete-cookie {:name "stale" :path "/"}]]}))
-    (let [f (rf/make-frame {:platform :server :on-create [:clean/all]})
+    (let [f (frame/make-frame {:platform :server :on-create [:clean/all]})
           resp (get-response f)]
       (is (some (fn [[k _]] (= "Cache-Control"   k)) (:headers resp)))
       (is (some (fn [[k _]] (= "X-Forwarded-For" k)) (:headers resp)))
@@ -2140,7 +2141,7 @@
       ;; defect into a proper 400.
       (rf/reg-event :bad/status
         (fn [_ _] {:fx [[:rf.server/set-status "not-an-int"]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/status] {:frame f})))
             status (:status (get-response f))]
@@ -2159,7 +2160,7 @@
     (testing ":rf.server/set-header missing :value → rejected + skipped"
       (rf/reg-event :bad/header
         (fn [_ _] {:fx [[:rf.server/set-header {:name "X-Foo"}]]}))   ;; :value absent
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/header] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2170,7 +2171,7 @@
     (testing ":rf.server/append-header with non-string :value → rejected"
       (rf/reg-event :bad/append
         (fn [_ _] {:fx [[:rf.server/append-header {:name "X-Bar" :value 42}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/append] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2179,7 +2180,7 @@
     (testing ":rf.server/set-cookie missing :value → rejected via [:ref :rf.server/cookie]"
       (rf/reg-event :bad/cookie
         (fn [_ _] {:fx [[:rf.server/set-cookie {:name "session"}]]})) ;; :value absent
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/cookie] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2193,7 +2194,7 @@
       (rf/reg-event :bad/cookie-samesite
         (fn [_ _] {:fx [[:rf.server/set-cookie
                          {:name "s" :value "v" :same-site :bogus}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/cookie-samesite] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2202,7 +2203,7 @@
     (testing ":rf.server/delete-cookie missing :name → rejected"
       (rf/reg-event :bad/delete
         (fn [_ _] {:fx [[:rf.server/delete-cookie {:path "/"}]]}))    ;; :name absent
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/delete] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2223,7 +2224,7 @@
       ;; shape check and does NOT reject the no-target redirect.
       (rf/reg-event :soft/redirect-no-target
         (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:soft/redirect-no-target] {:frame f})))]
         (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
@@ -2241,7 +2242,7 @@
     (testing ":rf.server/redirect with non-int :status → rejected"
       (rf/reg-event :bad/redirect-status
         (fn [_ _] {:fx [[:rf.server/redirect {:location "/x" :status "oops"}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/redirect-status] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2259,7 +2260,7 @@
       (rf/reg-event :bad/safe-redirect-status
         (fn [_ _] {:fx [[:rf.server/safe-redirect
                          {:location "/ok" :status "not-int"}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/safe-redirect-status] {:frame f})))
             resp   (get-response f)]
@@ -2278,7 +2279,7 @@
       ;; fails the shape gate.
       (rf/reg-event :bad/safe-redirect-no-location
         (fn [_ _] {:fx [[:rf.server/safe-redirect {:status 302}]]}))
-      (let [f      (rf/make-frame {:platform :server})
+      (let [f      (frame/make-frame {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/safe-redirect-no-location] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2300,7 +2301,7 @@
                                        :secure true :http-only true}]
               [:rf.server/delete-cookie {:name "stale" :path "/"}]
               [:rf.server/redirect    {:location "/dashboard" :status 302}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/all] {:frame f})))
           resp   (get-response f)]
@@ -2330,7 +2331,7 @@
                 :status         302
                 :relative-only? false
                 :allow          ["app.example.com"]}]]}))
-    (let [f      (rf/make-frame {:platform :server})
+    (let [f      (frame/make-frame {:platform :server})
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/safe-redirect] {:frame f})))
           resp   (get-response f)]
@@ -2385,7 +2386,7 @@
 
       (let [traces (atom [])]
         (rf/register-listener! ::ssr (fn [ev] (swap! traces conj ev)))
-        (let [f  (rf/make-frame
+        (let [f  (frame/make-frame
                    {:on-create    [:rf/server-init {:uri "/articles"}]
                     :fx-overrides {:http/get :http/get.canned-articles}})
               db (rf/app-db-value f)]

--- a/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
@@ -40,6 +40,7 @@
   there does not flip the wire — the rf2-hhutya conformance leg."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.error-emit :as error-emit]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
@@ -240,7 +241,7 @@
                           :rf/runtime-db [:runtime :is :a :vector]}]]
       (let [seen-records (capture-records!)]
         (register-hydration-handlers!)
-        (let [client-frame (rf/make-frame {:doc "ep0008-hguive client frame"
+        (let [client-frame (frame/make-frame {:doc "ep0008-hguive client frame"
                                            :platform :client})]
           ;; Seed a recognisable pre-hydration client slice so we can prove
           ;; the rejection left both partitions untouched (fail-closed).

--- a/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
@@ -33,6 +33,7 @@
   same substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
@@ -53,7 +54,7 @@
         {:fx [[:dispatch [:load/article]]]}))
 
     (with-redefs [interop/debug-enabled? false]
-      (let [f (rf/make-frame
+      (let [f (frame/make-frame
                 {:platform  :server
                  :on-create [:rf/server-init]
                  :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -73,7 +74,7 @@
             framework-private id used by both substrate installs). A
             tight error-record delivered through the substrate routes
             to the SSR projector buffer and stamps the response."
-    (let [f (rf/make-frame
+    (let [f (frame/make-frame
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -17,6 +17,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
@@ -75,7 +76,7 @@
                    (let [{:keys [title summary]} (get-in db [:articles (:id params)])]
                      {:title title
                       :meta  [{:name "description" :content summary}]})))
-    (let [f (rf/make-frame
+    (let [f (frame/make-frame
               {:doc       "head test frame"
                :platform  :server
                :on-create [:set-test-state]})]
@@ -98,14 +99,14 @@
   (testing "(render-head head-id frame-id) is sugar for (render-head head-id
             {:frame frame-id})"
     (rf/reg-head :head/simple (fn [_ _] {:title "bare"}))
-    (let [f (rf/make-frame {:doc "shorthand frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "shorthand frame" :platform :server})]
       (is (= {:title "bare"} (rf/render-head :head/simple f))))))
 
 (deftest render-head-accepts-explicit-route-override
   (testing ":route opt overrides the slice read from app-db — useful for
             tools that want a hypothetical-route preview"
     (rf/reg-head :head/echo (fn [_ route] {:title (str (:route-id route))}))
-    (let [f (rf/make-frame {:doc "explicit-route frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "explicit-route frame" :platform :server})]
       (is (= ":route/explicit"
              (:title (rf/render-head :head/echo
                                      {:frame f
@@ -113,7 +114,7 @@
 
 (deftest render-head-raises-on-unregistered-id
   (testing "render-head against an unknown id throws :rf.error/no-such-head"
-    (let [f (rf/make-frame {:doc "missing-head frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "missing-head frame" :platform :server})]
       (try
         (rf/render-head :head/nope {:frame f})
         (is false "expected exception")
@@ -128,7 +129,7 @@
             head-id) so head-snapshot reflects the latest output"
     (rf/reg-head :head/a (fn [_ _] {:title "A"}))
     (rf/reg-head :head/b (fn [_ _] {:title "B"}))
-    (let [f (rf/make-frame {:doc "snapshot frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "snapshot frame" :platform :server})]
       (rf/render-head :head/a {:frame f})
       (rf/render-head :head/b {:frame f})
       (let [snap (head/head-snapshot f)]
@@ -150,7 +151,7 @@
                   {:doc  "Article page"
                    :path "/articles/:id"
                    :head :head/article})
-    (let [f (rf/make-frame {:doc "active-route frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "active-route frame" :platform :server})]
       (rf/dispatch-sync
         [::seed-route] {:frame f})
       ;; The test sub-handler isn't registered; instead seed the runtime-db
@@ -170,7 +171,7 @@
     (rf/reg-route :route/no-head
                   {:doc  "Bare route"
                    :path "/"})
-    (let [f (rf/make-frame {:doc "Default-head probe" :platform :server})]
+    (let [f (frame/make-frame {:doc "Default-head probe" :platform :server})]
       (rf/reg-event ::seed-route-no-head
                        (fn [{rt :rf.db/runtime} _]
                          {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/no-head})}))
@@ -186,7 +187,7 @@
 
 (deftest active-head-uses-default-when-no-route-at-all
   (testing "no route slice (e.g. a frame that hasn't routed yet) → default"
-    (let [f (rf/make-frame {:doc "Bare" :platform :server})
+    (let [f (frame/make-frame {:doc "Bare" :platform :server})
           model (rf/active-head f)]
       (is (= "Bare" (:title model)))
       (is (seq (:meta model))))))
@@ -507,7 +508,7 @@
             head bookkeeping must not leak across requests, per Spec 011
             §Per-request frame teardown and rf2-fcj33"
     (rf/reg-head :head/leaktest (fn [_ _] {:title "snapshot-A"}))
-    (let [f (rf/make-frame {:doc "teardown frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "teardown frame" :platform :server})]
       (rf/render-head :head/leaktest {:frame f})
       (is (= {:title "snapshot-A"}
              (get (head/head-snapshot f) :head/leaktest))
@@ -520,8 +521,8 @@
   (testing "two frames carry independent head-snapshots — destroying one
             doesn't touch the other"
     (rf/reg-head :head/iso (fn [_ _] {:title "x"}))
-    (let [f1 (rf/make-frame {:doc "frame-1" :platform :server})
-          f2 (rf/make-frame {:doc "frame-2" :platform :server})]
+    (let [f1 (frame/make-frame {:doc "frame-1" :platform :server})
+          f2 (frame/make-frame {:doc "frame-2" :platform :server})]
       (rf/render-head :head/iso {:frame f1})
       (rf/render-head :head/iso {:frame f2})
       (is (seq (head/head-snapshot f1)))
@@ -547,7 +548,7 @@
             the internal re-frame.ssr.head/head-snapshot returns"
     (rf/reg-head :head/pub-a (fn [_ _] {:title "Pub-A"}))
     (rf/reg-head :head/pub-b (fn [_ _] {:title "Pub-B"}))
-    (let [f (rf/make-frame {:doc "rf/head-snapshot frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "rf/head-snapshot frame" :platform :server})]
       (is (= {} (rf/head-snapshot f))
           "empty pre-render")
       (rf/render-head :head/pub-a {:frame f})
@@ -592,7 +593,7 @@
                   {:doc  "Article page"
                    :path "/articles/:id"
                    :head :head/article})
-    (let [f (rf/make-frame {:doc "article frame" :platform :server})]
+    (let [f (frame/make-frame {:doc "article frame" :platform :server})]
       (rf/dispatch-sync [:seed-article] {:frame f})
       (let [model (rf/active-head f)
             html  (rf/head-model->html model)]
@@ -636,7 +637,7 @@
                      (fn [{rt :rf.db/runtime} _]
                        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
                                                  {:route-id :route/article-fr :params {:id "1"}})}))
-    (let [f (rf/make-frame {:platform :server})]
+    (let [f (frame/make-frame {:platform :server})]
       (rf/dispatch-sync [:seed-fr] {:frame f})
       (let [model (rf/active-head f)]
         (is (= "Article — fr-FR" (:title model)))

--- a/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
@@ -41,6 +41,7 @@
   the audit's §Drop-or-keep recommendation)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
@@ -95,7 +96,7 @@
             The mismatch is a downstream trace, not a hydration
             blocker (Spec 011 — degraded-but-running posture)."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -121,7 +122,7 @@
             hoisted to the trace envelope's top level (per Spec 009
             §Error event shape's recovery-hoist branch)."
     (register-handlers!)
-    (let [client-frame   (rf/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame   (frame/make-frame {:doc "ssr-mismatch client frame"
                                          :platform :client})
           ;; A second 8-hex string — anything other than \"deadbeef\".
           client-hash    "0badf00d"
@@ -161,7 +162,7 @@
             input and lock the shape + the not-equal-deadbeef
             invariant."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
                                        :platform :client})
           ;; A non-trivial hiccup tree — its computed hash is whatever
           ;; FNV-1a resolves to; we lock the shape and the not-equal
@@ -209,7 +210,7 @@
             error-emit path is the producer site — see
             `re-frame.ssr.hydrate/verify-hydration!`)."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
                                        :platform :client})
           _            (rf/dispatch-sync [:rf/hydrate mismatch-payload]
                                          {:frame client-frame})
@@ -238,7 +239,7 @@
             assertion here drives ::inc through `dispatch-sync`
             and reads :count via `subscribe-once`."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -273,7 +274,7 @@
             hash + failing-id payload as the trace, and :recovery is
             :hard-error."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr strict-mode frame"
+    (let [client-frame (frame/make-frame {:doc "ssr strict-mode frame"
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -296,7 +297,7 @@
             trace (monitoring integrations rely on it) AND throws — the
             two are not mutually exclusive."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr strict-mode frame"
+    (let [client-frame (frame/make-frame {:doc "ssr strict-mode frame"
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -316,7 +317,7 @@
             short-circuits the hash comparison entirely (Spec 011 item 4):
             no trace, no throw, even when the hashes diverge."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr detection-off frame"
+    (let [client-frame (frame/make-frame {:doc "ssr detection-off frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? false}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -335,7 +336,7 @@
             warns. Pins the default so a future refactor can't silently
             flip detection off."
     (register-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr default frame"
+    (let [client-frame (frame/make-frame {:doc "ssr default frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
       (let [traces (capture-traces!

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -44,6 +44,7 @@
   by the 3 adapter smokes per the audit's §Drop-or-keep recommendation)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.payload-policy :as payload-policy]
@@ -134,7 +135,7 @@
             post-hydrate values via subscribe-once (no view re-render
             machinery needed; the contract is the app-db state)."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -169,7 +170,7 @@
             observed the same via DOM re-render; subscribe-once reads
             the post-drain app-db directly)."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -201,7 +202,7 @@
             (resp-status, resp-ct, resp-cookies-count,
             resp-cookie-name)."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -230,7 +231,7 @@
             compatibility check; absence of the hook is degraded-
             but-running, never crash)."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)
           traces       (capture-traces!
@@ -269,7 +270,7 @@
             :rf.fx/skipped-on-platform warning per check on every server-
             side hydrate. The handler-level gate prevents that noise."
     (register-baseline-handlers!)
-    (let [server-frame (rf/make-frame {:doc "ssr-basic server frame"
+    (let [server-frame (frame/make-frame {:doc "ssr-basic server frame"
                                        :platform :server})
           ;; Add a :rf/schema-digest so BOTH checks would fire if the
           ;; handler enqueued them; otherwise only :rf.ssr/check-version
@@ -307,7 +308,7 @@
             and differing). Without this counter-assertion the
             server-side gate could silently strip both code paths."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)
           traces       (capture-traces!
@@ -335,7 +336,7 @@
             :rf.ssr/hydration-mismatch trace fires on the baseline
             surface (its payload's :rf/render-hash is nil)."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -384,7 +385,7 @@
                          {:rf/app-db "slice-is-a-string"}
                          {:rf/app-db [:slice :is :a :vector]}
                          {:rf/app-db 99}]]
-      (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
+      (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
                                          :platform :client})]
         ;; Seed a recognisable pre-hydration client slice so we can prove
         ;; it SURVIVES (was not replaced by the malformed payload).
@@ -416,7 +417,7 @@
             neither emits the malformed diagnostic."
     (register-baseline-handlers!)
     ;; (a) full server slice → replaces app-db, no diagnostic.
-    (let [client-frame (rf/make-frame {:doc "client frame a" :platform :client})
+    (let [client-frame (frame/make-frame {:doc "client frame a" :platform :client})
           traces       (capture-traces!
                          (fn []
                            (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 7 :title "seeded"}}]
@@ -426,7 +427,7 @@
       (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
           "no malformed diagnostic on a well-formed payload"))
     ;; (b) map payload with no app-db slice → existing client data survives.
-    (let [client-frame (rf/make-frame {:doc "client frame b" :platform :client})]
+    (let [client-frame (frame/make-frame {:doc "client frame b" :platform :client})]
       (rf/dispatch-sync [::set-title "kept"] {:frame client-frame})
       (let [traces (capture-traces!
                      (fn []
@@ -478,7 +479,7 @@
                     [:runtime :is :a :vector]
                     42
                     false]]
-      (let [client-frame (rf/make-frame {:doc "non-map-runtime-db client frame"
+      (let [client-frame (frame/make-frame {:doc "non-map-runtime-db client frame"
                                          :platform :client})]
         ;; Seed recognisable pre-hydration state in BOTH partitions.
         (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
@@ -529,7 +530,7 @@
     (subs/reg-runtime-sub :route-current
       (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
     ;; (a) map runtime-db slice → installs the runtime-db partition.
-    (let [client-frame (rf/make-frame {:doc "rt-ok client frame" :platform :client})
+    (let [client-frame (frame/make-frame {:doc "rt-ok client frame" :platform :client})
           payload {:rf/app-db     {:count 7 :title "seeded"}
                    :rf/runtime-db {:rf.runtime/routing {:current {:route-id :home}}}}
           traces  (capture-traces!
@@ -541,7 +542,7 @@
       (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
           "no malformed diagnostic on a well-formed two-partition payload"))
     ;; (b) wholly-absent :rf/runtime-db key → no-server-runtime fallback.
-    (let [client-frame (rf/make-frame {:doc "rt-absent client frame" :platform :client})
+    (let [client-frame (frame/make-frame {:doc "rt-absent client frame" :platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 3}}]
@@ -573,7 +574,7 @@
             a retired alias that stays dead. It behaves as an unknown no-slice
             payload (app-db unchanged, client-only fallback), not as an alias."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "alias-dead client frame"
+    (let [client-frame (frame/make-frame {:doc "alias-dead client frame"
                                        :platform :client})]
       ;; Seed a recognisable pre-hydration client slice so we can prove it
       ;; SURVIVES (was not replaced by the :app-db-keyed payload).
@@ -628,7 +629,7 @@
             sub reflects the seeded slice — the server-build → hydrate! →
             sub round-trip. hydrate! returns the applied payload."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "boot-helper client frame"
+    (let [client-frame (frame/make-frame {:doc "boot-helper client frame"
                                        :platform :client})
           ;; Server side: build the payload from the authoritative app-db
           ;; slice via the same payload-policy path the Ring adapter uses.
@@ -664,7 +665,7 @@
             first-load shape) does NOT dispatch :rf/hydrate and returns
             nil. The caller renders against the empty app-db."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "boot-helper client-only frame"
+    (let [client-frame (frame/make-frame {:doc "boot-helper client-only frame"
                                        :platform :client})
           returned     (ssr/hydrate! {:frame client-frame :payload nil})]
       (is (nil? returned)
@@ -685,7 +686,7 @@
             server's :emit-hash? marker."
     (register-baseline-handlers!)
     (rf/reg-view* ::boot-root (fn [] [:div.app [:span "client-render"]]))
-    (let [client-frame (rf/make-frame {:doc "boot-helper verify frame"
+    (let [client-frame (frame/make-frame {:doc "boot-helper verify frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Server hash is a DELIBERATELY divergent value so the verify
@@ -712,7 +713,7 @@
             successful hydration. Counter-test to the divergent-render case
             so the verify step can't be a false-positive generator."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "boot-helper verify-match frame"
+    (let [client-frame (frame/make-frame {:doc "boot-helper verify-match frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           client-tree   [:div.app [:span "client-render"]]
@@ -765,10 +766,10 @@
             :rf.error/hydration-frame-id-mismatch — the runtime never
             silently picks a side, and app-db is NOT replaced."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "mismatch client frame"
+    (let [client-frame (frame/make-frame {:doc "mismatch client frame"
                                        :platform :client})
           ;; Payload stamped with a DIFFERENT frame id than the client target.
-          other-frame  (rf/make-frame {:doc "the server's other frame"
+          other-frame  (frame/make-frame {:doc "the server's other frame"
                                        :platform :server})
           payload      (build-server-payload
                          other-frame {:count 7 :title "seeded"} "deadbeef"
@@ -792,7 +793,7 @@
             conflict — there is nothing to disagree with, so the explicit
             client target stands and hydration proceeds normally."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "no-payload-frame-id client"
+    (let [client-frame (frame/make-frame {:doc "no-payload-frame-id client"
                                        :platform :client})
           ;; A hand-built payload deliberately WITHOUT :rf/frame-id.
           payload      {:rf/version 1 :rf/app-db {:count 7 :title "seeded"}}
@@ -818,7 +819,7 @@
             This is the bypass the bead names: hydrate! throws pre-dispatch,
             but a direct dispatch hits ONLY the handler."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "nv3mua direct-dispatch client"
+    (let [client-frame (frame/make-frame {:doc "nv3mua direct-dispatch client"
                                        :platform :client})]
       ;; Seed a recognisable pre-hydration client slice so we can prove it
       ;; SURVIVES (was not replaced by the wrong-frame payload).
@@ -862,7 +863,7 @@
             dispatch target installs the slice normally (the validation is
             precise — it rejects only present-and-DIFFERENT, never a match)."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "nv3mua matching-frame client"
+    (let [client-frame (frame/make-frame {:doc "nv3mua matching-frame client"
                                        :platform :client})
           ;; Stamp the payload's :rf/frame-id with the SAME frame we hydrate
           ;; into — server + client agree, so the slice lands. A render-hash
@@ -884,7 +885,7 @@
             slice installs (the documented client-only / no-server-slice
             fallback shape). This is the path the baseline tests rely on."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "nv3mua absent-frame-id client"
+    (let [client-frame (frame/make-frame {:doc "nv3mua absent-frame-id client"
                                        :platform :client})
           ;; Deliberately NO :rf/frame-id key.
           payload      {:rf/app-db {:count 5 :title "no-frame-id"}}]
@@ -903,7 +904,7 @@
             host render happens between :rf/hydrate and the call. This locks
             the chosen contract in maintainer-visible terms."
     (register-baseline-handlers!)
-    (let [client-frame (rf/make-frame {:doc "boot-helper sync-contract frame"
+    (let [client-frame (frame/make-frame {:doc "boot-helper sync-contract frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Records WHEN render-tree-fn ran + WHAT app-db it saw.

--- a/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
@@ -62,7 +62,7 @@
   (testing "a default-realm SSR frame's side-channel slots key by the BARE frame
             id (no realm key) — the round-trip is byte-identical to the pre-realm
             keying"
-    (let [f (rf/make-frame {:platform :server :doc "default-realm SSR frame"})]
+    (let [f (frame/make-frame {:platform :server :doc "default-realm SSR frame"})]
       ;; frame-address collapses to the bare id for the default realm.
       (is (= f (frame/frame-address f))
           "frame-address of a default-realm frame is the bare frame id")

--- a/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
@@ -24,6 +24,7 @@
   `ssr-ring/ring_e2e_validator_test`); this suite isolates the trace."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
 
@@ -41,7 +42,7 @@
                                               (:operation ev))
                                        (swap! traces conj ev))))
       (try
-        (let [f  (rf/make-frame
+        (let [f  (frame/make-frame
                    {:platform :server
                     :ssr      {:public-error-id   :rf.ssr/default-error-projector
                                :dev-error-detail? false}})
@@ -110,7 +111,7 @@
       (try
         ;; Default platform is :client; project-render-exception! checks
         ;; `server-frame?` and short-circuits.
-        (let [f      (rf/make-frame {})
+        (let [f      (frame/make-frame {})
               t      (ex-info "should not fire" {})
               result (ssr/project-render-exception! f t)]
           (is (nil? result)
@@ -133,7 +134,7 @@
                                         (:operation ev))
                                  (swap! traces conj ev))))
       (try
-        (let [f (rf/make-frame
+        (let [f (frame/make-frame
                   {:platform :server
                    :ssr      {:public-error-id   :rf.ssr/default-error-projector
                               :on-view-exception :throw}})
@@ -153,7 +154,7 @@
             production default) project-render-exception! projects as
             normal. Pins the default so the escape-hatch can't silently
             become the default."
-    (let [f (rf/make-frame
+    (let [f (frame/make-frame
               {:platform :server
                :ssr      {:public-error-id :rf.ssr/default-error-projector}})
           t (ex-info "normal failure" {})

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -23,6 +23,7 @@
   adapter."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
@@ -63,7 +64,7 @@
 
 (deftest cofx-reads-populated-request
   (testing "(set-request! frame req) → :rf.cofx/requires [:rf.server/request] → handler reads req"
-    (let [server-frame (rf/make-frame
+    (let [server-frame (frame/make-frame
                          {:doc      "SSR request frame"
                           :platform :server})
           request      {:request-method :get
@@ -89,7 +90,7 @@
 
 (deftest get-request-mirrors-cofx
   (testing "ssr/get-request is the public read surface — same value as the cofx"
-    (let [server-frame (rf/make-frame {:platform :server})
+    (let [server-frame (frame/make-frame {:platform :server})
           request      {:request-method :post
                         :uri            "/api/articles"
                         :body           "{\"title\":\"new\"}"}]
@@ -105,7 +106,7 @@
 
 (deftest cofx-injects-nil-when-slot-unpopulated
   (testing "cofx returns nil when no host adapter has populated the slot"
-    (let [server-frame (rf/make-frame {:platform :server})
+    (let [server-frame (frame/make-frame {:platform :server})
           observed     (atom :unset)]
       (rf/reg-event :req-test/read-empty
         {:rf.cofx/requires [:rf.server/request]}
@@ -133,7 +134,7 @@
 (deftest cofx-is-skipped-on-client-frame
   (testing ":rf.server/request is skipped on a :platform :client frame
             and emits :rf.cofx/skipped-on-platform"
-    (let [client-frame (rf/make-frame {:platform :client})
+    (let [client-frame (frame/make-frame {:platform :client})
           traces       (collect-traces! ::req-client)
           observed     (atom :unset)]
       (rf/reg-event :req-test/read-on-client
@@ -173,8 +174,8 @@
 
 (deftest two-frames-carry-independent-request-data
   (testing "two simultaneous per-request frames have isolated request slots"
-    (let [frame-a    (rf/make-frame {:platform :server :doc "request A"})
-          frame-b    (rf/make-frame {:platform :server :doc "request B"})
+    (let [frame-a    (frame/make-frame {:platform :server :doc "request A"})
+          frame-b    (frame/make-frame {:platform :server :doc "request B"})
           request-a  {:uri "/articles/aaa" :headers {"cookie" "session=user-a"}}
           request-b  {:uri "/articles/bbb" :headers {"cookie" "session=user-b"}}
           observed-a (atom :unset)
@@ -205,7 +206,7 @@
 
 (deftest clear-request-removes-the-slot
   (testing "clear-request! removes the per-frame slot — subsequent reads return nil"
-    (let [server-frame (rf/make-frame {:platform :server})
+    (let [server-frame (frame/make-frame {:platform :server})
           request      {:uri "/x"}]
       (ssr/set-request! server-frame request)
       (is (= request (ssr/get-request server-frame)))
@@ -235,7 +236,7 @@
 (deftest set-request-is-the-test-seam
   (testing "set-request! supplies the request for a harness-driven drain; the
             declared cofx reads it (replacing the retired 2-arity override)"
-    (let [server-frame (rf/make-frame {:platform :server})
+    (let [server-frame (frame/make-frame {:platform :server})
           explicit     {:uri "/explicit" :headers {"x-test" "1"}}
           observed     (atom :unset)]
       (ssr/set-request! server-frame explicit)
@@ -257,7 +258,7 @@
 
 (deftest cofx-works-under-ssr-server-preset
   (testing "the cofx surfaces the request under a :preset :ssr-server frame"
-    (let [server-frame (rf/make-frame {:preset :ssr-server})
+    (let [server-frame (frame/make-frame {:preset :ssr-server})
           request      {:uri "/preset" :request-method :get}
           observed     (atom :unset)]
       (ssr/set-request! server-frame request)

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -138,7 +138,7 @@
   Returns the rendered HTML for sanity-check assertions."
   [i]
   (let [server-frame
-        (rf/make-frame
+        (frame/make-frame
           {:doc       (str "load-test request " i)
            :platform  :server
            :on-create [:load-test/server-init {:i i}]})]
@@ -304,7 +304,7 @@
     ;; trace-emit so we don't have to engineer a real handler failure
     ;; — the cleanup contract is the same).
     (dotimes [i 50]
-      (let [fid (rf/make-frame
+      (let [fid (frame/make-frame
                   {:doc       (str "error-buffer test " i)
                    :platform  :server
                    :on-create [:load-test/server-init {:i i}]})]


### PR DESCRIPTION
EP-0023 collapse wave, **slice 3b** (rf2-32siq3.46) — SSR caller-migration. Mirrors the just-merged slice 3a (core, rf2-32siq3.45). Sequenced: .45 core ✓ → **.46 ssr** → .47 adapters → .48 repoint+retire-guard.

## What

Migrate all **154** SSR-surface `rf/make-frame` call sites off the facade onto `re-frame.frame/make-frame` (the EP-0013 record constructor) so the eventual repoint (.48, where `rf/make-frame` flips to the object constructor) is a clean flip with these callers already byte-identical.

## Why record (not object) for every site

Every SSR call site depends on the EP-0013 record-constructor contract:
- passes record-config keys the OBJECT constructor does **not** consume: `:platform`, `:doc`, `:on-create`, `:ssr`, `:fx-overrides`, `:preset`; and/or
- treats the return as a **keyword frame-id** (passed to `ssr/set-request!`, `rf/destroy-frame!`, `rf/with-frame`, `swap!`-keyed slot maps).

`live-frame/make-frame` (the object constructor) destructures only `:images`/`:id`/`:initial-db`/`:capabilities`/`:adapter` and calls `(reg-frame runnable-id {})`, so it would silently drop that config and change the return shape — behaviour these tests assert against. The record constructor does **not** move in the repoint slice (only the facade var does), so `frame/make-frame` is byte-identical today and after the flip.

**None** of the SSR callers genuinely want the runnable object, so none stay on `lf/make-frame`. Record/object split: **154 record, 0 object.**

`[re-frame.frame :as frame]` require added to the 10 files that lacked it (two — `ssr_realm_address_test`, `ssr_teardown_load_test` — already had it).

## Out of scope (left untouched)

- **Docstrings/comments** referencing the PUBLIC facade `rf/make-frame` (what end-users call): `ssr/error_projector.cljc` reg-error-projector docstring, `ssr-ring/ring.clj` ssr-handler docstring + `pipeline.clj` comment, and prose refs in `ssr_hydration_test.clj` / `ring_test.clj`. **No production source code changed** — the bead's "1 production caller (error_projector.cljc)" is a docstring example, not a call site.
- No `rf/make-frame` repoint, no retirement of `assert-no-dual-make-frame!` (slice .48).
- No SSR window-pin tests exist (the s8 / migration pins live in core, untouched).
- Adapters (slice .47) untouched.
- No new always-on instrumentation ids → no spec/009 change.

**Hot-zone:** none touched (only `implementation/ssr/test/` + `implementation/ssr-ring/test/`).

## Files (12, all test)

`ssr-ring` `ring_test.clj`; `ssr/test` `ssr_compatibility_checks_test`, `ssr_end_to_end_test` (79 sites), `ssr_error_emit_promotion_test`, `ssr_error_projector_substrate_test`, `ssr_head_test`, `ssr_hydration_mismatch_test`, `ssr_hydration_test`, `ssr_realm_address_test`, `ssr_render_failed_test`, `ssr_request_cofx_test`, `ssr_teardown_load_test`.

## Gates

- ssr JVM: 347 tests / 1394 assertions / 0 fail
- ssr-ring JVM: 166 tests / 753 assertions / 0 fail
- `npm run test:cljs`: 7627 tests / 31470 assertions / 0 fail
- `npm run test:elision`: PASS
- `scripts/test-fast-pr.sh`: PASS
