### PR TITLE
fix(schemas): EP-0018 conformance + stale contracts + comments (rf2-dy5gp5, rf2-eare7o, rf2-uqh86d)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -252,7 +252,7 @@
     :description "Validate the app-db snapshot against the registered app-db schema."}
    {:key         :schemas/validate-cofx!
     :producer-ns 're-frame.schemas
-    :description "Validate a cofx map against the registered cofx schema."}
+    :description "DEMOTED (EP-0017): the dev-only injection-time cofx-validation hook. NOT the live runtime cofx schema-validation path — that is `re-frame.cofx/validate-recordable-value!` (`:rf.error/cofx-value-invalid`, a production hard error). No runtime consumer reaches this hook; it survives only for the elision probe / direct-call shape tests, pending the Spec 010 step-2 normative rewrite."}
    {:key         :schemas/validate-fx!
     :producer-ns 're-frame.schemas
     :design-bead "rf2-xp2o3"

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -191,9 +191,18 @@
 ;; validate-event! / validate-cofx! / validate-fx! / validate-sub! /
 ;; validate-app-schema!. The earlier validate-app-db! /
 ;; validate-sub-return! names were renamed for symmetry.
+;;
+;; `validate-cofx!` is DEMOTED (EP-0017): it is NOT the live runtime cofx
+;; schema-validation path. EP-0017 retired the ctx-mutating `inject-cofx`
+;; injection-time validation; the live cofx schema contract is
+;; `re-frame.cofx/validate-recordable-value!` (a production hard error →
+;; `:rf.error/cofx-value-invalid`), not the dev-only
+;; `:rf.error/schema-validation-failure :where :cofx` this fn emits. No runtime
+;; caller reaches `:schemas/validate-cofx!`; it survives for the elision probe
+;; / direct-call shape tests pending the Spec 010 step-2 normative rewrite.
 (def validate-app-schema! validate/validate-app-schema!)
 (def validate-event!      validate/validate-event!)
-(def validate-cofx!       validate/validate-cofx!)
+(def validate-cofx!       validate/validate-cofx!)   ;; DEMOTED — see note above
 (def validate-fx!         validate/validate-fx!)
 (def validate-sub!        validate/validate-sub!)
 
@@ -226,6 +235,10 @@
 ;; publication block (flows / machines / routing / http / ssr).
 
 ;; Validation hot-path hooks (consumed by router / cofx / subs / epoch).
+;; NB `:schemas/validate-cofx!` is DEMOTED (EP-0017) — no runtime consumer
+;; reaches it (the live cofx schema path is `re-frame.cofx/validate-recordable-
+;; value!` → `:rf.error/cofx-value-invalid`); the publication survives for the
+;; elision probe / direct-call shape tests pending the Spec 010 step-2 rewrite.
 (late-bind/set-fn! :schemas/validate-app-schema! validate-app-schema!)
 (late-bind/set-fn! :schemas/validate-event!      validate-event!)
 (late-bind/set-fn! :schemas/validate-sub!        validate-sub!)

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -1098,12 +1098,26 @@
      true)))
 
 (defn validate-cofx!
-  "Per Spec 010 §Validation order step 2 — after a cofx injects its
-  value into the merged context, validate that value against any
-  :schema on the cofx's metadata. Failures emit
-  `:rf.error/schema-validation-failure :where :cofx`; the caller
-  skips the handler (recovery: `:no-recovery`). Returns true/false
-  per the `run-validation` contract.
+  "DEMOTED (EP-0017): this is NOT the live runtime cofx schema-validation
+  contract. EP-0017 retired the ctx-mutating `inject-cofx` injection-time
+  validation; the live path is the recordable-value check in
+  `re-frame.cofx/validate-recordable-value!`, a PRODUCTION hard error that
+  emits `:rf.error/cofx-value-invalid` and THROWS (not the dev-only
+  `:rf.error/schema-validation-failure :where :cofx` trace this fn emits). No
+  runtime caller reaches the `:schemas/validate-cofx!` late-bind hook anymore;
+  the only callers are the elision probe and this artefact's direct-call shape
+  unit tests. The fn (and its hook publication) survive pending the Spec 010
+  §Validation order step-2 normative rewrite (tracked separately) — Spec 010
+  still documents step 2 as `:where :cofx`, so deleting the fn now would invert
+  the divergence. Once Spec 010 drops the injection-time step this fn and its
+  hook can be removed outright.
+
+  Historical contract (the shape the direct-call tests still pin): after a cofx
+  injected its value into the merged context, validate that value against any
+  `:schema` on the cofx's metadata; failures emit
+  `:rf.error/schema-validation-failure :where :cofx`; the caller skipped the
+  handler (recovery: `:no-recovery`). Returns true/false per the
+  `run-validation` contract.
 
   The optional 5-arity `frame` (rf2-9cm27) stamps a `:frame` tag onto
   the failure trace — the in-flight cascade's frame. Without it the

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -253,6 +253,24 @@
               nil
               steps))))
 
