### PR TITLE
fix(project-data): preserve CEDN-distinct keys/ids + elide :large? slots (rf2-260yhk, rf2-ka2nkx, rf2-8iciw8)

### DIFF
--- a/docs/api/16-resources.md
+++ b/docs/api/16-resources.md
@@ -317,9 +317,9 @@ A failure settles `:error` — there is **no `:refresh-error` analogue** (a writ
 - **Signature**:
   ```clojure
   (resources)            → {:resource-ids [...] :entries {}}
-  (resources {:frame …}) → {:resource-ids [...] :entries {<scoped-key> <entry>}}
+  (resources {:frame …}) → {:resource-ids [...] :entries {<key-id> <entry>}}
   ```
-- **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries.
+- **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries. The `:entries` map is keyed on the CEDN-1 byte `key-id` string (the same key the runtime storage / SSR wire use; it cannot collapse CEDN-distinct sequential-params entries the way an `=`-keyed scoped-key vector would). Each entry carries its kind-preserving scoped-resource-key `[scope resource-id params]` under `:resource/key` for destructure / scope-and-resource filtering.
 
 ### `mutation-meta`
 

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -158,29 +158,37 @@
   (`{<scoped-resource-key> <entry>}`). Without `:frame` only the static
   registry is returned (no ambient frame fallback, EP-0002).
 
-  The `:entries` map is REKEYED to the public scoped-resource-key VECTOR
-  `[canonical-scope resource-id canonical-params]` (rf2-jtlq7l). The
-  internal runtime storage is keyed on the opaque CEDN-1 byte `key-id`
-  (`state/entries-path`, `state/key-id`); leaking that byte key through
-  the public accessor breaks the documented contract — callers can't
-  destructure `[scope resource-id params]`, filter by scope/resource, or
-  compare against scoped keys. The kind-preserving scoped-key lives on
-  each entry under `:resource/key` (the same fact identity the live
-  tooling view reads — `tooling/live-resource-nodes`), so rekey from
-  there, not from the map key. Internal storage stays byte-keyed."
+  The `:entries` map is keyed on the CEDN-1 byte `key-id` STRING (the SAME
+  key the internal runtime storage, the SSR wire, and the reverse indexes
+  use — `state/entries-path`, `state/key-id`); each entry carries its
+  kind-preserving public scoped-resource-key VECTOR
+  `[canonical-scope resource-id canonical-params]` under `:resource/key`
+  (rf2-jtlq7l / rf2-ka2nkx). Callers that need to destructure
+  `[scope resource-id params]`, filter by scope/resource, or compare
+  against scoped keys read each entry's `:resource/key`; the byte string
+  map key is purely an opaque distinct identity.
+
+  WHY the map key is the byte string, NOT the scoped-key vector: Clojure
+  map keys compare by `=`, and `=` is COARSER than the CEDN-1 byte identity
+  for SEQUENTIAL params — `(= [scope rid {:xs [1 2 3]}] [scope rid {:xs '(1 2 3)}])`
+  is TRUE while their `canonical-bytes` differ (`v[…]` vs `l(…)`). Rekeying
+  the byte-keyed runtime map onto the `=`-colliding vector would `assoc`
+  one CEDN-distinct entry OVER the other, so the public read could report
+  ONE entry for TWO live cache entries (rf2-ka2nkx). Keying on the byte
+  `key-id` string (which compares by content, the exact CEDN-1 identity)
+  keeps every live entry distinct. Internal storage stays byte-keyed."
   ([] {:resource-ids (resource-ids) :entries {}})
   ([{:keys [frame]}]
    {:resource-ids (resource-ids)
     :entries      (if frame
                     (let [entries (get-in (frame/frame-runtime-db-value frame)
                                           (state/entries-path))]
-                      (reduce-kv
-                        ;; rf2-jtlq7l — rekey the internal byte `key-id` map to
-                        ;; the public scoped-key vector carried on each entry.
-                        (fn [acc _k-id entry]
-                          (assoc acc (:resource/key entry) entry))
-                        {}
-                        (or entries {})))
+                      ;; rf2-ka2nkx — the runtime `:entries` map is ALREADY keyed
+                      ;; on the CEDN-1 byte `key-id`; return it as-is (every entry
+                      ;; carries its kind-preserving `:resource/key` vector). Do
+                      ;; NOT rekey onto the `=`-colliding scoped-key vector — that
+                      ;; collapses CEDN-distinct sequential-params entries.
+                      (or entries {}))
                     {})}))
 
 (defn resource-state

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -64,7 +64,6 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.marks :as marks]
             [re-frame.path :as path]
-            [re-frame.privacy :as privacy]
             [re-frame.projection :as projection]
             [re-frame.resources.scope-registry :as scope-registry]))
 
@@ -322,27 +321,32 @@
 ;; composed layers, both deferring to SHARED primitives (never a
 ;; family-private resource elider):
 ;;
-;;   (a) the RESOURCE-OWNED per-slot `:data-schema` `:sensitive?` marks (the
-;;       canonical fine-grained owner surface, issue 11) redact their slots
-;;       to the `:rf/redacted` sentinel via the shared
-;;       `re-frame.privacy/redact-paths`. This is the OWNER's declaration
-;;       firing irrespective of frame app-db classification — a resource that
-;;       marks `[:token]` sensitive in its `:data-schema` redacts that slot on
-;;       SSR even when the frame's app-db classification says nothing about it
-;;       (resource cache data does not live at a frame app-db path).
+;;   (a) the RESOURCE-OWNED per-slot `:data-schema` `:sensitive?` AND `:large?`
+;;       marks (the canonical fine-grained owner surface, issue 11) project
+;;       through the shared frame-independent `re-frame.marks/redact-with-paths`
+;;       walker — `:sensitive?` slots redact to the `:rf/redacted` sentinel,
+;;       `:large?` slots elide to the `:rf.size/large-elided` marker. This is
+;;       the OWNER's declaration firing irrespective of frame app-db
+;;       classification — a resource that marks `[:token]` sensitive in its
+;;       `:data-schema` redacts that slot on SSR even when the frame's app-db
+;;       classification says nothing about it, and a `[:body]` `:large?` slot
+;;       elides on the wire whether or not the frame independently marks it
+;;       (resource cache data does not live at a frame app-db path; rf2-260yhk).
+;;       This is the SAME walker the CO-EQUAL `project-params` already uses for
+;;       the params component of the key — one walker, two owner surfaces.
 ;;   (b) the data is THEN projected through the merged frame-owned
 ;;       `re-frame.projection/project-egress` (over `elide-wire-value`) under
 ;;       the boundary profile, so any path the FRAME ALSO classifies redacts /
 ;;       elides as defense-in-depth.
 ;;
