### PR TITLE
fix(mcp-base): diff-encode diagnostics + scrub-snapshot reconcile (rf2-9titpp, rf2-cj75yv)

### DIFF
--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -56,7 +56,9 @@ The count feeds the indicator-field slot the agent reads to know the payload was
 
 Walks a snapshot map keyed by frame and, for each per-frame map, applies the strip-fn to the `:traces` and `:epochs` slices only. Returns `[scrubbed-snapshot total-dropped]`. Non-map slices and non-snapshot inputs pass through unchanged.
 
-The walk is **shallow by design** (per rf2-zq0n1 / rf2-3cted): it strips sensitive trace events from `:traces` / `:epochs` but **leaves `:app-db`, `:sub-cache`, and `:machines` untouched**. App-db payload redaction is `redact-interceptor`'s job at *write-time*, not the forwarder's job at *read-time* — `scrub-snapshot` does NOT descend into arbitrary sub-trees and does NOT redact app-db values. (A reviewer should not assume app-db redaction happens here; it does not.)
+`scrub-snapshot` is a **trace/epoch sensitivity filter only — NOT the complete snapshot privacy boundary.** The walk is **shallow by design** (per rf2-zq0n1 / rf2-3cted): it strips sensitive trace events from `:traces` / `:epochs` but **leaves `:app-db`, `:sub-cache`, and `:machines` untouched** — it does NOT descend into arbitrary sub-trees and does NOT redact app-db values. Its OUTPUT is therefore **not** already-projected full-snapshot output.
+
+Per [EP-0015](../../../docs/EP/EP-0015-frame-owned-egress-policy.md), the public privacy model is registration-owned `:sensitive` / `:large` classification plus centralized `project-egress` (under a named `:rf.egress/*` profile) at the egress boundary; the write-time `redact-interceptor` that earlier owned app-db payload redaction has been **removed**. So the **caller's egress pipeline** must run `project-egress` over the non-trace slices with the frame's known policy **before** the snapshot crosses an MCP/tool boundary. A consumer must NOT treat `scrub-snapshot` output as sufficient, and must NOT look for a write-time interceptor to have handled app-db redaction — it does not happen here, and there is no longer a write-time interceptor that does it.
 
 Two arities:
 

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -214,6 +214,51 @@
      :cljs (try (resolve 'malli.core/validate)
                 (catch :default _ nil))))
 
