### PR TITLE
docs(core): EP-0018 reg-event-ctx migration guidance in facade docstrings (rf2-lnleyu)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -309,7 +309,7 @@
 ;; `re-frame.events` throwing stubs, so a stale `(rf/reg-event-db …)` call site
 ;; resolves to a real var and fails LOUDLY with an actionable hard error naming
 ;; the replacement (`:rf.error/reg-event-db-removed` / `-fx-removed` names
-;; `reg-event`; `-ctx-removed` names `->interceptor`) — NOT an opaque "no such
+;; `reg-event`; `-ctx-removed` names `reg-interceptor`) — NOT an opaque "no such
 ;; var", NOT a working alias. They are plain `def` aliases (no macro / no
 ;; source-coord capture — they register nothing), platform-neutral so the stub
 ;; throws identically on JVM and CLJS. `^:no-doc` drops them from the API
@@ -331,9 +331,11 @@
 (def ^{:no-doc true
        :doc "DEMOTED to framework-internal in EP-0018. Calling public
   `reg-event-ctx` raises `:rf.error/reg-event-ctx-removed`, naming
-  `->interceptor` as the public replacement for application full-context
-  work. See `re-frame.events/reg-event-ctx` and spec/001-Registration.md
-  §The retired event-registration names."}
+  `reg-interceptor` as the public replacement for application full-context
+  work (register the interceptor by id, then reference it from a `reg-event`
+  registration's `:interceptors` chain; `->interceptor` is internal-only
+  post-EP-0022). See `re-frame.events/reg-event-ctx` and
+  spec/001-Registration.md §The retired event-registration names."}
   reg-event-ctx events/reg-event-ctx)
 
 ;; ---- reg-* macros (JVM-only; CLJS sees them via :require-macros) --------
@@ -355,8 +357,11 @@
        partition) is reserved by convention for framework /
        runtime-extension authority. Coeffects are declared uniformly via
        `:rf.cofx/requires`. Full-context work is expressed with an
-       interceptor (`->interceptor`). Captures source-coords (Spec 001) at
-       this call site. Additionally captures the whole `(reg-event :id ...)`
+       interceptor authored via `reg-interceptor` and referenced by id from
+       this registration's `:interceptors` chain (`->interceptor` is the
+       internal lowering constructor post-EP-0022, not the authoring form).
+       Captures source-coords (Spec 001) at this call site. Additionally
+       captures the whole `(reg-event :id ...)`
        form as a string under the handler's `:rf.handler/source` meta
        (Spec 009, rf2-xgfuy) — DEBUG-gated, elided in CLJS `:advanced` +
        `goog.DEBUG=false` production builds. See

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -14,8 +14,10 @@
   `reg-event-fx` / `reg-event-ctx` raise
   `:rf.error/reg-event-db-removed` / `-fx-removed` / `-ctx-removed`, per
   EP-0007 rule 2 — no working alias). Full-context work in application code
-  is expressed with interceptors (the public `context -> context` primitive,
-  `->interceptor`).
+  is expressed with interceptors authored via the public `reg-interceptor`
+  form and referenced by id from a `reg-event` registration's
+  `:interceptors` chain (`->interceptor` is the internal lowering
+  constructor post-EP-0022, not the application authoring form).
 
   All event registrations register under registry kind `:event` and share the
   ONE handler-wrapping interceptor `:rf/event-handler` (`:rf/default? true`);


### PR DESCRIPTION
## What

EP-0018 review finding (rf2-lnleyu): the `re-frame.core` facade comments and the `reg-event` macro doc still directed former `reg-event-ctx` users at `->interceptor` as the public full-context authoring form. Post-EP-0022 `->interceptor` is the framework-internal lowering constructor; the public authoring form is `reg-interceptor` (register the interceptor by id, then reference it by id from a `reg-event` registration's `:interceptors` chain).

This left the macro/facade layer internally inconsistent: the runtime `events/reg-event-ctx` stub already raises `:rf.error/reg-event-ctx-removed` naming `reg-interceptor`, and the conformance tests assert the stub names `reg-interceptor` and does NOT mention `->interceptor` — but the facade/macro prose still said `->interceptor`.

## Changes (docstring/comment-only — no behaviour change, no export change)

- `core.cljc` retired-names block comment: `-ctx-removed` now names `reg-interceptor`
- `core.cljc` `reg-event-ctx` `^:no-doc` facade var doc: names `reg-interceptor` + the register-by-id / reference-by-id model; notes `->interceptor` is internal-only post-EP-0022
- `core.cljc` `reg-event` macro doc: full-context work expressed via `reg-interceptor` referenced by id from the `:interceptors` chain
- `events.cljc` ns docstring: same realignment

The `:require-macros :refer` of `->interceptor` (a real macro symbol, the internal lowering constructor) is left intact — it is a code reference, not the stale guidance.

## No facade-export change

Only docstrings/comments changed; no facade var added or removed, so facade-classification does not apply.

## Gates

- `clojure -M -m re-frame.api-manifest.gen --check` — in sync (510 public vars; the changed `reg-event-ctx` var is `^:no-doc`, carries no manifest row)
- `npm run test:cljs` — green (7666 tests / 31597 assertions / 0 failures, includes the reg-event-ctx-removed conformance test)
- `sh scripts/test-fast-pr.sh` — PASS
