### PR TITLE
docs(examples): refresh _shared Reagent Slim substrate wording (rf2-1vvzrd, rf2-5tlbid)

### DIFF
--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -1,7 +1,8 @@
 # `examples/_shared/` — shared examples design system
 
 Shared stylesheet, favicon, and Open Graph imagery consumed by every
-example `index.html` across all three substrates (Reagent / UIx / Helix).
+example `index.html` across every example substrate (Reagent, Reagent
+Slim, UIx, Helix).
 The smoke orchestrator
 (`examples/scripts/serve-and-run-examples-tests.cjs`) stages this whole
 tree into each staged surface's output dir — for the adapter testbeds it

--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -3,7 +3,7 @@
  *
  * The classes here are layout-only (display/flex/grid, padding,
  * max-widths, grid-template-columns); typography + palette + atmosphere
- * live in style.css (one shared identity across all three substrates)
+ * live in style.css (one shared identity across every example substrate)
  * which @imports this file.
  * ========================================================================== */
 

--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -1,6 +1,7 @@
 /* ============================================================================
- * Shared examples design system — one identity across all three substrates
- * (Reagent / UIx / Helix). Substrate variety is communicated by the
+ * Shared examples design system — one identity across every example
+ * substrate (Reagent, Reagent Slim, UIx, Helix). Substrate variety is
+ * communicated by the
  * substrate selector + the per-substrate examples themselves — NOT via
  * visual identity.
  *

--- a/examples/_shared/img/favicon.svg
+++ b/examples/_shared/img/favicon.svg
@@ -3,9 +3,9 @@
   re-frame2 examples favicon.
 
   A 32x32 monogram: stylised "r2" glyph on a dark surface, with an amber
-  accent stroke under the descender. One favicon shared across all three
-  substrates (Reagent / UIx / Helix) — substrate variety is not
-  communicated via visual identity.
+  accent stroke under the descender. One favicon shared across every
+  example substrate (Reagent, Reagent Slim, UIx, Helix) — substrate
+  variety is not communicated via visual identity.
 
   Accent: #C8741A (matches --ex-accent in examples/_shared/css/style.css).
 -->


### PR DESCRIPTION
## What

The `examples/_shared` design-system surface still described its shared assets as covering "all three substrates (Reagent / UIx / Helix)". The examples tree and the adapter public surface now include **Reagent Slim** as a distinct substrate/adapter (`examples/reagent-slim/`, `:rf.adapter/reagent-slim`), so the exhaustive three-substrate phrasing was stale and could mislead example authors into excluding `examples/reagent-slim` from the shared design/asset contract.

## Change

Wording-only refresh across the four shared-surface comment sites so they name every example substrate (Reagent, Reagent Slim, UIx, Helix) rather than enumerating three:

- `examples/_shared/README.md` — header intro line
- `examples/_shared/css/style.css` — design-system header comment
- `examples/_shared/css/structure.css` — structural-baseline header comment
- `examples/_shared/img/favicon.svg` — source-art comment

No visual identity, asset paths, or staging behaviour change; no new shared assets or per-substrate visual divergence introduced.

## Gates

- `node examples/scripts/check-examples-assets.cjs` — GREEN (33 pages resolve assets; shared contract intact). This is the acceptance-criterion gate.
- reagent-slim smoke policy + all script-policy / script-helper gates — passed.
- Markdown link/anchor gates ran (diff touches a `.md`) and passed.
- The local `test:cljs` surface could not run in the fresh worktree (`shadow-cljs` binary absent — npm deps not installed); a comment-only edit to README/CSS/SVG cannot affect the CLJS suite, and CI runs it on this PR.

Closes the `examples-shared` substrate-wording drift tracked by rf2-5tlbid (and its duplicate rf2-1vvzrd).
