### PR TITLE
fix(machines): EP-0017 cofx requirements surface + comment cleanup (rf2-skhlw2.1, rf2-s0bjc5)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -132,7 +132,10 @@
 
 (defn finalize-machine
   "Per Spec 005 §Final states (rf2-gn80): orchestrate the `:on-done` +
-  auto-destroy cascade. Returns `{:db new-db :fx fx}` — the handler's
+  auto-destroy cascade. Returns `{:rf.db/runtime new-runtime-db :fx fx}` —
+  the snapshot teardown is a durable runtime-db write (EP-0001 rf2-vzld77),
+  returned under the framework-authority `:rf.db/runtime` partition, NOT
+  `:db` (see the return at `finalize-machine!`'s tail). It is the handler's
   return value when the post-transition snapshot has finished (its active
   leaf is `:final?`, or — for a parallel machine — every region's active
   leaf is `:final?`). Finality is RECOMPUTED by the caller

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -1,8 +1,10 @@
 (ns re-frame.machines.lifecycle-fx.registration
   "Registration boundary: handler factory + `reg-machine*`.
 
-  `make-machine-handler` is the event-fx handler factory beneath the
-  `reg-machine` macro; `reg-machine*` is the plain-fn surface used by
+  `make-machine-handler` is the `reg-event` handler factory beneath the
+  `reg-machine` macro (EP-0018 one-event surface — a single
+  `(cofx, event) -> effects-map-or-nil` handler, no `reg-event-fx` /
+  `reg-event-db` split); `reg-machine*` is the plain-fn surface used by
   the late-bind table and by REPL workflows. The factory decomposes
   into:
 

--- a/implementation/machines/test/re_frame/machine_algebra_view_test.clj
+++ b/implementation/machines/test/re_frame/machine_algebra_view_test.clj
@@ -236,9 +236,10 @@
 ;; ---- live instance view (singleton) --------------------------------------
 
 (defn- seed-snapshot!
-  "Install a snapshot for `machine-id` directly into runtime-db via an
-  event-db, repositioning the machine to a known live state (the
-  hierarchical-test pattern). EP-0001: snapshots are durable runtime-db state."
+  "Install a snapshot for `machine-id` directly into runtime-db via a
+  `reg-event` seed handler (returning `{:rf.db/runtime …}`), repositioning
+  the machine to a known live state (the hierarchical-test pattern).
+  EP-0001: snapshots are durable runtime-db state."
   [machine-id snap]
   (let [seed-id (keyword "test" (str "seed-" (name machine-id)))]
     (rf/reg-event seed-id

--- a/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
@@ -39,7 +39,8 @@
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
-  "Force the snapshot for `machine-id` to a known value via an event-db so a
+  "Force the snapshot for `machine-id` to a known value via a `reg-event`
+  seed handler (returning `{:rf.db/runtime …}`) so a
   test can reposition the machine to a non-initial leaf without rebuilding
   the machine, and so the no-op is measured against an INSTALLED state (the
   snapshot is synthesised lazily on first dispatch)."

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -30,7 +30,8 @@
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
-  "Force the snapshot for `machine-id` to a known value via an event-db.
+  "Force the snapshot for `machine-id` to a known value via a `reg-event`
+  seed handler (returning `{:rf.db/runtime …}`).
   Used to *reposition* a machine to a non-initial state mid-test (e.g. to
   exercise a different leaf without rebuilding the whole machine)."
   [machine-id snap]

--- a/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
@@ -29,7 +29,8 @@
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
-  "Force the snapshot for `machine-id` to a known value via an event-db, so
+  "Force the snapshot for `machine-id` to a known value via a `reg-event`
+  seed handler (returning `{:rf.db/runtime …}`), so
   a test can reposition the machine to a non-initial leaf without rebuilding
   the whole machine."
   [machine-id snap]

--- a/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
@@ -32,7 +32,8 @@
 (def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
-  "Force the snapshot for `machine-id` to a known value via an event-db, so
+  "Force the snapshot for `machine-id` to a known value via a `reg-event`
+  seed handler (returning `{:rf.db/runtime …}`), so
   a test can reposition the machine to a non-initial leaf without rebuilding
   the whole machine."
   [machine-id snap]

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -398,8 +398,41 @@ on-chart sim — nil for `:after` / `:always` / wildcard), `:fromPath`
 guard-blocked no-op marker; drives the PINK border + emphasised pink
 `IF <guard>` chip), `:internal`, `:reenter` (rf2-9dj21r —
 the external-restart axis; drives the `↻` reenter chip), `:machineLevel`,
-`:onClick` (the host-supplied callback), `:afterMs`, `:chart`
+`:guardRequires` / `:actionRequires` (rf2-skhlw2.1 — the named guard /
+action consumer's declared **`:rf.cofx/requires`** as a vector of compact
+id strings; EP-0017 consumer attachment — the replay-critical host facts
+the callback reads before it runs; nil when the named callback declares no
+facts, so an ordinary fact-free transition is visually unchanged; **ids
+only — never the executable `:fn` nor any `:source-*` snippet**; drives the
+quiet `needs <id>` chip + the `data-guard-requires` / `data-action-requires`
+DOM pins), `:onClick` (the host-supplied callback), `:afterMs`, `:chart`
 (resolved visual-constants).
+
+**State-node consumer attachment (rf2-skhlw2.1).** A state node's `:data`
+carries `:entryRequires` / `:exitRequires` — the `:entry` / `:exit`
+lifecycle action's declared `:rf.cofx/requires` (same compact-id-string
+vector, same ids-only contract), driving a quiet italic `needs <id>` line
+under the entry / exit action row + the `data-entry-requires` /
+`data-exit-requires` DOM pins. nil when the lifecycle action declares no
+facts. Resolution is machine-scoped: `chart.layout/attach-cofx-requires`
+resolves each guard / action / entry / exit ref against the machine
+definition's top-level `:guards` / `:actions` named-entry registries
+(XState v5 / Spec 005 §Registration — the machine is the event handler), so
+the one registry pair covers flat, compound, AND parallel machines.
+
+**Share / export handling (rf2-skhlw2.1).** A **share URL preserves** the
+safe `:rf.cofx/requires` metadata: `share/sanitise-definition` drops the
+entry's `:fn` / `:source-*` but keeps the requires vector (a plain vector of
+coeffect-id keywords), so the decoded definition re-derives the chart's
+`needs <id>` chips on the receiving side. **AI-generate is lossless by
+construction** (it returns a full machine spec; nothing strips a
+`:rf.cofx/requires` slot a generated `:guards` / `:actions` entry carries).
+**Mermaid + SCXML INTENTIONALLY omit** the requires diet (documented +
+test-locked lossy omission): Mermaid state-diagram syntax has no slot for
+per-callback coeffect metadata, and W3C SCXML has no native attribute for it
+(a re-frame2 import re-attaches it from its own registry) — both carry only
+guard / action NAMES, and the interactive MachineChart is the EP-0017 "which
+transitions consume which facts" surface.
 
 The inbound + outbound edges carry the structural / styling state
 that used to live on the single state→state edge: `:active`,

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -145,6 +145,144 @@
     (fn? v)      (or (some-> v meta :name str) "fn")
     :else        (str v)))
 
+;; ---- consumer-attachment requirements (rf2-skhlw2.1) --------------------
+;;
+;; EP-0017 / Spec 005 §Consumer attachment: a fact-consuming machine
+;; guard / action declares `:rf.cofx/requires` on its NAMED `:guards` /
+;; `:actions` entry MAP (the `{:rf.cofx/requires [...] :fn (fn ...)}` form).
+;; The runtime derives a per-(state × event-type) ensure-set from those
+;; declarations and ensures the facts onto the in-flight `:rf.cofx` record
+;; BEFORE transition selection runs. The chart resolves a guard / action /
+;; entry / exit REF against the machine's named-entry registry and surfaces
+;; the declared requirement IDS — so a reader sees which transitions /
+;; lifecycle actions consume replay-critical host facts. We carry the IDS
+;; only — never the executable `:fn` or any `:source-*` snippet.
+
+(defn- node-at-in-states
+  "Descend `states` (a `:states` map) along `path` (a vec of state-ids),
+  returning the raw state-node map or nil. Each step reads the child off
+  the current node's `:states`."
+  [states path]
+  (loop [node  {:states states}
+         p     (seq path)]
+    (cond
+      (nil? p)   (when (not= node {:states states}) node)
+      (nil? node) nil
+      :else      (recur (get-in node [:states (first p)]) (next p)))))
+
+(defn raw-node-at
+  "Return the RAW (pre-projection) state-node map for `path` within machine
+  `definition`, or nil. For a flat / compound machine the path resolves
+  within `(:states definition)`. For a parallel machine a node `:path` is
+  IN-REGION (region-relative — the region-id is NOT part of the path, per
+  `project-parallel`'s in-region `:path` preservation), so we try every
+  region's `:states` body and return the first hit. A synthetic node (the
+  machine-root / region-container — empty or single-id path with no raw
+  match) resolves to nil. Used to recover a node's ORIGINAL `:entry` /
+  `:exit` keyword refs (the projection rewrote them to `name-of` strings)."
+  [definition path]
+  (when (seq path)
+    (or (node-at-in-states (:states definition) path)
+        (some (fn [[_region region-def]]
+                (node-at-in-states (:states region-def) path))
+              (:regions definition)))))
+
+(defn requirement-label
+  "Render one `:rf.cofx/requires` entry (Spec 002 §`parse-requires` grammar:
+  a bare coeffect id, or an `[id arg]` pair) to a compact display string.
+  A bare keyword id reads as `ns/name` (via `name-of`); an `[id arg]` pair
+  reads as `ns/name(<arg>)` so a parameterized request stays legible. Any
+  other shape (a malformed declaration the engine would reject at
+  registration) falls through to `pr-str` — the viz never throws on a
+  badly-shaped spec it is only DISPLAYING."
+  [entry]
+  (cond
+    (keyword? entry) (name-of entry)
+    (and (vector? entry) (= 2 (count entry)) (keyword? (first entry)))
+    (str (name-of (first entry)) "(" (pr-str (second entry)) ")")
+    :else (pr-str entry)))
+
+(defn requires-for-ref
+  "Resolve a guard / action `ref` against the machine's named-entry
+  `registry` (`(:guards machine)` or `(:actions machine)`) and return the
+  vector of compact `:rf.cofx/requires` display strings declared on its
+  entry map, or nil when there are none.
+
+  `:rf.cofx/requires` rides ONLY a NAMED entry MAP (the
+  `{:rf.cofx/requires [...] :fn (fn ...)}` form) — an inline / bare-fn
+  guard-action cannot declare it (the engine rejects that at registration),
+  so only a KEYWORD `ref` can carry requirements. We extract the declared
+  IDS and render them; the `:fn` / `:source-*` slots are never read. nil
+  when `ref` is not a keyword, the registry has no such entry, the entry is
+  a bare fn / keyword indirection, or it declares no (or empty) requires."
+  [registry ref]
+  (when (keyword? ref)
+    (let [entry (get registry ref)]
+      (when (map? entry)
+        (let [reqs (:rf.cofx/requires entry)]
+          (when (seq reqs)
+            (mapv requirement-label reqs)))))))
+
+(defn- attach-edge-requires
+  "Decorate one parsed edge with `:guard-requires` / `:action-requires`
+  (the compact `:rf.cofx/requires` display vectors resolved from the
+  machine's `:guards` / `:actions` registries). A `cond->` assoc — an
+  undeclared guard / action leaves the edge untouched (so the renderer's
+  resting treatment is unchanged for the common no-facts case)."
+  [guards actions edge]
+  (cond-> edge
+    (requires-for-ref guards (:guard edge))
+    (assoc :guard-requires (requires-for-ref guards (:guard edge)))
+    (requires-for-ref actions (:action edge))
+    (assoc :action-requires (requires-for-ref actions (:action edge)))))
+
+(defn- attach-node-requires
+  "Decorate one parsed node with `:entry-requires` / `:exit-requires` (the
+  compact `:rf.cofx/requires` display vectors resolved from the machine's
+  `:actions` registry for the node's `:entry` / `:exit` lifecycle-action
+  refs). An `:entry` / `:exit` value is the ORIGINAL ref off the raw node;
+  the parsed node only carries the `name-of` STRING, so resolution reads
+  the keyword ref out of `raw-node`. Undeclared lifecycle actions leave the
+  node untouched."
+  [actions raw-node node]
+  (cond-> node
+    (requires-for-ref actions (:entry raw-node))
+    (assoc :entry-requires (requires-for-ref actions (:entry raw-node)))
+    (requires-for-ref actions (:exit raw-node))
+    (assoc :exit-requires (requires-for-ref actions (:exit raw-node)))))
+
+(defn attach-cofx-requires
+  "Post-pass over a projected `{:nodes :edges …}` graph: resolve every
+  edge's guard / action ref and every node's entry / exit ref against the
+  machine `definition`'s named-entry registries (`:guards` / `:actions`)
+  and surface their declared `:rf.cofx/requires` as compact display
+  vectors (rf2-skhlw2.1). Pure: a machine declaring no requires anywhere
+  returns the graph UNCHANGED (every `cond->` assoc is skipped).
+
+  Resolution is machine-scoped: `:guards` / `:actions` live at the
+  top-level definition and a region resolves a ref against them (XState v5
+  / Spec 005 §Registration — the machine is the event handler), so the ONE
+  top-level registry pair covers flat, compound, AND parallel machines.
+
+  Nodes need the ORIGINAL `:entry` / `:exit` keyword ref, which `collect-
+  nodes` already rewrote to a `name-of` STRING; we re-resolve it against
+  the raw definition by node `:path` via `raw-node-at`."
+  [definition graph]
+  (let [guards  (:guards definition)
+        actions (:actions definition)]
+    (if (and (empty? guards) (empty? actions))
+      graph
+      (-> graph
+          (update :edges
+                  (fn [edges]
+                    (mapv #(attach-edge-requires guards actions %) edges)))
+          (update :nodes
+                  (fn [nodes]
+                    (mapv (fn [n]
+                            (attach-node-requires
+                              actions (raw-node-at definition (:path n)) n))
+                          nodes)))))))
+
 (defn- resolve-target-path
   "Resolve a transition target relative to source-path.
 
@@ -1249,16 +1387,22 @@
   the frame around its children. An empty graph (nil definition) is left
   unwrapped."
   [definition]
-  (-> (cond
-        (nil? definition)
-        {:nodes [] :edges [] :initial-path nil}
+  (let [graph (cond
+                (nil? definition)
+                {:nodes [] :edges [] :initial-path nil}
 
-        (= :parallel (:type definition))
-        (project-parallel definition)
+                (= :parallel (:type definition))
+                (project-parallel definition)
 
-        :else
-        (project-flat definition))
-      wrap-in-root-container))
+                :else
+                (project-flat definition))]
+    ;; rf2-skhlw2.1 — surface each guard / action / entry / exit ref's
+    ;; declared `:rf.cofx/requires` (EP-0017 consumer attachment) onto the
+    ;; edges + nodes BEFORE the synthetic root-container wraps the graph (so
+    ;; the wrapper's `:path []` node is never resolved). A no-op for a
+    ;; machine that declares no requires.
+    (-> (attach-cofx-requires definition graph)
+        wrap-in-root-container)))
 
 (defn highlight-id
   "Resolve a single-active snapshot `:state` value to the node-id used

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -221,18 +221,28 @@
   action chip carrying a bolt glyph + the action name. The chip stays
   SUBORDINATE to the state title (quieter colour + smaller type). Reads
   geometry/typography off the resolved density `vc` map and colour off
-  the active-theme `ct`."
-  [{:keys [kind name-str vc ct]}]
+  the active-theme `ct`.
+
+  rf2-skhlw2.1 — when the named lifecycle action declares
+  `:rf.cofx/requires` (EP-0017 consumer attachment), append a quiet
+  `needs <id>` annotation + a `data-{entry,exit}-requires` DOM pin so a
+  reader sees the replay-critical host facts the action consumes. `requires`
+  is the CLJS vec of compact id strings, or nil — an action with no diet
+  renders exactly as before."
+  [{:keys [kind name-str requires vc ct]}]
   (let [{:keys [action-pill-height action-pill-pad-x action-pill-px
                 action-pill-radius action-caption-px action-caption-gap]} vc
         caption (case kind :entry "Entry actions" :exit "Exit actions")]
-    [:div {:data-testid (case kind
-                          :entry "rf-mv-chart-state-entry"
-                          :exit  "rf-mv-chart-state-exit")
-           (case kind :entry :data-entry :exit :data-exit) name-str
-           :style {:display        "flex"
-                   :flex-direction "column"
-                   :gap            (str action-caption-gap "px")}}
+    [:div (cond-> {:data-testid (case kind
+                                  :entry "rf-mv-chart-state-entry"
+                                  :exit  "rf-mv-chart-state-exit")
+                   (case kind :entry :data-entry :exit :data-exit) name-str
+                   :style {:display        "flex"
+                           :flex-direction "column"
+                           :gap            (str action-caption-gap "px")}}
+            (seq requires)
+            (assoc (case kind :entry :data-entry-requires :exit :data-exit-requires)
+                   (str/join " " requires)))
      ;; rf2-vcnvj — quiet TITLE-CASE caption ("Entry actions" / "Exit
      ;; actions"), NOT uppercase. The uppercase transform competed with
      ;; the state title for attention against the structure-first grammar;
@@ -266,7 +276,23 @@
                      :white-space   "nowrap"}}
       ;; subordinate bolt/action glyph (text convention — no icon dep)
       [:span {:style {:opacity 0.7}} "⚡"]
-      name-str]]))
+      name-str]
+     ;; rf2-skhlw2.1 — the consumer-attachment requirement annotation: a
+     ;; quiet italic `needs <id>` line surfacing the lifecycle action's
+     ;; declared `:rf.cofx/requires` (EP-0017). The QUIETEST tier (tertiary
+     ;; colour, caption type, italic), subordinate to the action chip;
+     ;; rendered ONLY when the action declared a non-empty diet.
+     (when (seq requires)
+       [:span {:data-testid (case kind
+                              :entry "rf-mv-chart-state-entry-requires"
+                              :exit  "rf-mv-chart-state-exit-requires")
+               :style {:font-family chart-label-stack
+                       :font-size   (str action-caption-px "px")
+                       :font-weight 400
+                       :font-style  "italic"
+                       :color       (:text-tertiary ct)
+                       :line-height "1"}}
+        (str "needs " (str/join ", " requires))])]))
 
 ;; ---- state node ---------------------------------------------------------
 
