### PR TITLE
docs: EP-0017/0018 comment accuracy across event-conformance/routing/resource (rf2-eor551, rf2-kmsqa4, rf2-lh934n, rf2-hugaa8, rf2-dya2m3)

### DIFF
--- a/implementation/event-conformance/deps.edn
+++ b/implementation/event-conformance/deps.edn
@@ -1,5 +1,18 @@
-;; re-frame2 EP-0018 one-form event-MODEL conformance tier
-;; (rf2-xhfxcs.6; EP-0018 §Conformance + Bead Plan item 7).
+;; re-frame2 event-conformance tier — the broader event-conformance TEST
+;; surface (rf2-xhfxcs.6; EP-0018 §Conformance + Bead Plan item 7).
+;;
+;; Its CORE lock is the EP-0018 one-form event-MODEL contract (the
+;; `event_model_conformance_cljs_test.cljc` umbrella), but follow-on locks
+;; have since landed alongside it on this same surface:
+;;
+;;   - the EP-0017 recordable-coeffect locks live IN the model-conformance
+;;     ns (flat declared delivery, the one-arg ambient supplier arg path,
+;;     and the slice-B recordable-generator / mint-policy machinery —
+;;     `:live` mint + write-back, `:strict` refuse-to-mint, `:explicit-live`
+;;     escape; rf2-lpyw1v); and
+;;   - the EP-0023 image-loaded frame dispatch-isolation lock is a SEPARATE
+;;     ns (`event_frame_isolation_conformance_cljs_test.cljc`, rf2-slvzn3)
+;;     this alias also runs.
 ;;
 ;; This is NOT a published Maven artefact — it has no `src/`. It is a
 ;; cross-artefact TEST surface (the precedent is `reply-conformance/` and

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -269,9 +269,13 @@
       (is (= "en-AU" @seen)
           "the declared coeffect arrived FLAT under its id (no nesting)"))))
 
-(deftest reg-event-rf-cofx-requires-generator-arg-path
-  (testing "EP-0017 generator path on reg-event: a `[:cofx-id arg]` declaration
-            passes the literal arg to the cofx generator, delivered flat"
+(deftest reg-event-rf-cofx-requires-one-arg-ambient-supplier-arg-path
+  (testing "EP-0017 §2 one-arg AMBIENT supplier on reg-event: a `[:cofx-id arg]`
+            declaration passes the literal arg to a call-site-parameterized
+            ambient supplier `(fn [arg] value)`, delivered flat. This is the
+            ambient (never-recorded) supplier-arg path — distinct from the
+            slice-B recordable-generator / mint-policy machinery exercised
+            below (which mints + writes back to the causal record)"
     (let [seen (atom ::unset)]
       ;; The call-site-parameterized supplier is one-arg `(fn [arg] value)`
       ;; (cofx.cljc §Supplier signatures), declared `[id arg]` in :rf.cofx/requires.
@@ -857,7 +861,9 @@
           "a FRAMEWORK-AUTHORITY handler writes :rf.db/runtime silently — NO app-handler-runtime-effect diagnostic"))))
 
 (deftest reg-event-unchanged-db-return-is-a-true-noop
-  (testing "EP-0018 §4 (rf2-na5i1z): a `{:db db}` return that re-installs the
+  (testing "COMMIT-SEMANTICS COMPANION — rf2-ekq28v (NOT EP-0018-owned; the
+            EP-0018 §4 Conformance section assigns the `{:db <identical>}` no-op
+            to rf2-ekq28v): a `{:db db}` return that re-installs the
             SAME app-db value is a true no-op — app-db is unchanged AND the
             change-trace stream reflects the no-op (`:rf.event/db-noop` fires,
             `:rf.event/db-changed` does NOT). A regression that treated every
@@ -886,7 +892,9 @@
             "an unchanged `{:db db}` return does NOT fire :rf.event/db-changed")))))
 
 (deftest reg-event-db-nil-return-is-coerced-to-empty-map-with-diagnostic
-  (testing "EP-0018 §4 + rf2-ekq28v (rf2-na5i1z): a `{:db nil}` return is
+  (testing "COMMIT-SEMANTICS COMPANION — rf2-ekq28v (NOT EP-0018-owned; the
+            EP-0018 §4 Conformance section assigns the `{:db nil}` -> `{:db {}}`
+            coercion to rf2-ekq28v): a `{:db nil}` return is
             COERCED to `{}` at the commit boundary (app-db is always a map,
             never nil — the v1 nil-footgun is removed structurally) AND emits
             the dev-mode `:rf.warning/db-nil-coerced` diagnostic for
@@ -917,8 +925,9 @@
             "the coercion diagnostic carries :recovery :warned (the value is still applied)")))))
 
 (deftest reg-event-deliberate-empty-db-clear-emits-no-diagnostic
-  (testing "EP-0018 §4 + rf2-ekq28v (rf2-na5i1z): a DELIBERATE clear — returning
-            `{:db {}}` (a distinct, non-nil empty map) — clears app-db WITHOUT
+  (testing "COMMIT-SEMANTICS COMPANION — rf2-ekq28v (NOT EP-0018-owned; the
+            companion to the `{:db nil}` coercion above): a DELIBERATE clear —
+            returning `{:db {}}` (a distinct, non-nil empty map) — clears app-db WITHOUT
             the `:rf.warning/db-nil-coerced` diagnostic, distinguishing the
             intentional empty-map clear from the accidental-nil footgun. A
             regression that warned on a deliberate `{:db {}}` clear goes RED"

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -146,7 +146,7 @@
   dedupe still WINS when work is in flight; fresh-skip applies only to a
   SETTLED fresh `:loaded` entry.
 
-  Returns the event-fx map `{:rf.db/runtime :fx}`."
+  Returns the reg-event effects map `{:rf.db/runtime :fx}`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id
     gen-allocation :rf.resource/generation-allocation
     time-ms :rf/time-ms, app-db :db}
@@ -567,7 +567,7 @@
   replies exactly as for any refetch). Fresh entries and owner-free entries
   are left untouched. Emits one `:rf.resource/refetch-decision` scan-summary
   trace (the broad-tab-return storm stays readable) plus the per-entry
