### PR TITLE
refactor(adapters): EP-0023 collapse migration — adapter callers (rf2-32siq3.47)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -36,6 +36,7 @@
        :data."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -153,7 +154,7 @@
   (testing "happy path: boot machine traverses :configuring → :loading-deps → :hydrating → :ready and all slices land"
     (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:on-create    [:boot/initialise]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
@@ -182,7 +183,7 @@
   (testing "per-child :data fns thread spawn-spec identity; no cross-talk between siblings"
     (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:on-create    [:boot/initialise]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
@@ -212,7 +213,7 @@
                          {:status 500
                           :body   "boot dependency unreachable"})
 
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:on-create    [:boot/initialise]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-fail}})]
@@ -287,7 +288,7 @@
     (let [frame  (atom nil)
           traces (collect-machine-data-traces!
                    #(reset! frame
-                      (rf/make-frame
+                      (frame/make-frame
                         {:on-create    [:boot/initialise]
                          :fx-overrides {:rf.http/managed
                                         :boot.test/canned-bad-config}})))]
@@ -316,7 +317,7 @@
                                           (= :app-db (-> ev :tags :where)))
                                  (swap! app-traces conj ev))))
       (try
-        (with-new-frame [f (rf/make-frame {})]
+        (with-new-frame [f (frame/make-frame {})]
           (rf/reg-app-schema [:config] [:maybe boot-schema/Config] {:frame f})
           (rf/dispatch-sync [::write-bad-config] {:frame f}))
         (finally (rf/unregister-listener! ::app)))

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -34,6 +34,7 @@
             ;; validator; without this require they'd soft-pass.
             [re-frame.schemas.malli]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.http-managed :as http-managed]
             ;; rf2-cdmle — canned-stub fxs (`:rf.http/managed-canned-success`,
             ;; `:rf.http/managed-canned-failure`) gate on explicit
@@ -275,10 +276,10 @@
           {:fx [[:rf.http/managed
                  {:request {:method :get :url "/articles/hello"}
                   :decode  :json}]]})))
-    (let [left  (rf/make-frame {:doc "left"
+    (let [left  (frame/make-frame {:doc "left"
                                 :fx-overrides
                                 {:rf.http/managed :rf.http/managed-canned-success}})
-          right (rf/make-frame {:doc "right"
+          right (frame/make-frame {:doc "right"
                                 :fx-overrides
                                 {:rf.http/managed :rf.http/managed-canned-success}})]
       (rf/dispatch-sync [:article/load] {:frame left})

--- a/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
@@ -22,6 +22,7 @@
        message) settles without any `:where :machine-data` trace."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -99,7 +100,7 @@
   (testing "a failure reply whose message is non-string drives :record-error to write a bad :error, failing the :machine-data boundary and rolling back"
     (reg-sync-failure-override! :login.test/canned-bad-message
                                 {:status 401 :message {:not "a string"}})
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:fx-overrides {:rf.http/managed
                                          :login.test/canned-bad-message}})]
       ;; A valid submit drives :idle → :submitting and fires :issue-request;
@@ -131,7 +132,7 @@
   (testing "a normal failing login (string message) settles with no :machine-data trace"
     (reg-sync-failure-override! :login.test/canned-ok-message
                                 {:status 401 :message "Invalid credentials."})
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:fx-overrides {:rf.http/managed
                                          :login.test/canned-ok-message}})]
       (let [traces (collect-machine-data-traces!

--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -27,6 +27,7 @@
    subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
@@ -66,7 +67,7 @@
    Both reach the same end-state: parent machine at :idle with cleared
    :data."
   []
-  (rf/make-frame {:on-create [:work/flow [:reset]]}))
+  (frame/make-frame {:on-create [:work/flow [:reset]]}))
 
 ;; ============================================================================
 ;; (1) SPAWN CASCADE — :start spawns 3 children

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -25,6 +25,7 @@
    leaves them intact for any subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
@@ -75,7 +76,7 @@
   {:rf.http/managed :nine-states.http/managed-demo})
 
 (defn- new-frame []
-  (rf/make-frame
+  (frame/make-frame
     {:on-create    [:nine-states.app/initialise]
      :fx-overrides demo-overrides}))
 
@@ -199,7 +200,7 @@
     ;; setup event.
     (is (some? (rf/handler-meta :event :nine-states.story/load-failing))
         ":nine-states.story/load-failing registered (stories.cljs required)")
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:on-create    [:nine-states.app/initialise]
                           :fx-overrides story-failure-overrides})]
       ;; Drive the variant's setup load event. The canned-failure stub
