### PR TITLE
fix(ssr): escaper char-literals + stable hash ordering + streaming wire-id collisions (rf2-g15jtb, rf2-mff1ht, rf2-yvc0t7)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -94,13 +94,31 @@
                (recur (next items) false)))
            (.push sb "}")))))
 
+(defn- key-canonical
+  "The canonical-EDN string of a map KEY, used as the map's sort key
+  (rf2-mff1ht). `(comp str key)` is NOT a total order — a keyword `:a`
+  and a string `\":a\"` both `str` to `\":a\"`, so `sort-by` falls back
+  to source iteration/insertion order and logically-equal maps can
+  canonicalise to different strings (and hash differently). The canonical
+  EDN of a key distinguishes those shapes (`:a` vs the quoted `\":a\"`)
+  while leaving keyword-only ordering byte-identical to the old `str`
+  order (a keyword's canonical form equals its `str` form), so the
+  parity-pinned fixtures stay green. A nil key (not pruned — only nil
+  VALUES are) canonicalises to the empty string, mirroring the prior
+  `(str nil)` => `\"\"` sort position."
+  [k]
+  (or (member-canonical k) ""))
+
 (defn- append-map!
   "Maps: emit `{` + sorted key-value pairs (`key value`, comma-joined) + `}`.
-  Nil-valued entries pruned per Spec 011 §Hydration-mismatch detection."
+  Entries sorted by the canonical-EDN form of the key (rf2-mff1ht) — a
+  total, cross-runtime-stable order, unlike `(comp str key)` which
+  collides string-form-equal keys of different types. Nil-valued entries
+  pruned per Spec 011 §Hydration-mismatch detection."
   [sb m]
   (let [entries (->> m
                      (remove (comp nil? val))
-                     (sort-by (comp str key)))]
+                     (sort-by (comp key-canonical key)))]
     #?(:clj  (.append ^StringBuilder sb \{)
        :cljs (.push sb "{"))
     (loop [es (seq entries) first? true]
@@ -168,8 +186,9 @@
         sb)))
 
 (defn canonical-edn
-  "Print a render-tree node in a stable order. Maps are sorted by key
-  string; sequences keep order. Functions and var-references appear
+  "Print a render-tree node in a stable order. Maps are sorted by the
+  canonical-EDN form of their keys (a total order — rf2-mff1ht);
+  sequences keep order. Functions and var-references appear
   as their toString — stable enough for trees that re-render the same
   view-fn from the same registry.
 

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -98,7 +98,12 @@
 
   This encoder scans the document tracking string-literal context (an EDN
   string literal opens/closes on an unescaped `\"`; `\\` escapes the next
-  char inside a string):
+  char inside a string). In token position a backslash opens an EDN
+  CHARACTER LITERAL (`\\\"`, `\\<`, `\\newline`, …): the char immediately
+  after the backslash is the literal's payload, so a `\\\"` (what
+  `(char 34)` prints as) does NOT open a string and a later real string
+  literal's `</script>` is escaped, not mis-read as a token-position
+  breakout (rf2-g15jtb):
 
     - INSIDE a string literal — every `<` becomes `\\u003c`. The reader
       decodes the escape back to `<` inside the string, so the value
@@ -156,6 +161,26 @@
               (recur (inc i) true false (conj! acc c)))
 
             ;; Outside any string literal — token / structural position.
