### PR TITLE
test(mcp-conformance): EP-0017 cofx + EP-0018 event-metadata wire conformance (rf2-jyxmtq, rf2-z0owya)

### DIFF
--- a/skills/re-frame2-pair/tests/fixture/README.md
+++ b/skills/re-frame2-pair/tests/fixture/README.md
@@ -21,7 +21,7 @@ Minimal re-frame2 counter app used by `tests/shim`, `tests/e2e`, and
 |---|---|
 | `shadow-cljs.edn` | Build config with `:devtools :preloads` set to `re-frame2-pair.runtime`. |
 | `deps.edn` | `:local/root` to `../../../../implementation` (the re-frame2 repo) plus Reagent. |
-| `src/counter/core.cljs` | Counter (`reg-event`, `reg-sub`, `reg-view`) — three events: `:counter/initialise`, `:counter/inc`, `:counter/dec`. |
+| `src/counter/core.cljs` | Counter (`reg-event`, `reg-sub`, `reg-view`) — four events: `:counter/initialise`, `:counter/inc`, `:counter/dec`, and `:counter/stamp` (declares `:rf.cofx/requires [:rf/time-ms]` and folds the recorded wall-clock fact into `:stamped-at` — the EP-0017 recordable-coeffects target the `tools/mcp-conformance` live cofx gate dispatches with a scripted `cofx`). |
 | `public/index.html` | Page host; loads `out/main.js`. |
 | `README.md` | This file. |
 

--- a/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
+++ b/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
@@ -28,6 +28,18 @@
 (rf/reg-event :counter/dec
  (fn [{:keys [db]} _event] {:db (update db :count dec)}))
 
+;; EP-0017 reproducible-coeffects fixture (rf2-jyxmtq). Declares
+;; `:rf.cofx/requires [:rf/time-ms]` so its `handler-meta` surfaces the
+;; authored declaration, and folds the recorded wall-clock fact (read FLAT as
+;; `time-ms`) into durable state under `:stamped-at`. The MCP conformance
+;; harness dispatches this with a scripted `cofx "{:rf/time-ms <n>}"` and
+;; asserts the SAME `<n>` lands in `:stamped-at` — proving the supplied
+;; coeffect reaches the resulting state across the SDK/nREPL wire.
+(rf/reg-event :counter/stamp
+ {:rf.cofx/requires [:rf/time-ms]}
+ (fn [{:keys [db rf/time-ms]} _event]
+  {:db (assoc db :stamped-at time-ms)}))
+
 (rf/reg-sub :count
  (fn [db _query] (:count db)))
 

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -140,6 +140,47 @@ keywordizes without a finite gate), that is a server-side bug to file
 against `mcp-base` / the owning server — not a hole in this cross-server
 wire gate.
 
+### Coverage boundary — EP-0017 cofx + EP-0018 event metadata (rf2-jyxmtq / rf2-z0owya)
+
+The EP-0017 recordable-coeffects (`cofx`) surface and the EP-0018 unified
+event-registration metadata are exercised across THREE layers; a future
+MCP change to either should land in the layer matching what it touches:
+
+- **SDK conformance harness (this artefact)** — the cross-MCP WIRE
+  contract. EP-0017: a `cofx` arg is accepted into the `dispatch` request
+  envelope (degraded `end-to-end-re-frame2-pair.cjs`); the supplied
+  `:rf/time-ms` reaches the resulting state, the malformed-`cofx`
+  structured refusals, and the `cofx`-kind `list-handlers`/`handler-meta`
+  visibility + authored `:rf.cofx/requires` (live
+  `live-re-frame2-pair-cofx.cjs`). EP-0018: the live event-metadata wire
+  reflects the unified shape and carries none of the retired markers (live
+  `live-re-frame2-pair-event-meta.cjs`). The degraded handler short-circuits
+  every live-runtime tool to `:nrepl-port-not-found` BEFORE the tool body —
+  so the cofx shape-check and the live event metadata are reachable ONLY
+  through the hermetic live gates, NOT the degraded harness (which proves
+  descriptor / arg-shape / CallToolResult wiring). The two live gates use
+  the fixture event `:counter/stamp` (EP-0017 `:rf.cofx/requires`) and
+  `:counter/inc` (EP-0018 plain `reg-event`) at
+  `skills/re-frame2-pair/tests/fixture/src/counter/core.cljs`.
+- **pair-MCP unit tests** — the server-side `cofx` parsing / threading
+  under `:rf.cofx`, owner-qualified facts, omitted-key behaviour, and the
+  malformed-input reasons in isolation
+  (`tools/re-frame2-pair-mcp/test/.../dispatch_test.cljs`); event
+  `handler-meta` projection shape
+  (`.../handler_meta_test.cljs`). These pin the projection / parse logic
+  without a live runtime or the SDK boundary.
+- **core tests** — the EP-0017 / EP-0018 semantics themselves: the router
+  preserving a supplied `:rf.cofx` verbatim, `:rf.cofx/requires` parse /
+  satisfaction, the one `:rf/event-handler` wrapper, the removed
+  `:event/kind`, and the retired-name hard errors
+  (`implementation/core/.../events.cljc` + its tests). These own the
+  behaviour the wire gates merely OBSERVE crossing the MCP boundary.
+
+Keep this surface free of the legacy `world-inputs` / `:rf.world/inputs`
+vocabulary as a LIVE assertion — EP-0017 replaced it with `cofx` /
+`:rf.cofx` / `:rf/time-ms`; any historical mention must name the
+replacement.
+
 ## Files
 
 - `package.json` — depends on `@modelcontextprotocol/sdk` only
@@ -173,12 +214,43 @@ wire gate.
   local runnability + parity with the overflow / subscribe variants —
   without a live port it SKIPs, with one (e.g. an externally-attached
   shadow-cljs) it runs the full gate.
