### PR TITLE
docs: sweep retired EP-0018 event vocabulary in docs/examples/template (rf2-4fmnww, rf2-p1xzjv, rf2-3lpcq9, rf2-4aln6m, rf2-lb69ue)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -61,7 +61,7 @@ The orchestrator and the runner consume `playwright` and `http-server` out of `i
 
 ## Reagent
 
-The full set of worked examples — twenty-three in total (counting each 7GUIs task individually), each paired with a shadow-cljs build id. There is no per-example Playwright spec — adapter-level smoke coverage lives at [`implementation/adapters/reagent/testbed/spec.cjs`](../implementation/adapters/reagent/testbed/spec.cjs) and the broader contract coverage lives in `npm run test:cljs` / `test:xray-feature-gate` / `test:bundle-isolation` / `test:perf-bundle`.
+The full set of worked examples — twenty-four in total (counting each 7GUIs task individually), each paired with a shadow-cljs build id. There is no per-example Playwright spec — adapter-level smoke coverage lives at [`implementation/adapters/reagent/testbed/spec.cjs`](../implementation/adapters/reagent/testbed/spec.cjs) and the broader contract coverage lives in `npm run test:cljs` / `test:xray-feature-gate` / `test:bundle-isolation` / `test:perf-bundle`.
 
 Build any example directly via shadow-cljs:
 

--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -22,7 +22,7 @@ surfaces change and in the scheduled/manual expensive workflow.
 | `npm run test:examples`            | The three adapter-level smokes at `implementation/adapters/{reagent,uix,helix}/testbed/spec.cjs` — mount + dispatch + assert per substrate. The `examples/` tree itself is test-free; this orchestrator drives the adapter smokes only. | [`scripts/serve-and-run-examples-tests.cjs`](scripts/serve-and-run-examples-tests.cjs)                                       |
 | `npm run test:examples-compile`    | **Compile-coverage gate.** `shadow-cljs compile` over EVERY declared standalone `:examples/*` build (the list is derived from `shadow-cljs.edn`, so a new example build is swept automatically). Fails on any compile-time error AND on any warning (a typo'd init-fn surfaces as an `:undeclared-var` warning, and `compile` exits 0 on warnings). NOT a Playwright/runtime check — no `spec.cjs` involved. | [`implementation/scripts/check-examples-compile.cjs`](../implementation/scripts/check-examples-compile.cjs) |
 
-The two surfaces are independent:
+The three surfaces are independent:
 
 - `test:browser` is **one bundle, one page, every test**. Every example
   namespace that is `:require`'d by a `*-cljs-test` wrapper is loaded into
@@ -415,7 +415,7 @@ A new example added to the `test:browser` surface needs:
    Per the convention above.
 2. **A prefixed id namespace.** Pick a stem (your example's folder name
    in `kebab-case` is a good default) and stick to it for every
-   `reg-event-*`, `reg-sub`, `reg-machine`, `reg-frame`, schema, etc.
+   `reg-event`, `reg-sub`, `reg-machine`, `reg-frame`, schema, etc.
 3. **A wrapper test ns** under
    `implementation/adapters/<substrate>/test/re_frame/<example>_cljs_test.cljs`
    ending in `-cljs-test` so the `:browser-test` build picks it up via

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -116,7 +116,7 @@
 ;; machine `:data` slot, so neither the app-db schema-marks bridge
 ;; (`populate-sensitive-from-schemas!`) nor the machine `:data-schema` egress
 ;; bridge (`register-data-schema-marks!`) applies, and a machine handler does
-;; not stash event-arg `:sensitive` paths (reg-event-fx skips that for
+;; not stash event-arg `:sensitive` paths (reg-event skips that for
 ;; `:rf/machine?`). So this slot mark does NOT by itself redact the password
 ;; from the dispatched event vector. The password's real off-box egress path
 ;; is the HTTP request body — redacted by the per-request `:sensitive? true`
@@ -394,7 +394,7 @@
 ;; :auth.login/flow)` reads (so the `:where :machine-data` walker resolves the
 ;; `:data-schema` and it VALIDATES) AND bridges the schema's `:sensitive?` /
 ;; `:large?` slots into snapshot-egress redaction — both in one place. The
-;; former hand-stamped `reg-event-fx` + `make-machine-handler` composition
+;; former hand-stamped `reg-event` + `make-machine-handler` composition
 ;; (which ran neither side-effect automatically) is gone.
 (rf/reg-machine :auth.login/flow
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -131,7 +131,7 @@
 ;; rf2-genufr / rf2-wgmipl — `reg-machine` is the single registration home.
 ;; The auth machine carries a `:data-schema` (validating the snapshot's
 ;; `:data` slot); registering it here (rather than the former hand-composed
-;; `reg-event-fx` + `make-machine-handler`) stamps the `:rf/machine?` /
+;; `reg-event` + `make-machine-handler`) stamps the `:rf/machine?` /
 ;; `:rf/machine` metadata that makes the `:data-schema` LIVE (`(machine-meta
 ;; :auth/flow)` reads it, the `:where :machine-data` walker resolves it) AND
 ;; bridges its redaction marks — both in one place. Under the old direct path

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -191,7 +191,7 @@
 ;; ============================================================================
 ;;
 ;; Two equivalent forms; we use the convenience `reg-machine`. The
-;; longer form `(reg-event-fx machine-id (make-machine-handler m))`
+;; longer form `(reg-event machine-id (make-machine-handler m))`
 ;; is what reg-machine wraps, and is the form to use when you need
 ;; registration metadata (`:doc`, `:interceptors`, ...).
 

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -365,7 +365,7 @@
 ;; MACHINE HANDLER + SUBSCRIPTIONS + INIT EVENT  (ns-load — the production-app idiom)
 ;; ============================================================================
 
-;; Use `rf/reg-machine` (not `reg-event-fx` + `make-machine-handler`) so
+;; Use `rf/reg-machine` (not `reg-event` + `make-machine-handler`) so
 ;; the registration metadata carries `:rf/machine? true` — declarative
 ;; `:spawn` resolves the spawn target via this metadata, and without it
 ;; the spawn-fx silently no-ops (the spawned actor's handler never

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -341,7 +341,7 @@ markdown_extensions:
         # emit <pre class="language-cljs-rf2">; docs/tools/playground's bootstrap turns
         # each into a CM6 editor whose last form is MOUNTED as a reagent2
         # component, evaluated against re-frame2's OWN public API (re-frame.core
-        # v2 — reg-event-db / reg-sub / dispatch / subscribe). The re-frame2 SCI
+        # v2 — reg-event / reg-sub / dispatch / subscribe). The re-frame2 SCI
         # bundle (cljs/playground-rf2.js, built by docs/tools/playground/sci) is
         # loaded on demand only on pages that have a ```cljs-rf2 cell. Plain
         # ```cljs cells are unchanged.

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -698,7 +698,7 @@ consumes the same helper and will plumb its own knob in a follow-up.
 #### Open-in-editor launch modes (rf2-wn3bh — Option B dev-server endpoint)
 
 Jump-to-source has TWO launch paths; the chip + the
-`:rf.story/open-in-editor` event-fx PREFER the first and FALL BACK to
+`:rf.story/open-in-editor` event PREFER the first and FALL BACK to
 the second. The mechanism is additive — B never removes the URI path.
 This is the JS-ecosystem standard (Vite `/__open-in-editor`,
 react-dev-utils, Next). See

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -200,7 +200,7 @@
 ;; expansion logic lives in `re-frame.story.macros`; the defmacro forms
 ;; here are thin wrappers so consumers writing
 ;; `(:require [re-frame.story :as story])` find the macros on the
-;; public ns (mirroring `re-frame.core`'s pattern for `reg-event-db`).
+;; public ns (mirroring `re-frame.core`'s pattern for `reg-event`).
 ;;
 ;; Each macro captures `&form` meta + `*file*` + `(ns-name *ns*)` from
 ;; the caller's compile environment. The helper merges these into

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -25,7 +25,7 @@
   ## Record, don't throw (per `004-Assertions.md` §Record-don't-throw semantics)
 
   Each `:rf.assert/*` event is dispatched through the standard re-frame
-  cascade. The handler is a plain `reg-event-fx` that:
+  cascade. The handler is a plain `reg-event` handler that:
 
   1. Evaluates the assertion semantics against the frame's current app-db
      (or the subscribed value, or the trace bus, or the machine snapshot).
@@ -49,7 +49,7 @@
   a handler.
 
   Per the `downstream EPs consume foundation` rule each assertion is a
-  regular re-frame event registered against `re-frame.core/reg-event-fx`
+  regular re-frame event registered with `re-frame.core/reg-event`
   — Story adds NO new registry kind for assertions. The vocabulary is
   enumerable via `(rf/registrations :event #(re-find #\"^:rf\\.assert/\"
   (str (:id %))))` per the existing registrar query API.
@@ -64,7 +64,7 @@
     `:passed? true` (used by Stage 5's `run-variant` test entry, and by
     consumer tests via the public `assertions-passing?`).
   - `canonical-assertion-ids` — the recognised canonical assertion ids:
-    the seven REGISTERED `reg-event-fx` handlers PLUS the tape-evaluated
+    the seven REGISTERED `reg-event` handlers PLUS the tape-evaluated
     `:rf.assert/schema-error` (rf2-5x1wt.21), which plan construction
     recognises but which is deliberately NEVER installed as a handler
     (it is evaluated against the epoch tape in `result.cljc`, not
@@ -389,7 +389,7 @@
 ;; ---------------------------------------------------------------------------
 ;; The canonical seven — defined as plain helper fns that produce the
 ;; assertion record. The `install-canonical-assertions!` boot fn wraps
-;; each in a `reg-event-fx` shell that consults the cofx for the frame
+;; each in a `reg-event` shell that consults the cofx for the frame
 ;; + dispatch-id and writes the record.
 ;; ---------------------------------------------------------------------------
 
@@ -597,7 +597,7 @@
 ;;
 ;; `:rf.assert/schema-error` declares that the run is EXPECTED to emit one
 ;; schema validation failure on a named surface. Unlike the seven app-db /
-;; trace-bus assertions it is NOT a `reg-event-fx` handler dispatched into
+;; trace-bus assertions it is NOT a `reg-event` handler dispatched into
 ;; the frame — it carries no app-db semantics. It is a TAPE-evaluated
 ;; expectation: the runner pairs each declared `:rf.assert/schema-error`
 ;; against the projected `:rf.error/schema-validation-failure` evidence
@@ -618,7 +618,7 @@
   NET-NEW `:rf.assert/schema-error` (rf2-5x1wt.21, spec/017 §Schema rule —
   the EXPECTED-schema-violation declaration). `:rf.assert/schema-error` is
   recognised (so plan construction accepts it) but is NOT installed as a
-  `reg-event-fx` handler: it is tape-evaluated in the result boundary, not
+  `reg-event` handler: it is tape-evaluated in the result boundary, not
   dispatched into the frame (see the section comment above)."
   #{id-path-equals
     id-path-matches
@@ -728,7 +728,7 @@
 ;; legal in exactly two positions: terminal `:assertions` and the in-script
 ;; `[:assert …]` checkpoint. Both positions produce ONE assertion-record
 ;; shape (the `[:assert …]` checkpoint dispatches the wrapped atom, whose
-;; reg-event-fx handler records the canonical record — rf2-5x1wt.17).
+;; reg-event handler records the canonical record — rf2-5x1wt.17).
 ;;
 ;; The shipping ergonomic script steps `:assert-db` / `:assert-dom` are NOT
 ;; authoring-distinct assertion kinds — they are sugar that FOLDS onto the
@@ -900,7 +900,7 @@
 ;; tape is the source of truth (spec/017 §Risks — "evidence projections
 ;; drift: use the epoch tape as source of truth").
 ;;
-;; Like `:rf.assert/schema-error` they carry NO `reg-event-fx` handler: they
+;; Like `:rf.assert/schema-error` they carry NO `reg-event` handler: they
 ;; are not dispatched into the frame, they are evaluated in the result
 ;; boundary (`re-frame.story.result/match-causal-expectations`) against the
 ;; projected `:reactive-counts`. They require the `:reactive-counts`
@@ -1014,7 +1014,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- handler-for-evaluator
-  "Build the `reg-event-fx` handler body for `assertion-id` whose
+  "Build the `reg-event` handler body for `assertion-id` whose
   evaluator returns the record extras.
 
   The handler reads `:db` directly from cofx — which the router has
@@ -1085,7 +1085,7 @@
   `004-Assertions.md` §Record-don't-throw semantics."
   []
   (when config/enabled?
-    ;; Internal event-db handler used by `record!`. Appends a record to
+    ;; Internal event handler used by `record!`. Appends a record to
     ;; the variant frame's [:rf.story/assertions] slot.
     (rf/reg-event
       ::append

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -276,11 +276,11 @@
         (fire-watchers! frame-id from to inner-event)
         to))))
 
-;; The mirror-state writer is a normal event-db handler. It writes the
+;; The mirror-state writer is a normal event handler. It writes the
 ;; current discrete state to `[:rf.story/lifecycle]` so callers can
 ;; read the state without going through the machine snapshot path.
 (defn install-mirror-writer!
-  "Register the `::set-lifecycle-state-mirror` event-db handler.
+  "Register the `::set-lifecycle-state-mirror` event handler.
   Idempotent."
   []
   (when config/enabled?

--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -6,7 +6,7 @@
   The defmacros themselves live in `re-frame.story` so end-users
   writing `(story/reg-story ...)` find `reg-story` as a Var on the
   public ns (matching the pattern `re-frame.core` uses for
-  `reg-event-db`).
+  `reg-event`).
 
   Per `001-Authoring.md` §Registration macros every emitted form threads through
   `(when re-frame.story.config/enabled? ...)` so the closure compiler
@@ -49,7 +49,7 @@
 
   Returns a compile-time Clojure form (a `cond->` expression) that
   evaluates to the map at runtime. Mirrors
-  `re-frame.core/reg-event-db`'s coord-capture pattern.
+  `re-frame.core/reg-event`'s coord-capture pattern.
 
   ## :file resolution (rf2-ulxi)
 

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -462,7 +462,7 @@
   "Build the step result for a (possibly-assertion-bearing) :dispatch /
   :dispatch-sync. If new failed assertions appeared in the frame's
   `:rf.story/assertions` since `prev` (typically because the
-  dispatched event was a `:rf.assert/*` whose reg-event-fx handler
+  dispatched event was a `:rf.assert/*` whose reg-event handler
   recorded a `:passed? false` record), surface them as a step-fail.
   Otherwise step-skip (no assertion contribution to pass/fail)."
   [frame-id prev idx step]
@@ -582,7 +582,7 @@
 ;;
 ;; The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
 ;; `:rf.assert/dom-text`) is the fold target for the shipping `:assert-dom`
-;; step (`.18`). It has no reg-event-fx handler yet (the DOM runner that
+;; step (`.18`). It has no reg-event handler yet (the DOM runner that
 ;; PROVES it lands later — the `:dom` capability is wired now via
 ;; `requirements`), so an `[:assert [:rf.assert/dom-* …]]` checkpoint is
 ;; EVALUATED directly through the DOM executor (`dom/assert-visible` /
@@ -817,10 +817,10 @@
 (defn- tape-evaluated-assertion?
   "True iff the assertion atom `atom-v` (`[:rf.assert/id & args]`) is
   evaluated AGAINST THE EPOCH TAPE in the result boundary rather than by
-  dispatching a `reg-event-fx` handler into the frame (rf2-8y47c +
+  dispatching a `reg-event` handler into the frame (rf2-8y47c +
   rf2-fh7g4).
 
-  Two assertion families carry NO `reg-event-fx` handler and are minted
+  Two assertion families carry NO `reg-event` handler and are minted
   by the result boundary (`re-frame.story.result`), not by a dispatch:
 
   - `:rf.assert/schema-error` — paired against the projected
@@ -865,7 +865,7 @@
   Four routes, by atom family:
 
   - The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /
-    `:rf.assert/dom-text`) has no reg-event-fx handler yet (the DOM runner
+    `:rf.assert/dom-text`) has no reg-event handler yet (the DOM runner
     that proves it lands later); it is EVALUATED directly through the DOM
     executor (`exec-assert-dom-atom!`), recording a canonical
     `:rf.assert/dom-*` record on the slot.
@@ -878,14 +878,14 @@
     floor) it records `:cannot-run`. The browser-only pair record
     `:cannot-run` under a headless run (their `browser-available?` guard).
   - The tape-evaluated families (`tape-evaluated-assertion?`: schema-error,
-    the causal / cascade family) carry no reg-event-fx handler — they are
+    the causal / cascade family) carry no reg-event handler — they are
     minted by the result boundary against the epoch tape, not by a dispatch.
     An in-script checkpoint for one of these records a no-op step-skip (the
     boundary owns its verdict); dispatching it would mint a spurious
     `:rf.error/no-such-handler` trace AND skip the real tape evaluation
     (rf2-8y47c + rf2-fh7g4).
   - Every other (dispatchable) `:rf.assert/*` atom dispatches the event
-    through `settled-boundary` — the standard reg-event-fx handler records
+    through `settled-boundary` — the standard reg-event handler records
     the `:passed?` record on the frame's `:rf.story/assertions` slot — and
     we bridge that record back into the runner step stream so a failing
     checkpoint flips the play's terminal status to `:fail`."
@@ -902,7 +902,7 @@
       (contains? assertions/browser-assertion-ids (first atom-v))
       (exec-assert-browser-atom! frame-id idx step atom-v)
 
-      ;; Tape-evaluated families carry no reg-event-fx handler; the result
+      ;; Tape-evaluated families carry no reg-event handler; the result
       ;; boundary owns their verdict. Record a no-op step-skip — never a
       ;; dispatch (which would hit :rf.error/no-such-handler) (rf2-8y47c +
       ;; rf2-fh7g4).
@@ -1045,7 +1045,7 @@
 ;;   - handler-backed atoms (`:rf.assert/path-equals` / `path-matches` /
 ;;     `sub-equals` / `dispatched?` / `state-is` / `no-warnings` /
 ;;     `effect-emitted`) are DISPATCHED through `settled-boundary`; the
-;;     reg-event-fx handler records the canonical record on the slot;
+;;     reg-event handler records the canonical record on the slot;
 ;;   - DOM-family atoms are evaluated by the DOM executor;
 ;;   - tape-evaluated atoms (`:rf.assert/schema-error`, the causal / cascade
 ;;     family, the browser-tier oracle family) record a no-op step-skip and
@@ -1072,7 +1072,7 @@
   `record-result-map` / `result/run-result` folds into the unified status).
 
   The tape-evaluated families (schema-error / causal / browser-tier) carry
-  no reg-event-fx handler; `exec-assert!` records a no-op step-skip for them
+  no reg-event handler; `exec-assert!` records a no-op step-skip for them
   and never dispatches — the result boundary already evaluates them against
   the epoch tape from the plan, so they are NOT double-processed here.
 
@@ -1140,7 +1140,7 @@
 ;; every in-script assertion arrives as the canonical `[:assert
 ;; assertion-atom]` checkpoint, and `exec-assert!` is the SOLE recorder:
 ;;
-;;   - a non-DOM `:rf.assert/*` atom dispatches its reg-event-fx handler,
+;;   - a non-DOM `:rf.assert/*` atom dispatches its reg-event handler,
 ;;     which writes the canonical record onto `:rf.story/assertions`;
 ;;   - a DOM-family atom is evaluated by `exec-assert-dom-atom!`, which
 ;;     writes a canonical `:rf.assert/dom-*` record.

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -473,7 +473,7 @@
   `filterv` over its output (rf2-2zncm). Feeds the tape-evaluated
   expectation matchers (`:rf.assert/schema-error`, `:rf.assert/caused` /
   `:rf.assert/no-cascade-rerender`, rf2-5x1wt.31) that — unlike a
-  `reg-event-fx`-backed assertion — carry NO handler and so must be
+  `reg-event`-backed assertion — carry NO handler and so must be
   collected from the plan, not the `:rf.story/assertions` accumulator."
   [plan executed-script]
   (try
@@ -496,7 +496,7 @@
   run, an exactly-expected violation passes.
 
   `:rf.assert/schema-error` is NOT dispatched into the frame (it has no
-  reg-event-fx handler — it is tape-evaluated), so collecting the DECLARED
+  reg-event handler — it is tape-evaluated), so collecting the DECLARED
   atoms here is the single path that feeds the consumption matcher.
 
   Defined as a FILTER over the shared `plan-assertion-atoms` collector —
@@ -946,7 +946,7 @@
 
   The tape-evaluated kinds (`:rf.assert/schema-error`, the causal / cascade
   family, the browser-tier oracle family) are NOT double-processed: they
-  carry no reg-event-fx handler, so `exec-assert!` records a no-op step-skip
+  carry no reg-event handler, so `exec-assert!` records a no-op step-skip
   for them and never dispatches — `result/run-result` already evaluates them
   against the epoch tape from the plan's `:schema-expectations` /
   `:causal-expectations` (collected by `plan-schema-expectations` /

--- a/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
@@ -13,7 +13,7 @@
   The dispatch console's autocomplete is read once per keystroke; the
   registry is process-global mutable state. A sub would require a
   reactive layer (a wrapper atom around the registrar that bumps on
-  every `reg-event-*`) and would deliver no useful caching since the
+  every `reg-event`) and would deliver no useful caching since the
   filter recomputes on every prefix change. A plain query fn is the
   honest shape — and it stays pure-data so tests can stub
   `registered-event-ids` via `with-redefs`.

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -10,7 +10,7 @@
   consume now. Story keeps its existing public chip API
   (`open-chip` / `open-chip-for-variant` / `open-source-coord!`) but
   delegates URI resolution to `resolve-uri` and adds a parallel
-  dispatch path (`:rf.story/open-in-editor` reg-event-fx) so a panel
+  dispatch path (`:rf.story/open-in-editor` reg-event) so a panel
   that doesn't render the chip directly can still hand off a
   source-coord through re-frame.
 
@@ -118,7 +118,7 @@
 ;; Per rf2-r2un8 (porting Xray's structure): URI building is extracted
 ;; into one helper so the chip path and the dispatch path share the same
 ;; logic — chip's `:href`, chip's `:on-click`, the inspector launcher, and
-;; the `:rf.story/open-in-editor` event-fx all call `resolve-uri`.
+;; the `:rf.story/open-in-editor` event all call `resolve-uri`.
 
 (defn- parse-file-line
   "Parse a `\"file:line\"` (or bare `\"file\"`) display string into the
@@ -395,7 +395,7 @@
 
   Registers two framework primitives:
 
-    - `:rf.story/open-in-editor` reg-event-fx — the dispatch shape any
+    - `:rf.story/open-in-editor` reg-event — the dispatch shape any
       host panel that wants the trace bus to record the click can fire.
       Accepts either a bare source-coord map or a wrapper
       `{:source-coord <coord-or-string>}`. The handler resolves the URI
@@ -428,7 +428,7 @@
   ;;       navigates the URI directly via `open!` (the endpoint needs the
   ;;       structured coord, so a uri-only arg uses the URI path).
   ;;
-  ;; Per rf2-wn3bh the event-fx now emits `:source-coord` (not `:uri`) so
+  ;; Per rf2-wn3bh the event now emits `:source-coord` (not `:uri`) so
   ;; the endpoint is preferred; the `:uri` shape stays for callers that
   ;; hold a pre-resolved URI.
   ;;

--- a/tools/story/src/re_frame/story/xray_preset.cljc
+++ b/tools/story/src/re_frame/story/xray_preset.cljc
@@ -377,7 +377,7 @@
 #?(:cljs
    (defn- apply-panel!
      "Select the Xray panel via `:rf.xray/select-panel`. Xray's
-     registry registers this event-db handler against the `:rf/xray`
+     registry registers this event handler against the `:rf/xray`
      frame."
      [panel]
      (when panel

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -213,7 +213,7 @@
 (deftest run-terminal-assertions-skips-tape-evaluated-no-double-process
   (testing "a tape-evaluated terminal atom (:rf.assert/schema-error) is NOT
             dispatched by run-terminal-assertions! — it carries no
-            reg-event-fx handler; the result boundary owns its verdict
+            reg-event handler; the result boundary owns its verdict
             against the tape, so no handler-backed record is minted here
             (rf2-nyjoa critical guard against double-processing)"
     (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
@@ -415,7 +415,7 @@
 ;;
 ;; rf2-5x1wt.19 — the runtime now consumes the `.18`-folded plan: a shipping
 ;; `:assert-db` step is rewritten to the canonical `[:assert
-;; [:rf.assert/path-equals …]]` checkpoint, whose reg-event-fx handler
+;; [:rf.assert/path-equals …]]` checkpoint, whose reg-event handler
 ;; records the CANONICAL `:rf.assert/path-equals` record on the slot. There
 ;; is no longer a synthetic `:rf.assert/db` / `:rf.assert/dom` rail — one
 ;; assertion-record vocabulary.
@@ -1233,7 +1233,7 @@
 ;; An in-script `[:assert [:rf.assert/schema-error …]]` /
 ;; `[:assert [:rf.assert/caused …]]` / `[:assert [:rf.assert/no-cascade-
 ;; rerender …]]` checkpoint names a TAPE-EVALUATED assertion family: these
-;; ids carry NO `reg-event-fx` handler — the result boundary mints their
+;; ids carry NO `reg-event` handler — the result boundary mints their
 ;; verdict against the epoch tape (`re-frame.story.result`). Before the
 ;; `tape-evaluated-assertion?` guard, `exec-assert!` special-cased ONLY the
 ;; DOM family, so every other id (schema-error / causal) fell through to
@@ -1360,7 +1360,7 @@
 
 (deftest tape-evaluated-assertion?-classifies-every-non-dispatched-family
   (testing "schema-error and the causal family are tape-evaluated (no
-            reg-event-fx handler); the dispatchable seven, the DOM family,
+            reg-event handler); the dispatchable seven, the DOM family,
             and the browser-tier oracle family are NOT"
     (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/schema-error {}]))))
     (is (true? (boolean (tape-evaluated-assertion? [:rf.assert/caused {:event :e}]))))
@@ -1376,7 +1376,7 @@
     (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/a11y-structural])))
         "a11y-structural is routed to the browser executor, not this classifier")
     (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/path-equals [:k] 1])))
-        "a dispatchable canonical assertion (has a reg-event-fx handler) is NOT tape-evaluated")
+        "a dispatchable canonical assertion (has a reg-event handler) is NOT tape-evaluated")
     (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/state-is :loaded])))
         "another of the dispatchable seven is NOT tape-evaluated")
     (is (false? (boolean (tape-evaluated-assertion? [:rf.assert/dom-visible "div"])))

--- a/tools/story/test/re_frame/story/test_support_test.clj
+++ b/tools/story/test/re_frame/story/test_support_test.clj
@@ -63,7 +63,7 @@
 (deftest canonical-vocabulary-installed-by-helper
   (testing "the helper re-installs the canonical Story vocabulary each test —
             the :rf.assert/* event handlers are registered on the FRAMEWORK
-            registrar (they're reg-event-fx handlers, not Story side-table
+            registrar (they're reg-event handlers, not Story side-table
             entries)"
     (let [events (registrar/registrations :event)]
       (is (contains? events :rf.assert/path-equals)

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -75,7 +75,7 @@
       (is (contains? events :rf.assert/state-is))
       (is (contains? events :rf.assert/no-warnings))
       (is (contains? events :rf.assert/effect-emitted))))
-  (testing ":rf.assert/schema-error is NOT a reg-event-fx handler (rf2-5x1wt.21)
+  (testing ":rf.assert/schema-error is NOT a reg-event handler (rf2-5x1wt.21)
             — it is tape-evaluated, not dispatched into the frame"
     (let [events (re-frame.registrar/registrations :event)]
       (is (not (contains? events :rf.assert/schema-error))))))

--- a/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
@@ -63,7 +63,7 @@
 ;; ===========================================================================
 ;; rf2-ysr4y — per-fx scenarios (HTTP / analytics / websocket / navigation)
 ;;
-;; Each scenario registers an event-fx that emits the fx-id under test, runs
+;; Each scenario registers an event that emits the fx-id under test, runs
 ;; a variant with the matching `force-fx-stub`, then asserts:
 ;;
 ;;   1. The lifecycle reaches :ready (no crash).

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -10,7 +10,7 @@
     URI when the coord carries `:file`.
   - The chip carries the `data-test` hook for the e2e suite.
   - `open-chip-for-variant` reads `:source` off the variant body.
-  - rf2-r2un8 — `:rf.story/open-in-editor` reg-event-fx + `:rf.editor/open`
+  - rf2-r2un8 — `:rf.story/open-in-editor` reg-event + `:rf.editor/open`
     reg-fx produce a resolved URI through the same allowlist seam the
     chip uses (Xray-parity port)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
@@ -452,7 +452,7 @@
 ;; ---- resolve-uri (rf2-r2un8) --------------------------------------------
 ;;
 ;; `resolve-uri` is the extracted URI-building helper the chip path, the
-;; `open-source-coord!` imperative path, and the dispatch-based event-fx
+;; `open-source-coord!` imperative path, and the dispatch-based event
 ;; all share. Pinning its contract here means the chip's `:href`, the
 ;; inspector launcher, and the fx-emitted `:uri` always agree on the
 ;; URI shape — one source of truth. Mirrors Xray's resolve-uri (port
@@ -512,7 +512,7 @@
   the fx args without touching `window.location`. Same pattern Xray's
   test suite uses.
 
-  Per rf2-wn3bh the event-fx now emits the structured `:source-coord`
+  Per rf2-wn3bh the event now emits the structured `:source-coord`
   (so the fx can prefer the dev-server endpoint). The capture stub
   resolves the coord through the SAME `resolve-uri` helper the chip uses
   and records the resolved URI under `:uri` so the existing

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1025,7 +1025,7 @@
 (deftest run-variant-terminal-tape-evaluated-not-double-counted
   (testing "a tape-evaluated terminal assertion (:rf.assert/schema-error) is
             NOT double-processed by the terminal auto-run — it carries no
-            reg-event-fx handler, so the auto-run records NO handler-backed
+            reg-event handler, so the auto-run records NO handler-backed
             record for it; the result boundary owns its single verdict
             against the epoch tape. Pinned alongside a handler-backed
             terminal assertion in the same block so the split is exercised

--- a/tools/template/spec/004-SSR-Validation-Report.md
+++ b/tools/template/spec/004-SSR-Validation-Report.md
@@ -330,7 +330,7 @@ SSR support is implementable as a template variant today.)
 | Template emission `acme/ssr-test :substrate :reagent` | succeeded; emitted 18-file pure-CLJS SPA (no SSR) |
 | Manual file-shape walk of emitted app | `src/acme/ssr_test/{core,events,subs,views,schema}.cljs` + `test/acme/ssr_test/events_test.cljs`; no `core.cljc`, no `server.clj`, no SSR coord, no Ring dep — matches §2 gap analysis |
 | `examples/reagent/ssr/` file inventory | `core.cljc` + `index.html` + `test/ssr/core_test.clj` — demonstrates SSR + hydration mechanics; Ring host-adapter boot reference lives in `implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj` |
-| `implementation/ssr/src/re_frame/ssr.cljc` `:rf/hydrate` auto-registration | confirmed at L146 (`events/reg-event-fx :rf/hydrate hydrate/hydrate-event-handler`) — scaffolded apps need only `:require` `re-frame.ssr` |
+| `implementation/ssr/src/re_frame/ssr.cljc` `:rf/hydrate` auto-registration | confirmed at L276-278 (`events/reg-event :rf/hydrate {:rf/framework-authority? true} hydrate/hydrate-event-handler`) — scaffolded apps need only `:require` `re-frame.ssr` |
 
 ## 6. Recommended next actions
 


### PR DESCRIPTION
## What

Sweeps stale, retired event-registration vocabulary out of prose, comments, docstrings, and test descriptions across docs / examples / template / tools/story. EP-0018 retired the public `reg-event-db` / `reg-event-fx` / `reg-event-ctx` spellings and consolidated public event authoring on the one `rf/reg-event` form (coeffects in, effects map / nil out). These were stale-vocabulary residue — no executable behaviour changes.

## Per-bead

- **rf2-4fmnww** (tools/story prose) — `src` / `spec` / `test` prose now describes Story handler-backed assertions and helper events as `reg-event` handlers (was `reg-event-fx` / `event-fx` / `event-db`); tape-evaluated families correctly described as carrying **no** `reg-event` handler. `macros.clj` / `story.cljc` mirror-pattern citations updated to `reg-event`. Full-tree grep for retired spellings is clean.
- **rf2-p1xzjv** (examples root docs) — `examples/TESTING.md` drops `reg-event-*` for `reg-event` and fixes the stale "two surfaces" wording to "three surfaces" (the listed surfaces are `test:browser` / `test:examples` / `test:examples-compile`); `examples/README.md` Reagent count corrected `twenty-three` → `twenty-four` to match the 24-row table.
- **rf2-3lpcq9** (examples/reagent comments) — `login` / `realworld` / `websocket` / `state_machine_walkthrough` comments now use `reg-event` (not the removed `reg-event-fx`) for the manual longer machine-handler form `(reg-event id (make-machine-handler m))`.
- **rf2-4aln6m** (template SSR validation report) — `:rf/hydrate` evidence row cites the current `events/reg-event` registration at `implementation/ssr/src/re_frame/ssr.cljc` L276-278 (with `{:rf/framework-authority? true}`) instead of the stale `reg-event-fx` / L146 reference.
- **rf2-lb69ue** (mkdocs cljs-rf2 fence) — the `cljs-rf2` live-cell fence comment now names `reg-event` as the v2 event registrar (was `reg-event-db`).

## Gates

- `mkdocs build --strict` — PASS (staged `docs/spec` from `spec`; built clean, only pre-existing INFO links)
- `test-fast-pr.sh` spine — all green: core JVM (1774 tests / 0 fail), **test:cljs (7646 tests / 31535 assertions / 0 failures)**, retired-spelling (EP-0007), README inventory ratchet, link/anchor + doc-slug validators, EP status-sync, runtime-subsystem grading
- `npm run test:examples` — PASS (3 adapter specs, 0 failures; examples compiled 0 warnings)
- tools/story JVM tests — PASS (1686 tests / 6247 assertions / 0 failures) confirming all comment-edited `.cljc` / `.clj` / `.cljs` files compile

## Note

`npm run test:story-feature-load` surfaced **one pre-existing, unrelated** browser-scenario failure (`share-url-hydrates-variant-modes-and-props` — a `Shared Label` share-URL override classified as dropped). Filed as **rf2-8q35fw**. This PR's edits are comment/docstring-only and touch none of `share.cljc` / `share.cljs` / `egress.cljc` / the testbed views.