### PR TITLE
chore(scripts): update ambient durable-read lint guidance to :rf.cofx (rf2-lvx4o6)

### DIFF
--- a/scripts/_test_fixtures/check_ambient_durable_reads/negative/debug_enabled_perf_probe.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/negative/debug_enabled_perf_probe.cljc
@@ -4,7 +4,7 @@
   names (`t0` / `elapsed`) and write NO durable field key, so they never match
   the violating `:durable-key <ambient-read>` shape in the first place. The
   durable `:updated-at` here is threaded from the reply token's causal
-  `:rf.world/inputs` `:time-ms` (the CORRECT pattern), NOT a fresh ambient read.
+  `:rf.cofx` `:rf/time-ms` (the CORRECT pattern), NOT a fresh ambient read.
 
   rf2-nftz2s §3: the generic `interop/debug-enabled?` window allowlist was
   REMOVED — a debug probe being merely NEAR a durable write no longer exempts
@@ -21,5 +21,5 @@
         elapsed (when interop/debug-enabled? (- (interop/now-ms) t0))]
     {:result     result
      ;; durable timestamp threaded from the causal token — NOT an ambient read
-     :updated-at (get-in reply-token [:rf.world/inputs :time-ms])
+     :updated-at (get-in reply-token [:rf.cofx :rf/time-ms])
      :elapsed-ms elapsed}))

--- a/scripts/_test_fixtures/check_ambient_durable_reads/negative/now_ms_in_docstring.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/negative/now_ms_in_docstring.cljc
@@ -4,7 +4,7 @@
   docstring even spells `:loaded-at (interop/now-ms)` as the anti-pattern it
   warns against:
 
-      Do NOT write `:loaded-at (interop/now-ms)` — thread `:time-ms` instead.
+      Do NOT write `:loaded-at (interop/now-ms)` — thread `:rf/time-ms` instead.
 
   Must stay GREEN (0 findings)."
   (:require [re-frame.interop :as interop]))
@@ -13,4 +13,4 @@
   [token]
   ;; The bad shape `:started-at (.now js/Date)` written here as a comment must
   ;; not fire — it is documentation of what NOT to do.
-  {:loaded-at (get-in token [:rf.world/inputs :time-ms])})
+  {:loaded-at (get-in token [:rf.cofx :rf/time-ms])})

--- a/scripts/_test_fixtures/check_ambient_durable_reads/negative/threaded_completed_at.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/negative/threaded_completed_at.cljc
@@ -1,14 +1,14 @@
 (ns fixtures.threaded-completed-at
   "NEGATIVE fixture: the CORRECT pattern. The durable `:completed-at` /
-  `:loaded-at` values are THREADED from the reply token's `:rf.world/inputs`
-  `:time-ms` (a supplied causal time), never read ambiently here. The function
-  takes `completed-at` as a parameter and binds `time-ms` from the token. Must
-  stay GREEN (0 findings)."
+  `:loaded-at` values are THREADED from the reply token's `:rf.cofx`
+  `:rf/time-ms` (a supplied causal time), never read ambiently here. The
+  function takes `completed-at` as a parameter and binds `time-ms` from the
+  token. Must stay GREEN (0 findings)."
   (:require [re-frame.interop :as interop]))   ;; required but not read at a durable site
 
 (defn build-reply
   [token outcome]
-  (let [time-ms (get-in token [:rf.world/inputs :time-ms])]
+  (let [time-ms (get-in token [:rf.cofx :rf/time-ms])]
     {:outcome      outcome
      :completed-at time-ms
      :loaded-at    time-ms}))

--- a/scripts/_test_fixtures/check_ambient_durable_reads/positive/epoch_now_into_settled_at.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/positive/epoch_now_into_settled_at.cljc
@@ -2,7 +2,7 @@
   "POSITIVE fixture: a mutation handler reads `interop/epoch-now-ms` while
   writing the durable `:settled-at` field. Even the wall-clock epoch reader is
   a violation AT the durable write site — the value must arrive via the reply
-  token's `:rf.world/inputs`. Must FLAG (1 finding)."
+  token's `:rf.cofx` `:rf/time-ms`. Must FLAG (1 finding)."
   (:require [re-frame.interop :as interop]))
 
 (defn settle-mutation

--- a/scripts/check_ambient_durable_reads.py
+++ b/scripts/check_ambient_durable_reads.py
@@ -61,8 +61,12 @@ mint (`:created-at`, `:completed-at`, `:errored-at`, `:restored-at`,
 `:installed-at`, `:registered-at`, `:updated-at`, `:detected-at`) and the
 durable-id keys (`:id`, `:entry-id`, `:request-id`, `:instance-id`,
 `:mutation-id`, `:temp-id`, `:correlation-id`). The CORRECT replacement is to
-thread the value from the reply/dispatch token's `:rf.world/inputs` `:time-ms`
-(or a supplied uuid/random world input) — never to read the host here.
+thread the value from the reply/dispatch token's flat `:rf.cofx` recordable-
+coeffect map — `(:rf/time-ms (:rf.cofx envelope))` for durable wall-clock time,
+or a supplied uuid/random recordable coeffect declared via `:rf.cofx/requires`
+— never to read the host here. (EP-0017 retired the `:rf.world/inputs` envelope
+in favour of the flat `:rf.cofx` map, with no alias; see docs/spec/002-Frames.md
+§Recordable coeffects.)
 
 
 WHY SCOPE BY NAMESPACE TOO (defence against false positives)
@@ -75,7 +79,8 @@ the sanctioned sites the spec calls out:
      the durable-write set, so a `:detected-at (interop/now-ms)` inside
      `(trace/emit! ...)` (router/diagnostics) or the `:completed-at
      (interop/epoch-now-ms)` transport-boundary causal read (http_transport —
-     the read that FEEDS `:rf.world/inputs`, sanctioned by EP-0010 step 4) is
+     the read that FEEDS the reply token's `:rf.cofx`, sanctioned by EP-0010
+     step 4) is
      never scanned. The frame-container `:created-at` lifecycle stamp
      (frame.cljc) is a host-transient frame-instance side table, also out of
      scope.
