### PR TITLE
fix(testbed-support): guard the open-in-editor dev endpoint (rf2-pnr56s)

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -10,11 +10,15 @@ browser testbeds. Three namespaces:
   host harness the Story showcase testbeds share.
 - `re-frame.testbed.open-in-editor-server` — a JVM-only (`.clj`)
   shadow-cljs `:dev-http` handler that answers the
-  `GET|POST /__rf-open-in-editor` endpoint, resolving a
+  `POST /__rf-open-in-editor` endpoint, resolving a
   classpath-relative source `:file` against the dev JVM's source-paths at
   runtime and launching the editor via the `launch-editor` npm package
-  (the re-frame2 equivalent of Vite's `/__open-in-editor`). It runs on the
-  shadow-cljs SERVER JVM and is never part of any browser/CLJS build.
+  (the re-frame2 equivalent of Vite's `/__open-in-editor`). Because it
+  launches the editor on a local file, it is POST-only and loopback-guarded
+  (the request must be addressed to a loopback `Host` and, when present,
+  carry a loopback `Origin`; CORS reflects that origin, never `*`) — the
+  drive-by class the historic Vite / react-dev-utils CVEs hit. It runs on
+  the shadow-cljs SERVER JVM and is never part of any browser/CLJS build.
 
 ## What it is
 

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -5,10 +5,24 @@
   Vite's `/__open-in-editor`, react-dev-utils' `launchEditorEndpoint`,
   Next.js' launch-editor middleware. This namespace is the re-frame2
   equivalent — a shadow-cljs `:dev-http` Ring `:handler` (a not-found
-  fallback) that answers `GET|POST /__rf-open-in-editor?file=<…>&line=<n>
+  fallback) that answers `POST /__rf-open-in-editor?file=<…>&line=<n>
   &column=<c>` by resolving the (classpath-relative) `:file` against the
   dev JVM's source-paths AT RUNTIME and launching the editor via the
   `launch-editor` npm package.
+
+  ## Why it is POST-only + loopback-guarded
+
+  The endpoint LAUNCHES the developer's editor on a local file path, so
+  left open it is a drive-by vector in the historic Vite / react-dev-utils
+  CVE class — any page the developer is visiting could fire a request at
+  `http://localhost:<dev-port>` and open an attacker-chosen file. The
+  handler therefore acts only on a POST that is addressed to a loopback
+  `Host` and (when one is present) carries a loopback `Origin`; CORS is
+  reflected to that validated loopback origin, never `*`. A simple GET/HEAD
+  drive-by, a request reaching a non-loopback hostname, or a POST from a
+  remote page's Origin is rejected before any path resolution. The default
+  client (`re-frame.source-coords.open-endpoint`) already POSTs from the
+  same/cross-PORT dev origin, so the dev DX is unchanged.
 
   ## Why server-side beats the editor:// URI scheme
 
@@ -243,15 +257,120 @@
   (when (and (string? s) (re-matches #"\d+" s))
     (try (Long/parseLong s) (catch Throwable _ nil))))
 
+;; ---- localhost / origin guard --------------------------------------------
+;;
+;; This endpoint LAUNCHES the developer's editor on an arbitrary local file
+;; path. Left open it is a drive-by vector in the historic Vite /
+;; react-dev-utils CVE class: any web page the developer happens to be
+;; visiting could fire a request at `http://localhost:<dev-port>` and open
+;; an attacker-chosen file in the editor. The guard pins the endpoint to the
+;; local machine and to local browsing contexts:
+;;
+;;   1. request-method must be POST (the launch path). A simple GET/HEAD —
+;;      the only thing an `<img>`/`<form>`/`<link>` drive-by or a `no-cors`
+;;      simple request can issue — never reaches `launch!`.
+;;   2. the `Host` header must name a loopback address: the request must
+;;      have been addressed to localhost / 127.0.0.1 / [::1]. This rejects a
+;;      request that reached the dev JVM via a non-loopback hostname (a
+;;      DNS-rebinding / public-binding attempt).
+;;   3. when an `Origin` header is present it must itself be a loopback
+;;      origin. A page served from `https://evil.example` carries that
+;;      Origin on its cross-origin POST and is rejected; a legitimate
+;;      cross-PORT dev request (Story shell on :8042 → app on :8031) carries
+;;      a `http://localhost:8042` Origin and passes. (A same-origin POST may
+;;      omit Origin entirely, which is allowed once 1 + 2 hold.)
+;;
+;; CORS is then reflected to the validated loopback Origin only — never the
+;; old `*` wildcard.
+
+(defn ^:private loopback-host?
+  "True when `host` (a `Host`-header value, optionally `name:port`, or the
+  host portion of an Origin/URL) names a loopback address: `localhost`,
+  `127.0.0.0/8`, or the IPv6 `[::1]`/`::1`. Case-insensitive; nil/blank is
+  not loopback."
+  [host]
+  (boolean
+    (when (and (string? host) (not (str/blank? host)))
+      (let [h    (str/lower-case (str/trim host))
+            ;; Drop a trailing :port. For a bracketed IPv6 literal
+            ;; (`[::1]:8080`) split on `]:`; otherwise on the last `:` only
+            ;; when there is exactly one (an unbracketed IPv6 has many and
+            ;; carries no port in a Host header).
+            bare (cond
+                   (str/starts-with? h "[")
+                   (let [close (str/index-of h "]")]
+                     (if close (subs h 1 close) h))
+
+                   (and (str/includes? h ":")
+                        (= 1 (count (filter #(= % \:) h))))
+                   (subs h 0 (str/index-of h ":"))
+
+                   :else h)]
+        (or (= bare "localhost")
+            (= bare "::1")
+            (and (str/starts-with? bare "127.")
+                 ;; a bare IPv4 in 127.0.0.0/8
+                 (re-matches #"127\.\d{1,3}\.\d{1,3}\.\d{1,3}" bare)))))))
+
+(defn ^:private origin-host
+  "Extract the host portion of an `Origin` header value (a serialized
+  origin, e.g. `http://localhost:8042`). Returns nil when it cannot be
+  parsed. The literal string `\"null\"` (an opaque origin — sandboxed
+  iframe, `file:`, some redirects) yields nil so it never passes the
+  loopback check."
+  [origin]
+  (when (and (string? origin)
+             (not (str/blank? origin))
+             (not= "null" (str/trim origin)))
+    (try
+      (.getHost (URI. (str/trim origin)))
+      (catch Throwable _ nil))))
+
+(defn ^:private get-header
+  "Read a request header case-insensitively from the Ring `:headers` map
+  (shadow-cljs dev-http lowercases header names, but read defensively)."
+  [headers nm]
+  (when (map? headers)
+    (or (get headers nm)
+        (some (fn [[k v]] (when (and (string? k)
+                                     (.equalsIgnoreCase ^String k nm))
+                            v))
+              headers))))
+
+(defn ^:private local-request?
+  "Guard predicate: true when the request is safe to act on — addressed to a
+  loopback `Host` AND, if it carries an `Origin`, that Origin is itself a
+  loopback origin. A same-origin request that omits Origin passes on the
+  Host check alone. See the `loopback-host?` comment for the threat model."
+  [{:keys [headers]}]
+  (let [host   (get-header headers "host")
+        origin (get-header headers "origin")]
+    (and (loopback-host? host)
+         (or (nil? origin)
+             (str/blank? origin)
+             (loopback-host? (origin-host origin))))))
+
+(defn ^:private allow-origin
+  "The `access-control-allow-origin` value to reflect: the request's own
+  Origin when it is a validated loopback origin (so a legitimate cross-PORT
+  dev request gets a usable CORS header), else `\"null\"` (deny). Never the
+  old `*` wildcard."
+  [{:keys [headers]}]
+  (let [origin (get-header headers "origin")]
+    (if (and origin (loopback-host? (origin-host origin)))
+      origin
+      "null")))
+
 (defn ^:private json-resp
-  [status m]
+  [status allow-origin-val m]
   {:status  status
    :headers {"content-type"                "application/json"
-             ;; The Xray/Story client fetches from the same origin
-             ;; (its own dev-http port), so CORS is not strictly needed,
-             ;; but the wildcard keeps a cross-port probe (e.g. a Story
-             ;; shell on 8042 reaching an app on 8031) working.
-             "access-control-allow-origin" "*"
+             ;; CORS reflected to the validated loopback Origin only —
+             ;; never `*`. A legitimate cross-PORT dev request (Story shell
+             ;; on :8042 reaching an app on :8031) gets its own origin back;
+             ;; everything else gets `null` (deny).
+             "access-control-allow-origin" allow-origin-val
+             "vary"                        "origin"
              "cache-control"               "no-store"}
    :body    (str "{"
                  (str/join ","
@@ -282,30 +401,53 @@
     `editor` — optional; the editor keyword as a bare string (e.g.
                \"cursor\"); maps to a launch-editor command hint.
 
+  Security: only a POST addressed to a loopback `Host` (with a loopback
+  `Origin` when one is present) reaches `launch!` — see `local-request?`.
+  A non-loopback / cross-origin request is rejected 403 before any path
+  resolution or editor launch; a non-POST (e.g. a drive-by GET) gets 405.
+
   Responses:
     200 `{\"ok\":true,\"file\":\"<abs>\"}`        — editor launched.
     400 `{\"ok\":false,\"error\":\"missing-file\"}` — no `file` param.
+    403 `{\"ok\":false,\"error\":\"forbidden\"}`    — non-loopback / cross-origin.
+    405 `{\"ok\":false,\"error\":\"method-not-allowed\"}` — not POST.
     422 `{\"ok\":false,\"error\":\"<msg>\"}`       — launch failed."
-  [{:keys [uri request-method query-string]}]
+  [{:keys [uri request-method query-string] :as req}]
   (when (= uri endpoint-path)
-    (if (= request-method :options)
-      ;; CORS preflight — some browsers preflight a cross-port POST.
-      {:status 204
-       :headers {"access-control-allow-origin"  "*"
-                 "access-control-allow-methods" "GET, POST, OPTIONS"
-                 "access-control-allow-headers" "content-type"}}
-      (let [q      (parse-query query-string)
-            file   (get q "file")
-            line   (->int (get q "line"))
-            column (->int (get q "column"))
-            cmd    (editor-hint (get q "editor"))]
-        (if (str/blank? file)
-          (json-resp 400 {:ok false :error "missing-file"})
-          (let [abs-path (resolve-file file)
-                {:keys [ok message]} (launch! abs-path line column cmd)]
-            (if ok
-              (json-resp 200 {:ok true :file abs-path})
-              (json-resp 422 {:ok false :error (or message "launch-failed")}))))))))
+    (let [ao (allow-origin req)]
+      (cond
+        ;; CORS preflight for the cross-PORT dev POST. Reflect the validated
+        ;; loopback origin (or deny via `null`); only POST is offered.
+        (= request-method :options)
+        {:status 204
+         :headers {"access-control-allow-origin"  ao
+                   "access-control-allow-methods" "POST, OPTIONS"
+                   "access-control-allow-headers" "content-type"
+                   "vary"                          "origin"}}
+
+        ;; Origin / host guard: reject anything not driven from the local
+        ;; machine + a local browsing context BEFORE touching the launch path.
+        (not (local-request? req))
+        (json-resp 403 ao {:ok false :error "forbidden"})
+
+        ;; The launch path is POST-only — a simple GET/HEAD drive-by
+        ;; (`<img>`/`<form>`/`no-cors` fetch) can never trigger an editor launch.
+        (not= request-method :post)
+        (json-resp 405 ao {:ok false :error "method-not-allowed"})
+
+        :else
+        (let [q      (parse-query query-string)
+              file   (get q "file")
+              line   (->int (get q "line"))
+              column (->int (get q "column"))
+              cmd    (editor-hint (get q "editor"))]
+          (if (str/blank? file)
+            (json-resp 400 ao {:ok false :error "missing-file"})
+            (let [abs-path (resolve-file file)
+                  {:keys [ok message]} (launch! abs-path line column cmd)]
+              (if ok
+                (json-resp 200 ao {:ok true :file abs-path})
+                (json-resp 422 ao {:ok false :error (or message "launch-failed")})))))))))
 
 (defn handler
   "The shadow-cljs `:dev-http` `:handler` entry-point. A not-found

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -104,3 +104,167 @@
     (is (nil? (oies/resolve-file nil)))
     (is (nil? (oies/resolve-file "")))
     (is (nil? (oies/resolve-file "   ")))))
+
+;; ---- security: the loopback / origin / method guard ----------------------
+;;
+;; The endpoint launches the editor on a local file path, so it must NOT be
+;; drivable by a drive-by GET or a cross-origin POST from a remote page. The
+;; guard pins it to a POST addressed to a loopback Host with (when present)
+;; a loopback Origin. These tests redirect `launch!` to a recording stub so
+;; no real editor is spawned, and assert: the one valid local POST reaches
+;; the launch path and answers 200, while every unauthenticated / wrong-
+;; method / cross-origin / non-loopback variant is rejected (403/405) BEFORE
+;; `launch!` is ever called.
+
+(defn ^:private req
+  "Build a minimal Ring request map for the endpoint. An explicit nil `host`
+  / `origin` omits that header (an explicit nil is respected over the :or
+  default, which only fills an ABSENT key)."
+  [{:keys [method host origin file]
+    :or   {method :post host "localhost:8031"}}]
+  {:uri            oies/endpoint-path
+   :request-method method
+   :query-string   (when file (str "file=" file "&line=10"))
+   :headers        (cond-> {}
+                     host   (assoc "host" host)
+                     origin (assoc "origin" origin))})
+
+(defmacro ^:private with-launch-spy
+  "Run `body` with `launch!` redirected to a stub that records each call in
+  `calls` (an atom holding a vector) and returns `{:ok true}`."
+  [calls & body]
+  `(with-redefs [oies/launch! (fn [& args#]
+                                (swap! ~calls conj (vec args#))
+                                {:ok true})]
+     ~@body))
+
+(deftest guard-allows-valid-local-post
+  (testing "a POST addressed to a loopback Host with a loopback Origin
+            (a cross-PORT dev request: Story shell on :8042 → app on :8031)
+            reaches the launch path and answers 200"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :post
+                           :host   "localhost:8031"
+                           :origin "http://localhost:8042"
+                           :file   "fake_ns/core.cljs"}))]
+          (is (= 200 (:status resp)) "valid local POST is accepted")
+          (is (= 1 (count @calls)) "launch! was invoked exactly once")
+          (is (= "http://localhost:8042"
+                 (get-in resp [:headers "access-control-allow-origin"]))
+              "CORS reflects the validated loopback origin, not `*`")))))
+  (testing "a same-origin POST that omits Origin entirely still passes on the
+            loopback Host check alone"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :post
+                           :host   "127.0.0.1:8031"
+                           :origin nil
+                           :file   "fake_ns/core.cljs"}))]
+          (is (= 200 (:status resp)))
+          (is (= 1 (count @calls))))))))
+
+(deftest guard-rejects-cross-origin-post
+  (testing "a POST whose Origin is a REMOTE page is rejected 403 and never
+            reaches launch! — the drive-by vector the guard closes"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :post
+                           :host   "localhost:8031"
+                           :origin "https://evil.example"
+                           :file   "/etc/passwd"}))]
+          (is (= 403 (:status resp)) "cross-origin POST is forbidden")
+          (is (zero? (count @calls)) "launch! was NEVER called")
+          (is (not= "*" (get-in resp [:headers "access-control-allow-origin"]))
+              "no wildcard CORS — the remote origin is not reflected"))))))
+
+(deftest guard-rejects-non-loopback-host
+  (testing "a POST addressed to a non-loopback Host (a public binding /
+            DNS-rebinding attempt) is rejected 403 before launch!"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :post
+                           :host   "app.evil.example"
+                           :origin nil
+                           :file   "/etc/passwd"}))]
+          (is (= 403 (:status resp)))
+          (is (zero? (count @calls)))))))
+  (testing "a missing Host header is also rejected"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :post :host nil :origin nil
+                           :file "/etc/passwd"}))]
+          (is (= 403 (:status resp)))
+          (is (zero? (count @calls))))))))
+
+(deftest guard-rejects-non-post-drive-by
+  (testing "a simple GET drive-by (the `<img>`/`<form>`/`no-cors` class) is
+            rejected 405 even from a loopback Host — it never launches"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :get
+                           :host   "localhost:8031"
+                           :origin nil
+                           :file   "/etc/passwd"}))]
+          (is (= 405 (:status resp)) "GET is method-not-allowed")
+          (is (zero? (count @calls)) "launch! was NEVER called"))))))
+
+(deftest guard-options-preflight-reflects-loopback-origin
+  (testing "an OPTIONS preflight from a loopback origin reflects that origin
+            and offers POST only (no GET) — never launches"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     (req {:method :options
+                           :host   "localhost:8031"
+                           :origin "http://localhost:8042"}))]
+          (is (= 204 (:status resp)))
+          (is (= "http://localhost:8042"
+                 (get-in resp [:headers "access-control-allow-origin"])))
+          (is (= "POST, OPTIONS"
+                 (get-in resp [:headers "access-control-allow-methods"]))
+              "GET is no longer an allowed method")
+          (is (zero? (count @calls))))))))
+
+(deftest guard-non-endpoint-path-falls-through
+  (testing "a request for any other path still falls through (nil) untouched"
+    (is (nil? (oies/handle {:uri "/something/else"
+                            :request-method :post
+                            :headers {"host" "localhost:8031"}})))))
+
+;; ---- header / origin parsing helpers -------------------------------------
+
+(deftest loopback-host?-classifies-correctly
+  (testing "loopback hosts (with/without port, IPv4, IPv6, case)"
+    (is (#'oies/loopback-host? "localhost"))
+    (is (#'oies/loopback-host? "localhost:8031"))
+    (is (#'oies/loopback-host? "LocalHost:8031"))
+    (is (#'oies/loopback-host? "127.0.0.1"))
+    (is (#'oies/loopback-host? "127.0.0.1:8042"))
+    (is (#'oies/loopback-host? "127.5.6.7"))
+    (is (#'oies/loopback-host? "::1"))
+    (is (#'oies/loopback-host? "[::1]:8080")))
+  (testing "non-loopback hosts are rejected"
+    (is (not (#'oies/loopback-host? "evil.example")))
+    (is (not (#'oies/loopback-host? "app.evil.example:8031")))
+    (is (not (#'oies/loopback-host? "10.0.0.5")))
+    (is (not (#'oies/loopback-host? "0.0.0.0")))
+    ;; not in 127.0.0.0/8 despite the `127` prefix textually
+    (is (not (#'oies/loopback-host? "127malicious.example")))
+    (is (not (#'oies/loopback-host? nil)))
+    (is (not (#'oies/loopback-host? "")))))
+
+(deftest origin-host-extracts-and-rejects-opaque
+  (testing "the host is extracted from a serialized origin"
+    (is (= "localhost" (#'oies/origin-host "http://localhost:8042")))
+    (is (= "127.0.0.1" (#'oies/origin-host "http://127.0.0.1:8031"))))
+  (testing "the opaque `null` origin and blank/nil yield nil (never loopback)"
+    (is (nil? (#'oies/origin-host "null")))
+    (is (nil? (#'oies/origin-host nil)))
+    (is (nil? (#'oies/origin-host "")))))


### PR DESCRIPTION
## Problem

The dev-only `open-in-editor` endpoint (`re-frame.testbed.open-in-editor-server`, a JVM-only `:dev-http` handler) launched the developer's editor on an **arbitrary local file** for **any cross-origin request**:

- `handle` answered both GET and POST (only `:options` was special-cased);
- `json-resp` set `access-control-allow-origin "*"`;
- a simple GET needs no CORS preflight.

So any web page the developer was visiting could fire `fetch("http://localhost:<dev-port>/__rf-open-in-editor?file=…", {mode:"no-cors"})` (or an `<img>`/`<form>`) and open an attacker-chosen file in the editor — `resolve-file` passes an absolute path (`/etc/passwd`, `C:/…`) or a `../`-traversal path straight through. Same drive-by class as the historic Vite / react-dev-utils CVEs. Dev-only + localhost + opens-in-editor (no file content returned over HTTP), but reachable from any browsed page.

## Fix

Pin the endpoint to the local machine and a local browsing context:

1. **POST-only launch path** — a simple GET/HEAD drive-by (the only thing an `<img>`/`<form>`/`no-cors` simple request can issue) gets `405` and never reaches `launch!`.
2. **Loopback `Host` required** — the request must have been addressed to `localhost` / `127.0.0.0/8` / `[::1]`; a non-loopback host (public-binding / DNS-rebinding attempt) gets `403` before any path resolution.
3. **Loopback `Origin` when present** — a remote page's cross-origin POST (`Origin: https://evil.example`) is rejected `403`; a legitimate cross-**PORT** dev request (Story shell on `:8042` → app on `:8031`) carries `http://localhost:8042` and passes. A same-origin POST may omit `Origin` and passes on the Host check alone.

CORS is reflected to the **validated loopback origin only** (with `vary: origin`) — the `*` wildcard is gone. The OPTIONS preflight now offers `POST, OPTIONS` (no GET).

## DX unchanged

The default client (`re-frame.source-coords.open-endpoint/fetch-launcher!`) already issues a **POST** from the same / cross-PORT dev origin, so the legitimate jump-to-source path is unaffected.

## Tests

Adds JVM regression tests (`clojure -M:test`) with `launch!` redirected to a recording stub:

- valid local POST (loopback Host + loopback Origin, and the omitted-Origin same-origin case) reaches `launch!` and answers `200`, reflecting its loopback origin;
- cross-origin POST → `403`, `launch!` **never called**, no wildcard CORS;
- non-loopback / missing Host → `403`, `launch!` never called;
- GET drive-by → `405`, `launch!` never called;
- OPTIONS preflight reflects loopback origin + offers POST only;
- unit coverage for `loopback-host?` (port / IPv4 127.0.0.0/8 / IPv6 / case / non-loopback `127malicious.example`) and `origin-host` (opaque `null` → nil).

`tools/testbed-support` JVM tests: 13 tests, 51 assertions, 0 failures. `scripts/test-fast-pr.sh`: 7642 tests, 0 failures (markdown gates green; mkdocs soft-skips on Windows).

Scope note: the bead also flags secondary defects (the `parse-query` `+`→space decode, a Story-shell hashchange teardown, a dropped-column edge); those are out of scope for this security fix and remain on the bead.