### PR TITLE
fix(xray): EP-0011 stale-status + live-work rendering/join + generated recordable coeffects (rf2-1dr4gc, rf2-909xun, rf2-ui2o0n, rf2-9l80u2)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -405,7 +405,12 @@ machines / timers:
 - **`status->class`** gives the one cross-surface colour class so a
   `:stale` HTTP reply and a `:stale` resource reply render the **same
   badge** (Cross-Cutting [F.11](019-Cross-Cutting-Insight.md) — the
-  unified `STALE` rendering).
+  unified `STALE` rendering). A `:stale-suppressed` row preserves the
+  canonical EP-0011 `:status :stale` + `:status-class :suppression` read off
+  the **unambiguous `:rf.reply/status`** (NEVER the bare `:status`, which on
+  a suppression row may carry the LEDGER status `:completed`/`:failed`/
+  `:suppressed`) — so a suppression row renders the SAME status/badge
+  contract a `:completed` row does, not just the `:stale?` phase flag.
 
 ### "What is still running?" and the stale-races view
 
@@ -417,9 +422,15 @@ status + trace cause, uniformly across families** — never per-family:
   §Work-ledger integration) and joins each to the **latest
   reply-envelope trace phase** for its `:work/id`, so the operator sees
   "the app is waiting on resource K (issued), HTTP req-5
-  (cancel-requested), …" with one query. `live-work-tally-by-kind`
-  counts live work per family — the active managed-effects dashboard
-  headline (Cross-Cutting F-C4).
+  (cancel-requested), …" with one query. The join keys on the canonical
+  `:work/id` **vector** carried on the ledger RECORD (`ledger-row` reads
+  `(:work/id record)`, falling back to the map key only for legacy /
+  nonconforming records) — the production `:rf.runtime/work-ledger` map is
+  keyed on the opaque CEDN-1 byte `work-id-id` STRING, so reading the record
+  field (not the map key) is what lets a live row join to the vector-keyed
+  trace rows and infer `:work-kind` from the kind-preserving head.
+  `live-work-tally-by-kind` counts live work per family — the active
+  managed-effects dashboard headline (Cross-Cutting F-C4).
 - **The stale-races view keys on `:work/id`** (Managed-Effects
   §Work-id correlation — `:work/id` is the *single* attempt identity,
   the key the ledger, stale suppression, and this view all share).

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -743,6 +743,21 @@ sections that read top-to-bottom as the developer scans.
      vocabulary fracture EP-0017 closes; the recorded map *is* the
      recordable GRADE of coeffect. The ambient grade keeps its own COEFFECTS
      section (§3 below); the two grades sit side by side.
+   - **Generated recordables** (EP-0017 slice B.7 · spec/009 §277) — a
+     declared recordable fact whose value is minted by a **generator** at
+     processing-start (when the fact is absent from the enqueue token) is
+     written back into the in-flight `:rf.cofx` record and emits
+     `:rf.cofx/generated`. The enqueue-time `:rf.event/dispatched` `:rf.cofx`
+     map **predates** generation, so the generated fact is read from the
+     `:rf.cofx/generated` trace ops (the post-generation source of truth)
+     and merged into the section, marked with a **`generated`** provenance
+     badge so the operator can tell a replayable generated coeffect apart
+     from a token-supplied one. A generated leaf whose key **already**
+     appears among the supplied leaves (a supplied/replayed value — the
+     generator did not run) is **not duplicated**: the supplied row wins.
+     The generated value summarizes/redacts through the same path as a
+     supplied leaf. The section renders off the generated ops even when the
+     enqueue token carried no `:rf.cofx` map at all.
    - **PRIVACY** (EP-0010 §Privacy / Open Issue 4, ruled 2026-06-11;
      EP-0017 §9 restates per leaf): `:rf/time-ms` is **ALWAYS safe to
      surface** (a wall-clock fact, never PII) and renders **verbatim**.
@@ -830,9 +845,11 @@ sections that read top-to-bottom as the developer scans.
 
 - **No call-site captured** — DISPATCH SITE shows
   `"source coord unavailable"`; no open chip rendered.
-- **No `:rf.cofx` map** — RECORDABLE COEFFECTS section ABSENT entirely
-  (silent-by-default — older runtimes, the production-elided emit arm, or
-  fixtures that synthesise an epoch without the `:rf.cofx` tag).
+- **No `:rf.cofx` map AND no `:rf.cofx/generated` op** — RECORDABLE
+  COEFFECTS section ABSENT entirely (silent-by-default — older runtimes, the
+  production-elided emit arm, or fixtures that synthesise an epoch without
+  the `:rf.cofx` tag). A `:rf.cofx/generated` op alone (no enqueue
+  `:rf.cofx` map) still renders the section with the generated row(s).
 - **`:rf.cofx` map carries only `:rf/time-ms`** — RECORDABLE COEFFECTS
   renders the single `time-ms <ms>` row (the time fact is worth surfacing
   on its own).

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -185,7 +185,7 @@ The Resources tab is a Dynamic L3 tab (`:rf.xray/selected-tab`
 `:resources`, mnemonic `s`, order 7 — after Routing). The view
 (`panels/resources.cljs`) is pure hiccup over the single composite sub
 `:rf.xray/resources-tab-data`; the projection algebra is pure data in
-`panels/resources_helpers.cljc` (JVM-portable, unit-tested). Eleven
+`panels/resources_helpers.cljc` (JVM-portable, unit-tested). Thirteen
 stacked sections:
 
 1. **Static resource registry** — per registered resource: id, source
@@ -220,6 +220,23 @@ stacked sections:
    promises) are structurally inaccessible — they live in side tables
    outside durable frame-state. Non-terminal (live) rows lead; the
    terminal recent-races tail trails dimmed.
+3a. **What is still running?** (EP-0011 live-work) — the cross-family
+   **uniform** reply-envelope read (NOT resource-private; see §Uniform
+   reply-envelope reads below): the live (non-terminal) work-ledger rows
+   joined to their latest reply-envelope trace **phase + emitting op** per
+   `:work/id`, each row carrying work-kind, ledger status, the joined
+   latest phase/op, attempt, owner count, and the canonical `:work/id`.
+   Below the rows, the **per-kind suppression tally** headline (the
+   active-effects dashboard count of stale suppressions per family).
+   **Silent-by-default**: the section renders nothing when there is no live
+   work AND no suppression data (a settled app shows no dashboard).
+3b. **Stale races** (EP-0011 stale-suppression / supersession) — the
+   cross-family stale-races view: every work/reply attempt arc that hit the
+   **stale-suppression correctness boundary** (carried ≠ current — one
+   attempt superseded another), grouped by `:work/id` and rendered with its
+   terminal `:stale` status, the phases the arc passed through, and the
+   `:work/id`. Only **suppressed** arcs render. **Silent-by-default**: the
+   section renders nothing when no arc was suppressed.
 4. **Route / resource graph** — per route declaring `:resources`: the
    route id + path, its declared resources, the **blocking vs
    non-blocking** split (blocking = **SSR wait point**), keep-previous