@@ -144,8 +149,8 @@ from typing import Iterable, NamedTuple
 #   - re_frame/frame.cljc                           -> frame-instance host-transient side table
 #   - resources/timers.cljc                         -> timer scheduling / cancellation
 #   - http/http_transport*.cljc, resources/transport*  -> effect-interpreter
-#       boundary (the causal `:completed-at` read that FEEDS :rf.world/inputs)
-#   - cofx.cljc, router.cljc world-input minting     -> the causal boundary itself
+#       boundary (the causal `:completed-at` read that FEEDS the token's :rf.cofx)
+#   - cofx.cljc, router.cljc :rf.cofx minting        -> the causal boundary itself
 DURABLE_WRITE_SUFFIXES: tuple[str, ...] = (
     # resource reducers + reply handlers
     "implementation/resources/src/re_frame/resources/events.cljc",
@@ -471,8 +476,10 @@ def scan(
 _FIX_HINT = (
     "EP-0010 §The Boundary Is Already Visible: a transition that performs a "
     "DURABLE write must be deterministic w.r.t. the host clock / RNG. Read the "
-    "value from the reply/dispatch token's `:rf.world/inputs` `:time-ms` (or a "
-    "supplied uuid/random world input) and thread it into the durable field — "
+    "value from the reply/dispatch token's flat `:rf.cofx` recordable-coeffect "
+    "map — `(:rf/time-ms (:rf.cofx envelope))` for durable wall-clock time, or a "
+    "supplied uuid/random recordable coeffect declared via `:rf.cofx/requires` "
+    "— and thread it into the durable field — "
     "do NOT read `interop/now-ms` / `js/Date.now` / `random-uuid` etc. at the "
     "durable write site. If this read is genuinely diagnostic (does not "
     "influence a durable write) move it into trace/perf code, or annotate the "


### PR DESCRIPTION
## Summary

EP-0017 retired the `:rf.world/inputs` envelope in favour of the flat `:rf.cofx` recordable-coeffect map, with no alias (docs/spec/002-Frames.md §Recordable coeffects). The ambient durable-read gate (`scripts/check_ambient_durable_reads.py`) still taught the retired envelope as the correct fix in its module docs, scope comments, `_FIX_HINT`, and several self-test fixtures.

This updates all fix guidance to the current `:rf.cofx` surface:
- Module docstring "CORRECT replacement" prose → thread from the flat `:rf.cofx` map: `(:rf/time-ms (:rf.cofx envelope))`, or a supplied uuid/random recordable coeffect declared via `:rf.cofx/requires`.
- Namespace-scope comment + `DURABLE_WRITE_SUFFIXES` excluded-namespace comment → "FEEDS the reply token's `:rf.cofx`" / "`:rf.cofx` minting".
- `_FIX_HINT` (the user-facing CI message) → same `:rf.cofx` / `:rf/time-ms` guidance.
- Fixtures modelling correct token threading (`negative/threaded_completed_at.cljc`, `negative/debug_enabled_perf_probe.cljc`, `negative/now_ms_in_docstring.cljc`, `positive/epoch_now_into_settled_at.cljc`) now use `[:rf.cofx :rf/time-ms]`.

The sole retained `:rf.world/inputs` mention is an explicit historical retirement note (not suggested as a fix), which the acceptance criteria permit. The `#_:rf.world/ambient-ok` reader-discard escape marker is a distinct annotation token (not the retired envelope key) and is left unchanged.

`scripts/check_inject_cofx_residue.py` and its fixtures intentionally reference `:rf.world/inputs` as the retired name they police — out of scope for this bead and untouched.

## Acceptance criteria
- [x] Module docs, comments, and `_FIX_HINT` instruct authors to thread from flat `:rf.cofx` / declared coeffects.
- [x] Fixtures modelling correct token threading updated to the `:rf.cofx` shape (`[:rf.cofx :rf/time-ms]`); the one retained mention is explicitly historical.
- [x] `python scripts/check_ambient_durable_reads.py --self-test` passes (14/14).
- [x] No current fix guidance in the ambient durable-read script/fixtures points at `:rf.world/inputs`.

## Gates
- `python scripts/check_ambient_durable_reads.py --self-test --verbose` → all 14 passed.
- `sh scripts/test-fast-pr.sh` → green (7650 tests, 31550 assertions, 0 failures, 0 errors).

Closes rf2-lvx4o6.