### PR TITLE
test(event-conformance): lock EP-0017 cofx matrix + EP-0018 negative shapes (rf2-dkkmig, rf2-lpyw1v, rf2-fiiwbb, rf2-k51wm0, rf2-tqrr1d)

### DIFF
--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -54,6 +54,7 @@
             [re-frame.core :as rf]
             [re-frame.cofx :as cofx]
             [re-frame.error-emit :as error-emit]
+            [re-frame.late-bind :as late-bind]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -350,6 +351,150 @@
     (is (= :rf.error/unregistered-cofx
            (thrown-error-id #(rf/dispatch-sync [:evt-conf/bad-requires])))
         "an unregistered declared cofx raises :rf.error/unregistered-cofx")))
+
+(deftest reg-event-malformed-requires-is-cofx-request-invalid
+  (testing "EP-0017 §8 error matrix (rf2-fiiwbb) — a malformed `:rf.cofx/requires`
+            declaration is the registration-time hard error
+            `:rf.error/cofx-request-invalid` (DISTINCT from the unregistered-id
+            typo case, `:rf.error/unregistered-cofx`, above). `:rf.cofx/requires`
+            must be a VECTOR of ids; a non-vector value (e.g. a bare keyword) and
+            a vector carrying a non-id entry (e.g. a number) both fail at
+            registration — typos die before dispatch semantics apply. This locks
+            the request-shape leg of the public error matrix the existing tier
+            pinned only partially. A regression that silently accepted a
+            malformed requires (delivering nothing, or a nil) turns this RED"
+    ;; A non-vector :rf.cofx/requires value.
+    (is (= :rf.error/cofx-request-invalid
+           (thrown-error-id
+             #(rf/reg-event :evt-conf/requires-not-vector
+                {:rf.cofx/requires :evt-conf/not-a-vector}
+                (fn [_ _] {}))))
+        "a non-vector :rf.cofx/requires is :rf.error/cofx-request-invalid at registration")
+    ;; A vector carrying a non-id (non-keyword, non-`[id arg]`) entry.
+    (is (= :rf.error/cofx-request-invalid
+           (thrown-error-id
+             #(rf/reg-event :evt-conf/requires-bad-entry
+                {:rf.cofx/requires [42]}
+                (fn [_ _] {}))))
+        "a non-id entry in :rf.cofx/requires is :rf.error/cofx-request-invalid at registration")))
+
+(deftest reg-cofx-malformed-grade-metadata-is-cofx-registration-invalid
+  (testing "EP-0017 §2/§8 error matrix (rf2-fiiwbb) — malformed `reg-cofx` GRADE
+            metadata is the registration-time hard error
+            `:rf.error/cofx-registration-invalid` (DISTINCT from
+            `:rf.error/cofx-name-collision`, which is reserved for genuine
+            duplicate ownership). The three malformed-grade shapes the supplier /
+            grade contract rejects: (1) `:provided?` without `:recordable?` (a
+            provided fact is recordable by definition); (2) a `:provided?` fact
+            carrying a supplier (silently ignored at delivery — the contradiction
+            is rejected at the call site); (3) an ambient (non-provided) fact
+            with NO supplier (it could never produce a value). This locks the
+            reg-cofx grade-validation leg the existing tier did not exercise. A
+            regression that registered any of these malformed grades (surfacing
+            as an opaque host NPE at delivery) turns this RED"
+    ;; (1) :provided? without :recordable?
+    (is (= :rf.error/cofx-registration-invalid
+           (thrown-error-id
+             #(rf/reg-cofx :evt-conf/provided-not-recordable {:provided? true})))
+        ":provided? without :recordable? is :rf.error/cofx-registration-invalid")
+    ;; (2) :provided? WITH a supplier (the silently-ignored contradiction).
+    (is (= :rf.error/cofx-registration-invalid
+           (thrown-error-id
+             #(rf/reg-cofx :evt-conf/provided-with-supplier
+                {:recordable? true :provided? true}
+                (fn [] :ignored))))
+        "a :provided? fact carrying a supplier is :rf.error/cofx-registration-invalid")
+    ;; (3) ambient (non-provided) fact with NO supplier.
+    (is (= :rf.error/cofx-registration-invalid
+           (thrown-error-id
+             #(rf/reg-cofx :evt-conf/ambient-no-supplier {:doc "no supplier"})))
+        "an ambient fact with no supplier is :rf.error/cofx-registration-invalid")))
+
+(deftest supplied-recordable-non-edn-value-is-cofx-value-invalid
+  (testing "EP-0017 §2/§5/§8 error matrix (rf2-fiiwbb) — a SUPPLIED recordable
+            value that fails the STRUCTURAL-EDN check (a host handle — a
+            function, atom, or other non-EDN object — stuffed into `:rf.cofx`)
+            is `:rf.error/cofx-value-invalid` with `reason
+            :non-edn-recordable-value`. Recordable coeffect values ride the
+            durable causal record (epoch ledger, replay, SSR payload, Xray) and
+            MUST be ordinary EDN data that reads back unchanged. The error fires
+            at the dispatch boundary BEFORE the handler. This locks the
+            structural-EDN half of the supplied-value validation matrix. A
+            regression that let a host handle reach the durable token (failing
+            far away at replay / Xray time, not at the boundary) turns this RED"
+    (let [fired? (atom false)]
+      (rf/reg-cofx :evt-conf/host-fact {:recordable? true :provided? true})
+      (rf/reg-event :evt-conf/reads-host-fact
+        {:rf.cofx/requires [:evt-conf/host-fact]}
+        (fn [_ _] (reset! fired? true) {}))
+      ;; Supply a HOST HANDLE (a function — never recordable EDN) as the value.
+      (let [thrown (thrown-error-id
+                     #(rf/dispatch-sync [:evt-conf/reads-host-fact]
+                                        {:rf.cofx {:evt-conf/host-fact (fn [] :a-host-handle)}}))]
+        (is (= :rf.error/cofx-value-invalid thrown)
+            "a supplied non-EDN recordable value is :rf.error/cofx-value-invalid")
+        (is (false? @fired?)
+            "the handler never ran — the boundary structural-EDN check halts before the handler")))))
+
+(deftest supplied-recordable-value-failing-schema-is-cofx-value-invalid-in-production
+  (testing "EP-0017 §5/§8 + disposition 9 (rf2-fiiwbb) — a SUPPLIED recordable
+            value that fails its `reg-cofx` `:schema` is the
+            `:rf.error/cofx-value-invalid` hard error, and it fires in
+            PRODUCTION as well as dev (the production-hard-error contract — an
+            out-of-contract recordable value folded into the durable ledger is
+            corrupt state, the `:dispatched-at` precedent). The `:schema` check
+            routes through the shared `set-schema-validator!` seam (Spec 010
+            §Non-Malli validators): a registered validator covers this surface
+            even without the Malli schemas artefact. Here we register a tiny
+            non-Malli validator directly via the late-bind seam and prove a
+            supplied value the validator rejects is the hard error; a value it
+            accepts is delivered. The `validate-recordable-value!` path is
+            ALWAYS-ON (not dev-gated), so this locks the production contract. A
+            regression that downgraded schema validation to a dev-only diagnostic
+            (or skipped it for supplied values) turns this RED"
+    ;; Register a tiny NON-Malli validator + explainer via the same late-bind
+    ;; seam `re-frame.schemas` publishes (Spec 010): the schema is `[:enum …]`,
+    ;; the validator accepts only the listed values. Restored in the finally so
+    ;; no hook leaks between tests.
+    (let [prev-validate (late-bind/get-fn :schemas/validate-with-registered-fn)
+          prev-explain  (late-bind/get-fn :schemas/explain-with-registered-fn)]
+      (try
+        (late-bind/set-fn! :schemas/validate-with-registered-fn
+          (fn [schema value]
+            ;; schema shape `[:enum a b …]` → membership check.
+            (and (vector? schema)
+                 (= :enum (first schema))
+                 (contains? (set (rest schema)) value))))
+        (late-bind/set-fn! :schemas/explain-with-registered-fn
+          (fn [schema value] {:schema schema :value value :failed true}))
+        (let [delivered (atom ::unset)]
+          (rf/reg-cofx :evt-conf/graded-fact
+            {:recordable? true :provided? true
+             :schema [:enum :allowed-a :allowed-b]})
+          (rf/reg-event :evt-conf/reads-graded-fact
+            {:rf.cofx/requires [:evt-conf/graded-fact]}
+            (fn [{:keys [evt-conf/graded-fact]} _] (reset! delivered graded-fact) {}))
+          ;; A value the validator REJECTS → :rf.error/cofx-value-invalid.
+          (is (= :rf.error/cofx-value-invalid
+                 (thrown-error-id
+                   #(rf/dispatch-sync [:evt-conf/reads-graded-fact]
+                                      {:rf.cofx {:evt-conf/graded-fact :not-allowed}})))
+              "a supplied recordable value failing its :schema is :rf.error/cofx-value-invalid")
+          ;; A value the validator ACCEPTS → delivered flat (validation is a pass).
+          (rf/dispatch-sync [:evt-conf/reads-graded-fact]
+                            {:rf.cofx {:evt-conf/graded-fact :allowed-a}})
+          (is (= :allowed-a @delivered)
+              "a supplied recordable value satisfying its :schema is delivered flat (validation passes)"))
+        (finally
+          ;; Restore the prior hooks (nil = no validator) so no leak.
+          (if prev-validate
+            (late-bind/set-fn! :schemas/validate-with-registered-fn prev-validate)
+            (swap! late-bind/hooks dissoc :schemas/validate-with-registered-fn))
+          (if prev-explain
+            (late-bind/set-fn! :schemas/explain-with-registered-fn prev-explain)
+            (swap! late-bind/hooks dissoc :schemas/explain-with-registered-fn))
+          (late-bind/invalidate-cache! :schemas/validate-with-registered-fn)
+          (late-bind/invalidate-cache! :schemas/explain-with-registered-fn))))))
 
 (deftest reg-event-undeclared-cofx-is-not-staged
   (testing "EP-0017 declared-only delivery on reg-event: an UNdeclared recordable

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -286,6 +286,69 @@
           (is (= :evt-conf/required-boundary (get-in (first errs) [:tags :rf.cofx/id]))
               ":rf.cofx/id names the absent provided fact"))))))
 
