### PR TITLE
fix(ssr): stream-handler final payload hash reflects post-drain state (rf2-1kqvbx)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -190,11 +190,22 @@
 
   rf2-9fw2de: `:doc-hash` is the canonical FULL-document structural hash
   (body tree + resolved head fragment + html/body attr bags) computed via
-  `lifecycle/render-document-hash`. It drives BOTH the final-payload
-  `:rf/render-hash` AND the streaming root-element `data-rf-render-hash`
-  marker (when `:emit-hash?` is true) — preserving wire/payload parity with
-  the non-streaming handler and folding the head into the unified hash
-  channel per Spec 011 §624-626/§648-650.
+  `lifecycle/render-document-hash`. It describes the PRE-drain shell — the
+  exact tree streamed in chunk 1 — and drives the streaming root-element
+  `data-rf-render-hash` marker (when `:emit-hash?` is true), folding the head
+  into the unified hash channel per Spec 011 §624-626/§648-650.
+
+  rf2-1kqvbx: `:doc-hash` no longer drives the FINAL-payload
+  `:rf/render-hash`. The final payload ships the live POST-drain `app-db`,
+  so its hash must describe the POST-drain render tree (the one a streaming
+  hydrate re-renders + verifies against). The writer re-resolves the root
+  view AFTER every continuation drains and recomputes that post-drain hash
+  via `lifecycle/render-document-hash` over the carried `:head-bag` (the head
+  is request-thread-resolved and drain-invariant in v1). When no continuation
+  mutates a root-read key the two hashes coincide; only a render-time
+  continuation mutation a root subtree reads makes the streamed-shell marker
+  (pre-drain) and the final-payload hash (post-drain) describe distinct
+  moments — which they genuinely are.
 
   Throws propagate to the caller (the handler's outer try/catch routes
   them through the projector → fail-closed non-200, rf2-r06pc). The
@@ -256,6 +267,15 @@
        :head-html     head-html
        :html-attrs    html-attrs
        :body-attrs    body-attrs
+       ;; rf2-1kqvbx — carry the resolved `head-bag` to the daemon writer so
+       ;; it can recompute the POST-drain final-payload `:rf/render-hash` over
+       ;; the re-resolved root tree using the SAME head channel the pre-drain
+       ;; `doc-hash` used. The head is resolved once on the request thread and
+       ;; does not change across continuation drains (it derives from the route
+       ;; / explicit `:head` opt, not from continuation-mutated app-db in v1),
+       ;; so the post-drain hash folds in the identical head fragment + attr
+       ;; bags — only the body tree re-renders against the drained state.
+       :head-bag      head-bag
        :doc-hash      doc-hash
        :shell-html    shell-html
        :continuations continuations
@@ -345,21 +365,28 @@
   ;; catch arm can name the in-flight phase.
   (let [phase (volatile! [:shell-prefix nil])]
    (try
-    (let [{:keys [emit-hash? version schema-digest payload]} opts
+    (let [{:keys [emit-hash? version schema-digest payload root-view]} opts
           ;; rf2-9fw2de — the writer no longer recomputes the hash from
-          ;; `hiccup`; `doc-hash` (full-document) was computed once on the
-          ;; request thread by `render-streaming-shell!`. `:hiccup` stays in
-          ;; the `rendered` map for diagnostics but is not destructured here.
+          ;; `hiccup`; `doc-hash` (full-document, PRE-drain) was computed once
+          ;; on the request thread by `render-streaming-shell!`. `:hiccup`
+          ;; stays in the `rendered` map for diagnostics but is not
+          ;; destructured here. rf2-1kqvbx — `:head-bag` rides along so the
+          ;; post-drain final-payload hash folds in the SAME head channel.
           {:keys [head-html html-attrs body-attrs
-                  doc-hash shell-html continuations realm-id]} rendered
+                  doc-hash head-bag shell-html continuations realm-id]} rendered
           shell-opts (merge opts
                             {:html-attrs  html-attrs
                              :body-attrs  body-attrs
-                             ;; rf2-9fw2de — honour `:emit-hash?` on the
-                             ;; streaming path: stamp the full-document
-                             ;; hash onto the root `#app` div when true, no
-                             ;; marker when false (a true no-op was the
-                             ;; bug). Same hash the final payload carries.
+                             ;; rf2-9fw2de / rf2-1kqvbx — honour `:emit-hash?`
+                             ;; on the streaming path: stamp the PRE-drain
+                             ;; full-document hash onto the root `#app` div when
+                             ;; true, no marker when false (a true no-op was the
+                             ;; bug). This marks the tree ACTUALLY streamed in
+                             ;; chunk 1 (the shell, with fallbacks + pre-drain
+                             ;; root reads). The FINAL payload carries a
+                             ;; POST-drain hash (recomputed below); the two
+                             ;; coincide unless a continuation mutates a
+                             ;; root-read key — see the final-payload block.
                              :render-hash (when emit-hash? doc-hash)})]
       ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks) +
       ;; the app-root close. rf2-l1qgjw — stamp the phase before each write
@@ -444,17 +471,32 @@
             (recur (into (pop queue) continuations)))))
       ;; Chunk N+2 — final canonical __rf_payload.
       ;;