@@ -551,9 +568,19 @@ The composite's `:live-work`, `:stale-races`, and `:stale-tally` slots are
 facts (`:work/id` / `:work/kind` / reply `:status` / stale-suppression
 carried+current) the SAME way for **every** managed-async family, via
 [`panels/reply_envelope.cljc`](../src/day8/re_frame2_xray/panels/reply_envelope.cljc).
+They are **rendered** by §3a ("What is still running?") and §3b ("Stale
+races") above — silent-by-default so a settled app surfaces neither.
 "What is still running?" is the live (non-terminal) work-ledger rows
 joined to the latest reply-envelope trace phase per `:work/id`; the
 stale-races view groups every cross-family work/reply row by `:work/id`.
+The live-work join keys on the canonical `:work/id` **vector** carried on
+the ledger record (`reply_envelope/ledger-row` reads `(:work/id record)`,
+falling back to the opaque CEDN-1 byte map key only for legacy records),
+so a live ledger row correctly joins to the vector-keyed reply-envelope
+trace rows. A `:stale-suppressed` row preserves the canonical EP-0011
+`:status :stale` + `:status-class :suppression` read off the unambiguous
+`:rf.reply/status` (never misreading a bare ledger `:status`), the same
+cross-surface badge contract a `:completed` row renders.
 The resource family is the only ledger writer today, so the rows are all
 `:work/kind :resource` (and `:mutation`) for now; as HTTP / route /
 machine / timer families write their own ledger rows and emit their

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -328,16 +328,55 @@
           vec)
      [])))
 
+(defn generated-cofx-rows
+  "Project the `:rf.cofx/generated` trace events of an epoch into
+  privacy-summarized recordable rows (EP-0017 slice B.7 · spec/009 §277).
+
+  A generator-backed recordable supplier runs at PROCESSING-START when its
+  declared recordable fact is absent from the enqueue-time token, mints the
+  value, writes it back into the in-flight `:rf.cofx` record, and emits the
+  dev op `:rf.cofx/generated` carrying `{:rf.cofx/id <fact-name>
+  :rf.cofx/value <produced-value>}`. The enqueue-time `:rf.event/dispatched`
+  `:rf.cofx` map PREDATES generation, so it cannot carry the generated fact —
+  the post-generation source of truth is this trace op (and the
+  generation-augmented record router/restamps; spec/009 §277).
+
+  Each row carries `{:key <fact-name> :value <summary> :generated? true}` so
+  the lens renders the generated provenance distinctly from a supplied /
+  replayed leaf. PRIVACY: the value is `summarize`d (redact-by-default — the
+  same path `recordable-cofx-rows` uses; the op's `:rf.cofx/value` is itself
+  already projected through the substrate marks chokepoint). Sorted by fact
+  name for stable rendering. Empty when no `:rf.cofx/generated` op fired.
+
+  `declared-recordables` (optional) filters to the handler's declared
+  recordable id set, exactly like `recordable-cofx-rows` — a generated fact
+  is by construction a DECLARED recordable, so this is consistent."
+  ([events] (generated-cofx-rows events nil))
+  ([events declared-recordables]
+   (->> (filter-op events :rf.cofx/generated)
+        (keep (fn [ev]
+                (let [id (common/tag-of ev :rf.cofx/id)]
+                  (when (and (some? id)
+                             (or (nil? declared-recordables)
+                                 (contains? declared-recordables id)))
+                    {:key       id
+                     :value     (rh/summarize (common/tag-of ev :rf.cofx/value))
+                     :generated? true}))))
+        (sort-by (comp str :key))
+        vec)))
+
 (defn recordable-cofx-row
   "Build the RECORDABLE COEFFECTS step from the epoch's
-  `:rf.event/dispatched` trace (rf2-9fyn40 · EP-0010 · EP-0017 §9). Reads
-  the flat recordable-coeffect map off `[:tags :rf.cofx]` (the
-  substrate-canonical slot `router/emit-dispatched-trace!` stamps per
-  rf2-alc1lf; `common/tag-of` is the canonical reader). Returns nil when
-  the epoch carries no dispatched trace OR no `:rf.cofx` map (older runtimes
-  / fixtures / the production-elided arm) — the step is silent-by-default,
-  like the ambient COEFFECT step, so a vanilla cascade with no surfaced
-  recordable coeffects renders no section.
+  `:rf.event/dispatched` trace (rf2-9fyn40 · EP-0010 · EP-0017 §9) PLUS the
+  post-generation `:rf.cofx/generated` trace ops (EP-0017 slice B.7 ·
+  spec/009 §277). Reads the flat recordable-coeffect map off
+  `[:tags :rf.cofx]` (the substrate-canonical slot
+  `router/emit-dispatched-trace!` stamps per rf2-alc1lf; `common/tag-of` is
+  the canonical reader). Returns nil when the epoch carries NEITHER a
+  `:rf.cofx` map NOR any `:rf.cofx/generated` op (older runtimes / fixtures /
+  the production-elided arm) — the step is silent-by-default, like the
+  ambient COEFFECT step, so a vanilla cascade with no surfaced recordable
+  coeffects renders no section.
 
   The row carries:
 
@@ -345,7 +384,8 @@
        :badge     :RECORDABLE-COFX
        :time-ms   <epoch-ms or nil>   ; ALWAYS-SAFE, surfaced verbatim
        :inputs    [{:key :counter/delta     :value <summary>}
-                   {:key :rf.route/location :value <summary>} …]}  ; SUMMARIZED
+                   {:key :rf.route/location :value <summary>}
+                   {:key :session/id :value <summary> :generated? true} …]} ; SUMMARIZED
 
   These are the handler's DECLARED RECORDABLE LEAVES (EP-0017 §9). PRIVACY:
   `:rf/time-ms` rides verbatim (always safe per Open Issue 4); every other
@@ -353,6 +393,20 @@
   `reply_envelope.cljc` uses). A map carrying ONLY `:rf/time-ms` still
   produces a row (the time fact is worth surfacing on its own); a map with
   no `:rf/time-ms` AND no other leaves (empty map) produces nil.