-  refetch ride their ordinary refetch traces. Returns the event-fx map
+  refetch ride their ordinary refetch traces. Returns the effects map
   (`:fx` only — the scan itself makes NO durable write; the refetch
   dispatches do).
 

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -1036,7 +1036,7 @@
   entry's `:revision` bumped. Emits `:rf.mutation/optimistic-applied`. The SETTLE
   slice consumes that recorded inverse (commit / rollback / reconcile).
 
-  Returns the event-fx map (`:rf.db/runtime` + `:fx`)."
+  Returns the effects map (`:rf.db/runtime` + `:fx`)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id
     gen-allocation :rf.resource/generation-allocation
     time-ms :rf/time-ms, app-db :db}

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -163,7 +163,7 @@
 
 ;; :rf.route.internal/settle-transition — Spec 012 §Per-route data
 ;; loading §2 FIFO settle. EP-0001 (rf2-vzld77): the route slice is durable
-;; runtime-db state, so this is a runtime-db event-fx handler.
+;; runtime-db state, so this is a runtime-db `reg-event` handler.
 (events/reg-event :rf.route.internal/settle-transition
                      framework-authority-meta
                      routing-events/settle-transition-handler)
@@ -280,8 +280,9 @@
 
 ;; :rf.route/nav-token cofx — Spec 012 §Navigation tokens — stale-result
 ;; suppression step 2. A value-returning AMBIENT supplier (EP-0017) for
-;; the current navigation epoch token; delivered under `:coeffects
-;; :rf.route/nav-token` to any `:on-match`-reached handler that declares
+;; the current navigation epoch token; delivered FLAT under the
+;; `:rf.route/nav-token` key in the coeffects map (EP-0017 §5) to any
+;; `:on-match`-reached handler that declares
 ;; `:rf.cofx/requires [:rf.route/nav-token]`, so the documented
 ;; `(fn [{:rf.route/keys [nav-token]} _] ...)` shape resolves the live
 ;; token (not nil). Owner-qualified to the routing subsystem root per

--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -131,8 +131,8 @@
 (defn maybe-block-navigation
   "Run the active route's `:can-leave` guard before allowing a transition
   to `requested-url`. Returns nil when the navigation should proceed (no
-  guard, guard allows, or `bypass-leave-guard?`); returns the cofx map
-  `{:db ... :fx ...}` that writes the routing pending-navigation slot
+  guard, guard allows, or `bypass-leave-guard?`); returns the effects map
+  `{:rf.db/runtime ... :fx ...}` that writes the routing pending-navigation slot
   (`[:rf.runtime/routing :pending-navigation]`) and dispatches
   `:rf.route/navigation-blocked` when the guard blocks.
 