-;; "Sensitive wins over large" holds across both: a slot the owner marks
-;; sensitive is already the redaction sentinel before (b) runs, and the
-;; sentinel is a non-matchable scalar the walker descends into nothing
-;; (idempotent under re-projection). Per-slot `:large?` owner marks compose
-;; through (b) when the frame also declares the path large; the common
-;; whole-resource-large case is the coarse `:large?` root-prop omit
-;; (`whole-entry-disposition` → `:omit`), so the durable large entry never
-;; reaches this serialize path at all.
+;; "Sensitive wins over large" holds across both: at the same slot the owner
+;; walker already resolves to the redaction sentinel (the walker's intrinsic
+;; ordering), and the sentinel is a non-matchable scalar the frame walker
+;; descends into nothing (idempotent under re-projection). The common
+;; whole-resource-large case is still the coarse `:large?` root-prop omit
+;; (`whole-entry-disposition` → `:omit`), so the durable whole-large entry
+;; never reaches this serialize path at all; the per-slot owner `:large?` here
+;; is the FINE-GRAINED complement for a `:serialize` entry with a large leaf.
 ;; ---------------------------------------------------------------------------
 
 (defn project-data
@@ -354,35 +358,46 @@
 
   Two composed layers, both shared primitives:
 
-    (a) the resource-owned `:data-schema` `:sensitive?` per-slot marks
-        (`data-schema-marks`) redact their slots to the `:rf/redacted`
-        sentinel via `re-frame.privacy/redact-paths` — the OWNER's fine-grained
-        declaration, firing regardless of frame app-db classification;
+    (a) the resource-owned `:data-schema` `:sensitive?` AND `:large?` per-slot
+        marks (`data-schema-marks`) project through the shared
+        `re-frame.marks/redact-with-paths` walker — `:sensitive?` slots redact
+        to the `:rf/redacted` sentinel, `:large?` slots elide to the
+        `:rf.size/large-elided` marker (sensitive wins at a co-marked slot) —
+        the OWNER's fine-grained declaration, firing regardless of frame app-db
+        classification (the CO-EQUAL counterpart to `project-params`);
     (b) the result is projected through the merged frame-owned
         `re-frame.projection/project-egress` (over `elide-wire-value`) under
         `boundary-profile`, so any path the FRAME classifies composes as
         defense-in-depth.
 
   When `frame-id` is nil (a frameless / pure projection — a test harness or
-  a tool with no resolvable frame), layer (b) is SKIPPED and the owner-redacted
+  a tool with no resolvable frame), layer (b) is SKIPPED and the owner-projected
   data rides as-is: the coarse whole-entry disposition
   (`whole-entry-disposition`) is the resource-owned authority that governs
   redact / omit, so a frameless serialized entry must not be over-redacted to
   the frame walker's fail-closed sentinel merely because no frame scope is
   carried (that fail-closed posture is for app-db egress, not the
-  resource-owned decision) — but the OWNER's own `:data-schema` sensitive marks
-  STILL fire (layer (a) is frame-independent). `spec` nil / no data-schema →
-  layer (a) is a no-op. Pure."
+  resource-owned decision) — but the OWNER's own `:data-schema` `:sensitive?` /
+  `:large?` marks STILL fire (layer (a) is frame-independent). `spec` nil / no
+  data-schema → layer (a) is a no-op. Pure."
   [data spec frame-id boundary-profile]
