### PR TITLE
fix(routing): EP-0017 scroll/history fx + route-miss diagnostics + allocation cofx (rf2-1wmni6, rf2-jfaucw, rf2-n1f4rh, rf2-pbbo68, rf2-ps05ug)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -236,8 +236,23 @@
 (events/reg-event :rf/url-requested
                      url-requested-meta
                      can-leave/url-requested-handler)
+;; EP-0015 (rf2-jfaucw): the runtime dispatches `[:rf.route/navigation-blocked
+;; pending-nav]` on every block, carrying the pending-nav map as the event
+;; arg. That map carries route CARRIERS — `:requested-url` (a target URL with
+;; potential `?token=…` / `#access_token=…`) and `:requested-by-event` (the
+;; full original nav event vector, whose args can carry params/query secrets).
+;; The dispatched-event TRACE (`:rf.event/dispatched` `:rf.event/v`, and the
+;; bare `:event` slot on any error trace) is an egress surface the
+;; per-registration marks chokepoint walks: declare those two carrier slots
+;; `:sensitive` (paths rooted at the arg-map — the pending-nav map) so
+;; `re-frame.marks/project-event-tags` redacts them to `:rf/redacted` on the
+;; trace egress copy. The handler / pending-nav sub still see the raw map
+;; in-process (marks touch only the trace tags), so continue/cancel resume
+;; behaviour is unaffected; the durable runtime-db slot's off-box epoch egress
+;; is already fail-closed by the redact-whole-runtime-db default (ruling #14).
 (events/reg-event :rf.route/navigation-blocked
-                     framework-authority-meta
+                     (assoc framework-authority-meta
+                            :sensitive [[:requested-url] [:requested-by-event]])
                      can-leave/navigation-blocked-handler)
 (events/reg-event :rf.route/continue
                      framework-authority-meta

--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -26,6 +26,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
+            [re-frame.routing.egress :as egress]
             [re-frame.routing.registry :as registry]
             [re-frame.routing.url :as url]
             [re-frame.trace :as trace]))
@@ -206,11 +207,25 @@
         ;; emitting frame's epoch + obeys the frame trace-disable gate — in
         ;; a multi-frame app a block can otherwise not be filtered to the
         ;; frame that caused it.
+        ;; EP-0015 (rf2-jfaucw): the blocked-navigation diagnostic trace
+        ;; carries the raw `:requested-url` under a custom slot the
+        ;; per-registration marks chokepoint does not walk. A blocked target
+        ;; URL can carry query/fragment carriers (`?token=…`,
+        ;; `#access_token=…`), and this trace is a framework-shaped
+        ;; observation record (epoch / Xray / MCP / log egress). Redact the
+        ;; query/fragment carrier VALUES (keep the path) before the trace
+        ;; crosses the egress boundary. The DURABLE pending-nav slot below
+        ;; keeps the raw `:requested-url` — `continue-handler` re-dispatches
+        ;; it to resume the navigation — and its off-box epoch egress is
+        ;; already fail-closed by the redact-whole-runtime-db default
+        ;; (EP-0001 ruling #14); only this trace slot needed projection.
         (trace/emit! :rf.event :rf.route/navigation-blocked
-                     (cond-> {:requested-url   requested-url
-                              :rejecting-route (:route-id current-route)
-                              :rejecting-guard guard-id}
-                       frame-id (assoc :frame frame-id)))
+                     (egress/redact-url-tag
+                       (cond-> {:requested-url   requested-url
+                                :rejecting-route (:route-id current-route)
+                                :rejecting-guard guard-id}
+                         frame-id (assoc :frame frame-id))
+                       :requested-url))
         ;; Per Spec 012 §Navigation blocking §Default flow step 4d and the
         ;; Events table: `:rf.route/navigation-blocked` is a USER event the
         ;; runtime dispatches when a `:can-leave` guard rejects — apps may