+- `test/live-re-frame2-pair-cofx.cjs` — re-frame2-pair-mcp **live**-runtime variant
+  (rf2-jyxmtq) pinning the EP-0017 recordable-coeffects (`cofx`) paths on
+  the SDK boundary. Dispatches the fixture's `[:counter/stamp]` (a
+  `reg-event` declaring `:rf.cofx/requires [:rf/time-ms]` that folds the
+  recorded wall-clock fact into app-db under `:stamped-at`) with a scripted
+  `cofx "{:rf/time-ms <N>}"` — TWICE with two distinct pinned-past times —
+  and asserts each lands verbatim in `:stamped-at` (reproducible-dispatch
+  determinism; a server stamping a live clock could never match two pinned
+  pasts). Then proves the malformed-`cofx` refusals the degraded handler
+  hides (non-map / unreadable / non-integer `:rf/time-ms` ⇒
+  `:invalid-cofx` / `:invalid-cofx-time-ms`, no state mutation), and the
+  EP-0017 tooling visibility: `list-handlers {kind "cofx"}` discovers
+  `:rf/time-ms`, `handler-meta {kind "cofx" id ":rf/time-ms"}` surfaces the
+  recordable grade (`:recordable? true :provided? true`), and the event
+  fixture's `handler-meta` exposes the authored `:rf.cofx/requires`. Gated
+  on `$SHADOW_CLJS_NREPL_PORT` (same posture as the other live variants).
+- `test/live-re-frame2-pair-event-meta.cjs` — re-frame2-pair-mcp **live**-runtime
+  variant (rf2-z0owya) pinning the EP-0018 unified event-registration
+  metadata on the SDK boundary. `list-handlers {kind "event"}` discovers
+  the fixture `rf/reg-event` id `:counter/inc`; `handler-meta {kind "event"
+  id ":counter/inc"}` asserts `:ok? true` / `:kind :event` / `:id` AND
+  rejects EP-0018 drift on the same wire response — NO `:event/kind`
+  sub-tag, NO `:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`
+  retired wrapper id, and the unified `:rf/event-handler` wrapper visible in
+  the effective interceptor chain. Closes the gap the degraded-only
+  `handler-meta` / `list-handlers` coverage left (degraded short-circuits to
+  the same `:nrepl-port-not-found` envelope for every live-runtime tool, so
+  the live event-metadata wire was never inspected). Gated on
+  `$SHADOW_CLJS_NREPL_PORT`.
 - `scripts/run-live-re-frame2-pair-overflow-hermetic.cjs` — hermetic
   orchestrator (rf2-uw6d6) that boots shadow-cljs against the re-frame2-pair
   fixture (`skills/re-frame2-pair/tests/fixture/`), launches headless
   Chromium so the runtime preload lands, then runs every live inner test
   (`live-re-frame2-pair-overflow.cjs`, `live-re-frame2-pair-subscribe.cjs`,
-  `live-re-frame2-pair-redaction.cjs`) against the spawned
+  `live-re-frame2-pair-redaction.cjs`, `live-re-frame2-pair-iserror.cjs`,
+  `live-re-frame2-pair-cofx.cjs`, `live-re-frame2-pair-event-meta.cjs`)
+  against the spawned
   `SHADOW_CLJS_NREPL_PORT`. Closes the CI-coverage gap the SKIP path
   leaves on each. **Observable-SKIP guard (rf2-ybiz0):** after each inner
   test exits 0 the orchestrator asserts it printed its `... CONFORMANCE
@@ -454,7 +526,14 @@ The `mcp-conformance-re-frame2-pair` job runs three steps in sequence:
    under CI's clean ephemeral runtime — not just on Mike's machine. The
    hermetic suite also runs `live-re-frame2-pair-subscribe.cjs`, which
    (booting non-degraded WITH `--no-eval`) pins pair-mcp's eval-cljs
-   opt-out wire envelope (`:rf.error/eval-cljs-disabled`) post-rf2-a0z0h.
+   opt-out wire envelope (`:rf.error/eval-cljs-disabled`) post-rf2-a0z0h;
+   `live-re-frame2-pair-iserror.cjs` (the read-family genuine-error
+   isError contract); `live-re-frame2-pair-cofx.cjs` (rf2-jyxmtq — EP-0017
+   reproducible-dispatch + cofx tooling visibility); and
+   `live-re-frame2-pair-event-meta.cjs` (rf2-z0owya — EP-0018 unified
+   event-metadata wire shape + retired-marker rejection). Each inner test
+   carries a success sentinel the orchestrator asserts (rf2-ybiz0), so a
+   silent in-hermetic SKIP turns the job RED.
 
 The `mcp-conformance-story` job runs two steps: **`test:story`** (the
 write-loop + read-path conformance + the rf2-ke5n56 callTool coverage

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -10,6 +10,8 @@
     "test:re-frame2-pair-live-subscribe": "node test/live-re-frame2-pair-subscribe.cjs",
     "test:re-frame2-pair-live-redaction": "node test/live-re-frame2-pair-redaction.cjs",
     "test:re-frame2-pair-live-iserror": "node test/live-re-frame2-pair-iserror.cjs",
+    "test:re-frame2-pair-live-cofx": "node test/live-re-frame2-pair-cofx.cjs",
+    "test:re-frame2-pair-live-event-meta": "node test/live-re-frame2-pair-event-meta.cjs",
     "test:re-frame2-pair-live-overflow-hermetic": "node scripts/run-live-re-frame2-pair-overflow-hermetic.cjs",
     "test:dedup-envelope": "node --test test/dedup-envelope.test.cjs",
     "test:story": "node test/end-to-end-story.cjs",

--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -236,6 +236,34 @@ const INNER_TESTS = [
     path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-iserror.cjs'),
     sentinel: 'RE-FRAME2-PAIR-MCP LIVE ISERROR-ON-OK-FALSE CONFORMANCE GREEN',
   },
+  {
+    // rf2-jyxmtq — EP-0017 recordable-coeffects (`cofx`) over the live MCP
+    // wire. Dispatches the fixture's [:counter/stamp] (a reg-event
+    // declaring `:rf.cofx/requires [:rf/time-ms]`) with a scripted
+    // `cofx "{:rf/time-ms <N>}"` and proves the supplied fact reaches the
+    // resulting app-db state (reproducible-dispatch determinism), the
+    // malformed-cofx refusals the degraded handler hides, and the EP-0017
+    // tooling visibility (`list-handlers`/`handler-meta` for the `cofx`
+    // kind + authored `:rf.cofx/requires` on the event). The degraded
+    // end-to-end only proves the `cofx` arg is ACCEPTED — this is the
+    // behaviour gate.
+    name: 'live EP-0017 cofx conformance (reproducible dispatch + cofx tooling)',
+    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-cofx.cjs'),
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE COFX CONFORMANCE GREEN',
+  },
+  {
+    // rf2-z0owya — EP-0018 unified event-registration metadata over the
+    // live MCP wire. Inspects a fixture `rf/reg-event` id (`:counter/inc`)
+    // via `list-handlers`/`handler-meta {kind "event"}` and pins the
+    // unified shape (`:ok? true`, `:kind :event`, `:id`, the
+    // `:rf/event-handler` wrapper) AND the absence of every retired marker
+    // (`:event/kind`, `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler`).
+    // The degraded gate only proves the descriptor/CallToolResult wiring —
+    // this proves the live event-metadata wire reflects EP-0018.
+    name: 'live EP-0018 event-metadata conformance (unified reg-event shape)',
+    path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-event-meta.cjs'),
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE EVENT-METADATA CONFORMANCE GREEN',
+  },
 ];
 
 function recordLine(line, stream = 'stdout') {

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -96,6 +96,14 @@ const TESTS = [
     argv: ['test/live-re-frame2-pair-iserror.cjs'],
   },
   {
+    name: 're-frame2-pair-mcp live-cofx — EP-0017 reproducible dispatch + cofx tooling (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
+    argv: ['test/live-re-frame2-pair-cofx.cjs'],
+  },
+  {
+    name: 're-frame2-pair-mcp live-event-meta — EP-0018 unified event metadata (SKIPs without $SHADOW_CLJS_NREPL_PORT)',
+    argv: ['test/live-re-frame2-pair-event-meta.cjs'],
+  },
+  {
     name: 'story-mcp end-to-end',
     argv: ['test/end-to-end-story.cjs'],
   },

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -272,6 +272,18 @@ runWithWatchdog(
       { name: 'get-stream-controls', arguments: {} },
       { name: 'handler-meta', arguments: { kind: 'event', id: ':rf-conformance/probe' } },
       { name: 'list-handlers', arguments: { kind: 'event' } },
+      // rf2-jyxmtq — EP-0017 cofx introspection over the SDK wire. The
+      // `cofx` kind is one of the closed-v1 registrar kinds `handler-meta`
+      // / `list-handlers` advertise (tool-descriptors.edn). Degraded mode
+      // routes both through `ensure-connection!` to the shared
+      // :nrepl-port-not-found envelope — which still proves the `cofx` kind
+      // is ACCEPTED into the envelope (an unsupported kind would return
+      // :invalid-kind instead, NOT :nrepl-port-not-found) and reaches the
+      // SDK. The LIVE positive (the `:rf/time-ms` recordable-cofx
+      // registration metadata is actually surfaced) is pinned by the
+      // hermetic live-re-frame2-pair-cofx.cjs gate.
+      { name: 'handler-meta', arguments: { kind: 'cofx', id: ':rf/time-ms' } },
+      { name: 'list-handlers', arguments: { kind: 'cofx' } },
       { name: 'read-recording', arguments: { 'recording-id': 'rf2-conformance-no-such' } },
       { name: 'read-sub', arguments: { sub: '[:rf-conformance/probe]' } },
       { name: 'record', arguments: { signals: '[[:rf-conformance/probe]]' } },
@@ -400,6 +412,38 @@ runWithWatchdog(
         'OK   tools/call ' + probe.name + ' (no --allow-writes, degraded) -> ' +
           'isError + :rf.error/writes-disabled (pre-connection refusal)',
       );
+    }
+
+    // 3c-ter. EP-0017 reproducible-dispatch `cofx` argument — degraded
+    // accept (rf2-jyxmtq). The `dispatch` tool advertises a `cofx`
+    // input-key (an EDN map of scripted recordable coeffects, e.g.
+    // `"{:rf/time-ms 1781078400123}"`) for deterministic replay. In
+    // degraded mode the server's `degraded-handler` short-circuits the
+    // tool to the shared `:nrepl-port-not-found` envelope BEFORE the tool
+    // body's cofx shape-check runs (same posture as every other
+    // live-runtime tool — UNLIKE the write gate, which refuses
+    // pre-connection). So a degraded probe cannot reach the cofx
+    // shape-check; what it DOES prove is that a `cofx` arg is ACCEPTED into
+    // the request envelope and the SDK's CallToolResultSchema parses the
+    // result (a regression that rejected the `cofx` arg shape at the SDK /
+    // descriptor boundary would surface here). Recorded in `degradedResp`
+    // so the universal :ok?/isError cross-check below sweeps it.
+    //
+    // The behaviours the cofx shape-check governs — the MALFORMED-cofx
+    // `:invalid-cofx` / `:invalid-cofx-time-ms` refusals AND the positive
+    // that a supplied `:rf/time-ms` reaches the resulting app-db state —
+    // are reachable ONLY with a live runtime (the degraded-handler hides
+    // the tool body), so they are pinned by the hermetic
+    // live-re-frame2-pair-cofx.cjs gate.
+    {
+      const resp = await assertDegraded({
+        name: 'dispatch',
+        arguments: {
+          event: '[:rf-conformance/probe]',
+          cofx: '{:rf/time-ms 1781078400123}',
+        },
+      });
+      degradedResp['dispatch+cofx'] = resp;
     }
 
     // 3c-bis. Universal isError <-> :ok? cross-check across the whole

--- a/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
@@ -1,0 +1,404 @@
+// Live-re-frame2-pair MCP-client conformance variant pinning the EP-0017
+// recordable-coeffects (`cofx`) paths over the real MCP SDK boundary.
+// Source: rf2-jyxmtq (senior-review coverage gap, tracking rf2-skhlw2).
+//
+// ## The hole this closes
+//
+// Before this gate, `tools/mcp-conformance` never exercised the EP-0017
+// reproducible-dispatch / `cofx` MCP paths against a LIVE runtime:
+//
+//   - `end-to-end-re-frame2-pair.cjs` runs DEGRADED — the server's
+//     `degraded-handler` short-circuits `dispatch` (and every other
+//     live-runtime tool) to the shared `:nrepl-port-not-found` envelope
+//     BEFORE the tool body's `cofx` shape-check runs, so neither the
+//     malformed-`cofx` refusal NOR the positive "supplied `:rf/time-ms`
+//     reaches the resulting state" affordance was observable on the wire.
+//     (It DOES now prove a well-formed `cofx` arg is ACCEPTED into the
+//     request envelope — but that is descriptor/arg-shape coverage, not
+//     the EP-0017 behaviour.)
+//   - The pair-mcp unit tests (`dispatch_test.cljs`) pin the `cofx`
+//     parsing / threading under `:rf.cofx`, but that is the server-side
+//     unit layer, NOT the SDK/client conformance boundary.
+//
+// EP-0017 makes reproducible dispatch (and Tool-Pair §Replay's strict
+// re-dispatch with recorded `:rf.cofx`) a load-bearing agent affordance:
+// an agent scripts `:rf/time-ms` and asserts the SAME app-db results. A
+// regression in the descriptor/wire path for that affordance could ship
+// GREEN through every existing conformance gate while breaking the
+// agent-facing replay surface. This gate is the live SDK-boundary net.
+//
+// ## What this test drives (across the MCP boundary, via the SDK Client)
+//
+//   1. POSITIVE — supplied `:rf/time-ms` reaches the resulting state.
+//      `tools/call dispatch` the fixture's `[:counter/stamp]` event (a
+//      `reg-event` declaring `:rf.cofx/requires [:rf/time-ms]` that folds
+//      the recorded wall-clock fact, read FLAT as `time-ms`, into app-db
+//      under `:stamped-at`) WITH a scripted `cofx "{:rf/time-ms <N>}"`.
+//      Then read `[:stamped-at]` back via `eval-cljs` and assert it equals
+//      the SCRIPTED `<N>` — proving the supplied coeffect threaded through
+//      `:rf.cofx` and the router preserved it verbatim (not a freshly
+//      stamped Date.now()). Dispatch TWICE with two different scripted
+//      times and assert each lands — so a server that ignored `cofx` and
+//      stamped a live clock fails (a live clock cannot equal two distinct
+//      pinned past timestamps).
+//   2. NEGATIVE — a malformed `cofx` returns the documented structured
+//      error BEFORE dispatching (the live tool body reaches the
+//      shape-check the degraded handler hides): non-map ⇒ `:invalid-cofx`,
+//      unreadable EDN ⇒ `:invalid-cofx`, non-integer `:rf/time-ms` ⇒
+//      `:invalid-cofx-time-ms`. Each MUST isError and MUST NOT mutate the
+//      stamped state (asserted: `:stamped-at` still reads the last GOOD
+//      scripted value after the malformed calls).
+//   3. TOOLING VISIBILITY — `list-handlers {kind "cofx"}` discovers the
+//      framework's one provided recordable coeffect `:rf/time-ms`, and
+//      `handler-meta {kind "cofx" id ":rf/time-ms"}` surfaces its
+//      registration metadata (`:ok? true`, `:kind :cofx`, `:id
+//      :rf/time-ms`, `:recordable? true`, `:provided? true` — the EP-0017
+//      grade). And an EVENT fixture's `handler-meta {kind "event" id
+//      ":counter/stamp"}` exposes the AUTHORED `:rf.cofx/requires
+//      [:rf/time-ms]` declaration (EP-0017 §4 / Spec 001 — the metadata
+//      key `register-event!` retains verbatim so tooling surfaces it).
+//
+// ## Catches
+//
+//   - the router dropping / overwriting a supplied `:rf/time-ms` (the
+//     headline replay-determinism regression) — step 1 goes RED.
+//   - the `cofx` arg silently ignored at the descriptor/wire/parse path —
+//     step 1 (state unchanged from a default live clock) goes RED.
+//   - the malformed-cofx shape-check renamed / dropped / reordered after
+//     the dispatch — step 2 goes RED (a malformed cofx would either
+//     dispatch anyway or return a different reason).
+//   - `:rf/time-ms` dropped from the `cofx` registrar, or its recordable
+//     grade metadata regressed — step 3 goes RED.
+//   - the authored `:rf.cofx/requires` no longer surviving onto event
+//     metadata (an EP-0017/EP-0018 inspectability regression) — step 3
+//     goes RED.
+//
+// ## Gating
+//
+// **Skipped unless `$SHADOW_CLJS_NREPL_PORT` is set.** Same posture as the
+// sibling live-* variants: without a live nREPL the server runs degraded
+// and `dispatch` / `handler-meta` / `list-handlers` return the
+// `:nrepl-port-not-found` envelope, so the EP-0017 surface is unreachable.
+// The hermetic orchestrator
+// (`scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`) boots
+// shadow-cljs + Chromium against `skills/re-frame2-pair/tests/fixture/`
+// and wires the env so this gate fires on CI.
+
+const path = require('node:path');
+const os = require('node:os');
+const { runWithWatchdog } = require('./_runner.cjs');
+
+const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
+
+// Two distinct, pinned-PAST wall-clock epoch-ms values. Distinct so a
+// server that ignored `cofx` and stamped a live `Date.now()` cannot match
+// BOTH (a live clock can coincidentally near one fixed value but never
+// equal two different pinned pasts on two dispatches). Pinned in the past
+// (2026-06-09 / 2025-01-01) so they are visibly NOT a live clock.
+const SCRIPTED_TIME_A = 1781078400123;
+const SCRIPTED_TIME_B = 1735689600000;
+
+// Concatenate every content block's text from an SDK callTool response.
+function responseText(resp) {
+  if (!resp || !Array.isArray(resp.content)) return '';
+  return resp.content
+    .map((c) => (c && typeof c.text === 'string' ? c.text : ''))
+    .join('\n');
+}
+
+// Read the fixture's `:stamped-at` app-db slot back through the runtime
+// snapshot — the slot `:counter/stamp` folds the recorded `:rf/time-ms`
+// into. Uses `eval-cljs` (the same internal-read seam the redaction gate
+// uses) so we observe the COMMITTED state, not the dispatch echo. Returns
+// the parsed integer (or NaN if absent / unreadable).
+async function readStampedAt(client) {
+  const resp = await client.callTool({
+    name: 'eval-cljs',
+    arguments: {
+      form:
+        '(get (re-frame2-pair.runtime/snapshot ' +
+        '(re-frame2-pair.runtime/current-frame)) :stamped-at)',
+    },
+  });
+  if (resp.isError) {
+    throw new Error(
+      'eval-cljs read of :stamped-at returned isError — cannot verify the ' +
+        'cofx reached state. Got: ' + responseText(resp).slice(0, 300),
+    );
+  }
+  const text = responseText(resp);
+  // The eval result rides in the structured `:value` slot (an integer
+  // literal). Pull the first long integer out of the text.
+  const m = text.match(/-?\d{10,}/);
+  return m ? Number(m[0]) : NaN;
+}
+
+// Dispatch `[:counter/stamp]` with a scripted `cofx`, queued so the
+// fixture's depth-0 epoch-recording posture does not surface a
+// `:no-epoch-recorded` isError (same rationale as the subscribe gate's
+// `:queued`). The db commit is synchronous regardless of epoch recording,
+// so the subsequent `:stamped-at` read sees the folded value.
+async function dispatchStamp(client, timeMs) {
+  const resp = await client.callTool({
+    name: 'dispatch',
+    arguments: {
+      event: '[:counter/stamp]',
+      cofx: '{:rf/time-ms ' + timeMs + '}',
+      queued: true,
+    },
+  });
+  if (resp.isError) {
+    throw new Error(
+      'dispatch [:counter/stamp] (:queued) with scripted cofx {:rf/time-ms ' +
+        timeMs + '} returned isError — the reproducible dispatch did not ' +
+        'land. Got: ' + responseText(resp).slice(0, 300),
+    );
+  }
+  return resp;
+}
+
+// Pre-flight SKIP — same posture as the sibling live-* variants.
+if (!process.env.SHADOW_CLJS_NREPL_PORT) {
+  runWithWatchdog.skip(
+    'live-re-frame2-pair-cofx: $SHADOW_CLJS_NREPL_PORT not set.\n' +
+      '      This variant requires a live shadow-cljs nREPL + browser\n' +
+      '      runtime — without one dispatch / handler-meta / list-handlers\n' +
+      '      return the degraded :nrepl-port-not-found envelope, so the\n' +
+      '      EP-0017 cofx surface (reproducible dispatch + cofx tooling\n' +
+      '      visibility) is unreachable. The hermetic orchestrator boots\n' +
+      '      the fixture runtime and wires the env so this gate fires on CI.',
+  );
+}
+
+runWithWatchdog(
+  {
+    watchdogMs: 30000,
+    clientName: 'mcp-conformance-re-frame2-pair-live-cofx',
+    transportSpec: {
+      command: process.execPath,
+      args: [SERVER],
+      cwd: os.tmpdir(),
+      env: { ...process.env },
+    },
+  },
+  async (client) => {
+    console.log(
+      'OK   connect -> server attached on nREPL',
+      process.env.SHADOW_CLJS_NREPL_PORT,
+    );
+
+    // ---- Step 1: POSITIVE — supplied :rf/time-ms reaches the state ------
+    // Dispatch [:counter/stamp] with scripted time A, read :stamped-at,
+    // assert it equals A — then again with a DIFFERENT scripted time B, so
+    // a server that ignores `cofx` and stamps a live clock fails (a live
+    // clock cannot equal two distinct pinned pasts).
+    await dispatchStamp(client, SCRIPTED_TIME_A);
+    const afterA = await readStampedAt(client);
+    if (afterA !== SCRIPTED_TIME_A) {
+      throw new Error(
+        ':counter/stamp dispatched with scripted cofx {:rf/time-ms ' +
+          SCRIPTED_TIME_A + '} but :stamped-at read back ' + afterA + '. The ' +
+          'supplied recordable coeffect did NOT reach the resulting state — ' +
+          'the router dropped/overwrote :rf/time-ms (EP-0017 reproducible ' +
+          'dispatch regression, rf2-jyxmtq).',
+      );
+    }
+    console.log(
+      'OK   dispatch [:counter/stamp] cofx {:rf/time-ms ' + SCRIPTED_TIME_A +
+        '} -> :stamped-at == scripted time (cofx reached state)',
+    );
+
+    await dispatchStamp(client, SCRIPTED_TIME_B);
+    const afterB = await readStampedAt(client);
+    if (afterB !== SCRIPTED_TIME_B) {
+      throw new Error(
+        'second :counter/stamp dispatch with scripted cofx {:rf/time-ms ' +
+          SCRIPTED_TIME_B + '} read back :stamped-at ' + afterB + '. A second ' +
+          'distinct scripted time MUST also land verbatim — a server stamping ' +
+          'a live clock could never match two distinct pinned pasts. ' +
+          '(rf2-jyxmtq replay-determinism.)',
+      );
+    }
+    console.log(
+      'OK   dispatch [:counter/stamp] cofx {:rf/time-ms ' + SCRIPTED_TIME_B +
+        '} -> :stamped-at == scripted time (two distinct times each land — ' +
+        'not a live clock)',
+    );
+
+    // ---- Step 2: NEGATIVE — malformed cofx refused BEFORE dispatch ------
+    // The live tool body reaches the cofx shape-check the degraded handler
+    // hides. Each malformed value MUST isError + carry the documented
+    // structured reason, and MUST NOT mutate state (asserted by re-reading
+    // :stamped-at — it must still read the last GOOD scripted value B).
+    const MALFORMED = [
+      { cofx: '[:not :a :map]',    reason: ':invalid-cofx',         why: 'a non-map cofx' },
+      { cofx: '{:rf/time-ms 1',    reason: ':invalid-cofx',         why: 'unreadable cofx EDN' },
+      { cofx: '{:rf/time-ms "now"}', reason: ':invalid-cofx-time-ms', why: 'a non-integer :rf/time-ms' },
+    ];
+    for (const m of MALFORMED) {
+      const resp = await client.callTool({
+        name: 'dispatch',
+        arguments: { event: '[:counter/stamp]', cofx: m.cofx, queued: true },
+      });
+      if (!resp.isError) {
+        throw new Error(
+          'dispatch [:counter/stamp] with ' + m.why + ' MUST isError ' +
+            '(EP-0017 cofx shape-check, rf2-q6s1nb); got: ' +
+            responseText(resp).slice(0, 300),
+        );
+      }
+      const text = responseText(resp);
+      if (!text.includes(m.reason)) {
+        throw new Error(
+          'dispatch [:counter/stamp] with ' + m.why + ' MUST carry the ' +
+            'documented structured error ' + m.reason + ' (EP-0017 cofx ' +
+            'contract); got: ' + text.slice(0, 300),
+        );
+      }
+      // The malformed-cofx refusal is reachable here ONLY because we have a
+      // live runtime; it must be the SHAPE-CHECK refusal, not the degraded
+      // :nrepl-port-not-found (which would mean the runtime detached).
+      if (text.includes('nrepl-port-not-found')) {
+        throw new Error(
+          'dispatch malformed-cofx returned :nrepl-port-not-found — the ' +
+            'runtime is not attached, so this gate is testing degraded mode, ' +
+            'not the live EP-0017 cofx shape-check. (rf2-jyxmtq.)',
+        );
+      }
+      console.log(
+        'OK   dispatch [:counter/stamp] (' + m.why + ') -> isError + ' +
+          m.reason + ' (live cofx shape-check)',
+      );
+    }
+    // A malformed cofx must NOT have dispatched — :stamped-at still reads
+    // the last GOOD scripted value (B). A refusal that dispatched anyway
+    // (or stamped a live clock) would move it.
+    const afterMalformed = await readStampedAt(client);
+    if (afterMalformed !== SCRIPTED_TIME_B) {
+      throw new Error(
+        'after three malformed-cofx refusals :stamped-at read back ' +
+          afterMalformed + ' but MUST still be the last GOOD scripted value ' +
+          SCRIPTED_TIME_B + ' — a malformed cofx MUST short-circuit WITHOUT ' +
+          'dispatching (rf2-jyxmtq / rf2-q6s1nb).',
+      );
+    }
+    console.log(
+      'OK   malformed cofx did NOT dispatch — :stamped-at unchanged ' +
+        '(short-circuit before dispatch verified)',
+    );
+
+    // ---- Step 3: TOOLING VISIBILITY — cofx kind + authored requires -----
+    // 3a. list-handlers {kind "cofx"} discovers :rf/time-ms (the
+    // framework's one provided recordable coeffect, cofx.cljc).
+    const listed = await client.callTool({
+      name: 'list-handlers',
+      arguments: { kind: 'cofx' },
+    });
+    if (listed.isError) {
+      throw new Error(
+        'list-handlers {kind "cofx"} returned isError — the cofx registrar ' +
+          'is not enumerable over the wire. Got: ' +
+          responseText(listed).slice(0, 300),
+      );
+    }
+    const listedText = responseText(listed);
+    if (!/:kind\s+:cofx\b/.test(listedText)) {
+      throw new Error(
+        'list-handlers {kind "cofx"} response MUST report :kind :cofx; got: ' +
+          listedText.slice(0, 300),
+      );
+    }
+    if (!listedText.includes(':rf/time-ms')) {
+      throw new Error(
+        'list-handlers {kind "cofx"} MUST discover the framework recordable ' +
+          'coeffect :rf/time-ms (EP-0017); got: ' + listedText.slice(0, 300),
+      );
+    }
+    console.log(
+      'OK   list-handlers {kind "cofx"} -> :rf/time-ms discoverable',
+    );
+
+    // 3b. handler-meta {kind "cofx" id ":rf/time-ms"} surfaces the
+    // framework registration metadata: :ok? true, :kind :cofx, :id
+    // :rf/time-ms, and the EP-0017 recordable grade
+    // (:recordable? true :provided? true — cofx.cljc:1032).
+    const cofxMeta = await client.callTool({
+      name: 'handler-meta',
+      arguments: { kind: 'cofx', id: ':rf/time-ms' },
+    });
+    if (cofxMeta.isError) {
+      throw new Error(
+        'handler-meta {kind "cofx" id ":rf/time-ms"} returned isError — the ' +
+          'framework recordable-coeffect registration is not inspectable. ' +
+          'Got: ' + responseText(cofxMeta).slice(0, 300),
+      );
+    }
+    const cofxMetaText = responseText(cofxMeta);
+    for (const [needle, desc] of [
+      [/:ok\?\s+true\b/, ':ok? true'],
+      [/:kind\s+:cofx\b/, ':kind :cofx'],
+      [/:id\s+:rf\/time-ms\b/, ':id :rf/time-ms'],
+      [/:recordable\?\s+true\b/, ':recordable? true (EP-0017 grade)'],
+      [/:provided\?\s+true\b/, ':provided? true (EP-0017 grade)'],
+    ]) {
+      if (!needle.test(cofxMetaText)) {
+        throw new Error(
+          'handler-meta {kind "cofx" id ":rf/time-ms"} MUST surface ' + desc +
+            '; got: ' + cofxMetaText.slice(0, 400),
+        );
+      }
+    }
+    console.log(
+      'OK   handler-meta {kind "cofx" id ":rf/time-ms"} -> :ok? true + ' +
+        ':kind :cofx + :id :rf/time-ms + recordable/provided grade',
+    );
+
+    // 3c. An EVENT fixture's handler-meta exposes the AUTHORED
+    // :rf.cofx/requires declaration. `:counter/stamp` declares
+    // `:rf.cofx/requires [:rf/time-ms]`; `register-event!` retains the
+    // authored key verbatim (events.cljc — EP-0017 §4 / Spec 001) so the
+    // tool surfaces it. This is the EP-0017 declaration-inspectability
+    // promise on the wire.
+    const evMeta = await client.callTool({
+      name: 'handler-meta',
+      arguments: { kind: 'event', id: ':counter/stamp' },
+    });
+    if (evMeta.isError) {
+      throw new Error(
+        'handler-meta {kind "event" id ":counter/stamp"} returned isError — ' +
+          'the fixture event is not inspectable. Got: ' +
+          responseText(evMeta).slice(0, 300),
+      );
+    }
+    const evMetaText = responseText(evMeta);
+    if (!/:ok\?\s+true\b/.test(evMetaText) || !/:kind\s+:event\b/.test(evMetaText)) {
+      throw new Error(
+        'handler-meta {kind "event" id ":counter/stamp"} MUST be :ok? true ' +
+          'with :kind :event; got: ' + evMetaText.slice(0, 400),
+      );
+    }
+    if (!evMetaText.includes(':rf.cofx/requires')) {
+      throw new Error(
+        'handler-meta {kind "event" id ":counter/stamp"} MUST surface the ' +
+          'AUTHORED :rf.cofx/requires declaration (EP-0017 §4 declaration ' +
+          'inspectability — register-event! retains it verbatim); got: ' +
+          evMetaText.slice(0, 400),
+      );
+    }
+    // The declared requirement names :rf/time-ms — pin the value, not just
+    // the key, so a requires that survives empty/wrong is caught.
+    if (!/:rf\/time-ms\b/.test(evMetaText)) {
+      throw new Error(
+        ':counter/stamp handler-meta carries :rf.cofx/requires but does NOT ' +
+          'name :rf/time-ms in it — the authored declaration was dropped or ' +
+          'mangled. Got: ' + evMetaText.slice(0, 400),
+      );
+    }
+    console.log(
+      'OK   handler-meta {kind "event" id ":counter/stamp"} -> authored ' +
+        ':rf.cofx/requires [:rf/time-ms] surfaced',
+    );
+
+    console.log('\nRE-FRAME2-PAIR-MCP LIVE COFX CONFORMANCE GREEN');
+  },
+);

