### PR TITLE
chore: sweep retired EP-0018 event vocabulary in impl tests/config (rf2-01phsr, rf2-55r2jv, rf2-a3pca0, rf2-v871kg)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -15,8 +15,8 @@
     1. Synchronous direct `rf/dispatch` from inside the handler body.
     2. `js/setTimeout` deferred direct `rf/dispatch` from inside the
        handler body (the rf2-yf97 case).
-    3. `:fx [[:dispatch ...]]` from a `reg-event-fx` handler (the
-       documented workaround).
+    3. `:fx [[:dispatch ...]]` from a `reg-event` handler returning an
+       `:fx` effects map (the documented workaround).
     4. `:fx [[:dispatch-later {:ms 0 :event ...}]]` and the
        `(:dispatch (rf/frame-handle))` capture-at-creation affordance.
 
@@ -87,7 +87,7 @@
 
 ;; ---- 1. Synchronous direct rf/dispatch ------------------------------------
 ;;
-;; A reg-event-fx handler running on :tenant-a calls (rf/dispatch [:landed])
+;; A reg-event handler running on :tenant-a calls (rf/dispatch [:landed])
 ;; in its body and returns no fx. The expectation: the queued :landed
 ;; event lands on :tenant-a (the in-flight handler's frame), not
 ;; :rf/default.

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -46,8 +46,8 @@
 
 ;; Snapshot/restore the registrar around each test (rf2-am9d). The
 ;; framework-shipped :rf.http/managed family registers at ns-load and
-;; survives the snapshot; per-test reg-event-* / reg-sub-* roll back
-;; on the way out.
+;; survives the snapshot; per-test reg-event / reg-sub registrations roll
+;; back on the way out.
 (use-fixtures :each
   (fn [test-fn]
     ;; Drop any in-flight registry leaks between tests.

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -51,7 +51,7 @@
 ;; ---- shared dispatch + sub --------------------------------------------------
 
 (deftest dispatch-sync-cljs
-  (testing "dispatch-sync runs an event-db handler under the Reagent adapter"
+  (testing "dispatch-sync runs a reg-event handler returning a :db effect under the Reagent adapter"
     (rf/reg-event :counter/init (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :counter/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/dispatch-sync [:counter/init])

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -42,7 +42,7 @@
 ;;
 ;; The websocket example's sub-namespaces — `websocket.schema`,
 ;; `websocket.connection`, `websocket.messages` — each install their
-;; reg-machine / reg-event-* / reg-sub / reg-app-schema entries at
+;; reg-machine / reg-event / reg-sub / reg-app-schema entries at
 ;; ns-load time (the production-app idiom; loading the ns IS the
 ;; registration). The example's `core.cljs` then registers the top-level
 ;; `:ws.app/initialise` event in the same idiomatic ns-load shape.

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -105,7 +105,7 @@
 ;;
 ;; FAITHFUL repro for the standard_epochs button-18 symptom. Mirrors the
 ;; live wiring: an app-db schema registered for the frame (button 19's
-;; [:auth]) PLUS a plain reg-event-db carrying the inline `:schema`
+;; [:auth]) PLUS a plain reg-event handler carrying the inline `:schema`
 ;; metadata button 18 uses verbatim. Dispatch the bad arg; the
 ;; `:rf.error/schema-validation-failure :where :event` violation MUST be
 ;; captured into the triggering epoch's `:trace-events` — exactly where

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1152,7 +1152,7 @@
 ;; 7f. No spurious `:rf.event/db-changed` on a no-write event — the
 ;;     deferred-install contract (rf2-q1sbo).
 ;;
-;; A `reg-event-fx` handler that returns NO `:db` (only `:fx`), whose
+;; A `reg-event` handler that returns NO `:db` (only `:fx`), whose
 ;; flows' inputs are all unchanged (so every flow SKIPS), produces no
 ;; `:db` effect at all → the deferred install is a no-op → ZERO
 ;; `:rf.event/db-changed` must be emitted. A spurious db-changed on a
@@ -1161,7 +1161,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest no-db-changed-on-no-write-event-with-stable-flows
-  (testing "a reg-event-fx returning only :fx [] (no :db), with flows whose
+  (testing "a reg-event returning only :fx [] (no :db), with flows whose
             inputs are unchanged, emits ZERO :rf.event/db-changed"
     (rf/reg-fx :test/noop (fn [& _] nil))
     ;; Seed :n so the flow computes once on the seed drain.

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -895,7 +895,8 @@
   ;;
   ;; rf2-6cq3u: previously the `perf-counter.core` entry-point lived in a
   ;; tool-owned testbed (tools/xray/testbeds/perf_counter/) carrying a
-  ;; deliberately non-canonical `reg-event-fx :db + :fx` init shape, which
+  ;; deliberately non-canonical pre-EP-0018 event-registration init shape
+  ;; (a `:db` + `:fx` handler under the retired event-fx registrar), which
   ;; only the now-deleted browser smoke (rf2-e3j8l, Wave 4) needed —
   ;; that smoke's User-Timing assertions migrated to pure CLJS at
   ;; implementation/core/test/re_frame/performance_emit_nightly_test.cljs


### PR DESCRIPTION
## Summary

EP-0018 retired the public `reg-event-db` / `reg-event-fx` / `reg-event-ctx` forms; handlers now register with `rf/reg-event` taking `(cofx event)` and returning an effects-map or nil. This sweeps residual stale vocabulary from `implementation/` test comments/prose and one build-config comment. **All changes are comment/prose-only — no behaviour changes.**

## Per-bead

- **rf2-01phsr** — `implementation/flows/test/re_frame/flows_trace_test.clj`: reworded the "A \`reg-event-fx\` handler..." comment (line 1155) and the `testing` string (line 1164) to "reg-event". The handler under test already registers with `rf/reg-event` and returns an `:fx`-only effects map.
- **rf2-55r2jv** — `implementation/epoch/`: the bead's cited code registrars (epoch_test.clj:139/140/260/293, epoch_cljs_test.cljs:81/82, etc.) were **already migrated to `rf/reg-event` by a prior EP-0018 sweep**. The only residual stale token was a comment in `epoch_cljs_test.cljs:108` ("a plain reg-event-db carrying the inline \`:schema\`") — reworded to "a plain reg-event handler". Post-sweep `git grep` of the epoch surface returns no retired registrar names (the `reroot-trace-event-db-slots` function name is unrelated).
- **rf2-a3pca0** — `implementation/adapters/reagent/test/`: reworded retired/wildcard event-registrar prose to the one public `reg-event` surface across `dispatch_frame_capture_cljs_test.cljs` (lines 18, 90), `runtime_cljs_test.cljs` (line 54), `http_managed_cljs_test.cljs` (line 49), and `websocket_cljs_test.cljs` (line 45). The intentional removal-stub assertions in `events_cljs_test.cljs` are left as-is (they assert the retired names throw).
- **rf2-v871kg** — `implementation/shadow-cljs.edn` (HOT-ZONE, sole toucher this wave): reworded the historical note at line ~898 from "deliberately non-canonical \`reg-event-fx :db + :fx\` init shape" to "deliberately non-canonical pre-EP-0018 event-registration init shape (a \`:db\` + \`:fx\` handler under the retired event-fx registrar)". Touched only the comment the bead names.

## Gates

- `npm run test:cljs` — green (7646 tests / 31535 assertions / 0 failures, 0 errors)
- `sh scripts/test-fast-pr.sh` — PASS