@@ -322,6 +348,11 @@
         tags-attr      (tag-title-attr tags)
         entry          (.-entry d)
         exit           (.-exit d)
+        ;; rf2-skhlw2.1 — the entry / exit lifecycle action's declared
+        ;; `:rf.cofx/requires` (EP-0017 consumer attachment), a JS array of
+        ;; compact id strings (nil when the action declares no facts).
+        entry-reqs     (some-> (.-entryRequires d) js->clj)
+        exit-reqs      (some-> (.-exitRequires d) js->clj)
         on-click       (.-onClick d)
         emphasised?    (or active? from-highlight? to-highlight?)
         active-affordance? (or active? to-highlight?)
@@ -432,9 +463,9 @@
                   sort
                   (map (fn [t] (tag-pill t ct vc))))])
           (when entry
-            (action-row {:kind :entry :name-str entry :vc vc :ct ct}))
+            (action-row {:kind :entry :name-str entry :requires entry-reqs :vc vc :ct ct}))
           (when exit
-            (action-row {:kind :exit :name-str exit :vc vc :ct ct}))])
+            (action-row {:kind :exit :name-str exit :requires exit-reqs :vc vc :ct ct}))])
        ;; xyflow attachment points (invisible — edges connect here)
        (four-cardinal-handles)])))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -37,7 +37,8 @@
   `visual-constants` map threaded through `:data {:chart ...}` —
   same pattern the state-node + edge components use. No hex literals
   appear in this ns; all colour goes through `theme/tokens`."