+            ;;
+            ;; An EDN character literal opens with a backslash (`\"`, `\<`,
+            ;; `\newline`, `A`, `\o101`). The character IMMEDIATELY
+            ;; following the backslash is the literal's payload, NOT a
+            ;; document delimiter — in particular a `\"` (the char literal
+            ;; for double-quote, what `(char 34)` prints as) must NOT be
+            ;; read as a string-opening quote (rf2-g15jtb). Emit the
+            ;; backslash and the following payload char verbatim, then
+            ;; resume normal token scanning. The payload char cannot itself
+            ;; start an HTML breakout: an EDN char literal is a single
+            ;; character (`\<`), and `pr-str` always separates it from the
+            ;; next token with whitespace / a structural delimiter, so the
+            ;; literal's `<` can never directly abut a following `/` or `!`.
+            (= c \\)
+            (if (< (inc i) n)
+              (recur (+ i 2) false false (-> acc (conj! c) (conj! (nth s (inc i)))))
+              ;; Trailing lone backslash (not reachable from valid `pr-str`
+              ;; output, but keep the scanner total) — emit verbatim.
+              (recur (inc i) false false (conj! acc c)))
+
             (= c \")
             (recur (inc i) true false (conj! acc c))
 

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -217,30 +217,51 @@
 
 ;; ---- duplicate-id detection ----------------------------------------------
 
+(defn- wire-id
+  "The canonical WIRE id string for a boundary `:id` — `(str id)`, the
+  exact value stamped into `data-rf2-suspense-id` /
+  `data-rf2-suspense-hydrate` (and matched by the client). Duplicate
+  detection MUST key on this, not the raw `:id`, so ids that DIFFER as
+  values but COLLIDE under `str` (`:a` keyword vs `\":a\"` string) are
+  treated as the same boundary — the client can only match them by the
+  one wire string (rf2-yvc0t7)."
+  [id]
+  (str id))
+
 (defn- dedupe-continuations
-  "Per Spec 011 §Boundary nesting and recursion — duplicate `:id` is a
-  programmer error. Emit `:rf.error/suspense-boundary-duplicate-id` and
-  keep the LAST registration (matches the spec's wire shape: the second
-  registration overwrites the first; the earlier fallback placeholder
-  is left in place because the client never finds a matching resolved
-  chunk). Fail-soft."
+  "Per Spec 011 §Boundary nesting and recursion — a duplicate boundary id
+  is a programmer error. Emit `:rf.error/suspense-boundary-duplicate-id`
+  and keep the LAST registration (matches the spec's wire shape: the
+  second registration overwrites the first; the earlier fallback
+  placeholder is left in place because the client never finds a matching
+  resolved chunk). Fail-soft.
+
+  Duplicates are detected on the canonical WIRE id (`wire-id`, i.e.
+  `(str id)`) — the exact string stamped into the suspense attributes and
+  matched by the client (rf2-yvc0t7). Grouping on the raw `:id` would let
+  string-colliding ids (`:a` keyword vs `\":a\"` string) escape detection
+  even though they share one `data-rf2-suspense-id` on the wire, leaving
+  two chunks the client can only resolve against the same mount."
   [conts]
-  (let [by-id (group-by :id conts)
-        dupes (->> by-id (filter (fn [[_ vs]] (> (count vs) 1))) (map key))]
+  (let [by-wire (group-by (comp wire-id :id) conts)
+        dupes   (->> by-wire (filter (fn [[_ vs]] (> (count vs) 1))) (map key))]
     (when (seq dupes)
       (doseq [dup dupes]
-        (trace/emit-error! :rf.error/suspense-boundary-duplicate-id
-                           {:id       dup
-                            :count    (count (by-id dup))
-                            :recovery :last-write-wins})))
-    ;; Reduce preserving insertion order — keep the LAST registration
-    ;; for each id by walking forward and overwriting.
+        (let [group (by-wire dup)]
+          (trace/emit-error! :rf.error/suspense-boundary-duplicate-id
+                             {:id       dup
+                              :raw-ids  (mapv :id group)
+                              :count    (count group)
+                              :recovery :last-write-wins}))))
+    ;; Reduce preserving insertion order — keep the LAST registration for
+    ;; each WIRE id by walking forward and overwriting.
     (let [seen (volatile! #{})]
       (->> (reverse conts)
            (filter (fn [{:keys [id]}]
-                     (if (contains? @seen id)
-                       false
-                       (do (vswap! seen conj id) true))))
+                     (let [w (wire-id id)]
+                       (if (contains? @seen w)
+                         false
+                         (do (vswap! seen conj w) true)))))
            reverse
            vec))))
 

--- a/implementation/ssr/test/re_frame/ssr/hash_parity_fixtures.cljc
+++ b/implementation/ssr/test/re_frame/ssr/hash_parity_fixtures.cljc
@@ -243,8 +243,25 @@
               literal key order; both runtimes MUST produce the same
               canonical string and therefore the same hash."})
 
