### PR TITLE
docs(skills): fix xray :target-frame + implementor rule count + re-frame2 cheatsheet rf/ prefixes (rf2-n1elqo, rf2-o2wjr7, rf2-rbvzuk)

### DIFF
--- a/skills/re-frame2-implementor/README.md
+++ b/skills/re-frame2-implementor/README.md
@@ -53,7 +53,7 @@ skills/re-frame2-implementor/
 ├── evals/
 │   └── evals.json                 # Trigger-accuracy fixtures for the description
 ├── references/
-│   ├── cardinal-rules.md          # The ten rules in prose + anti-pattern corollaries
+│   ├── cardinal-rules.md          # The eleven rules in prose + anti-pattern corollaries
 │   ├── kickoff-prompt.md          # Paste-ready prompt for a fresh session
 │   ├── phase-1-decisions.md       # The Phase 1 walkthrough
 │   ├── decision-record.md         # Fill-in template for the locked decisions

--- a/skills/re-frame2-implementor/spec/authoring-prompt.md
+++ b/skills/re-frame2-implementor/spec/authoring-prompt.md
@@ -27,7 +27,7 @@ A self-contained prompt that re-authors the `re-frame2-implementor` skill from t
 > ├── package.json (npm metadata; mirror re-frame-migration shape)
 > ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 > └── references/
-> ├── cardinal-rules.md (~90 lines; the ten rules in prose + anti-pattern corollaries)
+> ├── cardinal-rules.md (~90 lines; the eleven rules in prose + anti-pattern corollaries)
 > ├── kickoff-prompt.md (~80 lines; paste-ready prompt)
 > ├── phase-1-decisions.md (~200 lines; D1-D7 walkthrough)
 > ├── decision-record.md (~120 lines; fill-in template)

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -128,7 +128,7 @@ skills/re-frame2-implementor/
 ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 ├── evals/evals.json (trigger-accuracy fixtures for the description)
 ├── references/
-│ ├── cardinal-rules.md (the ten rules in prose + anti-pattern corollaries)
+│ ├── cardinal-rules.md (the eleven rules in prose + anti-pattern corollaries)
 │ ├── kickoff-prompt.md (paste-ready prompt)
 │ ├── phase-1-decisions.md (Phase 1 walkthrough)
 │ ├── decision-record.md (fill-in template)

--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -229,7 +229,7 @@ press).
 (require '[day8.re-frame2-xray.core :as xray])
 
 (xray/init!
- {:default-frame :app/main ; observed frame for the spine
+ {:target-frame :app/main ; observed frame for the spine
  :theme :dark ; / :light (settings persist)
  :density :compact ; / :cosy (settings persist)
  :buffer-depths {:epoch 50}}) ; per-frame ring depth
@@ -238,10 +238,10 @@ press).
 ```
 
 All four opts are wired today (the recognised set is exactly
-`:default-frame :theme :density :buffer-depths`, per the `init!` docstring
+`:target-frame :theme :density :buffer-depths`, per the `init!` docstring
 in [`core.cljs`](../../../tools/xray/src/day8/re_frame2_xray/core.cljs)):
 
-- `:default-frame` dispatches `:rf.xray/set-target-frame`.
+- `:target-frame` dispatches `:rf.xray/set-target-frame`.
 - `:theme` / `:density` write the persisted Settings shape and apply the
  matching class / font-size immediately (no reload).
 - `:buffer-depths` honours `{:epoch <n>}` only — it drives the substrate's

--- a/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
@@ -51,11 +51,11 @@ The `reg-event` metadata-map is the one **superset** middle slot — reflection 
 |---|---|
 | `rf/sub-machine` | `(machine-id)` → reaction `{:state :data :tags}` |
 | `rf/machine-has-tag?` | `(machine-id tag)` → reaction (boolean) |
-| `rf/machines` / `rf/machine-meta` | id list / registered spec |
-| `rf/machine-by-system-id` | `(system-id)` / `(... frame-id)` |
+| `re-frame.machines/machines` / `re-frame.machines/machine-meta` | id list / registered spec — owned-ns surface, **not** on the `rf/` façade |
+| `re-frame.machines/machine-by-system-id` | `(system-id)` / `(... frame-id)` — owned-ns surface, **not** on the `rf/` façade |
 | `rf/dispatch-to-system` | `(system-id event)` / `(... frame-id)` |
-| `rf/machine-transition` | `(machine snapshot event)` → `[snapshot' fx]` pure |
-| `rf/make-machine-handler` | `(machine)` → event-fx handler |
+| `re-frame.machines/machine-transition` | `(machine snapshot event)` → `[snapshot' fx]` pure — owned-ns surface, **not** on the `rf/` façade |
+| `re-frame.machines/make-machine-handler` | `(machine)` → event-fx handler — owned-ns surface, **not** on the `rf/` façade |
 
 ## Images and frames (EP-0023, `re-frame.core`)
 


### PR DESCRIPTION
Three small skill-doc fixes across disjoint skill directories. Each claim verified against the landed surface before editing.

## rf2-n1elqo — re-frame2-xray
`references/launch-modes.md` documented the `init!` frame-selection opt as the retired `:default-frame`. EP-0002 (rf2-bd4div) renamed it to `:target-frame` and retired `:default-frame` with no shim. Because `init!` silently ignores unknown opt keys, a user copying the old example got a silent no-op for frame selection. Fixed all three spots: the example key (L232), the recognised-set line (L241), and the dispatch description (L244). The dispatched event id `:rf.xray/set-target-frame` is unchanged (still correct).

Source of truth: `tools/xray/src/day8/re_frame2_xray/core.cljs` — `init!` destructures `{:keys [target-frame …]}` and its docstring states the legacy `:default-frame` key is RETIRED.

## rf2-o2wjr7 — re-frame2-implementor
`references/cardinal-rules.md` ships eleven rules (sections 1–11). `SKILL.md` already said "eleven", but `README.md` (layout comment) and the authoring-playground files `spec/authoring-prompt.md` and `spec/design.md` still said "the ten rules". Reconciled all three to "eleven".

## rf2-rbvzuk — re-frame2
`references/cross-cutting/api-cheatsheet.md` Machines rows listed `machines` / `machine-meta` / `machine-by-system-id` / `machine-transition` / `make-machine-handler` under the `rf/` prefix, but per the front-porch shrink (rf2-wad2fl) these are no longer re-exported from `re-frame.core` — copying the rows yields unresolved-var compile errors. They live on the owned `re-frame.machines` facade. Re-prefixed the four defective rows to `re-frame.machines/` (matching the sibling `references/state-machines/reg-machine.md` leaf) and noted them as owned-ns surfaces. `sub-machine` / `machine-has-tag?` / `dispatch-to-system` genuinely stay on the `rf/` facade and were left unchanged.

Source of truth: `implementation/core/src/re_frame/core.cljc` L1461–1490 (the "machine helpers" comment block) — confirms which helpers are no longer re-exported vs. the three sugar vars that stay on the facade.

## Gates
`scripts/test-fast-pr.sh` green: skill/MCP allowed-tools drift, skill migration cite-integrity, skill eval-docs match, README inventory ratchet, retired-spelling gate, core JVM, JS harness helpers, and CLJS node integration (7642 tests / 31520 assertions, 0 failures) all pass.