### PR TITLE
fix(core): EP-0018 ctx-shaped fixtures + :rf.world/inputs retirement (rf2-e4xvt0, rf2-rux58z)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1545,8 +1545,8 @@
 ;; on its own frame mid-drain runs INSIDE this binding, so the
 ;; `:halted-destroy` epoch record's `:committed-at` is the DESTROYING
 ;; event's causal time — replayable — rather than an ambient host-clock
-;; read at assembly time (per EP-0010 §Time / Spec 002 §The World-Input
-;; Rule). nil outside a drain — the moot out-of-cascade destroy commits no
+;; read at assembly time (per EP-0010 §Time / Spec 002 §Recordable
+;; coeffects). nil outside a drain — the moot out-of-cascade destroy commits no
 ;; record, so the epoch surface's nil-tolerant fallback applies.
 (def ^:dynamic *cascade-time-ms* nil)
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -80,10 +80,11 @@
 ;;
 ;; The CAUSAL BOUNDARY: `build-envelope` ensures every dispatch carries an
 ;; `:rf.cofx` map bearing `:rf/time-ms` — the one host-clock read whose value
-;; durable writes may fold (Spec 002 §The World-Input Rule, EP-0010). EP-0017
-;; (slice-A.2) renames the envelope field from `:rf.world/inputs` to the flat
-;; `:rf.cofx` map (one fact per owner-qualified key, no grouping sub-maps) and
-;; the framework time fact from the nested `:time-ms` to the flat `:rf/time-ms`.
+;; durable writes may fold (Spec 002 §Recordable coeffects, EP-0010). EP-0017
+;; (slice-A.2) RETIRED the EP-0010 envelope field `:rf.world/inputs`, renaming
+;; it to the flat `:rf.cofx` map (one fact per owner-qualified key, no grouping
+;; sub-maps) and the framework time fact from the nested `:time-ms` to the flat
+;; `:rf/time-ms`.
 ;; This is the ONLY place the clock is read for the causal token; it is NOT
 ;; re-read inside the handler, flow transform, resource reducer, work-ledger
 ;; writer, or commit.
@@ -183,7 +184,7 @@
                         the closed-enum trigger-kind / functional-origin
                         axis.
     :rf.cofx            EP-0017 recordable-coeffect map (flat, one fact per
-                        owner-qualified key; Spec 002 §The World-Input Rule).
+                        owner-qualified key; Spec 002 §Recordable coeffects).
                         The router ensures it exists and carries `:rf/time-ms`
                         (epoch-ms wall clock) stamped from
                         `interop/epoch-now-ms` HERE — the causal boundary —
@@ -232,7 +233,7 @@
         ;; EP-0010 (rf2-47lgee / rf2-nftz2s): VALIDATE a caller-supplied
         ;; `:rf.cofx` at the PUBLIC dispatch boundary BEFORE the clock
         ;; stamp below — a supplied value must be nil-or-map and a supplied
-        ;; `:rf/time-ms` must be an integer (Spec 002 §The World-Input Rule +
+        ;; `:rf/time-ms` must be an integer (Spec 002 §Recordable coeffects +
         ;; Spec-Schemas.md §:rf.cofx). A malformed causal token is not
         ;; a harmless typo: it folds straight into durable writes (the epoch
         ;; record's `:committed-at`, resource `:settled-at`) and breaks the
@@ -2330,11 +2331,13 @@
       registrar for the WHOLE cascade WHEN the frame belongs to a
       non-default realm (EP-0013 staging step 4, rf2-a15n62). This is
       the realm-routed resolution seam: the event-handler lookup
-      (`resolve-handler`), every cofx injection (`inject-cofx` runs as
-      an interceptor `:before` inside `run-handler-cascade!`), and the
-      whole fx walk (`do-fx` runs post-commit inside this same call) all
-      resolve through `registrar/active-registrar`, so binding once here
-      routes event + cofx + fx coherently to the realm that OWNS the
+      (`resolve-handler`), every declared coeffect's supplier /
+      generator lookup (`:rf.cofx/requires` delivery runs at context
+      assembly via `re-frame.cofx/deliver-declared-cofx`, BEFORE the
+      interceptor chain — EP-0017 retired the `inject-cofx` interceptor),
+      and the whole fx walk (`do-fx` runs post-commit inside this same
+      call) all resolve through `registrar/active-registrar`, so binding
+      once here routes event + cofx + fx coherently to the realm that OWNS the
       frame (ALL-OR-NOTHING — routing only some would be an incoherent
       half-dispatch where a realm-local handler's effects resolve in the
       default registrar). The realm is DERIVED from the carried frame
@@ -2436,7 +2439,7 @@
         ;; envelope at the causal boundary). Threaded into the synthesised
         ;; `:halted-depth` record's `:committed-at` so even this never-ran
         ;; marker carries a replayable causal time per EP-0010 §Time / Spec
-        ;; 002 §The World-Input Rule, not an ambient assembly-time read. nil
+        ;; 002 §Recordable coeffects, not an ambient assembly-time read. nil
         ;; only on the defensive empty-queue fallback (no envelope to read);
         ;; the epoch surface tolerates a nil `:committed-at` there.
         halting-time-ms (-> halting-envelope :rf.cofx :rf/time-ms)
@@ -2495,8 +2498,8 @@
   rf2-bh56rc: `committed-at` is the settling event's causal `:rf/time-ms` (its
   envelope's `:rf.cofx` `:rf/time-ms`, stamped at the causal boundary).
   Threaded into the epoch record's `:committed-at` so the durable
-  causal-time fact is replayable per EP-0010 §Time / Spec 002 §The
-  World-Input Rule, not an ambient assembly-time host-clock read."
+  causal-time fact is replayable per EP-0010 §Time / Spec 002 §Recordable
+  coeffects, not an ambient assembly-time host-clock read."
   [frame-id frame-state-before frame-state-after committed-at]
   (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
     (settle! frame-id frame-state-before frame-state-after committed-at)))