@@ -225,7 +226,7 @@
     ;; with no per-variant override. Guards that success and failure stay
     ;; SEPARATELY represented (acceptance: keep the success lifecycle
     ;; variant proving canned-success).
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:on-create    [:nine-states.app/initialise]
                           :fx-overrides {:rf.http/managed
                                          :rf.http/managed-canned-success}})]

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -24,6 +24,7 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
@@ -120,7 +121,7 @@
                                :bio      nil
                                :image    nil}})
 
-  (with-new-frame [f (rf/make-frame {:fx-overrides {:rf.http/managed      :realworld.test/login-success
+  (with-new-frame [f (frame/make-frame {:fx-overrides {:rf.http/managed      :realworld.test/login-success
                                                     :auth.session/persist :rf/no-op}})]
     ;; EP-0017 (rf2-16ck78): `:auth/initialise` consumes the RECORDABLE+PROVIDED
     ;; `:auth.session/token` coeffect — its value rides the dispatch token,
@@ -164,7 +165,7 @@
                        {:status 422
                         :body   {:errors {:body ["email or password is invalid"]}}})
 
-  (with-new-frame [f (rf/make-frame {:fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
+  (with-new-frame [f (frame/make-frame {:fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
     ;; EP-0017 (rf2-16ck78): supply the RECORDABLE+PROVIDED `:auth.session/token`
     ;; on the boot dispatch token (nil node-side), mirroring `realworld.core/run`.
     (rf/dispatch-sync [:auth/initialise]
@@ -196,7 +197,7 @@
                                              :following false}}]
                         :articlesCount 1})
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
     (is (= :idle (:status (rf/compute-sub [:articles/slice] (rf/frame-state-value f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
@@ -215,7 +216,7 @@
                        {:status 500
                         :body   "server error"})
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
     (is (= :error (:status (rf/compute-sub [:articles/slice] (rf/frame-state-value f)))))
@@ -238,7 +239,7 @@
                                   :favoritesCount 0
                                   :author {:username "alice" :bio nil :image nil :following false}}})
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     ;; The :mode region starts at :create; the :lifecycle region starts
@@ -261,7 +262,7 @@
     (is (false? (rf/compute-sub [:editor/dirty?] (rf/frame-state-value f))))))
 
 (defn- editor-can-leave-test []
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     (is (true? (rf/compute-sub [:editor/can-leave?] (rf/frame-state-value f))))
@@ -298,7 +299,7 @@
                                              :favoritesCount 0
                                              :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-article-and-comments}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -337,7 +338,7 @@
                                              :favoritesCount 0
                                              :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-comment-post}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -358,7 +359,7 @@
   ;; or a concurrent delete), a stale index can point past the current
   ;; vector. The rollback's `subvec` must NOT throw IndexOutOfBounds — it
   ;; clamps the index to the current length and re-inserts at the tail.
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     ;; Seed a single comment (the list is now length 1).
@@ -397,7 +398,7 @@
                        {:status 400
                         :body   {:errors {:body ["rollback"]}}})
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     ;; :article/toggle-favorite is auth-gated (rf2-ygh4m): a logged-out
@@ -447,7 +448,7 @@
                                                :favoritesCount 0
                                                :author {:username "eve" :bio nil :image nil :following false}}]})))
 
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-profile}})]
     (rf/dispatch-sync [:profile/initialise] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
@@ -485,7 +486,7 @@
                                :bio "New bio"
                                :image nil}})
 
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-save
                                                 :auth.session/persist :rf/no-op}})]
     ;; After :app/initialise → :settings/initialise → [:reset], the
@@ -549,7 +550,7 @@
   (reg-canned-failure! :realworld.test/canned-settings-failure
                        :rf.http/http-5xx
                        {:status 500 :body "server error"})
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-failure
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -581,7 +582,7 @@
   ;; validate inside :settings/submit would dispatch :submit-invalid
   ;; when the draft failed validation, matching Pattern-Forms'
   ;; §Standard events table.
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed       :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -629,7 +630,7 @@
                   (rf/frame-state-value frame)))
 
 (defn- tag-query-test []
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; rf2-e90vfv route-shape conformance: applying a tag navigates to the
     ;; official `/tag/:tag` PATH route, so the active tag is a route PARAM (read
@@ -645,7 +646,7 @@
   ;; The :tags lifecycle — load happy path through the machine.
   (reg-canned-success! :realworld.test/canned-tags
                        {:tags ["intro" "demo" "clojure"]})
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags}})]
     ;; After :app/initialise → :tags/initialise → [:reset], the machine
     ;; sits at :idle with empty :data.