-  (:require [reagent.core :as r]
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
              :refer [four-cardinal-handles chart-constants palette-of]]
             [day8.re-frame2-machines-viz.theme.tokens
@@ -99,6 +100,39 @@
                       :line-height      "1"}}
        order])))
 
+(defn requires-chip
+  "rf2-skhlw2.1 — a compact `needs <id>, <id>` chip surfacing a guard /
+  action consumer's declared `:rf.cofx/requires` (EP-0017 consumer
+  attachment): the replay-critical host facts the named callback reads
+  before it runs. The QUIETEST tier (tertiary colour, smallest type) — a
+  subordinate annotation on the event chip, never competing with the event
+  name. Carries a `data-*` pin (`data-guard-requires` / `data-action-requires`)
+  so tests + hosts read the requirements off the DOM. Returns nil for an
+  empty / nil requires vec so an undeclared callback paints nothing.
+
+  `kind` is `:guard` / `:action` (drives the `data-testid` + pin attr);
+  `reqs` the CLJS vec of compact id strings; `id` the host node id; `ct`
+  the resolved theme tokens; `px` the density font-size."
+  [kind reqs id ct px]
+  (when (seq reqs)
+    (let [label (str "needs " (str/join ", " reqs))
+          pin   (case kind :guard :data-guard-requires
+                           :action :data-action-requires)]
+      [:span {:data-testid (str "rf-mv-chart-event-" (name kind) "-requires-" id)
+              pin (str/join " " reqs)
+              :title (str (name kind) " consumes recordable coeffects: " label)
+              :style {:display       "inline-flex"
+                      :align-items   "center"
+                      :align-self    "flex-start"
+                      :margin-top    "2px"
+                      :font-size     (str (max 8 (- px 2)) "px")
+                      :font-weight   400
+                      :font-style    "italic"
+                      :color         (:text-tertiary ct)
+                      :line-height   "1"
+                      :white-space   "nowrap"}}
+       label])))
+
 (defn event-node
   "Reagent component for an event-node. The xyflow chart projector
   emits ONE event-node per spec transition (event-as-node paradigm,
@@ -151,6 +185,13 @@
         after-ms    (.-afterMs d)
         guard       (.-guard d)
         action      (.-action d)
+        ;; rf2-skhlw2.1 — the guard / action consumer's declared
+        ;; `:rf.cofx/requires` (EP-0017 consumer attachment), a JS array of
+        ;; compact id strings (nil when the named callback declares no facts).
+        ;; `js->clj` back to a CLJS vec for rendering; nil stays nil so an
+        ;; undeclared callback is visually unchanged.
+        guard-reqs  (some-> (.-guardRequires d) js->clj)
+        action-reqs (some-> (.-actionRequires d) js->clj)
         focused?    (boolean (.-focused d))
         fired?      (boolean (.-fired d))
         ;; rf2-fzrzlw — this transition's guard rejected the event this
@@ -223,6 +264,11 @@
              :data-after-ms (when after-ms (str after-ms))
              :data-guard (when guard (str guard))
              :data-action (when action (str action))
+             ;; rf2-skhlw2.1 — DOM pins for the guard / action consumer's
+             ;; declared `:rf.cofx/requires` (space-joined id strings) so
+             ;; tests + hosts read the replay-critical facts off the node.
+             :data-guard-requires (when (seq guard-reqs) (str/join " " guard-reqs))
+             :data-action-requires (when (seq action-reqs) (str/join " " action-reqs))
              :data-from-path (when from-path (pr-str from-path))
              :data-to-path (when to-path (pr-str to-path))
              :role (when clickable? "button")
@@ -341,6 +387,13 @@
                          :white-space   "nowrap"}}
           [:span {:style {:opacity 0.7}} "⚡"]
           action])