-  (let [sensitive-paths (keys (:sensitive (data-schema-marks spec)))
-        owner-redacted  (if (seq sensitive-paths)
-                          (privacy/redact-paths data sensitive-paths)
+  (let [{:keys [sensitive large]} (data-schema-marks spec)
+        ;; layer (a): BOTH owner axes through the SAME shared frame-independent
+        ;; `re-frame.marks/redact-with-paths` walker the CO-EQUAL `project-params`
+        ;; uses (sensitive → `:rf/redacted`, large → `:rf.size/large-elided`,
+        ;; sensitive wins over large at the same slot). A per-slot `:data-schema`
+        ;; `:large?` leaf is therefore ELIDED to the size marker on the wire
+        ;; rather than riding RAW — the fine-grained owner complement to the
+        ;; coarse whole-resource-large `:omit` (rf2-260yhk). No marks → `data`
+        ;; rides unchanged into layer (b).
+        owner-projected (if (or (seq sensitive) (seq large))
+                          (marks/redact-with-paths data (keys sensitive) (keys large))
                           data)]
     (if frame-id
-      (projection/project-egress owner-redacted
+      (projection/project-egress owner-projected
                                  {:frame             frame-id
                                   :rf.egress/profile boundary-profile})
-      owner-redacted)))
+      owner-projected)))
 
 ;; ---------------------------------------------------------------------------
 ;; Params projection — the CO-EQUAL fine-grained owner surface for the scoped

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -1286,31 +1286,42 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [instance mutation]}]]
   (let [runtime-db (or rt {})
         instances  (get-in runtime-db (mstate/instances-path))
-        target-ids (cond
-                     (some? instance) (filter #(= % instance) (keys instances))
-                     (some? mutation) (keep (fn [[iid inst]]
-                                              (when (= mutation (:mutation/id inst)) iid))
-                                            instances)
-                     :else            nil)
-        target-ids (vec target-ids)
+        ;; rf2-8iciw8 — the `:rf.runtime/mutations` map is keyed on the CEDN-1
+        ;; byte `key-id`; the storage targets (`dissoc` / `get`) MUST be those
+        ;; byte key-ids, never the raw caller-supplied instance id (which is
+        ;; `=`-coarser than the byte identity for sequential ids). An explicit
+        ;; `:instance` is matched by its OWN byte key-id so a `[:row 7]` clear
+        ;; does NOT also gate a CEDN-distinct `'(:row 7)` row.
+        target-kids (cond
+                      (some? instance) (let [k (mstate/instance-key-id instance)]
+                                         (when (contains? instances k) [k]))
+                      (some? mutation) (keep (fn [[kid inst]]
+                                               (when (= mutation (:mutation/id inst)) kid))
+                                             instances)
+                      :else            nil)
+        target-kids (vec target-kids)
         ;; collect in-flight work ids for the cleared instances (abort + cancel)
         in-flight  (into []
-                         (keep (fn [iid]
-                                 (let [inst (get instances iid)
+                         (keep (fn [kid]
+                                 (let [inst (get instances kid)
                                        wid  (:current-work inst)]
                                    (when wid
                                      [wid (:transport (work-ledger/get-record runtime-db wid))]))))
-                         target-ids)
+                         target-kids)
         rdb'       (-> runtime-db
                        (update-in (mstate/instances-path)
-                                  (fn [m] (reduce dissoc m target-ids)))
+                                  (fn [m] (reduce dissoc m target-kids)))
                        (as-> db (reduce (fn [d [wid _]]
                                           (work-ledger/update-record
                                             d wid work-ledger/mark-terminal
                                             :cancelled {:reason :mutation-clear}))
-                                        db in-flight)))]
+                                        db in-flight)))
+        ;; surface the kind-preserving `:instance/id` values in the trace (the
+        ;; byte key-ids are an opaque storage detail), read off the rows BEFORE
+        ;; they were dissoc'd.
+        cleared-ids (mapv #(:instance/id (get instances %)) target-kids)]
     (trace/emit! :rf.event :rf.mutation/cleared
-                 {:rf.frame/id frame-id :cleared target-ids
+                 {:rf.frame/id frame-id :cleared cleared-ids
                   :aborted (mapv first in-flight)})
     {:rf.db/runtime rdb'
      ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the token the

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -45,23 +45,55 @@
 
 (def mutations-key
   "The reserved runtime-db key for the mutation-instance subtree
-  (`:rf.runtime/mutations`). A map `{<instance-id> <instance>}`, keyed by
-  mutation INSTANCE id so concurrent submissions of the same mutation id
-  do not clobber each other. Per Spec 016 §Cache home and write authority /
-  EP-0003 §Mutations."
+  (`:rf.runtime/mutations`). A map `{<key-id> <instance>}`, keyed on the
+  CEDN-1 byte `key-id` of the mutation INSTANCE id (see `instance-key-id`) so
+  concurrent submissions of the same mutation id do not clobber each other.
+  Per Spec 016 §Cache home and write authority / EP-0003 §Mutations."
   :rf.runtime/mutations)
+
+(defn instance-key-id
+  "The CEDN-1 BYTE-IDENTITY map-key for a mutation INSTANCE id — its
+  `canonical-bytes` string (rf2-8iciw8). The SAME canonical identity the
+  resource cache key uses (`state/key-id`), applied to the instance id.
+
+  WHY (the EP-0012 `=`-collapse fix, mirrored for mutations): a caller MAY
+  supply a sequential / collection instance id (a row-keyed form addresses its
+  instance by `[:row 7]`; `validate-instance-id!` accepts any serializable
+  EDN). The instance id was used DIRECTLY as a Clojure map key under
+  `:rf.runtime/mutations`, and Clojure map keys compare by `=`, which is
+  COARSER than the authoritative CEDN-1 byte identity for SEQUENTIAL
+  vector-vs-list — `(= [:row 7] '(:row 7))` is TRUE while their
+  `canonical-bytes` differ (`v[…]` vs `l(…)`). Two CEDN-distinct submissions
+  could therefore address the SAME runtime row and clobber / gate each other.
+  Keying on the canonical-bytes STRING makes the map-key comparison EXACTLY
+  the CEDN-1 byte identity, so a list-id row and a vector-id row get DISTINCT
+  instances — without re-erasing the kind (the kind-preserving instance id is
+  stored alongside on the instance as `:instance/id`). The bytes string is
+  plain serializable EDN, so it rides the epoch / restore / trace wire with no
+  custom handler — exactly the resource cache (`state/key-id`) discipline.
+
+  Total on a `validate-instance-id!`-conforming id (`serializable-edn?` →
+  `canonical-bytes` is total on canonical EDN). Per EP-0003 §Mutations /
+  Conventions §Canonical EDN identity."
+  [instance-id]
+  (state/key-id instance-id))
 
 (defn instances-path
   "Runtime-db-relative path to the mutation-instances map
-  `{<instance-id> <instance>}`. Per Spec 016 §Cache home."
+  `{<key-id> <instance>}` — keyed on the CEDN-1 byte `key-id`
+  (`instance-key-id`), NOT the raw instance id (rf2-8iciw8). Per Spec 016
+  §Cache home."
   []
   [mutations-key])
 
 (defn instance-path
   "Runtime-db-relative path to a single mutation instance by its instance
-  id. Per EP-0003 §Mutations (runtime state keyed by mutation instance id)."
+  id — the map is keyed on the instance id's CEDN-1 byte `key-id`
+  (`instance-key-id`), so two CEDN-distinct sequential ids (`[:row 7]` vs
+  `'(:row 7)`) address DISTINCT rows (rf2-8iciw8). Per EP-0003 §Mutations
+  (runtime state keyed by mutation instance id)."
   [instance-id]
-  [mutations-key instance-id])
+  [mutations-key (instance-key-id instance-id)])
 
 ;; ---- durable mutation-instance shape -------------------------------------
 ;;

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -1072,16 +1072,21 @@
   `dangle-non-terminal-work!`, work-kind `:mutation`)."
   [runtime-db settled-at]
   (let [instances (get-in runtime-db (mutation-runtime/instances-path))
+        ;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the CEDN-1 byte
+        ;; `key-id`; iterate the map's OWN keys (already byte key-ids) and
+        ;; operate on the direct `[mutations-key <key-id>]` path. Do NOT re-feed
+        ;; a byte key-id through `instance-path` (that would re-encode it).
         pending   (into []
                         (comp (filter (fn [[_ inst]] (mutation-runtime/pending? inst)))
                               (map key))
                         instances)]
     (if (empty? pending)
       [runtime-db [] []]
-      (let [[rdb' rolled-keys]
+      (let [[rdb' rolled-keys dangled-ids]
             (reduce
-              (fn [[rdb rk] instance-id]
-                (let [inst (get-in rdb (mutation-runtime/instance-path instance-id))
+              (fn [[rdb rk dids] key-id]
+                (let [inst-path (conj (mutation-runtime/instances-path) key-id)
+                      inst (get-in rdb inst-path)
                       ;; EP-0019 Q3 — roll back the recorded optimistic apply
                       ;; (conflict-aware, INSIDE the pass) BEFORE settling the
                       ;; instance terminal, so the restored cache shows truth (the
@@ -1091,12 +1096,15 @@
                       spec (mutation-registry/mutation-meta (:mutation/id inst))
                       [rdb2 keys2] (mutation-runtime/dangle-rollback-optimistic
                                      rdb inst spec settled-at)]
-                  [(update-in rdb2 (mutation-runtime/instance-path instance-id)
+                  [(update-in rdb2 inst-path
                               mutation-runtime/instance-dangled settled-at)
-                   (into rk keys2)]))
-              [runtime-db []]
+                   (into rk keys2)
+                   ;; surface the kind-preserving `:instance/id` in the returned
+                   ;; dangled-id list (the byte key-id is opaque storage detail).
+                   (conj dids (:instance/id inst))]))
+              [runtime-db [] []]
               pending)]
-        [rdb' pending rolled-keys]))))
+        [rdb' dangled-ids rolled-keys]))))
 
 (defn clear-host-transients-on-restore!
   "Clear the restored `frame-id`'s HOST-SIDE transient resource caches that the

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -455,23 +455,30 @@
   - `:selectors` / `:authority` / `:source` / `:schema` / `:doc` / `:derive`
                      — carried through from the resource's static node.
 
-  Returns `{scoped-key <node>}` for every live entry in the frame's cache
-  (`{}` when the frame has no entries, an unknown / destroyed frame, or no
-  resource cache subtree). JVM-runnable — the cache entries + work records
-  are serializable EDN runtime-db facts (no host handles ride them; those
-  live in the side table)."
+  Returns `{<key-id> <node>}` for every live entry in the frame's cache —
+  keyed on the CEDN-1 byte `key-id` STRING (the same key the runtime storage
+  / SSR wire / indexes use), with each node carrying its kind-preserving
+  scoped-resource-key VECTOR under `:id`. `{}` when the frame has no entries,
+  an unknown / destroyed frame, or no resource cache subtree. JVM-runnable —
+  the cache entries + work records are serializable EDN runtime-db facts (no
+  host handles ride them; those live in the side table)."
   [frame-id]
   (let [runtime-db (frame/frame-runtime-db-value frame-id)
         entries    (get-in runtime-db (state/entries-path))]
     (reduce-kv
-      ;; rf2-9e0tyq — `:entries` is keyed on the opaque byte `key-id`; the live
-      ;; node's `:id` / inputs use the entry's own `:resource/key` VECTOR (the
-      ;; canonical fact identity), read from the entry, not the map key.
-      (fn [acc _k-id entry]
+      ;; rf2-9e0tyq / rf2-ka2nkx — `:entries` is keyed on the opaque byte
+      ;; `key-id`; the live node's `:id` / inputs use the entry's own
+      ;; `:resource/key` VECTOR (the canonical fact identity), read from the
+      ;; entry, not the map key. The RETURNED map MUST stay keyed on the byte
+      ;; `key-id` too: rekeying onto the `=`-colliding scoped-key vector would
+      ;; `assoc` one CEDN-distinct entry over the other (a list-params and a
+      ;; vector-params entry are Clojure-= as vectors), reporting ONE node for
+      ;; TWO live entries (rf2-ka2nkx).
+      (fn [acc k-id entry]
         (let [scoped-key  (:resource/key entry)
               resource-id (second scoped-key)
               static-node (resource-algebra-view resource-id)]
-          (assoc acc scoped-key
+          (assoc acc k-id
                  (live-node-for runtime-db scoped-key entry static-node))))
       {}
       (or entries {}))))

--- a/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
@@ -11,9 +11,10 @@
   multi-trigger evaluation set, the `:scoped-resource-key` lifecycle, with
   `:selectors` (the `:rf.resource/*` read facts) and `:commands` (the
   transport descriptors). `…/resource-cache-algebra-view` reports one node
-  per live cache entry keyed by its scoped resource key, with the realized
-  scope/param edges, the entry status, the work-ledger link, and the
-  host-transient in-flight handle address.
+  per live cache entry keyed by its CEDN-1 byte `key-id` (with the scoped
+  resource key carried on the node's `:id`), with the realized scope/param
+  edges, the entry status, the work-ledger link, and the host-transient
+  in-flight handle address.
 
   These tests pin the registrar-derived projection: the fixed
   classifications, the declared-input lowering (params + scope; `{:from-db}`
@@ -229,8 +230,8 @@
           scoped-key (install-live-entry! :rf/default :article/by-slug scope params
                                           {:status :loaded :owner [:route :route/article 17]})
           view       (resources-tooling/resource-cache-algebra-view :rf/default)
-          node       (get view scoped-key)]
-      (is (some? node) "the live entry is keyed by its concrete scoped resource key")
+          node       (get view (state/key-id scoped-key))]
+      (is (some? node) "the live entry node is reachable by its byte key-id")
       (is (has-live-fixed-classifications? node)
           "the live node keeps the fixed process classifications (lifecycle is the map form)")
       (is (= scoped-key (:id node)) "the node id is the concrete scoped key (live fact identity)")
@@ -258,7 +259,7 @@
           scoped-key (install-live-entry! :rf/default :article/by-slug scope params
                                           {:owner [:route :route/article 9] :in-flight? true})
           node       (get (resources-tooling/resource-cache-algebra-view :rf/default)
-                          scoped-key)
+                          (state/key-id scoped-key))
           work-id    (work-ledger/resource-work-id scoped-key 1)]
       (is (= :fetching (:status node)))
       (testing "the work-ledger link carries the work id + a serializable record summary"
@@ -268,6 +269,37 @@
         (is (= #{[:route :route/article 9]} (get-in node [:work-ledger :record :owners]))))
       (testing "the host-transient in-flight handle address names the work id"
         (is (= [[:rf.http/in-flight work-id]] (:host-transient node)))))))
+
+(deftest live-view-keeps-cedn-distinct-scoped-keys-distinct
+  (testing "rf2-ka2nkx ADVERSARIAL: two live entries whose params differ ONLY by
+            EDN collection kind (vector vs list) are Clojure-= as scoped-key
+            VECTORS but CEDN-distinct (distinct byte key-ids). The cache
+            algebra view must report TWO distinct nodes (one per byte-keyed
+            runtime entry), NOT collapse them onto one `=`-colliding key"
+    (rf/reg-resource :article/by-slug (article-spec))
+    (let [scope  :rf.scope/global
+          pv     {:xs [1 2 3]}
+          pl     {:xs '(1 2 3)}
+          kv     (install-live-entry! :rf/default :article/by-slug scope pv
+                                      {:status :loaded :owner [:lease :v 1]})
+          kl     (install-live-entry! :rf/default :article/by-slug scope pl
+                                      {:status :loaded :owner [:lease :l 1]})
+          view   (resources-tooling/resource-cache-algebra-view :rf/default)]
+      (is (= kv kl) "the scoped-key VECTORS are Clojure-= (the collapse routed around)")
+      (is (not= (state/key-id kv) (state/key-id kl))
+          "their byte key-ids differ (v[…] vs l(…))")
+      (is (= 2 (count view)) "TWO distinct nodes — no =-collapse onto one map key")
+      (is (= #{(state/key-id kv) (state/key-id kl)} (set (keys view)))
+          "the view is keyed on the byte key-ids of BOTH entries")
+      (testing "each node keeps its kind-preserving scoped-key on :id"
+        (let [nv (get view (state/key-id kv))
+              nl (get view (state/key-id kl))]
+          (is (= kv (:id nv)) "vector node keeps its vector key")
+          (is (= kl (:id nl)) "list node keeps its list key")
+          (is (vector? (-> nv :id (nth 2) :xs)) "vector-params node preserves vector kind")
+          (is (seq?    (-> nl :id (nth 2) :xs)) "list-params node preserves list kind")
+          (is (not= (:lifecycle nv) (:lifecycle nl))
+              "the two nodes carry their OWN distinct owner sets (not gated together)"))))))
 
 ;; ---- registry semantics --------------------------------------------------
 

--- a/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
@@ -268,6 +268,54 @@
       (is (= privacy/redacted-sentinel (:frame-secret projected)) "frame mark fired")
       (is (= "ok" (:title projected)) "unclassified sibling rides verbatim"))))
 
+(deftest project-data-elides-owner-data-schema-large-slot
+  (testing "rf2-260yhk: a resource-owned per-slot :data-schema :large? mark
+            (layer (a)) ELIDES its slot to the :rf.size/large-elided marker —
+            NOT riding RAW — REGARDLESS of frame classification (the canonical
+            fine-grained owner surface, firing even frameless; resource cache
+            data does not live at a frame app-db path). The CO-EQUAL counterpart
+            to project-params' large axis, which already did this"
+    (let [big  (apply str (repeat 500 "x"))
+          spec {:data-schema [:map
+                              [:body  {:large? true} :string]
+                              [:title :string]]}
+          projected (classification/project-data
+                      {:body big :title "public"} spec nil :rf.egress/ssr-hydration)]
+      (is (contains? (:body projected) :rf.size/large-elided)
+          "the owner-marked :body slot is elided to the size marker, even frameless")
+      (is (= "public" (:title projected)) "the unmarked sibling rides verbatim")
+      (is (not (str/includes? (pr-str projected) big))
+          "the raw large value does NOT ride on the wire"))))
+
+(deftest project-data-sensitive-wins-over-large-owner-slot
+  (testing "rf2-260yhk: a :data-schema slot marked BOTH :sensitive? and :large?
+            redacts (sensitive wins over large — the shared walker ordering,
+            same as project-params + HTTP body)"
+    (let [spec {:data-schema [:map [:token {:sensitive? true :large? true} :string]]}
+          projected (classification/project-data
+                      {:token (apply str (repeat 200 "z"))} spec nil :rf.egress/ssr-hydration)]
+      (is (= privacy/redacted-sentinel (:token projected))
+          "sensitive wins — the slot is the redaction sentinel, not a large marker"))))
+
+(deftest ssr-serialize-entry-elides-owner-data-schema-large-slot
+  (reg! :report/card {:data-schema [:map
+                                    [:blob {:large? true} :string]
+                                    [:name :string]]})
+  (testing "rf2-260yhk END-TO-END: a :serialize resource whose OWN :data-schema
+            marks a slot :large? ELIDES that slot on SSR projection — the
+            canonical fine-grained owner surface fires WITHOUT requiring a
+            matching frame app-db mark (the bug: the large leaf rode RAW)"
+    (let [big (apply str (repeat 1000 "q"))
+          k   (state/scoped-resource-key :rf.scope/global :report/card {:slug "r"})
+          e   (entry {:resource-id :report/card :data {:blob big :name "ok"}})
+          [_ we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+      (is (contains? (:blob (:data we)) :rf.size/large-elided)
+          "the owner-marked :blob slot is elided on the serialized entry")
+      (is (= "ok" (:name (:data we))) "the unmarked sibling rides verbatim")
+      (is (= :loaded (:status we)) "metadata (status) still rides")
+      (is (not (str/includes? (pr-str we) big))
+          "no raw large value rides on the serialized entry"))))
+
 ;; ===========================================================================
 ;; 4. SSR projection — the reconciliation end-to-end
 ;; ===========================================================================

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -1015,6 +1015,69 @@
       (is (= :pending (:status i)))
       (is (= [:row 7] (:instance/id i))))))
 
+(deftest cedn-distinct-sequential-instance-ids-do-not-clobber
+  ;; rf2-8iciw8 — two caller-supplied instance ids that are CEDN-distinct but
+  ;; Clojure-= (a vector `[:row 7]` and a list `'(:row 7)`) MUST address
+  ;; DISTINCT runtime rows. The instance id was used directly as a Clojure map
+  ;; key under :rf.runtime/mutations, and `(= [:row 7] '(:row 7))` is TRUE, so
+  ;; the second execute would clobber the first's row (and a later settle /
+  ;; clear would gate the wrong one).
+  (rf/reg-mutation :m/save (save-article-spec))
+  (let [all-args (atom [])]
+    (rf/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (let [iv [:row 7]
+          il '(:row 7)]
+      (is (= iv il) "the two instance ids are Clojure-= (the collapse routed around)")
+      (is (not= (mstate/instance-key-id iv) (mstate/instance-key-id il))
+          "their byte key-ids differ (v[…] vs l(…)) — distinct storage rows")
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/save :params {:slug "v"} :instance iv}])
+      (let [args-v (last @all-args)]
+        (rf/dispatch-sync [:rf.mutation/execute
+                           {:mutation :m/save :params {:slug "l"} :instance il}])
+        (let [args-l (last @all-args)]
+          (testing "TWO distinct instance rows exist (no =-collapse onto one)"
+            (is (= 2 (count (:instances (rf/mutations {:frame :rf/default})))))
+            (is (= :pending (:status (instance iv))))
+            (is (= :pending (:status (instance il))))
+            (is (= iv (:instance/id (instance iv))) "vector row keeps its vector id")
+            (is (= il (:instance/id (instance il))) "list row keeps its list id")
+            (is (vector? (:instance/id (instance iv))) "vector kind preserved")
+            (is (seq?    (:instance/id (instance il))) "list kind preserved")
+            (is (= {:slug "v"} (:params (instance iv))) "vector row keeps its OWN params")
+            (is (= {:slug "l"} (:params (instance il))) "list row keeps its OWN params"))
+          (testing "settling the LIST instance leaves the VECTOR instance untouched
+                    (no cross-gating between CEDN-distinct rows)"
+            (reply-success! args-l {:id :l})
+            (is (= :success (:status (instance il))) "list row settled")
+            (is (= {:id :l} (:result (instance il))))
+            (is (= :pending (:status (instance iv)))
+                "vector row is STILL pending — the list settle did not gate it"))
+          (testing "then settling the VECTOR instance"
+            (reply-success! args-v {:id :v})
+            (is (= :success (:status (instance iv))))
+            (is (= {:id :v} (:result (instance iv))))))))))
+
+(deftest cedn-distinct-sequential-instance-ids-clear-independently
+  ;; rf2-8iciw8 — `:rf.mutation/clear` must target the row by the SAME byte
+  ;; identity, so clearing `[:row 7]` does NOT also clear / gate `'(:row 7)`.
+  (rf/reg-mutation :m/save (save-article-spec))
+  (let [all-args (atom [])]
+    (rf/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (let [iv [:row 7]
+          il '(:row 7)]
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/save :params {:slug "v"} :instance iv}])
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/save :params {:slug "l"} :instance il}])
+      (is (= 2 (count (:instances (rf/mutations {:frame :rf/default})))) "two rows")
+      (rf/dispatch-sync [:rf.mutation/clear {:instance iv}])
+      (testing "only the vector row was cleared; the list row survives intact"
+        (is (nil? (instance iv)) "the vector row is gone")
+        (is (some? (instance il)) "the CEDN-distinct list row survives")
+        (is (= :pending (:status (instance il))))
+        (is (= il (:instance/id (instance il))) "and keeps its kind-preserving id")))))
+
 ;; ===========================================================================
 ;; ADVERSARIAL (rf2-sxyrzk / eu2ifi) — two frames executing the SAME mutation
 ;; instance at the SAME generation get DISTINCT frame-qualified transport

--- a/implementation/resources/test/re_frame/resources_optimistic_apply_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_apply_cljs_test.cljc
@@ -81,7 +81,9 @@
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations instance-id]))
+;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
+;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
+(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
 (defn- patch-summary [instance-id] (:patch-summary (instance instance-id)))
 
 (defn- reply-success! [args result]

--- a/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
@@ -74,7 +74,9 @@
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations instance-id]))
+;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
+;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
+(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
 (defn- patch-summary [instance-id] (:patch-summary (instance instance-id)))
 
 (defn- reply-success! [args result]
@@ -350,17 +352,18 @@
                                               (optimistic-entry 6 true 10)}
                                     :tag-index {} :owner-index {}}
                mstate/mutations-key
-               {:f1 (pending-optimistic-instance
-                      [(mstate/record-optimistic-entry article-key before :patch)])}}
+               {(mstate/instance-key-id :f1)
+                (pending-optimistic-instance
+                  [(mstate/record-optimistic-entry article-key before :patch)])}}
           out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 7777})
           e   (get-in out [state/resources-key :entries (state/key-id article-key)])]
       (testing "the optimistic value was ROLLED BACK to the recorded :before"
         (is (= 9 (get-in e [:data :article :favoritesCount])) "count reverted")
         (is (= false (get-in e [:data :article :favorited])) "heart un-flipped"))
       (testing "the instance is terminally dangled (the same pass)"
-        (is (= :error (get-in out [mstate/mutations-key :f1 :status])))
-        (is (= :dangling-on-restore (:reason (get-in out [mstate/mutations-key :f1 :error]))))
-        (is (nil? (get-in out [mstate/mutations-key :f1 :current-work]))))))
+        (is (= :error (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :status])))
+        (is (= :dangling-on-restore (:reason (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :error]))))
+        (is (nil? (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :current-work]))))))
   (testing "CONFLICT — a moved revision marks the entry durably STALE in the pass
             (NOT a racing dispatch), the read path refetches on next ensure"
     (let [before (merge (state/empty-entry :r/article article-key)
@@ -373,8 +376,9 @@
                                               (optimistic-entry 8 false 100)}
                                     :tag-index {} :owner-index {}}
                mstate/mutations-key
-               {:f1 (pending-optimistic-instance
-                      [(mstate/record-optimistic-entry article-key before :patch)])}}
+               {(mstate/instance-key-id :f1)
+                (pending-optimistic-instance
+                  [(mstate/record-optimistic-entry article-key before :patch)])}}
           out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 7777})
           e   (get-in out [state/resources-key :entries (state/key-id article-key)])]
       (testing "the conflicted entry is NOT restored — the newer truth (100) is kept"
@@ -384,4 +388,4 @@
         (is (= 7777 (:invalidated-at e))
             ":invalidated-at stamped from the restore causal time, in the reconcile pass"))
       (testing "the instance is still terminally dangled"
-        (is (= :error (get-in out [mstate/mutations-key :f1 :status])))))))
+        (is (= :error (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :status])))))))