@@ -296,7 +296,7 @@
       [:rf/url-requested {:url fallback-url :bypass-leave-guard? true}])))
 
 (defn url-requested-handler
-  "`:rf/url-requested` event-fx handler. Registered by the façade so a
+  "`:rf/url-requested` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar. rf2-vcop6y: declares only the
   RECORDABLE `:rf.route/pending-nav-allocation` cofx — its only allocation
   is a pending-nav id minted on a `:can-leave` block (it never mints a
@@ -358,7 +358,7 @@
               [:dispatch [:rf.route/transitioned app-url {:bypass-leave-guard? true}]]]})))
 
 (defn continue-handler
-  "`:rf.route/continue` event-fx handler. Registered by the façade so a
+  "`:rf.route/continue` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar."
   [{rdb :rf.db/runtime} [_ pn-id]]
     ;; Per Spec 012 §Navigation blocking — pending-nav protocol continue
@@ -404,7 +404,7 @@
         {})))
 
 (defn cancel-handler
-  "`:rf.route/cancel` event-fx handler. Registered by the façade so a
+  "`:rf.route/cancel` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar."
   [{rdb :rf.db/runtime} [_ pn-id]]
   ;; EP-0001 (rf2-vzld77): the pending-nav slot is durable routing runtime-db

--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -205,7 +205,7 @@
   `emit-activation-traces!` so the lifecycle pair carries `:frame` too.
   Without it those frame-known traces miss epoch capture (which buffers
   only frame-tagged events) and bypass the frame-level trace-disable gate.
-  Returns the event-fx cofx map `{:rf.db/runtime :fx}`."
+  Returns the effects map `{:rf.db/runtime :fx}`."
   [rdb {:keys [route-id params query fragment transition]} on-match-vec
    {:keys [prev-id prev-nav-token capture-fx scroll-fx push-fx nav-allocation app-db frame]}]
   (let [;; rf2-vcop6y: the nav-token rides the RECORDABLE `:rf.route/nav-allocation`
@@ -318,7 +318,7 @@
 ;; continue`, etc.). Same audience-split principle as
 ;; `:rf.route.nav-token/*` (Spec 012 §Navigation tokens).
 (defn settle-transition-handler
-  "`:rf.route.internal/settle-transition` event-fx handler. Registered by
+  "`:rf.route.internal/settle-transition` event handler. Registered by
   the `re-frame.routing` façade so a `:reload` of the façade re-runs the
   registration.
 

--- a/implementation/routing/src/re_frame/routing/nav_counters.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_counters.cljc
@@ -215,8 +215,9 @@
    :doc "A fresh nav-token allocation `{:token \"nav-N\" :counter N}`,
 minted at processing-start from the active frame's host nav-token
 high-water mark and RECORDED onto the causal token (EP-0017 recordable
-coeffect). Delivered under `:coeffects :rf.route/nav-allocation` to a nav
-commit handler that declares `:rf.cofx/requires [:rf.route/nav-allocation]`.
+coeffect). Delivered FLAT under the `:rf.route/nav-allocation` key in the
+coeffects map (EP-0017 §5) to a nav commit handler that declares
+`:rf.cofx/requires [:rf.route/nav-allocation]`.
 The handler writes only `:token` into the route slice and rides `:counter`
 on the `:rf.route/commit-nav-counter` fx (host high-water `max` bump).
 Recorded so record+replay re-presents the same nav-token verbatim
@@ -256,9 +257,9 @@ Recorded so record+replay re-presents the same nav-token verbatim
    :doc "A fresh pending-navigation id allocation `{:id \"pn-N\" :counter N}`,
 minted at processing-start from the active frame's host pending-nav
 high-water mark and RECORDED onto the causal token (EP-0017 recordable
-coeffect). Delivered under `:coeffects :rf.route/pending-nav-allocation` to
-a nav entry handler that declares `:rf.cofx/requires
-[:rf.route/pending-nav-allocation]`. On a `:can-leave` block the handler
+coeffect). Delivered FLAT under the `:rf.route/pending-nav-allocation` key
+in the coeffects map (EP-0017 §5) to a nav entry handler that declares
+`:rf.cofx/requires [:rf.route/pending-nav-allocation]`. On a `:can-leave` block the handler
 writes only `:id` into the pending-navigation slot and rides `:counter` on
 the `:rf.route/commit-nav-counter` fx. Recorded so a recorded
 `[:rf.route/continue \"pn-N\"]` re-matches under replay (replay-determinism

--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -3,9 +3,9 @@
 
   Per Spec 012 §Navigation tokens — stale-result suppression. Owns:
     - `:rf.route/nav-token` cofx — injects the current navigation epoch
-      token (`[:rf.runtime/routing :current :nav-token]`) into an
-      `:on-match` handler's `:coeffects` under key `:rf.route/nav-token`,
-      so the handler can capture it and thread it into an async
+      token (`[:rf.runtime/routing :current :nav-token]`) FLAT under the
+      `:rf.route/nav-token` key in an `:on-match` handler's coeffects map
+      (EP-0017 §5), so the handler can capture it and thread it into an async
       continuation;
     - `:rf.route/with-nav-token` fx — wraps an async-completion fx
       entry (`:do`) with a stale-result check: match → run; mismatch →
@@ -52,8 +52,8 @@
   Universal platform: the route slice exists on both client and server,
   so the cofx resolves under SSR and browser alike."
   {:doc "The current navigation epoch token, read from
-`[:rf.runtime/routing :current :nav-token]` and delivered under
-`:coeffects :rf.route/nav-token`. Declare with
+`[:rf.runtime/routing :current :nav-token]` and delivered FLAT under the
+`:rf.route/nav-token` key in the handler coeffects map (EP-0017 §5). Declare with
 `:rf.cofx/requires [:rf.route/nav-token]` on an `:on-match`-reached
 handler; capture the value and thread it into an async continuation so a
 superseding navigation suppresses the stale result. Per Spec 012

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -112,7 +112,7 @@
     tags))
 
 (defn navigate-handler
-  "`:rf.route/navigate` event-fx handler. Registered by the façade so a
+  "`:rf.route/navigate` event handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar.
 
   EP-0001 (rf2-vzld77): the route slice is durable framework runtime-db

--- a/implementation/routing/src/re_frame/routing/on_match_error.cljc
+++ b/implementation/routing/src/re_frame/routing/on_match_error.cljc
@@ -143,7 +143,7 @@
       (contains? (on-match-event-ids route-meta) event-id))))
 
 (defn on-match-error-handler
-  "`:rf.route.internal/on-match-error` event-fx handler. Registered by
+  "`:rf.route.internal/on-match-error` event handler. Registered by
   the `re-frame.routing` façade so a `:reload` of the façade re-runs the
   registration."
   [{rdb :rf.db/runtime} [_ {:keys [error nav-token]}]]

--- a/implementation/routing/src/re_frame/routing/test_support.cljc
+++ b/implementation/routing/src/re_frame/routing/test_support.cljc
@@ -60,7 +60,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn simulate-http-resolution-handler
-  "`:rf.test/simulate-http-resolution` event-fx handler. Registered at
+  "`:rf.test/simulate-http-resolution` event handler. Registered at
   ns-load (below) so a `(require 're-frame.routing.test-support :reload)`
   re-wires it on a fresh registrar.
 

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -57,7 +57,7 @@
 (defn- url-change-fx
   "Pure helper: given runtime-db + url + default scroll strategy (+ the
   `frame` to carry on the no-such-handler trace + the RECORDABLE
-  `nav-allocation`), return the cofx map `{:rf.db/runtime :fx}` for
+  `nav-allocation`), return the effects map `{:rf.db/runtime :fx}` for
   a URL-driven full slice rewrite. Performs the match-url lookup, publishes
   the nav-token from the recordable `nav-allocation` (rf2-vcop6y — recorded +
   replay-stable; the `:counter` high-water bump rides a
@@ -281,7 +281,7 @@
            :app-db       app-db})))))
 
 (defn transitioned-handler
-  "`:rf.route/transitioned` event-fx handler. Registered by the façade
+  "`:rf.route/transitioned` event handler. Registered by the façade
   so a `:reload` re-wires it on a fresh registrar. Per Spec 012 §URL
   changes are events / §Fragments. Forward nav (link click /
   programmatic push). After the leave-guard check, delegate to the
@@ -323,7 +323,7 @@
         (url-change-fx rdb url :top frame nav-allocation app-db))))
 
 (defn handle-url-change-handler
-  "`:rf.route/handle-url-change` event-fx handler. Registered by the
+  "`:rf.route/handle-url-change` event handler. Registered by the
   façade so a `:reload` re-wires it on a fresh registrar. Per Spec 012
   §URL changes are events — popstate, initial load, SSR. Delegates to
   the shared `url-change-fx`, which honours the fragment-only

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -70,11 +70,12 @@
             [re-frame.marks :as marks]
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.routing :as routing]
-            ;; Call `navigate-handler` directly (a plain event-fx handler fn)
-            ;; so site 2 exercises the REAL redaction path headless — no
-            ;; reactive-substrate adapter / `dispatch-sync` machinery needed.
-            ;; A `:params`-schema validation reject short-circuits inside the
-            ;; handler before any push/scroll fx, so a synthetic cofx suffices.
+            ;; Call `navigate-handler` directly (the `reg-event` handler fn,
+            ;; `(cofx event) -> effects-map-or-nil`) so site 2 exercises the
+            ;; REAL redaction path headless — no reactive-substrate adapter /
+            ;; `dispatch-sync` machinery needed. A `:params`-schema validation
+            ;; reject short-circuits inside the handler before any push/scroll
+            ;; fx, so a synthetic cofx suffices.
             [re-frame.routing.navigate :as navigate]
             [re-frame.routing.registry :as registry]
             [re-frame.test-support :as test-support]


### PR DESCRIPTION
Comment/docstring-only sweep fixing stale EP-0017/EP-0018 vocabulary across five now-merged surfaces. No runtime behaviour change.

## rf2-eor551 — event-conformance EP-0017 cofx comments
- `event-conformance/deps.edn` header reframed as the broader event-conformance tier (EP-0018 one-form model lock + EP-0017 recordable-coeffect locks + the separate EP-0023 frame-isolation ns the alias runs).
- Retitled the one-arg AMBIENT supplier arg-path test (was mislabelled a "generator path", which conflated it with the slice-B recordable-generator / mint-policy machinery exercised below it).

## rf2-kmsqa4 — routing stale EP-0018 vocabulary
- "event-fx handler" docstrings -> "event handler" (these are `reg-event` handlers) across `routing.cljc`, `can_leave.cljc`, `events.cljc`, `navigate.cljc`, `on_match_error.cljc`, `test_support.cljc`, `url_change.cljc`.
- Return-value wording: `maybe-block-navigation` / `commit-navigation` / `url-change-fx` now say "effects map `{:rf.db/runtime ... :fx ...}`" (was "cofx map `{:db ... :fx ...}`").
- cofx delivery prose for `:rf.route/nav-token` / `:rf.route/nav-allocation` / `:rf.route/pending-nav-allocation`: nested `:coeffects :id` path -> FLAT delivery under the id in the coeffects map (EP-0017 §5).
- Legitimate `reg-fx` / removed-name prose left alone.

## rf2-lh934n — event-conformance EP-0018 ownership after follow-on locks
- `deps.edn` (see above) now distinguishes EP-0018 model + EP-0017 + EP-0023 locks on this surface.
- The `{:db <identical>}` no-op and `{:db nil}` -> `{:db {}}` coercion / deliberate-clear tests are marked COMMIT-SEMANTICS COMPANIONS (rf2-ekq28v ownership, not EP-0018-owned) per EP-0018 §4 Conformance.

## rf2-hugaa8 — resources "event-fx map" docstrings
- Three handler docstrings in `resources/events.cljc` + `resources/mutation_events.cljc`: "event-fx map" -> "effects map" / "reg-event effects map". `rg "event-fx" implementation/resources` now clean.

## rf2-dya2m3 — security navigate-handler comment
- `error_slot_egress_security_cljs_test.cljc`: "plain event-fx handler fn" -> the `reg-event` handler shape (`(cofx event) -> effects-map-or-nil`).

## Gates
- `npm run test:cljs` green (7720 tests / 31839 assertions / 0 failures).
- `scripts/test-fast-pr.sh` green (PASS fast PR spine).