+(defn- normalize-event-handler
+  "Collapse the DSL `[body-shape handler]` pair `conformance/realise-event-
+  handler` returns into the single EP-0018 `reg-event` shape — a
+  `(cofx-in → effects-map-or-nil)` fn.
+
+  `body-shape` is a DSL-INTERNAL interpreter distinction, NOT a public
+  `:event/kind` (EP-0018 removed the public event sub-kind model: a registered
+  event is just kind `:event`). An `:event-db` body is `(fn [db event] new-db)`;
+  it is lifted to `(fn [cofx event] {:db (handler db event)})` — read db from
+  the coeffects, lower the returned db into a `{:db …}` effect (same observable
+  behaviour). An `:event-fx` body is already the single form and passes
+  through. Registering through this normaliser keeps the registration site free
+  of any kind branch."
+  [[body-shape handler]]
+  (case body-shape
+    :db (fn [{:keys [db]} event] {:db (handler db event)})
+    :fx handler))
+
 (defn- realise-handlers
   "Register every handler the fixture declares (events / subs / cofx /
   fx) and wire app-schemas. Mirrors core's realise-handlers for the
@@ -301,29 +319,33 @@
     ;; metadata key (the ctx→ctx `inject-cofx` interceptor wiring is retired).
     ;; The runtime delivers each declared recordable value flat under its
     ;; cofx-id and validates it against `:schema`.
+    ;; EP-0018 Slice Z: there is ONE public event registration form —
+    ;; `reg-event`, a `(cofx-in → effects-map-or-nil)` handler. There is no
+    ;; public event sub-kind axis. `conformance/realise-event-handler` returns a
+    ;; `[body-shape handler]` pair where `body-shape` is a DSL-INTERNAL
+    ;; interpreter distinction (does the body read cofx / emit fx → event-fx
+    ;; body-shape, else event-db body-shape) — NOT a public `:event/kind`.
+    ;; `normalize-event-handler` collapses both DSL body-shapes to the single
+    ;; effects-map handler so the registration site below never branches on a
+    ;; kind: an event-db body `(fn [db event] new-db)` is lifted to
+    ;; `(fn [cofx event] {:db …})` (read db from the coeffects, lower the
+    ;; returned db into a `{:db …}` effect — same observable behaviour); an
+    ;; event-fx body is already the single form and passes through.
     (doseq [[id steps] (:event hmap)]
-      (let [[kind handler] (conformance/realise-event-handler steps)
-            meta           (get event-meta id {})
-            ks             (collect-cofx-keys steps)
-            cofx-ids       (vec (mapcat (fn [k]
-                                          (or (get cofx-by-key k)
-                                              (when (contains? cofx-registry k) [k])))
-                                        ks))
-            meta'          (cond-> meta
-                             (seq cofx-ids)
-                             (assoc :rf.cofx/requires cofx-ids))]
-        (case kind
-          ;; EP-0018 Slice Z: one public `reg-event` (cofx-in, effects-map-out).
-          ;; A :db-kind fixture handler is `(fn [db event] new-db)`; adapt it to
-          ;; the single form by reading db from the coeffects and lowering the
-          ;; returned db into a `{:db …}` effect — same observable behaviour.
-          :db (let [h (fn [{:keys [db]} ev] {:db (handler db ev)})]
-                (if (seq meta')
-                  (rf/reg-event id meta' h)
-                  (rf/reg-event id h)))
-          :fx (if (seq meta')
-                (rf/reg-event id meta' handler)
-                (rf/reg-event id handler)))))
+      (let [handler  (normalize-event-handler
+                       (conformance/realise-event-handler steps))
+            meta     (get event-meta id {})
+            ks       (collect-cofx-keys steps)
+            cofx-ids (vec (mapcat (fn [k]
+                                    (or (get cofx-by-key k)
+                                        (when (contains? cofx-registry k) [k])))
+                                  ks))
+            meta'    (cond-> meta
+                       (seq cofx-ids)
+                       (assoc :rf.cofx/requires cofx-ids))]
+        (if (seq meta')
+          (rf/reg-event id meta' handler)
+          (rf/reg-event id handler))))
     ;; ---- subs ----------------------------------------------------------
     ;; Per Spec 010 §step 6 (rf2-wcam): sub meta carries :schema; the
     ;; runtime calls `:schemas/validate-sub!` after each compute.

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -98,29 +98,41 @@
         (is (= 0 @calls) "handler skipped")
         (is (= 1 (count (malformed-traces traces))) "one malformed-schema trace fired")))))
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation at injection time
-;; is retired with `inject-cofx` and deferred to slice B. `#_`-disabled until
-;; slice B wires recordable-value `:schema` validation.
-#_(deftest cofx-malformed-schema-fails-closed
-  (testing "rf2-a5kzs (finding 2) — a malformed cofx :schema does not run the
-            handler via throw-as-pass; the handler is skipped and a
-            malformed-schema trace fires."
+(defn- cofx-value-invalid-traces [traces]
+  (filter #(= :rf.error/cofx-value-invalid (:operation %)) traces))
+
+;; EP-0017 (replaces the disabled rf2-oa2dun inject-cofx test): the LIVE cofx
+;; schema path is the recordable-value check
+;; (`re-frame.cofx/validate-recordable-value!`), which also FAILS CLOSED on a
+;; malformed schema — the validator throw is caught as a plain `false`, so the
+;; path emits `:rf.error/cofx-value-invalid` and THROWS rather than coercing
+;; the throw to a pass. (Unlike the meta-bearing `run-validation` surfaces, the
+;; recordable path does not raise the distinct `:rf.error/malformed-schema`
+;; trace — it folds a malformed-schema throw into the same cofx-value-invalid
+;; hard error, since either way an out-of-contract value must not reach the
+;; durable ledger.)
+(deftest recordable-cofx-malformed-schema-fails-closed
+  (testing "EP-0017 / rf2-a5kzs (finding 2) — a malformed recordable-cofx
+            :schema does NOT run the handler via throw-as-pass; the validator
+            throw is caught as false, :rf.error/cofx-value-invalid fires, and
+            the handler is skipped (the recordable-value throw pre-empts it)."
     (rf/reg-cofx :cf/malformed
-      {:schema [:vector]}
-      (fn [ctx] (assoc-in ctx [:coeffects :cf/malformed] :whatever)))
+      {:recordable? true :provided? true
+       :schema [:vector]})                          ;; childless — Malli throws at validate-time
     (let [calls (atom 0)]
       (rf/reg-event :use/malformed-cofx
-        {:interceptors [(rf/inject-cofx :cf/malformed)]}
+        {:rf.cofx/requires [:cf/malformed]}
         (fn [_ _] (swap! calls inc) {}))
-      (let [traces (capture #(rf/dispatch-sync [:use/malformed-cofx]))]
-        (is (= 0 @calls) "handler skipped — cofx malformed-schema is no longer a silent pass")
-        (let [mal (malformed-traces traces)]
-          (is (= 1 (count mal)))
-          (is (= :cofx (-> (first mal) :tags :where)))
-          ;; rf2-mxs7a — cofx malformed-schema skips the handler
-          ;; (:no-recovery), matching the legitimate-failure path.
-          ;; `:recovery` hoists to the top-level envelope.
-          (is (= :no-recovery (:recovery (first mal)))))))))
+      (let [traces (capture
+                     #(try
+                        (rf/dispatch-sync [:use/malformed-cofx]
+                                          {:rf.cofx {:cf/malformed :whatever}})
+                        (catch clojure.lang.ExceptionInfo _)))]
+        (is (= 0 @calls)
+            "handler skipped — recordable-cofx malformed-schema fails closed")
+        (let [inv (cofx-value-invalid-traces traces)]
+          (is (= 1 (count inv)) "exactly one cofx-value-invalid trace fired")
+          (is (= :no-recovery (:recovery (first inv)))))))))
 
 (deftest fx-malformed-schema-fails-closed-skipping-only-offender
   (testing "rf2-a5kzs (finding 2) — a malformed fx :schema skips ONLY the

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -63,7 +63,7 @@
 
 (deftest event-malformed-schema-fails-closed
   (testing "rf2-a5kzs (finding 2) — a childless [:vector] :schema on a
-            reg-event-* handler does NOT throw-as-pass: the handler is
+            reg-event handler does NOT throw-as-pass: the handler is
             skipped and a :rf.error/malformed-schema trace fires."
     (let [calls (atom 0)]
       (rf/reg-event :ev/malformed
@@ -88,7 +88,7 @@
             (is (not (contains? (:tags m) :value)))))))))
 
 (deftest event-unknown-op-schema-fails-closed
-  (testing "rf2-a5kzs (finding 2) — an unknown-op :schema on a reg-event-*
+  (testing "rf2-a5kzs (finding 2) — an unknown-op :schema on a reg-event
             handler also fails closed with a distinct trace, no throw."
     (let [calls (atom 0)]
       (rf/reg-event :ev/unknown

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -933,60 +933,68 @@
 ;; above.) These tests assert the conforming sensitive sibling is ABSENT
 ;; from every egressed slot.
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation deferred to slice B (retired with inject-cofx).
-#_(deftest cofx-validation-conforming-sensitive-sibling-redacted-whole-value
-  (testing "rf2-3qam7b — a cofx schema with a CONFORMING sensitive sibling
-            (:token) AND a non-sensitive failing sibling (:count): every
-            value-bearing slot on this surface carries the WHOLE cofx value
-            (the conforming :token included), so the redaction scopes to the
-            ROOT check and the WHOLE value redacts. The conforming sensitive
-            sibling must be ABSENT from every egressed slot"
+;; EP-0017 (replaces the disabled rf2-oa2dun inject-cofx tests): the LIVE cofx
+;; `:schema` path is the recordable-value check
+;; (`re-frame.cofx/validate-recordable-value!` → `:rf.error/cofx-value-invalid`).
+;; It routes its off-box `:value` slot through the SAME shared
+;; `redact-validation-tags` seam (rf2-hdi6wr), so a `:sensitive?`-bearing
+;; recordable cofx schema redacts identically. The recordable path carries the
+;; WHOLE recordable value in `:value` (it is not narrowed), so a sensitive slot
+;; ANYWHERE in the schema redacts the whole value. (It does not carry a
+;; `:received` slot — only `:value`.)
+(deftest recordable-cofx-conforming-sensitive-sibling-redacted-whole-value
+  (testing "rf2-3qam7b (EP-0017 recordable path) — a recordable-cofx schema
+            with a CONFORMING sensitive sibling (:token) AND a non-sensitive
+            failing sibling (:count): the whole recordable value rides :value,
+            so a sensitive sibling redacts the WHOLE value. The conforming
+            sensitive sibling must be ABSENT from every egressed slot."
     (rf/reg-cofx :auth/ctx
-      {:schema [:map
+      {:recordable? true :provided? true
+       :schema [:map
                 [:token {:sensitive? true} :string]
-                [:count :int]]}
-      ;; :token "SECRET-COFX-tok" CONFORMS (sensitive sibling); :count fails
-      ;; (string, not int) — the failing slot is the NON-sensitive sibling.
-      (fn [ctx] (assoc-in ctx [:coeffects :auth/ctx]
-                          {:token "SECRET-COFX-tok" :count "not-an-int"})))
+                [:count :int]]})
     (rf/reg-event :auth/use-ctx
-      {:interceptors [(rf/inject-cofx :auth/ctx)]}
+      {:rf.cofx/requires [:auth/ctx]}
       (fn [_ _] {}))
     (let [traces (atom [])]
       (rf/register-listener! ::ctx (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:auth/use-ctx])
+      ;; :token "SECRET-COFX-tok" CONFORMS (sensitive sibling); :count fails
+      ;; (string, not int) — the failing slot is the NON-sensitive sibling.
+      (try
+        (rf/dispatch-sync [:auth/use-ctx]
+                          {:rf.cofx {:auth/ctx {:token "SECRET-COFX-tok"
+                                                :count "not-an-int"}}})
+        (catch clojure.lang.ExceptionInfo _))
       (rf/unregister-listener! ::ctx)
-      (let [v (first (filter #(and (= :rf.error/schema-validation-failure (:operation %))
-                                   (= :cofx (-> % :tags :where)))
+      (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
-        (is (some? v) "a cofx validation failure was traced")
+        (is (some? v) "a recordable-cofx validation failure was traced")
         (is (true? (:sensitive? v))
             ":sensitive? stamped — a whole-payload slot carries the conforming sensitive sibling")
         (is (= :rf/redacted (-> v :tags :value)) ":value (whole cofx) redacted")
-        (is (= :rf/redacted (-> v :tags :received)) ":received (whole cofx) redacted")
         (is (not (str/includes? (pr-str (:tags v)) "SECRET-COFX-tok"))
             "the conforming sensitive sibling :token is ABSENT from every egressed slot")))))
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation deferred to slice B (retired with inject-cofx).
-#_(deftest cofx-validation-sensitive-slot-failure-still-redacts
-  (testing "rf2-k0ew8n — the path-targeted check still REDACTS when the
-            FAILING slot itself is sensitive (no privacy regression)"
+(deftest recordable-cofx-sensitive-slot-failure-still-redacts
+  (testing "rf2-k0ew8n (EP-0017 recordable path) — redaction still fires when
+            the FAILING slot itself is sensitive (no privacy regression)"
     (rf/reg-cofx :auth/ctx2
-      {:schema [:map
+      {:recordable? true :provided? true
+       :schema [:map
                 [:token {:sensitive? true} :string]
-                [:count :int]]}
-      ;; :token fails (int, not string) — the FAILING slot IS sensitive.
-      (fn [ctx] (assoc-in ctx [:coeffects :auth/ctx2]
-                          {:token 1234 :count 3})))
+                [:count :int]]})
     (rf/reg-event :auth/use-ctx2
-      {:interceptors [(rf/inject-cofx :auth/ctx2)]}
+      {:rf.cofx/requires [:auth/ctx2]}
       (fn [_ _] {}))
     (let [traces (atom [])]
       (rf/register-listener! ::ctx2 (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:auth/use-ctx2])
+      ;; :token fails (int, not string) — the FAILING slot IS sensitive.
+      (try
+        (rf/dispatch-sync [:auth/use-ctx2]
+                          {:rf.cofx {:auth/ctx2 {:token 1234 :count 3}}})
+        (catch clojure.lang.ExceptionInfo _))
       (rf/unregister-listener! ::ctx2)
-      (let [v (first (filter #(and (= :rf.error/schema-validation-failure (:operation %))
-                                   (= :cofx (-> % :tags :where)))
+      (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v))
         (is (true? (:sensitive? v))
@@ -1216,54 +1224,63 @@
       (is (= tags out) "tags ride back unchanged — nothing sensitive to redact")
       (is (not (contains? out :sensitive?))))))
 
-;; ---- redaction at cofx validation site -----------------------------------
+;; ---- redaction at the recordable-cofx validation site --------------------
+;;
+;; EP-0017 replaced the injection-time cofx-validation site with the
+;; recordable-value path (`re-frame.cofx/validate-recordable-value!` →
+;; `:rf.error/cofx-value-invalid`). It routes its off-box `:value` slot through
+;; the SAME `redact-validation-tags` seam, so the schema-walker still drives
+;; redaction exclusively. The two tests below replace the disabled rf2-oa2dun
+;; `inject-cofx` tests for this surface.
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation deferred to slice B (retired with inject-cofx).
-#_(deftest cofx-validation-ignores-meta-sensitive
-  (testing "The handler-meta `:sensitive?` annotation has been removed.
-            Cofx-meta `:sensitive?` no longer triggers cofx-validation
-            redaction — the schema-walker now drives the decision
-            exclusively. With a plain `:string` spec (no per-slot
-            sensitive prop) the failure rides verbatim."
+(deftest recordable-cofx-ignores-meta-sensitive
+  (testing "The registration-meta `:sensitive?` annotation has been removed.
+            A bare `:sensitive?` on the cofx registration meta no longer
+            triggers redaction — the schema-walker drives the decision
+            exclusively. With a plain `:string` schema (no per-slot sensitive
+            prop) the recordable-value failure rides verbatim."
     (rf/reg-cofx :auth/credentials
-      {:doc "Inject the user's auth token"
+      {:doc "A recordable auth-token coeffect"
+       :recordable? true :provided? true
        :sensitive? true   ;; ignored — annotation removed
-       :schema :string}
-      (fn [ctx] (assoc-in ctx [:coeffects :auth/credentials] 42)))
+       :schema :string})
     (rf/reg-event :auth/use-creds
-      {:interceptors [(rf/inject-cofx :auth/credentials)]}
+      {:rf.cofx/requires [:auth/credentials]}
       (fn [_ _] {}))
     (let [traces (atom [])]
       (rf/register-listener! ::cf (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:auth/use-creds])
+      (try
+        (rf/dispatch-sync [:auth/use-creds]
+                          {:rf.cofx {:auth/credentials 42}})  ;; int, fails :string
+        (catch clojure.lang.ExceptionInfo _))
       (rf/unregister-listener! ::cf)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+      (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v))
         (is (not (true? (:sensitive? v)))
-            "no top-level :sensitive? stamp — schema has no per-slot :sensitive? prop")
+            "no :sensitive? stamp — schema has no per-slot :sensitive? prop")
         (is (= 42 (-> v :tags :value)))
-        (is (= 42 (-> v :tags :received)))
-        (is (= :cofx (-> v :tags :where))
-            "structural :where slot survives")
         (is (= :auth/credentials (-> v :tags :rf.cofx/id))
             "structural :rf.cofx/id survives")))))
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation deferred to slice B (retired with inject-cofx).
-#_(deftest cofx-validation-redacts-when-schema-container-sensitive
-  (testing "A container-level :sensitive? on the cofx :schema also triggers
-            redaction even when the cofx-meta doesn't carry the flag"
+(deftest recordable-cofx-redacts-when-schema-container-sensitive
+  (testing "A container-level :sensitive? on the recordable-cofx :schema also
+            triggers redaction even when the registration meta doesn't carry
+            the flag"
     (rf/reg-cofx :secret-blob
-      {:schema [:string {:sensitive? true}]}
-      (fn [ctx] (assoc-in ctx [:coeffects :secret-blob] 99))) ; int, fails :string
+      {:recordable? true :provided? true
+       :schema [:string {:sensitive? true}]})
     (rf/reg-event :use-secret
-      {:interceptors [(rf/inject-cofx :secret-blob)]}
+      {:rf.cofx/requires [:secret-blob]}
       (fn [_ _] {}))
     (let [traces (atom [])]
       (rf/register-listener! ::cb (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:use-secret])
+      (try
+        (rf/dispatch-sync [:use-secret]
+                          {:rf.cofx {:secret-blob 99}})  ;; int, fails :string
+        (catch clojure.lang.ExceptionInfo _))
       (rf/unregister-listener! ::cb)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+      (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
         (is (some? v))
         (is (true? (:sensitive? v))

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -369,77 +369,112 @@
         (is (= 1 (count violations))
             "exactly one trace from the malformed compute-sub call")))))
 
-;; ---- rf2-7leq — cofx validation ------------------------------------------
+;; ---- EP-0017 recordable-cofx `:schema` validation ------------------------
 ;;
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation at injection time
-;; is RETIRED with `inject-cofx` and DEFERRED to slice B (per Spec 009
-;; §`:rf.error/cofx-value-invalid` — "the `:schema` validation step is
-;; slice-B-built"). The two deftests below pinned the old inject-cofx-interceptor
-;; validation path; they are `#_`-disabled until slice B wires recordable-value
-;; `:schema` validation. The `validate-cofx!` DIRECT-call shape test
-;; (`cofx-validation-direct-call-shape`, below) still runs — the validator fn is
-;; unchanged; only its injection-time wiring moved to slice B.
+;; EP-0017 RETIRED the ctx-mutating `inject-cofx` injection-time validation
+;; (the old `:rf.error/schema-validation-failure :where :cofx` shape, with
+;; `inject-cofx`). The LIVE cofx schema-validation contract is the
+;; recordable-value path: a recordable coeffect declared on the handler's
+;; `:rf.cofx/requires` is delivered FLAT into the coeffects map, and its value
+;; (supplied / replayed / generated) is validated against the `reg-cofx`
+;; registration's `:schema` by `re-frame.cofx/validate-recordable-value!`. A
+;; malformed value emits `:rf.error/cofx-value-invalid` (a PRODUCTION hard
+;; error — an out-of-contract durable value is corrupt causal state) and THROWS
+;; during context assembly, so the handler is NOT invoked (recovery
+;; `:no-recovery`). The deftests below replace the disabled `inject-cofx`
+;; tests this file used to carry; the schemas conformance fixture
+;; `schema-cofx-validates.edn` exercises the same path through the corpus
+;; runner.
 
-#_(deftest cofx-validation-fires-and-skips-handler
-  (testing "Per Spec 010 §step 2 (rf2-7leq): a cofx whose injected value
-            fails its :schema emits :rf.error/schema-validation-failure
-            :where :cofx and the handler is NOT invoked"
-    (rf/reg-cofx :app-version/bad
-      {:schema :string}
-      (fn [ctx]
-        (assoc-in ctx [:coeffects :app-version/bad] 42)))
+(deftest recordable-cofx-value-invalid-fires-and-skips-handler
+  (testing "EP-0017 (replaces rf2-7leq): a recordable cofx whose supplied
+            value fails its `reg-cofx` `:schema` emits
+            :rf.error/cofx-value-invalid and the handler is NOT invoked"
+    ;; PROVIDED recordable fact — its value rides the dispatch token's
+    ;; `:rf.cofx` map (no supplier). The handler declares it via
+    ;; `:rf.cofx/requires`; delivery validates the supplied value against
+    ;; `:schema`, fails (42 is not a :string), and THROWS before the handler.
+    (rf/reg-cofx :app-version/v
+      {:recordable? true :provided? true :schema :string})
     (let [calls (atom 0)]
       (rf/reg-event :cap/seed
-        {:interceptors [(rf/inject-cofx :app-version/bad)]}
+        {:rf.cofx/requires [:app-version/v]}
         (fn [_cofx _]
           (swap! calls inc)
           {:db {:app-version "should-not-stash"}}))
       (let [traces (atom [])]
         (rf/register-listener! ::cf (fn [ev] (swap! traces conj ev)))
-        (rf/dispatch-sync [:cap/seed])
+        ;; The recordable-value failure throws out of dispatch-sync (a hard
+        ;; error in dev AND prod); the trace fires BEFORE the throw.
+        (try
+          (rf/dispatch-sync [:cap/seed] {:rf.cofx {:app-version/v 42}})
+          (catch clojure.lang.ExceptionInfo _))
         (rf/unregister-listener! ::cf)
         (is (= 0 @calls)
-            "handler was skipped because the cofx :schema failed")
-        (let [violations (filter #(= :rf.error/schema-validation-failure
+            "handler was skipped because the recordable cofx :schema failed")
+        (let [violations (filter #(= :rf.error/cofx-value-invalid
                                      (:operation %))
                                  @traces)]
           (is (= 1 (count violations)))
           (let [v (first violations)]
-            (is (= :cofx (-> v :tags :where)))
+            (is (= :app-version/v (-> v :tags :rf.cofx/id)))
             (is (= :cap/seed (-> v :tags :failing-id)))
-            (is (= :app-version/bad (-> v :tags :rf.cofx/id)))
-            (is (= :app-version/bad (-> v :tags :schema-id)))
-            ;; rf2-9cm27 — the :frame tag must ride the trace so the
-            ;; violation lands in the per-frame epoch :trace-events
-            ;; (epoch/capture buffers only frame-tagged traces). The
-            ;; dispatch ran on :rf/default.
-            (is (= :rf/default (-> v :tags :frame))
-                ":frame tag carries the in-flight cascade's frame")
+            (is (= 42 (-> v :tags :value)))
+            ;; :recovery is hoisted to the top-level trace event
+            ;; (Spec 009 §Core fields hoist contract), not under :tags.
             (is (= :no-recovery (:recovery v)))))))))
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation deferred to slice B.
-#_(deftest cofx-validation-passes-when-conforming
-  (testing "well-typed cofx values flow through to the handler — no trace, handler runs"
+(deftest recordable-cofx-value-valid-flows-to-handler
+  (testing "a conforming recordable cofx value flows through to the handler —
+            no :rf.error/cofx-value-invalid trace, handler runs"
     (rf/reg-cofx :app-version/well
-      {:schema :string}
-      (fn [ctx]
-        (assoc-in ctx [:coeffects :app-version/well] "1.4.5")))
+      {:recordable? true :provided? true :schema :string})
     (let [seen-version (atom nil)]
       (rf/reg-event :cap/seed-good
-        {:interceptors [(rf/inject-cofx :app-version/well)]}
-        (fn [cofx _]
-          (reset! seen-version (:app-version/well cofx))
+        {:rf.cofx/requires [:app-version/well]}
+        (fn [{:keys [app-version/well]} _]
+          (reset! seen-version well)
           {}))
       (let [traces (atom [])]
         (rf/register-listener! ::cf2 (fn [ev] (swap! traces conj ev)))
-        (rf/dispatch-sync [:cap/seed-good])
+        (rf/dispatch-sync [:cap/seed-good] {:rf.cofx {:app-version/well "1.4.5"}})
         (rf/unregister-listener! ::cf2)
         (is (= "1.4.5" @seen-version)
-            "handler ran and saw the well-typed cofx value")
-        (is (empty? (filter #(= :rf.error/schema-validation-failure
-                                (:operation %))
+            "handler ran and saw the well-typed recordable cofx value")
+        (is (empty? (filter #(= :rf.error/cofx-value-invalid (:operation %))
                             @traces))
-            "no schema-validation-failure trace fires for a conforming cofx")))))
+            "no cofx-value-invalid trace fires for a conforming value")))))
+
+(deftest recordable-cofx-value-invalid-redacts-sensitive-value
+  (testing "EP-0017 / rf2-hdi6wr — a recordable cofx whose :schema marks a slot
+            {:sensitive? true} redacts the value-bearing slots through the
+            shared `redact-validation-tags` seam: the trace's :value scrubs to
+            :rf/redacted and :sensitive? true is stamped (never the raw secret)"
+    ;; The cofx value is a map with a sensitive `:token` leaf; the failing
+    ;; value (an :int where a :string is required) must not egress verbatim.
+    (rf/reg-cofx :auth/creds
+      {:recordable? true :provided? true
+       :schema [:map [:token {:sensitive? true} :string]]})
+    (rf/reg-event :cap/seed-secret
+      {:rf.cofx/requires [:auth/creds]}
+      (fn [_ _] {}))
+    (let [traces (atom [])]
+      (rf/register-listener! ::cfs (fn [ev] (swap! traces conj ev)))
+      (try
+        (rf/dispatch-sync [:cap/seed-secret]
+                          {:rf.cofx {:auth/creds {:token 42}}})
+        (catch clojure.lang.ExceptionInfo _))
+      (rf/unregister-listener! ::cfs)
+      (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
+                             @traces))]
+        (is (some? v) "the recordable-cofx violation fired")
+        ;; :sensitive? is hoisted to the top-level trace event (Spec 009),
+        ;; not under :tags.
+        (is (true? (:sensitive? v))
+            ":sensitive? true is stamped (the schema marked a slot sensitive)")
+        (is (= :rf/redacted (-> v :tags :value))
+            "the value-bearing :value slot scrubbed to :rf/redacted — the raw
+             {:token 42} never egressed off-box")))))
 
 ;; ---- rf2-xp2o3 — fx-args validation (Spec 010 step 5) --------------------
 
@@ -569,46 +604,50 @@
           (is (not (contains? (:tags v) :frame))
               "direct 4-arity call emits no :frame (runtime callers supply it)"))))))
 
-;; ---- rf2-9cm27: cofx / fx / sub validation traces carry :frame -----------
+;; ---- rf2-9cm27: fx / sub validation traces carry :frame ------------------
 ;;
-;; CORRECTNESS. validate-cofx! / validate-fx! / validate-sub! must stamp a
-;; :frame tag on their :rf.error/schema-validation-failure trace — exactly
-;; like validate-event! (rf2-lo28u) and validate-app-schema! already do.
-;; re-frame.epoch.capture/capture-event! buffers a trace into the in-flight
-;; cascade ONLY when the trace's tags carry the cascade's :frame; an
-;; untagged violation reaches the global trace stream but is SILENTLY
-;; DROPPED from the per-frame epoch :trace-events, so the Xray Issues /
-;; Schema-timeline lens (which reads :trace-events) is blind to it.
+;; CORRECTNESS. validate-fx! / validate-sub! must stamp a :frame tag on their
+;; :rf.error/schema-validation-failure trace — exactly like validate-event!
+;; (rf2-lo28u) and validate-app-schema! already do. (The cofx surface carries
+;; :frame on the EP-0017 recordable path's :rf.error/cofx-value-invalid trace —
+;; see recordable-cofx-value-invalid-attributes-named-frame below — not on a
+;; :where :cofx trace; the injection-time validate-cofx! path was retired with
+;; `inject-cofx`.) re-frame.epoch.capture/capture-event! buffers a trace into
+;; the in-flight cascade ONLY when the trace's tags carry the cascade's
+;; :frame; an untagged violation reaches the global trace stream but is
+;; SILENTLY DROPPED from the per-frame epoch :trace-events, so the Xray Issues
+;; / Schema-timeline lens (which reads :trace-events) is blind to it.
 ;;
-;; The :rf/default-frame assertions on the three end-to-end tests above
-;; (cofx-validation-fires-and-skips-handler /
-;;  fx-args-validation-fires-and-skips-only-the-offending-fx /
+;; The :rf/default-frame assertions on the end-to-end tests above
+;; (fx-args-validation-fires-and-skips-only-the-offending-fx /
 ;;  sub-return-validation-fires-and-replaces-with-default) prove the tag
 ;; lands. These tests prove the tag carries the ACTUAL in-flight frame, not
 ;; a hardcoded default — a NAMED frame's dispatch / reaction must attribute
 ;; the violation to that frame (mirrors
 ;; schema-fires-only-on-the-frame-it-registers-against for :where :app-db).
 
-;; EP-0017 slice A.3 (rf2-oa2dun): cofx `:schema` validation deferred to slice B.
-#_(deftest cofx-validation-frame-tag-attributes-named-frame
-  (testing "rf2-9cm27 — a cofx validation failure on a NAMED frame stamps
-            that frame's id on the trace (not :rf/default), so the epoch
+(deftest recordable-cofx-value-invalid-attributes-named-frame
+  (testing "EP-0017 (replaces rf2-9cm27 cofx case) — a recordable-cofx
+            :schema failure on a NAMED frame stamps that frame's id on the
+            :rf.error/cofx-value-invalid trace (not :rf/default), so the epoch
             capture buffers it into the right per-frame cascade."
     (rf/reg-frame :test/cofx-frame {})
     (rf/reg-cofx :probe/cofx
-      {:schema :string}
-      (fn [ctx] (assoc-in ctx [:coeffects :probe/cofx] 42)))   ;; int, not string
+      {:recordable? true :provided? true :schema :string})
     (rf/reg-event :probe/cofx-seed
-      {:interceptors [(rf/inject-cofx :probe/cofx)]}
+      {:rf.cofx/requires [:probe/cofx]}
       (fn [_ _] {}))
     (let [traces (atom [])]
       (rf/register-listener! ::cf-frame (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:probe/cofx-seed] {:frame :test/cofx-frame})
+      (try
+        (rf/dispatch-sync [:probe/cofx-seed]
+                          {:frame :test/cofx-frame
+                           :rf.cofx {:probe/cofx 42}})   ;; int, not string
+        (catch clojure.lang.ExceptionInfo _))
       (rf/unregister-listener! ::cf-frame)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+      (let [v (first (filter #(= :rf.error/cofx-value-invalid (:operation %))
                              @traces))]
-        (is (some? v) "the cofx violation fired")
-        (is (= :cofx (-> v :tags :where)))
+        (is (some? v) "the recordable-cofx violation fired")
         (is (= :test/cofx-frame (-> v :tags :frame))
             ":frame tag carries the named in-flight cascade frame")))))
 
@@ -695,6 +734,13 @@
           (is (= :no-recovery (:recovery v))))))))
 
 (deftest cofx-validation-direct-call-shape
+  ;; NB `validate-cofx!` is DEMOTED (EP-0017) — NOT the live runtime cofx
+  ;; schema path (that is `re-frame.cofx/validate-recordable-value!` →
+  ;; `:rf.error/cofx-value-invalid`, covered by
+  ;; recordable-cofx-value-invalid-* above). This pins only the demoted fn's
+  ;; pure-shape contract (return value + trace tags) so a refactor of the
+  ;; shared `run-validation` core can't silently break it while the fn / its
+  ;; hook publication survive pending the Spec 010 step-2 rewrite.
   (testing "rf2-rbbmt — validate-cofx! returns true on pass, false on
             fail, true on the no-:schema soft-pass arm; emits the
             canonical :where :cofx trace with the locked tag shape"

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -1712,8 +1712,9 @@
 (deftest boundary-interceptor-sets-skip-handler-on-context
   (testing "Per Spec 010 §Per-step recovery step 1 — the boundary
             interceptor's :before sets :rf/skip-handler? on the context
-            when validation fails, so the handler-as-interceptor
-            (events.cljc :rf/db-handler / :rf/fx-handler) short-circuits.
+            when validation fails, so the handler-as-interceptor (the single
+            EP-0018 framework wrapper events.cljc :rf/event-handler)
+            short-circuits.
 
             The recovery is identical to the dev-mode step-1 path
             (validate-event! returning false), so the runtime's existing


### PR DESCRIPTION
Fixes three P2 beads on the `implementation/schemas` surface, aligned to the landed EP-0017/EP-0018 (+ EP-0015) model. Rebased on latest `main` (post schemas P1 cluster).

## rf2-dy5gp5 — conformance runner no longer branches on pre-EP-0018 event kinds
The schemas conformance runner branched on the DSL `[kind handler]` pair (`:db`/`:fx`) at the `reg-event` registration site. EP-0018 removed the public event sub-kind model (a registered event is just kind `:event`), so a `:db`/`:fx` case at the registration site reads like a stale public event-kind assumption and could mask fixture/schema drift. Introduced a `normalize-event-handler` helper that collapses both DSL body-shapes to the single `reg-event` effects-map handler before registration, so the site never branches on a kind. Behaviour identical (event-db bodies still lower to a `{:db …}` effect); documents the body-shape distinction as DSL-internal, not a public `:event/kind`.

## rf2-eare7o — retire/demote the stale injection-time cofx validation contract
EP-0017 retired the ctx-mutating `inject-cofx` injection-time cofx schema validation. The live cofx schema contract is the recordable-value path (`re-frame.cofx/validate-recordable-value!` → `:rf.error/cofx-value-invalid`, a production hard error), not the dev-only schemas `validate-cofx!` `:where :cofx` trace. No runtime caller reaches `:schemas/validate-cofx!`.
- **Demoted** `schemas.validate/validate-cofx!` (facade re-export, late-bind publication, late-bind directory entry) with a clear note that it is NOT the live runtime path. Kept (not deleted) because Spec 010 still documents step 2 as `:where :cofx` — full retirement awaits that normative rewrite, filed as **rf2-nkf4l3** (`discovered-from` this bead).
- **Replaced** the disabled `inject-cofx` unit tests (schemas_test / fail_open / sensitive) with active recordable-cofx tests asserting `:rf.error/cofx-value-invalid`, handler-skipped, fail-closed on a malformed schema, and `:sensitive?` redaction through `redact-validation-tags`.
- Annotated the surviving `validate-cofx!` direct-call shape tests as pinning the demoted fn's pure shape only.

## rf2-uqh86d — sweep stale EP-0018 event vocabulary in comments
EP-0018 leaves one public `reg-event` form and one framework wrapper `:rf/event-handler`. Updated stale comments: `schemas_fail_open_test.clj` (`reg-event-*` → `reg-event`), `schemas_test.clj` (the handler-as-interceptor comment named the gone per-kind `:rf/db-handler` / `:rf/fx-handler` ids → the single `:rf/event-handler` wrapper). No behaviour change.

## Gates
- `npm run test:cljs` — green (7720 tests, 31839 assertions)
- schemas JVM full suite — green (315 tests, 18844 assertions)
- `scripts/test-fast-pr.sh` — PASS