--- a/tools/mcp-conformance/test/live-re-frame2-pair-event-meta.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-event-meta.cjs
@@ -1,0 +1,242 @@
+// Live-re-frame2-pair MCP-client conformance variant pinning the EP-0018
+// unified event-registration metadata on the real MCP SDK boundary.
+// Source: rf2-z0owya (senior-review coverage gap, tracking rf2-6ktv66).
+//
+// ## The hole this closes
+//
+// EP-0018 consolidated public event registration to ONE `rf/reg-event`
+// (semantically reg-event-fx) and removed the event sub-kind split: a
+// `reg-event` entry is simply kind `:event`; the public `:event/kind :db
+// | :fx | :ctx` sub-tag is gone; the per-kind handler wrappers
+// (`:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`) collapse to
+// ONE `:rf/event-handler` interceptor (carrying `:rf/default? true`). The
+// EP-0018 §Conformance clause requires `handler-meta :event id` to surface
+// the metadata + effective interceptor chain with that unified wrapper.
+//
+// Before this gate, `tools/mcp-conformance` SDK-called `handler-meta` /
+// `list-handlers` ONLY in DEGRADED mode (`end-to-end-re-frame2-pair.cjs`),
+// where the server's `degraded-handler` short-circuits every live-runtime
+// tool to the SAME `:nrepl-port-not-found` envelope. That proves the
+// descriptor + CallToolResult wiring, but it NEVER inspects the live
+// pair-MCP wire output for event introspection — so a wire-layer
+// regression that reintroduced or decorated stale event-sub-kind metadata
+// (`:event/kind`) or an old wrapper id (`:rf/db-handler` …) on the MCP
+// response would ship GREEN.
+//
+// This gate fills that gap: with a live runtime attached it drives the
+// EP-0018 event-metadata surface over the SDK boundary and pins both the
+// presence of the unified shape AND the absence of every retired marker.
+//
+// ## What this test drives (across the MCP boundary, via the SDK Client)
+//
+//   1. `list-handlers {kind "event"}` proves at least one fixture
+//      `rf/reg-event` id — `:counter/inc` (counter/core.cljs) — is
+//      discoverable, and reports `:kind :event`.
+//   2. `handler-meta {kind "event" id ":counter/inc"}` asserts the MCP
+//      response is `:ok? true`, `:kind :event`, `:id :counter/inc`.
+//   3. EP-0018 DRIFT REJECTION on the same response:
+//        - NO `:event/kind` key (the removed sub-kind tag).
+//        - NO `:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`
+//          wrapper id (the retired per-kind wrappers).
+//        - the unified `:rf/event-handler` wrapper IS visible where the
+//          metadata exposes the effective interceptor chain (it carries
+//          `:rf/default? true`).
+//
+// ## Catches
+//
+//   - a wire-layer regression reintroducing the `:event/kind` sub-tag on
+//     the MCP response (step 3 goes RED).
+//   - a regression resurrecting an old per-kind handler wrapper id (step 3
+//     goes RED).
+//   - the unified `:rf/event-handler` wrapper dropping out of the
+//     effective interceptor chain the metadata exposes (step 3 goes RED).
+//   - `handler-meta`/`list-handlers` event introspection breaking on the
+//     live wire while the degraded gate stays green (steps 1-2 go RED).
+//
+// ## Gating
+//
+// **Skipped unless `$SHADOW_CLJS_NREPL_PORT` is set.** Same posture as the
+// sibling live-* variants: without a live nREPL the server runs degraded
+// and `handler-meta` / `list-handlers` return the `:nrepl-port-not-found`
+// envelope — never the live event metadata this gate inspects. The
+// hermetic orchestrator
+// (`scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`) boots
+// shadow-cljs + Chromium against `skills/re-frame2-pair/tests/fixture/`
+// and wires the env so this gate fires on CI.
+
+const path = require('node:path');
+const os = require('node:os');
+const { runWithWatchdog } = require('./_runner.cjs');
+
+const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
+
+// The fixture event id we inspect — a plain `rf/reg-event` handler in
+// counter/core.cljs (`(fn [{:keys [db]} _event] {:db (update db :count
+// inc)})`), i.e. the canonical EP-0018 coeffects-in / effects-out shape.
+const FIXTURE_EVENT = ':counter/inc';
+
+// The retired per-kind handler-wrapper ids EP-0018 collapsed into the one
+// `:rf/event-handler`. None may appear on the live MCP response.
+const RETIRED_WRAPPER_IDS = [':rf/db-handler', ':rf/fx-handler', ':rf/ctx-handler'];
+
+// Concatenate every content block's text from an SDK callTool response.
+function responseText(resp) {
+  if (!resp || !Array.isArray(resp.content)) return '';
+  return resp.content
+    .map((c) => (c && typeof c.text === 'string' ? c.text : ''))
+    .join('\n');
+}
+
+// Pre-flight SKIP — same posture as the sibling live-* variants.
+if (!process.env.SHADOW_CLJS_NREPL_PORT) {
+  runWithWatchdog.skip(
+    'live-re-frame2-pair-event-meta: $SHADOW_CLJS_NREPL_PORT not set.\n' +
+      '      This variant requires a live shadow-cljs nREPL + browser\n' +
+      '      runtime — without one handler-meta / list-handlers return the\n' +
+      '      degraded :nrepl-port-not-found envelope, so the EP-0018 live\n' +
+      '      event-metadata surface is unreachable. The hermetic\n' +
+      '      orchestrator boots the fixture runtime and wires the env so\n' +
+      '      this gate fires on CI.',
+  );
+}
+
+runWithWatchdog(
+  {
+    watchdogMs: 30000,
+    clientName: 'mcp-conformance-re-frame2-pair-live-event-meta',
+    transportSpec: {
+      command: process.execPath,
+      args: [SERVER],
+      cwd: os.tmpdir(),
+      env: { ...process.env },
+    },
+  },
+  async (client) => {
+    console.log(
+      'OK   connect -> server attached on nREPL',
+      process.env.SHADOW_CLJS_NREPL_PORT,
+    );
+
+    // ---- Step 1: list-handlers {kind "event"} discovers the fixture id --
+    const listed = await client.callTool({
+      name: 'list-handlers',
+      arguments: { kind: 'event' },
+    });
+    if (listed.isError) {
+      throw new Error(
+        'list-handlers {kind "event"} returned isError — the event registrar ' +
+          'is not enumerable over the live wire. Got: ' +
+          responseText(listed).slice(0, 300),
+      );
+    }
+    const listedText = responseText(listed);
+    if (!/:kind\s+:event\b/.test(listedText)) {
+      throw new Error(
+        'list-handlers {kind "event"} response MUST report :kind :event; ' +
+          'got: ' + listedText.slice(0, 300),
+      );
+    }
+    if (!listedText.includes(FIXTURE_EVENT)) {
+      throw new Error(
+        'list-handlers {kind "event"} MUST discover the fixture rf/reg-event ' +
+          'id ' + FIXTURE_EVENT + '; got: ' + listedText.slice(0, 300),
+      );
+    }
+    console.log(
+      'OK   list-handlers {kind "event"} -> ' + FIXTURE_EVENT + ' discoverable',
+    );
+
+    // ---- Step 2: handler-meta {kind "event"} -> :ok? true + :kind + :id -
+    const meta = await client.callTool({
+      name: 'handler-meta',
+      arguments: { kind: 'event', id: FIXTURE_EVENT },
+    });
+    if (meta.isError) {
+      throw new Error(
+        'handler-meta {kind "event" id "' + FIXTURE_EVENT + '"} returned ' +
+          'isError — the fixture event is not inspectable on the live wire. ' +
+          'Got: ' + responseText(meta).slice(0, 300),
+      );
+    }
+    const metaText = responseText(meta);
+    if (!/:ok\?\s+true\b/.test(metaText)) {
+      throw new Error(
+        'handler-meta {kind "event" id "' + FIXTURE_EVENT + '"} MUST be ' +
+          ':ok? true; got: ' + metaText.slice(0, 400),
+      );
+    }
+    if (!/:kind\s+:event\b/.test(metaText)) {
+      throw new Error(
+        'handler-meta response MUST carry :kind :event; got: ' +
+          metaText.slice(0, 400),
+      );
+    }
+    if (!/:id\s+:counter\/inc\b/.test(metaText)) {
+      throw new Error(
+        'handler-meta response MUST echo :id :counter/inc; got: ' +
+          metaText.slice(0, 400),
+      );
+    }
+    console.log(
+      'OK   handler-meta {kind "event" id "' + FIXTURE_EVENT + '"} -> ' +
+        ':ok? true + :kind :event + :id :counter/inc',
+    );
+
+    // ---- Step 3: EP-0018 drift rejection on the same response -----------
+    // 3a. NO `:event/kind` sub-tag (removed from public metadata, EP-0018
+    // §Spec-Schemas: "event-registration schema unified; :event/kind
+    // sub-kind removed from public metadata").
+    if (/:event\/kind\b/.test(metaText)) {
+      throw new Error(
+        'handler-meta {kind "event" id "' + FIXTURE_EVENT + '"} MUST NOT ' +
+          'carry the retired :event/kind sub-tag — EP-0018 unified the event ' +
+          'form and removed the :db|:fx|:ctx sub-kind from public metadata ' +
+          '(rf2-z0owya). A wire regression reintroduced it. Got: ' +
+          metaText.slice(0, 400),
+      );
+    }
+    console.log('OK   handler-meta response carries NO :event/kind sub-tag (EP-0018)');
+
+    // 3b. NO retired per-kind wrapper id.
+    for (const wrapperId of RETIRED_WRAPPER_IDS) {
+      if (metaText.includes(wrapperId)) {
+        throw new Error(
+          'handler-meta {kind "event" id "' + FIXTURE_EVENT + '"} MUST NOT ' +
+            'carry the retired per-kind handler wrapper id ' + wrapperId +
+            ' — EP-0018 collapsed :rf/db-handler / :rf/fx-handler / ' +
+            ':rf/ctx-handler into the one :rf/event-handler. A wire ' +
+            'regression resurrected it (rf2-z0owya). Got: ' +
+            metaText.slice(0, 400),
+        );
+      }
+    }
+    console.log(
+      'OK   handler-meta response carries NO :rf/db-handler / :rf/fx-handler ' +
+        '/ :rf/ctx-handler wrapper id (EP-0018)',
+    );
+
+    // 3c. The unified `:rf/event-handler` wrapper IS visible where the
+    // metadata exposes the effective interceptor chain. `register-event!`
+    // appends the inline `:rf/event-handler` interceptor (carrying
+    // `:rf/default? true`) at the tail of the effective `:interceptors`
+    // chain (events.cljc), and `handler-meta` surfaces that chain. Its
+    // presence is the positive control complementing 3a/3b — the chain is
+    // the EP-0018 unified wrapper, not a per-kind one.
+    if (!metaText.includes(':rf/event-handler')) {
+      throw new Error(
+        'handler-meta {kind "event" id "' + FIXTURE_EVENT + '"} MUST expose ' +
+          'the unified :rf/event-handler wrapper in the effective interceptor ' +
+          'chain (EP-0018 §Conformance — "the framework wrapper is ' +
+          ':rf/event-handler with :rf/default? true"). It is absent — either ' +
+          'the chain is not surfaced or the wrapper id regressed (rf2-z0owya). ' +
+          'Got: ' + metaText.slice(0, 400),
+      );
+    }
+    console.log(
+      'OK   handler-meta response exposes the unified :rf/event-handler ' +
+        'wrapper in the effective interceptor chain (EP-0018)',
+    );
+
+    console.log('\nRE-FRAME2-PAIR-MCP LIVE EVENT-METADATA CONFORMANCE GREEN');
+  },
+);