@@ -689,7 +690,7 @@
   (reg-canned-failure! :realworld.test/canned-tags-failure
                        :rf.http/http-5xx
                        {:status 500 :body "server error"})
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags-failure}})]
     (rf/dispatch-sync [:tags/load] {:frame f})
     (let [db   (rf/frame-state-value f)
@@ -705,7 +706,7 @@
 ;; ============================================================================
 
 (defn- routing-tests []
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:rf.route/navigate :realworld.article/show {:slug "hello"}] {:frame f})
     (is (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))
@@ -732,7 +733,7 @@
   ;; (core.cljs) BY ID (EP-0022). Configure the test frame with the same
   ;; id-reference so the guard is exercised end-to-end. Its descriptor is
   ;; registered at `realworld.routing` ns-load (required below).
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     ;; Unauthenticated: navigating to a :requires-auth route
@@ -776,7 +777,7 @@
   ;; assert all three paths now redirect to login.
 
   ;; --- direct-URL / reload / popstate (`:rf.route/handle-url-change`) ---
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     ;; Logged-out direct URL (or reload) to a :requires-auth route.
@@ -802,7 +803,7 @@
         "logged-out direct-URL to a non-auth route is unaffected"))
 
   ;; --- anchor click (`:rf/url-requested`) ---
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     ;; An anchor whose href targets a :requires-auth route. The
@@ -831,7 +832,7 @@
         "logged-out anchor to a non-auth route is unaffected"))
 
   ;; --- authenticated: every entry point now PASSES through ---
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
@@ -895,7 +896,7 @@
 ;; ============================================================================
 
 (defn- app-smoke-test []
-  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     ;; EP-0017 (rf2-16ck78): `:auth/initialise` is no longer in the

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -43,6 +43,7 @@
    contract is uniform across CLJS fixtures."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
@@ -238,13 +239,13 @@
             [:auth :token] from the cascade's frame and injects
             `Authorization: Token <jwt>`; it is a no-op when logged out"
     ;; LOGGED OUT — the public reads must not carry an auth header.
-    (with-new-frame [f (rf/make-frame {})]
+    (with-new-frame [f (frame/make-frame {})]
       (let [ctx {:frame f :request {:url "/articles"}}]
         (is (nil? (get-in (core/bearer-auth-interceptor ctx)
                           [:request :headers "Authorization"]))
             "no token → no Authorization header (logged-out reads unaffected)")))
     ;; AUTHED — the token in the frame's app-db is injected as a Bearer header.
-    (with-new-frame [f (rf/make-frame {})]
+    (with-new-frame [f (frame/make-frame {})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt-xyz"}] {:frame f})
       (let [ctx {:frame f :request {:url "/articles/feed"}}]
         (is (= "Token jwt-xyz"
@@ -262,7 +263,7 @@
             global article tags AND the session feed in one set of per-target
             descriptors, and fires no extra wiring; the call-site :reply-to
             continuation fires exactly once on settle"
-    (with-new-frame [f (rf/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-frame {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; log in so the session feed scope resolves
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -315,7 +316,7 @@
             valid-AND-dirty into app-db; a blank draft is invalid; a valid+dirty
             draft submits the save mutation; the :reply-to [:editor/replied]
             continuation re-seeds a clean draft and navigates to the saved article"
-    (with-new-frame [f (rf/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-frame {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; create-mode entry registers the :editor/can-submit? flow against this frame
       (rf/dispatch-sync [:editor/initialise] {:frame f})
@@ -354,7 +355,7 @@
             auth slice, drops the session-scoped cache via :rf.resource/clear-scope
             (so the next user never reads the prior user's feed), and releases the
             principal-switch lease. Public global reads are untouched."
-    (with-new-frame [f (rf/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-frame {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; ensure the session feed under the principal-switch lease the app uses
@@ -385,7 +386,7 @@
   (testing "examples/reagent/realworld_resources — the :auth/flow machine drives
             :idle → :submitting → :authed on a login success and stores the
             session (auth is a command/machine, deliberately NOT a read-resource)"
-    (with-new-frame [f (rf/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-frame {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op
                                                       :realworld-resources.session/persist :rf/no-op}})]
       ;; boot the machine at :idle (token nil → the has-token? guard routes to no-op)

--- a/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
@@ -32,6 +32,7 @@
    any subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
@@ -234,7 +235,7 @@
             :resources.app/preview-closed releases the lease so the entry can GC
             (the mandatory release path for an app-minted lease, Spec 016 §Active
             owners)"
-    (with-new-frame [f (rf/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-frame {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (let [lease-owner [:lease :resources.app/preview "fresh-skip"]
             dkey        (detail-key "fresh-skip")]

--- a/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
@@ -23,6 +23,7 @@
   §Multi-frame routing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.routing :as routing]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -51,7 +52,7 @@
     ;;
     ;; Test isolation: a fresh frame so prior tests' [:rf.db/runtime :rf.runtime/routing :current]
     ;; slices don't leak in.
-    (let [f (rf/make-frame {:doc "isolated frame for this test"})]
+    (let [f (frame/make-frame {:doc "isolated frame for this test"})]
       (rf/reg-route :route.cljs/home
                     {:path "/cljs/home"})
       (rf/reg-route :route.cljs/article
@@ -101,8 +102,8 @@
                                               :params [:map [:id :string]]})
     (subs/reg-runtime-sub :rf.cljs2/route (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
 
-    (let [left  (rf/make-frame {:doc "left tab frame"})
-          right (rf/make-frame {:doc "right tab frame"})]
+    (let [left  (frame/make-frame {:doc "left tab frame"})
+          right (frame/make-frame {:doc "right tab frame"})]
 
       ;; Each frame navigates independently.
       (rf/dispatch-sync [:rf.route/transitioned "/cljs2/articles"]

--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -44,6 +44,7 @@
    carried — run-order independence is now the fixture's contract."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
@@ -78,7 +79,7 @@
     ;; dispatch is issued explicitly here (not via :on-create, which does not
     ;; forward :rf.cofx) carrying the empty-localStorage / first-run value: an
     ;; empty sorted-map, exactly what the node-side boundary read yields.
-    (with-new-frame [f (rf/make-frame
+    (with-new-frame [f (frame/make-frame
                          {:fx-overrides {:todo.storage/save :rf/no-op}})]
       (rf/dispatch-sync [:todo/initialise]
                         {:frame   f

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -25,7 +25,7 @@
             [re-frame.fx :as fx]
             [re-frame.subs :as subs]
             [re-frame.late-bind :as late-bind]
-            [re-frame.frame]
+            [re-frame.frame :as frame]
             [re-frame.substrate.adapter]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
@@ -235,7 +235,7 @@
   ;; way. (We DO need the synthetic `[:rf.machine.timer/after-elapsed
   ;; delay epoch]` events to drive `:after` directly, which we do by
   ;; dispatching them ourselves.)
-  (rf/make-frame {:on-create    [:ws.app/initialise]
+  (frame/make-frame {:on-create    [:ws.app/initialise]
                   :fx-overrides {:dispatch-later nil}}))
 
 (defn- with-sync-mock! [f]


### PR DESCRIPTION
EP-0023 collapse wave, **slice 3c** (rf2-32siq3.47): migrate the ADAPTER-surface callers off the facade `rf/make-frame` so the eventual repoint (slice .48) is a clean flip. Mirrors slice 3a (core, .45) and 3b (ssr, .46).

## What changed
- **48 call sites** across **11 Reagent adapter test files** migrated `rf/make-frame` → `frame/make-frame` (`re-frame.frame`, the EP-0013 record constructor).
- Added `[re-frame.frame :as frame]` require to the 10 files lacking it; websocket already required `[re-frame.frame]` unaliased (kept for its fully-qualified `re-frame.frame/swap-runtime-db!` call) so its require was aliased `:as frame`.
- **UIx and Helix adapter trees have ZERO `rf/make-frame` callers** — nothing to migrate there.

## Record vs object split
**All 48 → record (`frame/make-frame`); none → object (`lf/make-frame`).** Every site is bound as a keyword frame-id (`with-new-frame`/`let`, used with `:frame f`, `rf/frame-state-value f`) and/or passes record-config keys the object constructor silently drops (`:on-create`, `:fx-overrides`, `:doc`, `:url-bound?`, `:interceptors`). No adapter caller genuinely wants the runnable object — identical to the ssr slice.

Behaviour is **byte-identical**: the facade `rf/make-frame` *is* `frame/make-frame` today (core.cljc), and the record constructor does not move in the repoint slice (only the facade var does).

## .48-safety check (the last migration slice before repoint)
Repo-wide executable `(rf/make-frame ...)` call sites remaining after this slice:
- The **two intentional window-pin tests** .45 named to flip at .48 — `ep0023_conformance` *s8-dual-make-frame-export-fails-loud* and `migration_cljs_test` *facade-make-frame-is-the-ep-0013-record-constructor-only* (both assert the facade returns a keyword during the window).
- `tools/template` scratch.cljs — a generated consumer-app scaffold calling the public facade intentionally; .48's repoint handles it by design (outside `implementation/` scope).

All other `rf/make-frame` hits repo-wide are docstrings / comments / quoted-symbol error contexts / migration-map `:replacement` keywords — not call sites. **.48 can repoint safely.**

## Scope notes
- HOT-ZONE: none touched (test files only).
- No `rf/make-frame` repoint, no `assert-no-dual-make-frame!` retirement (slice .48).
- No new always-on ids → no spec/009 change.

## Gates
- `npm run test:cljs` — 7627 tests / 31470 assertions / **0 fail** (includes the migrated Reagent adapter tests)
- `npm run test:elision` — **PASS**
- `scripts/test-fast-pr.sh` — **PASS**