### PR TITLE
docs: EP-0017 cofx accuracy in API.md + guide + projection doc (rf2-ah97vk, rf2-hk6wd2, rf2-tawage)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -261,6 +261,74 @@
   [extracted]
   (projection/vacuity-floor-problem "spec/API.md" extracted min-var-rows))
 
+;; ---------------------------------------------------------------------------
+;; EP-0017 reg-cofx contract pin.
+;;
+;; The tier/manifest reconcile above only checks that the `reg-cofx` row
+;; RESOLVES to a front-porch re-frame.core var with a matching tier — it
+;; says nothing about the row's SIGNATURE or CONTRACT prose. So the row
+;; could silently drift back toward the stale v1 ctx-transform shape, drop
+;; the value-returning-supplier wording, lose the grade metadata, or
+;; reintroduce an `inject-cofx`-as-delivery contract, and the gate would
+;; still pass green. This is a targeted content pin over the one `reg-cofx`
+;; row: the EP-0017 contract is small, settled, and high-blast-radius if it
+;; drifts (it is the public coeffect-registration surface), so it is worth
+;; asserting the row's load-bearing phrases directly.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-cofx-row-text
+  "The full raw text of the spec/API.md `reg-cofx` var-row (the `| ... |`
+   table line whose first cell is `` `reg-cofx` ``), or nil if absent. The
+   whole pipe-delimited line is returned so the contract pin below can
+   assert against the signature cell AND the notes-cell prose together."
+  []
+  (with-open [r (io/reader @api-md-file)]
+    (->> (line-seq r)
+         (some (fn [line]
+                 (when (re-find #"^\s*\|\s*`reg-cofx`\s*\|" line) line))))))
+
+(def ^:private reg-cofx-required-phrases
+  "The load-bearing EP-0017 `reg-cofx` contract phrases the spec/API.md row
+   MUST carry. Each is a regex matched against the row's full raw line. A
+   missing phrase is a contract-drift failure (the row resolved as a
+   front-porch var but lost its EP-0017 shape).
+
+   `[label regex]` — the label names the contract facet for the report."
+  [["signature (reg-cofx id ?metadata supplier)"
+    #"`\(reg-cofx id \?metadata supplier\)`"]
+   ["value-returning supplier"
+    #"(?i)value-returning supplier"]
+   ["grade :recordable?"
+    #":recordable\?"]
+   ["grade :provided?"
+    #":provided\?"]
+   ["flat delivery via :rf.cofx/requires"
+    #":rf\.cofx/requires"]
+   ["ctx->ctx + inject-cofx retired"
+    #"(?i)(?:ctx→ctx|ctx->ctx).*inject-cofx.*retired"]])
+
+(defn reg-cofx-contract-problems
+  "Pure contract-pin reconciler (rf2-ah97vk — extracted so the EP-0017
+   `reg-cofx` contract is unit-testable with a synthetic row). Given the
+   raw `reg-cofx` row line (or nil), return the seq of problem maps for any
+   missing load-bearing EP-0017 phrase, plus a guard problem when the row
+   is absent entirely.
+
+   The check is INTENTIONALLY positive (require the EP-0017 phrases) rather
+   than a denylist of stale wording — the stale v1 shape is open-ended, but
+   the EP-0017 contract is a small closed set, so pinning its presence is
+   the sound drift gate: a row that lost a phrase has drifted, whatever it
+   drifted to."
+  [row-line]
+  (if (nil? row-line)
+    [{:kind :reg-cofx-row-missing
+      :detail (str "spec/API.md has no `reg-cofx` var-row — the EP-0017 public "
+                   "coeffect-registration surface is unaccounted for")}]
+    (keep (fn [[label re]]
+            (when-not (re-find re row-line)
+              {:kind :reg-cofx-contract :facet label}))
+          reg-cofx-required-phrases)))
+
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
    every API.md var-row resolves to a manifest row with a MATCHING tier;
@@ -282,7 +350,19 @@
         problems   (reconcile {:rows               rows
                                :api-rows           api-rows
                                :known-unmanifested known-unmanifested
-                               :aliases            adapter-aliases})]
+                               :aliases            adapter-aliases})
+        ;; EP-0017 reg-cofx contract pin (rf2-ah97vk): the tier reconcile
+        ;; above only checks the row RESOLVES to a front-porch var — it
+        ;; cannot see the row's signature/contract prose drift back to the
+        ;; stale v1 ctx-transform shape. Pin the load-bearing EP-0017 phrases.
+        cofx-probs (reg-cofx-contract-problems (reg-cofx-row-text))
+        ;; EP-0017 keyword-drift guard (rf2-tawage): the var-row reconcile is
+        ;; blind to stale `:rf.world/inputs` keyword vocabulary creeping into
+        ;; API.md prose outside an explicit retirement/rename mention.
+        kw-probs   (projection/ep0017-keyword-drift-problems
+                     "spec/API.md"
+                     (with-open [r (io/reader @api-md-file)]
+                       (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r)))))]
     (cond
       ;; Vacuity-floor violation: extraction collapsed — refuse a green.
       floor
@@ -291,6 +371,28 @@
                                   "var-row(s) extracted, below the non-vacuous floor of %d.")
                              extracted min-var-rows))
             (println (str "  " (:detail floor))))
+          false)
+
+      (seq cofx-probs)
+      (do (binding [*out* *err*]
+            (println "DRIFT: spec/API.md `reg-cofx` row has lost EP-0017 contract wording.")
+            (println "The reg-cofx row must pin the EP-0017 cofx contract: signature")
+            (println "(reg-cofx id ?metadata supplier), value-returning supplier, grade")
+            (println "metadata (:recordable?/:provided?), flat delivery via :rf.cofx/requires,")
+            (println "and the retired ctx->ctx/inject-cofx delivery. Missing:")
+            (doseq [{:keys [kind facet detail]} cofx-probs]
+              (case kind
+                :reg-cofx-row-missing (println (str "  " detail))
+                :reg-cofx-contract    (println (format "  MISSING contract facet: %s" facet)))))
+          false)
+
+      (seq kw-probs)
+      (do (binding [*out* *err*]
+            (println "DRIFT: spec/API.md reintroduced stale EP-0017 keyword vocabulary.")
+            (println ":rf.world/inputs was renamed to the flat :rf.cofx map (no alias);")
+            (println "a mention must be an explicit retirement/rename reference. Problems:")
+            (doseq [{:keys [file line detail]} kw-probs]
+              (println (format "  %s:%d  %s" file line detail))))
           false)
 
       (empty? problems)

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
@@ -14,11 +14,25 @@
   V1-MIGRATION CHAPTER. `docs/guide/25-from-re-frame-v1.md` names removed
   re-frame v1 APIs (`on-changes`, …) as the left-hand side of migration
   guidance, exactly as the migration SKILL does. Its old-name mentions are
-  carried on the `:doc-guide-known-unmanifested` allowlist (by bare name)
-  rather than excluding the whole chapter, because the chapter ALSO teaches
-  live re-frame2 vars worth checking. Template placeholders the guide uses
-  in a syntax table (`set-x!` / `install-x!` — `<x>` stand-ins, not real
-  vars) ride the same allowlist."
+  carried on the `:doc-guide-known-unmanifested-scoped` allowlist rather
+  than excluding the whole chapter, because the chapter ALSO teaches live
+  re-frame2 vars worth checking. Template placeholders the guide uses in a
+  syntax table (`set-x!` / `install-x!` — `<x>` stand-ins, not real vars)
+  ride the same allowlist.
+
+  FILE-SCOPED ALLOWLIST (rf2-hk6wd2). The removed-name allowlist used to be
+  a BARE-NAME set: a name listed there was silenced ANYWHERE in the guide
+  tree. EP-0017 removed `inject-cofx`, and live teaching prose must use
+  `:rf.cofx/requires` — but a bare allowlist would let a future live
+  `(rf/inject-cofx …)` in any teaching chapter pass green, since the bare
+  name `inject-cofx` was unconditionally silenced. The allowlist is now
+  `:doc-guide-known-unmanifested-scoped` — `{removed-name -> #{approved
+  repo-relative file paths}}`. A call-position reference to a removed name
+  is silenced ONLY in its approved migration file(s); the SAME reference in
+  any other guide file is RED (it leaked into live teaching prose). This is
+  the negative check the bead asks for: live guide chapters cannot call
+  removed EP-0017 (or EP-0015/EP-0018) APIs outside approved migration
+  contexts."
   (:require [re-frame.api-manifest.gen :as gen]
             [re-frame.api-manifest.projection :as proj]))
 
@@ -33,25 +47,61 @@
    never on ordinary content churn."
   100)
 
+(defn reconcile
+  "Pure reconciler (rf2-hk6wd2 — extracted so the file-scoped allowlist
+   contract is unit-testable with synthetic inputs). Returns the seq of
+   problem maps for the supplied call-position references.
+
+   `references`  — `[{:var :line :raw :file} ...]` (`:file` repo-relative).
+   `core-vars`   — set of bare var names the manifest carries on
+                   `re-frame.core` (these always resolve).
+   `scoped-allow`— `{removed-name -> #{approved repo-relative file paths}}`
+                   (the `:doc-guide-known-unmanifested-scoped` sidecar key).
+
+   A reference resolves (no problem) when its var is a `re-frame.core`
+   manifest row, OR its var is on the scoped allowlist AND its file is in
+   that name's approved-file set. A reference to a scoped removed name in a
+   NON-approved file is flagged as a removed-API leak into live teaching
+   prose; an unknown name with no manifest row and no scope entry is flagged
+   as an unresolved reference."
+  [{:keys [references core-vars scoped-allow]}]
+  (keep (fn [{:keys [var line raw file]}]
+          (cond
+            (contains? core-vars var) nil
+            (contains? scoped-allow var)
+            (when-not (contains? (get scoped-allow var) file)
+              {:file file :line line :raw raw
+               :detail (format (str "removed API named outside its approved "
+                                    "migration file(s) %s — live guide prose "
+                                    "must not call removed APIs")
+                               (vec (sort (get scoped-allow var))))})
+            :else
+            {:file file :line line :raw raw
+             :detail "no re-frame.core manifest row"}))
+        references))
+
 (defn check!
   []
-  (let [rows      (proj/manifest-rows)
-        core-vars (set (map :var (proj/rows-in-ns rows core-ns)))
-        allow     (set (:doc-guide-known-unmanifested (gen/read-sidecar)))
-        dir       (proj/repo-file "docs" "guide")
+  (let [rows         (proj/manifest-rows)
+        core-vars    (set (map :var (proj/rows-in-ns rows core-ns)))
+        scoped-allow (:doc-guide-known-unmanifested-scoped (gen/read-sidecar))
+        dir          (proj/repo-file "docs" "guide")
         ;; require-markdown-files (rf2-utvst): fail loudly if docs/guide/
         ;; moves or is renamed, rather than silently checking zero files.
-        files     (proj/require-markdown-files "docs/guide/" dir)
-        results   (for [file files
-                        ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
-                    (assoc ref :file (proj/repo-relative file)))
-        problems  (keep (fn [{:keys [var line raw file]}]
-                          (when-not (or (contains? core-vars var)
-                                        (contains? allow var))
-                            {:file file :line line :raw raw
-                             :detail "no re-frame.core manifest row"}))
-                        results)]
-    (proj/report-with-floor! "docs/guide/" (count results) min-references problems)))
+        files        (proj/require-markdown-files "docs/guide/" dir)
+        references   (for [file files
+                           ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
+                       (assoc ref :file (proj/repo-relative file)))
+        var-problems (reconcile {:references   references
+                                 :core-vars    core-vars
+                                 :scoped-allow scoped-allow})
+        ;; EP-0017 keyword-drift guard (rf2-tawage): the var-resolution
+        ;; reconcile above cannot see stale `:rf.world/inputs` keyword
+        ;; vocabulary creeping back into teaching prose. Fold the keyword
+        ;; scan in so a reintroduction goes RED here too.
+        kw-problems  (proj/keyword-drift-problems-over-files files)
+        problems     (concat var-problems kw-problems)]
+    (proj/report-with-floor! "docs/guide/" (count references) min-references problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -214,6 +214,79 @@
     (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r)))))
 
 ;; ---------------------------------------------------------------------------