### PR DESCRIPTION
Closes two senior-review coverage gaps on the `tools/mcp-conformance` SDK boundary: the EP-0017 recordable-coeffects (`cofx`) paths and the EP-0018 unified event-registration metadata were never exercised against a LIVE runtime through the official `@modelcontextprotocol/sdk` Client. A wire/descriptor regression in either could ship GREEN while breaking the agent-facing reproducible-dispatch / event-introspection affordances.

Verified the markers exist on the LANDED wire surface before pinning them (dispatch `cofx` input-key + EP-0017 docs in `tool-descriptors.edn`; `handler-meta`/`list-handlers` advertise the `cofx` kind; `:rf/time-ms` registered recordable in core `cofx.cljc`; EP-0018 `:rf/event-handler` wrapper + removed `:event/kind` in core `events.cljc`).

## rf2-jyxmtq — EP-0017 cofx (split across layers)
- **Degraded `end-to-end-re-frame2-pair.cjs`**: `handler-meta`/`list-handlers` `cofx`-kind probes (kind accepted into the envelope, reaches the SDK) + a well-formed `cofx` accept-probe on `dispatch` (arg parsed + threaded over the SDK boundary). The degraded-handler short-circuits the tool body to `:nrepl-port-not-found` BEFORE the cofx shape-check, so the behaviour lives on the live gate.
- **New live `live-re-frame2-pair-cofx.cjs`** (hermetic inner test): dispatches fixture `[:counter/stamp]` with a scripted `cofx "{:rf/time-ms <N>}"` TWICE with two distinct pinned-past times → asserts each lands in `:stamped-at` (reproducible-dispatch determinism; a live clock can't match two pasts). Pins the malformed-cofx refusals (`:invalid-cofx` / `:invalid-cofx-time-ms`, no state mutation) and EP-0017 tooling visibility (cofx-kind list/meta surface `:rf/time-ms`'s recordable grade; the event's `handler-meta` surfaces authored `:rf.cofx/requires`).

## rf2-z0owya — EP-0018 event metadata (live)
- **New live `live-re-frame2-pair-event-meta.cjs`** (hermetic inner test): `list-handlers {kind "event"}` discovers fixture `:counter/inc`; `handler-meta {kind "event"}` asserts `:ok? true` / `:kind :event` / `:id` AND rejects EP-0018 drift on the same response — no `:event/kind`, no `:rf/db-handler`/`:rf/fx-handler`/`:rf/ctx-handler` retired wrapper id, unified `:rf/event-handler` wrapper visible in the effective interceptor chain.

## Supporting
- Fixture `counter/core.cljs` gains `:counter/stamp` (declares `:rf.cofx/requires [:rf/time-ms]`, folds the fact into `:stamped-at`) — the EP-0017 live-gate dispatch target.
- Hermetic orchestrator `INNER_TESTS` + npm scripts + `test-all.cjs` register both new live gates (each carries a GREEN sentinel the orchestrator's rf2-ybiz0 guard requires).
- README documents the EP-0017/EP-0018 coverage boundary (SDK harness vs pair-MCP unit tests vs core tests) and keeps the surface free of legacy `world-inputs` / `:rf.world/inputs` as live vocabulary.

## Gates (all green)
- core JVM — 1779 tests, 0 failures
- CLJS node integration — 0 failures, 0 errors
- degraded conformance — 29/29 tools SDK-called
- hermetic suite — 6 inner tests, all GREEN sentinels observed (incl. the 2 new live gates)
- wire-vocab JVM gate — 83 tests, 815 assertions, 0 failures