+(def str-colliding-keys-pair
+  {:label   "str-colliding-keys-order-independent"
+   ;; Both maps are Clojure-`=` (a keyword `:a` and a string `":a"`,
+   ;; each with the same value). They differ ONLY in construction order.
+   ;; `array-map` preserves insertion order on both runtimes, so the two
+   ;; inputs feed the canonicaliser in opposite orders.
+   :input-a (array-map :a 1 ":a" 2)
+   :input-b (array-map ":a" 2 :a 1)
+   :rationale "rf2-mff1ht — `(comp str key)` is NOT a total order: a
+              keyword `:a` and a string `\":a\"` both `str` to `\":a\"`,
+              so the old sort fell back to insertion order and the two
+              `=` maps canonicalised to different EDN (and hashed
+              differently). Sorting by the canonical-EDN of the key
+              (the keyword bare, the string quoted) is a total,
+              cross-runtime-stable order — both inputs MUST now hash
+              identically on JVM and CLJS."})
+
 (def equality-pairs
   "Input pairs whose hashes MUST agree (the agreed value isn't pinned
   to a specific literal here — see `nil-prune-pairs` for the variant
   that does pin a literal)."
-  [attr-key-order-pair])
+  [attr-key-order-pair str-colliding-keys-pair])

--- a/implementation/ssr/test/re_frame/ssr_hash_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hash_test.clj
@@ -91,6 +91,47 @@
            (hash/render-tree-hash [:div [:p "a"] [:p "b"]]))
         "interior nil child pruned")))
 
+;; ===========================================================================
+;; rf2-mff1ht — map ordering must be a TOTAL order (str-colliding keys)
+;;
+;; `append-map!` sorted entries by `(comp str key)`, which is NOT a total
+;; order: a keyword `:a` and a string `":a"` both `str` to `":a"`, so
+;; `sort-by` falls back to source iteration/insertion order. Two maps that
+;; are `=` in Clojure (`{:a 1 ":a" 2}`) could then canonicalise to
+;; different EDN strings and hash differently depending only on how the
+;; map was constructed — a false hydration mismatch. The fix sorts by the
+;; canonical-EDN form of the key (`:a` vs the quoted `":a"`), a total
+;; cross-runtime-stable order.
+;; ===========================================================================
+
+(deftest render-tree-hash-stable-for-str-colliding-keys
+  (testing "rf2-mff1ht: a map mixing a keyword `:a` and a string `\":a\"`
+            (whose `str` forms collide) hashes IDENTICALLY regardless of
+            insertion/construction order"
+    (let [a-first     (array-map :a 1 ":a" 2)
+          colon-first (array-map ":a" 2 :a 1)]
+      (is (= a-first colon-first)
+          "the two maps are Clojure-= (sanity: same logical map)")
+      (is (= (hash/render-tree-hash a-first)
+             (hash/render-tree-hash colon-first))
+          "render-tree-hash is insertion-order-independent for
+           str-colliding keys")
+      (is (= (hash/canonical-edn a-first)
+             (hash/canonical-edn colon-first))
+          "canonical EDN is byte-identical regardless of construction order"))
+
+    (testing "the canonical form distinguishes the two key shapes (the
+              keyword bare, the string quoted) so the order is total"
+      ;; The keyword sorts before the quoted string (`:` 0x3A < `\"` 0x22?
+      ;; no — `"` is 0x22, `:` is 0x3A, so the quoted string sorts first).
+      ;; We assert byte-equality across orders, not the absolute position.
+      (is (str/includes? (hash/canonical-edn (array-map :a 1 ":a" 2))
+                         "\":a\"")
+          "the string key keeps its quotes in canonical form")
+      (is (str/includes? (hash/canonical-edn (array-map :a 1 ":a" 2))
+                         ":a 1")
+          "the keyword key is bare in canonical form"))))
+
 (deftest render-tree-hash-prunes-nil-deeply
   (testing "pruning is recursive — nil-pruning applies at every level"
     (is (= (hash/render-tree-hash

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -2,11 +2,13 @@
   "Streaming SSR — `:rf/suspense-boundary` walker, continuation drain,
   failure semantics, per-subtree hydration delta. Per Spec 011 §Streaming
   SSR (rf2-ojakd / rf2-olb64 (a))."
-  (:require [clojure.string :as str]
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr :as ssr]
+            [re-frame.ssr.html-helpers :as html]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.streaming.constants :as wire]
             [re-frame.ssr.test-fixture :as tf]
@@ -223,6 +225,81 @@
                 @captured)
           ":rf.error/suspense-boundary-duplicate-id trace emitted"))))
 
