### PR TITLE
fix(events): EP-0018 re-lowering accepts projected reg-event handlers (rf2-untip9)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2099,7 +2099,17 @@
         ;; the ONE public `reg-event` runtime fn (coeffects in, a closed effects
         ;; map out). The former `:event/kind` sub-discriminator + the per-kind
         ;; reg fns are gone — every module event seats through the one shape.
-        :event (do (events/reg-event id meta handler) true)
+        ;;
+        ;; rf2-untip9: a PROJECTED descriptor (from `av/app-value`) carries the
+        ;; EFFECTIVE registrar metadata — the assembled `:interceptors` chain
+        ;; whose tail is the inline `:rf/event-handler` framework wrapper, plus
+        ;; the generated `:rf.cofx/requires-parsed`. Re-feeding those generated
+        ;; slots to `reg-event` makes its reference-only validation reject the
+        ;; wrapper (`:rf.error/inline-interceptor-removed`). `normalize-relowered-meta`
+        ;; strips them back to the authored shape (recovering the author's
+        ;; reference chain), so a projected/reconciled app value re-lowers
+        ;; faithfully; it is a no-op on a constructed descriptor.
+        :event (do (events/reg-event id (events/normalize-relowered-meta meta) handler) true)
         :sub   (do (subs/reg-sub id meta handler) true)
         :fx    (do (fx/reg-fx id meta handler) true)
         :cofx  (do (cofx/reg-cofx id meta handler) true)

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -940,6 +940,53 @@
         (register! :event id meta)))
     id))
 
+(defn normalize-relowered-meta
+  "Normalize a PROJECTED event's registration metadata back into the
+  AUTHORED metadata shape `reg-event` accepts, so a projected app-value event
+  descriptor can be re-lowered through the one `reg-event` form (EP-0018,
+  rf2-untip9).
+
+  An app value projected off the live registrar (`av/app-value`) carries each
+  event's EFFECTIVE registrar metadata under `:metadata` — including the slots
+  `register-event!` GENERATES rather than the author supplies:
+
+    * `:interceptors` — the EFFECTIVE chain `reg-event` assembled: the author's
+      interceptor REFERENCES at the head, the inline `:rf/event-handler`
+      framework wrapper (`:rf/default? true`) appended at the tail. Re-feeding
+      that effective chain to `reg-event` makes `validate-meta-interceptors!`
+      read the inline wrapper as an AUTHORED inline interceptor and reject it
+      `:rf.error/inline-interceptor-removed` (chains are reference-only since
+      EP-0022). The author's chain is the references with the framework wrapper
+      removed — the documented recovery `(remove :rf/default? interceptors)`
+      (`resolve-interceptors`).
+    * `:rf.cofx/requires-parsed` — the normalised cofx-requirement vector
+      `register-event!` derives from the authored `:rf.cofx/requires`. `reg-event`
+      regenerates it, so a stale projected copy is dropped (the author's
+      `:rf.cofx/requires` survives and is re-parsed).
+
+  Stripping the regenerated slots (and recovering the author's reference chain)
+  yields a metadata map structurally identical to what the author originally
+  passed `reg-event`, so re-lowering re-validates the references, re-parses the
+  cofx requirements, and re-appends a FRESH framework wrapper — a faithful
+  round-trip. A CONSTRUCTED descriptor (from `module`) never carries these
+  generated slots, so this is a no-op on it: an authored `:interceptors` chain
+  is references-only (no `:rf/default?` entry to strip) and carries no
+  `:rf.cofx/requires-parsed`. INTERNAL."
+  [meta]
+  (if-not (map? meta)
+    meta
+    (cond-> (dissoc meta :rf.cofx/requires-parsed)
+      ;; Recover the author's reference chain from the effective chain by
+      ;; dropping the framework-default wrapper(s). Done ONLY when the chain
+      ;; actually carries a `:rf/default?` entry, so an authored
+      ;; references-only chain is left byte-identical (and an empty residual
+      ;; chain is removed rather than passed as `[]`).
+      (some :rf/default? (:interceptors meta))
+      (as-> m (let [user-refs (filterv (complement :rf/default?) (:interceptors meta))]
+                (if (seq user-refs)
+                  (assoc m :interceptors user-refs)
+                  (dissoc m :interceptors)))))))
+
 (defn reg-event
   "Register a `(fn [coeffects event-vec] effect-map)` event handler under
   `id` — the ONE public event-registration form (EP-0018, ruled

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -663,6 +663,101 @@
             "the source-coord envelope survives the round-trip")))))
 
 ;; ---------------------------------------------------------------------------