--- a/implementation/resources/test/re_frame/resources_optimistic_validation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_validation_cljs_test.cljc
@@ -73,7 +73,9 @@
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations instance-id]))
+;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
+;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
+(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
 (defn- patch-summary [instance-id] (:patch-summary (instance instance-id)))
 
 (defn- reply-success! [args result]

--- a/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
@@ -85,8 +85,10 @@
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
+;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
 (defn- instance [instance-id]
-  (get-in (runtime-db) [:rf.runtime/mutations instance-id]))
+  (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
 
 (defn- reply-success! [args result]
   (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -300,6 +300,14 @@
          :work-id work-id :started-at 1000})
       (assoc :status status)))
 
+(defn- mutations-map
+  "Build a `:rf.runtime/mutations` map keyed the runtime way — on the CEDN-1
+  byte `key-id` of each instance id (rf2-8iciw8), each instance carrying its
+  own kind-preserving `:instance/id`. Takes `{<instance-id> <instance>}` pairs
+  (instance ids as the LOGICAL key) and rekeys to the byte storage key."
+  [m]
+  (into {} (map (fn [[iid inst]] [(mstate/instance-key-id iid) inst])) m))
+
 (deftest instance-dangled-settles-pending-and-clears-current-work
   (testing "instance-dangled: a :pending instance settles terminal :error with
             the :dangling-on-restore envelope and CLEARS :current-work"
@@ -320,12 +328,12 @@
     (let [pending (mutation-instance {:instance-id :inst-p
                                       :work-id [:rf.work/resource [:rf.mutation :inst-p 3] 3]})
           settled (mutation-instance {:instance-id :inst-s :status :success})
-          rdb {mstate/mutations-key {:inst-p pending :inst-s settled}}
+          rdb {mstate/mutations-key (mutations-map {:inst-p pending :inst-s settled})}
           [rdb' dangled] (ssr/dangle-pending-mutations! rdb 9999)]
-      (is (= [:inst-p] dangled) "only the pending instance is dangled")
-      (is (= :error (get-in rdb' [mstate/mutations-key :inst-p :status])))
-      (is (nil? (get-in rdb' [mstate/mutations-key :inst-p :current-work])))
-      (is (= :success (get-in rdb' [mstate/mutations-key :inst-s :status]))
+      (is (= [:inst-p] dangled) "only the pending instance is dangled (kind-preserving :instance/id)")
+      (is (= :error (get-in rdb' [mstate/mutations-key (mstate/instance-key-id :inst-p) :status])))
+      (is (nil? (get-in rdb' [mstate/mutations-key (mstate/instance-key-id :inst-p) :current-work])))
+      (is (= :success (get-in rdb' [mstate/mutations-key (mstate/instance-key-id :inst-s) :status]))
           "the terminal instance is untouched")))
   (testing "no mutation instances → no-op"
     ;; EP-0019 Q3 — the return is now `[rdb dangled rolled-back-keys]`.
@@ -335,10 +343,10 @@
   (testing "reconcile-on-restore reconciles the :rf.runtime/mutations slice too"
     (let [pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          rdb {mstate/mutations-key {:inst-1 pending}}
+          rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}
           out (ssr/reconcile-on-restore rdb :app/main)]
-      (is (= :error (get-in out [mstate/mutations-key :inst-1 :status])))
-      (is (nil? (get-in out [mstate/mutations-key :inst-1 :current-work]))))))
+      (is (= :error (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :status])))
+      (is (nil? (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :current-work]))))))
 
 (deftest dangled-instance-settled-at-is-the-restore-causal-time-not-the-live-clock
   ;; rf2-wshzsp (the option-1 CORRECTNESS fix) — a dangled-on-restore mutation
@@ -354,10 +362,10 @@
           live-sentinel 9999999999999  ; the (wrong) ambient install clock
           pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          rdb {mstate/mutations-key {:inst-1 pending}}]
+          rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}]
       (with-redefs [ssr/now-ms (constantly live-sentinel)]
         (let [out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms restore-time})
-              inst (get-in out [mstate/mutations-key :inst-1])]
+              inst (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1)])]
           (is (= :error (:status inst)) "the pending instance is terminally dangled")
           (is (= restore-time (:settled-at inst))
               ":settled-at is the causal :restore-time-ms — replay-stable")
@@ -368,10 +376,10 @@
     (let [live-sentinel 9999999999999
           pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          rdb {mstate/mutations-key {:inst-1 pending}}]
+          rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}]
       (with-redefs [ssr/now-ms (constantly live-sentinel)]
         (let [out (ssr/reconcile-on-restore rdb :app/main)]
-          (is (= live-sentinel (get-in out [mstate/mutations-key :inst-1 :settled-at]))
+          (is (= live-sentinel (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :settled-at]))
               "no causal time supplied → the unit path falls back to the live clock"))))))
 
 (deftest dangling-mutation-without-restore-time-warns-loudly
@@ -384,7 +392,7 @@
   ;; is loud, not a quiet footgun (no-silent-swallow).
   (let [pending (mutation-instance {:instance-id :inst-1
                                     :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-        rdb {mstate/mutations-key {:inst-1 pending}}
+        rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}
         recorder (fn []
                    (let [seen (atom [])
                          k    ::live-clock-warn-recorder]
@@ -439,7 +447,7 @@
                                         :scope :rf.scope/global :params {:slug "x"}})
           ;; the runtime-db that restore is about to install (reconciled first)
           snapshot  (-> (runtime-db-with {gkey loaded})
-                        (assoc mstate/mutations-key {instance-id pending})
+                        (assoc mstate/mutations-key (mutations-map {instance-id pending}))
                         (assoc-in (work-ledger/record-path work-id)
                                   (-> (work-ledger/work-record
                                         {:work-id work-id :frame-id fid
@@ -452,8 +460,8 @@
       ;; install the reconciled snapshot as the live frame-state
       (frame/replace-runtime-db! fid reconciled)
       (testing "post-reconcile the pending instance is terminal + current-work cleared"
-        (is (= :error (get-in reconciled [mstate/mutations-key instance-id :status])))
-        (is (nil? (get-in reconciled [mstate/mutations-key instance-id :current-work]))))
+        (is (= :error (get-in reconciled [mstate/mutations-key (mstate/instance-key-id instance-id) :status])))
+        (is (nil? (get-in reconciled [mstate/mutations-key (mstate/instance-key-id instance-id) :current-work]))))
       ;; NOW the late pre-restore mutation SUCCESS reply lands (carrying the
       ;; pre-restore work-id + generation that the snapshot instance held).
       (rf/dispatch-sync
@@ -466,7 +474,7 @@
             e    (get-in post [state/resources-key :entries (state/key-id gkey)])]
         (is (= {:title "post-restore"} (:data e))
             "the resource entry is UNCHANGED — the stale reply did not patch/populate it")
-        (is (= :error (get-in post [mstate/mutations-key instance-id :status]))
+        (is (= :error (get-in post [mstate/mutations-key (mstate/instance-key-id instance-id) :status]))
             "the dangled instance stays terminal :error — the stale reply did not revive it"))
       (frame/destroy-frame! fid))))
 

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -1023,14 +1023,20 @@
                     :params {:slug "w"} :frame :rf/default}))))))
 
 ;; ===========================================================================
-;; 17b. `resources` introspection rekeys to the public scoped-key vector
-;;      (rf2-jtlq7l) — the internal byte `key-id` must not leak
+;; 17b. `resources` introspection keys `:entries` on the CEDN-1 byte `key-id`
+;;      (rf2-jtlq7l intent, rf2-ka2nkx correction) — callers destructure /
+;;      filter via each entry's kind-preserving `:resource/key` vector
 ;; ===========================================================================
 
-(deftest resources-introspection-rekeys-to-scoped-key-vector
-  (testing "rf2-jtlq7l — `(resources {:frame f})` returns `:entries` keyed by
-            each entry's `:resource/key` VECTOR `[scope resource-id params]`,
-            not the internal CEDN byte `key-id` storage key"
+(deftest resources-introspection-keys-by-byte-key-id
+  (testing "rf2-ka2nkx (supersedes the rf2-jtlq7l vector-rekey): `(resources
+            {:frame f})` returns `:entries` keyed on the CEDN-1 byte `key-id`
+            STRING (the same key the runtime storage / SSR wire / indexes use,
+            which CANNOT collapse CEDN-distinct sequential-params entries); each
+            entry carries its kind-preserving `:resource/key` VECTOR `[scope
+            resource-id params]` for destructure / filter. Rekeying onto the
+            `=`-colliding scoped-key vector (the original rf2-jtlq7l approach)
+            collapsed a list-params and a vector-params entry onto one map key"
     (rf/reg-resource :intro/article (article-spec))
     (let [k1 (state/scoped-resource-key :rf.scope/global :intro/article {:slug "one"})
           k2 (state/scoped-resource-key :rf.scope/global :intro/article {:slug "two"})]
@@ -1042,34 +1048,70 @@
       (let [{:keys [resource-ids entries]} (re-frame.resources/resources {:frame :rf/default})]
         (testing "the static registry still lists the registered id"
           (is (contains? (set resource-ids) :intro/article)))
-        (testing "entry keys are scoped-key VECTORS, not byte key-id strings"
-          (is (= #{k1 k2} (set (keys entries)))
-              "the public accessor keys by :resource/key vector")
-          (is (every? vector? (keys entries))
-              "every entry key is a [scope resource-id params] vector")
-          (is (not-any? string? (keys entries))
-              "no internal byte key-id (a string) leaks through the accessor")
-          (is (not (contains? entries (state/key-id k1)))
-              "the byte key-id is NOT a public entry key"))
-        (testing "callers can destructure the public key shape + filter by it"
-          (let [[scope rid params] k1]
+        (testing "entry keys are the CEDN-1 byte key-id STRINGS (collapse-proof)"
+          (is (= #{(state/key-id k1) (state/key-id k2)} (set (keys entries)))
+              "the public accessor keys by the byte key-id, matching internal storage")
+          (is (every? string? (keys entries))
+              "every entry key is the byte key-id string")
+          (is (contains? entries (state/key-id k1))
+              "the byte key-id IS the public entry key"))
+        (testing "each entry carries its kind-preserving :resource/key VECTOR for
+                  destructure + scope/resource filtering (the rf2-jtlq7l goal,
+                  served via the entry not the map key)"
+          (is (= #{k1 k2} (set (map :resource/key (vals entries))))
+              "every entry exposes its scoped-key vector")
+          (is (every? vector? (map :resource/key (vals entries)))
+              "every :resource/key is a [scope resource-id params] vector")
+          (let [[scope rid params] (some #(when (= k1 (:resource/key %)) (:resource/key %))
+                                         (vals entries))]
             (is (= :rf.scope/global scope))
             (is (= :intro/article rid))
             (is (= {:slug "one"} params)))
-          ;; Filtering by [scope resource-id] over the vector keys is the
-          ;; documented use the byte key-id blocked.
           (is (= #{k1 k2}
-                 (set (for [[[scope rid params] _e] entries
+                 (set (for [e (vals entries)
+                            :let [[scope rid params] (:resource/key e)]
                             :when (and (= :rf.scope/global scope)
                                        (= :intro/article rid))]
                         [scope rid params])))
               "every entry filters cleanly by scope + resource-id"))
-        (testing "the entry value is carried through unchanged (still byte-keyed
-                  in internal storage)"
-          (is (= :intro/article (-> entries (get k1) :resource/key second)))
+        (testing "the entry value is carried through unchanged (byte-keyed
+                  in internal storage too)"
+          (is (= :intro/article (-> entries (get (state/key-id k1)) :resource/key second)))
           (let [raw (get-in (rf/runtime-db-value :rf/default) (state/entries-path))]
             (is (every? string? (keys raw))
                 "internal runtime storage remains byte-keyed (string key-ids)")))))))
+
+(deftest resources-introspection-keeps-cedn-distinct-scoped-keys-distinct
+  (testing "rf2-ka2nkx ADVERSARIAL: `(resources {:frame f})` preserves ONE
+            returned entry per byte-keyed runtime entry when two entries have
+            CEDN-distinct but Clojure-= scoped-key vectors (vector params vs
+            list params). The former vector-rekey `assoc`'d one entry OVER the
+            other (the `=`-collapse), reporting ONE entry for TWO live ones"
+    (rf/reg-resource :intro/article (article-spec))
+    (let [kv (state/scoped-resource-key :rf.scope/global :intro/article {:xs [1 2 3]})
+          kl (state/scoped-resource-key :rf.scope/global :intro/article {:xs '(1 2 3)})
+          ev (assoc (state/empty-entry :intro/article kv) :status :loaded :data {:v 1})
+          el (assoc (state/empty-entry :intro/article kl) :status :loaded :data {:l 1})]
+      (is (= kv kl) "the scoped-key VECTORS are Clojure-= (the collapse routed around)")
+      (is (not= (state/key-id kv) (state/key-id kl)) "their byte key-ids differ")
+      ;; write both entries the runtime way (byte-keyed paths) — a `{kv .. kl ..}`
+      ;; literal would itself throw `Duplicate key` (kv and kl are Clojure-=).
+      (frame/swap-runtime-db! :rf/default
+        (fn [rdb] (-> (or rdb {})
+                      (assoc-in (state/entry-path kv) ev)
+                      (assoc-in (state/entry-path kl) el))))
+      (let [{:keys [entries]} (re-frame.resources/resources {:frame :rf/default})]
+        (is (= 2 (count entries))
+            "TWO distinct returned entries — no =-collapse onto one map key")
+        (is (= #{(state/key-id kv) (state/key-id kl)} (set (keys entries)))
+            "keyed on the byte key-ids of BOTH entries")
+        (is (= {:v 1} (:data (get entries (state/key-id kv)))) "vector entry intact")
+        (is (= {:l 1} (:data (get entries (state/key-id kl)))) "list entry NOT overwritten")
+        (testing "each entry carries its kind-preserving :resource/key"
+          (is (vector? (-> (get entries (state/key-id kv)) :resource/key (nth 2) :xs))
+              "vector-params entry preserves vector kind on :resource/key")
+          (is (seq? (-> (get entries (state/key-id kl)) :resource/key (nth 2) :xs))
+              "list-params entry preserves list kind on :resource/key"))))))
 
 (deftest resources-introspection-without-frame-returns-empty-entries
   (testing "rf2-jtlq7l — `(resources)` (no frame) still returns


### PR DESCRIPTION
Three resources-artefact serialization-surface fixes (senior-review cluster, tracking rf2-071zlb). All changes confined to `implementation/resources/` + the resources API doc — no `tools/xray/` files touched.

## rf2-260yhk — Resource `:data-schema` `:large?` slots elide on the wire
`classification/project-data` only applied the owner's per-slot `:sensitive?` marks (via `privacy/redact-paths`); the per-slot `:large?` marks were extracted but never applied, so a `:serialize` entry with a `:data-schema` large leaf rode RAW on the SSR hydration wire. Fixed by routing layer (a) through the shared `re-frame.marks/redact-with-paths` walker (the CO-EQUAL counterpart `project-params` already used), so `:sensitive?` slots redact to `:rf/redacted` and `:large?` slots elide to `:rf.size/large-elided` (sensitive wins). Closes the impl gap vs spec/015 §Resource and mutation durable classification.

## rf2-ka2nkx — Read surfaces preserve CEDN-distinct scoped keys
`resources({:frame})` (resources.cljc) and `resource-cache-algebra-view` (tooling.cljc) rekeyed the byte-keyed `:entries` map onto the scoped-key VECTOR. Vector-vs-list params are Clojure-`=` but CEDN-distinct, so the `assoc` overwrote one entry with the other — the read could report one entry/node for two live cache entries. Both now key the returned map on the CEDN-1 byte `key-id` string (matching runtime storage / SSR wire / indexes); each entry/node carries its kind-preserving scoped-key on `:resource/key` / `:id` for destructure + scope/resource filtering. The derivation-graph composer + Xray consume these via `node-id-fn` (the node's `:id`), so they are unaffected by the map-key change.

## rf2-8iciw8 — Mutation instance rows preserve CEDN-distinct sequential ids
Caller-supplied mutation instance ids were used directly as Clojure map keys under `:rf.runtime/mutations`. Sequential ids that are CEDN-distinct but Clojure-`=` (`[:row 7]` vs `'(:row 7)`) addressed the same row and clobbered/gated each other. Instance rows now key on the instance id's CEDN-1 byte `key-id` (new `mstate/instance-key-id`, delegating to `state/key-id`), mirroring the resource cache. The kind-preserving id stays on the instance's `:instance/id`. The `:clear` handler and the restore dangle pass operate on byte key-ids and surface the kind-preserving `:instance/id` in traces. Vector instance ids (the documented row-keyed-form case, rf2-e8wj5t) stay accepted — validation was NOT tightened to reject collections.

## Tests (red→green, verified)
- project-data per-slot large elision + sensitive-wins + SSR end-to-end (classification test)
- adversarial vector-vs-list keys through the public `resources({:frame})` read (runtime test), the live algebra view (algebra-view test), and mutation execute/settle/clear no-clobber (mutation test)
- each new test confirmed RED against the un-fixed code and GREEN with the fix
- the pre-existing rf2-jtlq7l vector-rekey test was updated to the corrected byte-keyed contract (its destructure-by-key goal is preserved via each entry's `:resource/key`)

## Gates
- resources JVM `clojure -M:test`: 477 tests / 1972 assertions, 0 failures
- ssr / epoch / routing JVM suites: green
- `npm run test:cljs`: 7657 tests / 31597 assertions, 0 failures
- `scripts/test-fast-pr.sh`: PASS (incl. markdown link/anchor + EP-status gates; mkdocs soft-skip on Windows)