+
+  ## Generated recordables (EP-0017 slice B.7 · spec/009 §277)
+
+  When a declared recordable fact is ABSENT from the enqueue token, its
+  generator runs at processing-start, mints the value, writes it back into
+  the in-flight `:rf.cofx` record, and emits `:rf.cofx/generated`. The
+  enqueue-time `:rf.cofx` map predates that step, so the generated fact is
+  read from the `:rf.cofx/generated` op (the post-generation source of
+  truth) and merged in as `{:generated? true}`. A generated leaf whose key
+  ALREADY appears among the dispatched leaves (a supplied / replayed value
+  the generator did not re-mint) is NOT duplicated — the supplied row wins
+  (the supplied/replayed path renders the value the handler actually
+  consumed; the generator does not run in that case, so a duplicate would be
+  a spurious second row).
 
   ## Declared-recordable filtering (rf2-n9v5ga)
 
@@ -368,15 +422,24 @@
   show-all fallback holds (see `recordable-cofx-rows`)."
   ([events] (recordable-cofx-row events nil))
   ([events declared-recordables]
-   (when-let [ev (find-op events :rf.event/dispatched)]
-     (when-let [cofx (common/tag-of ev :rf.cofx)]
-       (when (and (map? cofx) (seq cofx))
-         (let [time-ms (get cofx time-ms-key)
-               inputs  (recordable-cofx-rows cofx declared-recordables)]
-           (cond-> {:step  :recordable-cofx
-                    :badge :RECORDABLE-COFX}
-             (some? time-ms) (assoc :time-ms time-ms)
-             (seq inputs)    (assoc :inputs inputs))))))))
+   (let [ev             (find-op events :rf.event/dispatched)
+         cofx           (when ev (common/tag-of ev :rf.cofx))
+         have-cofx?     (and (map? cofx) (seq cofx))
+         time-ms        (when have-cofx? (get cofx time-ms-key))
+         supplied       (when have-cofx?
+                          (recordable-cofx-rows cofx declared-recordables))
+         supplied-keys  (into #{} (map :key) supplied)
+         ;; generated facts ride the post-generation trace op, NOT the
+         ;; enqueue token. De-dup against the supplied leaves so a
+         ;; supplied/replayed value (the generator did not run) renders ONCE.
+         generated      (->> (generated-cofx-rows events declared-recordables)
+                             (remove #(contains? supplied-keys (:key %))))
+         inputs         (vec (concat supplied generated))]
+     (when (or have-cofx? (seq generated))
+       (cond-> {:step  :recordable-cofx
+                :badge :RECORDABLE-COFX}
+         (some? time-ms) (assoc :time-ms time-ms)
+         (seq inputs)    (assoc :inputs inputs))))))
 
 ;; ---- COEFFECT rows (the ambient grade — EP-0017 §1) ----------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -431,6 +431,20 @@
   {:color       text-tertiary-colour
    :white-space "nowrap"})
 