+;; EP-0017 keyword-drift guard (rf2-tawage).
+;;
+;; The projection checks above all scope to PUBLIC-VAR references and
+;; deliberately exclude the `:rf/*` reserved keyword namespace (the leading
+;; `(` discriminator drops `:rf/…` keywords so a `(rf/<var>` sweep does not
+;; drown in `:rf/default` etc.). That scoping is correct for var-rename
+;; drift, but it means a projection can reintroduce STALE EP-0017 KEYWORD
+;; vocabulary — `:rf.world/inputs` (renamed to the flat `:rf.cofx` map),
+;; grouped/non-flat `:rf.cofx` sub-maps, or coeffect prose missing the
+;; `:rf.cofx/requires` declaration — and every var-resolution check stays
+;; green.
+;;
+;; This guard closes that gap with a targeted KEYWORD-level scan. EP-0017's
+;; keyword surface is a small closed set:
+;;   - `:rf.world/inputs` is RETIRED (renamed to `:rf.cofx`, no alias). Its
+;;     only legitimate appearance is a retirement / rename / migration
+;;     mention — a line that ALSO names the `:rf.cofx` replacement, the
+;;     `:rf.error/world-inputs-renamed` hard error, or the words
+;;     retired/renamed/removed/superseded/migration. A `:rf.world/inputs`
+;;     mention WITHOUT such a marker is fresh stale vocabulary and is RED.
+;;
+;; The scan is per-line and prose-level (these surfaces are markdown), and
+;; intentionally CONSERVATIVE: it only fires on the retired keyword absent a
+;; same-line retirement marker, so historical/migration prose — which always
+;; names the replacement on the same line — stays green, while a fresh
+;; reintroduction in teaching prose goes red.
+;; ---------------------------------------------------------------------------
+
+(def ^:private world-inputs-retirement-markers
+  "Same-line tokens that mark a `:rf.world/inputs` mention as a legitimate
+   retirement / rename / migration reference (rather than fresh stale
+   vocabulary). A `:rf.world/inputs` line carrying ANY of these is approved;
+   one carrying NONE is flagged. The replacement keyword `:rf.cofx` and the
+   `:rf.error/world-inputs-renamed` error id are the strongest markers; the
+   prose words cover narrative migration mentions."
+  [":rf.cofx"
+   ":rf.error/world-inputs-renamed"
+   "world-inputs-renamed"
+   "retired" "renamed" "removed" "superseded" "migrat"])
+
+(defn ep0017-keyword-drift-problems
+  "Return a seq of EP-0017 keyword-drift problem maps for `lines` (a seq of
+   `[line-no text]`), tagged with `file` (repo-relative). Flags each
+   `:rf.world/inputs` mention NOT accompanied on its line by a retirement /
+   rename / migration marker (see `world-inputs-retirement-markers`).
+
+   Pure over the supplied lines so the contract is unit-testable with
+   synthetic inputs (rf2-tawage)."
+  [file lines]
+  (keep (fn [[n text]]
+          (when (str/includes? text ":rf.world/inputs")
+            (let [lc (str/lower-case text)]
+              (when-not (some #(str/includes? lc (str/lower-case %))
+                              world-inputs-retirement-markers)
+                {:file file :line n :raw ":rf.world/inputs"
+                 :detail (str "stale EP-0017 keyword — :rf.world/inputs was "
+                              "renamed to the flat :rf.cofx map (no alias); a "
+                              "mention must be an explicit retirement/rename/"
+                              "migration reference (name :rf.cofx or the "
+                              ":rf.error/world-inputs-renamed error on the line)")}))))
+        lines))
+
+(defn keyword-drift-problems-over-files
+  "Run `ep0017-keyword-drift-problems` over every file in `files` (io/file
+   seq), returning the concatenated problem seq with repo-relative `:file`
+   tags. The driver projection checks fold this into their problem list so a
+   keyword-drift reintroduction goes RED alongside any var-resolution drift."
+  [files]
+  (mapcat (fn [^java.io.File f]
+            (ep0017-keyword-drift-problems (repo-relative f) (numbered-lines f)))
+          files))
+
+;; ---------------------------------------------------------------------------
 ;; Reporting.
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
@@ -63,12 +63,19 @@
         results   (for [file files
                         ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
                     (assoc ref :file (proj/repo-relative file)))
-        problems  (keep (fn [{:keys [var line raw file]}]
-                          (when-not (or (contains? core-vars var)
-                                        (contains? allow var))
-                            {:file file :line line :raw raw
-                             :detail "no re-frame.core manifest row"}))
-                        results)]
+        var-problems (keep (fn [{:keys [var line raw file]}]
+                             (when-not (or (contains? core-vars var)
+                                           (contains? allow var))
+                               {:file file :line line :raw raw
+                                :detail "no re-frame.core manifest row"}))
+                           results)
+        ;; EP-0017 keyword-drift guard (rf2-tawage): scan the SAME checked
+        ;; skill files (the migration skill is already excluded above, where
+        ;; the retired keyword legitimately appears) for stale
+        ;; `:rf.world/inputs` vocabulary reintroduced outside an explicit
+        ;; retirement/rename mention.
+        kw-problems  (proj/keyword-drift-problems-over-files files)
+        problems     (concat var-problems kw-problems)]
     (proj/report-with-floor! "skills/ (excl. re-frame-migration)"
                              (count results) min-references problems)))
 

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -190,3 +190,62 @@
     ;; floor is calibrated below the live count, never tripping on real churn.
     (is (nil? (c/floor-violation (count (c/parse-api-md-var-rows))))
         "the real spec/API.md extraction must clear the floor")))