-      ;; rf2-5knxf.2 — the streaming final-payload `:rf/render-hash` is the
-      ;; full-document structural hash (`doc-hash`) computed ONCE on the
-      ;; request thread in `render-streaming-shell!` via
+      ;; rf2-1kqvbx — the streaming final-payload `:rf/render-hash` must
+      ;; describe the POST-drain render state, NOT the pre-drain shell.
+      ;; `build-final-payload` reads the LIVE frame `app-db` AFTER every
+      ;; continuation has drained, so its `:rf/app-db` is the post-drain
+      ;; state; pairing it with the pre-drain `doc-hash` shipped a payload
+      ;; whose state and hash described different moments. When a continuation
+      ;; mutates app-db and the ROOT tree reads that key, a streaming hydrate
+      ;; re-renders the root tree against the payload's post-drain `:rf/app-db`,
+      ;; hashes it, and fires a spurious `:rf.ssr/hydration-mismatch` against
+      ;; the stale pre-drain hash (Spec 011 §Hydration equivalence rule). So we
+      ;; RE-RESOLVE the root view here — on this daemon thread, inside the
+      ;; carried realm + frame binding, AFTER the drain loop — and recompute
+      ;; the full-document hash over the post-drain tree via the SAME
+      ;; `lifecycle/render-document-hash` mechanism (folding the carried
+      ;; `head-bag`, drain-invariant in v1). The streamed-shell
+      ;; `data-rf-render-hash` marker keeps the PRE-drain `doc-hash` (it marks
+      ;; the tree actually streamed in chunk 1); the two coincide when no
+      ;; continuation mutates a root-read key.
+      ;;
+      ;; rf2-5knxf.2 — the hash is still the full-document structural hash via
       ;; `lifecycle/render-document-hash` — the IDENTICAL mechanism the
       ;; non-streaming `build-full-response*` uses. rf2-9fw2de: it folds the
       ;; resolved head fragment (+ html/body attr bags) into the canonical
-      ;; input alongside the body `hiccup`, so a head-only divergence
-      ;; changes the hash (Spec 011 §624-626/§648-650). It is reused (not
-      ;; recomputed) so the final-payload `:rf/render-hash` and the streamed
-      ;; root-element `data-rf-render-hash` marker are byte-identical. This
-      ;; is the correct structural hash, NOT a streaming-specific divergence:
+      ;; input alongside the body tree, so a head-only divergence changes the
+      ;; hash (Spec 011 §624-626/§648-650). This is the correct structural
+      ;; hash, NOT a streaming-specific divergence:
       ;;
       ;;   - `render-tree-hash` is a PURE structural FNV-1a over the
       ;;     canonical-EDN of the hiccup (hash.cljc). It does NOT expand