+       ;; rf2-skhlw2.1 — the guard / action consumer-attachment requirement
+       ;; rows: a quiet `needs <id>` annotation surfacing the replay-critical
+       ;; host facts the named guard / action declares via `:rf.cofx/requires`
+       ;; (EP-0017). Each renders ONLY when its callback declared a non-empty
+       ;; diet, so an ordinary fact-free transition is visually unchanged.
+       (requires-chip :guard guard-reqs (.-id props) ct event-chip-action-px)
+       (requires-chip :action action-reqs (.-id props) ct event-chip-action-px)
        ;; xyflow attachment points. Handles on every side so elkjs can
        ;; pick the cleanest anchor based on the routed direction.
        (four-cardinal-handles)])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -1487,6 +1487,18 @@
                                           ;; the state declares none.
                                           :entry          (:entry n)
                                           :exit           (:exit n)
+                                          ;; rf2-skhlw2.1 — the entry / exit
+                                          ;; lifecycle action's declared
+                                          ;; `:rf.cofx/requires` (EP-0017 consumer
+                                          ;; attachment), as compact display
+                                          ;; strings the action row paints as a
+                                          ;; `needs …` chip. nil when the action
+                                          ;; declares no facts. IDS only. camelCase
+                                          ;; so the JS-interop `(.-entryRequires d)`
+                                          ;; resolves after xyflow `clj->js`-es the
+                                          ;; `:data` map (a kebab key would not).
+                                          :entryRequires  (:entry-requires n)
+                                          :exitRequires   (:exit-requires n)
                                           ;; rf2-m285a — a `:type :history`
                                           ;; pseudo-state's variant. The
                                           ;; `history-marker` renderer reads