+;; (5b) PROJECTED event re-lowering (rf2-untip9)
+;; ---------------------------------------------------------------------------
+;;
+;; A projected app value (from `av/app-value`) carries each event descriptor's
+;; EFFECTIVE registrar metadata under `:metadata` — including the `:interceptors`
+;; chain `reg-event` already assembled, whose tail is the inline `:rf/event-handler`
+;; framework wrapper. Re-lowering such a descriptor through `install!` /
+;; `reinstall!` calls `events/reg-event id meta handler` with that effective chain
+;; in `meta`. Before the fix, `reg-event`'s reference-only `:interceptors`
+;; validation rejected the inline wrapper with `:rf.error/inline-interceptor-removed`,
+;; so a legitimately-projected event could never be re-installed (the install /
+;; reinstall paths that source their value from a projection broke). The fix
+;; normalises projected event metadata before `reg-event` so the wrapper is dropped
+;; and the chain re-assembled.
+
+(deftest install-of-a-projected-app-value-relowers-a-sugar-reg-event
+  (testing "rf2-untip9: installing a projection that carries a sugar-registered
+            reg-event re-lowers the projected event descriptor (whose :metadata
+            holds the effective :interceptors chain with the inline
+            :rf/event-handler wrapper) through reg-event WITHOUT raising
+            :rf.error/inline-interceptor-removed — projected/reconciled apps are
+            app values too, and feeding their registrar-shaped event descriptors
+            back through reg-event must round-trip. This is the bead's direct
+            repro: reg-event sugar, then install! the projection."
+    ;; Sugar path: ordinary reg-event seats the effective interceptor chain
+    ;; (user chain + the appended :rf/event-handler wrapper) into the registrar.
+    (rf/reg-event :untip9/sugar {:doc "x"} (fn [{:keys [db]} _] {:db db}))
+    ;; The projected descriptor carries that effective chain under :metadata.
+    (let [proj-d (get-in (av/app-value) [:registrations :event :untip9/sugar])]
+      (is (some #(= :rf/event-handler (:id %)) (get-in proj-d [:metadata :interceptors]))
+          "the projection carries the effective chain with the inline :rf/event-handler wrapper"))
+    ;; Install a projection carrying ONLY the projected :untip9/sugar event
+    ;; descriptor (the artefact-load sugar also projects step-8-deferred :view /
+    ;; :error-projector kinds that install! refuses pre-lowering; isolate the
+    ;; event so the test exercises the re-lowering path the bead names, not the
+    ;; deferred-kind preflight). The projected event descriptor still carries the
+    ;; effective :interceptors chain under :metadata — the bug's trigger.
+    (let [full   (av/app-value :rf.realm/default)
+          proj-d (get-in full [:registrations :event :untip9/sugar])
+          proj   (assoc full :registrations {:event {:untip9/sugar proj-d}})
+          ed     (try (rf/install! proj) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                        (ex-data e)))]
+      (is (nil? ed)
+          (str "re-lowering the projected event must not throw; got "
+               (pr-str (:rf.error/id ed))))
+      (is (not= :rf.error/inline-interceptor-removed (:rf.error/id ed))
+          "the projected :rf/event-handler wrapper is no longer mis-read as an authored inline interceptor")
+      ;; The re-lowered event is a real, resolvable registration carrying a
+      ;; freshly-assembled :rf/event-handler wrapper (reg-event ran).
+      (is (some? (registrar/handler :event :untip9/sugar))
+          "the projected event re-lowered into a resolvable registration")
+      (is (some #(= :rf/event-handler (:id %))
+                (:interceptors (registrar/lookup :event :untip9/sugar)))
+          "reg-event re-assembled the framework wrapper on the re-lowered event"))))
+
+(deftest reinstall-changed-event-sourced-from-a-projection-relowers
+  (testing "rf2-untip9: a reinstall whose CHANGED event is sourced from a
+            projection (so its :metadata carries the effective :interceptors chain
+            with the inline :rf/event-handler wrapper) re-lowers through reg-event
+            without raising :rf.error/inline-interceptor-removed — the changed-event
+            path the bead names."
+    ;; Sugar-register the event so the registrar holds its EFFECTIVE interceptor
+    ;; chain; project a SINGLE-event app value off that descriptor (the default
+    ;; realm's artefact-load sugar also projects step-8-deferred :view /
+    ;; :error-projector kinds AND sibling events whose :metadata carries the same
+    ;; effective chain — isolate to the one event so the test exercises exactly
+    ;; the changed-event re-lowering path, not the deferred-kind preflight or a
+    ;; sibling event's identical re-lowering).
+    (rf/reg-event :untip9.re/e {:doc "base"} cart-add)
+    (let [full      (av/app-value :rf.realm/default)
+          proj-d    (get-in full [:registrations :event :untip9.re/e])
+          installed (assoc full :registrations {:event {:untip9.re/e proj-d}})]
+      (rf/install! installed)
+      ;; Build a new app that CHANGES :untip9.re/e by swapping its handler — the
+      ;; descriptor still carries the PROJECTED :metadata (effective interceptor
+      ;; chain + the inline wrapper). Exactly a projected registrar-shaped event
+      ;; descriptor fed back through reinstall! on the :changed path.
+      (let [changed (assoc proj-d :handler cart-remove)
+            new-app (assoc-in installed [:registrations :event :untip9.re/e] changed)
+            ed      (try (rf/reinstall! new-app) nil
+                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                           (ex-data e)))]
+        (is (nil? ed)
+            (str "re-lowering the changed projected event must not throw; got "
+                 (pr-str (:rf.error/id ed))))
+        (is (not= :rf.error/inline-interceptor-removed (:rf.error/id ed))
+            "the projected :rf/event-handler wrapper is not mis-read on the changed-event path")
+        (is (identical? cart-remove (registrar/handler :event :untip9.re/e))
+            "the changed handler re-lowered and resolves")
+        (is (some #(= :rf/event-handler (:id %))
+                  (:interceptors (registrar/lookup :event :untip9.re/e)))
+            "reg-event re-assembled the framework wrapper on the re-lowered changed event")))))
+
+;; ---------------------------------------------------------------------------
 ;; (6) KIND COVERAGE of the install! lowering seam (rf2-xmslkr)
 ;; ---------------------------------------------------------------------------
 ;;


