### PR TITLE
test(conformance): SSR recordable + routing with-nav-token (rf2-sb47ni, rf2-ux8sgg)

### DIFF
--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -122,8 +122,19 @@ superseding navigation suppresses the stale result. Per Spec 012
   not only the route-specific `:carried-token` / `:current-token` tokens.
   The facts are read off the `route-reply/suppress` `:reply` (the
   `:status :stale` / `:work/status :suppressed` / `:stale/reason` the
-  shared substrate produced)."
-  [{:keys [carried-token current-token event-id frame-id route-id loader-id]}]
+  shared substrate produced).
+
+  rf2-ux8sgg — `:completed-at` is the recordable `:rf/time-ms` completion
+  fact on the reply token (EP-0017): reply completions are causal tokens,
+  so a superseded route loader's stale reply/trace MUST carry the actual
+  replayed completion time, not drop it. The caller sources it from the
+  declared `:rf.cofx/requires [:rf/time-ms]` reply fact (NOT an ambient
+  clock read) and threads it here; it rides verbatim through
+  `route-reply/suppress` onto the stale reply and is stamped on the trace
+  when present, so route completion time tracks the HTTP / resource /
+  mutation families that already carry `:completed-at`. Absent ⇒ omitted
+  (a route loader that did not source a completion time)."
+  [{:keys [carried-token current-token event-id frame-id route-id loader-id completed-at]}]
   (let [{:keys [reply trace]} (route-reply/suppress
                           {;; rf2-azcmd3 — `route-id` is the route id CAPTURED
                            ;; at scheduling time (carried with the nav-token),
@@ -141,7 +152,12 @@ superseding navigation suppresses the stale result. Per Spec 012
                            :route-id  route-id
                            :nav-token carried-token
                            :loader-id loader-id
-                           :frame     frame-id}
+                           :frame     frame-id
+                           ;; rf2-ux8sgg — the recordable reply completion
+                           ;; time. `route-reply/suppress` only carries it onto
+                           ;; the reply when non-nil, so a route loader without
+                           ;; a sourced completion time is unaffected.
+                           :completed-at completed-at}
                           current-token)]
     (trace/emit-error! :rf.route.nav-token/stale-suppressed
                        (cond-> {:carried-token     carried-token
@@ -174,7 +190,17 @@ superseding navigation suppresses the stale result. Per Spec 012
                                 :rf.reply/work-status (:work/status reply)
                                 :rf.reply/stale-reason (:stale/reason reply)
                                 :recovery          :replaced-with-default}
-                         frame-id (assoc :frame frame-id)))))
+                         frame-id (assoc :frame frame-id)
+                         ;; rf2-ux8sgg — the recordable reply completion
+                         ;; time rides on the stale trace when the loader
+                         ;; sourced it (read off the suppressed `:reply`,
+                         ;; where `route-reply/suppress` placed it). The
+                         ;; uniform reply-envelope view ties the stale route
+                         ;; reply to the actual replayed completion token —
+                         ;; the same `:completed-at` the HTTP / resource /
+                         ;; mutation families carry. Absent ⇒ omitted.
+                         (some? (:completed-at reply))
+                         (assoc :completed-at (:completed-at reply))))))
 
 (def with-nav-token-meta
   "Metadata for the `:rf.route/with-nav-token` fx registration: the
@@ -195,7 +221,17 @@ superseding navigation suppresses the stale result. Per Spec 012
             ;; captured the route id at scheduling time and threads it here,
             ;; a cross-route stale completion attributes its work-id to the
             ;; route-loader ATTEMPT rather than the route live at arrival.
-            [:route-id {:optional true} :any]]})
+            [:route-id {:optional true} :any]
+            ;; rf2-ux8sgg — OPTIONAL reply completion time. The documented
+            ;; lane for the recordable `:rf/time-ms` completion fact on the
+            ;; reply token (EP-0017). When the route completion handler
+            ;; sources it from its declared `:rf.cofx/requires [:rf/time-ms]`
+            ;; and threads it here, a superseded route loader's stale reply /
+            ;; trace carries the actual replayed completion time, tying the
+            ;; route stale reply to the completion token like every other
+            ;; managed-async family. Sourced from the reply fact, NOT an
+            ;; ambient clock read.
+            [:completed-at {:optional true} :any]]})
 
 (defn with-nav-token-handler
   "`:rf.route/with-nav-token` fx handler. Registered by the façade so a
@@ -221,6 +257,12 @@ superseding navigation suppresses the stale result. Per Spec 012
         ;; when the stale completion arrives. Absent ⇒ nil (preferred over a
         ;; false live-route attribution).
         carried-route-id (get args :route-id)
+        ;; rf2-ux8sgg — the OPTIONAL reply completion time. Sourced by the
+        ;; route completion handler from its declared
+        ;; `:rf.cofx/requires [:rf/time-ms]` reply fact and threaded here, so
+        ;; a stale (superseded) route loader's reply / trace carries the
+        ;; actual replayed completion token time rather than dropping it.
+        completed-at    (get args :completed-at)
         ;; EP-0002 carried invariant — the fx context carries the cascade
         ;; envelope frame as `:frame`; a nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
@@ -264,4 +306,7 @@ superseding navigation suppresses the stale result. Per Spec 012
          ;; A cross-route stale completion would otherwise attribute the
          ;; stale loader to the CURRENT route id.
          :route-id      carried-route-id
-         :loader-id     (inner-fx-event-id do-entry)}))))
+         :loader-id     (inner-fx-event-id do-entry)
+         ;; rf2-ux8sgg — carry the reply completion time through the stale
+         ;; path so the suppressed reply / trace preserves it.
+         :completed-at  completed-at}))))