+;; Provenance marker for a recordable fact whose value was MINTED by a
+;; generator at processing-start (EP-0017 slice B.7) rather than supplied on
+;; the dispatch token. Distinguishes generated-vs-supplied provenance so the
+;; operator can tell a replayable generated coeffect apart from a token-borne
+;; one.
+(def ^:private recordable-cofx-generated-badge-style
+  {:color         accent-colour
+   :font-size     "9px"
+   :font-weight   600
+   :letter-spacing "0.04em"
+   :text-transform "uppercase"
+   :white-space   "nowrap"
+   :align-self    "center"})
+
 (def ^:private recordable-cofx-time-value-style
   {:color      text-primary-colour
    :min-width  0
@@ -2550,14 +2564,22 @@
    ;; value-bearing leaves — each rendered as a privacy summary chip
    ;; (redact-by-default). The leaf id rides verbatim (owner-qualified
    ;; vocabulary, not PII); only the VALUE is summarized.
-   (for [[idx {:keys [key value]}] (map-indexed vector inputs)]
+   (for [[idx {:keys [key value generated?]}] (map-indexed vector inputs)]
      ^{:key (str "recordable-cofx-" idx)}
      [:div {:data-testid (str "rf-xray-epoch-recordable-cofx-row-" (name key))
             :data-recordable-cofx-key (name key)
+            :data-recordable-cofx-generated (str (boolean generated?))
             :style recordable-cofx-row-style}
       [:span {:data-testid (str "rf-xray-epoch-recordable-cofx-key-" (name key))
               :style recordable-cofx-key-style}
        (fmt/ns-keyword key)]
+      ;; provenance: a generated fact was minted at processing-start
+      ;; (EP-0017 slice B.7), distinct from a token-supplied / replayed leaf.
+      (when generated?
+        [:span {:data-testid (str "rf-xray-epoch-recordable-cofx-generated-" (name key))
+                :style recordable-cofx-generated-badge-style
+                :title "minted by a generator at processing-start (EP-0017)"}
+         "generated"])
       (recordable-cofx-summary-view
         value
         (str "rf-xray-epoch-recordable-cofx-value-" (name key)))])])

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -510,18 +510,34 @@
     (when phase
       (let [tags    (trace-tags ev)
             work-id (work-id-of tags)
-            status  (when (= phase :completed)
-                      ;; rf2-waawic — read the closed reply status from EITHER
-                      ;; the bare `:status` OR the additive production
-                      ;; `:rf.reply/status` key (machine / resource / mutation
-                      ;; completion rows stamp the latter ALONGSIDE a bespoke
-                      ;; `:status`). Some resource completion rows stamp the
-                      ;; LEDGER status (`:completed`/`:failed`) under bare
-                      ;; `:status`; the closed reply status is what the
-                      ;; cross-surface badge keys on, so only surface a real
-                      ;; reply status, preferring the unambiguous
-                      ;; `:rf.reply/status` when present.
+            status  (cond
+                      (= phase :completed)
+                      ;; read the closed reply status from EITHER the bare
+                      ;; `:status` OR the additive production `:rf.reply/status`
+                      ;; key (machine / resource / mutation completion rows stamp
+                      ;; the latter ALONGSIDE a bespoke `:status`). Some resource
+                      ;; completion rows stamp the LEDGER status
+                      ;; (`:completed`/`:failed`) under bare `:status`; the
+                      ;; closed reply status is what the cross-surface badge keys
+                      ;; on, so only surface a real reply status, preferring the
+                      ;; unambiguous `:rf.reply/status` when present.
                       (let [s (or (:rf.reply/status tags) (:status tags))]
+                        (when (reply-status? s) s))
+
+                      (= phase :stale-suppressed)
+                      ;; EP-0011 treats `:stale` as one of the five closed reply
+                      ;; statuses (Managed-Effects §Status taxonomy). A failed
+                      ;; stale-suppression gate makes the reply outcome
+                      ;; `:status :stale`, stamped on the production row as
+                      ;; `:rf.reply/status`. Read ONLY the unambiguous
+                      ;; `:rf.reply/status` here — NOT the bare `:status`, which
+                      ;; on a suppression row may carry the LEDGER status
+                      ;; (`:completed`/`:failed`/`:suppressed`), not a reply
+                      ;; status — so the row carries the canonical `:stale`
+                      ;; status + the cross-surface `:suppression` badge that
+                      ;; `status->class` keys on, the SAME contract a completed
+                      ;; row renders.
+                      (let [s (:rf.reply/status tags)]
                         (when (reply-status? s) s)))]
         (cond-> {:id           (:id ev)
                  :operation    op
@@ -691,8 +707,17 @@
   The host handles (AbortControllers / promises / timer handles) live in a
   side table and are STRUCTURALLY absent from the serializable record
   (Managed-Effects §The reply map — the data-only invariant). Pure."
-  [[work-id record]]
-  (let [status (:status record)]
+  [[map-key record]]
+  (let [status (:status record)
+        ;; The production `:rf.runtime/work-ledger` map is keyed on the opaque
+        ;; CEDN-1 byte `work-id-id` STRING (resources/work-ledger §record-path);
+        ;; the kind-preserving work-id VECTOR is carried on the record as
+        ;; `:work/id`. Read the canonical vector from there — fall back to the
+        ;; map key only for a legacy/nonconforming record that lacks the stamp —
+        ;; so the displayed `:work-id`, the `:work-kind` inference, AND the
+        ;; live-work trace join all key on the kind-preserving identity, NOT the
+        ;; byte string. Mirror of resources-helpers/work-row.
+        work-id (or (:work/id record) map-key)]
     {:work-id      work-id
      :work-kind    (or (:work/kind record) (:kind record) (infer-work-kind work-id))
      :status       status

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -335,6 +335,125 @@
       (empty-caption "No in-flight or recent resource work in this frame."
                      "rf-xray-resources-work-empty"))))
 
+;; ---- §3b WHAT IS STILL RUNNING? (EP-0011 live-work) ---------------------
+;;
+;; The cross-family "what is the app waiting on, and why" view (Trace-Consumer
+;; §"What is still running?"): the live (non-terminal) work-ledger rows joined
+;; to their latest reply-envelope trace phase + emitting op, UNIFORM across
+;; HTTP / resources / mutations / routing / machines / timers. The projection
+;; (`reply/live-work`) is computed in the composite data sub; this view
+;; renders it. SILENT-BY-DEFAULT: renders nothing when there is no live work
+;; (the quiet baseline — a settled app shows no dashboard).
+
+(defn- live-work-row-view [row]
+  (let [testid (str "rf-xray-resources-live-work-row-" (hash (:work-id row)))]
+    [:div {:data-testid testid
+           :data-work-kind (str (some-> (:work-kind row) name))
+           :style {:display     "flex"
+                   :align-items "baseline"
+                   :gap         "10px"
+                   :flex-wrap   "wrap"
+                   :padding     "3px 0"
+                   :font-family mono-stack
+                   :font-size   "12px"}}
+     [:span {:data-testid (str testid "-kind")
+             :style {:color mode-accent :font-weight 600 :min-width "6rem"}}
+      (str (some-> (:work-kind row) name))]
+     [:span {:data-testid (str testid "-status")
+             :style {:color (:green tokens) :font-weight 600}}
+      (str (some-> (:status row) name))]
+     (when (:latest-phase row)
+       [:span {:data-testid (str testid "-phase")
+               :style {:color (:text-primary tokens)}}
+        "phase " (name (:latest-phase row))])
+     (when (:latest-op row)
+       [:span {:data-testid (str testid "-op")
+               :style {:color (:text-tertiary tokens)}}
+        (str (:latest-op row))])
+     (when (:attempt row)
+       [:span {:style {:color (:text-tertiary tokens)}} "attempt " (:attempt row)])
+     (when (seq (:owners row))
+       [:span {:style {:color (:text-tertiary tokens)}}
+        "owners " (count (:owners row))])
+     [:span {:data-testid (str testid "-id")
+             :style {:color (:text-tertiary tokens)}}
+      (str (:work-id row))]]))
+
+(defn- live-work-section [{:keys [live-work stale-tally]}]
+  ;; quiet when nothing is running AND nothing has been suppressed.
+  (when (or (seq live-work) (seq stale-tally))
+    (section
+      {:first? false :testid "rf-xray-resources-live-work"}
+      (section-caption "What is still running?" "rf-xray-resources-live-work-caption")
+      [:<>
+       (if (seq live-work)
+         (into [:div {:data-testid "rf-xray-resources-live-work-body"
+                      :style {:display "flex" :flex-direction "column" :gap "2px"}}]
+               (for [row live-work]
+                 ^{:key (str (:work-id row))} (live-work-row-view row)))
+         (empty-caption "No live managed-async work in this frame."
+                        "rf-xray-resources-live-work-empty"))
+       ;; the active-effects tally headline — live count per family.
+       (when (seq stale-tally)
+         (into [:div {:data-testid "rf-xray-resources-stale-tally"
+                      :style {:display "flex" :gap "10px" :flex-wrap "wrap"
+                              :margin-top "8px" :font-family mono-stack
+                              :font-size "11px" :color (:text-tertiary tokens)}}
+                [:span {:style {:font-weight 600}} "suppressed: "]]
+               (for [[kind n] (sort-by (comp str key) stale-tally)]
+                 ^{:key (str kind)}
+                 [:span {:data-testid (str "rf-xray-resources-stale-tally-"
+                                           (some-> kind name))
+                         :style {:color (:warning tokens)}}
+                  (str (some-> kind name) " " n)])))])))
+
+;; ---- §3c STALE RACES (EP-0011 stale-suppression / supersession) ---------
+;;
+;; The cross-family stale-races view (Trace-Consumer §stale-races / Resources
+;; panel §uniform reply-envelope reads): every work/reply attempt arc grouped
+;; by `:work/id`, showing the arcs that hit the stale-suppression correctness
+;; boundary (carried ≠ current — one attempt superseded another). The
+;; projection (`reply/races-by-work-id`) is computed in the composite data
+;; sub. SILENT-BY-DEFAULT: only the SUPPRESSED arcs render; renders nothing
+;; when no arc was suppressed.
+
+(defn- stale-race-row-view [arc]
+  (let [testid (str "rf-xray-resources-stale-race-row-" (hash (:work-id arc)))]
+    [:div {:data-testid testid
+           :data-work-kind (str (some-> (:work-kind arc) name))
+           :style {:display     "flex"
+                   :align-items "baseline"
+                   :gap         "10px"
+                   :flex-wrap   "wrap"
+                   :padding     "3px 0"
+                   :font-family mono-stack
+                   :font-size   "12px"}}
+     [:span {:data-testid (str testid "-kind")
+             :style {:color mode-accent :font-weight 600 :min-width "6rem"}}
+      (str (some-> (:work-kind arc) name))]
+     [:span {:data-testid (str testid "-terminal")
+             :style {:color (:warning tokens) :font-weight 600}}
+      (str (some-> (:terminal-status arc) name))]
+     [:span {:style {:color (:text-tertiary tokens)}}
+      "phases " (str/join " " (sort (map name (:phases arc))))]
+     [:span {:data-testid (str testid "-id")
+             :style {:color (:text-tertiary tokens)}}
+      (str (:work-id arc))]]))
+
+(defn- stale-races-section [stale-races]
+  (let [suppressed (->> (vals stale-races)
+                        (filter :suppressed?)
+                        (sort-by (comp str :work-id)))]
+    ;; quiet when no arc hit the stale-suppression boundary.
+    (when (seq suppressed)
+      (section
+        {:first? false :testid "rf-xray-resources-stale-races"}
+        (section-caption "Stale races" "rf-xray-resources-stale-races-caption")
+        (into [:div {:data-testid "rf-xray-resources-stale-races-body"
+                     :style {:display "flex" :flex-direction "column" :gap "2px"}}]
+              (for [arc suppressed]
+                ^{:key (str (:work-id arc))} (stale-race-row-view arc)))))))
+
 ;; ---- §4 ROUTE / RESOURCE GRAPH -----------------------------------------
 
 (defn- freshness-colour [freshness]
@@ -843,6 +962,7 @@
   instances, renders the silent-by-default caption."
   []
   (let [{:keys [silent? registry scope-resolvers instances work route-graph
+                live-work stale-races stale-tally
                 timeline invalidations scope-resolutions mutation-invalidations
                 continuations optimistic-mutations optimistic-force-clobbers
                 cache-growth audit]}
@@ -863,6 +983,12 @@
         (scope-resolvers-section scope-resolvers)
         (instances-section instances)
         (work-ledger-section work)
+        ;; EP-0011 uniform reply-envelope reads — "what is still running?"
+        ;; (live work + active-effects tally) and the cross-family stale-races
+        ;; view. Silent-by-default: each renders nothing when its data is
+        ;; empty (quiet baseline for a settled app).
+        (live-work-section {:live-work live-work :stale-tally stale-tally})
+        (stale-races-section stale-races)
         (route-graph-section route-graph)
         (timeline-section timeline)
         (invalidation-section invalidations)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -453,6 +453,101 @@
     (let [ev (dispatched-with-cofx [:counter/inc] {})]
       (is (nil? (proj/recordable-cofx-row [ev]))))))
 
+;; ---- generated recordable coeffects (EP-0017 slice B.7 · spec/009 §277) --
+;;
+;; A generator-backed recordable supplier runs at PROCESSING-START when its
+;; declared fact is absent from the enqueue token; it mints the value, writes
+;; it back into the in-flight `:rf.cofx` record, and emits `:rf.cofx/generated`
+;; carrying `{:rf.cofx/id <fact-name> :rf.cofx/value <produced-value>}`. The
+;; enqueue-time `:rf.event/dispatched` `:rf.cofx` map predates generation, so
+;; the lens must read the generated fact from the trace op (the post-generation
+;; source of truth), summarize/redact its value, and mark its provenance.
+
+(defn- generated-cofx-ev
+  "A `:rf.cofx/generated` trace event (spec/009 §277) carrying the produced
+  recordable fact under `:tags`."
+  ([id value] (generated-cofx-ev id value nil))
+  ([id value arg]
+   (ev :rf.cofx :rf.cofx/generated
+       (cond-> {:rf.cofx/id id :rf.cofx/value value :frame :rf/default}
+         (some? arg) (assoc :rf.cofx/arg arg)))))
+
+(deftest generated-cofx-rows-unit-test
+  (testing "EP-0017 slice B.7 — generated rows project from :rf.cofx/generated
+            ops, value summarized, :generated? true, sorted by fact name"
+    (let [events [(generated-cofx-ev :session/id "sess-7")
+                  (generated-cofx-ev :request/nonce {:n 42})]
+          rows   (proj/generated-cofx-rows events)
+          by-key (into {} (map (juxt :key identity) rows))]
+      (is (= [:request/nonce :session/id] (mapv :key rows)) "sorted by fact name")
+      (is (every? :generated? rows) "every generated row marked :generated?")
+      ;; values summarized (redact-by-default), never raw
+      (is (= "string" (:type (:value (by-key :session/id)))))
+      (is (map? (:value (by-key :request/nonce))))
+      (is (= "map" (:type (:value (by-key :request/nonce)))))))
+  (testing "EP-0017 — declared filter applies to generated rows too"
+    (let [events [(generated-cofx-ev :session/id "sess-7")
+                  (generated-cofx-ev :other/x 1)]]
+      (is (= [:session/id] (mapv :key (proj/generated-cofx-rows events #{:session/id}))))))
+  (testing "no :rf.cofx/generated op → empty"
+    (is (= [] (proj/generated-cofx-rows [(dispatched-with-cofx [:e] {:a/x 1})])))))
+
+(deftest recordable-cofx-row-surfaces-generated-test
+  (testing "EP-0017 slice B.7 — a generated recordable fact (minted at
+            processing-start, absent from the enqueue token) surfaces in
+            RECORDABLE COEFFECTS, read from the :rf.cofx/generated op, marked
+            :generated? true, value summarized"
+    (let [disp (dispatched-with-cofx [:auth/login] {:rf/time-ms 1781078400123
+                                                    :counter/delta {:roll 4}})
+          gen  (generated-cofx-ev :session/id "sess-7")
+          r    (proj/recordable-cofx-row [disp gen])
+          by-key (into {} (map (juxt :key identity) (:inputs r)))]
+      (is (= :recordable-cofx (:step r)))
+      (is (= 1781078400123 (:time-ms r)) ":rf/time-ms still verbatim")
+      ;; supplied leaf present, NOT marked generated
+      (is (contains? by-key :counter/delta))
+      (is (not (:generated? (by-key :counter/delta))))
+      ;; generated leaf present, marked generated, value summarized
+      (is (contains? by-key :session/id) "generated fact surfaces")
+      (is (true? (:generated? (by-key :session/id))) "provenance marked")
+      (is (= "string" (:type (:value (by-key :session/id))))
+          "generated value summarized, never raw")))
+  (testing "EP-0017 — a generated fact surfaces even when the enqueue token
+            carried NO :rf.cofx map at all (only the dispatched event)"
+    (let [disp (dispatched-ev [:auth/login] :ui)
+          gen  (generated-cofx-ev :session/id "sess-7")
+          r    (proj/recordable-cofx-row [disp gen])]
+      (is (some? r) "the step renders off the generated op alone")
+      (is (= [:session/id] (mapv :key (:inputs r))))
+      (is (true? (:generated? (first (:inputs r)))))))
+  (testing "EP-0017 no-duplicate case — when a value is SUPPLIED/replayed on
+            the token (the generator did NOT run, but a stray generated op for
+            the same key exists), the supplied row wins and the key is NOT
+            duplicated"
+    (let [disp (dispatched-with-cofx [:auth/login] {:session/id "supplied-9"})
+          gen  (generated-cofx-ev :session/id "would-have-generated")
+          r    (proj/recordable-cofx-row [disp gen])
+          rows (filter #(= :session/id (:key %)) (:inputs r))]
+      (is (= 1 (count rows)) "exactly one :session/id row — no duplicate")
+      (is (not (:generated? (first rows))) "the supplied row wins")))
+  (testing "EP-0017 — the declared-recordable filter applies to generated facts
+            end-to-end through `project`"
+    (let [disp (dispatched-with-cofx [:auth/login] {:counter/delta 1 :app/extra 2})
+          gen  (generated-cofx-ev :session/id "sess-7")
+          rec  (record [disp gen])
+          steps (proj/project rec
+                              {:resolve-event-recordables
+                               (fn [event-id]
+                                 (when (= :auth/login event-id)
+                                   #{:counter/delta :session/id}))})
+          rcofx (some #(when (= :recordable-cofx (:step %)) %) steps)
+          by-key (into {} (map (juxt :key identity) (:inputs rcofx)))]
+      (is (some? rcofx))
+      (is (contains? by-key :counter/delta) "declared supplied leaf")
+      (is (contains? by-key :session/id) "declared generated leaf")
+      (is (true? (:generated? (by-key :session/id))))
+      (is (not (contains? by-key :app/extra)) "undeclared token leaf filtered out"))))
+
 (deftest project-places-recordable-cofx-after-dispatch-test
   (testing "rf2-9fyn40 · EP-0017 — `project` slots the RECORDABLE COEFFECTS
             step RIGHT AFTER DISPATCH SITE (before the ambient COEFFECTS), and

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -413,6 +413,120 @@
       (is (some? (:current row)) "current gate summarized + present"))))
 
 ;; ---------------------------------------------------------------------------
+;; (6b) stale-suppressed rows preserve the canonical EP-0011 :stale STATUS.
+;;
+;; EP-0011 treats `:stale` as one of the five closed reply statuses; a failed
+;; stale-suppression gate makes the reply outcome `:status :stale`, stamped on
+;; the production row as `:rf.reply/status`. A stale-suppressed row must
+;; therefore project `:status :stale` + `:status-class :suppression` — the
+;; SAME cross-surface badge contract a completed row renders — read off the
+;; UNAMBIGUOUS `:rf.reply/status`, NOT the bare `:status` (which on a
+;; suppression row may carry a LEDGER status like :completed/:failed).
+;; ---------------------------------------------------------------------------
+
+(deftest stale-suppression-preserves-status
+  (testing "a PRODUCTION-shaped resource stale-suppressed row carrying
+            :rf.reply/status :stale projects :status :stale +
+            :status-class :suppression"
+    (let [work-id [:rf.work/resource [:s :article/by-id {:id 1}] 1]
+          row (re/work-event-row
+                {:id 50 :operation :rf.resource/stale-suppressed
+                 :time 300
+                 :tags {:rf.frame/id  :rf/default
+                        :resource/key [:s :article/by-id {:id 1}]
+                        :work/id      work-id
+                        :generation   1
+                        :outcome      {:reason :stale-reply}
+                        :rf.reply/status       :stale
+                        :rf.reply/work-status  :suppressed
+                        :rf.reply/stale-reason :rf.resource/superseded
+                        :rf.reply/carried {:work/id work-id :generation 1}
+                        :rf.reply/current {:generation 2}}})]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :stale (:status row)) "canonical EP-0011 reply status preserved")
+      (is (= :suppression (:status-class row)) "cross-surface suppression badge")
+      (is (true? (:stale? row)))))
+  (testing "a PRODUCTION-shaped MUTATION stale-suppressed row (resource head,
+            :work/kind :mutation) preserves :status :stale + :suppression"
+    (let [work-id [:rf.work/resource [:s :update-article {:id 1}] 2]
+          row (re/work-event-row
+                {:id 51 :operation :rf.resource/stale-suppressed
+                 :time 310
+                 :tags {:work/id      work-id
+                        :work/kind    :mutation
+                        :rf.reply/status       :stale
+                        :rf.reply/work-status  :suppressed
+                        :rf.reply/stale-reason :rf.resource/superseded}})]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :mutation (:work-kind row)))
+      (is (= :stale (:status row)))
+      (is (= :suppression (:status-class row)))))
+  (testing "a PRODUCTION-shaped ROUTE stale-suppressed row preserves the status"
+    (let [work-id [:rf.work/route :nav 3]
+          row (re/work-event-row
+                {:id 52 :operation :rf.route/stale-suppressed
+                 :time 320
+                 :tags {:work/id      work-id
+                        :work/kind    :route
+                        :rf.reply/status       :stale
+                        :rf.reply/work-status  :suppressed
+                        :rf.reply/stale-reason :rf.route/nav-superseded}})]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :route (:work-kind row)))
+      (is (= :stale (:status row)))
+      (is (= :suppression (:status-class row)))))
+  (testing "a PRODUCTION-shaped HTTP supersession stale row preserves the status"
+    (let [row (re/work-event-row
+                {:id 53 :operation :rf.http/stale-suppressed
+                 :time 330 :tags {:work/id [:rf.work/http :search 1 1] :work/kind :http
+                                  :rf.reply/status      :stale
+                                  :rf.reply/work-status :suppressed
+                                  :rf.reply/stale-reason :rf.http/request-id-superseded
+                                  :rf.reply/carried {:work/id [:rf.work/http :search 1 1]}
+                                  :rf.reply/current {:work/id [:rf.work/http :search 2 1]}}})]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :http (:work-kind row)))
+      (is (= :stale (:status row)))
+      (is (= :suppression (:status-class row)))))
+  (testing "a PRODUCTION-shaped MACHINE :after-timer stale row preserves the status"
+    (let [row (re/work-event-row
+                {:id 54 :operation :rf.machine.timer/stale-after
+                 :time 340 :tags {:work/id [:rf.work/timer [:auth :loading] 3]
+                                  :work/kind :timer
+                                  :rf.reply/status       :stale
+                                  :rf.reply/work-status  :suppressed
+                                  :rf.reply/stale-reason :rf.machine.timer/after-epoch-mismatch}})]
+      (is (= :stale-suppressed (:phase row)))
+      (is (= :timer (:work-kind row)))
+      (is (= :stale (:status row)))
+      (is (= :suppression (:status-class row)))))
+  (testing "the bare LEDGER :status on a suppression row is NOT misread as a
+            reply status — only the unambiguous :rf.reply/status surfaces. A
+            row stamping bare :status :completed but NO :rf.reply/status gets
+            no reply status (the row is a suppression, not an :ok completion)"
+    (let [row (re/work-event-row
+                {:id 55 :operation :rf.resource/stale-suppressed
+                 :time 350 :tags {:work/id [:rf.work/resource :k 1]
+                                  :work/kind :resource
+                                  ;; bare ledger status, NOT a reply status fact
+                                  :status :completed}})]
+      (is (= :stale-suppressed (:phase row)))
+      (is (nil? (:status row)) "bare ledger :status :completed not misread")
+      (is (nil? (:status-class row)))
+      (is (true? (:stale? row)) "still a stale-suppressed row")))
+  (testing "completed rows are unchanged — the four non-stale closed statuses
+            still project from a :completed row"
+    (doseq [[s expected-class] {:ok :success :partial :partial
+                                :error :failure :cancelled :cancellation}]
+      (let [row (re/work-event-row
+                  {:id 56 :operation :rf.http/work-completed
+                   :time 360 :tags {:work/id [:rf.work/http :req 1]
+                                    :rf.reply/status s}})]
+        (is (= :completed (:phase row)))
+        (is (= s (:status row)) (str "completed status " s " unchanged"))
+        (is (= expected-class (:status-class row)))))))
+
+;; ---------------------------------------------------------------------------
 ;; (7) stale-races — keyed on :work/id; cross-surface tally; attempt arcs.
 ;; ---------------------------------------------------------------------------
 
@@ -504,6 +618,48 @@
   (testing "the single-arity form returns live rows without the trace join"
     (let [live (re/live-work ledger)]
       (is (every? #(not (contains? % :latest-phase)) live))))
+  (testing "PRODUCTION byte/string-keyed ledger — the :rf.runtime/work-ledger
+            map is keyed on the opaque CEDN-1 byte `work-id-id` STRING, while
+            the kind-preserving work-id VECTOR rides on the record as :work/id.
+            ledger-row / live-work must read the CANONICAL vector from the
+            record (not the byte key) so the row joins to a trace row keyed by
+            the vector and inference works when :work/kind is present."
+    (let [work-id    [:rf.work/resource [:s :article/by-id {:id 1}] 2]
+          byte-key   "£opaque-byte-work-id-id"
+          ;; the PRODUCTION ledger shape: byte string key → record with :work/id
+          prod-ledger {byte-key
+                       {:work/id work-id :work/kind :resource :work/frame :f
+                        :resource/key [:s :article/by-id {:id 1}] :generation 2
+                        :status :running :owners #{} :causes [] :cancellable? true
+                        :transport :rf.http/managed}}
+          ;; the trace row is keyed by the kind-preserving VECTOR work id
+          trace      [{:id 1 :operation :rf.resource/work-abort-requested :time 100
+                       :tags {:work/id work-id :reason :superseded}}]
+          row        (re/ledger-row (first prod-ledger))]
+      ;; ledger-row reads the canonical vector, NOT the opaque byte key
+      (is (= work-id (:work-id row)) "canonical :work/id vector, not the byte key")
+      (is (= :resource (:work-kind row)))
+      (is (true? (:live? row)))
+      ;; live-work joins the byte-keyed ledger row to the vector-keyed trace row
+      (let [live  (re/live-work prod-ledger trace)
+            joined (first live)]
+        (is (= 1 (count live)))
+        (is (= work-id (:work-id joined)))
+        (is (= :cancel-requested (:latest-phase joined))
+            "joined to the vector-keyed trace row")
+        (is (= :rf.resource/work-abort-requested (:latest-op joined))))))
+  (testing "kind inference works off the canonical vector when :work/kind is
+            absent on a byte-keyed production record"
+    (let [work-id  [:rf.work/http :req 7]
+          byte-key "opaque"
+          row      (re/ledger-row [byte-key {:work/id work-id :status :running}])]
+      (is (= work-id (:work-id row)) "canonical vector, not the byte key")
+      (is (= :http (:work-kind row)) "kind inferred from the vector head, not the byte key")))
+  (testing "a LEGACY/nonconforming record lacking :work/id falls back to the
+            map key (existing vector-keyed behavior unchanged)"
+    (let [row (re/ledger-row [[:rf.work/resource :k 2] {:status :running}])]
+      (is (= [:rf.work/resource :k 2] (:work-id row)))
+      (is (= :resource (:work-kind row)))))
   (testing "latest-phase-by-work-id keeps the MOST-RECENT phase per work id"
     (let [trace [{:id 1 :operation :rf.resource/work-started :time 100
                   :tags {:work/id [:rf.work/resource :k 2]}}

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -305,6 +305,77 @@
           (is (re-find #":realworld/save-article" (node-text row))
               "the mutation id surfaced"))))))
 
+;; ---- (3a) EP-0011 live-work + stale-races render ------------------------
+;;
+;; The uniform reply-envelope reads (`reply/live-work` / `races-by-work-id` /
+;; `stale-tally-by-kind`) are computed in the composite data sub; the Panel
+;; must RENDER them — "what is still running?" (live work + active-effects
+;; tally) and the cross-family stale-races view. Silent-by-default: a settled
+;; app (no live work, no suppression) renders neither section.
+
+(def ep0011-live-work-id
+  [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4])
+
+(def ep0011-buffer
+  [;; the live resource work's latest reply-envelope trace phase (issued) —
+   ;; live-work joins the running ledger row to THIS by :work/id.
+   {:id 70 :op-type :rf.resource :operation :rf.resource/work-started
+    :tags {:work/id ep0011-live-work-id :work/kind :resource}}
+   ;; a cross-family HTTP supersession stale-suppressed row — drives the
+   ;; stale-races view + the per-kind suppression tally.
+   {:id 71 :op-type :rf.http :operation :rf.http/stale-suppressed
+    :tags {:work/id [:rf.work/http :search 1 1] :work/kind :http
+           :rf.reply/status :stale :rf.reply/work-status :suppressed
+           :rf.reply/stale-reason :rf.http/request-id-superseded
+           :rf.reply/carried {:work/id [:rf.work/http :search 1 1]}
+           :rf.reply/current {:work/id [:rf.work/http :search 2 1]}}}])
+
+(deftest ep0011-live-work-and-stale-races-render
+  (testing "the EP-0011 'what is still running?' live-work + active-effects
+            tally and the cross-family stale-races view render from the work
+            ledger + trace buffer"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides!)
+      (rf/dispatch-sync [:rf.xray/sync-trace-buffer ep0011-buffer] {:frame :rf/xray})
+      (let [tree (resources/Panel)]
+        ;; "what is still running?" section + the live resource row, joined
+        ;; to its latest trace phase (issued via :rf.resource/work-started).
+        (is (some? (find-by-testid tree "rf-xray-resources-live-work-caption"))
+            "live-work section rendered")
+        (let [row (find-by-testid
+                    tree (str "rf-xray-resources-live-work-row-" (hash ep0011-live-work-id)))]
+          (is (some? row) "the live resource work row rendered")
+          (is (re-find #"resource" (node-text row)) "work-kind surfaced")
+          (is (re-find #"issued" (node-text row)) "latest trace phase joined + surfaced"))
+        ;; the active-effects / suppression tally headline (per kind).
+        (is (some? (find-by-testid tree "rf-xray-resources-stale-tally-http"))
+            "per-kind suppression tally rendered")
+        ;; the cross-family stale-races view — the suppressed HTTP arc.
+        (is (some? (find-by-testid tree "rf-xray-resources-stale-races-caption"))
+            "stale-races section rendered")
+        (let [arc (find-by-testid
+                    tree (str "rf-xray-resources-stale-race-row-"
+                              (hash [:rf.work/http :search 1 1])))]
+          (is (some? arc) "the suppressed HTTP attempt arc rendered")
+          (is (re-find #"stale" (node-text arc)) "terminal :stale status surfaced")
+          (is (re-find #"http" (node-text arc)) "work-kind surfaced")))))
+  (testing "silent-by-default — a settled app (no live work, no suppression)
+            renders NEITHER the live-work NOR the stale-races section"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test resource-regs]
+                        {:frame :rf/xray})
+      ;; no live ledger, no trace buffer
+      (rf/dispatch-sync [:rf.xray/set-resource-work-ledger-override-for-test {}]
+                        {:frame :rf/xray})
+      (rf/dispatch-sync [:rf.xray/sync-trace-buffer []] {:frame :rf/xray})
+      (let [tree (resources/Panel)]
+        (is (nil? (find-by-testid tree "rf-xray-resources-live-work-caption"))
+            "no live-work section when nothing is running / suppressed")
+        (is (nil? (find-by-testid tree "rf-xray-resources-stale-races-caption"))
+            "no stale-races section when no arc was suppressed")))))
+
 ;; ---- (3b) EP-0019 optimistic mutation lifecycle render ------------------
 
 (def ep0019-buffer


### PR DESCRIPTION
Surface-clustered set of 4 P2 beads, all on `tools/xray`, aligned to the landed EP-0011 reply-envelope + EP-0017 cofx model.

## rf2-1dr4gc — preserve EP-0011 `:stale` status on stale-suppression rows
`work-event-row` only read reply status on `:completed` rows, so a production stale-suppressed row carrying `:rf.reply/status :stale` lost the canonical status fact. It now reads the **unambiguous** `:rf.reply/status` on `:stale-suppressed` rows too — projecting `:status :stale` + `:status-class :suppression` (the same cross-surface badge contract a completed row renders) — while never misreading a bare ledger `:status` (`:completed`/`:failed`) on a suppression row. Completed-row projection for `:ok`/`:partial`/`:error`/`:cancelled` is unchanged. Regression coverage for production-shaped resource, mutation, route, HTTP, and machine stale rows.

## rf2-ui2o0n — fix EP-0011 live-work join on production ledger keys
The generic `reply_envelope/ledger-row` treated the work-ledger map KEY as the work id. The production `:rf.runtime/work-ledger` is keyed on the opaque CEDN-1 byte `work-id-id` string; the kind-preserving vector rides on the record as `:work/id`. `ledger-row` now reads `(:work/id record)` (falling back to the map key only for legacy records), so the displayed work-id, `:work-kind` inference, and the `live-work` trace join all key on the canonical vector. Regression test with a byte-keyed production ledger record + vector-keyed trace row proving the join attaches `:latest-phase`/`:latest-op`.

## rf2-909xun — render EP-0011 live-work and stale-races data
The composite data sub already computed `:live-work` / `:stale-races` / `:stale-tally`, but the Resources `Panel` never rendered them. Added the **"What is still running?"** section (live work joined to its latest reply-envelope phase/op, plus the per-kind suppression tally) and the **"Stale races"** section (suppressed attempt arcs grouped by `:work/id`). Both **silent-by-default** — a settled app with no live work and no suppression renders neither. Resources panel render test with synthetic ledger + trace data, plus the silent-state assertion.

## rf2-9l80u2 — Xray omits generated recordable coeffects
The RECORDABLE COEFFECTS step read `:rf.cofx` only off the enqueue-time `:rf.event/dispatched` trace, which predates processing-start generation. `recordable-cofx-row` now merges generated facts read from `:rf.cofx/generated` trace ops (the post-generation source of truth), summarized/redacted via the existing path and marked `:generated?` for provenance (rendered with a `generated` badge). A supplied/replayed value wins on a key collision (no duplicate when the generator did not run); the section renders off generated ops even with no enqueue `:rf.cofx` map. Unit + end-to-end projection tests incl. the no-duplicate case.

## Spec updates (same-PR standing rule)
- `024-Resources-Panel.md`: added §3a / §3b to the rendered section list (silent-by-default); documented the canonical `:work/id` vector join + `:stale-suppressed` status preservation.
- `013-Trace-Consumer.md`: `status->class` now fires on stale-suppressed rows via the unambiguous `:rf.reply/status`; `live-work` joins on the canonical work-id vector carried on the ledger record.
- `018-Event-Spine.md`: documented generated recordable coeffects (read from `:rf.cofx/generated`, `generated` provenance, no-duplicate vs supplied).

## Gates
- `tools/xray` JVM suite: 1229 tests / 5580 assertions, 0 failures.
- `npm run test:cljs`: 7755 tests / 32049 assertions, 0 failures (includes the new resources panel render test).
- `scripts/test-fast-pr.sh`: PASS (markdown link/anchor gates ran clean; mkdocs soft-skipped on Windows).
- Feature matrix unchanged (new sections are silent-by-default on the counter testbed) — gate not required.