+(defn- patch-shape
+  "Value-free shape summary of one (malformed) patch tuple, for an
+  egress-safe diagnostic. A patch is `[<path> <op> <value?>]`; the
+  `<value>` at position 2 is the app-db leaf the egress policy expects
+  to stay projected, so it is DELIBERATELY excluded. The path is a
+  vector of structural keys (the breadcrumb the encoder walked), the op
+  is a grammar keyword, and the arity disambiguates assoc/dissoc — all
+  value-free. A non-vector patch reports only its type."
+  [patch]
+  (if (vector? patch)
+    {:path  (when (vector? (nth patch 0 nil)) (nth patch 0 nil))
+     :op    (let [op (nth patch 1 nil)] (when (keyword? op) op))
+     :arity (count patch)}
+    {:type (some-> patch type pr-str)}))
+
+(defn- section-shape
+  "Value-free shape summary of one (malformed) section map. A section is
+  `{:section-path [...] :section-kind k :patches [...]}`; the nested
+  `:patches` can carry app-db leaf values, so it is excluded — only the
+  structural breadcrumb, the kind keyword, and a value-free patch count
+  are reported. A non-map section reports only its type."
+  [section]
+  (if (map? section)
+    {:section-path (let [p (:section-path section)] (when (vector? p) p))
+     :section-kind (let [k (:section-kind section)] (when (keyword? k) k))
+     :patch-count  (let [ps (:patches section)] (when (counted? ps) (count ps)))}
+    {:type (some-> section type pr-str)}))
+
+(defn- first-bad
+  "Walk `data` (the offending sequential batch) and return
+  `[bad-index element-summary]` for the FIRST element that fails
+  `element-schema`, using `summarize` to render a value-free shape of
+  that element. Returns `nil` when `data` is not a sequential batch or
+  when no individual element is at fault (the batch shape itself —
+  e.g. a non-sequential value — is the violation; the count/shape slots
+  already convey that). `summarize` never receives or emits the raw leaf
+  value, so the result is egress-safe."
+  [validate element-schema data summarize]
+  (when (sequential? data)
+    (loop [i 0 xs (seq data)]
+      (when xs
+        (if (validate element-schema (first xs))
+          (recur (inc i) (next xs))
+          [i (summarize (first xs))])))))
+
 (defn- validate-against!
   "Shared soft-pass Malli gate behind `validate-patches!` /
   `validate-sections!`. Validates `data` against `schema` and throws
@@ -224,21 +269,37 @@
 
   `where` is the calling-site symbol threaded through to the ex-info
   `:where` slot so it reflects the ACTUAL wire boundary that tripped
-  (rf2-4ypau) rather than a hardcoded one side. `data-key` names the
-  ex-data slot the offending value rides under (`:patches` /
-  `:sections`) so an operator reading the ex-data finds it under the
-  shape it expected. Returns nil."
-  [schema data where error-id reason data-key]
+  (rf2-4ypau) rather than a hardcoded one side.
+
+  ## Egress-safe diagnostics (EP-0015)
+
+  The diff-encode wire carries epoch `:db-before` / `:db-after`
+  payloads, so the VALUE side of an `:assoc` patch (and any map a
+  section's `:patches` carries) can be an app-db leaf the egress policy
+  expects to stay projected / redacted. The thrown diagnostic must NOT
+  smuggle that value back out — neither under a `:patches` / `:sections`
+  ex-data slot, nor in the exception message, nor in any value reachable
+  via `pr-str`. So the offending `data` is NEVER stored raw. Instead the
+  diagnostic carries value-FREE shape: the error id, boundary `:where`,
+  `:recovery`, `:reason`, the static grammar `:schema` (the encoder's
+  own definition — no app-db content), a `:count` of the batch, and —
+  when the batch is sequential — the first failing element's
+  `:bad-index` and a value-free `:shape` (path / op / kind / arity /
+  type, never the leaf value). This mirrors `assoc-in-safe`, which
+  reports path + parent TYPE instead of the parent VALUE."
+  [schema element-schema data where error-id reason summarize]
   (when validate-patches?
     (when-let [validate (resolve-malli-validate)]
       (when-not (validate schema data)
-        (throw (ex-info (str error-id)
-                        {:rf.error/id error-id
-                         :where       where
-                         :recovery    :no-recovery
-                         :reason      reason
-                         :schema      schema
-                         data-key     data})))))
+        (let [[bad-index shape] (first-bad validate element-schema data summarize)]
+          (throw (ex-info (str error-id)
+                          (cond-> {:rf.error/id error-id
+                                   :where       where
+                                   :recovery    :no-recovery
+                                   :reason      reason
+                                   :schema      schema
+                                   :count       (when (counted? data) (count data))}
+                            bad-index (assoc :bad-index bad-index :shape shape))))))))
   nil)
 
 (defn- validate-patches!
@@ -253,12 +314,13 @@
   `'mcp-base/apply-patches` from the decoder. Both boundaries call
   this; hardcoding one side misattributes a decode-side throw to the
   encoder and misleads operator triage about which side of the wire
-  drifted."
+  drifted. The thrown diagnostic is value-free (EP-0015): it reports the
+  first bad patch's path / op / arity, never the patch VALUE."
   [patches where]
-  (validate-against! patches-schema patches where
+  (validate-against! patches-schema patch-schema patches where
                      :rf.error/bad-diff-patches
                      "diff-encode patch grammar violated"
-                     :patches))
+                     patch-shape))
 
 (defn- validate-sections!
   "Validate `sections` against `sections-schema` and throw ex-info on
@@ -270,12 +332,14 @@
   (rf2-4ypau): `'mcp-base/diff-encode-db-after` from the encoder
   (after the section-grouping pass, rf2-qeous), `'mcp-base/decode-db-after`
   from the decoder. Both boundaries call this; hardcoding one side
-  misattributes a decode-side throw to the encoder."
+  misattributes a decode-side throw to the encoder. The thrown
+  diagnostic is value-free (EP-0015): it reports the first bad section's
+  breadcrumb / kind / patch-count, never the nested patch VALUEs."
   [sections where]
-  (validate-against! sections-schema sections where
+  (validate-against! sections-schema section-schema sections where
                      :rf.error/bad-diff-sections
                      "diff-encode section grammar violated"
-                     :sections))
+                     section-shape))
 
 (declare collect-patches-into)
 

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -252,12 +252,26 @@
   total-dropped]`. Non-map slices and non-snapshot inputs pass
   through unchanged.
 
-  Per rf2-zq0n1 / rf2-3cted, sensitive trace events are stripped from
-  `:traces` and `:epochs` but `:app-db`, `:sub-cache`, `:machines`
-  are LEFT ALONE — app-db payload redaction is `redact-interceptor`'s job
-  at write-time, not the forwarder's job at read-time. Re-asserted
-  by the snapshot-scrubber tests in every MCP that emits per-frame
-  snapshots.
+  ## What this is — and is NOT (EP-0015)
+
+  This is a TRACE/EPOCH sensitivity FILTER only — NOT the complete
+  snapshot privacy boundary. Sensitive trace events are stripped from
+  the `:traces` and `:epochs` slices, but the value-carrying slices
+  `:app-db`, `:sub-cache`, and `:machines` are LEFT ALONE: the walk is
+  shallow by design (rf2-zq0n1 / rf2-3cted) and does NOT descend into
+  arbitrary sub-trees or redact app-db values.
+
+  Consequently the OUTPUT is NOT already-projected full-snapshot output.
+  Per EP-0015 the public privacy model is registration-owned `:sensitive`
+  / `:large` classification plus centralized `project-egress` (under a
+  named `:rf.egress/*` profile) at the egress boundary — the write-time
+  `redact-interceptor` that earlier owned app-db payload redaction has
+  been REMOVED. So the CALLER's egress pipeline must run `project-egress`
+  over the non-trace slices with the frame's known policy BEFORE the
+  snapshot crosses an MCP/tool boundary; do not treat `scrub-snapshot`
+  output as sufficient and do not look for a write-time interceptor to
+  have handled it. Re-asserted by the snapshot-scrubber tests in every
+  MCP that emits per-frame snapshots.
 
   ## Strip-fn parameter (rf2-zpmmr)
 

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -1,7 +1,8 @@
 (ns re-frame.mcp-base.diff-encode-test
   "Tests for the path-keyed structural diff used at the MCP wire
   boundary (rf2-1wdzp, shared across both servers via rf2-vw4sq)."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string]
+            [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [re-frame.mcp-base.diff-encode :as de]))
 
@@ -525,6 +526,87 @@
         (catch clojure.lang.ExceptionInfo e
           (is (= 'mcp-base/apply-patches (:where (ex-data e)))
               "decoder caller threads its own site"))))))
+
+;; ---------------------------------------------------------------------------
+;; Sanitized validation diagnostics (EP-0015 egress-policy).
+;;
+;; The diff-encode wire boundary carries epoch :db-before/:db-after
+;; payloads, so the *value* side of an `:assoc` patch (and any map a
+;; section's :patches carries) can be an app-db leaf the egress policy
+;; expects to stay projected / redacted. A malformed patch/section that
+;; trips the Malli gate must not smuggle that value back out through the
+;; exception — neither in the message, the ex-data, nor the pr-str of the
+;; thrown data. The replacement diagnostic carries value-FREE shape only
+;; (error id, boundary, recovery, reason, schema identity, count, and the
+;; first bad index / path / op / element type), mirroring `assoc-in-safe`
+;; which reports path + parent TYPE rather than the parent VALUE.
+;; ---------------------------------------------------------------------------
+
+(defn- secret-absent?
+  "True when `secret` appears nowhere in the thrown ExceptionInfo's
+  message, the pr-str of its ex-data, or the pr-str of any individual
+  ex-data value — the three egress surfaces a diagnostic can leak from."
+  [^clojure.lang.ExceptionInfo e secret]
+  (let [data (ex-data e)]
+    (and (not (clojure.string/includes? (str (.getMessage e)) secret))
+         (not (clojure.string/includes? (pr-str data) secret))
+         (every? (fn [[_ v]] (not (clojure.string/includes? (pr-str v) secret)))
+                 data))))
+
+(deftest validate-patches!-diagnostics-omit-raw-patch-values
+  ;; A malformed patch whose VALUE side is an obvious secret must not
+  ;; appear anywhere reachable from the thrown exception.
+  (let [secret "s3cr3t-token-DO-NOT-LEAK"
+        ;; Malformed: 3-element :dissoc tuple is rejected by the grammar,
+        ;; but the trailing element carries the secret payload.
+        bad    [[[:user :api-key] :dissoc secret]]]
+    (try
+      (#'de/validate-patches! bad 'mcp-base/diff-encode-db-after)
+      (is false "expected the grammar gate to throw")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/bad-diff-patches (:rf.error/id (ex-data e))))
+        (is (secret-absent? e secret)
+            "the raw patch value must not leak via message / ex-data / pr-str")
+        ;; Value-free shape info is retained for triage.
+        (let [data (ex-data e)]
+          (is (= 'mcp-base/diff-encode-db-after (:where data)))
+          (is (= :no-recovery (:recovery data)))
+          (is (string? (:reason data)))
+          (is (nil? (:patches data)) "the raw :patches slot is gone")
+          (is (= 1 (:count data)) "value-free count of the offending batch")
+          (is (= 0 (:bad-index data)) "first bad element index"))))))
+
+(deftest validate-patches!-diagnostics-omit-secret-map-leaf
+  ;; The :assoc VALUE can itself be a map of secrets; even a well-typed
+  ;; tuple that fails for an unrelated reason (bad op) must not carry it.
+  (let [secret "pw-9f3a-LEAK"
+        bad    [[[:session] :replace {:password secret :token secret}]]]
+    (try
+      (#'de/validate-patches! bad 'mcp-base/apply-patches)
+      (is false "expected throw")
+      (catch clojure.lang.ExceptionInfo e
+        (is (secret-absent? e secret)
+            "a secret map carried as the patch value must not leak")
+        (is (= 'mcp-base/apply-patches (:where (ex-data e))))))))
+
+(deftest validate-sections!-diagnostics-omit-raw-section-values
+  ;; A section's nested :patches can carry secret values; a malformed
+  ;; section that trips the sections gate must not leak them.
+  (let [secret "section-secret-XYZ-LEAK"
+        bad    [{:section-path :not-a-vector ;; malformed → trips the gate
+                 :section-kind :modified
+                 :patches      [[[:creds :password] :assoc secret]]}]]
+    (try
+      (#'de/validate-sections! bad 'mcp-base/decode-db-after)
+      (is false "expected the sections gate to throw")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/bad-diff-sections (:rf.error/id (ex-data e))))
+        (is (secret-absent? e secret)
+            "the raw section/patch value must not leak via message / ex-data / pr-str")
+        (let [data (ex-data e)]
+          (is (nil? (:sections data)) "the raw :sections slot is gone")
+          (is (= 1 (:count data)))
+          (is (= 0 (:bad-index data))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Decoder-boundary validation (rf2-8e61v / F17).

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -148,9 +148,14 @@
     (is (= [] (get-in out [:stories :traces])))))
 
 (deftest scrub-snapshot-leaves-non-trace-slices-alone
-  ;; App-db payload redaction is `redact-interceptor`'s job, not the
-  ;; forwarder's. The scrubber must NOT touch :app-db / :sub-cache /
-  ;; :machines even when they carry literal "sensitive"-looking shapes.
+  ;; `scrub-snapshot` is a TRACE/EPOCH sensitivity filter only — NOT the
+  ;; complete snapshot privacy boundary. It deliberately does not descend
+  ;; into :app-db / :sub-cache / :machines, so those slices pass through
+  ;; UNPROJECTED. The caller's egress pipeline (EP-0015 `project-egress`
+  ;; under the frame's classification + an `:rf.egress/*` profile) is
+  ;; responsible for projecting those non-trace slices BEFORE they cross
+  ;; an MCP/tool boundary. This test pins the shallow-by-design contract:
+  ;; the scrubber output is NOT already-projected full-snapshot output.
   (let [snap {:rf/default
               {:app-db    {:password "still-here" :sensitive? true}
                :sub-cache {:user/profile {:sensitive? true :data "x"}}
@@ -158,11 +163,36 @@
                :traces    [{:id 1}]}}
         [out _] (sensitive/scrub-snapshot snap false)]
     (is (= {:password "still-here" :sensitive? true}
-           (get-in out [:rf/default :app-db])))
+           (get-in out [:rf/default :app-db]))
+        "non-trace slices ride through raw — the CALLER's egress projector must project them")
     (is (= {:user/profile {:sensitive? true :data "x"}}
            (get-in out [:rf/default :sub-cache])))
     (is (= {:auth {:state :idle}}
            (get-in out [:rf/default :machines])))))
+
+(deftest scrub-snapshot-is-not-a-full-snapshot-projector
+  ;; rf2-cj75yv: a consumer must not mistake `scrub-snapshot` output for
+  ;; already-projected full-snapshot output. The function does ONE thing —
+  ;; filter sensitive trace events out of :traces / :epochs — and leaves
+  ;; the value-carrying slices (:app-db / :sub-cache / :machines) exactly
+  ;; as it found them. There is NO write-time redaction model standing in
+  ;; for the egress projection EP-0015 requires; this test fails loudly if
+  ;; a future change starts redacting non-trace payloads here (which would
+  ;; wrongly imply the scrubber is the complete privacy boundary) OR stops
+  ;; filtering traces (its actual job).
+  (let [secret-db {:password "leak-me" :token {:value "abc"}}
+        snap      {:rf/default
+                   {:app-db   secret-db
+                    :traces   [{:id 1 :sensitive? true} {:id 2}]}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    ;; The trace filter DID run (its job): the sensitive trace event is gone.
+    (is (= 1 dropped) "sensitive trace event was dropped")
+    (is (= [{:id 2}] (get-in out [:rf/default :traces])))
+    ;; The value-carrying slice is byte-identical — UNPROJECTED. A caller
+    ;; that ships this slice off-box without running `project-egress` over
+    ;; it leaks `secret-db`; the scrubber explicitly does not own that.
+    (is (identical? secret-db (get-in out [:rf/default :app-db]))
+        "scrub-snapshot leaves :app-db unprojected — it is NOT a full-snapshot privacy boundary")))
 
 (deftest scrub-snapshot-include-opt-in-passes-everything
   (let [snap {:rf/default {:traces [{:id 1 :sensitive? true}


### PR DESCRIPTION
@
Surface-clustered pair on the `tools/mcp-base` shared MCP base library, both aligned to the landed EP-0015 egress-policy model.

## rf2-9titpp (P1) — sanitize diff-encode validation diagnostics

The diff-encode wire boundary carries epoch `:db-before`/`:db-after` payloads, so the value side of an `:assoc` patch (and any map a sections `:patches` carries) can be an app-db leaf the egress policy expects to stay projected/redacted. `validate-against!` previously stored the raw offending `data` under `:patches`/`:sections` in the thrown `ex-info`, so a malformed patch/section could disclose that value if the failure was logged, returned through an MCP error envelope, or surfaced in an operator diagnostic.

**Fix:** replace the raw payload with value-free shape — error id, boundary `:where`, `:recovery`, `:reason`, the static grammar `:schema`, a `:count` of the batch, and the first failing elements `:bad-index` plus a value-free `:shape` (path / op / kind / arity / type, never the leaf value). Mirrors `assoc-in-safe`, which already reports path + parent **type** rather than the parent value.

Regression tests assert obvious secret strings/maps carried in malformed `:patches` and `:sections` never appear in the exception message, ex-data, or `pr-str` of any ex-data value.

## rf2-cj75yv (P2) — reconcile scrub-snapshot contract with EP-0015

`scrub-snapshot`s docstring, `spec/sensitive.md`, and `sensitive_test.clj` described and locked in a privacy model EP-0015 removed: they said `:app-db`/`:sub-cache`/`:machines` are left raw because app-db payload redaction is `redact-interceptor`s write-time job. `redact-interceptor` is removed from the public API; the model is now registration-owned `:sensitive`/`:large` classification plus centralized `project-egress` at egress boundaries. mcp-base is the shared base contract for MCP/tool surfaces, so a future consumer could treat `scrub-snapshot` output as sufficient or look for write-time redaction that no longer exists.

**Fix:** reframe `scrub-snapshot` as a trace/epoch sensitivity **filter only — NOT the complete snapshot privacy boundary**. Replace the write-time-redaction wording with EP-0015 language: non-trace slices ride through unprojected and the callers egress pipeline must run `project-egress` over them with the frames known policy before they cross an MCP/tool boundary. Added a regression test pinning the scrubber output as NOT already-projected full-snapshot output (sensitive trace dropped, `:app-db` identical/raw).

## Gates
- mcp-base JVM tests: 240 tests / 803 assertions, 0 failures.
- mcp-conformance wire-vocab (incl. egress-profile gate): 83 tests / 815 assertions, 0 failures.
- `scripts/test-fast-pr.sh`: PASS (CLJS node integration 7678 tests green; markdown link/anchor gates green; mkdocs soft-skipped locally, CI covers).

## Note (out of scope)
`vocab.cljc:153` / `vocab.md:49` still mention `redact-interceptor` as a producer of the `:rf/redacted` sentinel. That is sentinel-origin documentation, not the snapshot privacy contract these beads target; left untouched to keep the diff scoped.
@