@@ -508,11 +550,33 @@
       (let [final-payload (frame/call-with-realm realm-id
                             (fn []
                               (rf/with-frame frame-id
-                                (streaming/build-final-payload
-                                  frame-id doc-hash
-                                  {:version       version
-                                   :schema-digest schema-digest
-                                   :payload       payload}))))]
+                                ;; rf2-1kqvbx — re-resolve the root view against
+                                ;; the POST-drain frame state and recompute the
+                                ;; full-document hash over it, so the payload's
+                                ;; `:rf/render-hash` describes the SAME moment as
+                                ;; its post-drain `:rf/app-db`. Routed through
+                                ;; the SAME realm registrar the shell render walk
+                                ;; used (rf2-bzw8gd) so registered-view + head
+                                ;; lookups resolve in the owning realm; a
+                                ;; default-realm frame binds nothing
+                                ;; (byte-identical). Falls back to the pre-drain
+                                ;; `doc-hash` when no `:root-view` could be
+                                ;; re-resolved (defensive — `validate-construction-opts!`
+                                ;; requires `:root-view`, so this is belt-and-braces).
+                                (let [post-drain-hash
+                                      (if root-view
+                                        (frame/call-with-frame-realm-registrar
+                                          (frame/frame frame-id)
+                                          (fn []
+                                            (lifecycle/render-document-hash
+                                              (lifecycle/resolve-root-view root-view)
+                                              head-bag)))
+                                        doc-hash)]
+                                  (streaming/build-final-payload
+                                    frame-id post-drain-hash
+                                    {:version       version
+                                     :schema-digest schema-digest
+                                     :payload       payload})))))]
         ;; Shared id-pinned, `</script>`-escaped payload <script>
         ;; (rf2-7ksyr) — same helper the non-streaming shell uses.
         (write-chunk! out (shell/payload-script-tag (pr-str final-payload))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -8,7 +8,8 @@
     3. streaming writer flushes shell → continuations → final payload → close
     4. response body is a PipedInputStream; we drain it into a string
     5. asserts on chunk shapes + final-payload."
-  (:require [clojure.set]
+  (:require [clojure.edn]
+            [clojure.set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -1241,3 +1242,119 @@
       (is (some? (stream-payload-hash body))
           "the final payload still carries :rf/render-hash when :emit-hash?
            is false (only the wire MARKER is gated by the opt)"))))
+
+;; ===========================================================================
+;; rf2-1kqvbx — the streaming final-payload :rf/render-hash MUST describe the
+;; SAME (post-drain) render state as the :rf/app-db it ships.
+;;
+;; Defect: `doc-hash` is computed in `render-streaming-shell!` on the request
+;; thread BEFORE any continuation drains (over the PRE-drain root hiccup),
+;; but `build-final-payload` reads the LIVE frame app-db AFTER every
+;; continuation has drained. When a continuation mutates app-db and the ROOT
+;; tree reads that mutated key, the final payload carries POST-drain state
+;; (`:rf/app-db`) with a PRE-drain `:rf/render-hash`. A streaming hydrate
+;; re-renders the root tree against the payload's post-drain app-db, hashes
+;; it, and sees a mismatch against the pre-drain `:rf/render-hash` even though
+;; the server shipped its own canonical final state — firing a spurious
+;; `:rf.ssr/hydration-mismatch` (Spec 011 §Hydration equivalence rule).
+;;
+;; The fix recomputes the final-payload `:rf/render-hash` from the post-drain
+;; render tree (re-resolving the root view after all continuations drain), so
+;; the hash and the `:rf/app-db` describe the same moment in the request.
+;; ===========================================================================
+
+(defn- stream-payload-edn
+  "Pull the EDN body of the streamed `__rf_payload` script and read it."
+  [body]
+  (let [payload-edn (second (re-find
+                              #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                              body))]
+    (when payload-edn
+      (clojure.edn/read-string payload-edn))))
+
+(deftest stream-handler-final-hash-reflects-post-drain-state
+  (testing "rf2-1kqvbx: a continuation that MUTATES app-db a ROOT-read key
+            depends on → the final payload's :rf/render-hash describes the
+            POST-drain render tree (the one the client hydrates against),
+            NOT the pre-drain shell render. The hash and the shipped
+            :rf/app-db describe the same moment."
+    ;; A db-mutating event the deferred subtree dispatches during its render.
+    (rf/reg-event :rf.test/bump-counter
+      {:platforms #{:server}}
+      (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
+    ;; on-create seeds :counter 0 alongside the fixture's articles/comments.
+    (rf/reg-event :rf.test.server/init-counter
+      {:platforms #{:server}}
+      (fn [_ _] {:db {:counter 0}}))
+    ;; Client hydration replaces app-db with the payload slice wholesale.
+    (rf/reg-event :rf.test/hydrate-db
+      {:platforms #{:server}}
+      (fn [_ [_ db]] {:db db}))
+    (rf/reg-sub :counter (fn [db _] (:counter db)))
+    ;; A deferred subtree that MUTATES :counter during its continuation render.
+    (rf/reg-view ^{:rf/id :test/counter-mutator} counter-mutator []
+      (rf/dispatch-sync [:rf.test/bump-counter])
+      [:div.mutated "bumped"])
+    ;; The ROOT view READS :counter INLINE — `render-tree-hash` is a pure
+    ;; structural hash that does NOT expand view-refs, so the subscribed
+    ;; value must land directly in the root hiccup for the hash to depend on
+    ;; it (pre-drain 0 vs post-drain 1 → different hashes). The deferred
+    ;; subtree stays a view-ref child of the suspense boundary (the streaming
+    ;; walker drains it; the hash leaves the boundary marker unexpanded).
+    (rf/reg-view ^{:rf/id :test/counter-root} counter-root []
+      [:main
+       [:span.counter (str "counter=" @(subscribe [:counter]))]
+       [:rf/suspense-boundary
+        {:id :test/bump :fallback [:p "loading"]}
+        [:test/counter-mutator]]])
+    (let [head-html "<title>Counter</title>"
+          handler  (ssr-ring/stream-handler
+                     ;; EXPANDED :root-view form (symmetric with the client's
+                     ;; :render-tree-fn) so the streamed hash is over the
+                     ;; rendered counter-bearing tree, not an unexpanded
+                     ;; view-ref vector. Explicit `:head` so the document hash
+                     ;; folds in a KNOWN head fragment we can replay on the
+                     ;; client side below (the default route head would be
+                     ;; unknown to the client model).
+                     {:on-create [:rf.test.server/init-counter]
+                      :root-view (fn [] ((rf/view :test/counter-root)))
+                      :head      head-html
+                      :payload   :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          body     (drain-stream (:body response))
+          payload  (stream-payload-edn body)
+          db-slice (:rf/app-db payload)
+          server-hash (:rf/render-hash payload)]
+      (is (= 200 (:status response)) "stream still 200")
+      (is (str/includes? body "bumped")
+          "the mutating boundary's resolved body streamed")
+      ;; The shipped app-db is the POST-drain state (counter bumped to 1).
+      (is (= 1 (:counter db-slice))
+          "the final payload's :rf/app-db carries the post-drain counter=1")
+      ;; Model the streaming client: it hydrates against the payload's
+      ;; post-drain :rf/app-db and re-renders the root tree, then hashes it.
+      ;; That hash MUST equal the payload's :rf/render-hash, or
+      ;; :rf.ssr/hydration-mismatch fires on a page the server just shipped.
+      (let [cfid (keyword "rf.frame" (str (gensym "client")))]
+        (rf/reg-frame cfid {:platform :server})
+        (try
+          (rf/with-frame cfid
+            ;; Hydrate the client frame with the payload's post-drain app-db
+            ;; (the :replace-app-db hydration semantics, modelled via a
+            ;; whole-db replace event).
+            (rf/dispatch-sync [:rf.test/hydrate-db db-slice])
+            (let [client-hiccup ((rf/view :test/counter-root))
+                  client-hash   (lifecycle/render-document-hash
+                                  client-hiccup
+                                  {:head-html head-html
+                                   :html-attrs nil :body-attrs nil})]
+              ;; THE PIN — the load-bearing assertion. Pre-fix the server hash
+              ;; describes counter=0 (pre-drain) while the client renders
+              ;; counter=1 (post-drain), so these DIFFER → spurious mismatch.
+              (is (= server-hash client-hash)
+                  "rf2-1kqvbx: the final-payload :rf/render-hash describes the
+                   SAME post-drain render state the client hydrates against;
+                   the server hash matches the client's re-render hash over the
+                   shipped :rf/app-db (no spurious :rf.ssr/hydration-mismatch)")))
+          (finally
+            (rf/destroy-frame! cfid)))))))


### PR DESCRIPTION
## What

The streaming SSR writer paired the final `__rf_payload`'s `:rf/render-hash`
with `doc-hash` — the full-document structural hash computed on the **request
thread** in `render-streaming-shell!` **before any continuation drains**. But
`build-final-payload` reads the **live frame `app-db` after** every continuation
drains, so the payload's `:rf/app-db` is post-drain state.

When a continuation mutates `app-db` and the root tree reads that key, the final
payload shipped **post-drain state with a pre-drain hash**. A streaming hydrate
re-renders the root tree against the payload's post-drain `:rf/app-db`, hashes
it, and fires a spurious `:rf.ssr/hydration-mismatch` against the stale
pre-drain hash — violating Spec 011's hydration equivalence rule on a page the
server just finished rendering.

## Fix

The writer now re-resolves the root view on the daemon thread **after** the
drain loop (inside the carried realm + frame binding + realm registrar) and
recomputes the full-document hash over the **post-drain** tree via the same
`lifecycle/render-document-hash` mechanism, folding the carried `:head-bag`
(request-thread-resolved, drain-invariant in v1). `build-final-payload` receives
that post-drain hash, so its `:rf/render-hash` and `:rf/app-db` describe the
same moment.

The streamed-shell `data-rf-render-hash` **root marker keeps the pre-drain
`doc-hash`** — it marks the tree actually streamed in chunk 1 (shell + fallbacks
+ pre-drain root reads), which is genuinely a distinct moment from the post-drain
reconciled payload. The two hashes coincide whenever no continuation mutates a
root-read key (the common case), so the existing marker-equals-payload regression
(`stream-handler-emit-hash-true-stamps-root-marker-equal-to-payload`) still
holds; they diverge only on the supported render-time-mutation shape, which they
should.

## Regression

Adds `stream-handler-final-hash-reflects-post-drain-state`: a streaming
continuation mutates `app-db`; the root view inline-reads that key; the test
models the streaming client hydrating against the shipped post-drain `:rf/app-db`
and asserts its re-render hash equals the payload's `:rf/render-hash`.
- **Red before the fix:** server pre-drain hash (`counter=0`) != client
  post-drain re-render hash (`counter=1`).
- **Green after.**

## Gates

- `ssr-ring` JVM: 167 tests / 757 assertions green (incl. new red→green + existing parity tests)
- `ssr` core JVM: 347 tests / 1394 assertions green
- `npm run test:cljs`: 7642 tests / 31520 assertions green
- `scripts/test-fast-pr.sh`: PASS

Closes rf2-1kqvbx.