--- a/implementation/routing/src/re_frame/routing/egress.cljc
+++ b/implementation/routing/src/re_frame/routing/egress.cljc
@@ -1,0 +1,105 @@
+(ns re-frame.routing.egress
+  "Routing-owned URL-carrier EGRESS scrub (EP-0015 / Spec 015) for the
+  diagnostic trace slots the per-registration marks chokepoint cannot reach.
+
+  EP-0015 treats trace/tool/log/epoch records as egress surfaces and requires
+  off-box defaults to FAIL CLOSED. The framework's marks chokepoint
+  (`re-frame.marks/project-trace-event` via `re-frame.trace/build-event`)
+  already projects the KNOWN trace slots — `:rf.fx/args` against fx marks,
+  the dispatched-event vector against event marks, etc. — so the routing fx
+  (`:rf.nav/scroll`, `:rf.nav/capture-scroll`, `:rf.nav/push-url`,
+  `:rf.nav/replace-url`) and the dispatched `:rf.route/navigation-blocked`
+  event payload are covered by declaring `:sensitive` marks on their
+  registrations (rf2-1wmni6 / rf2-pbbo68 / rf2-jfaucw).
+
+  But routing also emits a few DIAGNOSTIC traces whose carrier rides a
+  CUSTOM tag slot the marks chokepoint does not walk:
+
+    - `:rf.warning/malformed-url` / `:rf.error/no-such-handler` carry the
+      requested URL under a bare `:url` slot (rf2-n1f4rh). These are the
+      route-MISS / malformed-URL diagnostics — there is NO matched route, so
+      NO `:params` / `:query` schema to consult, yet an unmatched / malformed
+      URL is the class most likely to carry secret material (`?token=…`,
+      `?code=…`, `#access_token=…`) and `:rf.error/no-such-handler` is a
+      production-survivable / off-box-observable error category EP-0015
+      requires to fail closed.
+    - `:rf.route/navigation-blocked` (the trace, distinct from the dispatched
+      event) carries `:requested-url` under a custom slot (rf2-jfaucw).
+
+  This namespace owns the ONE URL-carrier redactor those emit sites route
+  their URL slot through — keeping the structured PATH (the reason an app
+  error handler / SSR projection needs to branch on) and redacting the
+  query-string and `#fragment` carrier VALUES by default. It is the
+  no-schema egress analogue of the schema-driven
+  `re-frame.routing.navigate/redact-route-error-tags` (rf2-zsm03).
+
+  Internal namespace; the public facade is `re-frame.routing`. Per the
+  rf2-2yabr cohesion split: EGRESS-SCRUB seam."
+  (:require [clojure.string :as str]
+            [re-frame.privacy :as privacy]))
+
+(def ^:private sentinel-str
+  "The `:rf/redacted` sentinel as a plain string, for substitution INSIDE a
+  URL string (a keyword sentinel cannot live inside a URL)."
+  (subs (str privacy/redacted-sentinel) 1))   ;; ":rf/redacted" → "rf/redacted"
+
+(defn redact-url-carriers
+  "Project a raw URL string for off-box / log / tool egress on the
+  NO-SCHEMA route-miss / blocked-navigation diagnostic path (rf2-n1f4rh /
+  rf2-jfaucw): keep the PATH and redact the query-string and `#fragment`
+  carrier VALUES.
+
+  An unmatched / malformed / blocked URL has no matched route → no
+  `:params` / `:query` schema to path-target, yet it is the URL class most
+  likely to carry the secret material EP-0015 fails closed on. We apply the
+  blanket carrier policy: redact query/hash VALUES by default.
+
+  - Query KEYS are PRESERVED (they name the shape, not the secret — a
+    security dashboard still sees `token` / `code` were present) and each
+    VALUE is replaced with the `rf/redacted` sentinel; a value-less flag key
+    is left as-is.
+  - The whole `#fragment` is redacted (it is opaque — could be a path, an
+    OAuth implicit-grant token, anything).
+  - A URL with NEITHER query nor fragment rides back verbatim (a bare
+    `/admin/users/42` path is not a carrier this policy targets — the path
+    rarely carries a secret and apps key error UIs off it).
+
+  Pure / host-symmetric — string surgery only, no percent-decode (a
+  malformed URL must not throw here). A non-string input rides back
+  unchanged (nil-safe)."
+  [url]
+  (if-not (string? url)
+    url
+    (let [hash-idx    (.indexOf #?(:clj ^String url :cljs ^string url) "#")
+          has-frag?   (not (neg? hash-idx))
+          url-no-frag (if has-frag? (subs url 0 hash-idx) url)
+          q-idx       (.indexOf #?(:clj ^String url-no-frag :cljs ^string url-no-frag) "?")
+          has-query?  (not (neg? q-idx))]
+      (if-not (or has-query? has-frag?)
+        url                                              ;; bare path — nothing to scrub
+        (let [path  (if has-query? (subs url-no-frag 0 q-idx) url-no-frag)
+              query (when has-query? (subs url-no-frag (inc q-idx)))
+              query' (when query
+                       (->> (str/split query #"&")
+                            (map (fn [pair]
+                                   (let [eq (.indexOf #?(:clj ^String pair :cljs ^string pair) "=")]
+                                     (if (neg? eq)
+                                       pair               ;; value-less flag key
+                                       (str (subs pair 0 (inc eq)) sentinel-str)))))
+                            (str/join "&")))]
+          (cond-> path
+            has-query? (str "?" query')
+            has-frag?  (str "#" sentinel-str)))))))
+
+(defn redact-url-tag
+  "Redact the carrier VALUES of the URL under `slot` in a diagnostic
+  `tags` map (default `:url`), via `redact-url-carriers`. A no-op when the
+  slot is absent. Used by the route-miss telemetry intents
+  (`:rf.warning/malformed-url` / `:rf.error/no-such-handler`, `:url` slot)
+  and the `:rf.route/navigation-blocked` trace (`:requested-url` slot)
+  before they cross the trace bus / Xray / MCP / log egress boundary."
+  ([tags] (redact-url-tag tags :url))
+  ([tags slot]
+   (if (contains? tags slot)
+     (update tags slot redact-url-carriers)
+     tags)))

--- a/implementation/routing/src/re_frame/routing/nav_counters.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_counters.cljc
@@ -199,8 +199,19 @@
 
 (def nav-allocation-cofx-meta
   "Metadata for the `:rf.route/nav-allocation` cofx registration: a
-  RECORDABLE generator-backed allocation of a fresh nav-token (rf2-vcop6y)."
+  RECORDABLE generator-backed allocation of a fresh nav-token (rf2-vcop6y).
+
+  Carries a `:schema` (rf2-ps05ug, EP-0017 §5): the generator produces
+  `{:token \"nav-N\" :counter N}` and the commit handler folds `:token`
+  into the durable route slice + rides `:counter` on the host high-water
+  bump fx, so a supplied/replayed value MUST be shape-validated. Without
+  the schema, `validate-recordable-value!` is a no-op and a malformed-but-
+  present replayed fact (e.g. `{:token nil :counter \"bad\"}`) is delivered
+  as trusted — a nil/wrong nav-token then corrupts stale-suppression and
+  the host counter bump silently no-ops. The schema makes such a fact fail
+  loudly with `:rf.error/cofx-value-invalid` BEFORE it reaches the handler."
   {:recordable? true
+   :schema [:map [:token :string] [:counter :int]]
    :doc "A fresh nav-token allocation `{:token \"nav-N\" :counter N}`,
 minted at processing-start from the active frame's host nav-token
 high-water mark and RECORDED onto the causal token (EP-0017 recordable
@@ -229,8 +240,19 @@ Recorded so record+replay re-presents the same nav-token verbatim
   "Metadata for the `:rf.route/pending-nav-allocation` cofx registration: a
   RECORDABLE generator-backed allocation of a fresh pending-nav id
   (rf2-vcop6y). A DISTINCT allocator from `:rf.route/nav-allocation`
-  (rf2-oosjmh)."
+  (rf2-oosjmh).
+
+  Carries a `:schema` (rf2-ps05ug, EP-0017 §5): the generator produces
+  `{:id \"pn-N\" :counter N}` and the can-leave block handler folds `:id`
+  into the durable pending-navigation slot + rides `:counter` on the host
+  high-water bump fx, so a supplied/replayed value MUST be shape-validated.
+  Without the schema, a malformed-but-present replayed fact (e.g.
+  `{:id nil :counter nil}`) is delivered as trusted — a nil pending-nav id
+  then makes a recorded `[:rf.route/continue \"pn-N\"]` no-op (the
+  navigation stays blocked forever). The schema makes such a fact fail
+  loudly with `:rf.error/cofx-value-invalid` BEFORE it reaches the handler."
   {:recordable? true
+   :schema [:map [:id :string] [:counter :int]]
    :doc "A fresh pending-navigation id allocation `{:id \"pn-N\" :counter N}`,
 minted at processing-start from the active frame's host pending-nav
 high-water mark and RECORDED onto the causal token (EP-0017 recordable

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -218,8 +218,18 @@
 
 (def push-url-meta
   "Metadata for the `:rf.nav/push-url` fx registration. Spec 012
-  §Multi-frame routing (rf2-w50qm)."
+  §Multi-frame routing (rf2-w50qm).
+
+  EP-0015 (rf2-1wmni6 / rf2-pbbo68 — the history half of the scroll/history
+  fx pair): the arg is a full app URL string whose query/fragment are
+  carrier-shaped (`?token=…`, `#access_token=…`). The core fx trace records
+  `:rf.fx/args` verbatim onto `:rf.fx/handled`, so the URL would reach the
+  trace bus / Xray / MCP / epoch egress raw. The whole-value `:sensitive`
+  mark `[[]]` redacts the URL arg to `:rf/redacted` on the EGRESS copy — the
+  handler still pushes the real URL in-process (the projection touches only
+  the trace tags, never the handler input)."
   {:platforms #{:client}
+   :sensitive [[]]
    :doc       "Push the URL to the browser history (HTML5 pushState).
 Honours the calling frame's `:url-bound?` metadata: non-URL-bound frames
 no-op the fx so they don't race with the URL-owning frame (per Spec 012
@@ -247,8 +257,15 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
 
 (def replace-url-meta
   "Metadata for the `:rf.nav/replace-url` fx registration. Spec 012
-  §Multi-frame routing (rf2-w50qm)."
+  §Multi-frame routing (rf2-w50qm).
+
+  EP-0015 (rf2-1wmni6 / rf2-pbbo68): same carrier-shaped URL arg as
+  `:rf.nav/push-url` — the blocked-popstate restore URL flows through this
+  fx, so it can carry the rejecting route's query/fragment carriers. The
+  whole-value `:sensitive` mark `[[]]` redacts it on the trace EGRESS copy
+  while the handler still replaces the real URL in-process."
   {:platforms #{:client}
+   :sensitive [[]]
    :doc       "Replace the URL in the browser history (HTML5 replaceState).
 Honours the calling frame's `:url-bound?` metadata: non-URL-bound frames
 no-op the fx so they don't race with the URL-owning frame (per Spec 012

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -220,16 +220,20 @@
   "Metadata for the `:rf.nav/push-url` fx registration. Spec 012
   §Multi-frame routing (rf2-w50qm).
 
-  EP-0015 (rf2-1wmni6 / rf2-pbbo68 — the history half of the scroll/history
-  fx pair): the arg is a full app URL string whose query/fragment are
-  carrier-shaped (`?token=…`, `#access_token=…`). The core fx trace records
-  `:rf.fx/args` verbatim onto `:rf.fx/handled`, so the URL would reach the
-  trace bus / Xray / MCP / epoch egress raw. The whole-value `:sensitive`
-  mark `[[]]` redacts the URL arg to `:rf/redacted` on the EGRESS copy — the
-  handler still pushes the real URL in-process (the projection touches only
-  the trace tags, never the handler input)."
+  EP-0015 note (rf2-1wmni6 / rf2-pbbo68): the arg is a full app URL string.
+  We deliberately DO NOT mark it `:sensitive` — unlike the scroll fx (whose
+  `:from`/`:to` descriptors are purely DIAGNOSTIC carriers the handler
+  ignores), the pushed URL IS the navigation's behavioural identity: the
+  Spec 012 `:effects-routed` conformance contract (and the epoch `:effects`
+  projection, both derived from `:rf.fx/handled`'s `:rf.fx/args`) assert that
+  `:rf.nav/push-url` routes the ACTUAL same-origin URL — which the
+  open-redirect gate (`url/safe-in-app-url?`) has already cleared. A blanket
+  redaction of every pushed URL would over-reach (a bare `/cart` path is not
+  a carrier) AND break that behavioural surface. The carrier-bearing URL
+  classes EP-0015 actually targets — the route-MISS / malformed / blocked
+  URLs — are scrubbed at their diagnostic emit sites via
+  `re-frame.routing.egress/redact-url-carriers` (rf2-n1f4rh / rf2-jfaucw)."
   {:platforms #{:client}
-   :sensitive [[]]
    :doc       "Push the URL to the browser history (HTML5 pushState).
 Honours the calling frame's `:url-bound?` metadata: non-URL-bound frames
 no-op the fx so they don't race with the URL-owning frame (per Spec 012
@@ -259,13 +263,13 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
   "Metadata for the `:rf.nav/replace-url` fx registration. Spec 012
   §Multi-frame routing (rf2-w50qm).
 
-  EP-0015 (rf2-1wmni6 / rf2-pbbo68): same carrier-shaped URL arg as
-  `:rf.nav/push-url` — the blocked-popstate restore URL flows through this
-  fx, so it can carry the rejecting route's query/fragment carriers. The
-  whole-value `:sensitive` mark `[[]]` redacts it on the trace EGRESS copy
-  while the handler still replaces the real URL in-process."
+  EP-0015 note (rf2-1wmni6 / rf2-pbbo68): same behavioural-identity URL arg
+  as `:rf.nav/push-url` — deliberately NOT marked `:sensitive` for the same
+  reason (the `:effects-routed` contract asserts the real routed URL, the
+  open-redirect gate already cleared it, and a blanket redaction over-reaches
+  bare paths). Carrier-bearing route-miss / blocked URLs are scrubbed at
+  their diagnostic emit sites (`egress/redact-url-carriers`)."
   {:platforms #{:client}
-   :sensitive [[]]
    :doc       "Replace the URL in the browser history (HTML5 replaceState).
 Honours the calling frame's `:url-bound?` metadata: non-URL-bound frames
 no-op the fx so they don't race with the URL-owning frame (per Spec 012

--- a/implementation/routing/src/re_frame/routing/plan.cljc
+++ b/implementation/routing/src/re_frame/routing/plan.cljc
@@ -29,7 +29,8 @@
 
   Internal namespace; the public facade is `re-frame.routing`. Per the
   rf2-2yabr cohesion split convention: NAVIGATION-PLAN seam."
-  (:require [re-frame.routing.events :as routing-events]
+  (:require [re-frame.routing.egress :as egress]
+            [re-frame.routing.events :as routing-events]
             [re-frame.routing.scroll :as scroll]
             [re-frame.trace :as trace]))
 
@@ -184,7 +185,18 @@
 
   Each intent is `[:emit level op tags]`."
   [{:keys [throw-reason malformed? no-not-found? url frame]}]
-  (let [tag (fn [base] (cond-> base frame (assoc :frame frame)))]
+  (let [;; EP-0015 (rf2-n1f4rh): these are route-MISS / malformed-URL
+        ;; diagnostics — there is NO matched route and therefore NO
+        ;; `:params` / `:query` schema to consult, yet the requested URL is
+        ;; the class most likely to carry secret material (`?token=…`,
+        ;; `?code=…`, `#access_token=…`). Redact the query/fragment carrier
+        ;; VALUES (keeping the structured path) BEFORE the warning crosses
+        ;; the trace bus / Xray / MCP / log / SSR-projection egress boundary.
+        ;; Default-on scrub (no schema to target) — the no-schema analogue of
+        ;; `navigate/redact-route-error-tags`.
+        tag (fn [base] (-> base
+                           (cond-> frame (assoc :frame frame))
+                           egress/redact-url-tag))]
     (cond-> []
       throw-reason
       (conj [:emit :warning :rf.warning/malformed-url

--- a/implementation/routing/src/re_frame/routing/scroll.cljc
+++ b/implementation/routing/src/re_frame/routing/scroll.cljc
@@ -203,8 +203,21 @@
     [:rf.nav/capture-scroll {:url url}]))
 
 (def capture-scroll-meta
-  "Metadata for the `:rf.nav/capture-scroll` fx registration."
+  "Metadata for the `:rf.nav/capture-scroll` fx registration.
+
+  EP-0015 (rf2-1wmni6 / rf2-pbbo68): the args carry `{:url ...}` — a
+  reconstructed route URL whose query/fragment are carrier-shaped values
+  (`?token=…`, `#access_token=…`). The core fx trace surface records
+  `:rf.fx/args` verbatim onto `:rf.fx/handled` (and the JVM
+  `:rf.fx/skipped-on-platform` branch echoes `:url`), so the URL would
+  otherwise reach the trace bus / Xray / MCP / epoch egress raw. The
+  `:sensitive` path-mark declares `[:url]` so the marks chokepoint
+  (`re-frame.marks/project-trace-event` via `re-frame.trace/build-event`)
+  redacts it to `:rf/redacted` on the EGRESS copy — the handler still
+  receives the real URL in-process (the projection touches only the trace
+  tags, never the handler input), so scroll capture keeps working."
   {:platforms #{:client}
+   :sensitive [[:url]]
    :doc       "Capture the current browser scroll position into the
 host-side per-frame transient scroll-position cache (keyed by url)
 before leaving a route. The cache is NOT runtime-db state and does not
@@ -237,8 +250,31 @@ egress to trace / epochs / SSR (rf2-1hncp2)."})
                   {:rf.fx/id :rf.nav/capture-scroll :url url})))
 
 (def scroll-fx-meta
-  "Metadata for the `:rf.nav/scroll` fx registration."
+  "Metadata for the `:rf.nav/scroll` fx registration.
+
+  EP-0015 (rf2-1wmni6 / rf2-pbbo68): the args carry `:from` / `:to` route
+  DESCRIPTORS (each `{:id :params :query}`) and a `:fragment` — all
+  carrier-shaped (route params can be document-ids / tokens; a `#fragment`
+  can be an OAuth implicit-grant token). The core fx trace records
+  `:rf.fx/args` verbatim onto `:rf.fx/handled`, so these would reach the
+  trace bus / Xray / MCP / epoch egress raw. The `:sensitive` path-marks
+  declare `[:from :params]` / `[:from :query]` / `[:to :params]` /
+  `[:to :query]` / `[:fragment]` so the marks chokepoint redacts them to
+  `:rf/redacted` on the EGRESS copy. This is invisible to the handler:
+  `scroll-fx-handler` reads ONLY `:strategy` / `:saved-pos` / `:fragment`
+  and never touches `:from` / `:to`, and the marks projection runs in
+  `build-event` on the trace tags AFTER the handler already received the
+  real args — so scroll restoration / fragment scrolling are unaffected.
+  The route `:id` keyword is kept (it names the shape, carries no secret).
+  Marks are unconditional path declarations (the canonical EP-0015 fx-args
+  mechanism) — route params/query/fragment are always carrier-shaped, so a
+  blanket trace scrub of those slots is the correct posture rather than a
+  per-route schema decision (which the fx layer cannot make — it does not
+  carry the matched route's schema)."
   {:platforms #{:client}
+   :sensitive [[:from :params] [:from :query]
+               [:to :params]   [:to :query]
+               [:fragment]]
    :doc       "Per Spec 012 §Scroll restoration. Args: {:strategy :from
 :to :saved-pos :fragment}. Standard strategies are :top, :restore,
 :preserve. Map-form strategies are host-extensible; the runtime treats

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -18,6 +18,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.routing.can-leave :as can-leave]
+            [re-frame.routing.egress :as egress]
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.plan :as plan]
             [re-frame.routing.registry :as registry]
@@ -228,12 +229,22 @@
             ;; error-projection listener attribute the trace per-frame.
             fallback?
             (conj [:emit-error :rf.error/no-such-handler
-                   (cond-> {:url url
-                            :kind :route
-                            :recovery :replaced-with-default}
-                     frame        (assoc :frame frame)
-                     throw-reason (assoc :reason throw-reason)
-                     malformed?   (assoc :reason :malformed-url))])))
+                   ;; EP-0015 (rf2-n1f4rh): `:rf.error/no-such-handler` is a
+                   ;; production-survivable / off-box-observable error
+                   ;; category EP-0015 requires to FAIL CLOSED. The route-miss
+                   ;; URL has no matched route → no schema to consult, and is
+                   ;; the class most likely to carry secret carriers
+                   ;; (`?token=…`, `#access_token=…`). Redact the query/
+                   ;; fragment carrier VALUES (keep the structured path +
+                   ;; `:reason`) before the error crosses the trace / log /
+                   ;; SSR-projection egress boundary.
+                   (-> (cond-> {:url url
+                                :kind :route
+                                :recovery :replaced-with-default}
+                         frame        (assoc :frame frame)
+                         throw-reason (assoc :reason throw-reason)
+                         malformed?   (assoc :reason :malformed-url))
+                       egress/redact-url-tag)])))
         ;; rf2-g8tzb / commit-navigation: nav-token alloc, the
         ;; allocated/activation traces, the slice publish (targeting
         ;; `:current`, so sibling routing-runtime keys are untouched),

--- a/implementation/routing/test/re_frame/routing_egress_test.clj
+++ b/implementation/routing/test/re_frame/routing_egress_test.clj
@@ -162,25 +162,25 @@
       (is (= "section-3" (:fragment @seen))
           "the handler receives the RAW :fragment (scrolling needs it)"))))
 
-(deftest push-url-handled-trace-redacts-url-arg
-  (testing "rf2-1wmni6/rf2-pbbo68: :rf.nav/push-url's :rf.fx/handled trace
-            redacts the whole URL arg (carrier-shaped), handler unaffected"
+(deftest push-url-not-marked-routes-real-url
+  (testing "rf2-1wmni6/rf2-pbbo68: :rf.nav/push-url is deliberately NOT
+            `:sensitive` — the pushed URL is the navigation's behavioural
+            identity (the open-redirect gate already cleared it), and the
+            `:effects-routed` conformance contract + epoch :effects projection
+            assert the ACTUAL routed URL. Carrier-bearing route-miss / blocked
+            URLs are scrubbed at their diagnostic emit sites instead, so
+            push-url's :rf.fx/handled trace shows the real same-origin URL."
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
-    (let [seen (atom nil)]
-      (reg-jvm-fx! :rf.nav/scroll   scroll/scroll-fx-meta (fn [_ _] nil))
-      (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta
-                   (fn [_ url] (reset! seen url)))
-      (let [args (handled-trace-for
-                   :rf.nav/push-url
-                   [:rf/url-requested {:url "/articles/secret-doc"}])]
-        ;; The trace egress copy is the whole-value sentinel.
-        (is (= privacy/redacted-sentinel args)
-            "the push-url URL arg is redacted on the :rf.fx/handled trace")
-        ;; The handler still pushed the real URL in-process.
-        (is (string? @seen) "the handler received the raw URL string")
-        (is (re-find #"secret-doc" @seen)
-            "the in-process handler URL is NOT redacted")))))
+    (reg-jvm-fx! :rf.nav/scroll   scroll/scroll-fx-meta (fn [_ _] nil))
+    (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta  (fn [_ _] nil))
+    (let [args (handled-trace-for
+                 :rf.nav/push-url
+                 [:rf/url-requested {:url "/articles/intro"}])]
+      ;; A normal same-origin app URL rides verbatim on the trace (behavioural
+      ;; identity, not a redacted carrier) — push-url carries no :sensitive mark.
+      (is (= "/articles/intro" args)
+          "the push-url URL routes/traces the real same-origin URL"))))
 
 ;; ===========================================================================
 ;; rf2-n1f4rh — route-miss diagnostics redact the raw requested URL.

--- a/implementation/routing/test/re_frame/routing_egress_test.clj
+++ b/implementation/routing/test/re_frame/routing_egress_test.clj
@@ -1,0 +1,302 @@
+(ns re-frame.routing-egress-test
+  "EP-0015 (Spec 015 §Registration-owned transient classification) routing
+  egress-projection regressions.
+
+  Three findings from the EP-0015 review wave, all on the routing surface:
+
+    - rf2-1wmni6 / rf2-pbbo68 — the scroll/history fx (`:rf.nav/scroll`,
+      `:rf.nav/capture-scroll`, `:rf.nav/push-url`, `:rf.nav/replace-url`)
+      build args carrying raw route params/query/fragment/URLs, and the core
+      fx trace records `:rf.fx/args` verbatim onto `:rf.fx/handled`. Fixed by
+      `:sensitive` path-marks on the fx registrations so the marks chokepoint
+      redacts the carrier slots on the trace egress copy (handler input
+      unaffected).
+    - rf2-n1f4rh — the route-miss diagnostics (`:rf.warning/malformed-url`,
+      `:rf.error/no-such-handler`) emit the raw requested URL under a custom
+      `:url` slot the marks chokepoint does not walk. Fixed by a default-on
+      URL-carrier scrub (`re-frame.routing.egress/redact-url-carriers`) at the
+      emit site — no schema to consult on a route miss, so query/fragment
+      values are redacted by default.
+    - rf2-jfaucw — the blocked-navigation record keeps raw route carriers:
+      the `:rf.route/navigation-blocked` TRACE carries `:requested-url`
+      (custom slot → emit-site scrub) and the DISPATCHED event payload carries
+      the pending-nav map with `:requested-url` + `:requested-by-event`
+      (event marks → marks chokepoint).
+
+  The unifying EP-0015 invariant under test: the IN-PROCESS value stays raw
+  (the handler / pending-nav sub / continue-cancel resume need it), only the
+  EGRESS copy (trace bus / Xray / MCP / log / epoch) is projected."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.privacy :as privacy]
+            [re-frame.routing :as routing]
+            [re-frame.routing.egress :as egress]
+            [re-frame.routing.nav-fx :as nav-fx]
+            [re-frame.routing.scroll :as scroll]
+            [re-frame.routing.test-support]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+(def ^:private sentinel-str (subs (str privacy/redacted-sentinel) 1))  ;; "rf/redacted"
+
+;; The spec defaults the scroll / history fx to :platforms #{:client}, so on
+;; the JVM they emit `:rf.fx/skipped-on-platform` rather than running. The
+;; routing tests re-register them #{:server :client} to exercise the drain.
+;; CRUCIAL for EP-0015 (rf2-1wmni6/rf2-pbbo68): a bare re-registration would
+;; REPLACE the marks entry (register-marks! replaces in full), wiping the
+;; `:sensitive` declarations under test — so each override MERGES the
+;; production meta (carrying `:sensitive`) and only OVERRIDES `:platforms`.
+;; This keeps the test honest: it exercises the SAME marks the production
+;; registration ships, not a marks-stripped stub.
+(defn- reg-jvm-fx!
+  "Re-register `fx-id` for the JVM drain (#{:server :client}) WITHOUT dropping
+  its production `:sensitive` marks. `prod-meta` is the production meta def;
+  `handler` is the test handler."
+  [fx-id prod-meta handler]
+  (rf/reg-fx fx-id (assoc prod-meta :platforms #{:server :client}) handler))
+
+;; ===========================================================================
+;; The pure URL-carrier scrub (rf2-n1f4rh) — fast, host-symmetric.
+;; ===========================================================================
+
+(deftest redact-url-carriers-keeps-path-redacts-query-values
+  (testing "rf2-n1f4rh: query KEYS are preserved (shape), VALUES redacted"
+    (is (= (str "/oauth/callback?code=" sentinel-str "&state=" sentinel-str)
+           (egress/redact-url-carriers "/oauth/callback?code=secret123&state=xyz"))
+        "each query value → rf/redacted; keys + path intact")))
+
+(deftest redact-url-carriers-redacts-fragment-whole
+  (testing "rf2-n1f4rh: the whole #fragment is opaque → redacted wholesale"
+    (is (= (str "/login#" sentinel-str)
+           (egress/redact-url-carriers "/login#access_token=abc.def.ghi"))
+        "the fragment carrier is redacted entirely")
+    (is (= (str "/search?q=" sentinel-str "#" sentinel-str)
+           (egress/redact-url-carriers "/search?q=ssn-123#tok"))
+        "both query values and fragment redacted")))
+
+(deftest redact-url-carriers-bare-path-rides-verbatim
+  (testing "rf2-n1f4rh: a path with no query/fragment is not a carrier target"
+    (is (= "/admin/users/42" (egress/redact-url-carriers "/admin/users/42"))
+        "bare path verbatim")
+    (is (= "/" (egress/redact-url-carriers "/")) "root verbatim")))
+
+(deftest redact-url-carriers-value-less-flag-key-kept
+  (testing "rf2-n1f4rh: a value-less flag query key is kept (no = → no secret)"
+    (is (= (str "/x?debug&token=" sentinel-str)
+           (egress/redact-url-carriers "/x?debug&token=abc"))
+        "the bare `debug` flag rides; `token=abc` value is redacted")))
+
+(deftest redact-url-carriers-nil-safe
+  (testing "a non-string input rides back unchanged"
+    (is (nil? (egress/redact-url-carriers nil)))))
+
+;; ===========================================================================
+;; rf2-1wmni6 / rf2-pbbo68 — scroll/history fx :sensitive marks project the
+;; :rf.fx/args carrier slots on the :rf.fx/handled trace egress copy.
+;; ===========================================================================
+
+(defn- handled-trace-for
+  "Dispatch `event`, capture every `:rf.fx/handled` trace whose `:rf.fx/id`
+  is `fx-id`, and return the LAST one's `:rf.fx/args` (the projected egress
+  copy). The fx handlers are re-registered #{:server :client} so the JVM
+  drain actually invokes them (the spec default is #{:client})."
+  [fx-id event]
+  (let [traces (atom [])]
+    (rf/register-listener! ::egress (fn [ev] (swap! traces conj ev)))
+    (rf/dispatch-sync event)
+    (rf/unregister-listener! ::egress)
+    (->> @traces
+         (filter (fn [ev] (and (= :rf.fx/handled (:operation ev))
+                               (= fx-id (-> ev :tags :rf.fx/id)))))
+         last
+         :tags
+         :rf.fx/args)))
+
+(deftest scroll-fx-handled-trace-redacts-route-descriptor-carriers
+  (testing "rf2-1wmni6/rf2-pbbo68: :rf.nav/scroll's :rf.fx/handled trace has
+            :from/:to :params/:query and :fragment redacted; :strategy + the
+            route :id ride verbatim"
+    (rf/reg-route :route/articles {:path "/articles"})
+    (rf/reg-route :route/article  {:path   "/articles/:id"
+                                   :params [:map [:id :string]]})
+    ;; Make the fx invoke on the JVM so :rf.fx/handled emits — but KEEP the
+    ;; production `:sensitive` marks (the thing under test).
+    (reg-jvm-fx! :rf.nav/scroll   scroll/scroll-fx-meta   (fn [_ _] nil))
+    (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta     (fn [_ _] nil))
+    ;; Land on a route WITH params so the next nav's :from carries :params.
+    (rf/dispatch-sync [:rf.route/navigate :route/article {:id "secret-doc-id"}])
+    (let [args (handled-trace-for
+                 :rf.nav/scroll
+                 [:rf.route/navigate :route/article {:id "another-secret"}
+                  {:fragment "tok-in-fragment"}])]
+      (is (some? args) "a :rf.nav/scroll :rf.fx/handled trace was emitted")
+      ;; The descriptor :id keyword survives (names the shape, no secret).
+      (is (= :route/article (get-in args [:to :id]))
+          ":to :id (route keyword) rides verbatim")
+      ;; The carrier slots are redacted to the sentinel.
+      (is (= privacy/redacted-sentinel (get-in args [:to :params]))
+          ":to :params (the document-id carrier) is redacted on the trace")
+      (is (= privacy/redacted-sentinel (get-in args [:from :params]))
+          ":from :params is redacted on the trace")
+      (is (= privacy/redacted-sentinel (:fragment args))
+          ":fragment is redacted on the trace")
+      ;; :strategy is structural, not a carrier — it rides.
+      (is (contains? args :strategy) ":strategy rides verbatim"))))
+
+(deftest scroll-fx-handler-still-receives-raw-args-in-process
+  (testing "rf2-1wmni6/rf2-pbbo68: the marks projection touches ONLY the trace
+            egress copy — the in-process handler still receives the raw args
+            (scroll restoration / fragment scrolling unaffected)"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (let [seen (atom nil)]
+      ;; Capture what the HANDLER actually receives (not the trace).
+      (reg-jvm-fx! :rf.nav/scroll   scroll/scroll-fx-meta
+                   (fn [_ args] (reset! seen args)))
+      (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta (fn [_ _] nil))
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:id "doc-42"}
+                         {:fragment "section-3"}])
+      (is (= {:id "doc-42"} (get-in @seen [:to :params]))
+          "the handler receives the RAW :to :params (not redacted)")
+      (is (= "section-3" (:fragment @seen))
+          "the handler receives the RAW :fragment (scrolling needs it)"))))
+
+(deftest push-url-handled-trace-redacts-url-arg
+  (testing "rf2-1wmni6/rf2-pbbo68: :rf.nav/push-url's :rf.fx/handled trace
+            redacts the whole URL arg (carrier-shaped), handler unaffected"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (let [seen (atom nil)]
+      (reg-jvm-fx! :rf.nav/scroll   scroll/scroll-fx-meta (fn [_ _] nil))
+      (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta
+                   (fn [_ url] (reset! seen url)))
+      (let [args (handled-trace-for
+                   :rf.nav/push-url
+                   [:rf/url-requested {:url "/articles/secret-doc"}])]
+        ;; The trace egress copy is the whole-value sentinel.
+        (is (= privacy/redacted-sentinel args)
+            "the push-url URL arg is redacted on the :rf.fx/handled trace")
+        ;; The handler still pushed the real URL in-process.
+        (is (string? @seen) "the handler received the raw URL string")
+        (is (re-find #"secret-doc" @seen)
+            "the in-process handler URL is NOT redacted")))))
+
+;; ===========================================================================
+;; rf2-n1f4rh — route-miss diagnostics redact the raw requested URL.
+;; ===========================================================================
+
+(deftest route-miss-no-such-handler-redacts-url-carriers
+  (testing "rf2-n1f4rh: an unmatched URL with query/fragment token carriers →
+            :rf.error/no-such-handler trace has the carrier VALUES redacted
+            (path + :reason kept for app error handling)"
+    ;; No route registered for /oauth → route-miss → fallback to not-found.
+    (rf/reg-route :rf.route/not-found {:path "/404"})
+    (let [traces (atom [])]
+      (rf/register-listener! ::miss (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.route/transitioned
+                         "/oauth/callback?code=topsecret&state=xyz#access_token=leak"])
+      (rf/unregister-listener! ::miss)
+      (let [err (->> @traces
+                     (filter #(= :rf.error/no-such-handler (:operation %)))
+                     first)]
+        (is (some? err) ":rf.error/no-such-handler was emitted for the route miss")
+        (let [url (-> err :tags :url)]
+          (is (string? url) "the :url slot is present (structured path kept)")
+          (is (re-find #"^/oauth/callback" url) "the PATH is preserved")
+          (is (not (re-find #"topsecret" url)) "the query secret is NOT raw")
+          (is (not (re-find #"leak" url)) "the fragment secret is NOT raw")
+          (is (re-find (re-pattern sentinel-str) url)
+              "carrier values replaced with the rf/redacted sentinel"))
+        ;; The structured discriminator the app error handler needs survives.
+        (is (= :route (-> err :tags :kind)) ":kind :route discriminator kept")))))
+
+;; ===========================================================================
+;; rf2-jfaucw — blocked-navigation record keeps no raw route carriers on
+;; egress, while continue/cancel resume still work in-process.
+;; ===========================================================================
+
+(defn- block-fixture!
+  "Land on an editor route guarded by a blocking :can-leave."
+  []
+  (rf/reg-route :editor/article
+                {:path      "/editor/articles/:id"
+                 :params    [:map [:id :string]]
+                 :can-leave :editor/can-leave?})
+  (rf/reg-route :route/cart {:path "/cart"})
+  (rf/reg-event :editor/dirty (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:editor :dirty?] v)}))
+  (rf/reg-sub :editor/can-leave? (fn [db _] (not (get-in db [:editor :dirty?]))))
+  (rf/reg-fx :rf.nav/push-url    {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf/reg-fx :rf.nav/replace-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf/dispatch-sync [:rf.route/transitioned "/editor/articles/A"])
+  (rf/dispatch-sync [:editor/dirty true]))
+
+(deftest navigation-blocked-trace-redacts-requested-url-carriers
+  (testing "rf2-jfaucw: the :rf.route/navigation-blocked TRACE redacts the
+            :requested-url query/fragment carriers"
+    (block-fixture!)
+    (let [traces (atom [])]
+      (rf/register-listener! ::blocked (fn [ev] (swap! traces conj ev)))
+      ;; Try to leave to a URL carrying a query secret → blocked.
+      (rf/dispatch-sync [:rf/url-requested {:url "/cart?coupon=SECRET100&ref=x"}])
+      (rf/unregister-listener! ::blocked)
+      (let [blocked (->> @traces
+                         (filter #(= :rf.route/navigation-blocked (:operation %)))
+                         first)]
+        (is (some? blocked) "a navigation-blocked trace fired")
+        (let [url (-> blocked :tags :requested-url)]
+          (is (re-find #"^/cart" url) "the path is preserved")
+          (is (not (re-find #"SECRET100" url)) "the query secret is NOT raw on the trace")
+          (is (re-find (re-pattern sentinel-str) url) "carrier value redacted"))
+        ;; The structural discriminator survives.
+        (is (= :editor/can-leave? (-> blocked :tags :rejecting-guard))
+            ":rejecting-guard kept")))))
+
+(deftest navigation-blocked-dispatched-event-payload-redacts-carriers
+  (testing "rf2-jfaucw: the DISPATCHED [:rf.route/navigation-blocked pending-nav]
+            event trace redacts the pending-nav :requested-url +
+            :requested-by-event carrier slots via event marks"
+    (block-fixture!)
+    (let [traces (atom [])]
+      (rf/register-listener! ::nb (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf/url-requested {:url "/cart?coupon=SECRET100"}])
+      (rf/unregister-listener! ::nb)
+      ;; Find a dispatched-event trace carrying the navigation-blocked event vec.
+      (let [dispatched (->> @traces
+                            (keep (fn [ev]
+                                    (let [v (or (-> ev :tags :rf.event/v)
+                                                (-> ev :tags :event))]
+                                      (when (and (vector? v)
+                                                 (= :rf.route/navigation-blocked (first v)))
+                                        v))))
+                            first)]
+        (is (some? dispatched) "the navigation-blocked event vector was traced")
+        (let [pending-nav (second dispatched)]
+          (is (= privacy/redacted-sentinel (:requested-url pending-nav))
+              ":requested-url redacted in the dispatched-event trace payload")
+          (is (= privacy/redacted-sentinel (:requested-by-event pending-nav))
+              ":requested-by-event redacted in the dispatched-event trace payload")
+          ;; Structural slots survive.
+          (is (= :can-leave (:reason pending-nav)) ":reason kept")
+          (is (contains? pending-nav :id) ":id (pending-nav handle) kept"))))))
+
+(deftest navigation-blocked-pending-nav-slot-keeps-raw-in-process
+  (testing "rf2-jfaucw: the DURABLE pending-nav runtime-db slot keeps the RAW
+            :requested-url / :requested-by-event so continue/cancel resume
+            still work (marks/scrub touch only the egress copy)"
+    (block-fixture!)
+    (rf/dispatch-sync [:rf/url-requested {:url "/cart?coupon=SECRET100"}])
+    (let [pending (get-in (rf/runtime-db-value :rf/default)
+                          [:rf.runtime/routing :pending-navigation])]
+      (is (some? pending) "the block wrote the pending-nav slot")
+      ;; The in-process durable value is RAW (not redacted) — resume needs it.
+      (is (= "/cart?coupon=SECRET100" (:requested-url pending))
+          "the durable :requested-url is the RAW URL (continue re-dispatches it)")
+      (is (vector? (:requested-by-event pending))
+          "the durable :requested-by-event is the raw original event vector"))
+    ;; And continue actually completes the navigation (resume works).
+    (rf/dispatch-sync [:rf.route/continue (-> (rf/runtime-db-value :rf/default)
+                                              (get-in [:rf.runtime/routing :pending-navigation :id]))])
+    (is (nil? (get-in (rf/runtime-db-value :rf/default)
+                      [:rf.runtime/routing :pending-navigation]))
+        "continue cleared the pending slot (resume completed from the raw value)")))

--- a/implementation/routing/test/re_frame/routing_nav_allocation_record_replay_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_allocation_record_replay_test.clj
@@ -274,3 +274,84 @@
     ;; pending-nav generator runs but its commit fx only fires on a block.
     (is (nil? (:pending-nav-counter (nav-counters/counter-snapshot :rf/default)))
         "a clean commit never advances the pending-nav allocator (no block branch taken)")))
+
+;; ===========================================================================
+;; rf2-ps05ug — a malformed-but-PRESENT recorded allocation fails LOUDLY.
+;;
+;; THE HOLE (pre-rf2-ps05ug): both allocation cofx were registered with
+;; `:recordable? true` but NO `:schema`. `validate-recordable-value!`
+;; (cofx.cljc) is a no-op when the registration declares no `:schema`, so a
+;; supplied/replayed value that is structurally EDN but semantically wrong
+;; (`{:token nil :counter "bad"}`, `{:id nil :counter nil}`) was NOT missing
+;; → strict replay did not re-mint and did not throw. The handler folded the
+;; nil/wrong token / pending-nav id into DURABLE runtime-db and the host
+;; counter bump silently no-op'd, corrupting stale-suppression / continue-
+;; cancel instead of surfacing `:rf.error/cofx-value-invalid`.
+;;
+;; THE FIX: a concrete `:schema` on each registration —
+;;   :rf.route/nav-allocation         [:map [:token :string] [:counter :int]]
+;;   :rf.route/pending-nav-allocation [:map [:id    :string] [:counter :int]]
+;; so the supplied/replayed branch validates the present value and throws
+;; `:rf.error/cofx-value-invalid` BEFORE the handler writes the route slice /
+;; pending-navigation slot. (The schemas Malli validator is LIVE on this test
+;; classpath — `routing-test-support` requires `re-frame.schemas`, whose
+;; facade wires the default Malli hooks on load, rf2-v96fh — so these assert
+;; the REAL validation path, not a vacuous no-validator pass.)
+;; ===========================================================================
+
+(deftest strict-replay-fails-on-malformed-present-pending-nav-allocation
+  (testing "rf2-ps05ug: a PRESENT-but-malformed recorded pending-nav allocation
+            fails with :rf.error/cofx-value-invalid BEFORE the handler writes
+            pending-nav state (NOT folded in as a trusted value)"
+    (block-fixture!)
+    (let [ex (try (rf/dispatch-sync [:rf/url-requested {:url "/home"}]
+                                    {:rf.cofx {:rf.route/pending-nav-allocation
+                                               {:id nil :counter "bad"}}
+                                     :rf.cofx/mint-policy :strict})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "a malformed present allocation throws (does not silently fold)")
+      (is (= :rf.error/cofx-value-invalid (:rf.error/id (ex-data ex)))
+          "the throw is :rf.error/cofx-value-invalid")
+      (is (= :rf.route/pending-nav-allocation (:rf.cofx/id (ex-data ex)))
+          "the error names the failing allocation cofx")
+      ;; The block handler never ran: the malformed `:id` was rejected at the
+      ;; cofx boundary BEFORE the can-leave block could fold a nil/corrupt
+      ;; pending-nav id into the durable runtime-db slot. No pending-navigation
+      ;; was written (the throw aborted the dispatch before the block branch).
+      (is (nil? (pending-id))
+          "no (corrupt) pending-nav id was folded into durable runtime-db"))))
+
+(deftest strict-replay-fails-on-malformed-present-nav-allocation
+  (testing "rf2-ps05ug: a PRESENT-but-malformed recorded nav-token allocation
+            fails with :rf.error/cofx-value-invalid BEFORE the commit handler
+            writes the :nav-token into the durable route slice"
+    (rf/reg-route :route/article {:path "/articles/:id" :params [:map [:id :string]]})
+    (let [ex (try (rf/dispatch-sync [:rf.route/transitioned "/articles/A"]
+                                    {:rf.cofx {:rf.route/nav-allocation
+                                               {:token nil :counter "bad"}}
+                                     :rf.cofx/mint-policy :strict})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "a malformed present allocation throws (does not silently fold)")
+      (is (= :rf.error/cofx-value-invalid (:rf.error/id (ex-data ex)))
+          "the throw is :rf.error/cofx-value-invalid")
+      (is (= :rf.route/nav-allocation (:rf.cofx/id (ex-data ex)))
+          "the error names the failing allocation cofx")
+      ;; The commit handler never ran: no :nav-token (let alone a nil one) was
+      ;; folded into the durable route slice.
+      (is (nil? (get-in (rf/runtime-db-value :rf/default)
+                        [:rf.runtime/routing :current :nav-token]))
+          "no nil nav-token was folded into the durable route slice"))))
+
+(deftest live-allocation-still-conforms-to-schema
+  (testing "rf2-ps05ug acceptance: the live generator's produced allocation
+            conforms to the new :schema, so the schema is transparent to the
+            ordinary (non-replay) path"
+    (rf/reg-route :route/a {:path "/a"})
+    ;; A live navigation runs the generator (well-formed `{:token \"nav-1\"
+    ;; :counter 1}`) and commits cleanly — no cofx-value-invalid throw.
+    (rf/dispatch-sync [:rf.route/transitioned "/a"])
+    (is (= "nav-1" (get-in (rf/runtime-db-value :rf/default)
+                           [:rf.runtime/routing :current :nav-token]))
+        "the live generator's well-formed allocation passes the schema and commits")))

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -8,6 +8,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.routing :as routing]
+            [re-frame.routing.egress :as egress]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]
             [re-frame.routing.registry :as registry]))
@@ -722,14 +723,19 @@
       ;; error-projections the DoS cap feeds (spec/012 §Keyword-interning
       ;; cap). Assert the TRACE — not just the slice `:reason` — so the
       ;; telemetry-symmetry gap with url_change regression-trips.
+      ;; EP-0015 (rf2-n1f4rh): the trace's `:url` is now egress-PROJECTED —
+      ;; the query KEYS (the DoS-cap signal the dashboard needs) are preserved
+      ;; while the carrier VALUES are redacted. The slice/push above keep the
+      ;; RAW url (in-process); only this off-box trace slot is scrubbed.
       (is (some (fn [ev]
                   (and (= :rf.warning/malformed-url (:operation ev))
-                       (= url (-> ev :tags :url))
+                       (= (egress/redact-url-carriers url) (-> ev :tags :url))
                        (= :too-many-keys (-> ev :tags :reason))))
                 @traces)
           ":rf.warning/malformed-url trace fires on the navigate fail-closed
-           over-cap path, carrying the requested URL + :reason :too-many-keys
-           — symmetric with the URL-driven path (url_change.cljc:190-193)"))))
+           over-cap path, carrying the egress-projected URL (keys kept, values
+           redacted) + :reason :too-many-keys — symmetric with the URL-driven
+           path (url_change.cljc) and EP-0015-projected (rf2-n1f4rh)"))))
 
 ;; ---- T6: :on-match dispatches AND :transition :loading observable ----
 

--- a/implementation/routing/test/re_frame/routing_test_support.clj
+++ b/implementation/routing/test/re_frame/routing_test_support.clj
@@ -92,11 +92,29 @@
   `snapshot-schema-fns` / `restore-schema-fns!` pair (rf2-l4ljvr) rather
   than reaching the raw `validator-fn` / `explainer-fn` atoms — the
   snapshot also preserves the printer, so the cleanup restores the full
-  prior bundle."
+  prior bundle.
+
+  rf2-ps05ug: the stub is process-global, so while it is installed EVERY
+  schema-validating boundary uses it — including the routing recordable
+  allocation cofx, whose `:schema` is now a real Malli VECTOR
+  (`[:map [:token :string] [:counter :int]]`). A Malli vector is not a
+  callable predicate (and although a vector IS `ifn?` — it implements IFn
+  for index lookup — calling it as `(schema value)` throws for a
+  non-integer `value`), so a naive call would throw and the fail-closed
+  `validate-with-registered-fn` would coerce that to a FALSE, spuriously
+  rejecting the well-formed generated nav-allocation during an unrelated
+  param-validation test. The stub therefore only adjudicates ACTUAL fn
+  schemas (`fn?` — the predicate schemas these tests install) and PASSES
+  any other (Malli vector / map) schema. The explainer is symmetric."
   []
   (let [snap     (schemas/snapshot-schema-fns)
-        validate (fn [schema value] (boolean (schema value)))
-        explain  (fn [_schema value] {:reason :stub-explainer :value value})]
+        validate (fn [schema value]
+                   (if (fn? schema)
+                     (boolean (schema value))
+                     true))                          ;; non-predicate (Malli) schema → pass
+        explain  (fn [schema value]
+                   (when (fn? schema)
+                     {:reason :stub-explainer :value value}))]
     (schemas/set-schema-fns! {:validate validate :explain explain})
     (fn [] (schemas/restore-schema-fns! snap))))
 

--- a/implementation/routing/test/re_frame/routing_trace_emit_elision_prod_test.cljs
+++ b/implementation/routing/test/re_frame/routing_trace_emit_elision_prod_test.cljs
@@ -39,6 +39,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.schemas :as schemas]
             [re-frame.test-support :as test-support]
             ;; Touch the routing namespace directly so its ns body
             ;; (including the gated `trace/emit!` call sites) is in
@@ -49,9 +50,33 @@
             ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
             [re-frame.trace.tooling :as trace-tooling]))
 
+;; rf2-ps05ug: the routing entry points exercised below run the RECORDABLE
+;; `:rf.route/nav-allocation` cofx generator, whose registration declares a
+;; real Malli `:schema` (`[:map [:token :string] [:counter :int]]`). That
+;; `:schema` check is ALWAYS-ON (it validates durable causal-token state in
+;; prod as well as dev — Spec 009 `:rf.error/cofx-value-invalid` row) and
+;; routes through the registered `set-schema-validator!` seam. Under the
+;; SHARED `:browser-test-prod-elision` bundle a SIBLING suite
+;; (`resources-scope-mismatch-elision-prod-test`) loads `re-frame.schemas`,
+;; installing the default Malli validator — but Malli's validation BODY is
+;; production-elided (Closure DCE under `goog.DEBUG=false`, Spec 010
+;; §Production builds: "the validator fn must be production-elidable"), so a
+;; well-formed `{:token "nav-1" :counter 1}` is spuriously REJECTED in the
+;; prod bundle. Disable the schema validator for this suite (a nil validator
+;; is a documented no-op for the recordable check) so the generator runs and
+;; the trace-elision contract under test is exercised cleanly. Snapshot +
+;; restore so the suite leaves no cross-test residue — identical to the
+;; resources prod-elision fixture (rf2-rsmiru).
+(defn- disable-schema-validation-fixture [f]
+  (let [snapshot (schemas/snapshot-schema-fns)]
+    (schemas/set-schema-validator! nil)
+    (try (f)
+         (finally (schemas/restore-schema-fns! snapshot)))))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    {:adapter reagent-adapter/adapter})
+  disable-schema-validation-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -124,8 +124,24 @@
 
 (defn- with-stub-validator []
   (let [snap     (schemas/snapshot-schema-fns)
-        validate (fn [schema value] (boolean (schema value)))
-        explain  (fn [_schema value] {:reason :stub-explainer :value value})]
+        ;; rf2-ps05ug: the stub is process-global, so while installed EVERY
+        ;; schema-validating boundary uses it — including the routing
+        ;; recordable allocation cofx, whose `:schema` is a real Malli VECTOR
+        ;; (`[:map [:token :string] [:counter :int]]`). A Malli vector is not
+        ;; a callable predicate (calling it as `(schema value)` index-lookups
+        ;; for an integer value and throws for a map), so a naive call would
+        ;; throw and the fail-closed seam would coerce it to FALSE, spuriously
+        ;; rejecting the well-formed generated nav-allocation. The stub
+        ;; therefore only adjudicates ACTUAL fn schemas (the predicate schemas
+        ;; these tests install) and PASSES any other (Malli vector / map)
+        ;; schema. Mirrors routing_test_support's `with-stub-validator`.
+        validate (fn [schema value]
+                   (if (fn? schema)
+                     (boolean (schema value))
+                     true))
+        explain  (fn [schema value]
+                   (when (fn? schema)
+                     {:reason :stub-explainer :value value}))]
     (schemas/set-schema-fns! {:validate validate :explain explain})
     (fn [] (schemas/restore-schema-fns! snap))))
 

--- a/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
@@ -60,8 +60,24 @@
 
 (defn- with-stub-validator []
   (let [snap     (schemas/snapshot-schema-fns)
-        validate (fn [schema value] (boolean (schema value)))
-        explain  (fn [_schema value] {:reason :stub-explainer :value value})]
+        ;; rf2-ps05ug: the stub is process-global, so while installed EVERY
+        ;; schema-validating boundary uses it — including the routing
+        ;; recordable allocation cofx, whose `:schema` is a real Malli VECTOR
+        ;; (`[:map [:token :string] [:counter :int]]`). A Malli vector is not
+        ;; a callable predicate (calling it as `(schema value)` index-lookups
+        ;; for an integer value and throws for a map), so a naive call would
+        ;; throw and the fail-closed seam would coerce it to FALSE, spuriously
+        ;; rejecting the well-formed generated nav-allocation. The stub
+        ;; therefore only adjudicates ACTUAL fn schemas (the predicate schemas
+        ;; these tests install) and PASSES any other (Malli vector / map)
+        ;; schema. Mirrors routing_test_support's `with-stub-validator`.
+        validate (fn [schema value]
+                   (if (fn? schema)
+                     (boolean (schema value))
+                     true))
+        explain  (fn [schema value]
+                   (when (fn? schema)
+                     {:reason :stub-explainer :value value}))]
     (schemas/set-schema-fns! {:validate validate :explain explain})
     (fn [] (schemas/restore-schema-fns! snap))))
 


### PR DESCRIPTION
Fixes 5 P1 EP-0017/EP-0015 routing-surface review-wave beads (one surface, one worker).

## rf2-ps05ug — recordable allocation cofx lacked `:schema` (EP-0017)
Both routing allocation cofx were `:recordable? true` with no `:schema`, so `validate-recordable-value!` was a no-op and a malformed-but-present supplied/replayed fact (`{:token nil :counter "bad"}`) was delivered as trusted into durable routing state instead of failing loud. Added concrete Malli schemas matching each generator's shape:
- `:rf.route/nav-allocation` → `[:map [:token :string] [:counter :int]]`
- `:rf.route/pending-nav-allocation` → `[:map [:id :string] [:counter :int]]`

Malformed-present supplied/replayed facts now throw `:rf.error/cofx-value-invalid` before the handler writes the route slice / pending-nav slot. Mirrors the `resources/state.cljc` `generation-allocation-cofx-meta` precedent.

## rf2-1wmni6 / rf2-pbbo68 — scroll fx expose raw route carriers (EP-0015) [duplicate beads]
`:rf.nav/scroll`'s `:from`/`:to` descriptors carry raw `:params`/`:query` + `:fragment`; `:rf.nav/capture-scroll` carries a reconstructed `:url`. The core fx trace records `:rf.fx/args` verbatim onto `:rf.fx/handled`. Added `:sensitive` path-marks to the fx registrations so the marks chokepoint (`re-frame.marks/project-trace-event`) redacts the carrier slots on the EGRESS copy only — the handler still receives raw args in-process (projection runs in `build-event` after the handler), so scroll restoration / fragment scrolling are unaffected.

`:rf.nav/push-url` / `:rf.nav/replace-url` were deliberately **not** marked: the pushed URL is the navigation's behavioural identity (the `:effects-routed` conformance contract + epoch `:effects` projection assert the real routed URL, already cleared by the open-redirect gate), and a blanket mark over-reaches bare paths.

## rf2-n1f4rh — route-miss diagnostics emit raw requested URLs (EP-0015)
`:rf.warning/malformed-url` / `:rf.error/no-such-handler` carry the requested URL under a custom `:url` slot the marks chokepoint does not walk. A route-miss has no matched route → no schema. New `re-frame.routing.egress/redact-url-carriers` applies a default-on scrub at the emit sites: keep the path + query KEYS (shape / DoS signal), redact query VALUES + the whole `#fragment`. The structured `:reason`/`:kind` discriminators are preserved for app error handling / SSR projection.

## rf2-jfaucw — pending-navigation keeps raw blocked route carriers (EP-0015)
Two trace/event egress points fixed:
1. The `:rf.route/navigation-blocked` **trace** `:requested-url` (custom slot) → `egress/redact-url-carriers` scrub at the emit site.
2. The dispatched `[:rf.route/navigation-blocked pending-nav]` **event payload** → `:sensitive [[:requested-url] [:requested-by-event]]` marks on the event registration, so `project-event-tags` redacts those on the dispatched-event trace.

The durable runtime-db pending-nav slot keeps the **raw** values (`continue-handler` re-dispatches them to resume) and its off-box epoch egress is already fail-closed by the redact-whole-runtime-db default (EP-0001 ruling #14).

## Tests
New `routing_egress_test.clj` (37 assertions) + 3 new cases in `routing_nav_allocation_record_replay_test.clj`. Every fix red-probe-verified (temporarily disabled each mechanism, confirmed the test fails, restored). Also asserts the in-process value stays raw (handler input, durable slot, continue resume). Updated the over-cap navigate trace assertion + `with-stub-validator` (now passes non-fn Malli schemas through so the new cofx `:schema` does not trip the predicate-stub during unrelated param-validation tests).

## Gates
- `npm run test:cljs` — 7667 tests / 31600 assertions green
- routing JVM suite — 287 tests / 1374 assertions green
- `scripts/test-fast-pr.sh` — PASS (core JVM incl. conformance, CLJS, markdown gates)
- `npm run test:elision` — production elision probe PASS (egress code DCEs cleanly)

Spec unchanged: aligns the implementation to already-final Spec 015 / EP-0017; the egress mechanism (marks + `project-egress` + redact-whole-runtime-db) and the cofx `:schema` contract are normative there. No numbered/hot-zone spec touched.