@@ -2658,8 +2661,8 @@
               ;; rf2-bh56rc: this event's causal `:rf/time-ms` — the
               ;; `:rf.cofx` `:rf/time-ms` stamped on the envelope at the
               ;; causal boundary (`build-envelope`). Threaded into the epoch
-              ;; record's `:committed-at` (per EP-0010 §Time / Spec 002 §The
-              ;; World-Input Rule) so the durable causal-time fact is
+              ;; record's `:committed-at` (per EP-0010 §Time / Spec 002
+              ;; §Recordable coeffects) so the durable causal-time fact is
               ;; replayable rather than an ambient assembly-time clock read.
               time-ms   (-> envelope :rf.cofx :rf/time-ms)]
           ;; Per rf2-9neiq: expose this event's pre-cascade frame-state to a

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -305,7 +305,7 @@
 
   EP-0017 makes `:rf.cofx` the durable causal token (the flat
   recordable-coeffect map): its `:rf/time-ms` is the one host-clock fact
-  durable writes fold (Spec 002 §The World-Input Rule), and replay / restore
+  durable writes fold (Spec 002 §Recordable coeffects), and replay / restore
   / SSR-hydration feed it verbatim. So a malformed token is not a harmless
   typo — a non-map supplied value, or a non-integer `:rf/time-ms`, propagates
   straight into durable-write code (the epoch record's `:committed-at`,
@@ -345,8 +345,8 @@
   Checked at the causal boundary in `re-frame.router/build-envelope` BEFORE
   `ensure-cofx` stamps `:rf/time-ms`, so an invalid token fails fast WITHOUT
   first reading the clock for a dispatch that cannot proceed (the same
-  fail-before-clock-read ordering as the retirement check). Per Spec 002 §The
-  World-Input Rule + EP-0010 §Time + EP-0017 §The envelope field."
+  fail-before-clock-read ordering as the retirement check). Per Spec 002
+  §Recordable coeffects + EP-0010 §Time + EP-0017 §The envelope field."
   [opts event]
   (when (contains? opts :rf.cofx)
     (let [supplied (:rf.cofx opts)]
@@ -354,8 +354,8 @@
         (error/throw-error!
           :rf.error/invalid-cofx 're-frame.router/build-envelope
           (str ":rf.cofx must be nil or a MAP "
-               "of recordable coeffect facts (Spec 002 §The "
-               "World-Input Rule), got "
+               "of recordable coeffect facts (Spec 002 "
+               "§Recordable coeffects), got "
                (pr-str supplied)
                ". The map's `:rf/time-ms` (wall-clock "
                "epoch ms) is the durable causal token "

--- a/implementation/core/test/re_frame/app_value_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_cljs_test.cljc
@@ -120,7 +120,7 @@
   (testing "fx and cofx registrations project to descriptors with their
             handlers lifted"
     (rf/reg-fx :av/send {:doc "send"} (fn [_] nil))
-    (rf/reg-cofx :av/now {:doc "now"} (fn [cofx] (assoc cofx :now 42)))
+    (rf/reg-cofx :av/now {:doc "now"} (fn [] 42))
     (let [v (av/app-value)]
       (is (fn? (get-in v [:registrations :fx :av/send :handler]))
           "the fx handler is lifted")

--- a/implementation/core/test/re_frame/cofx_envelope_test.clj
+++ b/implementation/core/test/re_frame/cofx_envelope_test.clj
@@ -1,9 +1,9 @@
-(ns re-frame.world-inputs-test
-  "EP-0010 §Causal World Inputs core slice (rf2-s9ss0t).
+(ns re-frame.cofx-envelope-test
+  "EP-0017 `:rf.cofx` recordable-coeffect envelope core slice (rf2-s9ss0t).
 
   Pins the `:rf.cofx` envelope + coeffect contract that makes the
   frame fold deterministic with respect to prior frame-state plus the
-  causal token (Spec 002 §The World-Input Rule):
+  causal token (Spec 002 §Recordable coeffects):
 
     - the router STAMPS `:rf.cofx {:rf/time-ms ...}` when the caller
       omits it (Spec 002 §Dispatch Envelope Stamping);
@@ -19,6 +19,11 @@
       other framework defaults (`fx/framework-coeffect-keys`);
     - `:dispatched-at` is RETIRED in the same change (rider b) — its
       diagnostic dispatch-time need is the trace event `:time` stamp.
+
+  EP-0017 renamed the EP-0010 envelope field `:rf.world/inputs` to the flat
+  `:rf.cofx` map (no alias); this namespace pins the live `:rf.cofx` contract.
+  The retired-key hard-error coverage lives in `re-frame.cofx-cljs-test` and
+  `re-frame.event-model-conformance-cljs-test`.
 
   JVM-only — the stamping path is platform-agnostic (`interop/now-ms`
   realises on both hosts); no CLJS host dependency under test."
@@ -134,7 +139,7 @@
 ;; core boundary that protects ordinary public dispatch.
 ;; ===========================================================================
 
-(deftest non-map-world-inputs-is-a-hard-error
+(deftest non-map-cofx-is-a-hard-error
   (testing "a supplied non-map :rf.cofx is a hard error (not silently stamped)"
     (rf/reg-frame :wi/bad-shape {:doc "ctx"})
     (testing "build-envelope throws even with the dev gate OFF (prod-survivable)"
@@ -190,7 +195,7 @@
         (is (re-find #"INTEGER" (:reason data))
             "the message states the integer/epoch-ms contract")))))
 
-(deftest valid-world-inputs-shapes-pass
+(deftest valid-cofx-shapes-pass
   (testing "the valid shapes the validator must NOT reject"
     (rf/reg-frame :wi/valid {:doc "ctx"})
     (testing "nil :rf.cofx passes (the router stamps a fresh map)"
@@ -355,14 +360,14 @@
                                             :rf.cofx "not-a-map"}))
           "both the map-shape guard and the structural slice-A guard are always-on"))))
 
-(deftest invalid-world-inputs-rejected-before-clock-read
-  ;; Mirrors retired-dispatched-at-rejected-before-world-input-clock-read: the
-  ;; validation runs BEFORE the world-input clock stamp, so an invalid token
+(deftest invalid-cofx-rejected-before-clock-read
+  ;; Mirrors retired-dispatched-at-rejected-before-causal-clock-read: the
+  ;; validation runs BEFORE the causal-token clock stamp, so an invalid token
   ;; fails fast WITHOUT triggering the always-on epoch-now-ms read for a
   ;; dispatch that cannot proceed. Redefine epoch-now-ms to throw a distinct
   ;; marker; if the clock is read before validation, that marker surfaces.
   (testing "a malformed :rf.cofx throws the validation error WITHOUT
-            reading the world-input clock first"
+            reading the causal-token clock first"
     (rf/reg-frame :wi/order2 {:doc "ctx"})
     (with-redefs [interop/epoch-now-ms
                   (fn [] (throw (ex-info "clock read before validation"
@@ -375,11 +380,11 @@
             data (ex-data ex)]
         (is (some? ex) "an exception was thrown")
         (is (not (::clock-read data))
-            "the world-input clock was NOT read before validation — failed fast")
+            "the causal-token clock was NOT read before validation — failed fast")
         (is (= :rf.error/invalid-cofx (:rf.error/id data))
             "the surfaced error is the validation error, proving it ran first")))))
 
-(deftest invalid-world-inputs-raised-through-full-dispatch
+(deftest invalid-cofx-raised-through-full-dispatch
   (testing "the full dispatch path (not just build-envelope) raises the validation error"
     (rf/reg-frame :wi/dispatch-bad {:doc "ctx"})
     (rf/reg-event :wi/bad-noop (fn [{:keys [db]} _] {:db db}))
@@ -390,7 +395,7 @@
         "dispatch-sync surfaces the malformed-token error synchronously")))
 
 ;; ===========================================================================
-;; Child dispatch gets its OWN world-input map (no :rf/time-ms inheritance)
+;; Child dispatch gets its OWN :rf.cofx map (no :rf/time-ms inheritance)
 ;; ===========================================================================
 
 (deftest child-dispatch-gets-fresh-time-ms
@@ -399,7 +404,7 @@
     (let [envelopes (atom [])]
       ;; A user fx-handler receives the parent dispatch envelope under
       ;; (:envelope m); each handler in the cascade fires its own capture,
-      ;; so we read both the parent's and child's stamped world map.
+      ;; so we read both the parent's and child's stamped :rf.cofx map.
       (rf/reg-fx :wi/capture-env
         (fn [m _args] (swap! envelopes conj (:envelope m))))
       (rf/reg-event :wi/parent
@@ -426,7 +431,7 @@
             "child did NOT inherit the parent's :rf/time-ms — distinct causal token (EP-0010)")))))
 
 ;; ===========================================================================
-;; rf2-irbjjq: a :dispatch-later child gets FRESH world-inputs stamped at
+;; rf2-irbjjq: a :dispatch-later child gets a FRESH :rf.cofx map stamped at
 ;; FIRE time (the causal boundary is when the deferred dispatch RUNS, not when
 ;; it was enqueued) — :rf/time-ms is NOT the parent's, NOT the enqueue-time clock,
 ;; while the inherited envelope fields (:frame / :trace-id / :origin) still
@@ -442,7 +447,7 @@
 ;; settled. `:rf.cofx` is deliberately ABSENT from
 ;; `re-frame.fx/inheritable-envelope-keys`, so the deferred child is stamped
 ;; a fresh `:rf/time-ms` at fire from `interop/epoch-now-ms` rather than copying
-;; the parent's — the mechanism the existing world-input tests pin only for
+;; the parent's — the mechanism the existing :rf.cofx tests pin only for
 ;; the synchronous case.
 ;;
 ;; We make the wall clock ADVANCE between enqueue and fire (a mutable clock
@@ -453,8 +458,8 @@
 ;; :rf.cofx to the inheritable set, fails loudly here.
 ;; ===========================================================================
 
-(deftest dispatch-later-child-gets-fresh-world-inputs-stamped-at-fire-time
-  (testing "a :fx [[:dispatch-later …]] child is stamped FRESH world-inputs at
+(deftest dispatch-later-child-gets-fresh-cofx-stamped-at-fire-time
+  (testing "a :fx [[:dispatch-later …]] child is stamped a FRESH :rf.cofx at
             FIRE time — :rf/time-ms is the fire-time clock, NOT the parent token,
             NOT the enqueue-time clock; inherited fields still propagate"
     (rf/reg-frame :wi/later {:doc "ctx"})
@@ -467,7 +472,7 @@
           captured-child (atom nil)]
       ;; The deferred child reads its own envelope off the fx-handler ctx
       ;; (:envelope m) — the same surface child-dispatch-gets-fresh-time-ms
-      ;; uses — so we observe the world-inputs map the router stamped for it.
+      ;; uses — so we observe the :rf.cofx map the router stamped for it.
       (rf/reg-fx :wi.later/capture-env
         (fn [m _args] (reset! captured-child (:envelope m))))
       (rf/reg-event :wi.later/parent
@@ -540,7 +545,7 @@
 ;; Coeffect visibility + trace projection filtering
 ;; ===========================================================================
 
-(deftest world-inputs-visible-as-coeffect
+(deftest cofx-visible-as-coeffect
   (testing "handlers read :rf.cofx from the coeffect map"
     (rf/reg-frame :wi/cofx {:doc "ctx"})
     (let [cofx (capture-coeffects :wi/cofx
@@ -550,7 +555,7 @@
       (is (= 1781078400456 (get-in cofx [:rf.cofx :rf/time-ms]))
           "the supplied :rf/time-ms is what the handler reads"))))
 
-(deftest world-inputs-filtered-from-user-cofx-projection
+(deftest cofx-filtered-from-user-cofx-projection
   (testing "fx/user-injected-coeffects strips :rf.cofx like the other framework defaults"
     (is (contains? fx/framework-coeffect-keys :rf.cofx)
         ":rf.cofx is in the framework-coeffect-keys filter set")
@@ -615,17 +620,17 @@
                                       :dispatched-at 123}))
           "dispatch-sync surfaces the retirement hard error synchronously"))))
 
-(deftest retired-dispatched-at-rejected-before-world-input-clock-read
+(deftest retired-dispatched-at-rejected-before-causal-clock-read
   ;; rf2-s2mizv finding #3: the retired-opt validation runs BEFORE the
-  ;; world-input clock stamp, so an invalid dispatch fails fast WITHOUT first
-  ;; triggering the always-on `epoch-now-ms` read + world-input map allocation.
+  ;; causal-token clock stamp, so an invalid dispatch fails fast WITHOUT first
+  ;; triggering the always-on `epoch-now-ms` read + :rf.cofx map allocation.
   ;; Pre-fix, `build-envelope` stamped `:rf.cofx {:rf/time-ms …}` and only
   ;; THEN rejected `:dispatched-at` — wasting a clock read on a dispatch that
   ;; cannot proceed. We assert ordering by redefining `epoch-now-ms` to throw a
   ;; DISTINCT marker: if the clock is read before the retirement check, that
   ;; marker surfaces instead of the retirement error.
   (testing "supplying :dispatched-at throws the retirement error WITHOUT reading
-            the world-input clock first"
+            the causal-token clock first"
     (rf/reg-frame :wi/order {:doc "ctx"})
     (with-redefs [interop/epoch-now-ms
                   (fn [] (throw (ex-info "clock read before retirement check"
@@ -637,7 +642,7 @@
             data (ex-data ex)]
         (is (some? ex) "an exception was thrown")
         (is (not (::clock-read data))
-            "the world-input clock was NOT read before the retirement check —
+            "the causal-token clock was NOT read before the retirement check —
              the dispatch failed fast on the retired opt")
         (is (= :rf.error/dispatched-at-retired (:rf.error/id data))
             "the surfaced error is the retirement hard error, proving the
@@ -666,7 +671,7 @@
             and the supplied values land in app-db EXACTLY as supplied"
     (rf/reg-frame :wi/todos {:doc "ctx"})
     ;; The durable handler: reads the causal token's scripted id + colour from
-    ;; the world-input coeffect (NOT an ambient `random-uuid` / `rand-nth`) and
+    ;; the :rf.cofx coeffect (NOT an ambient `random-uuid` / `rand-nth`) and
     ;; folds them into a durable app-db entity. A `reg-event` handler so we can
     ;; read the `:rf.cofx` framework coeffect off the cofx map.
     (rf/reg-event :todo/create
@@ -690,7 +695,7 @@
         (is (= color (:todo/color entity))
             "the durable :todo/color equals the supplied :random value exactly")
         (is (= "buy milk" (:todo/text entity))
-            "the event arg rides through alongside the world-input ids")))))
+            "the event arg rides through alongside the :rf.cofx ids")))))
 
 (deftest supplied-uuid-replay-stable-where-ambient-would-diverge
   (testing "re-running the SAME causal token reproduces the SAME durable id

--- a/implementation/core/test/re_frame/cofx_router_stamp_clock_cljs_test.cljs
+++ b/implementation/core/test/re_frame/cofx_router_stamp_clock_cljs_test.cljs
@@ -1,9 +1,9 @@
-(ns re-frame.world-inputs-router-stamp-clock-cljs-test
+(ns re-frame.cofx-router-stamp-clock-cljs-test
   "rf2-qz0uog (EP-0010 §Dispatch Envelope Stamping) — CLJS LIVE-path
   regression for the router's `:rf.cofx` `:rf/time-ms` stamp.
 
-  WHY A NEW CLJS SUITE. The existing core world-input tests
-  (`re-frame.world-inputs-test`) are JVM-ONLY and assert only that an
+  WHY A NEW CLJS SUITE. The existing core `:rf.cofx` envelope tests
+  (`re-frame.cofx-envelope-test`) are JVM-ONLY and assert only that an
   omitted `:time-ms` is stamped to a NUMBER. On the JVM `interop/now-ms`
   (elapsed) and `interop/epoch-now-ms` (wall-clock) are BOTH
   `System.currentTimeMillis`-ish, so a regression swapping the router's
@@ -77,14 +77,14 @@
         ;; intentionally UNSCRIPTED — no :rf.cofx opt — so the router's
         ;; build-envelope performs the live host-clock read under test.
         (rf/dispatch-sync [:wi.clk/capture] {:frame :wi.clk/cofx})
-        (let [after   (js/Date.now)
-              cofx    @captured
-              world   (:rf.cofx cofx)
-              time-ms (:rf/time-ms world)]
+        (let [after    (js/Date.now)
+              cofx     @captured
+              rf-cofx  (:rf.cofx cofx)
+              time-ms  (:rf/time-ms rf-cofx)]
           (is (some? cofx) "the handler ran and captured its coeffects")
           (is (contains? cofx :rf.cofx)
               ":rf.cofx is a framework coeffect on the handler ctx")
-          (is (map? world) ":rf.cofx is a map")
+          (is (map? rf-cofx) ":rf.cofx is a map")
           (is (number? time-ms) ":rf/time-ms is a stamped number")
           ;; The CLASS assertion: wall-clock epoch ms, not a perf origin time.
           ;; Pre-swap ~1.78e12; a now-ms swap lands ~1e4 (performance.now) on
@@ -105,7 +105,7 @@
 
 (deftest router-stamps-omitted-time-ms-as-wall-clock-epoch-on-the-dispatched-trace
   (testing "rf2-qz0uog — the SAME omitted-time-ms stamp rides the
-            :rf.event/dispatched trace (the Xray Event-lens WORLD INPUTS
+            :rf.event/dispatched trace (the Xray Event-lens :rf.cofx
             surface, rf2-jt854w): the trace-side :rf.cofx :time-ms is
             ALSO a wall-clock epoch ms (> 1e12), not a perf-clock value. Covers
             the router envelope-stamp path as seen by the trace stream, not
@@ -123,10 +123,10 @@
                              first)
               ;; the op-type-specific payload slots ride under :tags;
               ;; build-event hoists only :source to top-level (rf2-jt854w).
-              world     (get-in enqueue [:tags :rf.cofx])
-              time-ms   (:rf/time-ms world)]
+              rf-cofx   (get-in enqueue [:tags :rf.cofx])
+              time-ms   (:rf/time-ms rf-cofx)]
           (is (some? enqueue) ":rf.event/dispatched fired")
-          (is (map? world)
+          (is (map? rf-cofx)
               ":rf.cofx rides the dispatched trace under :tags")
           (is (number? time-ms) "the trace-side :rf/time-ms is a stamped number")
           (is (> time-ms wall-clock-floor)

--- a/implementation/core/test/re_frame/dispatched_trace_cofx_test.clj
+++ b/implementation/core/test/re_frame/dispatched_trace_cofx_test.clj
@@ -1,8 +1,9 @@
-(ns re-frame.dispatched-trace-world-inputs-test
+(ns re-frame.dispatched-trace-cofx-test
   "Per rf2-jt854w (EP-0010 observability completion) — the
   `:rf.event/dispatched` enqueue trace carries the envelope's causal
-  `:rf.cofx` map so Xray's Event lens (rf2-9fyn40, the WORLD INPUTS
-  surface) has data to render.
+  `:rf.cofx` map so Xray's Event lens (rf2-9fyn40, the RECORDABLE
+  COEFFECTS surface — renamed from WORLD INPUTS by EP-0017 §9) has data
+  to render.
 
   Before this, `emit-dispatched-trace!` stamped
   `:rf.event/v` / `:frame` / `:rf.event/origin` / `:source` / `:rf.event/sync?`
@@ -19,7 +20,7 @@
   prod-elision probe (`npm run test:elision`): the whole `:rf.event/dispatched`
   emit DCE's under `:advanced` + `goog.DEBUG=false` (the `event/dispatched`
   op keyword is a `check-elision.cjs` dev-only sentinel), so the dev arm —
-  including the world-inputs stamp — rides that same whole-body elision. This
+  including the `:rf.cofx` stamp — rides that same whole-body elision. This
   JVM test pins the DEV-SIDE PRESENCE contract (`interop/debug-enabled?` is
   true by default on the JVM).
 
@@ -63,7 +64,7 @@
 
 ;; ---- the dispatched trace carries :rf.cofx ------------------------
 
-(deftest dispatched-trace-carries-world-inputs-with-time-ms
+(deftest dispatched-trace-carries-cofx-with-time-ms
   (testing ":rf.event/dispatched carries the envelope's :rf.cofx map,
    and that map carries the framework-stamped causal :time-ms"
     (rf/reg-event :rf2-jt854w/noop (fn [{:keys [db]} _] {:db db}))
@@ -73,17 +74,17 @@
           ;; The op-type-specific payload slots (`:rf.event/v`,
           ;; `:rf.event/origin`, `:rf.cofx`, ...) ride under
           ;; `:tags`; `build-event` hoists only `:source` to top-level.
-          wi         (get-in enqueue [:tags :rf.cofx])]
+          rf-cofx    (get-in enqueue [:tags :rf.cofx])]
       (is (some? enqueue) ":rf.event/dispatched fired")
       (is (contains? (:tags enqueue) :rf.cofx)
           ":rf.cofx is stamped on the dispatched trace (rf2-jt854w)")
-      (is (map? wi) ":rf.cofx is a map")
-      (is (contains? wi :rf/time-ms)
+      (is (map? rf-cofx) ":rf.cofx is a map")
+      (is (contains? rf-cofx :rf/time-ms)
           "the recordable-coeffect map carries the framework-stamped :rf/time-ms")
-      (is (integer? (:rf/time-ms wi))
+      (is (integer? (:rf/time-ms rf-cofx))
           ":rf/time-ms is an epoch-ms integer"))))
 
-(deftest dispatched-trace-preserves-caller-supplied-world-inputs
+(deftest dispatched-trace-preserves-caller-supplied-cofx
   (testing "a caller-supplied :rf.cofx (test/replay/SSR fixture) rides
    onto the dispatched trace verbatim — additional owner-qualified facts
    are preserved alongside the framework-required :rf/time-ms"
@@ -98,7 +99,7 @@
           [enqueue]  (dispatched-of evs)]
       (is (some? enqueue) ":rf.event/dispatched fired")
       (is (= scripted (get-in enqueue [:tags :rf.cofx]))
-          "the caller-supplied causal world-input map is stamped verbatim"))))
+          "the caller-supplied causal :rf.cofx map is stamped verbatim"))))
 
 (deftest dispatched-trace-fills-missing-time-ms-from-supplied-map
   (testing "a caller-supplied map WITHOUT :rf/time-ms has it filled by the router;
@@ -109,17 +110,17 @@
                          (rf/dispatch-sync [:rf2-jt854w/fill]
                                            {:rf.cofx {:todo/score 0.99}})))
           [enqueue]  (dispatched-of evs)
-          wi         (get-in enqueue [:tags :rf.cofx])]
+          rf-cofx    (get-in enqueue [:tags :rf.cofx])]
       (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (= 0.99 (:todo/score wi)) "caller-supplied fact preserved")
-      (is (integer? (:rf/time-ms wi))
+      (is (= 0.99 (:todo/score rf-cofx)) "caller-supplied fact preserved")
+      (is (integer? (:rf/time-ms rf-cofx))
           ":rf/time-ms filled by the router at the causal boundary"))))
 
-(deftest world-inputs-rides-under-tags-alongside-event-payload-slots
+(deftest cofx-rides-under-tags-alongside-event-payload-slots
   (testing ":rf.cofx rides under :tags alongside the other op-type-
    specific payload slots (:rf.event/v, :rf.event/origin, :rf.event/sync?) —
    build-event hoists only :source to top-level, so the Event lens reads the
-   world-input map off (get-in event [:tags :rf.cofx])"
+   :rf.cofx map off (get-in event [:tags :rf.cofx])"
     (rf/reg-event :rf2-jt854w/placement (fn [{:keys [db]} _] {:db db}))
     (let [evs       (record-traces
                       (fn [] (rf/dispatch-sync [:rf2-jt854w/placement])))

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -360,7 +360,7 @@
     (rf/reg-event :test.6z20/ev (fn [{:keys [db]} _] {:db db}))
     (rf/reg-sub :test.6z20/sub (fn [_ _] :stub))
     (rf/reg-fx :test.6z20/fx (fn [_ _] nil))
-    (rf/reg-cofx :test.6z20/cofx (fn [ctx] ctx))
+    (rf/reg-cofx :test.6z20/cofx (fn [] :stub))
     (rf/clear-event)
     (is (nil? (registrar/lookup :event :test.6z20/ev))
         ":event was cleared")

--- a/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
@@ -38,7 +38,7 @@
      `:rf.cofx/mint-policy :strict` (which re-feeds the recorded value
      verbatim and never re-mints) and asserts the durable id is the token's
      id on BOTH runs (identical across runs). Mirrors
-     `world_inputs_test/supplied-uuid-replay-stable-where-ambient-would-diverge`,
+     `cofx_envelope_test/supplied-uuid-replay-stable-where-ambient-would-diverge`,
      but executed against the EXAMPLES' OWN handlers — so a drift back to a
      write-site `(random-uuid)` (the rf2-wbgb74 bug) fails loud here.
 

--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -22,8 +22,8 @@
 
 (def ^:private build-envelope
   "Pull the private envelope builder — the dispatch envelope is not
-  exposed to user handlers, so the EP-0010 world-input stamping
-  (rf2-s9ss0t) is asserted directly against `build-envelope`'s output."
+  exposed to user handlers, so the EP-0017 `:rf.cofx` recordable-coeffect
+  stamping (rf2-s9ss0t) is asserted directly against `build-envelope`'s output."
   #'router/build-envelope)
 
 (use-fixtures :each
@@ -79,7 +79,7 @@
             "event-emit substrate fired under disabled debug gate
              — always-on means always-on")))))
 
-(deftest dispatched-at-retired-world-inputs-stamped-regardless-of-gate
+(deftest dispatched-at-retired-cofx-stamped-regardless-of-gate
   (testing "Per EP-0010 rider b (rf2-s9ss0t): `:dispatched-at` is RETIRED
             in the same change that lands the envelope stamp — no
             coexistence window. Its diagnostic dispatch-time need is the

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -181,7 +181,7 @@
           (rf/reg-event :k/event-doc-missing (fn [{:keys [db]} _] {:db db}))
           (rf/reg-sub       :k/sub-doc-missing   (fn [db _] (:x db)))
           (rf/reg-fx        :k/fx-doc-missing    (fn [_ _] nil))
-          (rf/reg-cofx      :k/cofx-doc-missing  (fn [cofx _] cofx))))
+          (rf/reg-cofx      :k/cofx-doc-missing  (fn [] :stub))))
       (let [warns (warnings-of recorded :rf.warning/missing-doc)
             kinds (into #{} (map #(get-in % [:tags :kind])) warns)]
         (is (= 4 (count warns))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -924,7 +924,7 @@
                (fn [_ _] nil))
 
     ;; ---- :cofx --------------------------------------------------------
-    (rf/reg-cofx :rf2-o1bp/cofx1 (fn [cofx _] cofx))
+    (rf/reg-cofx :rf2-o1bp/cofx1 (fn [] :stub))
 
     ;; ---- :view --------------------------------------------------------
     ;; reg-view* is the JVM-safe registration path. On CLJS it wraps the

--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -109,7 +109,7 @@
 
 (deftest reg-cofx-file-is-not-no-source-path
   (testing "rf2-mdjp: reg-cofx emits a real :file under CLJS"
-    (rf/reg-cofx :rf2-mdjp/reg-cofx-sample (fn [ctx] ctx))
+    (rf/reg-cofx :rf2-mdjp/reg-cofx-sample (fn [] :sample))
     (let [f (:file (rf/handler-meta :cofx :rf2-mdjp/reg-cofx-sample))]
       (is (not= "NO_SOURCE_PATH" f)))))
 

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -141,7 +141,7 @@
 (deftest source-coords-on-reg-cofx
   (testing "reg-cofx stamps :ns / :line / :file"
     (rf/reg-cofx :rf2-k84s/reg-cofx-sample
-                 (fn [ctx] ctx))
+                 (fn [] :sample))
     (assert-coords (rf/handler-meta :cofx :rf2-k84s/reg-cofx-sample)
                    :cofx :rf2-k84s/reg-cofx-sample)))
 


### PR DESCRIPTION
Two P2 EP-0017/EP-0018 review-finding cleanups on `implementation/core` (one surface, one worker).

## rf2-e4xvt0 — ctx-shaped reg-cofx fixtures → value suppliers
EP-0017 makes `reg-cofx` value-returning; six core test fixtures still registered suppliers in the retired ctx→ctx shape (`(fn [ctx] ctx)`, `(fn [cofx _] cofx)`, `(fn [cofx] (assoc cofx :now 42))`). These are metadata / source-coords / introspection / kind-coverage fixtures that never invoke the supplier, but preserved the retired shape. Converted each to a value-returning nullary supplier:

- `app_value_cljs_test.cljc` — `(fn [] 42)`
- `events_test.clj` — `(fn [] :stub)`
- `registrar_warnings_test.clj` — `(fn [] :stub)`
- `smoke_test.clj` — `(fn [] :stub)`
- `source_coords_cljs_test.cljs` — `(fn [] :sample)`
- `source_coords_test.clj` — `(fn [] :sample)`

## rf2-rux58z — `:rf.world/inputs` / world-inputs vocabulary retirement
EP-0017 renamed the EP-0010 envelope field `:rf.world/inputs` → flat `:rf.cofx` (no alias) and the Xray lens WORLD INPUTS → RECORDABLE COEFFECTS. Active core test namespaces, deftest names, docstrings, and source comments still framed **current** `:rf.cofx` behavior in the retired world-inputs vocabulary. Renamed to cofx / causal-token vocabulary:

- `world_inputs_test.clj` → `cofx_envelope_test.clj` (ns + deftests + comments)
- `world_inputs_router_stamp_clock_cljs_test.cljs` → `cofx_router_stamp_clock_cljs_test.cljs`
- `dispatched_trace_world_inputs_test.clj` → `dispatched_trace_cofx_test.clj`
- `jvm_prod_gate_integration_test.clj` deftest + docstring
- `example_frame_scoping_cljs_test.cljs` cross-ref to renamed ns
- `router.cljc` / `frame.cljc` / `router/diagnostics.cljc`: stale `Spec 002 §The World-Input Rule` citations retargeted to the current `Spec 002 §Recordable coeffects`; corrected the stale `inject-cofx runs as an interceptor` comment to the EP-0017 context-assembly delivery model.

`:rf.world/inputs` is kept ONLY in explicit retired-key hard-error / migration sites (`router/diagnostics.cljc` throw, `cofx_cljs_test`, `event_model_conformance`, `conformance_test` retirement notes).

## Gates
- core JVM tests: 1779 tests / 7731 assertions, 0 failures
- `npm run test:cljs`: 7716 tests / 31788 assertions, 0 failures
- `scripts/test-fast-pr.sh`: PASS
- No manifest / hot-zone spec touched (only source comments + test files), so `gen --check` not required.