### PR TITLE
fix(ssr): EP-0017 hydration projection + request cofx + machine snapshots (rf2-bt9kct, rf2-jm2u63, rf2-mx9w6q, rf2-uc3cs4, rf2-aqwvhh)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -412,6 +412,10 @@
     :producer-ns 're-frame.machines
     :design-bead "rf2-ma0wvq"
     :description "Spawned-actor ownership resolver `(fn [frame-id event-id]) -> actor-id|nil` (Spec 014 §Abort on actor destroy). Returns the spawned actor's address that owns `event-id` — i.e. `event-id` itself when it is registered in the frame's runtime-db spawn registry (`re-frame.machines.paths/spawned-path`) — else nil. The INVERSION of the old http→machines coupling (rf2-ma0wvq): the machines artefact OWNS the `:spawned` registry shape, so the structural membership walk lives next to it; re-frame.http-registry consults this hook (instead of re-stating the path + walking it itself) to decide whether a managed request belongs to a spawned actor, and falls back to nil when the machines artefact is absent. Step-1 set semantics = registry membership (declarative `:spawn` / `:spawn-all` only), set-identical to the pre-inversion walk; a separate step-2 bead widens it to imperative spawns under its own destroy-cancellation test."}
+   {:key         :machines/project-ssr-runtime-db
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-jm2u63"
+    :description "SSR hydration projector for the durable `:rf.runtime/machines` slice `(fn [runtime-db frame-id]) -> machines-slice`. `re-frame.ssr.payload-policy/project-runtime-db` consults it so each machine snapshot's `:data` is redacted/elided per the owning machine's `:data-schema` `:sensitive?` / `:large?` classification under `:rf.egress/ssr-hydration` (the same `marks/marks-for :event <actor-id>` marks the trace-egress chokepoint uses, via `marks/redact-with-paths` then `project-egress`) BEFORE it rides the hydration wire — closing the raw-classified-machine-data hydration leak (EP-0015 §6/§8). Mirrors the resources `:ssr/extend-runtime-db-projection` model; absent the machines artefact the slice rides unchanged."}
 
    ;; ---- re-frame.routing (rf2-k682) -----------------------------------------
    {:key         :routing/reg-route

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -61,6 +61,7 @@
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.ssr :as machines-ssr]
             [re-frame.machines.timer :as timer]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
