### PR TITLE
fix(machines-viz): EP-0017 egress metadata + diagnostics + image redaction (rf2-z0cw6s, rf2-1xb3ec, rf2-27e38h)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -604,6 +604,40 @@ else
           cljs_node_test=true
         fi
         ;;
+      tools/machines-viz/*)
+        # rf2-z0cw6s — tools/machines-viz ships day8/re-frame2-machines-viz
+        # (the MachineChart component + read-only viewer + Mermaid/SCXML/
+        # PNG/SVG/share-URL export surfaces, rf2-o9arp). It is a CLJS-only
+        # tool (no JVM unit tests, no MCP wrapper): its src+test are listed
+        # as :source-paths of the consolidated :node-test AND :browser-test
+        # builds (implementation/shadow-cljs.edn). So a CLJS/CLJC change
+        # must fire BOTH the `cljs` (node-test) job and the `cljs-browser`
+        # job — the latter runs the `*-dom-cljs-test` export/redaction +
+        # chart DOM suites under headless Chromium (where EP-0015 image-
+        # export egress is verified). No tools_jvm / mcp_conformance /
+        # template_expensive fan-out: machines-viz has no JVM suite, is not
+        # consumed by an MCP wrapper, and is not part of the deps-new
+        # template's generated app.
+        #
+        # spec-md guard (mirrors story/xray above): a pure documentation
+        # change under tools/machines-viz/spec/**.md cannot affect any
+        # compiled output, so it fires nothing runtime — covered by
+        # docs.yml + the nightly full matrix.
+        case "$file" in
+          tools/machines-viz/spec/*.md)
+            : # spec doc only — no runtime/CLJS fan-out
+            ;;
+          *)
+            # Every non-spec-md change (src/test .cljs/.cljc, deps.edn,
+            # public/viewer.html, README, EDN) conservatively fires the
+            # node-test + browser gates. The node-test build picks up the
+            # *_cljs_test suites; the browser build picks up the
+            # *-dom-cljs-test export/chart-DOM suites.
+            cljs_node_test=true
+            cljs_browser=true
+            ;;
+        esac
+        ;;
       tools/story-mcp/*)
         # rf2-os0c1 — MCP wrappers don't run in a browser; story-xray-browser
         # exercises the Story/Xray CLJS runtimes via Playwright and is

--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -19,9 +19,12 @@
 # (for non-core) :local/root "../core".
 #
 # Per rf2-lwtke the deployable jars under tools/* also participate in
-# lockstep — every Clojars-publishable tool (xray, story, story-mcp)
-# carries :clein/build :version "../../VERSION" and must not hand-edit
-# a literal :mvn/version for any day8/re-frame2-* artefact.
+# lockstep — every Clojars-publishable tool (xray, story, story-mcp,
+# machines-viz) carries :clein/build :version "../../VERSION" and must
+# not hand-edit a literal :mvn/version for any day8/re-frame2-* artefact.
+# tools/machines-viz/ (rf2-o9arp) ships day8/re-frame2-machines-viz with
+# the same lockstep posture as xray — :local/root "../../implementation/core"
+# in dev, rewritten to :mvn/version at release.
 # tools/re-frame2-pair-mcp/ ships as a Node binary on npm and carries no
 # :clein/build alias, so it is intentionally excluded. tools/template/
 # is similarly excluded as of rf2-40vmd (rf2-dolpf §2.5): it ships via
@@ -285,6 +288,7 @@ declare -A TOOLS_PATHS=(
   [xray]="xray"
   [story]="story"
   [story-mcp]="story-mcp"
+  [machines-viz]="machines-viz"
 )
 
 # Newline-separated `tool|"day8/re-frame2-x {:local/root \"…\"}"` pairs
@@ -298,10 +302,11 @@ story|day8/re-frame2 {:local/root "../../implementation/core"}
 story|day8/re-frame2-reagent {:local/root "../../implementation/adapters/reagent"}
 story|day8/re-frame2-machines {:local/root "../../implementation/machines"}
 story-mcp|day8/re-frame2-story {:local/root "../story"}
+machines-viz|day8/re-frame2 {:local/root "../../implementation/core"}
 EOF
 )
 
-TOOLS=(xray story story-mcp)
+TOOLS=(xray story story-mcp machines-viz)
 
 for tool in "${TOOLS[@]}"; do
   subpath="${TOOLS_PATHS[$tool]}"

--- a/TESTING.md
+++ b/TESTING.md
@@ -373,8 +373,8 @@ boolean GitHub-Actions outputs per surface:
 |---|---|
 | `implementation_jvm` | JVM artefact under `implementation/` changed; gates JVM unit + conformance jobs. |
 | `adapter_diagnostic` | Adapter artefact changed; gates the diagnostic skip-ok JVM classpath probes. |
-| `cljs_node_test` | A surface that compiles into the consolidated `:node-test` build changed (core, any adapter, any feature artefact, `spec/conformance/fixtures/*`, the build config in `implementation/{shadow-cljs.edn,package.json,package-lock.json}` + `implementation/scripts/*`, or a `.cljs`/`.cljc` file under `tools/{story,xray}/{src,test}` — rf2-f79t8); gates the `cljs` job (`shadow-cljs compile node-test` + `node out/node-test.js`). |
-| `cljs_browser` | CLJS surface that the browser tests cover changed; gates the separate `cljs-browser` job (`:browser-test` DOM build via Playwright). |
+| `cljs_node_test` | A surface that compiles into the consolidated `:node-test` build changed (core, any adapter, any feature artefact, `spec/conformance/fixtures/*`, the build config in `implementation/{shadow-cljs.edn,package.json,package-lock.json}` + `implementation/scripts/*`, a `.cljs`/`.cljc` file under `tools/{story,xray}/{src,test}` — rf2-f79t8 — or any non-spec-md change under `tools/machines-viz/*` — rf2-z0cw6s, whose `{src,test}` are also `:node-test` source paths); gates the `cljs` job (`shadow-cljs compile node-test` + `node out/node-test.js`). |
+| `cljs_browser` | CLJS surface that the browser tests cover changed (incl. any non-spec-md `tools/machines-viz/*` change — rf2-z0cw6s, whose `*-dom-cljs-test` export/chart-DOM suites run under `:browser-test` where EP-0015 image-export egress is verified); gates the separate `cljs-browser` job (`:browser-test` DOM build via Playwright). |
 | `cljs_prod` | Surface that release-mode probes (`browser-test-prod-elision`, schemas boundary prod) cover changed. |
 | `bundle_isolation` | Surface that can affect bundle boundaries (adapters, build scripts, examples used as probes, package metadata) changed. |
 | `reagent_slim_bundle` | Reagent Slim adapter / its example / its check script changed. |
@@ -481,6 +481,7 @@ must re-run the matrix).
 | S10 | `tools/template/*` |   |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |   |
 | S11 | `tools/story/{src,testbeds}/**`, `tools/xray/{src,testbeds}/**` (runtime-extension files — rf2-k9ekz; `.cljs`/`.cljc` also fire `cljs_node_test` — rf2-f79t8) |   |   | ✓ |   |   |   |   |   | ✓ |   | ✓ |   | ✓ |   |   |
 | S11a | `tools/story/{spec,test,bench}/**`, `tools/xray/{spec,test}/**`, `tools/{story,xray}/{deps.edn,README.md}` (non-runtime under story/xray; a `.cljs`/`.cljc` file under `test/**` still compiles into `:node-test` and fires `cljs_node_test` — rf2-f79t8 — but `spec/**.md`, `bench/**`, `deps.edn`, `README.md` do not) |   |   | ✓ |   |   |   |   |   | ✓ |   | ✓ |   |   |   |   |
+| S11b | `tools/machines-viz/*` (rf2-z0cw6s — `day8/re-frame2-machines-viz`, the shipped MachineChart + viewer + Mermaid/SCXML/PNG/SVG/share-URL export tool; CLJS-only, `{src,test}` are `:node-test` + `:browser-test` source paths. Every non-spec-md change fires `cljs_node_test` + `cljs_browser` — the latter runs the `*-dom-cljs-test` export/redaction suites verifying EP-0015 image-export egress. `spec/**.md` fires nothing. No JVM/MCP/template fan-out: CLJS-only, no MCP wrapper, not in the deps-new `:app`) |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |   |
 | S12 | `tools/story-mcp/*` |   |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |   |
 | S13 | `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*` |   |   |   |   |   |   |   |   | ✓ |   | ✓ | ✓ |   |   |   |
 | S14 | `tools/mcp-conformance/*` |   |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   |   |   |

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -180,6 +180,49 @@ test('Xray CLJS src change runs cljs (node-test compiles tools/xray) (rf2-f79t8)
   assert.equal(result.cljs_node_test, 'true');
 });
 
+// rf2-z0cw6s — tools/machines-viz is a CLJS-only tool (day8/re-frame2-machines-viz):
+// its src+test are :source-paths of the consolidated :node-test AND :browser-test
+// builds, so a CLJS change fires cljs (node-test) + cljs-browser, and nothing else
+// (no JVM suite, no MCP wrapper, not in the deps-new template's :app).
+
+test('machines-viz src .cljs change runs cljs + cljs-browser (rf2-z0cw6s)', () => {
+  const result = classify('tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+});
+
+test('machines-viz src .cljc change runs cljs + cljs-browser (rf2-z0cw6s)', () => {
+  const result = classify('tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+});
+
+test('machines-viz test-tree change runs cljs + cljs-browser (rf2-z0cw6s)', () => {
+  const result = classify('tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+});
+
+test('machines-viz does NOT fan out to tools_jvm / mcp_conformance / template_expensive (rf2-z0cw6s)', () => {
+  const result = classify('tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs');
+  assert.equal(result.tools_jvm, 'false');
+  assert.equal(result.mcp_conformance, 'false');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('machines-viz spec-only .md change fires nothing runtime (rf2-z0cw6s)', () => {
+  const result = classify('tools/machines-viz/spec/API.md');
+  assert.equal(result.cljs_node_test, 'false');
+  assert.equal(result.cljs_browser, 'false');
+  assert.equal(result.tools_jvm, 'false');
+});
+
+test('machines-viz deps.edn change fires cljs + cljs-browser (rf2-z0cw6s)', () => {
+  const result = classify('tools/machines-viz/deps.edn');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+});
+
 // rf2-4ka7c2.1 — API-manifest probe routing false-green fix. The CLJS-only
 // adapter / Xray / pair-MCP public surfaces live in the sidecar
 // (spec/api-manifest-metadata.edn) under :cljs-only and are carried into

--- a/tools/deps.edn
+++ b/tools/deps.edn
@@ -2,15 +2,17 @@
 ;;
 ;; The published artefacts are
 ;;   - xray/       (day8/re-frame2-xray)
+;;   - machines-viz/ (day8/re-frame2-machines-viz)
 ;;   - mcp-base/    (day8/re-frame2-mcp-base)
 ;;   - re-frame2-pair-mcp/   (@day8/re-frame2-pair-mcp, npm only)
 ;;   - story/       (day8/re-frame2-story)
 ;;   - story-mcp/   (day8/re-frame2-story-mcp)
 ;;   - template/    (day8/re-frame2-template — git-coord, not Clojars
 ;;                   per rf2-dolpf §2.5)
-;; see tools/xray/deps.edn, tools/mcp-base/deps.edn,
-;; tools/re-frame2-pair-mcp/deps.edn, tools/story/deps.edn,
-;; tools/story-mcp/deps.edn, and tools/template/deps.edn.
+;; see tools/xray/deps.edn, tools/machines-viz/deps.edn,
+;; tools/mcp-base/deps.edn, tools/re-frame2-pair-mcp/deps.edn,
+;; tools/story/deps.edn, tools/story-mcp/deps.edn, and
+;; tools/template/deps.edn.
 ;;
 ;; Other tool directories (machines-viz-mcp/, mcp-conformance/) are
 ;; spec-only or Node-only today — no `deps.edn` / CLJ surface to
@@ -19,10 +21,28 @@
 ;; self-contained JVM conformance test; it is run from its own
 ;; directory and is not coordinated here.
 ;;
-;; (Per rf2-yamkm the `tools/machines-viz/` artefact was collapsed:
-;; the pure Mermaid emitter relocated to `implementation/machines/`,
-;; and the live chart-component role was absorbed by Xray's Machine
-;; Inspector panel (PR #1400/#1402/#1407).)
+;; ## machines-viz is shipped (rf2-o9arp), NOT collapsed (rf2-z0cw6s)
+;;
+;; A prior note here said `tools/machines-viz/` had been COLLAPSED
+;; (rf2-yamkm — Mermaid relocated, chart role absorbed by Xray). That is
+;; STALE. rf2-o9arp REVIVED machines-viz as its own published artefact:
+;; `tools/machines-viz/deps.edn` declares real `:paths ["src"]`, a
+;; runtime transit-cljs dep, a `:test` alias, and a `:clein/build` for
+;; `day8/re-frame2-machines-viz` with the SAME lockstep posture as Xray.
+;; Xray now CONSUMES machines-viz (its Machine Inspector re-exports the
+;; chart via thin shims), rather than owning the chart. The Mermaid
+;; emitter lives in THIS jar again (rf2-sqhqu), not implementation/machines.
+;;
+;; ## Why machines-viz is NOT in the JVM aggregate :test (CLJS-only)
+;;
+;; Like Xray, machines-viz is CLJS-only (the chart `:require`s
+;; `@xyflow/react` + `elkjs`, JVM-unloadable). Its tests run under the
+;; consolidated `implementation/shadow-cljs.edn` `:node-test` build
+;; (`*_cljs_test`) AND the `:browser-test` build (`*-dom-cljs-test` — the
+;; DOM/export suites), NOT on the JVM. So it sits in the coordinator
+;; `:deps` (classpath only; nothing requires it on the JVM) but its tests
+;; are intentionally absent from the JVM aggregate `:test` `:extra-paths`
+;; below — the same justified exclusion the Xray coverage-gap note records.
 ;;
 ;; This top-level deps.edn is *not* itself a published artefact — it is
 ;; the build coordinator that pulls every tool artefact onto a single
@@ -49,11 +69,12 @@
 ;; the *coordinator's* classpath; nothing under implementation/ may
 ;; :require anything under tools/.
 {:paths []
- :deps  {day8/re-frame2-xray     {:local/root "xray"}
-         day8/re-frame2-mcp-base  {:local/root "mcp-base"}
-         day8/re-frame2-pair-mcp  {:local/root "re-frame2-pair-mcp"}
-         day8/re-frame2-story     {:local/root "story"}
-         day8/re-frame2-story-mcp {:local/root "story-mcp"}}
+ :deps  {day8/re-frame2-xray         {:local/root "xray"}
+         day8/re-frame2-machines-viz {:local/root "machines-viz"}
+         day8/re-frame2-mcp-base     {:local/root "mcp-base"}
+         day8/re-frame2-pair-mcp     {:local/root "re-frame2-pair-mcp"}
+         day8/re-frame2-story        {:local/root "story"}
+         day8/re-frame2-story-mcp    {:local/root "story-mcp"}}
 
  :aliases
  {;; Aggregate JVM-side test run across every tool whose tests are
@@ -66,6 +87,10 @@
   ;;   - tools/xray/ — CLJS-side only (DOM + Reagent shell). Its tests
   ;;     run under the implementation/shadow-cljs.edn :node-test build,
   ;;     not on the JVM.
+  ;;   - tools/machines-viz/ — CLJS-only (rf2-z0cw6s). Same posture as
+  ;;     Xray: tests run under the implementation/shadow-cljs.edn
+  ;;     :node-test build (`*_cljs_test`) + :browser-test build
+  ;;     (`*-dom-cljs-test`, the DOM/export suites), not on the JVM.
   ;;   - tools/re-frame2-pair-mcp/ — CLJS Node-script. Its tests run under
   ;;     tools/re-frame2-pair-mcp/shadow-cljs.edn :server-test (mirrored in
   ;;     tools/shadow-cljs.edn).

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -72,6 +72,9 @@ registry).
 | `:overlays` | no | `nil` | rf2-7w4qr. A **vector of host-fed overlay descriptor maps**, each keyed on `:id`. The single slot through which hosts compose the host-fed, spec+tick+callbacks overlay family (after-rings / spawn-all-join / cancellation-cascade) — collapses the former flat per-overlay props so a new overlay adds **one descriptor variant**, not 3–5 trunk props. The chart dispatches each descriptor to its already-modular rendering namespace by `:id` (`chart.cljs/render-overlay`); the renderers are unchanged. A per-descriptor `:tick` unifies the former `:after-ring-tick` + `:overlay-tick` (one rAF clock per chart stays host-owned — Lock #8 — just delivered per-overlay). A descriptor whose `:id` is outside the recognised set is **ignored** (a host data error, not a runtime fallback; dev builds emit a `js/console.warn`). Non-map entries are skipped. `nil` / `[]` → no overlays. See [§`:overlays` slot descriptor schema](#overlays-slot-descriptor-schema-rf2-7w4qr) for the multispec. |
 | `:machine-data` | no | `nil` | rf2-qo5xy; rf2-q129z8; rf2-3q4k5b. CLJS map fed into the Context BAND in the ROOT-CONTAINER frame header (was a top-left corner panel pre-q129z8). Host projection: either live `:data` (key→value) or the **static context shape** (key→type-caption, via Xray's `static-context-shape`), which is **declared over inferred** — authoritative off a `:data-schema` when present, else inferred from one `:data` sample (rf2-3q4k5b). `nil` / empty → no band. See [§Context band](#context-band-rf2-qo5xy-rf2-q129z8--now-in-the-frame-header). |
 | `:machine-data-inferred?` | no | `true` | rf2-5tz9p; rf2-3q4k5b. Provenance gate for the Context-band badge. When `true` (default) the band shows a subtle `inferred from :data` badge — a type shape **inferred** from one sample of the definition's `:data`, **not** a declared schema and **not** the live runtime `:data`. When `false` the inferred badge is **dropped** and a positive `declared` badge shows instead; hosts pass `false` when feeding live `:data` **values** OR an AUTHORITATIVE shape off a `:data-schema` (rf2-3q4k5b · EP-0005). Ignored when no band renders. See [§Context band](#context-band-rf2-qo5xy-rf2-q129z8--now-in-the-frame-header). |
+| `:machine-data-sensitive` | no | `#{}` | rf2-27e38h · EP-0015. A SET of Context-band keys whose VALUES are redacted to `:rf/redacted` before they reach the DOM (and therefore the SVG/PNG/clipboard export). The host derives it from the machine's `:data-schema` `:sensitive?` slot props. See [§Context-band egress contract](#context-band-egress-contract--local-redacted-by-default-rf2-27e38h--ep-0015). |
+| `:machine-data-large` | no | `#{}` | rf2-27e38h · EP-0015. A SET of Context-band keys whose values are elided to a content-FREE `:rf/large {:bytes N}` form before export. Unmarked over-cap values elide too; sensitive wins over large. |
+| `:machine-data-raw?` | no | `false` | rf2-27e38h · EP-0015. The explicit trusted-local (`:rf.egress/local-raw`) opt-in. `true` skips Context-band redaction and serialises raw values — an operator act for a developer inspecting their own process. Default `false` keeps the band local-redacted. |
 | `:testid` | no | `"rf-mv-chart"` | Root wrapper `data-testid` so tests + hosts can find the chart. |
 
 ### `:overlays` slot descriptor schema (rf2-7w4qr)
@@ -580,6 +583,51 @@ provenance, gated by the optional `:machine-data-inferred?` prop
   declared `:data-schema` (EP-0005's declared-over-inferred upgrade,
   closing the deferred `rf2-wto1k` option A). The badge distinguishes
   an authoritative/declared shape from the one-sample inference.
+
+#### Context-band egress contract — local-redacted by default (rf2-27e38h · EP-0015)
+
+The Context band is painted into the live viewport DOM, and the
+**image exporters serialise that DOM**: `export/chart-as-svg` clones the
+live `.react-flow__viewport` into a `<foreignObject>`, and the PNG +
+clipboard-image lanes derive from that SVG. A framework-created
+export/copy artefact is **egress** per
+[EP-0015](../../../docs/EP/EP-0015-frame-owned-egress-policy.md) §96-110.
+So when a host feeds **live `:data` VALUES** (the `:machine-data-inferred?
+false` value path above), a schema-marked sensitive or large slot would
+otherwise be embedded in the exported SVG/PNG/clipboard verbatim.
+
+The chart therefore applies a **local-redacted projection
+(`:rf.egress/local-redacted`) to the Context band by default**, at the
+single `chart.projection/xyflow-graph` projection chokepoint — so the
+redaction is identical for the on-screen band AND every export derived
+from it. The host declares which slots carry sensitive/large content
+(the machine's `:data-schema` `:sensitive?` / `:large?` per-slot props —
+the EP-0005 mechanism; `context-redaction/derive-classification` extracts
+them) via two optional props:
+
+| Prop | Default | Meaning |
+|------|---------|---------|
+| `:machine-data-sensitive` | `#{}` | A SET of band keys whose VALUES are redacted to the `:rf/redacted` sentinel before they reach the DOM/export. |
+| `:machine-data-large` | `#{}` | A SET of band keys whose values are elided to a content-FREE `:rf/large {:bytes N}` form (size diagnostic only — no content head). An unmarked value over a defensive char cap is elided too. |
+| `:machine-data-raw?` | `false` | The explicit **trusted-local** (`:rf.egress/local-raw`) opt-in. When `true`, redaction is skipped and the raw values are painted/serialised. An operator act, for a developer inspecting their own process. |
+
+Sensitive **wins over** large (the EP-0015 ordering). The redaction
+defaults are **on** (`:machine-data-raw? false`, empty sets), so:
+
+- A host feeding the **static type-caption shape** (the sole production
+  feeder today — `topology-view/static-context-shape`, key→type-caption)
+  is a redaction **no-op**: captions like `"string"` are neither
+  sensitive markers nor large, so the production surface is unchanged.
+- A host feeding **live values** gets local-redacted output unless it
+  both declares the classification AND opts into raw.
+
+The contract answers the "must `:machine-data` be pre-projected?"
+question: **the host MAY pass raw live `:data` and declare the
+sensitive/large slots; the chart applies the local-redacted projection
+itself.** A host that has already projected its own values may pass an
+empty classification (the values are then treated as non-sensitive). The
+sentinels render as content-free text (`🔒 :rf/redacted`, `… :rf/large
+{:bytes N}`) in both the band and any export.
 
 #### Legacy paradigm sections below
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -60,6 +60,32 @@
                :cljs [cljs.reader :as edn])))
 
 ;; ---------------------------------------------------------------------------
+;; Value-free error diagnostics (rf2-8nzxib)
+
+(defn- response-summary
+  "EP-0015 / Spec 015 §exception-path residual — a value-FREE diagnostic
+  for an LLM resolver `response` (or the fence-stripped form). The raw
+  string can carry prompt artefacts, user text, or LLM-returned secrets,
+  and projection cannot walk `ex-data` after the fact, so the thrown
+  error reports only the TYPE + character length — never the content."
+  [s]
+  (if (string? s)
+    {:type :string :length (count s)}
+    {:type (cond (nil? s) :nil (keyword? s) :keyword (map? s) :map
+                 (vector? s) :vector (sequential? s) :seq :else :value)}))
+
+(defn- spec-summary
+  "Value-FREE diagnostic for a parsed (but invalid) machine `spec`: the
+  type tag plus, for a map, the top-level key SET — never the values (a
+  parsed spec can embed LLM-returned strings / `:data` runtime values)."
+  [spec]
+  (cond
+    (map? spec)     {:type :map :keys (vec (sort-by str (keys spec)))}
+    (vector? spec)  {:type :vector :count (count spec)}
+    (nil? spec)     {:type :nil}
+    :else           {:type :value}))
+
+;; ---------------------------------------------------------------------------
 ;; System prompt
 
 (def system-prompt
@@ -261,7 +287,8 @@
                                 "a string (the LLM's EDN response); it returned a "
                                 "non-string value.")
                            {:recovery :return-a-string-from-the-resolver
-                            :extra    {:response response}}))
+                            ;; rf2-8nzxib — value-FREE; never the raw response.
+                            :extra    {:response-summary (response-summary response)}}))
          stripped      (strip-fences response)
          [stage spec-or-reason] (parse-edn stripped)]
      (cond
@@ -273,8 +300,10 @@
               "EDN (" spec-or-reason "). The resolver must return a single EDN "
               "machine-spec map, optionally inside a ```edn fenced block.")
          {:recovery :return-valid-edn-from-the-resolver
-          :extra    {:response response
-                     :stripped stripped}})
+          ;; rf2-8nzxib — value-FREE; the raw response/stripped text can
+          ;; carry prompt artefacts or LLM-returned secrets.
+          :extra    {:response-summary (response-summary response)
+                     :stripped-summary (response-summary stripped)}})
 
        :else
        (let [[stage2 ok-or-reason] (validate-spec spec-or-reason)]
@@ -288,5 +317,7 @@
                   "resolver return a spec with :initial + :states (or :type "
                   ":parallel + :regions).")
              {:recovery :return-a-valid-machine-spec
-              :extra    {:response response
-                         :spec     spec-or-reason}})))))))
+              ;; rf2-8nzxib — value-FREE; the response + parsed spec can
+              ;; embed LLM-returned secrets / runtime :data.
+              :extra    {:response-summary (response-summary response)
+                         :spec-summary     (spec-summary spec-or-reason)}})))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -1235,6 +1235,9 @@
                  overlays
                  machine-data
                  machine-data-inferred?
+                 machine-data-sensitive
+                 machine-data-large
+                 machine-data-raw?
                  fit-signal
                  testid]
           :or   {direction         :tb
@@ -1244,6 +1247,14 @@
                  show-minimap?     false
                  show-controls?    true
                  show-background?  true
+                 ;; rf2-27e38h (EP-0015) — Context-band egress defaults:
+                 ;; local-redacted ON (raw? false), empty classification
+                 ;; sets. A host feeding live `:data` declares the
+                 ;; sensitive/large slots; the value-free type-caption
+                 ;; production feeder is a redaction no-op.
+                 machine-data-sensitive #{}
+                 machine-data-large     #{}
+                 machine-data-raw?      false
                  ;; rf2-5tz9p — the Context panel's sole production feeder is
                  ;; the static INFERRED shape (Xray's `static-context-shape`,
                  ;; key→type-caption). Default the inferred badge ON so the
@@ -1554,7 +1565,12 @@
                             fired-edge-id-set guard-blocked-edge-id-set
                             sim? callback edge-callback
                             density theme
-                            machine-id machine-data machine-data-inferred?]
+                            machine-id machine-data machine-data-inferred?
+                            ;; rf2-27e38h — a change in the Context-band
+                            ;; egress classification / raw opt-in must
+                            ;; rebuild the projected band display.
+                            machine-data-sensitive machine-data-large
+                            machine-data-raw?]
                 {:keys [js-nodes js-edges]}
                 (project+convert!
                   cache-key
@@ -1601,7 +1617,17 @@
                                ;; corner-pinned title strip + Context overlay).
                                :machine-id        machine-id
                                :machine-data      machine-data
-                               :machine-data-inferred? machine-data-inferred?})))
+                               :machine-data-inferred? machine-data-inferred?
+                               ;; rf2-27e38h (EP-0015) — local-redacted
+                               ;; Context-band egress contract. The band is
+                               ;; serialised into SVG/PNG/clipboard, so live
+                               ;; `:data` values are redacted by default; the
+                               ;; host declares which slots are sensitive/large
+                               ;; (from the machine's `:data-schema`) and may
+                               ;; opt into raw via `:machine-data-raw?`.
+                               :machine-data-sensitive machine-data-sensitive
+                               :machine-data-large machine-data-large
+                               :machine-data-raw? machine-data-raw?})))
                 aria-label (str "State machine"
                                 (when machine-id
                                   (str ": " (name machine-id)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
@@ -1,0 +1,160 @@
+(ns day8.re-frame2-machines-viz.chart.context-redaction
+  "EP-0015 local-redacted projection for the chart's root Context band
+  (rf2-27e38h).
+
+  ## Why this exists
+
+  The Context band paints a `(key, value)` map the host feeds as
+  `:machine-data`. The SOLE production feeder today is the static context
+  SHAPE (key → type-caption — value-free; see `context-shape`). But the
+  contract also lets a host feed the LIVE machine `:data` VALUES
+  (`:machine-data-inferred? false`). Those values land in the rendered
+  DOM (`chart.nodes/root-container-node`), and the SVG / PNG / clipboard
+  exporters serialise that DOM (`export/chart-as-svg` clones the live
+  `.react-flow__viewport`). So a host that feeds live `:data` carrying a
+  schema-marked **sensitive** or **large** slot would otherwise embed the
+  raw value in an official egress artefact with no local-redacted default.
+
+  Per [EP-0015](../../../docs/EP/EP-0015-frame-owned-egress-policy.md)
+  §96-110, §985-989: framework-created export/copy artefacts are egress;
+  local tools default `:rf.egress/local-redacted`; raw requires an
+  explicit trusted-local opt-in. EP-0015 issue 12 / Spec 015 §Machine
+  `:data`: machine `:data` sensitivity is **schema-first** — per-slot
+  `:sensitive?` / `:large?` props on the machine's `:data-schema`.
+
+  ## What this does
+
+  `redact-context` projects the band's `(key, value)` map to a
+  local-redacted display map BEFORE it reaches the DOM:
+
+    - a key declared **sensitive** projects to the sentinel `:rf/redacted`;
+    - a **large** value projects to `:rf/large {:bytes N}` (size
+      diagnostic preserved; NO content head — a head fragment would leak
+      into the export);
+    - sensitive WINS over large (the EP-0015 ordering);
+    - everything else passes through unchanged.
+
+  Sensitivity is supplied as a SET of sensitive keys + a SET of large keys
+  (`derive-classification` extracts them from a `:data-schema`), so this
+  namespace stays dependency-free and JVM-portable (no Malli runtime — it
+  reads the schema as plain data, mirroring `context-shape`).
+
+  The static type-caption shape is already value-free, so redaction over
+  it is a no-op (captions like `\"string\"` are neither sensitive markers
+  nor large). The default-on redaction therefore never changes the
+  production surface; it only fires for a host feeding live values.")
+
+;; ---------------------------------------------------------------------------
+;; Classification extraction from a :data-schema (plain-data walk)
+
+(def ^:private map-unwrap-heads
+  "Malli wrapper heads whose first contained schema carries the real map —
+  mirrors `context-shape/map-unwrap-heads`."
+  #{:and :or :schema :ref})
+
+(defn- map-schema
+  "Unwrap common Malli wrappers to the contained `[:map …]` vector, else
+  nil. Mirrors `context-shape/map-schema` (kept local so this ns carries
+  no cross-dep on the caption namespace)."
+  [schema]
+  (loop [s schema budget 32]
+    (when (and (vector? s) (pos? budget))
+      (let [head (first s)]
+        (cond
+          (= :map head) s
+          (contains? map-unwrap-heads head)
+          (recur (some #(when-not (map? %) %) (rest s)) (dec budget))
+          :else nil)))))
+
+(defn- entry-props
+  "The per-entry props map of a Malli `:map` entry `[k props? child]`, or
+  nil. An entry is `[k child]` or `[k {…} child]`."
+  [entry]
+  (let [maybe-props (second entry)]
+    (when (map? maybe-props) maybe-props)))
+
+(defn derive-classification
+  "Extract `{:sensitive #{k …} :large #{k …}}` from a machine's
+  `:data-schema` by reading the per-slot `:sensitive?` / `:large?` props
+  on each `:map` entry (EP-0005 / Spec 015 §Machine `:data`). Pure;
+  walks the schema as plain data — no Malli runtime. Returns
+  `{:sensitive #{} :large #{}}` when the schema is absent or carries no
+  `:map`."
+  [data-schema]
+  (if-let [ms (map-schema data-schema)]
+    (let [entries (->> (rest ms) (filter vector?))]
+      (reduce (fn [acc entry]
+                (let [k     (first entry)
+                      props (entry-props entry)]
+                  (cond-> acc
+                    (:sensitive? props) (update :sensitive conj k)
+                    (:large? props)     (update :large conj k))))
+              {:sensitive #{} :large #{}}
+              entries))
+    {:sensitive #{} :large #{}}))
+
+;; ---------------------------------------------------------------------------
+;; Large-value heuristic
+
+(def ^:private default-large-char-cap
+  "A printed value longer than this many chars is elided as large even
+  when the schema did not mark it `:large?`. A defensive size guard so a
+  big unmarked slot cannot bloat (and leak its content into) the export.
+  Conservative — ordinary context values render well under this."
+  512)
+
+(defn- printed-size
+  "The char length of `(pr-str v)` — the size the band would otherwise
+  render — used both for the large heuristic and the `:bytes` diagnostic."
+  [v]
+  (count (pr-str v)))
+
+;; ---------------------------------------------------------------------------
+;; Projection
+
+(defn redact-value
+  "Project one context VALUE under the resolved classification.
+
+    - sensitive (key ∈ `sensitive`)  → `:rf/redacted`
+    - large (key ∈ `large`, OR printed size > `large-char-cap`)
+                                      → `:rf/large {:bytes N}` (no head)
+    - otherwise                       → `v` unchanged
+
+  Sensitive WINS over large (EP-0015). Returns the value to render."
+  [k v {:keys [sensitive large large-char-cap]
+        :or   {sensitive #{} large #{} large-char-cap default-large-char-cap}}]
+  (cond
+    (contains? sensitive k) :rf/redacted
+    (or (contains? large k)
+        (> (printed-size v) large-char-cap))
+    [:rf/large {:bytes (printed-size v)}]
+    :else v))
+
+(defn redact-context
+  "Project the band's `(key, value)` map to a local-redacted display map
+  (EP-0015 `:rf.egress/local-redacted`). `classification` is
+  `{:sensitive #{k} :large #{k} :large-char-cap N?}`. Order-preserving.
+
+  Returns the redacted map; `nil` / empty in → `nil` out (band hidden)."
+  [machine-data classification]
+  (when (seq machine-data)
+    (into (empty machine-data)
+          (map (fn [[k v]] [k (redact-value k v classification)]))
+          machine-data)))
+
+;; ---------------------------------------------------------------------------
+;; Display rendering — what the band paints for a (possibly redacted) value
+
+(defn display-string
+  "The display TEXT the band paints for a (possibly redacted) value `v`.
+  `:rf/redacted` and the `:rf/large` rich form render as stable,
+  content-FREE sentinels so they read clearly in the chart AND in any
+  serialised export. Everything else renders via `pr-str` (the prior
+  behaviour)."
+  [v]
+  (cond
+    (= :rf/redacted v) "🔒 :rf/redacted"
+    (and (vector? v) (= :rf/large (first v)) (map? (second v)))
+    (let [bytes (:bytes (second v))]
+      (str "… :rf/large" (when bytes (str " {:bytes " bytes "}"))))
+    :else (pr-str v)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -33,6 +33,7 @@
       JVM.
     - **Topology parsing** — lives in `chart.layout`."
   (:require [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.chart.context-redaction :as ctx-redact]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
@@ -1281,15 +1282,39 @@
    {:keys [highlight-ids from-highlight-id to-highlight-id sim?
            on-state-click on-edge-click edge-points edge-labels
            fired-edge-ids guard-blocked-edge-ids chart palette
-           machine-id machine-data machine-data-inferred?]
+           machine-id machine-data machine-data-inferred?
+           machine-data-sensitive machine-data-large machine-data-raw?]
     :or   {chart vc/chart-regular edge-points {} edge-labels {}
            fired-edge-ids #{} guard-blocked-edge-ids #{}
-           machine-data-inferred? true}}]
+           machine-data-inferred? true
+           machine-data-sensitive #{} machine-data-large #{}
+           machine-data-raw? false}}]
   (let [;; rf2-az6e2 — resolve the chart-semantic token map for the
         ;; active theme ONCE. nil → dark chart-tokens (a theme-less
         ;; caller keeps the dark surface). Threaded onto every node/edge
         ;; `:data {:palette}` so the renderers paint the active theme.
         ct (or palette (tokens/chart-tokens))
+        ;; rf2-27e38h (EP-0015) — the Context band is serialised into the
+        ;; SVG / PNG / clipboard export (export/chart-as-svg clones the
+        ;; live viewport DOM). It defaults to a LOCAL-REDACTED projection:
+        ;; a `:machine-data-sensitive` key renders `:rf/redacted` and a
+        ;; large value is elided WITHOUT a content head, so a host feeding
+        ;; live `:data` cannot leak a schema-marked secret/large slot into
+        ;; an egress artefact. `:machine-data-raw? true` is the explicit
+        ;; trusted-local (`:rf.egress/local-raw`) opt-in that skips it.
+        ;; The production feeder's value-free type-caption shape is a
+        ;; no-op under redaction, so the default surface is unchanged.
+        ctx-display (when (seq machine-data)
+                      (let [redacted (if machine-data-raw?
+                                       machine-data
+                                       (ctx-redact/redact-context
+                                         machine-data
+                                         {:sensitive machine-data-sensitive
+                                          :large     machine-data-large}))]
+                        (mapv (fn [[k v]]
+                                [(if (keyword? k) (str (symbol k)) (str k))
+                                 (ctx-redact/display-string v)])
+                              redacted)))
         ;; rf2-uw3vmi — guarded-fork branch-order. Derived ONCE from the
         ;; ordered `:edges` vector (the parse preserves the source
         ;; candidate vector order, which IS the engine's first-pass-wins
@@ -1529,13 +1554,11 @@
                                           :machineName (when machine-id
                                                          (name machine-id))
                                           :parallel    (boolean parallel?)
-                                          :context     (when (seq machine-data)
-                                                         (mapv (fn [[k v]]
-                                                                 [(if (keyword? k)
-                                                                    (str (symbol k))
-                                                                    (str k))
-                                                                  (pr-str v)])
-                                                               machine-data))
+                                          ;; rf2-27e38h — the local-redacted
+                                          ;; band display rows (computed once
+                                          ;; above; never the raw values unless
+                                          ;; `:machine-data-raw?` opted in).
+                                          :context     ctx-display
                                           :contextInferred (boolean
                                                              machine-data-inferred?)))
                        :draggable false

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -911,6 +911,22 @@
        (seq regions)
        (every? valid-state-tree? (vals regions))))
 
+(defn- definition-summary
+  "EP-0015 / Spec 015 §exception-path residual (rf2-8nzxib) — a
+  value-FREE diagnostic for an invalid `definition`. A definition can
+  carry a `:data` slot holding live runtime values, and projection
+  cannot walk `ex-data` after the fact, so the thrown error reports only
+  STRUCTURAL facts: the top-level key SET, parallel?, and child counts —
+  never the `:data` values."
+  [definition]
+  (if (map? definition)
+    (cond-> {:type     :map
+             :keys     (vec (sort-by str (keys definition)))
+             :parallel (parallel-definition? definition)}
+      (map? (:states definition))  (assoc :state-count  (count (:states definition)))
+      (map? (:regions definition)) (assoc :region-count (count (:regions definition))))
+    {:type (cond (nil? definition) :nil (vector? definition) :vector :else :value)}))
+
 (defn emit
   "Emit a Mermaid `stateDiagram-v2` string for `definition`.
 
@@ -953,7 +969,9 @@
            (str "Mermaid export: a definition must carry :initial + a "
                 "non-empty :states map. Provide those."))
          {:recovery :supply-a-valid-definition
-          :extra    {:definition definition}})))
+          ;; rf2-8nzxib — value-FREE; never the raw definition (its
+          ;; :data slot can hold live runtime values).
+          :extra    {:definition-summary (definition-summary definition)}})))
    (let [body (if (parallel-definition? definition)
                 (render-parallel-body definition header-comment?)
                 (render-flat-or-compound-body definition header-comment?))]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -135,6 +135,35 @@
             [day8.re-frame2-machines-viz.chart.layout :as layout]))
 
 ;; ---------------------------------------------------------------------------
+;; Value-free error diagnostics (rf2-8nzxib)
+;;
+;; EP-0015 / Spec 015 §exception-path residual — a thrown error must NOT
+;; carry the raw rejected payload. A machine spec can carry a `:data`
+;; slot of live runtime values and an SCXML input string can carry
+;; interpolated secrets; projection cannot walk `ex-data` after the fact,
+;; so the assembly site names the SHAPE (type tag, key SET, length) —
+;; never the values.
+
+(defn- spec-summary
+  "Value-FREE diagnostic for a rejected machine `spec`: type tag plus —
+  for a map — the top-level key SET, parallel?, and child counts."
+  [spec]
+  (if (map? spec)
+    (cond-> {:type     :map
+             :keys     (vec (sort-by str (keys spec)))
+             :parallel (= :parallel (:type spec))}
+      (map? (:states spec))  (assoc :state-count  (count (:states spec)))
+      (map? (:regions spec)) (assoc :region-count (count (:regions spec))))
+    {:type (cond (nil? spec) :nil (vector? spec) :vector :else :value)}))
+
+(defn- input-summary
+  "Value-FREE diagnostic for a rejected SCXML `input`: type + length."
+  [input]
+  (if (string? input)
+    {:type :string :length (count input)}
+    {:type (cond (nil? input) :nil (map? input) :map :else :value)}))
+
+;; ---------------------------------------------------------------------------
 ;; Id codec — FULLY INJECTIVE, xsd:ID-conformant (rf2-mnp93.1)
 ;;
 ;; Re-frame2 ids are keywords (`:idle`, `:auth/login-flow`,
@@ -792,7 +821,9 @@
           (str "SCXML export: a parallel machine spec requires a non-empty "
                ":regions map; add :regions to the parallel spec.")
           {:recovery :supply-non-empty-regions
-           :extra    {:spec machine-spec}}))
+           ;; rf2-8nzxib — value-FREE; never the raw spec (its :data
+           ;; slot can carry live runtime values).
+           :extra    {:spec-summary (spec-summary machine-spec)}}))
       (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
            (str/join "\n" (emit-parallel machine-spec 0))))
 
@@ -808,7 +839,8 @@
            ":states map, or :type :parallel + :regions. Provide one of "
            "those shapes.")
       {:recovery :supply-a-valid-machine-spec
-       :extra    {:spec machine-spec}})))
+       ;; rf2-8nzxib — value-FREE; never the raw spec.
+       :extra    {:spec-summary (spec-summary machine-spec)}})))
 
 ;; ---------------------------------------------------------------------------
 ;; XML parse — minimal regex-based reader for the SCXML subset we
@@ -1417,7 +1449,8 @@
       'machines-viz/scxml->spec
       "SCXML import: scxml->spec expects an SCXML string; pass the SCXML document as a string."
       {:recovery :pass-an-scxml-string
-       :extra    {:input scxml-string}}))
+       ;; rf2-8nzxib — value-FREE; never the raw input.
+       :extra    {:input-summary (input-summary scxml-string)}}))
   (let [tokens (-> scxml-string strip-prolog lift-action-comments strip-comments tokenize vec)
         root-start (first (filter #(= "scxml" (:tag %)) tokens))]
     (when-not root-start

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -401,6 +401,27 @@
 ;; ---------------------------------------------------------------------------
 ;; Errors
 
+(defn- value-free-summary
+  "EP-0015 / Spec 015 §Author guidance for the exception-path residual —
+  a value-FREE diagnostic for a rejected payload `v`. Projection cannot
+  walk `ex-data` after the fact, so a thrown error must NOT carry the raw
+  payload (a forged share URL can smuggle `:snapshot {:data …}` /
+  arbitrary runtime values). We name the SHAPE — type tag + (for maps)
+  the key SET — never the values. The reader still recovers the category
+  + structural diagnostics; no secret-bearing slot survives."
+  [v]
+  (cond
+    (map? v)  {:type :map  :keys (vec (sort-by str (keys v))) :count (count v)}
+    (vector? v) {:type :vector :count (count v)}
+    (set? v)  {:type :set :count (count v)}
+    (sequential? v) {:type :seq}
+    (string? v) {:type :string :length (count v)}
+    (keyword? v) {:type :keyword :value v}     ; a keyword IS a state name/address, not data
+    (number? v) {:type :number}
+    (boolean? v) {:type :boolean}
+    (nil? v)  {:type :nil}
+    :else     {:type :value}))
+
 (defn- decode-error
   "Throw the documented `:rf.machines-viz.share/decode-failed` ex-info.
 
@@ -478,7 +499,9 @@
                           :recovery    :supply-a-valid-chart-state
                           :reason      :invalid-chart-state
                           :message     msg
-                          :chart-state chart-state}))))
+                          ;; rf2-8nzxib — value-FREE summary, NOT the raw
+                          ;; chart-state (which can carry runtime :data).
+                          :chart-state-summary (value-free-summary chart-state)}))))
      (let [envelope    (canonicalise
                          {:rf.machines-viz.share/v       current-version
                           :rf.machines-viz.share/chart   allowlisted
@@ -556,7 +579,9 @@
                      (contains? envelope :rf.machines-viz.share/chart))
         (decode-error :missing-envelope
                       "payload missing :rf.machines-viz.share/v or …/chart"
-                      {:envelope envelope}))
+                      ;; rf2-8nzxib — a forged payload's :envelope can carry
+                      ;; raw runtime values; report only its value-free shape.
+                      {:envelope-summary (value-free-summary envelope)}))
       (let [v     (:rf.machines-viz.share/v envelope)
             chart (:rf.machines-viz.share/chart envelope)
             ;; Versions are integer-valued strings ("1" at v1.0).
@@ -577,7 +602,9 @@
         (when-not (valid-chart-state? chart)
           (decode-error :invalid-chart-state
                         "…/chart does not validate against the ChartState schema"
-                        {:chart chart}))
+                        ;; rf2-8nzxib — a forged :chart can smuggle
+                        ;; :snapshot {:data …}; report value-free shape only.
+                        {:chart-summary (value-free-summary chart)}))
         envelope))))
 
 (defn decode-share-url-safe

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
@@ -18,8 +18,19 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
+            [clojure.walk :as walk]
             [day8.re-frame2-machines-viz.ai-generate :as ai]
             [day8.re-frame2-machines-viz.scxml :as scxml]))
+
+(defn- deep-strings
+  "Every string anywhere in `m` (deep walk) — so a test can assert a
+  secret never survives into the error map under any key."
+  [m]
+  (let [acc (volatile! [])]
+    (walk/postwalk
+      (fn [x] (when (string? x) (vswap! acc conj x)) x)
+      m)
+    @acc))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -182,6 +193,56 @@
                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is ex)
       (is (= :ai-generate/invalid-spec (:rf.error/id (ex-data ex)))))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 — error ex-data carries NO raw LLM payload (rf2-8nzxib)
+;;
+;; The resolver response can carry user prompt artefacts or LLM-returned
+;; secrets/source text, and the parsed spec can embed runtime :data;
+;; projection cannot walk ex-data after the fact (Spec 015). The error
+;; keeps value-FREE diagnostics (type, length, key set) — never the raw
+;; response / stripped text / parsed spec.
+
+(deftest parse-failed-omits-raw-response
+  (testing "unparseable-EDN :parse-failed keeps only value-free response/stripped summaries"
+    (let [secret   "OPENAI-SK-leaked-key-9f2a"
+          ;; A response that fails EDN parsing (unbalanced braces) but
+          ;; embeds a secret string the error must not retain.
+          resolver (stub-resolver (str "{:leaked \"" secret "\" {{{ not-edn }}}"))
+          d        (try (ai/generate-machine "x" {:resolver resolver}) nil
+                        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :ai-generate/parse-failed (:rf.error/id d)) "category preserved")
+      (is (not (contains? d :response)) "no raw :response slot")
+      (is (not (contains? d :stripped)) "no raw :stripped slot")
+      (is (some? (:response-summary d)) "value-free response summary present")
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
+
+(deftest non-string-response-omits-raw-response
+  (testing "non-string resolver response keeps only a value-free summary"
+    (let [secret   "card-number-4111111111111111"
+          resolver (fn [_] {:leak secret})            ;; non-string → parse-failed
+          d        (try (ai/generate-machine "x" {:resolver resolver}) nil
+                        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :ai-generate/parse-failed (:rf.error/id d)))
+      (is (not (contains? d :response)))
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
+
+(deftest invalid-spec-omits-raw-parsed-spec
+  (testing "invalid-spec keeps only a value-free spec summary, not the parsed spec"
+    (let [secret   "ssn-123-45-6789"
+          ;; Parses as EDN (a map) but is not a valid machine spec, and
+          ;; embeds a secret-bearing :data slot.
+          resolver (stub-resolver (str "{:not-a-machine true :data {:ssn \"" secret "\"}}"))
+          d        (try (ai/generate-machine "x" {:resolver resolver}) nil
+                        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :ai-generate/invalid-spec (:rf.error/id d)) "category preserved")
+      (is (not (contains? d :spec)) "no raw :spec slot")
+      (is (not (contains? d :response)) "no raw :response slot")
+      (is (some? (:spec-summary d)) "value-free spec summary present")
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
 
 ;; ---------------------------------------------------------------------------
 ;; End-to-end — generated specs work with the rest of the substrate

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_cljs_test.cljc
@@ -1,0 +1,124 @@
+(ns day8.re-frame2-machines-viz.chart.context-redaction-cljs-test
+  "EP-0015 local-redacted Context-band projection (rf2-27e38h).
+
+  Pins the contract that a host feeding LIVE machine `:data` into the
+  Context band cannot leak a schema-marked sensitive or large slot into
+  the SVG / PNG / clipboard export: the band defaults to a local-redacted
+  projection, and the redacted display text is content-FREE. Pure `.cljc`
+  → the JVM corpus pins it without a browser."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.chart.context-redaction :as r]))
+
+;; ---------------------------------------------------------------------------
+;; derive-classification — reads :sensitive? / :large? slot props off a
+;; machine's :data-schema (EP-0005 plain-data walk).
+
+(deftest derive-classification-reads-slot-props
+  (testing "sensitive? / large? slot props become the classification sets"
+    (let [schema [:map
+                  [:user/email {:sensitive? true} :string]
+                  [:auth/token {:sensitive? true} :string]
+                  [:receipt    {:large? true}     :string]
+                  [:count      :int]]
+          {:keys [sensitive large]} (r/derive-classification schema)]
+      (is (= #{:user/email :auth/token} sensitive))
+      (is (= #{:receipt} large)))))
+
+(deftest derive-classification-unwraps-refinement
+  (testing "a :map nested under :and is still walked (declared-but-wrapped)"
+    (let [schema [:and [:map [:secret {:sensitive? true} :string]] [:fn 'map?]]
+          {:keys [sensitive]} (r/derive-classification schema)]
+      (is (= #{:secret} sensitive)))))
+
+(deftest derive-classification-absent-schema-is-empty
+  (testing "no schema / non-map schema → empty sets (band passes through)"
+    (is (= {:sensitive #{} :large #{}} (r/derive-classification nil)))
+    (is (= {:sensitive #{} :large #{}} (r/derive-classification :int)))))
+
+;; ---------------------------------------------------------------------------
+;; redact-value / redact-context — the projection itself
+
+(deftest redact-value-sensitive-becomes-sentinel
+  (testing "a sensitive key projects to :rf/redacted regardless of value"
+    (is (= :rf/redacted (r/redact-value :tok "hunter2" {:sensitive #{:tok}})))))
+
+(deftest redact-value-large-becomes-elided-no-head
+  (testing "a large key elides to :rf/large {:bytes N} with NO content head"
+    (let [big (apply str (repeat 50 "x"))
+          out (r/redact-value :blob big {:large #{:blob}})]
+      (is (vector? out))
+      (is (= :rf/large (first out)))
+      (is (number? (:bytes (second out))))
+      (is (not (contains? (second out) :head)) "no content head leaks"))))
+
+(deftest redact-value-large-heuristic-fires-for-unmarked-big-value
+  (testing "an unmarked value over the char cap is still elided as large"
+    (let [big (apply str (repeat 1000 "y"))
+          out (r/redact-value :unmarked big {})]
+      (is (= :rf/large (first out)) "defensive size guard fires"))))
+
+(deftest redact-value-sensitive-wins-over-large
+  (testing "a key that is BOTH sensitive and large redacts as sensitive"
+    (is (= :rf/redacted
+           (r/redact-value :k (apply str (repeat 1000 "z"))
+                           {:sensitive #{:k} :large #{:k}})))))
+
+(deftest redact-value-passes-ordinary-through
+  (testing "an unclassified small value is unchanged"
+    (is (= 42 (r/redact-value :count 42 {})))
+    (is (= [:a :b] (r/redact-value :seen [:a :b] {})))))
+
+(deftest redact-context-projects-the-whole-band
+  (testing "the band map is redacted slot-by-slot, order preserved"
+    (let [band  (array-map :name "Alice" :token "secret-tok" :count 3)
+          out   (r/redact-context band {:sensitive #{:token}})]
+      (is (= "Alice"      (:name out)))
+      (is (= :rf/redacted (:token out)))
+      (is (= 3            (:count out)))
+      (is (= [:name :token :count] (keys out)) "order preserved"))))
+
+(deftest redact-context-empty-is-nil
+  (testing "nil / empty band → nil (band hidden)"
+    (is (nil? (r/redact-context nil {})))
+    (is (nil? (r/redact-context {} {})))))
+
+;; ---------------------------------------------------------------------------
+;; display-string — the content-FREE export-safe text
+
+(deftest display-string-redacted-is-content-free
+  (testing ":rf/redacted renders a content-free sentinel"
+    (let [s (r/display-string :rf/redacted)]
+      (is (str/includes? s ":rf/redacted")))))
+
+(deftest display-string-large-shows-size-not-content
+  (testing ":rf/large renders size only, never the content"
+    (let [s (r/display-string [:rf/large {:bytes 4096}])]
+      (is (str/includes? s ":rf/large"))
+      (is (str/includes? s "4096"))
+      (is (not (str/includes? s "xxxx")) "no content head"))))
+
+(deftest display-string-ordinary-is-pr-str
+  (testing "ordinary values still render via pr-str (unchanged behaviour)"
+    (is (= "3"      (r/display-string 3)))
+    (is (= "[:a :b]" (r/display-string [:a :b])))))
+
+;; ---------------------------------------------------------------------------
+;; The end-to-end leak guard: a secret-bearing live value, projected with
+;; its schema's sensitivity, never produces display text carrying the
+;; secret — so it cannot reach the serialised SVG/PNG/clipboard.
+
+(deftest secret-never-survives-into-display-text
+  (testing "a sensitive live :data slot never appears in the band display text"
+    (let [secret "card-4111-1111-1111-1111"
+          schema [:map [:card {:sensitive? true} :string] [:count :int]]
+          cls    (r/derive-classification schema)
+          band   (array-map :card secret :count 7)
+          rows   (->> (r/redact-context band cls)
+                      (mapv (fn [[k v]] [(str (symbol k)) (r/display-string v)])))
+          texts  (mapcat identity rows)]
+      (is (not (some #(str/includes? % secret) texts))
+          "the secret must not appear in any display row")
+      ;; the non-sensitive slot still renders its value
+      (is (some #(= "7" %) texts) ":count still rendered"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
@@ -413,3 +413,50 @@
                   "chart-as-mermaid still emits a stateDiagram from the live seam")
               (is (str/includes? md "mermaid")
                   "chart-as-mermaid still fences the block"))))))))
+
+;; ---- 5. EP-0015 — live Context band redacts before export (rf2-27e38h) --
+
+(deftest svg-export-redacts-sensitive-live-context
+  (testing "rf2-27e38h — chart-as-svg of a chart fed LIVE :machine-data with
+            a schema-marked sensitive slot does NOT carry the raw secret in
+            the serialised SVG (the band is local-redacted by default); the
+            :rf/redacted sentinel appears instead and a non-sensitive slot
+            still renders."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (let [secret "card-4111-1111-1111-1111"]
+        (with-mounted-chart
+          {:machine-id :test/flow :definition idle-loading-done
+           :current-state :loading
+           ;; A host feeding LIVE values (inferred? false) declares which
+           ;; slots are sensitive (derived from the machine's :data-schema).
+           :machine-data {:card secret :count 7}
+           :machine-data-inferred? false
+           :machine-data-sensitive #{:card}}
+          (fn [node]
+            (let [svg (export/chart-as-svg (chart-root-of node "rf-mv-chart"))]
+              (is (string? svg))
+              (is (not (str/includes? svg secret))
+                  "the raw secret must not appear in the exported SVG")
+              (is (str/includes? svg ":rf/redacted")
+                  "the redaction sentinel appears in place of the secret")
+              (is (str/includes? svg "7")
+                  "the non-sensitive :count slot still renders"))))))))
+
+(deftest svg-export-passes-live-context-when-raw-opted-in
+  (testing "rf2-27e38h — :machine-data-raw? true is the explicit
+            trusted-local opt-in: the raw value IS serialised (local-raw)."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (let [value "visible-debug-value"]
+        (with-mounted-chart
+          {:machine-id :test/flow :definition idle-loading-done
+           :current-state :loading
+           :machine-data {:dbg value}
+           :machine-data-inferred? false
+           :machine-data-sensitive #{:dbg}   ;; would redact by default…
+           :machine-data-raw? true}           ;; …but raw opt-in overrides
+          (fn [node]
+            (let [svg (export/chart-as-svg (chart-root-of node "rf-mv-chart"))]
+              (is (str/includes? svg value)
+                  "raw opt-in serialises the value (local-raw trusted path)"))))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -7,7 +7,15 @@
   picks it up via `cljs-test$`."
   (:require [clojure.test  :refer [deftest is testing]]
             [clojure.string :as str]
+            [clojure.walk :as walk]
             [day8.re-frame2-machines-viz.mermaid :as m]))
+
+(defn- deep-strings
+  "Every string anywhere in `m` (deep walk)."
+  [m]
+  (let [acc (volatile! [])]
+    (walk/postwalk (fn [x] (when (string? x) (vswap! acc conj x)) x) m)
+    @acc))
 
 ;; -----------------------------------------------------------------------------
 ;; Fixtures — small, hand-curated machine definitions per Spec 005
@@ -196,6 +204,22 @@
                  (m/emit {:type :parallel
                           :regions {:data {:initial :idle
                                            :states  {}}}})))))
+
+(deftest emit-error-omits-raw-definition
+  ;; EP-0015 (rf2-8nzxib) — an invalid definition can carry a :data slot
+  ;; of live runtime values; the thrown error keeps a value-FREE summary
+  ;; (category, key SET, counts), never the raw definition.
+  (testing "invalid-definition ex-data carries a value-free summary, not the raw definition"
+    (let [secret "api-key-leak-7f3c"
+          ;; Invalid (empty :states) but carries a secret :data slot.
+          def    {:initial :idle :states {} :data {:api-key secret}}
+          d      (try (m/emit def) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :mermaid/invalid-definition (:rf.error/id d)) "category preserved")
+      (is (not (contains? d :definition)) "no raw :definition slot")
+      (is (some? (:definition-summary d)) "value-free summary present")
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
 
 (deftest emit-renders-wildcard-transitions
   (testing ":* wildcard transitions render as real topology"

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -15,7 +15,15 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
+            [clojure.walk :as walk]
             [day8.re-frame2-machines-viz.scxml :as scxml]))
+
+(defn- deep-strings
+  "Every string anywhere in `m` (deep walk)."
+  [m]
+  (let [acc (volatile! [])]
+    (walk/postwalk (fn [x] (when (string? x) (vswap! acc conj x)) x) m)
+    @acc))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures — small, hand-curated machine definitions per Spec 005
@@ -323,6 +331,48 @@
   (testing "input without <scxml> throws :scxml/parse-error"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
                  (scxml/scxml->spec "<not-scxml/>")))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 — error ex-data carries NO raw payload (rf2-8nzxib)
+;;
+;; A machine spec can carry a `:data` slot of live runtime values; the
+;; thrown error must keep value-FREE diagnostics (category, key SET,
+;; counts) — never the raw spec or input (Spec 015 §exception-path).
+
+(deftest invalid-spec-error-omits-raw-spec
+  (testing "spec->scxml invalid-spec ex-data carries a value-free summary, not the raw spec"
+    (let [secret "patient-record-secret-42"
+          ;; Invalid (no :initial/:states) but carries a secret :data slot.
+          spec   {:type :machine :data {:diagnosis secret}}
+          d      (try (scxml/spec->scxml spec) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/invalid-spec (:rf.error/id d)) "category preserved")
+      (is (not (contains? d :spec)) "no raw :spec slot")
+      (is (some? (:spec-summary d)) "value-free summary present")
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
+
+(deftest parallel-invalid-spec-error-omits-raw-spec
+  (testing "parallel-without-regions invalid-spec keeps only a value-free summary"
+    (let [secret "token-deadbeef"
+          spec   {:type :parallel :data {:token secret}}   ;; no :regions
+          d      (try (scxml/spec->scxml spec) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/invalid-spec (:rf.error/id d)))
+      (is (not (contains? d :spec)))
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
+
+(deftest parse-error-omits-raw-input
+  (testing "scxml->spec non-string input keeps only a value-free summary"
+    (let [secret "session-id-cafef00d"
+          d      (try (scxml/scxml->spec {:leak secret}) nil   ;; non-string
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/parse-error (:rf.error/id d)) "category preserved")
+      (is (not (contains? d :input)) "no raw :input slot")
+      (is (some? (:input-summary d)) "value-free summary present")
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the secret must not survive anywhere in ex-data"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Documentation of lossy features

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -20,6 +20,7 @@
   - Host override + `chart-state->props` projection."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
+            [clojure.walk]
             [cognitect.transit :as transit]
             [day8.re-frame2-machines-viz.share :as share]))
 
@@ -634,3 +635,73 @@
     (let [cs    (assoc parallel-state :snapshot {:state {:data :dirty :form :busy}})
           props (share/chart-state->props (share/decode-share-url (share/encode-share-url cs)))]
       (is (= {:data :dirty :form :busy} (:current-state props))))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 — error ex-data carries NO raw payload (rf2-8nzxib)
+;;
+;; A thrown encode/decode error must NOT retain the rejected payload in
+;; ex-data: a forged share URL can smuggle a `:snapshot {:data …}` map or
+;; arbitrary runtime values, and projection cannot walk ex-data after the
+;; fact (Spec 015 §exception-path residual). The error keeps value-FREE
+;; structural diagnostics (reason/category, key SET, type) instead.
+
+(defn- ex-data-strings
+  "Every string that appears ANYWHERE in `m` (deep walk) — so a test can
+  assert a secret value never survives into the error map under any key."
+  [m]
+  (let [acc (atom [])]
+    (clojure.walk/postwalk
+      (fn [x] (when (string? x) (swap! acc conj x)) x)
+      m)
+    @acc))
+
+(deftest encode-error-omits-raw-chart-state
+  (testing "encode-failed ex-data carries a value-free summary, not the raw chart-state"
+    ;; A chart-state whose :snapshot smuggles a secret-bearing :data map,
+    ;; AND a malformed :state so encode rejects it.
+    (let [secret "hunter2-super-secret-token"
+          leaky  {:machine-id :auth/flow
+                  :frame-id   :app/main
+                  :definition idle-loading-success
+                  :snapshot   {:state "not-an-arm"        ;; rejected
+                               :data  {:password secret}}}
+          d      (try (share/encode-share-url leaky)
+                      (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d)) "reason/category preserved")
+      (is (not (contains? d :chart-state)) "no raw chart-state slot")
+      (is (some? (:chart-state-summary d)) "value-free summary present")
+      (is (not (some #(str/includes? % secret) (ex-data-strings d)))
+          "the secret string must not survive anywhere in ex-data"))))
+
+(deftest decode-error-omits-raw-envelope
+  (testing "missing-envelope decode-failed carries a value-free envelope summary, not the raw envelope"
+    (let [secret  "session-cookie-abc123"
+          ;; A forged envelope missing the required keys but carrying a secret.
+          url     (envelope->url {:totally :wrong :secret secret})
+          d       (try (share/decode-share-url url)
+                       (catch :default e (ex-data e)))]
+      (is (= :missing-envelope (:reason d)) "reason/category preserved")
+      (is (not (contains? d :envelope)) "no raw envelope slot")
+      (is (some? (:envelope-summary d)) "value-free summary present")
+      (is (not (some #(str/includes? % secret) (ex-data-strings d)))
+          "the secret string must not survive anywhere in ex-data"))))
+
+(deftest decode-error-omits-raw-chart
+  (testing "invalid-chart-state decode-failed carries a value-free chart summary, not the raw chart"
+    (let [secret "bearer-token-xyz789"
+          ;; A well-formed envelope whose :chart smuggles a secret via a
+          ;; :snapshot {:data …} the viewer will reject (closed-map rule).
+          forged  {:rf.machines-viz.share/v     "1"
+                   :rf.machines-viz.share/chart {:machine-id :auth/flow
+                                                 :frame-id   :app/main
+                                                 :definition idle-loading-success
+                                                 :snapshot   {:state :loading
+                                                              :data  {:token secret}}}}
+          url     (envelope->url forged)
+          d       (try (share/decode-share-url url)
+                       (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d)) "reason/category preserved")
+      (is (not (contains? d :chart)) "no raw chart slot")
+      (is (some? (:chart-summary d)) "value-free summary present")
+      (is (not (some #(str/includes? % secret) (ex-data-strings d)))
+          "the secret string must not survive anywhere in ex-data"))))

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -960,6 +960,19 @@ behaviour (rf2-3q4k5b). Both surfaces consume the SAME
 band shows the SHAPE only — never live `:data` VALUES — so a declared
 shape carries no value-redaction concern.
 
+> **machines-viz chart defends the live-value path independently
+> (rf2-27e38h · EP-0015).** Xray feeds the value-free SHAPE, but the
+> machines-viz `MachineChart` contract also accepts **live `:data`
+> values** (`:machine-data-inferred? false`), and that band is serialised
+> into the chart's SVG/PNG/clipboard export. The chart therefore applies
+> a **local-redacted projection to the Context band by default**, keyed
+> on host-declared `:machine-data-sensitive` / `:machine-data-large`
+> sets (derived from the machine's `:data-schema` slot props) with an
+> explicit `:machine-data-raw?` trusted-local opt-in — see
+> [machines-viz API §Context-band egress contract](../../machines-viz/spec/API.md#context-band-egress-contract--local-redacted-by-default-rf2-27e38h--ep-0015).
+> Xray's value-free type-caption shape is a redaction no-op, so this
+> does not change the Machine Inspector surface.
+
 ### Redacted `:data` — the panel reads the EGRESSED snapshot
 
 A `:sensitive?` / `:large?` marker anywhere in a `:data-schema` is


### PR DESCRIPTION
EP-0015 egress correctness on the machines-viz tool surface. Three clustered beads (rf2-1xb3ec was a closed duplicate of the live rf2-8nzxib, which this PR actions).

## rf2-8nzxib (P2) — value-free error diagnostics
Several public machines-viz tool errors attached the raw rejected payload in `ex-data`. Projection cannot walk an arbitrary `ex-data` map after the fact (Spec 015 §exception-path residual), so a forged share URL or LLM response could retain runtime `:data`/secrets in the error record consumed by tools, browser consoles, or hosted error listeners. Replaced the raw-payload slots with value-FREE structural summaries (type tag, top-level key SET, counts, string length):

- `share`: `:chart-state` / `:envelope` / `:chart` → `*-summary`
- `ai-generate`: `:response` / `:stripped` / `:spec` → `*-summary`
- `mermaid`: `:definition` → `:definition-summary`
- `scxml`: `:spec` (×2) / `:input` → `:spec-summary` / `:input-summary`

`reason`/`category` (`:rf.error/id`, `:reason`) remain. Secret-bearing tests per surface assert the secret never appears anywhere in `ex-data` while the category survives.

## rf2-27e38h (P2) — local-redacted Context-band image export
The chart Context band is serialised into the SVG/PNG/clipboard export (`chart-as-svg` clones the live viewport DOM), so a host feeding LIVE machine `:data` values (`:machine-data-inferred? false`) could embed a schema-marked sensitive/large slot in an official egress artefact. Added a local-redacted projection at the single `xyflow-graph` projection chokepoint (new `chart.context-redaction` ns, JVM-portable):

- `:machine-data-sensitive #{k}` → `:rf/redacted` (sensitive wins over large)
- `:machine-data-large #{k}` → `:rf/large {:bytes N}` (no content head); unmarked over-cap values elide too
- `:machine-data-raw? false` (default) applies redaction; `true` is the explicit trusted-local (`:rf.egress/local-raw`) opt-in

The host derives the classification from the machine's `:data-schema` `:sensitive?`/`:large?` slot props (EP-0005). Redaction runs identically for the on-screen band and every export derived from it. The sole production feeder (Xray's value-free type-caption shape) is a redaction no-op, so the production surface is unchanged. Browser DOM tests confirm a secret-bearing live slot is absent from the serialised SVG by default and present under the raw opt-in.

## rf2-z0cw6s (P1) — tools-root reconciliation
Decided the root truth: `tools/machines-viz/` is SHIPPED + Clojars-publishable (`day8/re-frame2-machines-viz`, rf2-o9arp), NOT collapsed. The READMEs already said so; the root coordinator + CI/release metadata contradicted it. Aligned to the shipped truth:

- `tools/deps.edn`: removed the stale rf2-yamkm "collapsed" note; added to the coordinator `:deps`; documented the CLJS-only justified exclusion from the JVM aggregate `:test` (mirrors the Xray coverage-gap note).
- `verify-version-lockstep.sh`: added machines-viz to the publishable-tool lockstep inventory (now 4 tools). Dedicated per-tool release workflow stays deferred — same state as story/story-mcp (only xray has a `release-*.yml` today).
- `report-changed-surfaces.sh`: new `tools/machines-viz/*` case firing `cljs_node_test` + `cljs_browser` (the `*-dom-cljs-test` export/redaction suites verify EP-0015 image egress); spec-md guard fires nothing; no JVM/MCP/template fan-out. +6 routing tests.
- `TESTING.md`: gate-matrix rows + new S11b surface-input row.

## Spec
machines-viz `API.md` documents the Context-band egress contract + the three new props; xray `003-Machine-Inspector.md` cross-notes that the chart defends the live-value path (shared spec-tree rule).

## Gates
- machines-viz `clojure -M:test`: 535 tests, 0 failures (was 514 baseline; +21 new)
- consolidated node CLJS gate (`npm run test:cljs`): 7704 tests, 0 failures
- browser tests (`npm run test:browser`): 220 tests, 0 failures (incl. the new DOM export-leak guards)
- lockstep verifier: PASS (18 artefacts: 14 impl + 4 tools)
- changed-surfaces test: 110 passed
- fast PR spine: PASS

No hot-zone files touched (`spec/009-Instrumentation.md` / `spec/Spec-Schemas.md` / `.github/workflows/*` all avoided; only `.github/scripts/*`).