+(deftest reg-event-framework-provided-rf-time-ms-declared-delivered-undeclared-absent
+  (testing "EP-0017 §1/§2/§4/§5 (rf2-dkkmig) — the framework-STAMPED `:rf/time-ms`
+            provided-recordable matrix, the no-implicit-time rule. `:rf/time-ms`
+            is the framework's ONE built-in `{:recordable? true :provided? true}`
+            registration, stamped onto every dispatch envelope at enqueue (so it
+            is always present on the token without the caller supplying it). The
+            two legs prove the provided-vs-ambient recordable contract for the
+            STAMPED fact: (1) a handler DECLARING `:rf/time-ms` receives the
+            framework-stamped value flat (the stamp guarantees the provided fact
+            is present — no `:rf.error/missing-required-cofx`, distinct from the
+            generator-less custom provided fact that IS absent); (2) a handler
+            NOT declaring it never sees it in its coeffects map (no implicit
+            time — the most-consumed fact gets no special treatment).
+            A regression re-introducing implicit time delivery (staging
+            `:rf/time-ms` for an undeclared handler) turns leg 2 RED; a
+            regression that stopped stamping the provided fact turns leg 1 RED
+            (it would surface as missing-required)"
+    (let [declared-time   (atom ::unset)
+          undeclared-has? (atom ::unset)]
+      ;; Leg 1 — DECLARED: the framework-stamped provided `:rf/time-ms` is
+      ;; delivered flat from the enqueue stamp, NO caller supply needed.
+      (rf/reg-event :evt-conf/declares-time
+        {:rf.cofx/requires [:rf/time-ms]}
+        (fn [{:keys [rf/time-ms]} _] (reset! declared-time time-ms) {}))
+      ;; Leg 2 — UNDECLARED: the same stamped fact is NOT staged.
+      (rf/reg-event :evt-conf/ignores-time
+        (fn [cofx _] (reset! undeclared-has? (contains? cofx :rf/time-ms)) {}))
+      ;; Dispatch WITHOUT supplying `:rf/time-ms` — the enqueue stamp provides it.
+      (rf/dispatch-sync [:evt-conf/declares-time])
+      (rf/dispatch-sync [:evt-conf/ignores-time])
+      (is (number? @declared-time)
+          "the DECLARED framework-stamped :rf/time-ms arrived flat from the enqueue stamp (a provided fact, always present — never missing-required)")
+      (is (false? @undeclared-has?)
+          "the UNDECLARED handler never sees :rf/time-ms — no implicit time (declared-only delivery, the most-consumed fact gets no exemption)"))))
+
+(deftest reg-event-custom-provided-cofx-supplied-on-token-is-delivered-flat
+  (testing "EP-0017 §2/§4/§5 (rf2-dkkmig) — a CUSTOM `{:recordable? true
+            :provided? true}` cofx (no generator), SUPPLIED on the dispatch
+            token, is delivered FLAT under its id when declared. This is the
+            POSITIVE delivery leg complementing
+            `reg-event-registered-but-absent-provided-fact-is-missing-required-cofx`
+            (the negative leg): a registered provided fact PRESENT on the token
+            is delivered verbatim (supplied values win — no host read, no
+            generator), exactly like the framework's own `:rf/time-ms` but for an
+            app-owned boundary fact. Together the two legs lock the provided
+            recordable matrix: present → delivered flat; absent →
+            missing-required. A regression that failed to deliver a supplied
+            provided fact (or that ran a phantom supplier) turns this RED"
+    (let [seen (atom ::unset)]
+      ;; A custom provided recordable fact — NO supplier (its owner stamps the
+      ;; token). The valid provided shape: `{:recordable? true :provided? true}`.
+      (rf/reg-cofx :evt-conf/session-token
+        {:recordable? true :provided? true
+         :doc "A boundary fact the dispatch site stamps onto the token."})
+      (rf/reg-event :evt-conf/reads-token
+        {:rf.cofx/requires [:evt-conf/session-token]}
+        (fn [{:keys [evt-conf/session-token]} _] (reset! seen session-token) {}))
+      ;; SUPPLY the provided fact's value on the dispatch token.
+      (rf/dispatch-sync [:evt-conf/reads-token]
+                        {:rf.cofx {:evt-conf/session-token "jwt-abc-123"}})
+      (is (= "jwt-abc-123" @seen)
+          "the SUPPLIED custom provided recordable fact arrived FLAT under its id from the token (supplied values win — no generator, no host read)"))))
+
 (deftest inject-cofx-is-off-the-public-facade-and-the-removal-is-a-hard-error
   (testing "EP-0017 slice A.3 + rf2-w9xyx1 (rf2-q5w74i): the v1 ctx→ctx
             `inject-cofx` delivery idiom is REMOVED with no alias —

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -777,6 +777,85 @@
         (is (= :dispatch (get-in (first shape-traces) [:tags :offending-key]))
             "the diagnostic names the offending legacy top-level key")))))
 
+(deftest reg-event-bare-app-db-shaped-return-is-effect-map-shape-not-committed
+  (testing "EP-0018 §4 closed-effects contract (rf2-tqrr1d) — a BARE app-db-shaped
+            return (a map of application keys, e.g. `{:count 1}`, NOT wrapped in
+            `{:db …}`) is rejected as `:rf.error/effect-map-shape`
+            (`:recovery :logged-and-skipped`): its application top-level key is
+            FOREIGN to the closed `#{:db :rf.db/runtime :fx}` effect map. This is
+            DISTINCT from the legacy-`:dispatch`-shortcut case (a known v1
+            shortcut id) — it is the db-RETURN convenience the EP-0018 collapse
+            removed (`reg-event-db`'s bare-db return is GONE; the db-write is the
+            explicit `:db` effect). A regression that partially revived the old
+            db-return convenience for application keys — committing `{:count 1}`
+            as app-db, or otherwise avoiding the shape error — passes the existing
+            `{:db …}` positive tier while VIOLATING the closed contract; this
+            lock turns it RED. The lock has two legs: the offending app key emits
+            the shape error, AND app-db is NOT mutated to the bare map"
+    (let [traces (atom [])]
+      (rf/reg-sub :evt-conf/bare-count (fn [db _] (:count db :absent)))
+      ;; Seed app-db with a sentinel so a wrongly-committed bare return is
+      ;; observable (the bare `{:count 1}` would clobber `:count :seeded`).
+      (rf/reg-event :evt-conf/bare-seed! (fn [{:keys [db]} _] {:db (assoc db :count :seeded)}))
+      ;; A handler returning a BARE app-db-shaped map — `:count` is a FOREIGN
+      ;; top-level effect key, NOT the `{:db …}` write effect.
+      (rf/reg-event :evt-conf/bare-db-return (fn [_ _] {:count 1}))
+      (rf/dispatch-sync [:evt-conf/bare-seed!])
+      (rf/register-listener! :evt-conf/bare-recorder (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:evt-conf/bare-db-return])
+      (rf/unregister-listener! :evt-conf/bare-recorder)
+      (is (= :seeded @(rf/subscribe [:evt-conf/bare-count]))
+          "the bare `{:count 1}` return was NOT committed as app-db (the db-return convenience is GONE)")
+      (let [shape-traces (filter #(and (= :rf.error/effect-map-shape (:operation %))
+                                       (= :count (get-in % [:tags :offending-key])))
+                                 @traces)]
+        (is (seq shape-traces)
+            "the bare app-db-shaped return's foreign app key emits :rf.error/effect-map-shape naming :count")
+        (is (= :logged-and-skipped (:recovery (first shape-traces)))
+            "the bare-db-return shape diagnostic carries :recovery :logged-and-skipped")))))
+
+(deftest reg-event-app-handler-runtime-effect-keeps-the-diagnostic-unless-framework-authority
+  (testing "EP-0018 §Conformance + EP-0001 (rf2-tqrr1d) — an app-authored
+            `reg-event` handler returning `{:rf.db/runtime …}` keeps the
+            `:rf.warning/app-handler-runtime-effect` diagnostic UNLESS the
+            handler has framework-write authority. `:rf.db/runtime` is the
+            runtime-db partition reserved BY CONVENTION for framework /
+            runtime-extension code (NOT a security boundary — the effect is
+            still applied, `:recovery :warned`); an ordinary app handler emitting
+            it is the dev diagnostic, while a framework-authority handler (the
+            reserved `:rf/framework-authority? true` registration meta) writes it
+            silently. The existing tier only proves `:rf.db/runtime` PRESENT in
+            the coeffects map — this locks the RETURN-side authority guard. A
+            regression that dropped the diagnostic for app handlers (or fired it
+            for framework-authority handlers) turns the respective leg RED. The
+            diagnostic rides the dev trace bus, so observe it via a trace
+            listener filtering on `:operation`"
+    (let [app-traces (atom [])
+          fw-traces  (atom [])]
+      ;; Leg 1 — an APP handler (no authority) returning :rf.db/runtime fires
+      ;; the diagnostic.
+      (rf/reg-event :evt-conf/app-writes-runtime
+        (fn [_ _] {:rf.db/runtime {:rf.runtime/marker :app-wrote}}))
+      (rf/register-listener! :evt-conf/app-runtime-recorder (fn [ev] (swap! app-traces conj ev)))
+      (rf/dispatch-sync [:evt-conf/app-writes-runtime])
+      (rf/unregister-listener! :evt-conf/app-runtime-recorder)
+      (let [warn-traces (filter #(= :rf.warning/app-handler-runtime-effect (:operation %)) @app-traces)]
+        (is (seq warn-traces)
+            "an APP handler returning :rf.db/runtime keeps the :rf.warning/app-handler-runtime-effect diagnostic")
+        (is (= :warned (:recovery (first warn-traces)))
+            "the diagnostic carries :recovery :warned (the effect is still applied — convention, not enforcement)"))
+      ;; Leg 2 — a FRAMEWORK-AUTHORITY handler (the reserved
+      ;; `:rf/framework-authority? true` registration meta) writes :rf.db/runtime
+      ;; WITHOUT the diagnostic.
+      (rf/reg-event :evt-conf/fw-writes-runtime
+        {:rf/framework-authority? true}
+        (fn [_ _] {:rf.db/runtime {:rf.runtime/marker :fw-wrote}}))
+      (rf/register-listener! :evt-conf/fw-runtime-recorder (fn [ev] (swap! fw-traces conj ev)))
+      (rf/dispatch-sync [:evt-conf/fw-writes-runtime])
+      (rf/unregister-listener! :evt-conf/fw-runtime-recorder)
+      (is (empty? (filter #(= :rf.warning/app-handler-runtime-effect (:operation %)) @fw-traces))
+          "a FRAMEWORK-AUTHORITY handler writes :rf.db/runtime silently — NO app-handler-runtime-effect diagnostic"))))
+
 (deftest reg-event-unchanged-db-return-is-a-true-noop
   (testing "EP-0018 §4 (rf2-na5i1z): a `{:db db}` return that re-installs the
             SAME app-db value is a true no-op — app-db is unchanged AND the

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -153,9 +153,16 @@
           "the `{:db …}` effect committed cumulatively (the db-write IS an effect)"))))
 
 (deftest reg-event-handler-receives-the-canonical-coeffect-keys
-  (testing "EP-0018 §4 + spec/002 §Event handlers: the coeffects map a handler
-            receives carries `:db`, `:event`, `:rf.frame/id`, `:rf.db/runtime`,
-            and `:rf.cofx` — the framework-supplied baseline (NO `:event/kind`)"
+  (testing "EP-0018 §4 + spec/002 §Event handlers + EP-0017 §3/§5: the coeffects
+            map a handler receives carries `:db`, `:event`, `:rf.frame/id`,
+            `:rf.db/runtime`, and the canonical complete `:rf.cofx` RECORD — the
+            framework-supplied baseline (NO `:event/kind`). `:rf.cofx` is the
+            envelope's flat recordable-coeffect record reachable through the
+            context for generic code (per EP-0017 §5); the handler's DECLARED
+            facts are delivered FLAT under their own ids (see
+            `reg-event-rf-cofx-requires-delivers-the-fact-flat`), NOT nested
+            here. The retired `:rf.world/inputs` successor is GONE from the
+            baseline (the flat-envelope rename — EP-0017 §3)"
     (let [cofx (atom ::unset)]
       (rf/reg-event :evt-conf/inspect-cofx
         (fn [coeffects _] (reset! cofx coeffects) {}))
@@ -169,8 +176,67 @@
         (is (= :rf/default (:rf.frame/id c))
             "the ambient frame id is delivered as `:rf.frame/id`")
         (is (contains? c :rf.db/runtime) "`:rf.db/runtime` present in the coeffects map")
+        (is (contains? c :rf.cofx)
+            "the canonical complete `:rf.cofx` record is reachable in the coeffects map (the flat envelope record — EP-0017 §5)")
+        (is (map? (:rf.cofx c))
+            "`:rf.cofx` is the FLAT recordable-coeffect map (fact-name → value, no grouping sub-maps)")
+        (is (not (contains? c :rf.world/inputs))
+            "the retired `:rf.world/inputs` successor is GONE from the coeffects baseline (EP-0017 §3 flat rename)")
         (is (not (contains? c :event/kind))
             "the `:event/kind` sub-tag is GONE from the coeffects map (one form)")))))
+
+(deftest dispatch-opt-rf-world-inputs-is-the-world-inputs-renamed-hard-error
+  (testing "EP-0017 §3/§8 (rf2-k51wm0) — the OLD coeffect key: supplying the
+            retired `:rf.world/inputs` DISPATCH OPT is the hard error
+            `:rf.error/world-inputs-renamed`, naming `:rf.cofx` as the
+            replacement (no alias, no coexistence window — EP-0007 rule 2). The
+            recordable-coeffect map moved to the flat `:rf.cofx` envelope field;
+            supplying the old key fails LOUDLY rather than being silently
+            ignored. This is an always-on correctness contract (fires in
+            production too). The umbrella tier lacked this old-key negative lock.
+            A regression that re-accepted `:rf.world/inputs` (silently, or as an
+            alias) turns this RED"
+    (rf/reg-event :evt-conf/inspect-renamed (fn [_ _] {}))
+    (let [thrown (thrown-error-id
+                   #(rf/dispatch-sync [:evt-conf/inspect-renamed]
+                                      {:rf.world/inputs {:rf/time-ms 1781078400123}}))]
+      (is (= :rf.error/world-inputs-renamed thrown)
+          "the retired `:rf.world/inputs` dispatch opt is the hard error :rf.error/world-inputs-renamed"))
+    (let [reason (thrown-error-reason
+                   #(rf/dispatch-sync [:evt-conf/inspect-renamed]
+                                      {:rf.world/inputs {:rf/time-ms 1781078400123}}))]
+      (is (string? reason)
+          "the renamed-key error carries a :reason string")
+      (is (re-find #":rf.cofx" reason)
+          "the renamed-key error names `:rf.cofx` as the replacement (the flat envelope field)"))))
+
+(deftest live-event-coeffects-carry-no-rf-world-inputs-flat-delivery
+  (testing "EP-0017 §3/§5 (rf2-k51wm0) — the flat / no-live-world-inputs
+            contract: a live event's coeffects (and the supplied recordable
+            facts) carry the flat `:rf.cofx` record, NOT the retired
+            `:rf.world/inputs` nested envelope. A handler DECLARING a recordable
+            fact receives it FLAT under its id, while the canonical `:rf.cofx`
+            record (present in the coeffects) is flat too — there is NO
+            `:rf.world/inputs` key anywhere in the live coeffects, and no nested
+            `:cofx` successor. This locks the positive flat delivery against the
+            negative absence of the old shape in ONE assertion bundle. A
+            regression that re-introduced an `:rf.world/inputs` nested map in the
+            live coeffects turns this RED"
+    (let [c (atom ::unset)]
+      (rf/reg-event :evt-conf/flat-delivery
+        {:rf.cofx/requires [:rf/time-ms]}
+        (fn [coeffects _] (reset! c coeffects) {}))
+      (rf/dispatch-sync [:evt-conf/flat-delivery]
+                        {:rf.cofx {:rf/time-ms 1781078400123}})
+      (let [cofx @c]
+        (is (= 1781078400123 (:rf/time-ms cofx))
+            "the declared recordable fact arrived FLAT under its id (:rf/time-ms), not nested")
+        (is (not (contains? cofx :rf.world/inputs))
+            "the live coeffects carry NO `:rf.world/inputs` key (the retired nested envelope is gone)")
+        (is (not (contains? cofx :cofx))
+            "the live coeffects carry NO nested `:cofx` successor (flat delivery only)")
+        (is (= 1781078400123 (get (:rf.cofx cofx) :rf/time-ms))
+            "the canonical complete record under `:rf.cofx` is the FLAT recordable map (fact-name → value)")))))
 
 (deftest reg-event-second-arg-is-the-event-vector
   (testing "EP-0018 §1 (D4): the handler is TWO-ARG `(fn [coeffects event-vec])`

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -216,6 +216,130 @@
       (is (= :hello @seen)
           "the generator arg was threaded and the result delivered flat"))))
 