@@ -1755,6 +1767,19 @@
                                        :afterMs     (:after edge)
                                        :guard       (layout/name-of (:guard edge))
                                        :action      (layout/name-of (:action edge))
+                                       ;; rf2-skhlw2.1 — the guard / action
+                                       ;; consumer's declared `:rf.cofx/requires`
+                                       ;; (EP-0017 consumer attachment), as
+                                       ;; compact display strings the event-node
+                                       ;; paints as a `needs …` chip. nil when the
+                                       ;; named guard / action declares no facts
+                                       ;; (so an undeclared callback is visually
+                                       ;; unchanged). IDS only — never the `:fn`.
+                                       ;; camelCase so the JS-interop
+                                       ;; `(.-guardRequires d)` resolves after
+                                       ;; xyflow `clj->js`-es the `:data` map.
+                                       :guardRequires  (:guard-requires edge)
+                                       :actionRequires (:action-requires edge)
                                        ;; rf2-uw3vmi — 1-based priority index
                                        ;; WHEN this event-node is one branch of
                                        ;; a genuine guarded multi-branch fork

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -53,6 +53,16 @@
   - Microstep flashes, transition glow, `:tags`, guard evaluation,
     actions — none of these are part of the static topology. Guard
     ids still appear on edge labels when present.
+  - Consumer-attachment `:rf.cofx/requires` (EP-0017 — the
+    replay-critical host facts a named guard / action consumes;
+    rf2-skhlw2.1): INTENTIONALLY OMITTED. Mermaid state-diagram syntax
+    has no slot for per-callback coeffect metadata, and an edge label
+    carries only `event [guard] / action` (names, never the named-entry
+    registry the requirements live on). The interactive MachineChart is
+    the EP-0017 'which transitions consume which facts' surface (it paints
+    a `needs <id>` chip per guard / action / entry / exit consumer); the
+    Markdown-paste lane stays a topology sketch. The omission is locked by
+    `mermaid-cljs-test`'s no-cofx-vocabulary regression.
   - Parallel-region broadcast macrosteps — regions render, but Mermaid
     does not model the shared one-event/many-regions transition
     semantics.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -119,6 +119,17 @@
     comments but are not part of this round-trip.
   - Source-coord metadata — stripped at export time (same posture as
     share-URL encoding; see `Principles.md` §No session data in shares).
+  - Consumer-attachment `:rf.cofx/requires` (EP-0017 — the replay-critical
+    host facts a named guard / action / entry / exit consumes; rf2-skhlw2.1):
+    INTENTIONALLY OMITTED. W3C SCXML has no native attribute for re-frame2
+    coeffect requirements, and the requirements ride the `:guards` /
+    `:actions` named-entry registry, which SCXML does not carry (only the
+    NAME survives, via `cond=` / the action comment). On import a re-frame2
+    machine re-attaches its requirements from its own registry, so a comment
+    round-trip would be redundant. The interactive MachineChart is the
+    EP-0017 'which transitions consume which facts' surface; SCXML stays W3C
+    topology interop. The omission is locked by `scxml-cljs-test`'s no-cofx-
+    vocabulary regression.
 
   Round-trip failure modes throw the canonical thrown-error shape (Spec
   009 §The thrown-error shape): `:rf.error/id` is the `:scxml/...`

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -1269,3 +1269,102 @@
           "exactly one is the plain :on edge")
       (is (= 2 (count (set ids)))
           "the :on and :after edges to the same target mint DISTINCT ids"))))