### PR DESCRIPTION
## What

EP-0018's app-value event re-lowering path wrongly rejected a legitimately-projected `reg-event` handler. `core/install-descriptor!` lowered every `:event` descriptor straight through `events/reg-event`, but a PROJECTED descriptor (from `av/app-value`) carries the EFFECTIVE registrar metadata under `:metadata` — the assembled `:interceptors` chain whose tail is the inline `:rf/event-handler` framework wrapper, plus the generated `:rf.cofx/requires-parsed`. Re-feeding the effective chain made `validate-meta-interceptors!` read the inline wrapper as an AUTHORED inline interceptor and reject it `:rf.error/inline-interceptor-removed` (chains are reference-only since EP-0022). So any install/reinstall sourcing its value from a projection broke.

## Root cause

`install-descriptor!`'s `:event` case passed the projected `:metadata` verbatim to `events/reg-event`. The projected `:interceptors` chain still carries the framework-appended `:rf/event-handler` wrapper (`:rf/default? true`), which the reference-only registration validation rejects.

## Fix

- New `events/normalize-relowered-meta`: strips the registrar-regenerated slots back to the AUTHORED shape — recovers the author's reference chain via the documented `(remove :rf/default? interceptors)` and drops the regenerated `:rf.cofx/requires-parsed` (re-derived from the surviving authored `:rf.cofx/requires`). No-op on a constructed `module` descriptor (references-only chain, no generated slots).
- `install-descriptor!`'s `:event` case normalises through it before `reg-event`, so projected/reconciled app values re-lower faithfully (references re-validated, cofx re-parsed, a fresh wrapper re-appended).

## Red → green evidence

Two regressions in `app_value_install_cljs_test.cljc`:
- `install-of-a-projected-app-value-relowers-a-sugar-reg-event` (the bead's direct repro: reg-event sugar → install! the projection)
- `reinstall-changed-event-sourced-from-a-projection-relowers` (the changed-event reinstall path the bead names)

Both were RED with `:rf.error/inline-interceptor-removed` naming the projected `:rf/event-handler` wrapper before the fix; both green after.

## Gates

- `npm run test:cljs` — 7648 tests / 31544 assertions, 0 failures
- core JVM `re-frame.events-test`, `app-value-*`, `hot-reload-test` — green
- `scripts/test-fast-pr.sh` — PASS

Closes rf2-untip9.