+(deftest reg-event-recordable-generator-mints-under-live-and-writes-back-to-the-record
+  (testing "EP-0017 §5/§6 slice-B.7 (rf2-lpyw1v) — a declared-absent RECORDABLE
+            NON-PROVIDED generator-backed cofx (a `{:recordable? true}` reg-cofx
+            WITH a value-returning supplier — NOT `:provided?`) runs its
+            generator at processing-start under the router's default `:live`
+            mint policy, the produced value is DELIVERED flat AND written back
+            into the in-flight `:rf.cofx` causal record (so the epoch captures
+            the post-generation token and replay re-presents it). Distinct from
+            the existing one-arg AMBIENT supplier (`:evt-conf/echo`, which is
+            never recorded): this is the recordable generator the existing tier
+            lacked. The write-back is observed through the canonical envelope
+            `:rf.cofx` reachable in the coeffects map. A regression that
+            generated but failed to write back (the epoch missing the fact,
+            replay re-generating a different value) turns the record assertion
+            RED; one that did not mint at all (treating an absent
+            generator-backed fact as missing-required under `:live`) turns the
+            delivery assertion RED"
+    (let [delivered (atom ::unset)
+          recorded  (atom ::unset)
+          calls     (atom 0)]
+      ;; A RECORDABLE generator (NOT :provided?) — a value-returning supplier
+      ;; the framework records, replays, and enforces. A monotonic counter so
+      ;; a re-run (which would be a write-back failure) is observable.
+      (rf/reg-cofx :evt-conf/mint-id
+        {:recordable? true}
+        (fn [] (swap! calls inc) (str "id-" @calls)))
+      (rf/reg-event :evt-conf/uses-mint
+        {:rf.cofx/requires [:evt-conf/mint-id]}
+        (fn [{:keys [evt-conf/mint-id] :as cofx} _]
+          (reset! delivered mint-id)
+          ;; The canonical complete record is reachable in the coeffects map
+          ;; under :rf.cofx (the runtime restamps it post-generation).
+          (reset! recorded (get (:rf.cofx cofx) :evt-conf/mint-id))
+          {}))
+      ;; Dispatch WITHOUT supplying the fact — under the default :live policy
+      ;; the generator mints it at processing-start.
+      (rf/dispatch-sync [:evt-conf/uses-mint])
+      (is (= "id-1" @delivered)
+          "the recordable generator minted the absent fact under :live and delivered it flat")
+      (is (= "id-1" @recorded)
+          "the generated value was WRITTEN BACK into the in-flight :rf.cofx record (the post-generation token the epoch captures)")
+      (is (= 1 @calls)
+          "the generator ran exactly once (the write-back, not a re-read, supplies the record)"))))
+
+(deftest reg-event-recordable-generator-emits-rf-cofx-generated-trace-op
+  (testing "EP-0017 §9 slice-B.7 (rf2-lpyw1v) — the generation step emits the
+            dev-mode `:rf.cofx/generated` trace op (fact-name + supplier id +
+            produced value) so traces are self-describing even though the record
+            is flat. This is the slice-B trace vocabulary the existing tier did
+            not exercise. Observed via a trace listener filtering `:operation`.
+            A regression that stopped emitting the op (or renamed it) turns this
+            RED"
+    (let [traces (atom [])]
+      (rf/reg-cofx :evt-conf/gen-fact
+        {:recordable? true}
+        (fn [] :minted-value))
+      (rf/reg-event :evt-conf/triggers-gen
+        {:rf.cofx/requires [:evt-conf/gen-fact]}
+        (fn [_ _] {}))
+      (rf/register-listener! :evt-conf/gen-recorder (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:evt-conf/triggers-gen])
+      (rf/unregister-listener! :evt-conf/gen-recorder)
+      (let [gen-traces (filter #(= :rf.cofx/generated (:operation %)) @traces)]
+        (is (seq gen-traces)
+            "the generation step emits the :rf.cofx/generated trace op")
+        (is (= :evt-conf/gen-fact (get-in (first gen-traces) [:tags :rf.cofx/id]))
+            ":rf.cofx/id names the generated fact")
+        (is (= :minted-value (get-in (first gen-traces) [:tags :rf.cofx/value]))
+            "the op carries the produced value (fact-name + value, self-describing)")))))
+
+(deftest reg-event-strict-mint-policy-refuses-to-generate-and-raises-missing-required
+  (testing "EP-0017 §5/§6 slice-B.8 (rf2-lpyw1v) — STRICT replay/test behaviour:
+            under the `:strict` mint policy a declared-absent generator-backed
+            recordable fact is NOT minted (no host read, no generator run) — it
+            is the hard error `:rf.error/missing-required-cofx`. Replay is
+            unconditionally strict: an incomplete record MUST fail loudly rather
+            than silently re-read the host. The policy is supplied per-call via
+            the `:rf.cofx/mint-policy` dispatch opt (the same opt a Tool-Pair
+            replay supplies). This is the strict-replay lock the existing tier
+            lacked: it proves `:strict` REFUSES to mint the very fact `:live`
+            mints in the test above. A regression that minted under `:strict`
+            (re-reading the host on replay) turns this RED"
+    (let [calls  (atom 0)
+          fired? (atom false)]
+      (rf/reg-cofx :evt-conf/strict-fact
+        {:recordable? true}
+        (fn [] (swap! calls inc) :should-not-mint))
+      (rf/reg-event :evt-conf/needs-strict-fact
+        {:rf.cofx/requires [:evt-conf/strict-fact]}
+        (fn [_ _] (reset! fired? true) {}))
+      ;; Dispatch under :strict WITHOUT supplying the fact — strict refuses to mint.
+      (let [thrown (thrown-error-id
+                     #(rf/dispatch-sync [:evt-conf/needs-strict-fact]
+                                        {:rf.cofx/mint-policy :strict}))]
+        (is (= :rf.error/missing-required-cofx thrown)
+            "a declared-absent generator-backed fact under :strict is :rf.error/missing-required-cofx (no mint, no host read)")
+        (is (zero? @calls)
+            "the generator NEVER ran under :strict (no silent host read on replay)")
+        (is (false? @fired?)
+            "the handler never ran — missing-required halts the cascade before the handler")))))
+
+(deftest reg-event-explicit-live-mint-policy-mints-the-declared-nondeterminism-escape
+  (testing "EP-0017 §6 slice-B.8 (rf2-lpyw1v) — `:explicit-live` is the
+            declared-nondeterminism ESCAPE: like `:live` it mints a
+            declared-absent generator-backed recordable fact, but the test has
+            explicitly opted into nondeterminism (distinct from the `:test`
+            preset's `:strict` default). Supplied per-call via the
+            `:rf.cofx/mint-policy` dispatch opt. This completes the policy
+            triad — `:live` (router default, minted above), `:strict` (refuses,
+            above), `:explicit-live` (mints, here) — locking all three binding
+            points. A regression that conflated `:explicit-live` with `:strict`
+            (refusing to mint) turns this RED"
+    (let [delivered (atom ::unset)]
+      (rf/reg-cofx :evt-conf/escape-fact
+        {:recordable? true}
+        (fn [] :minted-under-escape))
+      (rf/reg-event :evt-conf/uses-escape-fact
+        {:rf.cofx/requires [:evt-conf/escape-fact]}
+        (fn [{:keys [evt-conf/escape-fact]} _] (reset! delivered escape-fact) {}))
+      (rf/dispatch-sync [:evt-conf/uses-escape-fact]
+                        {:rf.cofx/mint-policy :explicit-live})
+      (is (= :minted-under-escape @delivered)
+          ":explicit-live mints a declared-absent generator-backed fact (the declared-nondeterminism escape, NOT strict)"))))
+
 (deftest reg-event-typo-cofx-is-the-hard-error
   (testing "EP-0017 typo path on reg-event: declaring `:rf.cofx/requires` for an
             UNregistered cofx is the hard error `:rf.error/unregistered-cofx`


### PR DESCRIPTION
Adds the missing EP-0017 / EP-0018 conformance locks to the umbrella event-model tier (`implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc`). All additions are conformance-TEST coverage that lock real, already-shipped behaviour — no implementation changed.

## Coverage added (per bead)

- **rf2-dkkmig** — EP-0017 provided-cofx delivery matrix. The framework-stamped `:rf/time-ms` declared (delivered flat from the enqueue stamp — never missing-required) / undeclared (not staged — the no-implicit-time rule) legs, plus a custom `{:recordable? true :provided? true}` cofx supplied on the token delivered flat (supplied values win). Completes the provided-vs-ambient recordable matrix.
- **rf2-lpyw1v** — EP-0017 strict-replay + generator matrix. A recordable non-provided generator under `:live` (mints at processing-start + writes the value back into the in-flight `:rf.cofx` record, generator runs exactly once), the dev `:rf.cofx/generated` trace op (fact-name + supplier id + value), `:strict` refusing to mint (`:rf.error/missing-required-cofx`, no host read), and `:explicit-live` minting — locking all three mint-policy binding points via the `:rf.cofx/mint-policy` dispatch opt.
- **rf2-fiiwbb** — EP-0017 cofx error + validation matrix. `:rf.error/cofx-request-invalid` (malformed `:rf.cofx/requires`), `:rf.error/cofx-registration-invalid` (the three malformed `reg-cofx` grade shapes), and the supplied-value `:rf.error/cofx-value-invalid` matrix: the structural-EDN host-handle case AND the declared-`:schema` production hard error (exercised through the Spec 010 non-Malli `set-schema-validator!` late-bind seam, registered + restored in-test).
- **rf2-k51wm0** — EP-0017 old-cofx-key + flat-envelope negatives. The `:rf.world/inputs` dispatch-opt hard error (`:rf.error/world-inputs-renamed` naming `:rf.cofx`), the flat/no-live-world-inputs contract (live coeffects carry no `:rf.world/inputs` nor nested `:cofx`; the canonical `:rf.cofx` record is the flat map), and a prose clarification on the canonical-coeffect-keys baseline.
- **rf2-tqrr1d** — EP-0018 db-map + runtime-return negatives. A bare app-db-shaped return (`{:count 1}`) is `:rf.error/effect-map-shape` AND not committed; the `:rf.db/runtime` return authority guard fires `:rf.warning/app-handler-runtime-effect` for app handlers and is silent for `:rf/framework-authority?` handlers.

## Gates

- conformance JVM suite (`clojure -M:test` in `implementation/event-conformance`): 53 tests / 164 assertions, 0 failures.
- `npm run test:cljs`: 7660 tests / 31573 assertions, 0 failures (the `.cljc` runs clean under the CLJS runtime too).
- `scripts/test-fast-pr.sh`: PASS.

No implementation bugs surfaced; no follow-up beads filed.