--- a/implementation/routing/src/re_frame/routing/test_support.cljc
+++ b/implementation/routing/src/re_frame/routing/test_support.cljc
@@ -79,8 +79,15 @@
   CAPTURED at request time (mirrors the production `:route-id` arg). It is
   used for the suppressed attempt's work-id rather than the live slice id at
   stale-arrival, so a cross-route stale completion attributes its work-id to
-  the route-loader attempt, not whatever route is live when it arrives."
-  [{frame :rf.frame/id rdb :rf.db/runtime} [_ {:keys [on-success-event carried-nav-token carried-route-id]}]]
+  the route-loader attempt, not whatever route is live when it arrives.
+
+  rf2-ux8sgg — the payload's optional `:carried-completed-at` is the reply
+  completion time the loader captured (the recordable `:rf/time-ms` fact on
+  the reply token, EP-0017). It mirrors the production
+  `:rf.route/with-nav-token` `:completed-at` arg: when supplied, a stale
+  (superseded) completion's reply / trace carries it, so the test path
+  exercises the same completion-time-preservation contract as production."
+  [{frame :rf.frame/id rdb :rf.db/runtime} [_ {:keys [on-success-event carried-nav-token carried-route-id carried-completed-at]}]]
   ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
   (let [slice   (get-in (or rdb {}) [:rf.runtime/routing :current])
         current (:nav-token slice)]
@@ -104,7 +111,10 @@
            ;; handler` fix so a cross-route stale completion attributes its
            ;; work-id to the route-loader attempt, not the current route id.
            :route-id      carried-route-id
-           :loader-id     event-id})
+           :loader-id     event-id
+           ;; rf2-ux8sgg — mirror the production `:completed-at` lane so the
+           ;; stale reply / trace carries the captured reply completion time.
+           :completed-at  carried-completed-at})
         {}))))
 
 ;; ---- test-only fixture event registration --------------------------------

--- a/implementation/routing/test/re_frame/routing_nav_token_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_token_test.clj
@@ -295,6 +295,134 @@
                               @traces)))
           "exactly one stale-suppressed trace fired — the fresh :do did NOT trip the validation"))))
 
+;; ---- rf2-ux8sgg — stale route reply preserves the completion time ---------
+;;
+;; EP-0017 makes reply completions causal tokens: the completion time is the
+;; recordable `:rf/time-ms` fact on the flat reply `:rf.cofx`, and route-loader
+;; stale replies are part of the uniform managed-async reply envelope. Before
+;; the fix the production `:rf.route/with-nav-token` path and the test fixture
+;; both dropped the completion time on the stale path — `route-reply/suppress`
+;; accepted `:completed-at` but no caller threaded one. These regressions prove
+;; a stale route-loader completion that supplies the reply token time produces a
+;; stale reply / trace carrying that `:completed-at`, so route completion time
+;; tracks the HTTP / resource / mutation families that already carry it.
+
+(deftest with-nav-token-fx-stale-preserves-completed-at
+  (testing "rf2-ux8sgg — a stale `:rf.route/with-nav-token` completion that
+            threads `:completed-at` (the reply token's :rf/time-ms fact)
+            produces a stale-suppressed trace carrying that completion time"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
+    ;; The async completion handler sources the completion time from its
+    ;; declared `:rf.cofx/requires [:rf/time-ms]` reply fact (modelled here as
+    ;; a payload value) and threads it through the production fx — NOT an
+    ;; ambient clock read.
+    (rf/reg-event :article/loaded-via-nav-token
+                     (fn [_ctx [_ {:keys [carried-token carried-route-id completed-at id payload]}]]
+                       {:fx [[:rf.route/with-nav-token
+                              {:do           [:dispatch [:article/loaded id payload]]
+                               :nav-token    carried-token
+                               :route-id     carried-route-id
+                               :completed-at completed-at}]]}))
+
+    (let [traces        (atom [])
+          completion-ts 1717000123456]
+      (rf/register-listener! ::completed-at-fx (fn [ev] (swap! traces conj ev)))
+
+      ;; 1. Land on A (nav-1), then supersede with B (nav-2).
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/A"])
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/B"])
+
+      ;; 2. A's stale completion arrives carrying nav-1 AND its reply token's
+      ;; completion time. Current is nav-2 → suppressed; the trace must carry
+      ;; the completion time.
+      (rf/dispatch-sync [:article/loaded-via-nav-token
+                         {:carried-token    "nav-1"
+                          :carried-route-id :route/article
+                          :completed-at     completion-ts
+                          :id               "A"
+                          :payload          "A-payload"}])
+
+      (rf/unregister-listener! ::completed-at-fx)
+
+      (let [stale (some (fn [ev]
+                          (when (= :rf.route.nav-token/stale-suppressed
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+        (is (some? stale) "a production stale-suppressed trace fired")
+        (is (= completion-ts (-> stale :tags :completed-at))
+            "the stale trace carries the threaded reply completion time (pre-fix: dropped)")))))
+
+(deftest with-nav-token-fx-stale-omits-completed-at-when-absent
+  (testing "rf2-ux8sgg — when no completion time is threaded, the stale trace
+            omits `:completed-at` (a loader that sourced none) — the slot is
+            optional, never a nil placeholder"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
+    (rf/reg-event :article/loaded-via-nav-token
+                     (fn [_ctx [_ {:keys [carried-token carried-route-id id payload]}]]
+                       {:fx [[:rf.route/with-nav-token
+                              {:do        [:dispatch [:article/loaded id payload]]
+                               :nav-token carried-token
+                               :route-id  carried-route-id}]]}))
+
+    (let [traces (atom [])]
+      (rf/register-listener! ::no-completed-at (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/A"])
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/B"])
+      (rf/dispatch-sync [:article/loaded-via-nav-token
+                         {:carried-token    "nav-1"
+                          :carried-route-id :route/article
+                          :id               "A"
+                          :payload          "A-payload"}])
+      (rf/unregister-listener! ::no-completed-at)
+      (let [stale (some (fn [ev]
+                          (when (= :rf.route.nav-token/stale-suppressed
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+        (is (some? stale) "a stale-suppressed trace fired")
+        (is (not (contains? (:tags stale) :completed-at))
+            "no :completed-at tag when none was sourced (slot is optional)")))))
+
+(deftest simulate-http-resolution-stale-preserves-completed-at
+  (testing "rf2-ux8sgg — the test fixture `:rf.test/simulate-http-resolution`
+            mirrors the production lane: a stale completion carrying
+            `:carried-completed-at` produces a stale trace with that time"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-event :article/loaded
+                     (fn [{:keys [db]} [_ id payload]]
+                       {:db (assoc db :article {:id id :payload payload})}))
+
+    (let [traces        (atom [])
+          completion-ts 1717009999999]
+      (rf/register-listener! ::fixture-completed-at (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/A"])
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/B"])
+      ;; A's stale resolution carries nav-1 + its captured completion time.
+      (rf/dispatch-sync [:rf.test/simulate-http-resolution
+                         {:on-success-event     [:article/loaded "A" "A-payload"]
+                          :carried-nav-token    "nav-1"
+                          :carried-route-id     :route/article
+                          :carried-completed-at completion-ts}])
+      (rf/unregister-listener! ::fixture-completed-at)
+      (let [stale (some (fn [ev]
+                          (when (= :rf.route.nav-token/stale-suppressed
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+        (is (some? stale) "the fixture stale-suppressed trace fired")
+        (is (= completion-ts (-> stale :tags :completed-at))
+            "the fixture stale trace carries the captured reply completion time")))))
+
 ;; ---- Spec 012 §Navigation tokens step 2 — the `:rf.route/nav-token` cofx ----------
 ;;
 ;; rf2-8fnwq: the spec promised an `:on-match`-reachable `:rf.route/nav-token`

--- a/implementation/routing/test/re_frame/routing_reply_test.clj
+++ b/implementation/routing/test/re_frame/routing_reply_test.clj
@@ -92,6 +92,32 @@
         (is (= {:route/nav-token "nav-2"} (:rf.reply/current trace)) "current gate")
         (is (= :rf.route/nav-token-stale (:stale/reason trace)))))))
 
+(deftest suppress-carries-completed-at-on-stale-reply
+  (testing "rf2-ux8sgg — a route loader that supplies the reply completion
+            time (`:completed-at`, the recordable :rf/time-ms fact, EP-0017)
+            carries it verbatim onto the stale reply; absence omits it. This
+            pins the production lane the pure substrate exposes — the stale
+            route reply is tied to the actual replayed completion token."
+    (let [{:keys [reply]}
+          (route-reply/suppress {:route-id     :route/article
+                                 :nav-token    "nav-1"
+                                 :loader-id    :article/loaded
+                                 :frame        :rf/default
+                                 :completed-at 1717000000000}
+                                "nav-2")]
+      (is (= 1717000000000 (:completed-at reply))
+          "the supplied completion time rides the stale reply (not dropped)")
+      (is (= :stale (:status reply)) "still a stale reply")
+      (is (not (contains? reply :value)) "still app-state-safe (no :value)"))
+    (testing "absence omits the slot — a loader that sourced no completion time"
+      (let [{:keys [reply]}
+            (route-reply/suppress {:route-id  :route/article
+                                   :nav-token "nav-1"
+                                   :loader-id :article/loaded}
+                                  "nav-2")]
+        (is (not (contains? reply :completed-at))
+            ":completed-at is omitted when the caller supplies none")))))
+
 (deftest suppress-honours-dispatch-stale-opt-in
   (testing "a framework test/tool target may opt into stale delivery via :dispatch-stale?
             (app targets MUST NOT) — delegated to re-frame.reply/suppress"

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -244,24 +244,39 @@
         cofx-registry (get-in fixture [:fixture/registry :cofx] {})
         helpers       (adapter-helpers)]
     ;; ---- cofx -----------------------------------------------------------
-    ;; EP-0017: `reg-cofx` registers a value-returning AMBIENT supplier
-    ;; (`(fn [] value)`), not the retired ctx→ctx injector. For ssr the cofx
-    ;; registry slots are declarative only (their presence in
-    ;; :fixture/registry exists so meta lookups don't 404); fixtures that
-    ;; need real cofx delivery use the core conformance-test ns. The
-    ;; supplier returns the fixture's declared value (or nil for a bare
-    ;; `[[:noop]]`), delivered flat under the cofx-id to handlers that
-    ;; declare `:rf.cofx/requires [cofx-id]`.
+    ;; EP-0017 distinguishes TWO cofx shapes; the SSR runner now exercises
+    ;; both (rf2-sb47ni):
+    ;;
+    ;;   - AMBIENT value-returning cofx — `reg-cofx` takes a supplier
+    ;;     `(fn [] value)`; the runtime runs it at context assembly and
+    ;;     delivers the value flat under the cofx-id to a handler that
+    ;;     declares `:rf.cofx/requires [cofx-id]`. The supplier returns the
+    ;;     fixture's declared value (or nil for a bare `[[:noop]]`).
+    ;;
+    ;;   - PROVIDED recordable cofx (`{:provided? true …}`, typically
+    ;;     `:recordable? true`) — a BOUNDARY-supplied fact with NO supplier;
+    ;;     its VALUE rides the dispatch token flat under `:rf.cofx`, not a
+    ;;     generator. Post-#4104 `reg-cofx` REJECTS `provided? true` + a
+    ;;     supplier as `:rf.error/cofx-registration-invalid` (the shape
+    ;;     rf2-xuhdni fixed in the core runner), so register WITHOUT one. A
+    ;;     declared provided fact that is absent from the token throws
+    ;;     `:rf.error/missing-required-cofx` at delivery. This mirrors the
+    ;;     core runner so an SSR/hydration fixture can exercise the EP-0017
+    ;;     replay contract: provided facts ride flat on the token, absence
+    ;;     fails loudly (Spec 002 §Satisfaction algorithm + §The :rf.cofx
+    ;;     envelope is the host-integration path SSR/hydration uses).
     (doseq [[cofx-id meta] cofx-registry]
-      (let [body     (get-in hmap [:cofx cofx-id] [[:noop]])
-            supplier (fn []
-                       (reduce (fn [v step]
-                                 (case (first step)
-                                   :set (let [[_ _ sv] step] sv)
-                                   v))
-                               nil
-                               body))]
-        (rf/reg-cofx cofx-id meta supplier)))
+      (if (:provided? meta)
+        (rf/reg-cofx cofx-id meta)
+        (let [body     (get-in hmap [:cofx cofx-id] [[:noop]])
+              supplier (fn []
+                         (reduce (fn [v step]
+                                   (case (first step)
+                                     :set (let [[_ _ sv] step] sv)
+                                     v))
+                                 nil
+                                 body))]
+          (rf/reg-cofx cofx-id meta supplier))))
     ;; ---- events --------------------------------------------------------
     ;; EP-0017: a handler takes delivery of a cofx by DECLARING it in the
     ;; `:rf.cofx/requires` registration metadata — not via an `inject-cofx`
@@ -533,7 +548,11 @@
           ;; under its declared :platform / :ssr config.
           _            (rf/destroy-frame! :rf/default)
           _            (rf/reg-frame :rf/default frame-config)
-          dispatches   (or (:fixture/dispatches fixture) [])]
+          dispatches   (or (:fixture/dispatches fixture) [])
+          ;; rf2-sb47ni — accumulate per-dispatch boundary-throw mismatches
+          ;; (the `:expect-error` cofx-delivery assertions). Mirrors the core
+          ;; runner's `dispatch-error-failures` channel.
+          dispatch-error-failures (atom [])]
       ;; EP-0002 (rf2-9o48ih): a bare `dispatch-sync` with no explicit
       ;; `{:frame …}` opt resolves its target from the established frame
       ;; scope, never from an invented `:rf/default` floor (the carried
@@ -542,6 +561,43 @@
       (rf/with-frame :rf/default
       (doseq [ev dispatches]
         (cond
+          ;; ---- map-form dispatch (rf2-sb47ni) --------------------------
+          ;; A map dispatch carries `:event` plus optional opts. EP-0017
+          ;; SSR/hydration fixtures use this to supply a PROVIDED recordable
+          ;; fact flat on the token via `:rf.cofx {…}`, and to assert the
+          ;; boundary throw a MISSING declared provided fact raises via
+          ;; `:expect-error`. The remaining opts (`:rf.cofx`, `:source`)
+          ;; pass through to `dispatch-sync` verbatim.
+          (and (map? ev) (contains? ev :expect-error))
+          ;; EP-0017 cofx-delivery errors throw during context assembly,
+          ;; escaping `dispatch-sync` (not captured into the chain). Catch
+          ;; here and compare the ex-data `:rf.error/id`. Mirrors the core
+          ;; runner's `:expect-error` branch.
+          (let [event (:event ev)
+                want  (:expect-error ev)
+                opts  (dissoc ev :event :expect-error)
+                got   (try (rf/dispatch-sync event opts) ::no-throw
+                           (catch clojure.lang.ExceptionInfo e
+                             (:rf.error/id (ex-data e)))
+                           (catch Throwable e e))]
+            (cond
+              (= got ::no-throw)
+              (swap! dispatch-error-failures conj
+                     (str "dispatch " (pr-str event) " expected to throw "
+                          want " but did not throw"))
+              (not= got want)
+              (swap! dispatch-error-failures conj
+                     (str "dispatch " (pr-str event) " expected error " want
+                          " but got " (if (instance? Throwable got)
+                                        (str "a non-ExceptionInfo throw: "
+                                             (some-> ^Throwable got .getMessage))
+                                        got)))))
+
+          (map? ev)
+          ;; A map dispatch with no `:expect-error` — `:event` plus opts
+          ;; (e.g. `:rf.cofx` provided-fact delivery) flow to dispatch-sync.
+          (rf/dispatch-sync (:event ev) (dissoc ev :event))
+
           (and (vector? ev) (= :rf/hydrate (first ev)))
           ;; Per Spec 011 §The :rf/hydrate event the call site stamps
           ;; :source :ssr-hydration on the dispatch envelope. The
@@ -659,6 +715,7 @@
                                  (every? #(= (:expected %) (:actual %)) sub-checks)
                                  (empty? trace-failures)
                                  (empty? not-emit-failures)
+                                 (empty? @dispatch-error-failures)
                                  (or (nil? pe-check) (:passed? pe-check))
                                  (or (nil? head-check) (:passed? head-check))
                                  (or (nil? req-check) (:passed? req-check))
@@ -668,6 +725,7 @@
          :sub-checks        sub-checks
          :trace-failures    trace-failures
          :not-emit-failures not-emit-failures
+         :dispatch-error-failures @dispatch-error-failures
          :pe-check          pe-check
          :head-check        head-check
          :req-check         req-check
@@ -745,6 +803,8 @@
             (println "    trace:" tf))
           (doseq [nef (:not-emit-failures f)]
             (println "    not-emit:" nef))
+          (doseq [def (:dispatch-error-failures f)]
+            (println "    expect-error:" def))
           (when-let [pe (:pe-check f)]
             (when-not (:passed? pe)
               (println "    public-error expected:" (:expected pe))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3177,10 +3177,13 @@ Args of the framework-supplied `:rf.route/with-nav-token` fx wrapper, per [012 �
   [:map
    [:do        [:vector :any]]                                            ;; an fx entry to perform — typically [:dispatch [<event-id> args ...]]
    [:nav-token :any]                                                      ;; the token captured at scheduling time (gensym or counter)
-   [:route-id {:optional true} :any]])                                    ;; OPTIONAL captured route id: when present, a cross-route stale completion attributes its work-id to the route-loader attempt, not the route live at arrival
+   [:route-id {:optional true} :any]                                      ;; OPTIONAL captured route id: when present, a cross-route stale completion attributes its work-id to the route-loader attempt, not the route live at arrival
+   [:completed-at {:optional true} :any]])                                ;; OPTIONAL reply completion time — the recordable :rf/time-ms fact on the reply token; when a stale completion supplies it, the suppressed reply/trace carries it so route completion time tracks the other managed-async families
 ```
 
 Registered under spec id `:rf.fx/with-nav-token-args`. The wrapped fx receives the carried token in cofx; on receipt, the `:rf.route/nav-token` cofx (a subsystem-registered coeffect a handler declares via `:rf.cofx/requires [:rf.route/nav-token]` per [001 §`:rf.cofx/requires`](001-Registration.md#rfcofxrequires--the-declaration-key)) checks the carried token against the current route slice's (`[:rf.runtime/routing :current]`) `:nav-token`. Mismatch → suppress + emit `:rf.route.nav-token/stale-suppressed` trace.
+
+Per EP-0017 a reply completion is a causal token: the completion time is the recordable `:rf/time-ms` fact on the flat reply `:rf.cofx`. A route completion handler should source `:completed-at` from its declared `:rf.cofx/requires [:rf/time-ms]` reply fact (NOT an ambient clock read) and thread it through this fx, so a superseded (stale) route-loader completion's reply/trace carries the actual replayed completion time rather than dropping it. The slot is optional — a loader that sourced no completion time omits it (never a `nil` placeholder), and the stale reply/trace omits `:completed-at` in turn. This keeps route stale completions tied to their completion token alongside the HTTP / resource / mutation families, which carry the same `:completed-at`.
 
 ### `:rf/hydration-payload`
 

--- a/spec/conformance/fixtures/ssr-cofx-missing-required.edn
+++ b/spec/conformance/fixtures/ssr-cofx-missing-required.edn
@@ -1,0 +1,52 @@
+;; Conformance fixture: ssr/cofx-missing-required
+;;
+;; rf2-sb47ni — the NEGATIVE half of the EP-0017 provided-recordable SSR
+;; contract (companion to `ssr-cofx-provided-recordable.edn`). A server handler
+;; DECLARES a provided recordable boundary fact via `:rf.cofx/requires`, but the
+;; dispatch token does NOT carry the value under `:rf.cofx`. A `:provided?` fact
+;; has no supplier and cannot be minted, so its absence is
+;; `:rf.error/missing-required-cofx` in EVERY mode (Spec 002 §Mint policies +
+;; Spec 009 §Error catalogue) — the cascade halts during context assembly,
+;; BEFORE the handler runs. This is the replay safety contract: a provided fact
+;; that the boundary forgot to stamp fails LOUD rather than silently delivering
+;; nil into app state.
+;;
+;; The dispatch carries `:expect-error :rf.error/missing-required-cofx`; the SSR
+;; conformance runner (rf2-sb47ni) asserts the dispatch threw an `ex-info`
+;; whose `:rf.error/id` ex-data slot equals that id (mirrors the core runner's
+;; `:expect-error` convention). The handler body never runs, so no `:never`
+;; slot is written.
+
+{:fixture/id           :ssr/cofx-missing-required
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/error}
+ :fixture/doc          "EP-0017 provided recordable cofx absence: a server handler declaring `:rf.cofx/requires [:ssr.cofx/request-time]` whose token does NOT carry the provided value throws `:rf.error/missing-required-cofx` during context assembly (every mode — a provided fact has no supplier and cannot be minted). The handler body never runs. A port that delivers nil, throws generically, or fails to throw FAILS."
+
+ :fixture/registry
+ {:event {:ssr/needs-request-time
+          {:doc       "Server handler: declares a provided recordable fact whose value is ABSENT from the token."
+           :platforms #{:server}}}
+  :cofx  {:ssr.cofx/request-time
+          ;; Provided recordable boundary fact — no supplier. Absent from the
+          ;; token here ⇒ `:rf.error/missing-required-cofx` at delivery.
+          {:recordable? true :provided? true
+           :doc "Provided recordable request-time fact; deliberately NOT stamped on the token."}}}
+
+ :fixture/handlers
+ {:event {:ssr/needs-request-time
+          ;; Reading the registered provided fact auto-wires it onto
+          ;; `:rf.cofx/requires` and forces the event-fx shape. The body never
+          ;; runs — delivery throws first (the value is absent + unminteable).
+          [[:set [:never] [:cofx-key :ssr.cofx/request-time]]]}}
+
+ :fixture/frame-config {:platform :server}
+
+ :fixture/dispatches
+ ;; No `:rf.cofx` on the token — the declared provided fact is absent. The
+ ;; runner asserts the boundary throw rather than a committed app-db.
+ [{:event [:ssr/needs-request-time] :expect-error :rf.error/missing-required-cofx}]
+
+ :fixture/expect
+ ;; The handler body never ran (context assembly threw first), so the `:never`
+ ;; slot was never written.
+ {:final-app-db {}}}

--- a/spec/conformance/fixtures/ssr-cofx-provided-recordable.edn
+++ b/spec/conformance/fixtures/ssr-cofx-provided-recordable.edn
@@ -1,0 +1,67 @@
+;; Conformance fixture: ssr/cofx-provided-recordable
+;;
+;; rf2-sb47ni — EP-0017 PROVIDED recordable cofx through the SSR/hydration
+;; replay path. SSR is one of the host-integration paths Spec 002 calls out as
+;; a place where callers supply EXACT recordable facts via the dispatch token's
+;; flat `:rf.cofx`. This fixture pins the POSITIVE replay contract: a server
+;; init handler that DECLARES a provided recordable boundary fact
+;; (`:rf.cofx/requires`) receives the value the request boundary stamped onto
+;; the token under `:rf.cofx`, flat under the cofx-id.
+;;
+;; The cofx is registered `{:recordable? true :provided? true}` — a
+;; BOUNDARY-supplied fact with NO supplier (its value is the request-time
+;; replayed fact, not a generator output). The SSR conformance runner
+;; (rf2-sb47ni) registers a provided cofx without a supplier — exercising the
+;; EP-0017 recordable semantics rather than minting an ambient supplier for it
+;; (which post-#4104 `reg-cofx` would reject as
+;; `:rf.error/cofx-registration-invalid`).
+;;
+;; The companion `ssr-cofx-missing-required.edn` fixture pins the NEGATIVE
+;; contract (the same declaration with the fact ABSENT from the token →
+;; `:rf.error/missing-required-cofx`).
+
+{:fixture/id           :ssr/cofx-provided-recordable
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub}
+ :fixture/doc          "EP-0017 provided recordable cofx through the SSR token: a server handler declaring `:rf.cofx/requires [:ssr.cofx/request-time]` receives the value the request boundary stamped flat on the dispatch token's `:rf.cofx`. The provided fact has no supplier; its value rides the token, not a generator. The captured value must equal the stamped fact verbatim."
+
+ :fixture/registry
+ {:event {:ssr/capture-request-time
+          {:doc       "Server handler: capture the provided recordable request-time fact delivered flat from the token."
+           :platforms #{:server}}}
+  :sub   {:ssr/captured-time {:doc "Read the captured request-time fact."}}
+  :cofx  {:ssr.cofx/request-time
+          ;; A PROVIDED recordable boundary fact — no supplier. Its value is
+          ;; the exact recordable fact the SSR request boundary stamps onto
+          ;; the dispatch token under `:rf.cofx`. The runner registers it
+          ;; without a supplier (rf2-sb47ni).
+          {:recordable? true :provided? true
+           :doc "Provided recordable request-time fact; supplied on the token under :rf.cofx."}}}
+
+ :fixture/handlers
+ {:event {:ssr/capture-request-time
+          ;; Reading `[:cofx-key :ssr.cofx/request-time]` auto-wires the
+          ;; (registered, fully-qualified) provided id onto the handler's
+          ;; `:rf.cofx/requires` and forces the event-fx shape, so the full
+          ;; coeffect context (the flat-delivered provided fact) is reachable.
+          [[:set [:captured-time] [:cofx-key :ssr.cofx/request-time]]]}
+  :sub   {:ssr/captured-time [[:get [:captured-time]]]}}
+
+ :fixture/frame-config {:platform :server}
+
+ :fixture/dispatches
+ ;; The provided recordable fact rides FLAT on the dispatch token under
+ ;; `:rf.cofx` — exactly the EP-0017 host-integration shape SSR callers use to
+ ;; supply an exact replayed fact. `:rf/time-ms` is the framework-provided
+ ;; recordable fact every token carries; `:ssr.cofx/request-time` is the
+ ;; owner-qualified provided fact this handler declares.
+ [{:event  [:ssr/capture-request-time]
+   :rf.cofx {:rf/time-ms            1781078400123
+             :ssr.cofx/request-time 1781078400123}}]
+
+ :fixture/expect
+ {:final-app-db
+  {:captured-time 1781078400123}
+
+  :sub-values
+  {[:ssr/captured-time] 1781078400123}}}


### PR DESCRIPTION
Two P2 EP-0017 conformance-coverage gaps. Disjoint surfaces (SSR runner / routing nav-token), one branch.

## rf2-sb47ni — SSR conformance runner exercises provided recordable cofx

The SSR conformance runner built a value-supplier for every fixture `:cofx` entry and auto-wired `:rf.cofx/requires`, modelling only ambient value-returning cofx. It could not exercise EP-0017 recordable/provided cofx semantics — a `{:recordable? true :provided? true}` fixture would still be passed a supplier (the `:rf.error/cofx-registration-invalid` shape rf2-xuhdni fixed in the core runner), and the runner did not parse/supply per-dispatch `:rf.cofx` data or assert the replay contract. SSR is a host-integration path Spec 002 calls out as a place callers supply exact recordable facts via the token's flat `:rf.cofx`.

Runner changes (mirror the core runner rf2-xuhdni / rf2-mrp8jg):
- register a `:provided?` cofx WITHOUT a supplier; keep the ambient supplier path for genuinely ambient cofx
- support map-form dispatches: `:event` + `:rf.cofx` (flat provided-fact delivery) + `:expect-error` (boundary-throw assertion, new `dispatch-error-failures` channel folded into `:passed?` + the failure printout)

Two new SSR fixtures:
- `ssr-cofx-provided-recordable.edn` — a server handler declaring `:rf.cofx/requires` receives the provided recordable fact stamped flat on the token, verbatim
- `ssr-cofx-missing-required.edn` — the same declaration with the fact ABSENT throws `:rf.error/missing-required-cofx` during context assembly (a provided fact has no supplier — missing in every mode); the handler body never runs

## rf2-ux8sgg — routing `:rf.route/with-nav-token` stale path carries completion time

`route-reply/suppress` already accepted `:completed-at` and rode it onto the stale reply, but neither the production `:rf.route/with-nav-token` path nor the test fixture ever passed one — a superseded route-loader completion dropped its completion time, leaving tools/ledgers unable to tie a stale route reply to the replayed completion token (route completion time drifting from the HTTP / resource / mutation families that carry `:completed-at`).

Production lane added:
- `with-nav-token-meta` schema gains optional `:completed-at`
- `with-nav-token-handler` reads it from args and threads it into `emit-stale-suppressed!`
- `emit-stale-suppressed!` passes it through `route-reply/suppress` and stamps it on the stale trace when present (omitted when absent)
- `:rf.test/simulate-http-resolution` mirrors the lane via `:carried-completed-at`
- `spec/Spec-Schemas.md` `:rf.fx/with-nav-token-args` documents the slot + the "source from declared `:rf.cofx/requires [:rf/time-ms]`, not an ambient clock" convention

Regressions: pure `suppress` carries/omits `:completed-at`; production fx + test-fixture stale paths preserve the completion time on the trace; absence omits the tag (no nil placeholder).

## Verification

- Both rf2-ux8sgg and rf2-sb47ni regressions verified load-bearing (production-path nav-token test fails when threading is removed; SSR corpus reports 14 runnable / 0 skipped, breaking expected value/error-id fails the gate)
- routing JVM suite: 291 tests, 0 failures
- ssr JVM suite: 364 tests, 0 failures
- core conformance: green (new SSR fixtures pass in the core runner too)
- `npm run test:cljs`: 7726 tests, 0 failures (CLJS conformance runner reads the new fixtures cross-host)
- `scripts/test-fast-pr.sh`: PASS (CLJS + markdown link/anchor + EP status-sync gates green; mkdocs soft-skipped locally on Windows)