@@ -480,6 +481,15 @@
 ;; `:where :machine-data` boundary (Spec 005 §Schema validation, Spec
 ;; 010 §Per-step recovery row 7).
 (late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
+;; Per rf2-jm2u63 — the SSR hydration projector for durable machine snapshots.
+;; `re-frame.ssr.payload-policy/project-runtime-db` consults this hook to project
+;; the `:rf.runtime/machines` slice so each snapshot's `:data` is redacted /
+;; elided per the owning machine's `:data-schema` `:sensitive?` / `:large?`
+;; classification under `:rf.egress/ssr-hydration` BEFORE it rides the wire —
+;; closing the raw-classified-machine-data hydration leak (EP-0015 §6/§8).
+;; Late-bound so SSR never statically requires the machines artefact.
+(late-bind/set-fn! :machines/project-ssr-runtime-db
+                   machines-ssr/project-ssr-runtime-db)
 ;; Per rf2-ma0wvq — spawned-actor ownership resolver. The http artefact
 ;; consults this to classify whether a managed request's originating
 ;; event-id belongs to a spawned actor (so an actor-destroy cascade can

--- a/implementation/machines/src/re_frame/machines/ssr.cljc
+++ b/implementation/machines/src/re_frame/machines/ssr.cljc
@@ -1,0 +1,139 @@
+(ns re-frame.machines.ssr
+  "LATE-BOUND SSR / hydration projection for durable machine snapshots.
+  Per Spec 011 §The hydration payload (`:rf/runtime-db`) + EP-0015 §6/§8
+  (durable machine `:data` classification owned by the machine
+  `:data-schema` `:sensitive?` / `:large?` per-slot props) + Spec 015
+  §State machines.
+
+  ## The leak this closes (rf2-jm2u63)
+
+  Machine snapshots are durable runtime-db state living at
+  `[:rf.runtime/machines :snapshots <actor-id>]`, each carrying a
+  `{:state :data :tags …}` body. The SSR hydration payload's
+  `:rf/runtime-db` slice ships `:rf.runtime/machines` so the client
+  re-materialises actors. But `re-frame.ssr.payload-policy/project-runtime-db`
+  previously copied `:rf.runtime/machines` WHOLESALE — so a snapshot whose
+  machine `:data-schema` marks a slot `:sensitive?` (an auth token in
+  machine data) or `:large?` shipped that field RAW in the hydration blob,
+  exactly the leak the schema classification exists to prevent. Unlike
+  resources (which has `:ssr/extend-runtime-db-projection`), machines had no
+  SSR projection hook.
+
+  ## What this does
+
+  `project-ssr-runtime-db` projects the `:rf.runtime/machines` slice for the
+  SSR hydration boundary: it walks each snapshot's `:data` against the
+  owning machine's `:data-schema` per-slot marks — the SAME marks the
+  trace-egress chokepoint redacts (`marks/marks-for :event <actor-id>`,
+  snapshot-rooted under `[:data …]` by `reg-machine`'s schema bridge, EP-0005
+  rf2-w46fpt). A `:sensitive?` slot redacts to the `:rf/redacted` sentinel; a
+  `:large?` slot elides to the `:rf.size/large-elided` marker, via the SHARED
+  frame-independent `re-frame.marks/redact-with-paths` walker — NEVER a
+  family-private elider. The marks are also UNIONED with any frame-owned
+  `:rf.egress/ssr-hydration` projection through `re-frame.projection/project-egress`
+  so a frame-declared sensitive path inside `:data` redacts as
+  defense-in-depth.
+
+  Snapshots whose machine declares no `:data-schema` marks (and that carry no
+  frame-classified `:data` slot) ride VERBATIM — the projection is precise, not
+  a blanket scrub. The sibling registry slots (`:system-ids`, `:spawned`,
+  `:spawn-counter`) are durable bookkeeping (reverse indexes + counters — no
+  user `:data`) and ride unchanged.
+
+  ## Late-binding
+
+  Published as the late-bound `:machines/project-ssr-runtime-db` hook so SSR
+  consults it WITHOUT statically `:require`ing the machines artefact (SSR
+  depends on core only; machines is optional). An app that loads machines but
+  does not SSR carries none of this path; an SSR app without machines sees the
+  hook unbound and ships the (already machine-less) runtime-db unchanged.
+  Pure / host-agnostic CLJC — SSR runs on the JVM."
+  (:require [re-frame.machines.paths :as paths]
+            [re-frame.marks :as marks]
+            [re-frame.projection :as projection]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn project-snapshot-data
+  "Project ONE machine snapshot's `:data` for the SSR hydration boundary.
+
+  `actor-id` is the snapshot's key (the singleton machine-id OR a spawned
+  instance id — both are keyed under `:event` by `reg-machine`'s schema bridge
+  at registration / spawn time, snapshot-rooted under `[:data …]`). `frame-id`
+  is the SSR request frame whose app-db classification composes as
+  defense-in-depth (nil ⇒ owner marks only; no frame walk).
+
+  Two composed layers, both SHARED primitives (never a machines-private elider):
+
+    (a) the machine's OWNER per-slot `:data-schema` `:sensitive?` / `:large?`
+        marks (`marks/marks-for :event actor-id`, rooted under `[:data …]`)
+        project through `re-frame.marks/redact-with-paths` — `:sensitive?`
+        slots redact to `:rf/redacted`, `:large?` slots elide to the
+        `:rf.size/large-elided` marker (sensitive wins at a co-marked slot).
+        This fires irrespective of frame app-db classification — a machine that
+        marks `[:data :token]` sensitive redacts that slot on SSR even when the
+        frame says nothing about it.
+    (b) when `frame-id` resolves, the result is THEN projected through the
+        merged frame-owned `re-frame.projection/project-egress` under the
+        `:rf.egress/ssr-hydration` profile, so any `:data` path the FRAME ALSO
+        classifies redacts / elides as defense-in-depth.
+
+  The snapshot's NON-`:data` slots (`:state`, `:tags`, `:rf/machine-type`, the
+  reserved spawn-counter slot, …) are durable structural facts the client needs
+  to re-materialise the actor — they ride VERBATIM. Returns the snapshot with
+  its `:data` projected (or unchanged when the snapshot carries no `:data`)."
+  [actor-id snapshot frame-id]
+  (if-not (and (map? snapshot) (contains? snapshot :data))
+    snapshot
+    (let [data (:data snapshot)
+          {:keys [sensitive large]} (marks/marks-for :event actor-id)
+          ;; The schema bridge roots marks under [:data …]; the marks/redact
+          ;; walker indexes from the value root, so strip the leading :data
+          ;; segment to index into the snapshot's :data MAP directly.
+          strip (fn [paths] (into [] (comp (filter #(= :data (first %)))
+                                           (map #(subvec % 1)))
+                                  paths))
+          s-paths (strip sensitive)
+          l-paths (strip large)
+          ;; layer (a): owner per-slot marks (frame-independent).
+          owner-projected (if (or (seq s-paths) (seq l-paths))
+                            (marks/redact-with-paths data s-paths l-paths)
+                            data)
+          ;; layer (b): merged frame-owned egress projection (defense in depth).
+          projected (if frame-id
+                      (projection/project-egress
+                        owner-projected
+                        {:frame             frame-id
+                         :rf.egress/profile :rf.egress/ssr-hydration})
+                      owner-projected)]
+      (assoc snapshot :data projected))))
+
+(defn project-ssr-runtime-db
+  "Project the `:rf.runtime/machines` slice of `runtime-db` for the SSR
+  hydration `:rf/runtime-db` payload (the body behind the
+  `:machines/project-ssr-runtime-db` late-bind hook). Returns the
+  `:rf.runtime/machines` value with every snapshot's `:data` projected per its
+  machine's `:data-schema` classification (`project-snapshot-data`); or
+  `runtime-db`'s `:rf.runtime/machines` value unchanged when it carries no
+  snapshots.
+
+  `frame-id` is the SSR request frame (nil ⇒ owner marks only — see
+  `project-snapshot-data`). The `:snapshots` map is re-projected entry-by-entry
+  keyed on actor-id; the sibling registry slots (`:system-ids`, `:spawned`,
+  `:spawn-counter`) ride verbatim (durable reverse indexes + counters carrying
+  no user `:data`). Returns nil when `runtime-db` carries no
+  `:rf.runtime/machines` slice (so the SSR projector omits the key). Pure."
+  [runtime-db frame-id]
+  (when (map? runtime-db)
+    (let [machines (get runtime-db :rf.runtime/machines)]
+      (when (some? machines)
+        (let [snapshots (:snapshots machines)]
+          (if (seq snapshots)
+            (assoc machines :snapshots
+                   (reduce-kv
+                     (fn [acc actor-id snapshot]
+                       (assoc acc actor-id
+                              (project-snapshot-data actor-id snapshot frame-id)))
+                     {}
+                     snapshots))
+            machines))))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -60,6 +60,13 @@
   ([frame-id app-db runtime-db render-hash {:as policy-opts}]
    (payload-policy/build-payload
     frame-id
-    (payload-policy/apply-policy app-db policy-opts)
+    ;; rf2-bt9kct — allowlist FIRST (`apply-policy`), THEN run the surviving
+    ;; slice through the centralized `:rf.egress/ssr-hydration` projection
+    ;; seeded at the request frame, so a frame-classified sensitive/large path
+    ;; inside an allowlisted (or whole-app-db) slice redacts/elides as
+    ;; defense-in-depth before it serializes into `:rf/app-db` (EP-0015 §14).
+    (payload-policy/project-app-db-egress
+     (payload-policy/apply-policy app-db policy-opts)
+     frame-id)
     render-hash
     (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db)))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -463,9 +463,27 @@
             ;; the client would parse and discard. `failed?` continuations
             ;; carry `:delta nil` (also falsy here), so the `not failed?`
             ;; arm is now redundant but kept for intent clarity.
-            (when (and (not failed?) (seq delta))
-              (vreset! phase [:continuation-delta id])
-              (write-chunk! out (streaming/hydrate-delta-script id (pr-str delta))))
+            ;; rf2-uc3cs4 — a streaming hydration delta is browser-delivered
+            ;; hydration state, so it obeys the SAME allowlist-first-then-
+            ;; project boundary the final `__rf_payload` does (EP-0015 §14): an
+            ;; off-allowlist changed key is DROPPED by the handler `:payload`
+            ;; policy and a frame-sensitive child inside an allowed changed key
+            ;; redacts under `:rf.egress/ssr-hydration`. `project-delta` runs
+            ;; the raw delta through `payload-policy/apply-policy` +
+            ;; `project-app-db-egress` under the request frame on THIS daemon
+            ;; thread (inside the carried realm + `with-frame` scope re-bound
+            ;; above for the continuation render — so `project-app-db-egress`'s
+            ;; frame walk resolves the realm frame's elision registry). A delta
+            ;; that projects to empty (every changed key off-allowlist, or all
+            ;; redacted away to an empty map) emits NO script.
+            (let [projected (frame/call-with-realm realm-id
+                              (fn []
+                                (rf/with-frame frame-id
+                                  (streaming/project-delta delta frame-id
+                                                           {:payload payload}))))]
+              (when (and (not failed?) (map? projected) (seq projected))
+                (vreset! phase [:continuation-delta id])
+                (write-chunk! out (streaming/hydrate-delta-script id (pr-str projected)))))
             ;; Pop the drained entry, append any nested continuations at
             ;; the tail (FIFO), continue until empty.
             (recur (into (pop queue) continuations)))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/app_db_egress_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/app_db_egress_projection_test.clj
@@ -1,0 +1,104 @@
+(ns re-frame.ssr.ring.app-db-egress-projection-test
+  "rf2-bt9kct (+ rf2-mx9w6q dup) — the final hydration app-db slice MUST be
+  run through the centralized `:rf.egress/ssr-hydration` projection AFTER the
+  `:payload` allowlist, so a frame-classified sensitive child inside an
+  allowlisted (or whole-app-db) top-level key redacts before it serializes into
+  `:rf/app-db`.
+
+  EP-0015 §14: SSR/hydration is allowlist-FIRST, and frame classification
+  COMPOSES as defense-in-depth. The prior `re-frame.ssr.ring.payload/build-payload`
+  handed `(apply-policy app-db policy-opts)` straight to `build-payload` — only
+  allowlisting, never the frame-owned egress projector. A frame declaring
+  `:sensitive {:app-db [[:session :token]]}` and shipping `:session` (via the
+  allowlist OR `:rf.ssr.payload/whole-app-db`) serialized the raw token.
+
+  This drives the ACTUAL non-streaming payload-build path
+  (`re-frame.ssr.ring.payload/build-payload`) against a registered server frame
+  carrying a `:sensitive :app-db` declaration."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.privacy :as privacy]
+            [re-frame.ssr.ring.payload :as payload]
+            [re-frame.ssr.ring.test-support :as ts]))
+
+(use-fixtures :each ts/reset-runtime)
+
+(def ^:private server-frame :rf.bt9kct/server)
+
+(defn- reg-sensitive-frame! []
+  ;; A server frame whose classification marks the nested :session :token path
+  ;; sensitive — the canonical durable app-db egress route (EP-0015 §3/§8).
+  (rf/reg-frame server-frame
+    {:platform  :server
+     :sensitive {:app-db [[:session :token]]}}))
+
+(def ^:private app-db
+  "An app-db whose allowlisted :session key carries a frame-sensitive child
+  (:token) alongside a public sibling (:user), plus a server-only :secrets key
+  that must never be allowlisted."
+  {:session {:token "secret-jwt" :user "alice"}
+   :public  {:page :dashboard}
+   :secrets {:api-key "internal-only"}})
+
+;; ---- allowlist + projection compose ---------------------------------------
+
+(deftest allowlisted-key-sensitive-child-redacted
+  (testing "an allowlisted top-level key (:session) ships, but its
+            frame-sensitive child (:token) is redacted by the ssr-hydration
+            projection; the public sibling (:user) rides verbatim; unlisted
+            keys (:public / :secrets) are omitted by the allowlist"
+    (reg-sensitive-frame!)
+    (let [out    (payload/build-payload server-frame app-db "h1"
+                                        {:payload [:session :public]})
+          db     (:rf/app-db out)]
+      (is (= privacy/redacted-sentinel (get-in db [:session :token]))
+          "the frame-sensitive nested :token is redacted on the hydration wire")
+      (is (= "alice" (get-in db [:session :user]))
+          "the public sibling rides verbatim")
+      (is (= {:page :dashboard} (:public db))
+          "another allowlisted key rides through the projection unchanged")
+      (is (not (contains? db :secrets))
+          ":secrets (unlisted) is omitted by the allowlist")
+      (is (not (.contains (pr-str out) "secret-jwt"))
+          "no raw token survives anywhere in the emitted payload"))))
+
+(deftest whole-app-db-still-projects-sensitive-children
+  (testing "an explicit :rf.ssr.payload/whole-app-db opt-in ships every key,
+            but STILL projects frame-sensitive children — the raw token never
+            rides even when the whole app-db is opted in"
+    (reg-sensitive-frame!)
+    (let [out (payload/build-payload server-frame app-db "h1"
+                                     {:payload :rf.ssr.payload/whole-app-db})
+          db  (:rf/app-db out)]
+      (is (= privacy/redacted-sentinel (get-in db [:session :token]))
+          "whole-app-db still redacts the frame-sensitive :token")
+      (is (= "alice" (get-in db [:session :user])))
+      (is (= "internal-only" (get-in db [:secrets :api-key]))
+          ":secrets rides under whole-app-db opt-in (no frame mark on it)")
+      (is (not (.contains (pr-str out) "secret-jwt"))))))
+
+;; ---- fail-closed: an unknown / unregistered frame redacts the whole slice --
+
+(deftest missing-frame-policy-fails-closed
+  (testing "building the payload against an UNREGISTERED frame (no resolvable
+            elision policy) fails CLOSED — the whole app-db slice redacts to
+            the :rf/redacted sentinel rather than ship under no policy"
+    ;; deliberately do NOT register :rf.bt9kct/ghost
+    (let [out (payload/build-payload :rf.bt9kct/ghost app-db "h1"
+                                     {:payload [:session]})]
+      (is (= privacy/redacted-sentinel (:rf/app-db out))
+          "an unresolvable frame redacts the whole slice (fail-closed)")
+      (is (not (.contains (pr-str out) "secret-jwt"))
+          "no raw value escapes under a missing frame policy"))))
+
+(deftest no-classification-frame-rides-allowlisted-slice-verbatim
+  (testing "a registered frame with NO :sensitive classification ships its
+            allowlisted slice verbatim (the projection is a precise
+            classification walk, not a blanket scrub)"
+    (rf/reg-frame :rf.bt9kct/plain {:platform :server})
+    (let [out (payload/build-payload :rf.bt9kct/plain app-db "h1"
+                                     {:payload [:session]})
+          db  (:rf/app-db out)]
+      (is (= {:token "secret-jwt" :user "alice"} (:session db))
+          "no frame classification → allowlisted slice rides verbatim")
+      (is (not (contains? db :public))))))

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -385,19 +385,50 @@ under rf2-ny6v7's Ring adapter; host-defined for other adapters) so handlers
 can read URL, headers, session cookies, etc. without threading the request as
 an event arg.
 
+GRADE — AMBIENT, host-transient read. This cofx is for NON-DURABLE request
+reads: branching on `:request-method`, reading a header for a decision that
+does NOT fold into durable app-db / runtime-db. EP-0017 §1: the ambient grade
+is legal only where NO durable write depends on the value — its supplier
+re-runs on replay, so it never re-presents the value a recorded run actually
+saw (and after per-request frame teardown it reads nil). A handler that folds a
+request-derived fact into the hydration payload (durable app-db) through THIS
+cofx is the SSR analogue of the ambient-localStorage replay hole (rf2-aqwvhh /
+the rf2-16ck78 family).
+
+DURABLE request-derived facts — the boundary pattern (rf2-aqwvhh). When a setup
+handler writes durable state from the request (auth user / session state read
+from a cookie, an `accept-language` folded into a locale slice, …), the host
+adapter SANITIZES the request at the boundary and supplies the derived fact as
+a recordable leaf, so it lands on the causal token and replay re-presents it
+verbatim. Two slice-A-legal shapes, both replayable:
+
+  - EVENT PAYLOAD — the host dispatches the setup event WITH the derived fact:
+    `[:auth/server-init {:user (extract-user request)}]`. The fact rides
+    `:event`, recorded as part of the dispatch.
+  - PROVIDED recordable `:rf.cofx` LEAF — register an app-owned
+    `{:recordable? true :provided? true}` cofx (e.g. `:auth.session/user`) and
+    the host adapter STAMPS the sanitized value onto the boot dispatch token
+    (`{:rf.cofx {:auth.session/user …}}`). The handler declares
+    `:rf.cofx/requires [:auth.session/user]`; a record missing it fails LOUDLY
+    with `:rf.error/missing-required-cofx` rather than silently re-reading the
+    host. NEVER stamp the whole request map onto the token — it carries
+    secrets / PII and is a host handle (Spec 011 §Request storage substrate);
+    stamp only the sanitized derived projection.
+
 The host adapter populates the per-frame slot via `re-frame.ssr/set-request!`
 once per request before the drain begins. A server-side event handler consumes
-it by declaring `{:rf.cofx/requires [:rf.server/request]}` on its registration
-and reading the value FLAT under `:rf.server/request`. The supplier runs at
-context assembly, reading the active frame's slot; it is never recorded, and
-replay re-runs it.
+the AMBIENT read by declaring `{:rf.cofx/requires [:rf.server/request]}` on its
+registration and reading the value FLAT under `:rf.server/request`. The supplier
+runs at context assembly, reading the active frame's slot; it is never recorded,
+and replay re-runs it.
 
 Tests and conformance harnesses that drive the drain without a host adapter
 `re-frame.ssr/set-request!` the target frame's slot before dispatching (the
 visible seam — there is no `inject-cofx` value override anymore: `inject-cofx`
 is removed in EP-0017).
 
-Per Spec 011 §Server-only `reg-cofx` for request context."
+Per Spec 011 §Server-only `reg-cofx` for request context + §Durable
+request-derived facts."
    :platforms #{:server}}
   request/request-cofx)
 

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -100,6 +100,7 @@
     `re-frame.ssr.streaming/build-final-payload`  - streaming SSR"
   (:refer-clojure :exclude [resolve])
   (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
@@ -349,12 +350,29 @@
   Returns nil for a nil / empty runtime-db OR when no durable subsystem fact
   is present, so `build-payload` omits the optional `:rf/runtime-db` key
   (the client-only / no-server-runtime fallback). nil-pruned: a subsystem
-  whose durable slice is absent contributes no key."
+  whose durable slice is absent contributes no key.
+
+  rf2-jm2u63 — the `:rf.runtime/machines` slice is NOT shipped raw: each
+  durable machine snapshot's `:data` is projected per the owning machine's
+  `:data-schema` `:sensitive?` / `:large?` classification under the
+  `:rf.egress/ssr-hydration` boundary (via the late-bound machines-owned
+  `:machines/project-ssr-runtime-db` hook), so a sensitive/large field inside a
+  durable snapshot redacts/elides rather than riding the hydration blob raw —
+  symmetric with the resource projection's `:ssr/extend-runtime-db-projection`.
+  When the machines artefact is absent the hook is unbound and the slice rides
+  unchanged (a runtime-db with `:rf.runtime/machines` but no machines artefact
+  loaded cannot carry actor snapshots anyway)."
   [runtime-db]
   (when (map? runtime-db)
-    (let [slice (cond-> {}
+    (let [project-machines (late-bind/get-fn :machines/project-ssr-runtime-db)
+          frame-id         (frame/resolve-current-frame)
+          machines-slice   (when (contains? runtime-db :rf.runtime/machines)
+                             (if project-machines
+                               (project-machines runtime-db frame-id)
+                               (:rf.runtime/machines runtime-db)))
+          slice (cond-> {}
                   (contains? runtime-db :rf.runtime/machines)
-                  (assoc :rf.runtime/machines (:rf.runtime/machines runtime-db))
+                  (assoc :rf.runtime/machines machines-slice)
 
                   (seq (select-keys (:rf.runtime/routing runtime-db) durable-routing-keys))
                   (assoc :rf.runtime/routing

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -102,6 +102,7 @@
   (:require [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
+            [re-frame.projection :as projection]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -291,6 +292,46 @@
     ;; arm and the construction arm produce the same structured error
     ;; shape — tests can assert on one keyword and cover both surfaces.
     (validate-policy-opts! opts)))
+
+;; ---- ssr-hydration egress projection of the app-db slice (rf2-bt9kct) -----
+;;
+;; Per EP-0015 §14 + Spec 015 §Projection: SSR/hydration is ALLOWLIST-FIRST
+;; (the `apply-policy` `:payload` contract above), and frame classification
+;; COMPOSES as defense-in-depth — after allowlisting, the surviving slice is
+;; run through the centralized record-level boundary primitive
+;; `re-frame.projection/project-egress` under the `:rf.egress/ssr-hydration`
+;; profile, seeded at the request frame. So a frame that declares
+;; `:sensitive {:app-db [[:session :token]]}` and ships `:session` (via the
+;; allowlist OR `:rf.ssr.payload/whole-app-db`) redacts the nested token before
+;; it serializes into `:rf/app-db`, instead of shipping the raw secret.
+;;
+;; project-egress on a kindless map walks it as a tree-shaped VALUE via
+;; `elide-wire-value`, which resolves the frame's elision registry from the
+;; explicit `:frame` opt. EP-0002 / EP-0015 issue 1 fail-closed: an
+;; unresolvable / never-registered frame redacts the WHOLE value to
+;; `:rf/redacted` rather than borrow another frame's policy — so a missing
+;; frame policy fails CLOSED here too (a server render always carries the live
+;; request frame, so the projection runs against real declarations).
+
+(defn project-app-db-egress
+  "Run the already-allowlisted `db-slice` through the centralized
+  `:rf.egress/ssr-hydration` egress projection seeded at `frame-id`, so a
+  frame-classified `:sensitive` / `:large` path inside an allowlisted (or
+  whole-app-db) slice redacts / elides as defense-in-depth before it serializes
+  into the hydration `:rf/app-db` (EP-0015 §14). Defers to
+  `re-frame.projection/project-egress` (over the shared `elide-wire-value`
+  walker) — never a family-private elider.
+
+  Fail-closed (EP-0002 / EP-0015 issue 1): an unresolvable / never-registered
+  `frame-id` redacts the whole slice to `:rf/redacted` rather than ship it under
+  no policy. A server render carries the live request frame, so the projection
+  runs against that frame's real declarations; a nil `frame-id` is the same
+  fail-closed case (no frame policy ⇒ whole-value redaction)."
+  [db-slice frame-id]
+  (projection/project-egress
+    db-slice
+    {:frame             frame-id
+     :rf.egress/profile :rf.egress/ssr-hydration}))
 
 ;; ---- runtime-db projection (EP-0001 rf2-30kzz2) --------------------------
 ;;

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -5,9 +5,28 @@
 
   The `:rf.server/request` cofx surfaces the active HTTP request map to
   event handlers that declare `:rf.cofx/requires [:rf.server/request]`
-  (EP-0017 — `inject-cofx` is removed). Use cases: reading the URL inside
-  `:rf/server-init`, pulling a session cookie in `:auth/check-session`,
-  branching on `:request-method`, etc.
+  (EP-0017 — `inject-cofx` is removed). It is an AMBIENT, host-transient
+  read — legal for NON-DURABLE request reads (branching on
+  `:request-method`, reading a header for a decision that does not fold
+  into durable app-db / runtime-db).
+
+  DURABLE request-derived facts use the boundary pattern, NOT this ambient
+  read (rf2-aqwvhh). EP-0017 §1: an ambient supplier re-runs on replay, so a
+  durable write that folds a value read through `:rf.server/request` (an auth
+  user / session state folded into the hydration payload) is a replay hole —
+  replay re-runs the live supplier instead of re-presenting the value the
+  recorded run saw (and reads nil after per-request frame teardown). When a
+  setup handler writes durable state from the request, the host adapter
+  SANITIZES the request and supplies the derived fact as a recordable leaf so
+  it lands on the causal token: either as EVENT PAYLOAD
+  (`[:auth/server-init {:user (extract-user request)}]`) or as a PROVIDED
+  recordable `:rf.cofx` leaf (an app-owned
+  `{:recordable? true :provided? true}` cofx the host stamps onto the boot
+  token; a record missing it fails loudly with
+  `:rf.error/missing-required-cofx`). The whole request map NEVER rides the
+  token — only the sanitized projection (Spec 011 §Request storage
+  substrate). See `re-frame.ssr`'s `:rf.server/request` registration doc for
+  the full pattern.
 
   The mechanism is a per-frame slot — NOT a single dynamic var — so two
   simultaneous per-request frames (the common SSR shape under concurrent
@@ -168,8 +187,13 @@
 
   The request is HOST-CONTROLLED INPUT (a read of the active host wire-shape),
   delivered to handlers that declare `:rf.cofx/requires [:rf.server/request]`
-  and never recorded — replay re-runs it. Tests / conformance harnesses that
-  drive the drain without a host adapter `set-request!` the slot for the
-  target frame first (the visible seam), exactly as before."
+  and never recorded — replay re-runs it (and reads nil after the per-request
+  frame's slot is cleared). Because the read is unrecorded, this AMBIENT cofx
+  is for NON-DURABLE request reads only; a durable request-derived fact uses
+  the recordable boundary pattern (event payload or a provided recordable
+  `:rf.cofx` leaf the host stamps after sanitizing the request — rf2-aqwvhh).
+  Tests / conformance harnesses that drive the drain without a host adapter
+  `set-request!` the slot for the target frame first (the visible seam),
+  exactly as before."
   []
   (get-request frame/*current-frame*))

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -191,6 +191,59 @@
             {}
             (keys only-in-after))))
 
+;; ---- streaming hydration-delta egress projection (rf2-uc3cs4) -------------
+;;
+;; A per-boundary hydration delta is BROWSER-DELIVERED hydration state — it
+;; arrives in the stream BEFORE the final `__rf_payload` and the client merges
+;; it into the live app-db. `subtree-delta` computes it as the raw changed/new
+;; top-level keys each mapped to the FULL `after-db` value, so without
+;; projection a continuation that mutates `:secret` streams `{:secret …}` even
+;; when the handler's `:payload` allowlist names only public keys, and a changed
+;; sensitive CHILD under an allowed top-level key rides raw. That violates
+;; EP-0015 §14: production browser egress is ALLOWLIST-FIRST and then centrally
+;; projected under `:rf.egress/ssr-hydration` — the SAME contract the final
+;; `__rf_payload`'s `:rf/app-db` already obeys (rf2-bt9kct).
+;;
+;; `project-delta` applies that SAME two-step boundary to the raw delta:
+;;
+;;   1. ALLOWLIST — `payload-policy/apply-policy` over the delta map, so an
+;;      off-allowlist changed key (`:secret`) is dropped (a vector `:payload`
+;;      selects only the named keys; `:rf.ssr.payload/whole-app-db` keeps them
+;;      all — the deliberate whole-db opt-in);
+;;   2. PROJECT — `payload-policy/project-app-db-egress` under the request
+;;      frame, so a frame-sensitive child inside an allowed changed key redacts
+;;      (fail-closed against a missing frame policy, exactly like the final
+;;      payload).
+;;
+;; Pure (the policy + projection are pure over the supplied delta + frame). The
+;; Ring host adapter calls this on each non-empty delta BEFORE serialising the
+;; `data-rf2-suspense-hydrate` EDN script (mirroring how it filters the final
+;; payload through the same `payload-policy`).
+
+(defn project-delta
+  "Project a streaming per-subtree hydration `delta` (from `render-continuation`)
+  for browser egress before it serialises into the `data-rf2-suspense-hydrate`
+  EDN script (rf2-uc3cs4). Applies the handler's `:payload` allowlist
+  (`payload-policy/apply-policy`) then the centralized `:rf.egress/ssr-hydration`
+  projection under `frame-id` (`payload-policy/project-app-db-egress`) — the
+  SAME allowlist-first-then-project boundary the final `__rf_payload` obeys, so
+  an off-allowlist changed key is dropped and a frame-sensitive child inside an
+  allowed changed key redacts. `policy-opts` carries the `:payload` policy
+  (validated at handler-construction time, so a malformed policy never reaches
+  here). A nil / empty delta returns `{}` (nothing to hydrate). Pure."
+  [delta frame-id {:as policy-opts}]
+  (if-not (seq delta)
+    {}
+    (let [allowed (payload-policy/apply-policy delta policy-opts)]
+      ;; An allowlist that drops every changed key yields an empty map — there
+      ;; is nothing to project (and projecting `{}` against a fail-closed
+      ;; unresolvable frame would redact the empty map to the scalar
+      ;; `:rf/redacted` sentinel, which the host's `(seq …)` emit guard cannot
+      ;; walk). Short-circuit to `{}` so the host emits no delta script.
+      (if (seq allowed)
+        (payload-policy/project-app-db-egress allowed frame-id)
+        {}))))
+
 ;; ---- continuation registry (per-request, transient) -----------------------
 ;;
 ;; The walker owns a per-call mutable seq accumulator. We do NOT use a
@@ -612,7 +665,15 @@
         runtime-db (frame/frame-runtime-db-value frame-id)]
     (payload-policy/build-payload
      frame-id
-     (payload-policy/apply-policy app-db policy-opts)
+     ;; rf2-bt9kct — allowlist FIRST (`apply-policy`), THEN run the surviving
+     ;; slice through the centralized `:rf.egress/ssr-hydration` projection
+     ;; seeded at the request frame (defense-in-depth, EP-0015 §14) — symmetric
+     ;; with the non-streaming `re-frame.ssr.ring.payload/build-payload` so a
+     ;; frame-sensitive child inside an allowlisted key never rides the final
+     ;; `__rf_payload` raw.
+     (payload-policy/project-app-db-egress
+      (payload-policy/apply-policy app-db policy-opts)
+      frame-id)
      render-hash
      (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db)))))
 

--- a/implementation/ssr/test/re_frame/ssr_machine_snapshot_projection_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_machine_snapshot_projection_test.clj
@@ -1,0 +1,116 @@
+(ns re-frame.ssr-machine-snapshot-projection-test
+  "rf2-jm2u63 — durable machine snapshots must NOT hydrate raw classified
+  `:data`.
+
+  EP-0015 §6/§8: durable machine `:data` classification is owned by the
+  machine `:data-schema` `:sensitive?` / `:large?` per-slot props, and
+  hydration is a serialized-state egress boundary projected under
+  `:rf.egress/ssr-hydration`. The SSR `:rf/runtime-db` payload ships
+  `:rf.runtime/machines` so the client re-materialises actors — but the prior
+  `project-runtime-db` copied the machines slice WHOLESALE, so a snapshot whose
+  `:data-schema` marks a slot `:sensitive?` (an auth token in machine data) or
+  `:large?` shipped that field RAW in the hydration blob.
+
+  This pins the fix end-to-end on the ACTUAL SSR projection path
+  (`re-frame.ssr.payload-policy/project-runtime-db` →
+  `re-frame.ssr.payload-policy/build-payload`), with a real `reg-machine`
+  `:data-schema` and the machines artefact loaded (so the late-bound
+  `:machines/project-ssr-runtime-db` hook is bound). The schemas artefact
+  provides the schema-mark walker the `reg-machine` bridge consults."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Loading machines publishes :machines/project-ssr-runtime-db +
+            ;; the reg-machine schema-mark bridge; schemas + schemas.malli
+            ;; provide the schema-mark walker the bridge consults.
+            [re-frame.machines]
+            [re-frame.schemas]
+            [re-frame.schemas.malli]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(def ^:private auth-id :rf.ssr-machine/auth)
+
+(def ^:private auth-schema
+  "A machine `:data-schema` with one sensitive slot, one large slot, and a
+  plain sibling that must ride the hydration wire verbatim."
+  [:map
+   [:retries :int]
+   [:token   {:sensitive? true} [:maybe :string]]
+   [:blob    {:large? true}     [:maybe :string]]])
+
+(defn- reg-auth-machine! []
+  (rf/reg-machine auth-id
+    {:initial     :anon
+     :data        {:retries 0 :token nil :blob nil}
+     :data-schema auth-schema
+     :states      {:anon   {:on {:login :authed}}
+                   :authed {}}}))
+
+(defn- runtime-db-with-secret-snapshot
+  "A runtime-db carrying ONE durable machine snapshot whose `:data` holds a
+  live secret token + large blob + a plain sibling — the shape the SSR
+  hydration payload would ship."
+  []
+  {:rf.runtime/machines
+   {:snapshots {auth-id {:state :authed
+                         :data  {:retries 2
+                                 :token   "secret-jwt-snapshot"
+                                 :blob    "huge-blob-value"}}}
+    :system-ids {}
+    :spawned    {}}})
+
+;; ---- the leak regression (project-runtime-db) -----------------------------
+
+(deftest sensitive-machine-data-redacted-in-hydration-projection
+  (testing "a :sensitive? :data-schema slot inside a durable machine snapshot
+            is redacted to :rf/redacted in the SSR :rf/runtime-db projection;
+            the :large? slot elides; the plain sibling rides verbatim"
+    (reg-auth-machine!)
+    (let [slice    (payload-policy/project-runtime-db
+                     (runtime-db-with-secret-snapshot))
+          snapshot (get-in slice [:rf.runtime/machines :snapshots auth-id])]
+      (is (= :rf/redacted (get-in snapshot [:data :token]))
+          ":sensitive? token redacted in the hydration runtime-db slice")
+      (is (contains? (get-in snapshot [:data :blob]) :rf.size/large-elided)
+          ":large? blob elided to the size marker")
+      (is (= 2 (get-in snapshot [:data :retries]))
+          "plain sibling rides the wire verbatim")
+      (is (= :authed (:state snapshot))
+          ":state (durable structural fact) rides verbatim")
+      (is (not (.contains (pr-str slice) "secret-jwt-snapshot"))
+          "no raw token survives anywhere in the projected runtime-db slice")
+      (is (not (.contains (pr-str slice) "huge-blob-value"))
+          "no raw large value survives in the projected runtime-db slice"))))
+
+(deftest full-hydration-payload-redacts-machine-snapshot-data
+  (testing "the full :rf/hydration-payload's :rf/runtime-db carries the
+            redacted/elided machine :data, not the raw classified fields"
+    (reg-auth-machine!)
+    (let [rt-slice (payload-policy/project-runtime-db
+                     (runtime-db-with-secret-snapshot))
+          payload  (payload-policy/build-payload
+                     auth-id {:public/page :dashboard} "h1"
+                     {:version 1 :runtime-db rt-slice})
+          snap     (get-in payload [:rf/runtime-db :rf.runtime/machines
+                                    :snapshots auth-id])]
+      (is (= :rf/redacted (get-in snap [:data :token])))
+      (is (contains? (get-in snap [:data :blob]) :rf.size/large-elided))
+      (is (not (.contains (pr-str payload) "secret-jwt-snapshot"))
+          "the hydration blob the client receives carries no raw secret")
+      (is (not (.contains (pr-str payload) "huge-blob-value"))))))
+
+(deftest schemaless-machine-snapshot-rides-verbatim
+  (testing "a machine with no :data-schema marks ships its snapshot :data
+            verbatim — the projection is precise, not a blanket scrub"
+    (rf/reg-machine :rf.ssr-machine/plain
+      {:initial :idle :data {:public "ok"} :states {:idle {}}})
+    (let [rt    {:rf.runtime/machines
+                 {:snapshots {:rf.ssr-machine/plain
+                              {:state :idle :data {:public "ok"}}}}}
+          slice (payload-policy/project-runtime-db rt)
+          snap  (get-in slice [:rf.runtime/machines :snapshots
+                               :rf.ssr-machine/plain])]
+      (is (= "ok" (get-in snap [:data :public]))
+          "unclassified machine data rides the hydration wire verbatim"))))

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -2,9 +2,11 @@
   "Coverage for the :rf.server/request cofx + per-frame request slot
   (rf2-e825b). Per Spec 011 §Server-only `reg-cofx` for request context.
 
-  The cofx surfaces the active HTTP request map to event handlers so
-  setup events can read URL, headers, session cookies, etc. without
-  threading the request through as an event arg. Mechanism:
+  The cofx surfaces the active HTTP request map to event handlers as an
+  AMBIENT, host-transient read — for NON-DURABLE request reads (branching on
+  `:request-method`, reading a header for a non-durable decision). Durable
+  request-derived facts use the recordable boundary pattern instead, covered
+  by `re-frame.ssr-request-durable-fact-test` (rf2-aqwvhh). Mechanism:
 
     1. The host adapter (rf2-ny6v7 ships the Ring adapter) populates
        the per-frame request slot via `re-frame.ssr/set-request!`

--- a/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
@@ -1,0 +1,138 @@
+(ns re-frame.ssr-request-durable-fact-test
+  "rf2-aqwvhh — durable request-derived facts use the RECORDABLE boundary
+  pattern, NOT the ambient `:rf.server/request` read.
+
+  EP-0017 §1 + Spec 011 §Durable request-derived facts: `:rf.server/request`
+  is an AMBIENT, host-transient read — its supplier re-runs on replay and never
+  re-presents the value a recorded run saw (and reads nil after per-request
+  frame teardown). So a setup handler that folds a request-derived fact into
+  DURABLE app-db (auth user / session state that ships in the hydration
+  payload) must NOT read it through the ambient cofx; it takes the fact as a
+  RECORDABLE leaf so the causal token carries it and replay re-presents it
+  verbatim. Two slice-A-legal shapes:
+
+    1. EVENT PAYLOAD — the host dispatches the setup event WITH the sanitized
+       derived fact; it rides `:event`, recorded as part of the dispatch.
+    2. PROVIDED recordable `:rf.cofx` LEAF — an app-owned
+       `{:recordable? true :provided? true}` cofx the host stamps onto the boot
+       token; a record missing it fails LOUDLY with
+       `:rf.error/missing-required-cofx` rather than silently re-reading the
+       host (the strict-replay contract).
+
+  This pins both shapes producing the durable app-db slice, the fail-loud on a
+  missing provided fact, AND the contrast that the ambient `:rf.server/request`
+  value is NOT recorded on the token (the symptom the pattern avoids)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- collect-traces! [id]
+  (let [acc (atom [])]
+    (rf/register-listener! id (fn [ev] (swap! acc conj ev)))
+    acc))
+
+;; ---- shape 1: event payload (the sanitized fact rides :event) -------------
+
+(deftest durable-app-db-from-request-fact-via-event-payload
+  (testing "a setup handler writes durable app-db from a request-derived fact
+            supplied as EVENT PAYLOAD — the fact rides :event (recorded), the
+            handler never reads the ambient request cofx"
+    (let [server-frame (frame/make-frame {:platform :server})]
+      ;; The handler reads the SANITIZED session off its event arg, NOT off the
+      ;; ambient :rf.server/request cofx — so the durable write folds a recorded
+      ;; fact (the event), replay-stable.
+      (rf/reg-event :auth/server-init
+        {:platforms #{:server}}
+        (fn [{:keys [db]} [_ {:keys [user authed?]}]]
+          {:db (assoc db :auth/user user
+                         :auth/state (if authed? :authed :idle))}))
+      ;; Host adapter sanitizes the request and dispatches WITH the fact.
+      (rf/dispatch-sync [:auth/server-init {:user "alice" :authed? true}]
+                        {:frame server-frame})
+      (let [db (frame/frame-app-db-value server-frame)]
+        (is (= "alice" (:auth/user db))
+            "durable app-db carries the request-derived user from event payload")
+        (is (= :authed (:auth/state db)))))))
+
+;; ---- shape 2: provided recordable :rf.cofx leaf ---------------------------
+
+(deftest durable-app-db-from-request-fact-via-provided-cofx
+  (testing "a setup handler writes durable app-db from a PROVIDED recordable
+            :rf.cofx leaf the host stamped onto the token after sanitizing the
+            request — the value is recorded + replay-stable, delivered flat"
+    (let [server-frame (frame/make-frame {:platform :server})]
+      (rf/reg-cofx :auth.session/user
+        {:recordable? true :provided? true
+         :doc "Sanitized session user, stamped by the SSR host adapter."})
+      (rf/reg-event :auth/server-init-cofx
+        {:platforms        #{:server}
+         :rf.cofx/requires [:auth.session/user]}
+        (fn [{:keys [db auth.session/user]} _]
+          {:db (assoc db :auth/user user
+                         :auth/state (if user :authed :idle))}))
+      ;; Host adapter stamps the sanitized derived fact onto the boot token.
+      (rf/dispatch-sync [:auth/server-init-cofx]
+                        {:frame   server-frame
+                         :rf.cofx {:auth.session/user "bob"}})
+      (let [db (frame/frame-app-db-value server-frame)]
+        (is (= "bob" (:auth/user db))
+            "durable app-db carries the request-derived user from the recorded :rf.cofx leaf")
+        (is (= :authed (:auth/state db)))))))
+
+(deftest missing-provided-request-fact-fails-loud
+  (testing "a PROVIDED recordable request fact absent from the token fails
+            LOUDLY with :rf.error/missing-required-cofx — NOT a silent
+            fall-back to get-request / nil (the strict-replay contract)"
+    (let [server-frame (frame/make-frame {:platform :server})
+          traces       (collect-traces! ::missing)]
+      (rf/reg-cofx :auth.session/user
+        {:recordable? true :provided? true
+         :doc "Sanitized session user, stamped by the SSR host adapter."})
+      (rf/reg-event :auth/server-init-strict
+        {:platforms        #{:server}
+         :rf.cofx/requires [:auth.session/user]}
+        (fn [{:keys [db auth.session/user]} _]
+          {:db (assoc db :auth/user user)}))
+      ;; Host did NOT stamp :auth.session/user — the provided fact is absent.
+      (let [ex (try (rf/dispatch-sync [:auth/server-init-strict] {:frame server-frame})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (rf/unregister-listener! ::missing)
+        (is (some? ex) "dispatch threw rather than silently delivering nil")
+        (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data ex)))
+            "the throw is :rf.error/missing-required-cofx (fail-closed)")
+        (is (seq (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces))
+            "a :rf.error/missing-required-cofx error trace was emitted")
+        ;; And no durable write landed.
+        (is (nil? (:auth/user (frame/frame-app-db-value server-frame)))
+            "no durable app-db slice was written from a missing provided fact")))))
+
+;; ---- contrast: the ambient :rf.server/request value is NOT recorded -------
+
+(deftest ambient-request-read-is-not-recorded-on-the-token
+  (testing "the ambient :rf.server/request value does NOT appear on the causal
+            token's :rf.cofx record — proving it is unrecorded (replay re-runs
+            the supplier), which is exactly why a DURABLE write must not fold it
+            (it would diverge on replay / read nil after teardown)"
+    (let [server-frame (frame/make-frame {:platform :server})
+          seen-cofx    (atom ::unset)]
+      (ssr/set-request! server-frame {:request-method :get :uri "/x"
+                                      :headers {"cookie" "session=raw-secret"}})
+      ;; A handler that READS the ambient request (a legal NON-durable use:
+      ;; here just to capture the recorded :rf.cofx for the assertion).
+      (rf/reg-event :req/inspect-record
+        {:platforms        #{:server}
+         :rf.cofx/requires [:rf.server/request]}
+        (fn [{:as ctx :keys [rf.server/request]} _]
+          (reset! seen-cofx (:rf.cofx ctx))
+          {}))
+      (rf/dispatch-sync [:req/inspect-record] {:frame server-frame})
+      (is (not (contains? (or @seen-cofx {}) :rf.server/request))
+          "the ambient request value is NOT on the token's :rf.cofx record")
+      (is (not (.contains (pr-str @seen-cofx) "raw-secret"))
+          "the raw request/cookie never rides the causal token"))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
@@ -1,0 +1,118 @@
+(ns re-frame.ssr-streaming-hydration-egress-test
+  "rf2-uc3cs4 — streaming per-subtree hydration DELTAS obey the same
+  allowlist-first-then-`:rf.egress/ssr-hydration`-project boundary the final
+  `__rf_payload` does (rf2-bt9kct, EP-0015 §14).
+
+  A streaming delta is browser-delivered hydration state — it arrives in the
+  stream BEFORE the final payload and the client merges it into the live
+  app-db. `subtree-delta` computes it as the raw changed/new top-level keys
+  each mapped to the FULL after-db value, and the Ring adapter serialized
+  `(pr-str delta)` directly. So a continuation mutating `:secret` streamed
+  `{:secret …}` even when the handler `:payload` allowlist named only public
+  keys, and a frame-sensitive child under an allowed changed key rode raw.
+
+  `re-frame.ssr.streaming/project-delta` is the fix — the pure helper the Ring
+  adapter calls before serialising the delta script. This pins it directly
+  (allowlist drop + sensitive-child redaction + the empty-delta short-circuit)
+  AND the streaming final-payload's app-db projection (the streaming arm of
+  rf2-bt9kct) through the actual `build-final-payload` path."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.privacy :as privacy]
+            [re-frame.ssr.streaming :as streaming]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(def ^:private sframe :rf.uc3cs4/server)
+
+(defn- reg-sensitive-server-frame!
+  "Register a server frame whose classification marks [:session :token]
+  sensitive and seed its app-db with a sensitive child + public siblings."
+  [db]
+  (rf/reg-event :rf.uc3cs4/seed (fn [{d :db} [_ v]] {:db v}))
+  (rf/reg-frame sframe
+    {:platform  :server
+     :sensitive {:app-db [[:session :token]]}
+     :on-create [:rf.uc3cs4/seed db]}))
+
+;; ---- project-delta: allowlist + projection on the streaming delta ---------
+
+(deftest off-allowlist-changed-key-dropped-from-delta
+  (testing "a continuation that changed an OFF-ALLOWLIST key (:secret) does
+            NOT ride the streaming delta — the handler :payload allowlist drops
+            it before the delta script is written"
+    (reg-sensitive-server-frame! {})
+    (let [;; the continuation mutated :secret (off-allowlist) and :public (allowed)
+          raw-delta {:secret {:api-key "leak-me"}
+                     :public {:page :dashboard}}
+          projected (rf/with-frame sframe
+                      (streaming/project-delta raw-delta sframe {:payload [:public]}))]
+      (is (not (contains? projected :secret))
+          ":secret (off-allowlist) is dropped from the streaming delta")
+      (is (= {:page :dashboard} (:public projected))
+          "the allowlisted changed key rides the delta")
+      (is (not (.contains (pr-str projected) "leak-me"))
+          "no off-allowlist secret survives in the projected delta"))))
+
+(deftest sensitive-child-redacted-in-delta
+  (testing "a frame-sensitive child (:token) inside an ALLOWED changed key
+            (:session) is redacted in the streaming delta by the ssr-hydration
+            projection; the public sibling rides verbatim"
+    (reg-sensitive-server-frame! {})
+    (let [raw-delta {:session {:token "secret-jwt" :user "bob"}}
+          projected (rf/with-frame sframe
+                      (streaming/project-delta raw-delta sframe {:payload [:session]}))]
+      (is (= privacy/redacted-sentinel (get-in projected [:session :token]))
+          "the frame-sensitive nested :token is redacted in the streamed delta")
+      (is (= "bob" (get-in projected [:session :user]))
+          "the public sibling rides verbatim")
+      (is (not (.contains (pr-str projected) "secret-jwt"))
+          "no raw token survives in the streamed delta"))))
+
+(deftest whole-app-db-delta-still-redacts-sensitive-child
+  (testing ":rf.ssr.payload/whole-app-db keeps every changed key in the delta
+            but STILL redacts a frame-sensitive child"
+    (reg-sensitive-server-frame! {})
+    (let [raw-delta {:session {:token "secret-jwt" :user "bob"}
+                     :secret  {:api-key "x"}}
+          projected (rf/with-frame sframe
+                      (streaming/project-delta
+                        raw-delta sframe {:payload :rf.ssr.payload/whole-app-db}))]
+      (is (= privacy/redacted-sentinel (get-in projected [:session :token])))
+      (is (contains? projected :secret)
+          "whole-app-db keeps the changed :secret key (no allowlist filtering)")
+      (is (not (.contains (pr-str projected) "secret-jwt"))))))
+
+(deftest empty-and-all-dropped-deltas-short-circuit
+  (testing "an empty delta, and a delta whose every changed key is
+            off-allowlist, both project to {} so the host emits no delta script"
+    (reg-sensitive-server-frame! {})
+    (rf/with-frame sframe
+      (is (= {} (streaming/project-delta {} sframe {:payload [:public]}))
+          "empty delta → {}")
+      (is (= {} (streaming/project-delta {:secret {:k 1}} sframe {:payload [:public]}))
+          "all-off-allowlist delta → {} (no :rf/redacted scalar)"))))
+
+;; ---- the streaming arm of rf2-bt9kct: build-final-payload's :rf/app-db -----
+
+(deftest streaming-final-payload-redacts-sensitive-app-db-child
+  (testing "build-final-payload's :rf/app-db runs the allowlisted slice through
+            the ssr-hydration projection so a frame-sensitive child redacts in
+            the final __rf_payload (the streaming arm of rf2-bt9kct)"
+    (reg-sensitive-server-frame!
+      {:session {:token "secret-jwt-final" :user "carol"}
+       :public  {:page :home}
+       :secrets {:api-key "internal"}})
+    (let [payload (rf/with-frame sframe
+                    (streaming/build-final-payload
+                      sframe "h1" {:version 1 :payload [:session :public]}))
+          db      (:rf/app-db payload)]
+      (is (= privacy/redacted-sentinel (get-in db [:session :token]))
+          "the frame-sensitive :token redacts in the streaming final payload")
+      (is (= "carol" (get-in db [:session :user])))
+      (is (= {:page :home} (:public db)))
+      (is (not (contains? db :secrets)) ":secrets (unlisted) omitted by allowlist")
+      (is (not (.contains (pr-str payload) "secret-jwt-final"))
+          "no raw token survives in the streaming final payload"))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -412,6 +412,17 @@ A standard cofx for accessing the current request:
 
 Setup events take delivery by declaring `{:rf.cofx/requires [:rf.server/request]}` on their registration metadata; the request map then arrives flat under `:rf.server/request` in the handler's coeffects so it can read the URL, headers, session, etc. The `:platforms` metadata mirrors `reg-fx`.
 
+`:rf.server/request` is an **ambient** coeffect (the default EP-0017 grade): its supplier reads the per-frame request slot at context assembly, the value is never recorded, and replay re-runs the supplier. Per [EP-0017](../docs/EP/EP-0017-recordable-coeffects.md) §1 the ambient grade is legal **only where no durable write depends on the value** — so `:rf.server/request` is for **non-durable request reads** (branching on `:request-method`, reading a header for a decision that does not fold into durable app-db / runtime-db). A handler that folds a request-derived fact into durable state through this ambient read is the SSR analogue of the ambient-localStorage replay hole: replay re-runs the live supplier instead of re-presenting the value the recorded run actually folded (and reads `nil` after the per-request frame's slot is cleared). Durable request-derived facts use the boundary pattern below.
+
+#### Durable request-derived facts
+
+When a setup handler writes **durable** state from the request — auth user / session state read from a cookie folded into the hydration payload, an `accept-language` folded into a locale slice — the value MUST arrive as a **recordable** fact so the causal token carries it and replay re-presents it verbatim ([002-Frames §The recordable-coeffect rule](002-Frames.md)). The host adapter **sanitizes** the request at the boundary and supplies the *derived projection* (never the whole request map) by one of two slice-A-legal shapes:
+
+- **Event payload.** The host dispatches the setup event WITH the derived fact: `[:auth/server-init {:user (extract-user request)}]`. The fact rides `:event`, recorded as part of the dispatch.
+- **Provided recordable `:rf.cofx` leaf.** The app registers an owner-qualified `{:recordable? true :provided? true}` coeffect (e.g. `:auth.session/user`) and the host adapter STAMPS the sanitized value onto the boot dispatch token (`{:rf.cofx {:auth.session/user …}}`). The handler declares `:rf.cofx/requires [:auth.session/user]`; a record missing it fails **loudly** with `:rf.error/missing-required-cofx` rather than silently re-reading the host.
+
+The whole request map MUST NOT ride the causal token — it carries `Cookie` / `Authorization` / raw bodies (secrets / PII) and is a host handle (recording a secret makes it durable, not safe). Stamp only the sanitized derived projection.
+
 #### Request storage substrate
 
 The `:rf.server/request` cofx surfaces host-controlled wire-shape input (Ring request map, Pedestal context, raw-HTTP request, edge-runtime request, etc.) into the handler's `:coeffects`. The **storage substrate** for the active request map is normative — getting this wrong has direct privacy consequences.
@@ -880,15 +891,16 @@ The contract: the `:fragment` value is preserved across the SSR round-trip; no S
 
 Server-side auth/session lives in `app-db` via a declared coeffect (`:rf.cofx/requires`) at `:rf/server-init` time. No SSR-specific auth surface.
 
+The session feeds **durable** app-db that ships in the hydration payload, so it MUST arrive as a recordable fact via the [§Durable request-derived facts](#durable-request-derived-facts) boundary pattern — NOT an ambient `:rf.server/request` read folded into durable state at the write site (that is a replay hole: replay re-runs the live cofx supplier instead of re-presenting the session the recorded run folded).
+
 Concrete:
 
-1. Server middleware (Ring/Pedestal/etc.) extracts the session from the request — cookie-based, JWT-based, whatever the host uses.
-2. The session is attached to the request map as `:session` (or whatever key the host's middleware uses).
-3. `:rf/server-init` reads the session via cofx: `[:dispatch [:auth/server-init (:session request)]]`.
-4. `:auth/server-init` (`:platforms #{:server}`) sets the relevant `app-db` slice: `{:auth/user (or session-user nil) :auth/state (if session :authed :idle)}`.
-5. The client side is hydrated with this slice; the user's authed-state survives the round-trip.
+1. Server middleware (Ring/Pedestal/etc.) extracts + **sanitizes** the session from the request — cookie-based, JWT-based, whatever the host uses — to a wire-safe derived projection (e.g. `{:user "alice" :authed? true}`), never the raw cookie / token.
+2. The host adapter supplies the sanitized session as a **recordable** fact, either as event payload — `make-frame` with `:on-create [:auth/server-init {:user … :authed? …}]` — or by stamping a provided recordable `:rf.cofx` leaf (`:auth.session/user`) onto the boot token.
+3. `:auth/server-init` (`:platforms #{:server}`) reads the fact off `:event` (or declares `:rf.cofx/requires [:auth.session/user]`) and sets the relevant `app-db` slice: `{:auth/user (or user nil) :auth/state (if authed? :authed :idle)}`. A missing provided fact fails loudly with `:rf.error/missing-required-cofx` rather than silently re-reading the host.
+4. The client side is hydrated with this slice; the user's authed-state survives the round-trip, and epoch-restore / replay re-presents the SAME session fact off the token.
 
-The framework provides no auth-specific machinery. The pattern's primitives — events, cofx, frames per request — are sufficient.
+The framework provides no auth-specific machinery. The pattern's primitives — events, recordable coeffects, frames per request — are sufficient.
 
 ### `:after` is no-op under SSR
 


### PR DESCRIPTION
Surface-clustered EP-0015/EP-0017 SSR fixes from the review wave — all on the SSR surface (`implementation/ssr` + `ssr-ring` + the machines projector hook). Worktree off latest `origin/main`; clean rebase.

## Beads

- **rf2-bt9kct** (+ **rf2-mx9w6q**, dup) — *final hydration app-db bypasses ssr-hydration projection.* `apply-policy` only allowlisted; the surviving slice never ran through the frame-owned egress projector, so a frame-sensitive child inside an allowlisted (or whole-app-db) key serialized raw. Added `payload-policy/project-app-db-egress` (allowlist FIRST, then `project-egress` under `:rf.egress/ssr-hydration` seeded at the request frame, fail-closed on an unresolvable frame); wired into both `ring.payload/build-payload` (non-streaming) and `streaming/build-final-payload` (streaming).
- **rf2-jm2u63** — *runtime-db machine snapshots hydrate raw classified data.* `project-runtime-db` shipped `:rf.runtime/machines` wholesale, so a snapshot whose machine `:data-schema` marks a slot `:sensitive?`/`:large?` rode raw. Added machines-owned `re-frame.machines.ssr/project-ssr-runtime-db` (published via the `:machines/project-ssr-runtime-db` late-bind hook + directory entry); walks each snapshot's `:data` against the machine's `:data-schema` marks (the same `marks/marks-for :event <actor-id>` the trace egress uses) through `marks/redact-with-paths` then `project-egress` under `:rf.egress/ssr-hydration`. Mirrors the resources `:ssr/extend-runtime-db-projection` model.
- **rf2-uc3cs4** — *streaming hydration deltas bypass payload policy and projection.* Per-boundary deltas were `pr-str`'d raw — an off-allowlist changed key, or a sensitive child under an allowed key, rode the wire. Added `streaming/project-delta` (allowlist + `:rf.egress/ssr-hydration` projection under the request frame); the Ring streaming adapter calls it inside the carried realm + frame scope before serialising the `data-rf2-suspense-hydrate` script. Empty / all-dropped deltas short-circuit to `{}` (no script).
- **rf2-aqwvhh** — *SSR request cofx is ambient but documented for durable hydration setup.* `:rf.server/request` is ambient (re-runs on replay, reads nil after teardown), so folding a request-derived fact into the hydration payload was a replay hole. Stopped presenting it as the durable setup source; documented the recordable boundary pattern (event payload OR a provided recordable `:rf.cofx` leaf the host stamps after sanitizing the request; whole request map never rides the token; a missing provided fact fails loud). Updated the `:rf.server/request` reg-cofx doc, `request.cljc`, and Spec 011 (new §Durable request-derived facts + reworked §Authentication/sessions).

## Tests (red→green on the actual SSR path)

- `ssr/test/.../ssr_machine_snapshot_projection_test.clj` — machine `:data-schema` sensitive/large redaction through `project-runtime-db` + full payload.
- `ssr-ring/test/.../app_db_egress_projection_test.clj` — allowlist+projection compose, whole-app-db still projects, fail-closed on unregistered frame.
- `ssr/test/.../ssr_streaming_hydration_egress_test.clj` — `project-delta` (off-allowlist drop, sensitive-child redaction, whole-app-db, empty short-circuit) + the streaming arm of bt9kct via `build-final-payload`.
- `ssr/test/.../ssr_request_durable_fact_test.clj` — both boundary shapes, fail-loud on missing provided fact, and the contrast that the ambient request value is unrecorded.

## Gates

`npm run test:cljs` green (7678 tests). SSR JVM (364) + ssr-ring JVM (171) green. `scripts/test-fast-pr.sh` green (core JVM 1776, CLJS 7678, markdown anchor/link gates incl. the new Spec 011 §Durable request-derived facts anchor).