+;; ===========================================================================
+;; rf2-yvc0t7 — duplicate detection keys on the WIRE id, not the raw :id
+;;
+;; Boundary ids are serialised to the wire as `(str id)` —
+;; `data-rf2-suspense-id` / `data-rf2-suspense-hydrate` — and the client
+;; matches mounts by that one string. The old `dedupe-continuations`
+;; grouped by the RAW `:id`, so two boundaries whose ids DIFFER as values
+;; but COLLIDE under `str` (a keyword `:a` and a string `":a"`) escaped
+;; detection: both stamped the same `data-rf2-suspense-id=":a"`, yet two
+;; continuations survived. The client could then materialise/resolve the
+;; wrong mount or skip the later chunk via its seen-set. The fix keys
+;; dedup on the canonical wire id `(str id)`.
+;; ===========================================================================
+
+(deftest duplicate-wire-id-collision-emits-trace-and-keeps-last
+  (testing "rf2-yvc0t7: two boundaries whose raw ids differ (`:a` keyword
+            vs `\":a\"` string) but whose WIRE ids collide under `str`
+            are detected as duplicates — one continuation survives
+            (last-write-wins), the trace fires, and both fallback
+            templates carry the same wire id attribute"
+    (let [tree [:div
+                [:rf/suspense-boundary {:id :a :fallback [:p "first"]} [:p "first body"]]
+                [:rf/suspense-boundary {:id ":a" :fallback [:p "second"]} [:p "second body"]]]
+          captured (atom [])
+          {:keys [continuations shell-html]}
+          (with-trace-capture captured #(streaming/render-shell tree))]
+      ;; The wire surface: both boundaries stamp the SAME wire id, so the
+      ;; client cannot tell them apart — the collision is real.
+      (is (= 2 (count (re-seq (re-pattern (str wire/attr-suspense-id "=\":a\""))
+                              shell-html)))
+          "both fallback templates stamp the same wire id `:a` — the
+           collision the client would face")
+      ;; The fix: dedup collapses the colliding ids to a single
+      ;; continuation (the old raw-:id grouping left two).
+      (is (= 1 (count continuations))
+          "only one continuation survives dedup on the wire id")
+      ;; Last-write-wins: the surviving entry is the SECOND (string `:a`)
+      ;; registration.
+      (is (= ":a" (:id (first continuations)))
+          "last-write-wins keeps the LAST registration (the string id)")
+      (is (= [:p "second"] (:fallback (first continuations)))
+          "the surviving entry carries the last registration's :fallback")
+      ;; The documented programmer-error trace fires.
+      (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                    (:operation %))
+                                @captured)]
+        (is (= 1 (count dup-traces))
+            ":rf.error/suspense-boundary-duplicate-id fires once for the
+             colliding pair")
+        (when-let [ev (first dup-traces)]
+          (is (= ":a" (get-in ev [:tags :id]))
+              "the trace reports the colliding WIRE id")
+          (is (= 2 (get-in ev [:tags :count]))
+              ":count reports the colliding cardinality")
+          (is (= [:a ":a"] (get-in ev [:tags :raw-ids]))
+              ":raw-ids surfaces the distinct raw ids that collided")
+          (is (= :last-write-wins (:recovery ev))
+              ":recovery names the applied policy"))))))
+
+(deftest distinct-wire-ids-are-not-deduped
+  (testing "rf2-yvc0t7 guard: boundaries with genuinely distinct wire ids
+            (the common keyword case) are NOT collapsed"
+    (let [tree [:div
+                [:rf/suspense-boundary {:id :a :fallback [:p "fa"]} [:p "ba"]]
+                [:rf/suspense-boundary {:id :b :fallback [:p "fb"]} [:p "bb"]]]
+          captured (atom [])
+          {:keys [continuations]}
+          (with-trace-capture captured #(streaming/render-shell tree))]
+      (is (= 2 (count continuations))
+          "distinct wire ids both survive — no false collapse")
+      (is (empty? (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                               (:operation %))
+                           @captured))
+          "no duplicate-id trace for distinct ids"))))
+
 (deftest build-final-payload-shape
   (testing "Final payload carries the canonical :rf/hydration-payload shape"
     (let [fid (make-frame {:db {:articles [{:id "a"}]}})
@@ -401,3 +478,66 @@
                           #":rf.error/ssr-edn-script-breakout"
                           (streaming/hydrate-delta-script
                             :boundary/x (pr-str {:k (symbol "a</script>b")}))))))
+
+;; ===========================================================================
+;; rf2-g15jtb — EDN char literals must not be mis-scanned as string state
+;;
+;; `escape-edn-script-body` scans the already-`pr-str`'d EDN document
+;; tracking string-literal context. An EDN CHARACTER LITERAL also opens
+;; with a backslash, so `(char 34)` prints as a backslash + a raw `"`
+;; byte (`\"`). The old scanner had no char-literal state: it read that
+;; raw `"` as the START of a string literal, flipping its in-string
+;; tracking out of phase. A later REAL string literal carrying `</script>`
+;; was then scanned in token position and rejected fail-loud with
+;; `:rf.error/ssr-edn-script-breakout` — a data-dependent false positive
+;; on otherwise-safe app-db data. The fix treats a token-position
+;; backslash as a char-literal introducer: it consumes the following
+;; payload char verbatim, so `\"` does not toggle string state.
+;; ===========================================================================
+
+(deftest escape-edn-script-body-handles-char-literals
+  (testing "rf2-g15jtb: a char literal for double-quote (`(char 34)` →
+            prints `\\\"`) does NOT toggle string state, so a later string
+            literal's `</script>` is escaped (not mis-read as a token
+            breakout); the body carries no literal `</script` and
+            round-trips through the EDN reader"
+    (let [value {:x (char 34) :y "</script>"}
+          edn-doc (pr-str value)
+          body  (html/escape-edn-script-body edn-doc)]
+      ;; The pre-fix behaviour THREW here; the fix must produce a body.
+      (is (string? body) "escaper returns a body (no false-positive throw)")
+      (is (not (str/includes? (str/lower-case body) "</script"))
+          "no literal </script breakout survives")
+      (is (= value (edn/read-string body))
+          "the EDN reader recovers the full value verbatim — char literal
+           and the (now-escaped) string both round-trip")))
+
+  (testing "rf2-g15jtb: char literals for the breakout chars themselves
+            (`<`, `/`) are single-char literals separated from neighbours
+            by pr-str, so they round-trip without a false breakout"
+    (doseq [v [(char 60) (char 47) (char 33)]]
+      (let [value {:c v :s "safe"}
+            body  (html/escape-edn-script-body (pr-str value))]
+        (is (= value (edn/read-string body))
+            (str "char literal " (pr-str v) " round-trips")))))
+
+  (testing "rf2-g15jtb: a genuine token-position breakout (a SYMBOL value
+            printing a literal `</`) still fails loud — the char-literal
+            relaxation does not weaken the breakout guard"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":rf.error/ssr-edn-script-breakout"
+                          (html/escape-edn-script-body
+                            (pr-str {:k (symbol "a</script>b")}))))))
+
+(deftest hydrate-delta-script-char-literal-round-trips
+  (testing "rf2-g15jtb: the streaming delta call site (`hydrate-delta-script`)
+            shares the fixed helper, so a delta whose value is a char
+            literal `(char 34)` alongside a string carrying `</script>`
+            emits cleanly and round-trips"
+    (let [delta  {:x (char 34) :y "</script>"}
+          script (streaming/hydrate-delta-script :boundary/x (pr-str delta))
+          body   (delta-script-body script)]
+      (is (not (str/includes? (str/lower-case body) "</script"))
+          "delta body carries no literal </script breakout")
+      (is (= delta (edn/read-string body))
+          "delta round-trips through the EDN reader verbatim"))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -1020,6 +1020,8 @@ Callers needing custom shell content under streaming use the split-envelope surf
 
 Edge case — the same `:id` appearing twice (e.g. a buggy author using `:id :news/comments` on two separate boundaries): the runtime emits `:rf.error/suspense-boundary-duplicate-id` (per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)) and the second registration overwrites the first in the drain queue. The wire ships only the last-registered continuation's chunk; the earlier `<template data-rf2-suspense-id="<id>" data-rf2-suspense-fallback="1">` placeholder is left in place (the client-side runtime never finds a matching resolved chunk and keeps the fallback rendered). Duplicate ids are a programmer error; the contract is fail-soft (no 500), with a visible trace.
 
+Duplicate detection is keyed on the **canonical wire id** — `(str id)`, the exact value stamped into `data-rf2-suspense-id` / `data-rf2-suspense-hydrate` and matched by the client — not the raw `:id` value. Two boundaries whose ids differ *as values* but collide under `str` (e.g. the keyword `:a` and the string `":a"`) therefore count as duplicates: they share one `data-rf2-suspense-id` on the wire, so the client cannot tell them apart, and shipping both chunks would let the client resolve the wrong mount or skip the later chunk via its seen-set. Keying detection on the wire id keeps the server's duplicate contract aligned with the one string the client actually matches against.
+
 #### Late-bind hook surface
 
 The streaming surface composes from three late-bind hooks (per [Conventions §Late-bind hook key grammar](Conventions.md#late-bind-hook-key-grammar)):


### PR DESCRIPTION
Fixes three SSR defects clustered on the SSR surface (tracking bead rf2-071zlb). Each reproduced with a red test on the actual SSR path, fixed, with the green test kept as the regression guard. Distinct from the recently-merged final-hash fix (#4443).

## rf2-g15jtb — EDN script escaper mis-handles character literals
`escape-edn-script-body` scans the `pr-str`'d EDN document tracking string-literal context but had no char-literal state. An EDN character literal opens with a backslash, so `(char 34)` prints as `\` + a raw `"` byte — the scanner read that `"` as a string opener, flipping its in-string tracking out of phase, then rejected a later real string literal's `</script>` as a token-position breakout (`:rf.error/ssr-edn-script-breakout` false positive on otherwise-safe app-db data).

**Fix:** treat a token-position backslash as a char-literal introducer — consume the following payload char verbatim so `\"` no longer toggles string state. Genuine token-position breakouts (a symbol value `a</script>b`) still fail loud.

## rf2-mff1ht — render-tree hash map ordering unstable for str-colliding keys
`append-map!` sorted entries by `(comp str key)`, which is not a total order: a keyword `:a` and a string `":a"` both `str` to `":a"`, so `sort-by` fell back to insertion order and two `=` maps could canonicalise to different EDN (and hash differently) by construction order.

**Fix:** sort by the canonical-EDN form of the key (bare keyword vs quoted string) — a total, cross-runtime-stable order. Keyword-only ordering and every parity fixture stay byte-identical (verified against the full JVM+CLJS parity corpus).

## rf2-yvc0t7 — streaming duplicate detection ignores wire-id collisions
Boundary ids serialise to the wire as `(str id)` (`data-rf2-suspense-id`), but `dedupe-continuations` grouped by the raw `:id`. A keyword `:a` and a string `":a"` shared one `data-rf2-suspense-id` yet escaped detection, shipping two chunks the client can only match to one mount.

**Fix:** key dedup on the canonical wire id `(str id)` so colliding ids collapse to the last registration and emit `:rf.error/suspense-boundary-duplicate-id`.

## Tests / gates
- red→green regressions for all three (char-literal round-trip + symbol-breakout-still-loud; str-colliding-keys hash parity on JVM **and** CLJS via the shared fixtures ns; wire-id-collision dedup + distinct-id no-false-collapse guard)
- SSR JVM `clojure -M:test`: 352 tests, 0 failures
- ssr-ring JVM `clojure -M:test`: 167 tests, 0 failures
- `npm run test:cljs`: 7650 tests, 0 failures
- `scripts/test-fast-pr.sh` (incl. `--with-docs`): PASS
- Spec 011 §Boundary nesting clarified to key duplicate detection on the wire id