+
+;; ---------------------------------------------------------------------------
+;; EP-0017 reg-cofx contract pin (rf2-ah97vk).
+;;
+;; The tier/manifest reconcile only checks the `reg-cofx` row RESOLVES to a
+;; front-porch var — it cannot see the row's signature/contract prose drift
+;; back to the stale v1 ctx-transform shape. The contract pin asserts the
+;; load-bearing EP-0017 phrases are present on the row.
+;; ---------------------------------------------------------------------------
+
+(def ^:private good-reg-cofx-row
+  "A synthetic `reg-cofx` row carrying every EP-0017 contract facet (a
+   trimmed paraphrase of the live spec/API.md row)."
+  (str "| `reg-cofx` | M | `(reg-cofx id ?metadata supplier)` | v1 (changed, "
+       "EP-0017) | front-porch | 001, 002 | Register a coeffect id with a "
+       "value-returning supplier and a grade — ambient or recordable "
+       "(`:recordable? true`, optionally `:provided? true`). Delivery via "
+       "`:rf.cofx/requires`. The ctx→ctx handler shape and `inject-cofx` are "
+       "retired (EP-0017 slice A). |"))
+
+(deftest reg-cofx-good-row-has-no-contract-problems
+  (testing "a row carrying every EP-0017 facet passes the contract pin"
+    (is (empty? (c/reg-cofx-contract-problems good-reg-cofx-row)))))
+
+(deftest reg-cofx-stale-ctx-transform-row-fails
+  (testing "a row that drifted back to the v1 ctx-transform shape — dropping
+            the value-returning-supplier wording, the grades, the flat
+            :rf.cofx/requires delivery, and the inject-cofx-retired note —
+            is flagged on every missing facet"
+    (let [stale (str "| `reg-cofx` | M | `(reg-cofx id handler)` | v1 | "
+                     "front-porch | 002 | Register a coeffect handler "
+                     "`(fn [ctx] ctx)` that threads a value into the "
+                     "interceptor context; inject via the interceptor "
+                     "vector. |")
+          probs (c/reg-cofx-contract-problems stale)
+          facets (set (map :facet probs))]
+      (is (pos? (count probs)) "the stale ctx-transform row must be flagged")
+      (is (every? #(= :reg-cofx-contract (:kind %)) probs))
+      (is (contains? facets "value-returning supplier"))
+      (is (contains? facets "grade :recordable?"))
+      (is (contains? facets "grade :provided?"))
+      (is (contains? facets "flat delivery via :rf.cofx/requires"))
+      (is (contains? facets "ctx->ctx + inject-cofx retired"))
+      (is (contains? facets "signature (reg-cofx id ?metadata supplier)")
+          "the stale (reg-cofx id handler) signature must be flagged"))))
+
+(deftest reg-cofx-missing-row-is-flagged
+  (testing "an absent reg-cofx row is a contract problem, not a vacuous pass"
+    (let [probs (c/reg-cofx-contract-problems nil)]
+      (is (= 1 (count probs)))
+      (is (= :reg-cofx-row-missing (:kind (first probs)))))))
+
+(deftest reg-cofx-live-row-reconciles-clean
+  (testing "the committed spec/API.md reg-cofx row carries the full EP-0017
+            contract (the CI contract)"
+    (let [row (#'c/reg-cofx-row-text)]
+      (is (some? row) "spec/API.md must carry a `reg-cofx` var-row")
+      (is (empty? (c/reg-cofx-contract-problems row))
+          "live drift: spec/API.md reg-cofx row lost an EP-0017 contract facet"))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_guide_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_guide_check_test.clj
@@ -1,0 +1,92 @@
+(ns re-frame.api-manifest.doc-guide-check-test
+  "Regression tests for the docs/guide projection check's FILE-SCOPED
+  removed-name allowlist (rf2-hk6wd2).
+
+  THE BUG. `:doc-guide-known-unmanifested` was a BARE-NAME set: a name
+  listed there was silenced ANYWHERE in the guide tree. EP-0017 removed
+  `inject-cofx` and live teaching prose must use `:rf.cofx/requires` — but
+  because `inject-cofx` was on the bare allowlist for the from-v1 migration
+  chapter, a future live `(rf/inject-cofx …)` in ANY teaching chapter would
+  have passed the gate green.
+
+  THE FIX. The allowlist is now `:doc-guide-known-unmanifested-scoped` —
+  `{removed-name -> #{approved repo-relative file paths}}`. A call-position
+  reference to a removed name is silenced ONLY in its approved migration
+  file(s); the SAME reference in any other guide file is RED. These tests
+  pin that contract through the pure `reconcile` reconciler with synthetic
+  references, plus a live smoke that the committed guide reconciles clean."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.doc-guide-check :as c]
+            [re-frame.api-manifest.gen :as gen]))
+
+(def ^:private core-vars #{"reg-event" "reg-sub" "dispatch"})
+
+(def ^:private scoped-allow
+  {"inject-cofx" #{"docs/guide/25-from-re-frame-v1.md"
+                   "docs/guide/concepts/effects-and-coeffects.md"}
+   "reg-event-db" #{"docs/guide/25-from-re-frame-v1.md"}})
+
+(defn- problems-for [references]
+  (c/reconcile {:references references :core-vars core-vars
+                :scoped-allow scoped-allow}))
+
+(deftest core-var-reference-resolves
+  (testing "a live re-frame.core var resolves anywhere with no problem"
+    (is (empty? (problems-for
+                  [{:var "reg-event" :line 1 :raw "rf/reg-event"
+                    :file "docs/guide/concepts/events.md"}])))))
+
+(deftest removed-name-in-approved-file-is-silenced
+  (testing "a removed name in its approved migration file is silenced"
+    (is (empty? (problems-for
+                  [{:var "inject-cofx" :line 112 :raw "rf/inject-cofx"
+                    :file "docs/guide/25-from-re-frame-v1.md"}
+                   {:var "inject-cofx" :line 121 :raw "rf/inject-cofx"
+                    :file "docs/guide/concepts/effects-and-coeffects.md"}])))))
+
+(deftest removed-name-in-live-teaching-file-is-red
+  (testing "THE BUG (rf2-hk6wd2): a removed name in a NON-approved teaching
+            file is flagged — the bare global allowlist would have passed it"
+    (let [probs (problems-for
+                  [{:var "inject-cofx" :line 50 :raw "rf/inject-cofx"
+                    :file "docs/guide/concepts/interceptors.md"}])]
+      (is (= 1 (count probs)))
+      (is (= "docs/guide/concepts/interceptors.md" (:file (first probs))))
+      (is (re-find #"removed API named outside its approved" (:detail (first probs)))))))
+
+(deftest scope-is-per-name-not-shared
+  (testing "a name's scope does not leak to another name's approved file —
+            reg-event-db is approved only in the from-v1 chapter"
+    (is (empty? (problems-for
+                  [{:var "reg-event-db" :line 48 :raw "rf/reg-event-db"
+                    :file "docs/guide/25-from-re-frame-v1.md"}])))
+    (let [probs (problems-for
+                  [{:var "reg-event-db" :line 1 :raw "rf/reg-event-db"
+                    :file "docs/guide/concepts/effects-and-coeffects.md"}])]
+      (is (= 1 (count probs))
+          "reg-event-db is NOT approved in effects-and-coeffects.md"))))
+
+(deftest unknown-non-manifest-name-is-red
+  (testing "a name that is neither a core var nor on the scoped allowlist is
+            an unresolved reference"
+    (let [probs (problems-for
+                  [{:var "totally-gone" :line 1 :raw "rf/totally-gone"
+                    :file "docs/guide/concepts/x.md"}])]
+      (is (= 1 (count probs)))
+      (is (re-find #"no re-frame.core manifest row" (:detail (first probs)))))))
+
+(deftest live-doc-guide-reconciles-clean
+  (testing "the committed docs/guide reconciles against the committed manifest
+            + scoped allowlist with zero problems (the CI contract)"
+    (is (true? (c/check!))
+        "live drift: docs/guide names removed APIs outside approved files")))
+
+(deftest scoped-allowlist-sidecar-key-is-present-and-scopes-inject-cofx
+  (testing "the committed sidecar carries the file-scoped allowlist and scopes
+            inject-cofx to exactly the two approved migration files"
+    (let [scoped (:doc-guide-known-unmanifested-scoped (gen/read-sidecar))]
+      (is (map? scoped) "the scoped allowlist must be a {name -> #{files}} map")
+      (is (= #{"docs/guide/25-from-re-frame-v1.md"
+               "docs/guide/concepts/effects-and-coeffects.md"}
+             (get scoped "inject-cofx"))
+          "inject-cofx must be scoped to the from-v1 chapter + the cofx callout"))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
@@ -54,3 +54,59 @@
     ;; The committed skills/ surface exists and carries many *.md files.
     (let [files (proj/require-markdown-files "skills/" (proj/repo-file "skills"))]
       (is (pos? (count files))))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0017 keyword-drift guard (rf2-tawage).
+;;
+;; The projection checks scope to public-VAR references and exclude the
+;; `:rf/*` keyword namespace, so a surface could reintroduce stale EP-0017
+;; keyword vocabulary (`:rf.world/inputs`) and stay green. The keyword guard
+;; flags a `:rf.world/inputs` mention NOT accompanied on its line by a
+;; retirement/rename/migration marker.
+;; ---------------------------------------------------------------------------
+
+(deftest keyword-drift-flags-bare-stale-mention
+  (testing "a fresh :rf.world/inputs mention with no retirement marker is flagged"
+    (let [probs (proj/ep0017-keyword-drift-problems
+                  "docs/guide/x.md"
+                  [[10 "Supply recordable facts under :rf.world/inputs on dispatch."]])]
+      (is (= 1 (count probs)))
+      (is (= 10 (:line (first probs))))
+      (is (= "docs/guide/x.md" (:file (first probs))))
+      (is (re-find #"renamed to the flat :rf.cofx" (:detail (first probs)))))))
+
+(deftest keyword-drift-allows-rename-mention-naming-replacement
+  (testing "a :rf.world/inputs line that names the :rf.cofx replacement is approved"
+    (is (empty? (proj/ep0017-keyword-drift-problems
+                  "spec/Spec-Schemas.md"
+                  [[5 "The EP-0010 :rf.world/inputs field is renamed to :rf.cofx (EP-0017)."]])))))
+
+(deftest keyword-drift-allows-error-id-and-prose-markers
+  (testing "the :rf.error/world-inputs-renamed error id marks a legitimate mention"
+    (is (empty? (proj/ep0017-keyword-drift-problems
+                  "spec/002-Frames.md"
+                  [[1 "Supplying :rf.world/inputs is a hard error :rf.error/world-inputs-renamed."]]))))
+  (testing "the prose words retired/renamed/migrat each mark a legitimate mention"
+    (is (empty? (proj/ep0017-keyword-drift-problems
+                  "x.md"
+                  [[1 "The :rf.world/inputs key is retired."]
+                   [2 "A migration mention of :rf.world/inputs."]])))))
+
+(deftest keyword-drift-ignores-lines-without-the-keyword
+  (testing "lines that do not mention :rf.world/inputs produce no problems"
+    (is (empty? (proj/ep0017-keyword-drift-problems
+                  "x.md"
+                  [[1 "Declare coeffects via :rf.cofx/requires; values arrive flat."]
+                   [2 "The :rf.cofx envelope map is the one nested record."]])))))
+
+(deftest keyword-drift-over-files-tags-repo-relative-file
+  (testing "the file-driver scans committed surfaces and flags zero on the
+            live tree (every committed :rf.world/inputs mention is a
+            retirement/rename reference)"
+    ;; The committed docs/guide/ + skills/ surfaces carry only
+    ;; retirement/rename mentions, so the live scan must be clean — a
+    ;; regression catches a fresh reintroduction.
+    (let [guide-files (proj/markdown-files (proj/repo-file "docs" "guide"))]
+      (is (pos? (count guide-files)))
+      (is (empty? (proj/keyword-drift-problems-over-files guide-files))
+          "live drift: a docs/guide file reintroduced stale :rf.world/inputs"))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -291,7 +291,7 @@
  ;; surface; a non-empty entry names a legitimate non-manifest reference
  ;; (e.g. a CLJS-only var) or, as here, a removed API still named in skill
  ;; prose pending that skill's rewrite (the same role `on-changes` plays in
- ;; :doc-guide-known-unmanifested). The re-frame-migration skill is excluded
+ ;; :doc-guide-known-unmanifested-scoped). The re-frame-migration skill is excluded
  ;; wholesale (it names removed old APIs by design — see
  ;; re-frame.api-manifest.skills-check).
  :skills-known-unmanifested
@@ -306,35 +306,47 @@
                           ; until that coherent rewrite lands.
 
  ;; docs/guide/ call-position `(rf/<var>` references the manifest does not
- ;; carry: removed re-frame v1 names the from-v1 migration chapter names as
- ;; old→new guidance, plus `<x>` template placeholders in a syntax table.
- :doc-guide-known-unmanifested
- #{"on-changes"   ; docs/guide/25-from-re-frame-v1.md — removed v1 reaction API, named as migration guidance
-   ;; EP-0017 + rf2-w9xyx1: `inject-cofx` removed from the public façade
-   ;; (no manifest row). docs/guide/25-from-re-frame-v1.md +
-   ;; concepts/effects-and-coeffects.md name the v1 `(rf/inject-cofx …)`
-   ;; interceptor entry as the left-hand side of old→new migration guidance
-   ;; (it becomes `:rf.cofx/requires` registration metadata). Named here as
-   ;; removed-v1-in-migration-prose, exactly the role `on-changes` plays above.
-   "inject-cofx"  ; docs/guide/25-from-re-frame-v1.md + concepts/effects-and-coeffects.md — removed v1 cofx interceptor, named as migration guidance
-   ;; EP-0018 Z (rf2-xhfxcs.14): `reg-event-db` / `reg-event-fx` removed from
-   ;; the public façade (throwing stubs, no manifest row — `reg-event` is the
-   ;; ONE public event form). docs/guide/25-from-re-frame-v1.md names the v1
-   ;; `(rf/reg-event-db …)` / `(rf/reg-event-fx …)` forms as the left-hand
-   ;; side of old→new migration guidance (they become `(rf/reg-event …)`).
-   ;; Named here as removed-v1-in-migration-prose, exactly the role
-   ;; `on-changes` / `inject-cofx` play above.
-   "reg-event-db" ; docs/guide/25-from-re-frame-v1.md — removed v1 event registrar, named as migration guidance
-   "reg-event-fx" ; docs/guide/25-from-re-frame-v1.md — removed v1 event registrar, named as migration guidance
-   "set-x!"       ; docs/guide/24-config-and-safety.md — `(rf/set-x!)` is an `<x>` placeholder in the config-shape table
-   "install-x!"   ; docs/guide/24-config-and-safety.md — `(rf/install-x!)` is an `<x>` placeholder
-   ;; EP-0015 §3 (rf2-mngp4o): `add-marks` / `set-marks` removed from the
-   ;; public façade. docs/guide/23-privacy-and-large-things.md still teaches
-   ;; the runtime path-marks API (now flagged superseded by a banner there);
-   ;; its rewrite around frame-owned classification is EP-0015 item 12. Named
-   ;; here pending that rewrite, same role as `on-changes` above.
-   "add-marks"    ; docs/guide/23-privacy-and-large-things.md — superseded runtime path-marks (EP-0015 item 12)
-   "set-marks"}   ; docs/guide/23-privacy-and-large-things.md — superseded runtime path-marks (EP-0015 item 12)
+ ;; carry. This used to be a BARE-NAME allowlist (a name listed here was
+ ;; silenced ANYWHERE in the guide tree). EP-0017 (rf2-hk6wd2) tightened it:
+ ;; every entry here names a REMOVED API whose only legitimate guide
+ ;; appearance is the left-hand side of old→new MIGRATION guidance in ONE
+ ;; or TWO specific files (the from-v1 chapter, plus the per-concept
+ ;; migration callouts). A bare global allowlist let a future live
+ ;; `(rf/inject-cofx …)` in any teaching chapter pass green even though
+ ;; EP-0017 removed it and live prose must teach `:rf.cofx/requires`. So the
+ ;; allowlist is now FILE-SCOPED: each entry maps the removed name to the
+ ;; set of repo-relative file paths where it is approved. A call-position
+ ;; reference to the name OUTSIDE those files is RED (it leaked into live
+ ;; teaching prose). See re-frame.api-manifest.doc-guide-check.
+ ;;
+ ;; Globbing: a scope entry is a literal repo-relative path; a reference
+ ;; whose file equals (string `=`) any approved path is silenced.
+ :doc-guide-known-unmanifested-scoped
+ {"on-changes"   #{"docs/guide/25-from-re-frame-v1.md"}   ; removed v1 reaction API, named as migration guidance
+  ;; EP-0017 + rf2-w9xyx1: `inject-cofx` removed from the public façade (no
+  ;; manifest row). The from-v1 chapter AND the effects-and-coeffects
+  ;; concept page's "Coming from re-frame v1?" callout name the v1
+  ;; `(rf/inject-cofx …)` interceptor entry as the left-hand side of old→new
+  ;; migration guidance (it becomes `:rf.cofx/requires` registration
+  ;; metadata). A `(rf/inject-cofx …)` ANYWHERE ELSE in the guide is live
+  ;; teaching prose that EP-0017 forbids — and now goes RED.
+  "inject-cofx"  #{"docs/guide/25-from-re-frame-v1.md"
+                   "docs/guide/concepts/effects-and-coeffects.md"}
+  ;; EP-0018 Z (rf2-xhfxcs.14): `reg-event-db` / `reg-event-fx` removed from
+  ;; the public façade (`reg-event` is the ONE public event form). Named as
+  ;; the left-hand side of old→new migration guidance in the from-v1 chapter.
+  "reg-event-db" #{"docs/guide/25-from-re-frame-v1.md"}
+  "reg-event-fx" #{"docs/guide/25-from-re-frame-v1.md"}
+  ;; `(rf/set-x!)` / `(rf/install-x!)` are `<x>` placeholders in the
+  ;; config-shape syntax table, not real vars.
+  "set-x!"       #{"docs/guide/24-config-and-safety.md"}
+  "install-x!"   #{"docs/guide/24-config-and-safety.md"}
+  ;; EP-0015 §3 (rf2-mngp4o): `add-marks` / `set-marks` removed from the
+  ;; public façade; the privacy chapter still teaches the superseded runtime
+  ;; path-marks API (flagged by a banner there) pending its EP-0015 item-12
+  ;; rewrite.
+  "add-marks"    #{"docs/guide/23-privacy-and-large-things.md"}
+  "set-marks"    #{"docs/guide/23-privacy-and-large-things.md"}}
 
  ;; --------------------------------------------------------------------------
  ;; JVM-introspected classification — keyed ["namespace" "var"].


### PR DESCRIPTION
Harden the api-manifest projection gates so they pin the landed EP-0017 cofx contracts and cannot stay green while stale EP-0017 wording drifts back into the public docs/spec. The docs/spec prose is already correct against the landed EP-0017 cofx behaviour; these changes add the **enforcement** that keeps it correct.

## rf2-ah97vk — api-md-check pins the reg-cofx contract

The tier reconcile only checked that the `reg-cofx` row RESOLVES to a front-porch `re-frame.core` var; it was blind to the row's signature/contract prose. So the row could drift back to the stale v1 ctx-transform shape and still pass. Added a targeted EP-0017 contract pin over the one `reg-cofx` row, asserting the load-bearing phrases: signature `(reg-cofx id ?metadata supplier)`, value-returning supplier, grade metadata (`:recordable?`/`:provided?`), flat delivery via `:rf.cofx/requires`, and the retired ctx-to-ctx / inject-cofx delivery.

## rf2-hk6wd2 — doc-guide-check scopes the removed-name allowlist

`:doc-guide-known-unmanifested` was a bare-name set: a name listed there was silenced anywhere in the guide tree, so any future live `(rf/inject-cofx ...)` in a teaching chapter would pass green even though EP-0017 removed it. Replaced it with a file-scoped allowlist `:doc-guide-known-unmanifested-scoped` (`{removed-name -> #{approved files}}`). A removed name is silenced only in its approved migration file(s); the same call anywhere else is RED. Covers `inject-cofx`, `reg-event-db`/`reg-event-fx`, `on-changes`, `add-marks`/`set-marks`, and the `<x>` placeholders.

## rf2-tawage — projection adds an EP-0017 keyword-drift guard

The var-resolution checks exclude the `:rf/*` keyword namespace, so stale `:rf.world/inputs` envelope vocabulary could be reintroduced into a projection surface and stay green. Added a keyword-drift guard that flags a `:rf.world/inputs` mention NOT accompanied on its line by a retirement/rename/migration marker (the `:rf.cofx` replacement, the `:rf.error/world-inputs-renamed` error id, or the words retired/renamed/removed/superseded/migration). Folded into api-md-check, doc-guide-check, and skills-check. Conservative by design: the committed historical/migration mentions all name the replacement on-line and stay green.

## Tests / gates

- New + extended regression tests: reg-cofx contract pin (good/stale/missing/live row), file-scoped doc-guide reconcile (approved/leaked/unknown + live + sidecar shape), keyword-drift guard (bare/marked/error-id/prose + live file scan).
- api-manifest JVM suite: 43 tests, 92 assertions, 0 failures.
- All five live projection checks green (api-md, story-spec, xray-spec, skills, doc-guide); `gen --check` green; `mkdocs build --strict` green; full CLJS spine `npm run test:cljs` 7678 tests / 0 failures.
- Negative-path verified: a deliberately injected live `(rf/inject-cofx ...)` + `:rf.world/inputs` in a teaching chapter correctly turns the doc-guide gate RED (reverted).