+
+;; ---- consumer-attachment requirements (rf2-skhlw2.1) -------------------
+;;
+;; EP-0017 / Spec 005 §Consumer attachment: a fact-consuming named guard /
+;; action declares `:rf.cofx/requires` on its `:guards` / `:actions` entry
+;; MAP. `attach-cofx-requires` resolves the transition / lifecycle ref
+;; against that registry and surfaces the declared IDS (never the `:fn`).
+
+(def cofx-machine
+  "A machine whose named guard, transition action, entry action, and exit
+  action each declare `:rf.cofx/requires`, plus a bare-fn guard / undeclared
+  action that declare nothing (so the no-facts case stays visually
+  unchanged). Mirrors Spec 005 §Consumer attachment's worked example."
+  {:initial :idle
+   :guards  {:within-window? {:rf.cofx/requires [:rf/time-ms]
+                              :fn (fn [_] true)}
+             :always-ok?     (fn [_] true)}            ;; bare fn → no diet
+   :actions {:schedule-retry {:rf.cofx/requires [:payment/retry-jitter-ms]
+                             :fn (fn [_] nil)}
+             :stamp-started  {:rf.cofx/requires [:rf/time-ms]
+                             :fn (fn [_] nil)}
+             :stamp-ended    {:rf.cofx/requires [[:ui/local-theme "theme"]]
+                             :fn (fn [_] nil)}
+             :log-it         (fn [_] nil)}             ;; bare fn → no diet
+   :states  {:idle    {:entry :stamp-started
+                       :exit  :stamp-ended
+                       :on    {:go {:target :busy
+                                    :guard  :within-window?
+                                    :action :schedule-retry}
+                               :noop {:target :busy
+                                      :guard  :always-ok?
+                                      :action :log-it}}}
+             :busy    {}}})
+
+(defn- edge-with-event [edges ev]
+  (first (filter #(= ev (:event %)) edges)))
+
+(deftest cofx-requires-on-guard-and-action-edges
+  (testing "rf2-skhlw2.1 — a named guard / action declaring :rf.cofx/requires
+            surfaces its declared IDS (compact strings) on the edge"
+    (let [{:keys [edges]} (layout/project-definition cofx-machine)
+          go-edge   (edge-with-event edges :go)
+          noop-edge (edge-with-event edges :noop)]
+      (is (= ["rf/time-ms"] (:guard-requires go-edge))
+          "the guard's :rf.cofx/requires id surfaces")
+      (is (= ["payment/retry-jitter-ms"] (:action-requires go-edge))
+          "the action's :rf.cofx/requires id surfaces")
+      ;; the undeclared (bare-fn) guard/action edge carries NOTHING — the
+      ;; no-facts case is visually unchanged.
+      (is (nil? (:guard-requires noop-edge))
+          "a bare-fn guard declares no requires → no key")
+      (is (nil? (:action-requires noop-edge))
+          "a bare-fn action declares no requires → no key"))))
+
+(deftest cofx-requires-on-entry-and-exit-nodes
+  (testing "rf2-skhlw2.1 — a named entry / exit action declaring
+            :rf.cofx/requires surfaces its IDS on the state node"
+    (let [{:keys [nodes]} (layout/project-definition cofx-machine)
+          idle (first (filter #(= [:idle] (:path %)) nodes))]
+      (is (= ["rf/time-ms"] (:entry-requires idle))
+          "the entry action's :rf.cofx/requires id surfaces on the node")
+      (is (= ["ui/local-theme(\"theme\")"] (:exit-requires idle))
+          "the exit action's parameterized [id arg] requirement reads as id(arg)"))))
+
+(deftest cofx-requires-noop-for-fact-free-machine
+  (testing "rf2-skhlw2.1 — a machine declaring no :rf.cofx/requires anywhere
+            projects UNCHANGED (no requires keys appear)"
+    (let [{:keys [edges nodes]} (layout/project-definition idle-loading-success)]
+      (is (not-any? :guard-requires edges))
+      (is (not-any? :action-requires edges))
+      (is (not-any? :entry-requires nodes))
+      (is (not-any? :exit-requires nodes)))))
+
+(deftest cofx-requires-never-serialises-fn-or-source
+  (testing "rf2-skhlw2.1 — the surfaced requirements carry IDS only — never
+            the executable :fn nor any :source-* snippet"
+    (let [{:keys [edges nodes]} (layout/project-definition cofx-machine)
+          all (concat (mapcat (juxt :guard-requires :action-requires) edges)
+                      (mapcat (juxt :entry-requires :exit-requires) nodes))]
+      (is (every? (fn [reqs] (every? string? (or reqs []))) all)
+          "every surfaced requirement is a plain display string")
+      (is (not-any? (fn [reqs] (some #(re-find #"fn|source" (str %)) (or reqs [])))
+                    all)
+          "no :fn / :source vocabulary leaks into the surfaced requirements"))))
+
+(deftest cofx-requires-machine-scoped-across-parallel-regions
+  (testing "rf2-skhlw2.1 — a region guard/action resolves its requires
+            against the MACHINE-LEVEL :guards/:actions (XState v5 scoping)"
+    (let [m {:type    :parallel
+             :guards  {:ready? {:rf.cofx/requires [:rf/time-ms]
+                               :fn (fn [_] true)}}
+             :regions {:a {:initial :one
+                          :states {:one {:on {:go {:target :two :guard :ready?}}}
+                                   :two {}}}
+                       :b {:initial :x :states {:x {}}}}}
+          {:keys [edges]} (layout/project-definition m)
+          go-edge (edge-with-event edges :go)]
+      (is (= ["rf/time-ms"] (:guard-requires go-edge))
+          "a region guard resolves its requires against the machine registry"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -3663,3 +3663,59 @@
                             "elk.layered.crossingMinimization.semiInteractive"))
             (str "non-fork fixture " m
                  " root-container child omits semiInteractive"))))))
+
+;; ---- consumer-attachment requirements on :data (rf2-skhlw2.1) ----------
+;;
+;; EP-0017 / Spec 005 §Consumer attachment — the projection carries a named
+;; guard / action / entry / exit consumer's declared `:rf.cofx/requires` onto
+;; the event-node + state-node `:data` (camelCase so the JS-interop renderer
+;; reads it after xyflow `clj->js`-es the map). IDS only — never the `:fn`.
+
+(def cofx-projection-machine
+  {:initial :idle
+   :guards  {:within-window? {:rf.cofx/requires [:rf/time-ms]
+                              :fn (fn [_] true)}}
+   :actions {:schedule-retry {:rf.cofx/requires [:payment/retry-jitter-ms]
+                             :fn (fn [_] nil)}
+             :stamp-started  {:rf.cofx/requires [:rf/time-ms]
+                             :fn (fn [_] nil)}
+             :stamp-ended    {:rf.cofx/requires [:rf/uuid]
+                             :fn (fn [_] nil)}}
+   :states  {:idle {:entry :stamp-started
+                    :exit  :stamp-ended
+                    :on    {:go {:target :busy
+                                 :guard  :within-window?
+                                 :action :schedule-retry}}}
+             :busy {}}})
+
+(deftest event-node-data-carries-guard-action-requires
+  (testing "rf2-skhlw2.1 — the :go event-node's :data carries
+            :guardRequires / :actionRequires (the named callbacks' IDS)"
+    (let [parsed (layout/project-definition cofx-projection-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          ;; the single :go transition's event-node (eventId is the raw kw).
+          ev     (first (filter #(and (= "rf2-event" (:type %))
+                                      (= :go (:eventId (:data %))))
+                                (:nodes graph)))]
+      (is (some? ev) "the :go transition projects an event-node")
+      (is (= ["rf/time-ms"] (:guardRequires (:data ev))))
+      (is (= ["payment/retry-jitter-ms"] (:actionRequires (:data ev)))))))
+
+(deftest state-node-data-carries-entry-exit-requires
+  (testing "rf2-skhlw2.1 — the :idle state-node's :data carries
+            :entryRequires / :exitRequires (the lifecycle actions' IDS)"
+    (let [parsed (layout/project-definition cofx-projection-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          idle   (node-by-id graph (layout/node-id [:idle]))]
+      (is (= ["rf/time-ms"] (:entryRequires (:data idle))))
+      (is (= ["rf/uuid"]    (:exitRequires (:data idle)))))))
+
+(deftest fact-free-machine-omits-requires-data
+  (testing "rf2-skhlw2.1 — a machine declaring no :rf.cofx/requires carries
+            nil :guardRequires / :entryRequires (visually unchanged)"
+    (let [parsed (layout/project-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          ev     (first (filter #(= "rf2-event" (:type %)) (:nodes graph)))]
+      (is (some? ev))
+      (is (nil? (:guardRequires (:data ev))))
+      (is (nil? (:actionRequires (:data ev)))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -764,3 +764,38 @@
     (is (not= (m/emit reenter-self-machine {:fenced? false :header-comment? false})
               (m/emit internal-self-machine {:fenced? false :header-comment? false}))
         "external vs internal must produce DISTINCT Mermaid")))
+
+;; ---- consumer-attachment :rf.cofx/requires — intentional omission ------
+;;
+;; rf2-skhlw2.1 — Mermaid INTENTIONALLY omits EP-0017 consumer-attachment
+;; `:rf.cofx/requires` (the chart is the "which transitions consume which
+;; facts" surface). Lock the omission so the lossy posture stays documented +
+;; deliberate, and guard against any `:rf.world/inputs` / `inject-cofx`
+;; vocabulary slipping in (the bead's negative regression).
+
+(def cofx-bearing-machine
+  {:initial :idle
+   :guards  {:within-window? {:rf.cofx/requires [:rf/time-ms]
+                              :fn (fn [_] true)}}
+   :actions {:schedule-retry {:rf.cofx/requires [:payment/retry-jitter-ms]
+                             :fn (fn [_] nil)}}
+   :states  {:idle {:on {:go {:target :busy
+                              :guard  :within-window?
+                              :action :schedule-retry}}}
+             :busy {}}})
+
+(deftest mermaid-omits-cofx-requires-vocabulary
+  (testing "rf2-skhlw2.1 — Mermaid surfaces guard/action NAMES but omits the
+            consumer-attachment requires diet (documented lossy omission)"
+    (let [out (m/emit cofx-bearing-machine {:fenced? false :header-comment? false})]
+      ;; the guard NAME still renders on the transition label (existing
+      ;; contract — Mermaid edge labels carry `event [guard]`).
+      (is (str/includes? out "within-window?"))
+      ;; the requires diet + its cofx ids are NOT emitted
+      (is (not (str/includes? out "rf.cofx")))
+      (is (not (str/includes? out "requires")))
+      (is (not (str/includes? out "rf/time-ms")))
+      (is (not (str/includes? out "retry-jitter-ms")))
+      ;; the bead's negative regression: NO retired/foreign cofx vocabulary
+      (is (not (str/includes? out "rf.world/inputs")))
+      (is (not (str/includes? out "inject-cofx"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -1323,3 +1323,40 @@
                   internal-self-machine
                   reenter-ancestor-machine]]
       (assert-targets-declared (scxml/spec->scxml spec)))))
+
+;; ---- consumer-attachment :rf.cofx/requires — intentional omission ------
+;;
+;; rf2-skhlw2.1 — SCXML INTENTIONALLY omits EP-0017 consumer-attachment
+;; `:rf.cofx/requires` (W3C SCXML has no attribute for it; a re-frame2 import
+;; re-attaches it from its own registry, and the chart is the "which
+;; transitions consume which facts" surface). Lock the omission + the bead's
+;; negative regression (no `:rf.world/inputs` / `inject-cofx` vocabulary).
+
+(def scxml-cofx-bearing-machine
+  {:initial :idle
+   :guards  {:within-window? {:rf.cofx/requires [:rf/time-ms]
+                              :fn (fn [_] true)}}
+   :actions {:schedule-retry {:rf.cofx/requires [:payment/retry-jitter-ms]
+                             :fn (fn [_] nil)}}
+   :states  {:idle {:on {:go {:target :busy
+                              :guard  :within-window?
+                              :action :schedule-retry}}}
+             :busy {}}})
+
+(deftest scxml-omits-cofx-requires-vocabulary
+  (testing "rf2-skhlw2.1 — SCXML surfaces the guard `cond=` NAME + the action
+            comment NAME but omits the consumer-attachment requires diet"
+    (let [out (scxml/spec->scxml scxml-cofx-bearing-machine)]
+      ;; the guard `cond=` + the action comment still render (XML-mangled
+      ;; names — SCXML escapes `-` / `?` to `_2d` / `_3f`); a transition
+      ;; carries both so the topology survives.
+      (is (str/includes? out "cond="))
+      (is (str/includes? out "action:"))
+      ;; the requires diet + its cofx ids are NOT emitted
+      (is (not (str/includes? out "rf.cofx")))
+      (is (not (str/includes? out "requires")))
+      (is (not (str/includes? out "time-ms")))
+      (is (not (str/includes? out "retry-jitter-ms")))
+      ;; the bead's negative regression: NO retired/foreign cofx vocabulary
+      (is (not (str/includes? out "rf.world/inputs")))
+      (is (not (str/includes? out "inject-cofx"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -350,6 +350,45 @@
         (is (keyword? a)  "it became an opaque label keyword")))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-skhlw2.1 — consumer-attachment `:rf.cofx/requires` (EP-0017) is SAFE
+;; topology metadata (a vector of coeffect-id keywords), so a share URL must
+;; PRESERVE it: `sanitise-definition` drops the entry's `:fn` / `:source-*`
+;; but keeps the requires vector. The decoded definition re-derives the
+;; chart's `needs <id>` chips on the receiving side.
+
+(def cofx-requires-definition
+  "A named guard / action / entry / exit each declaring `:rf.cofx/requires`
+  alongside a live `:fn` (the macro-stamped entry-map shape)."
+  {:initial :idle
+   :guards  {:within-window? {:rf.cofx/requires [:rf/time-ms]
+                              :fn (fn [_] true)}}
+   :actions {:schedule-retry {:rf.cofx/requires [:payment/retry-jitter-ms]
+                             :fn (fn [_] nil)}
+             :stamp-started  {:rf.cofx/requires [:rf/time-ms]
+                             :fn (fn [_] nil)}}
+   :states  {:idle {:entry :stamp-started
+                    :on    {:go {:target :busy
+                                 :guard  :within-window?
+                                 :action :schedule-retry}}}
+             :busy {}}})
+
+(deftest cofx-requires-survive-share-round-trip
+  (testing "rf2-skhlw2.1 — a share URL PRESERVES safe :rf.cofx/requires
+            metadata while still dropping the executable :fn"
+    (let [cs   (assoc chart-state :definition cofx-requires-definition)
+          url  (share/encode-share-url cs)
+          dfn  (:definition
+                 (:rf.machines-viz.share/chart (share/decode-share-url url)))]
+      ;; the requires vectors survive intact (safe topology metadata)
+      (is (= [:rf/time-ms] (get-in dfn [:guards :within-window? :rf.cofx/requires])))
+      (is (= [:payment/retry-jitter-ms]
+             (get-in dfn [:actions :schedule-retry :rf.cofx/requires])))
+      (is (= [:rf/time-ms] (get-in dfn [:actions :stamp-started :rf.cofx/requires])))
+      ;; but the executable :fn is still stripped (privacy / Transit contract)
+      (is (nil? (get-in dfn [:guards :within-window? :fn])))
+      (is (nil? (get-in dfn [:actions :schedule-retry :fn]))))))
+
+;; ---------------------------------------------------------------------------
 ;; rf2-07gg7h — `:fn` as a TOPOLOGY key (state id / event id / region id) is
 ;; valid and MUST survive sanitisation. The pre-fix sanitiser dropped EVERY
 ;; map entry whose key was `:fn`, silently removing such a state / transition /


### PR DESCRIPTION
## Summary

Two P2 machines-surface beads.

### rf2-skhlw2.1 — surface machine cofx requirements in machines-viz
EP-0017 / Spec 005 §Consumer attachment lets a **named** guard / action / entry / exit declare `:rf.cofx/requires` (the replay-critical host facts it reads before running). The implementation side is fully landed, but `tools/machines-viz` treated guard/action/entry/exit refs as **names only**, hiding which transitions / lifecycle actions consume facts. This PR closes that gap.

- **`chart.layout/attach-cofx-requires`** — a pure post-pass that resolves each edge's guard/action ref + each node's entry/exit ref against the machine definition's top-level `:guards` / `:actions` named-entry registries (machine-scoped — covers flat, compound, **and** parallel) and surfaces the declared **IDs** as compact display strings (e.g. `rf/time-ms`, `ui/local-theme("theme")`). **IDs only — never the executable `:fn` nor any `:source-*` snippet.** A machine declaring no requires projects **unchanged**.
- **`chart.projection`** threads `:guardRequires`/`:actionRequires` onto event-node `:data` and `:entryRequires`/`:exitRequires` onto state-node `:data` (camelCase so the JS-interop renderer reads them after xyflow `clj->js`-es the map).
- **Renderers** (`event-node`, `nodes/action-row`) paint a quiet `needs <id>` chip / line + expose `data-guard-requires` / `data-action-requires` / `data-entry-requires` / `data-exit-requires` DOM pins. Undeclared callbacks stay visually unchanged.
- **Share/export** — share URLs already **preserve** the safe requires metadata (`sanitise-definition` drops `:fn`/`:source-*` but keeps the requires vector); locked by a round-trip test. AI-generate is lossless by construction. **Mermaid + SCXML intentionally omit** it (no format slot; the MachineChart is the EP-0017 "which facts" surface) — documented in both namespace docstrings + `API.md`, and test-locked with a no-`:rf.world/inputs`/`inject-cofx` negative regression.

### rf2-s0bjc5 — implementation/machines comment cleanup
Replaced stale pre-EP-0018 `event-fx`/`event-db` vocabulary and the old `{:db new-db}` return-shape prose with `reg-event` / `{:rf.db/runtime ...}` language matching the landed EP-0018 one-event surface. Comment/docstring-only — no behaviour change. The acceptance grep is clean except two intentional references documenting the *retired* split.

## Tests
- New focused tests: layout-level (guard/action edge requires, entry/exit node requires, fact-free no-op, ids-only, parallel machine-scoped resolution), projection-level (event-node + state-node `:data`), share round-trip preservation, Mermaid + SCXML intentional-omission regressions.
- machines-viz JVM: **545 tests / 1898 assertions, 0 failures**.
- machines JVM (s0bjc5): **754 tests, 0 failures**.
- CLJS node integration: **7727 tests, 0 failures**.
- `machines-viz-viewer` browser build compiles clean (0 warnings).