### PR TITLE
fix(resources): EP-0011 abort-reply envelopes + EP-0015 cache/trace redaction (rf2-qsn30x, rf2-iu0z8t, rf2-0t0l3w, rf2-84l82t)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -527,6 +527,10 @@
     :producer-ns 're-frame.resources
     :design-bead "rf2-hls77w"
     :description "Resolver helper: resolve a named scope resolver against a SUPPLIED db value, returning the canonical scope or nil — a plain function over the resolver registry, NOT an effect (no app-state / dispatch side effects). Not a pure data helper, though: like every resolution site it emits :rf.resource/scope-resolved dev-time trace evidence. Canonical use is the logout/account-switch idiom (resolve the concrete old scope from the handler's coeffect db, then pass it to :rf.resource/clear-scope concretely). Per Spec 016 §clear-scope resolves the concrete scope from the coeffect db (EP-0016 issue 7)."}
+   {:key         :resources/project-scope-resolved-egress
+    :producer-ns 're-frame.resources
+    :design-bead "rf2-84l82t"
+    :description "OFF-BOX trace egress projector for a :rf.resource/scope-resolved row's resolver-owned values (EP-0015). The row carries the resolver's resolved :input-values (raw app-db reads) + the derived :scope (the identity tuple embedding them) — owner-local values the generic value-path trace egress walk cannot classify once copied into trace tags. Given the row's :tags, FAILS CLOSED: redacts :input-values + :scope to :rf/redacted + stamps :sensitive? for any db-reading resolver not explicitly declassified (:output-sensitivity :rf.egress/public), preserving the structural :resource-id / declared :inputs names / :kind / :resolved-nil?. Consulted by the epoch tool-pair's off-box :trace-events projection (omit-off-box-resource-scope-values, gated on the off-box :include-sensitive? default; the trusted-local opt-in lifts it). No-op / nil when no resources artefact is loaded (an app with no resources emits no scope-resolved rows). The on-box listener keeps the raw dev evidence; the leak is at off-box / epoch / MCP egress. Per Spec 015 §10 / Derivations §Tool redaction."}
    {:key         :resources/reset-resources!
     :producer-ns 're-frame.resources.test-support
     :design-bead "rf2-p10npe"

--- a/implementation/epoch/deps.edn
+++ b/implementation/epoch/deps.edn
@@ -100,6 +100,13 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
+                       ;; rf2-84l82t — TEST-ONLY: the resources artefact
+                       ;; publishes the `:resources/project-scope-resolved-egress`
+                       ;; hook the off-box `:trace-events` projection consults; an
+                       ;; integration test loads it to prove the wiring fires
+                       ;; (production epoch never deps resources — the hook is
+                       ;; nil-safe / no-op when absent).
+                       day8/re-frame2-resources  {:local/root "../resources"}
                        ;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1250,6 +1250,39 @@
                       event-arg-tag-slots)))
           trace-events)))
 
+(defn- omit-off-box-resource-scope-values
+  "Per rf2-84l82t (EP-0015): redact the resolver-owned VALUES on a
+  `:rf.resource/scope-resolved` trace row for off-box egress. The row carries
+  the resolved `:input-values` (the concrete db reads) and the derived `:scope`
+  (which embeds them) — owner-local identity-bearing values the generic
+  value-path egress walk cannot classify once copied into trace tags. The
+  resource family owns the row's egress projector (the SSR/tool-projection
+  analogue), consulted here through the late-bound
+  `:resources/project-scope-resolved-egress` hook the resources artefact
+  publishes: it FAILS CLOSED (redacts `:input-values` / `:scope`, stamps
+  `:sensitive? true`) for any db-reading resolver not explicitly declassified
+  (`:output-sensitivity :rf.egress/public`), preserving the structural
+  `:resource-id` / `:inputs` (declared NAMES) / `:kind` / `:resolved-nil?`.
+
+  The redaction is the off-box default; the trusted-local `:include-sensitive?`
+  opt-in lifts it (the `local-raw` boundary — the same switch the app-db /
+  HTTP-body redactions honour). No-op when no resources artefact is loaded (the
+  hook is nil — an app with no resources emits no scope-resolved rows anyway).
+  Idempotent (`:rf/redacted` re-redacts to itself) and nil/non-sequential-
+  preserving."
+  [trace-events {:keys [include-sensitive?]}]
+  (if (or include-sensitive? (not (sequential? trace-events)))
+    trace-events
+    (if-let [project (late-bind/get-fn :resources/project-scope-resolved-egress)]
+      (mapv (fn [ev]
+              (if (and (map? ev)
+                       (= :rf.resource/scope-resolved (:operation ev))
+                       (map? (:tags ev)))
+                (update ev :tags project)
+                ev))
+            trace-events)
+      trace-events)))
+
 (defn- elide-trace-events-slot
   "The `:trace-events` projection chain (rf2-ta0y7): first re-root the
   per-event `:rf.event/db` slots on the t1 / t2 trace events so the
@@ -1270,6 +1303,10 @@
         (reroot-trace-event-db-slots frame-id opts)
         (omit-off-box-event-args opts)
         (omit-off-box-http-bodies opts)
+        ;; rf2-84l82t — redact the resolver-owned `:input-values` / `:scope`
+        ;; on `:rf.resource/scope-resolved` rows (fail-closed; the generic
+        ;; walk below cannot classify resolver-owned values copied into tags).
+        (omit-off-box-resource-scope-values opts)
         (projection/project-egress (egress-opts frame-id opts)))))
 
 (defn- elide-sub-run-row

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_scope_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_scope_test.clj
@@ -1,0 +1,120 @@
+(ns re-frame.epoch-egress-resource-scope-test
+  "Coverage for the OFF-BOX egress redaction of a `:rf.resource/scope-resolved`
+  trace row's resolver-owned values inside an epoch record's `:trace-events`
+  (rf2-84l82t, EP-0015).
+
+  The `:rf.resource/scope-resolved` trace row carries the resolver's resolved
+  `:input-values` (the concrete app-db reads — e.g. `{:username \"jake\"}`) and
+  the derived `:scope` (the identity tuple embedding them). These are
+  owner-local, identity-bearing values the generic value-path trace egress walk
+  (`re-frame.epoch.tool-pair/elide-trace-events-slot` → `project-egress`) is
+  structurally blind to once they have been copied into trace tags — a frame's
+  declared `:sensitive` app-db PATHS do not match a resolver's resolved VALUES.
+
+  The resource family owns the row's egress projector
+  (`re-frame.resources.scope-registry/project-scope-resolved-egress`), published
+  as the late-bound `:resources/project-scope-resolved-egress` hook the epoch
+  tool-pair consults from `omit-off-box-resource-scope-values`. This test proves
+  the WIRING fires end-to-end: with resources loaded, `projected-record` redacts
+  the resolver values for the off-box default, and the trusted-local
+  `:include-sensitive?` opt-in lifts the redaction (the `local-raw` boundary).
+
+  resources is a TEST-ONLY dep here (production epoch never deps resources; the
+  hook is nil-safe when absent — proven by the `epoch_egress_trace_events_test`
+  suite which runs without resources)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as epoch]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            ;; load-bearing: publishes the :resources/* late-bind hooks,
+            ;; including :resources/project-scope-resolved-egress.
+            [re-frame.resources]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (rf/reg-frame :test/rs {})
+                ;; a db-reading resolver (the :inherit default — fail-closed
+                ;; off-box); NOT explicitly declassified.
+                (rf/reg-resource-scope :rs/session
+                  {:inputs  {:username [:db [:auth :user :username]]}
+                   :resolve (fn [{:keys [username]} _]
+                              (when username [:rf.scope/session {:username username}]))})
+                ;; an explicitly :rf.egress/public resolver (the declassified
+                ;; audit surface — rides verbatim off-box).
+                (rf/reg-resource-scope :rs/public-locale
+                  {:inputs  {:locale [:db [:i18n :locale]]}
+                   :rf.egress/output-sensitivity :rf.egress/public
+                   :resolve (fn [{:keys [locale]} _]
+                              (when locale [:rf.scope/locale {:locale locale}]))}))}))
+
+(def ^:private secret "jake-SECRET")
+
+(defn- contains-secret? [v]
+  (boolean
+    (cond
+      (= v secret) true
+      (map? v)     (or (some contains-secret? (keys v)) (some contains-secret? (vals v)))
+      (coll? v)    (some contains-secret? v)
+      :else        false)))
+
+(defn- scope-resolved-event [resource-id input-values scope]
+  {:op-type   :rf.event
+   :operation :rf.resource/scope-resolved
+   :tags      {:resource-id   resource-id
+               :kind          :resource-scope
+               :inputs        (vec (keys input-values))
+               :input-values  input-values
+               :whole-db?     false
+               :scope         scope
+               :resolved-nil? false}})
+
+(defn- record-with [trace-events]
+  {:epoch-id            1
+   :frame               :test/rs
+   :committed-at        0
+   :event-id            :login
+   :trigger-event       [:login]
+   :db-before           {}
+   :db-after            {}
+   :outcome             :ok
+   :trace-events        trace-events
+   :sub-runs            []
+   :renders             []
+   :effects             []})
+
+(deftest off-box-projection-redacts-sensitive-resolver-values
+  (testing "rf2-84l82t — projected-record redacts a db-reading (:inherit)
+            resolver's :input-values + :scope for the off-box default; the
+            structural attribution slots survive and no raw secret egresses"
+    (let [record    (record-with
+                       [(scope-resolved-event :rs/session
+                                              {:username secret}
+                                              [:rf.scope/session {:username secret}])])
+          projected (epoch/projected-record record)
+          row       (first (:trace-events projected))]
+      (is (= :rf/redacted (get-in row [:tags :input-values]))
+          "the raw db reads are redacted off-box")
+      (is (= :rf/redacted (get-in row [:tags :scope]))
+          "the derived identity tuple is redacted off-box")
+      (is (true? (get-in row [:tags :sensitive?])) "stamped sensitive")
+      (testing "the structural attribution slots ride verbatim"
+        (is (= :rs/session (get-in row [:tags :resource-id])))
+        (is (= [:username]  (get-in row [:tags :inputs]))))
+      (testing "no raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest off-box-projection-keeps-declassified-resolver-values
+  (testing "rf2-84l82t — an explicitly :rf.egress/public resolver's values ride
+            VERBATIM off-box (the trusted, enumerable declassification surface)"
+    (let [record    (record-with
+                       [(scope-resolved-event :rs/public-locale
+                                              {:locale "en"}
+                                              [:rf.scope/locale {:locale "en"}])])
+          projected (epoch/projected-record record)
+          row       (first (:trace-events projected))]
+      (is (= {:locale "en"} (get-in row [:tags :input-values])))
+      (is (= [:rf.scope/locale {:locale "en"}] (get-in row [:tags :scope])))
+      (is (not (get-in row [:tags :sensitive?]))))))

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -588,4 +588,12 @@
    ;; static :require.
    :resources/reg-resource-scope     reg-resource-scope
    :resources/clear-resource-scope   clear-resource-scope
-   :resources/resolve-resource-scope resolve-resource-scope})
+   :resources/resolve-resource-scope resolve-resource-scope
+   ;; rf2-84l82t (EP-0015): the OFF-BOX trace egress projector for a
+   ;; `:rf.resource/scope-resolved` row — the central trace egress pipeline
+   ;; (epoch tool-pair) consults it to redact the resolver's resolved
+   ;; `:input-values` / `:scope` (a value-path walk is structurally blind to
+   ;; resolver-owned values once copied into trace tags). Published so the
+   ;; epoch artefact reaches it without a static :require on resources.
+   :resources/project-scope-resolved-egress
+   scope-registry/project-scope-resolved-egress})

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1743,29 +1743,88 @@
                       :status-before (:status entry) :status-after (:status entry')})
         {:rf.db/runtime rdb'}))))
 
+(def ^:private aborted-event-failure
+  "The synthetic `:rf.http/aborted` failure envelope the legacy
+  `:rf.resource.internal/aborted` event lowers through the canonical failure
+  path. The production managed-HTTP abort path arrives as an `:rf.http/aborted`
+  FAILURE through `failed-handler`; this legacy/ad-hoc reply event carries no
+  transport envelope of its own, so it synthesises the same abort kind so it
+  flows the SAME `rreply/failure-reply` → `:status :cancelled` lowering, the
+  SAME `live-entry-for-reply` verification, and the SAME stale-wins-over-
+  cancelled suppression boundary (rf2-iu0z8t)."
+  {:kind :rf.http/aborted :reason :aborted})
+
 (defn aborted-handler
-  "`:rf.resource.internal/aborted` — a transport read was aborted. For the
-  cache ENTRY this is a stale reply — the verification gate suppresses it
-  (the entry settles to its last stable status through its own subsequent
-  transitions, never left stranded), so this handler makes NO durable entry
-  write. For the WORK LEDGER it settles the work row terminal `:cancelled`
-  and clears the host handle. Per Spec 016 §Cancellation is opportunistic;
-  stale suppression is mandatory / §Ledger row retention and identity.
+  "`:rf.resource.internal/aborted` — a transport read was aborted. A LEGACY /
+  ad-hoc reply event: the PRODUCTION managed-HTTP abort path already arrives
+  as an `:rf.http/aborted` FAILURE through `failed-handler` (Spec 014 routes
+  an intentional cancellation through `:on-failure`), so this event is
+  retained only for direct-dispatch / test callers — and it is now LOWERED
+  through the SAME canonical failure / stale-suppression path rather than
+  ad-hoc settling the row from the verification payload (rf2-iu0z8t). It:
+
+   - builds the canonical reply via `rreply/failure-reply` with a synthetic
+     `:rf.http/aborted` envelope → `:status :cancelled`;
+   - runs `live-entry-for-reply` (frame + work-id + generation verification),
+     so a STALE / superseded / CROSS-FRAME aborted event NEVER settles an
+     accepted `:cancelled` — it is SUPPRESSED (stale validation wins over the
+     natural cancellation status; a cross-frame event is rejected without
+     touching this frame's entry or ledger);
+   - on the live path settles the entry to a non-error stable state
+     (`entry-abort-settled` — no `:error` / `:refresh-error`), marks the work
+     row terminal `:cancelled`, drains any route blocking slot like a
+     non-error settle, and clears the host handle.
 
   EP-0017 declared-only delivery (rf2-rl27r2): a cancellation is still a
   managed-async completion with a reply token, so its terminal work-ledger
   outcome carries the reply token's causal `:completed-at` (DECLARED
-  `:rf/time-ms`, consumed FLAT) — symmetric with the failure / success paths."
+  `:rf/time-ms`, consumed FLAT) — symmetric with the failure / success paths.
+
+  Event shape: `[_ <verification-payload>]`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
-   [_event-id {work-id :work/id resource-key :resource/key :keys [generation]}]]
-  (let [runtime-db (or rt {})]
-    (work-ledger/clear-handle! frame-id work-id)
-    (trace/emit! :rf.event :rf.resource/work-abort-requested
-                 {:rf.frame/id frame-id :resource/key resource-key
-                  :work/id work-id :generation generation})
-    {:rf.db/runtime (work-ledger/update-record
-                      runtime-db work-id work-ledger/mark-terminal
-                      :cancelled {:reason :aborted :completed-at time-ms})}))
+   [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload}]]
+  (let [runtime-db   (or rt {})
+        completed-at time-ms
+        ;; lower through the SHARED failure reply builder — a synthetic
+        ;; `:rf.http/aborted` envelope yields `:status :cancelled`
+        ;; (Managed-Effects §Status taxonomy), exactly as the production abort
+        ;; arriving via `failed-handler` does.
+        _reply       (rreply/failure-reply payload aborted-event-failure
+                                           {:work-kind rreply/work-kind-resource
+                                            :completed-at completed-at})
+        entry        (live-entry-for-reply runtime-db frame-id payload)]
+    (if (nil? entry)
+      ;; STALE / CROSS-FRAME SUPPRESSION (mandatory): a superseded / vanished /
+      ;; cross-frame aborted event never mutates a newer (or another frame's)
+      ;; entry, and the row settles terminal :suppressed — NEVER an accepted
+      ;; :cancelled (stale validation wins over the natural cancellation
+      ;; status, rf2-jzh5gq / rf2-iu0z8t). The :outcome diagnostic records
+      ;; :aborted for tooling.
+      (let [stale (stale-suppress-reply runtime-db resource-key payload
+                                        {:outcome :aborted})]
+        (emit-resource-stale-suppressed!
+          frame-id resource-key work-id generation :aborted stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed {:reason :stale-reply :outcome :aborted
+                                       :completed-at completed-at})})
+      ;; LIVE accepted cancellation: settle the entry to a non-error stable
+      ;; state, mark the work row terminal :cancelled, drain a route blocking
+      ;; slot like a non-error settle. NO :error / :refresh-error write.
+      (let [entry' (entry-abort-settled entry)
+            rdb'   (-> runtime-db
+                       (assoc-in (state/entry-path resource-key) entry')
+                       (work-ledger/update-record
+                         work-id work-ledger/mark-terminal
+                         :cancelled {:reason :aborted :completed-at completed-at})
+                       (route/drain-blocking resource-key entry' :success))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation
+                      :status-before (:status entry) :status-after (:status entry')})
+        {:rf.db/runtime rdb'}))))
 
 (defn stale-fired-handler
   "`:rf.resource.internal/stale-fired` — a stale timer fired. The timer is

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -1804,6 +1804,18 @@
                                          {:work-kind rreply/work-kind-mutation
                                           :completed-at completed-at})
         error      (:error reply)
+        ;; rf2-qsn30x (EP-0011 §Status taxonomy / §Work-status mapping): an
+        ;; `:rf.http/aborted` failure envelope is an intentional CANCELLATION,
+        ;; which `failure-reply` lowers to `:status :cancelled` /
+        ;; `:work/status :cancelled` (not `:error` / `:failed`). The accepted
+        ;; live path MUST settle the work-ledger row terminal `:cancelled`,
+        ;; agreeing with the reply's `:work/status` — settling it `:failed`
+        ;; while the reply says `:cancelled` violates the closed status
+        ;; taxonomy. A STALE abort still settles `:suppressed` (the nil-inst
+        ;; path below): stale validation wins over the natural cancellation
+        ;; status (Managed-Effects §Stale suppression). The canonical reply's
+        ;; `:status` drives the branch (the family's classifier).
+        aborted?   (= :cancelled (:status reply))
         inst       (live-instance-for-reply runtime-db frame-id payload)]
     (if (nil? inst)
       ;; STALE SUPPRESSION (mandatory): a superseded / cleared / cross-frame
@@ -1890,9 +1902,20 @@
                        rolled-summary (assoc :patch-summary rolled-summary))
             rdb'     (-> settle-db
                          (assoc-in (mstate/instance-path instance-id) inst')
+                         ;; rf2-qsn30x: the ledger row settles `:cancelled` for
+                         ;; an accepted abort (the reply lowered it to
+                         ;; `:status :cancelled`), else `:failed`. The outcome
+                         ;; summary mirrors the resource abort path
+                         ;; (`{:reason :aborted …}` carries no error envelope —
+                         ;; an abort is not a user-visible failure) so the
+                         ;; ledger status and the canonical reply `:work/status`
+                         ;; agree (Managed-Effects §Status taxonomy).
                          (work-ledger/update-record
                            work-id work-ledger/mark-terminal
-                           :failed {:error error}))
+                           (:work/status reply)
+                           (if aborted?
+                             {:reason :aborted :completed-at completed-at}
+                             {:error error})))
             ;; PHASE 6 — the continuation fires for ANY accepted terminal reply
             ;; (D1 delivery rule: keyed on acceptance, not a status
             ;; enumeration), so an accepted `:error` (and an accepted terminal

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -416,6 +416,60 @@
         (keep (fn [[_input-name [_source rf-path]]] rf-path))
         (or inputs {})))
 
+;; ---- off-box trace egress projection of scope-resolution rows (rf2-84l82t) -
+;;
+;; The `:rf.resource/scope-resolved` trace row carries the resolver's resolved
+;; `:input-values` (the concrete db reads — e.g. `{:username "jake"}`) and the
+;; derived `:scope` (e.g. `[:rf.scope/session {:username "jake"}]`). These are
+;; owner-local, identity-bearing values the CENTRAL trace egress pipeline only
+;; knows as generic tag slots — a value-path walk cannot classify a resolver's
+;; `:input-values` once they have been copied into trace tags (EP-0015; the
+;; resource trace family is an egress record set). So the resource family owns
+;; an egress projector for the row, the SSR/tool-projection analogue, consumed
+;; off-box through a late-bound hook (epoch tool-pair); on-box listeners keep
+;; the raw evidence (the row is dev observability — the leak is at off-box /
+;; epoch / MCP egress, not the local listener).
+
+(defn scope-resolver-egress-sensitive?
+  "FAIL-CLOSED off-box egress classification for a `:rf.resource/scope-resolved`
+  row's resolver `scope-id` (rf2-84l82t). A db-reading resolver MAY read a
+  frame-sensitive path the off-box walk cannot prove safe (the row carries the
+  resolved VALUES, not the path provenance), so the conservative posture
+  mirrors `re-frame.resources.classification/resolver-derived-sensitive?`'s
+  fail-closed footing: the resolved `:input-values` / `:scope` are egress-
+  sensitive UNLESS the resolver explicitly DECLASSIFIES via
+  `:output-sensitivity :rf.egress/public` (the standing audit surface — the
+  resolver asserts its derived scope is safe to surface raw). A resolver that
+  is not registered (no spec to read) is sensitive (fail-closed). Pure."
+  [scope-id]
+  (let [spec (scope-resolver-meta scope-id)]
+    (not (= :rf.egress/public (:output-sensitivity spec)))))
+
+(defn project-scope-resolved-egress
+  "Project a `:rf.resource/scope-resolved` trace row's `tags` for OFF-BOX
+  egress (rf2-84l82t). When the row's resolver
+  (`scope-resolver-egress-sensitive?`) is egress-sensitive (the fail-closed
+  default for any db-reading resolver not explicitly declassified), the
+  resolved `:input-values` (the raw db reads) and `:scope` (the derived
+  identity tuple, which embeds those reads) are replaced by the `:rf/redacted`
+  sentinel and the row is stamped `:sensitive? true`. The STRUCTURAL slots —
+  `:resource-id` (the resolver id), `:kind`, the declared input NAMES
+  (`:inputs`), `:whole-db?`, `:resolved-nil?` — ride verbatim (they carry no
+  user value and a tool needs them to attribute the resolution). An explicitly
+  declassified (`:rf.egress/public`) resolver rides verbatim. Idempotent
+  (`:rf/redacted` re-redacts to itself); a non-map `tags` rides unchanged.
+  Pure. The on-box listener path never calls this — the raw evidence stays for
+  dev tooling; this is the OFF-BOX egress projector."
+  [tags]
+  (if-not (map? tags)
+    tags
+    (if (scope-resolver-egress-sensitive? (:resource-id tags))
+      (-> tags
+          (assoc :input-values :rf/redacted
+                 :scope        :rf/redacted
+                 :sensitive?   true))
+      tags)))
+
 ;; ---- the pure resolve helper (Spec 016 §`clear-scope` … coeffect db) ------
 
 (defn resolve-scope*-pure
@@ -450,10 +504,17 @@
 
   Emits `:rf.resource/scope-resolved` carrying the resolver id, the declared
   input NAMES, the resolved input VALUES, and the resolved scope (or
-  `:resolved-nil? true`) — the values flow through the trace pipeline's
-  egress/marks projection (Spec 015 / EP-0015) for off-box safety. Tooling
-  reads the declared inputs to avoid unnecessary whole-db re-resolution and
-  to mark the whole-db-sugar cost (EP-0015 disposition 8). PASSIVE reads
+  `:resolved-nil? true`). The resolved `:input-values` / `:scope` are
+  owner-local identity-bearing values the generic value-path trace egress walk
+  cannot classify, so the resource family owns their OFF-BOX egress projector
+  (`project-scope-resolved-egress`, published as
+  `:resources/project-scope-resolved-egress` and consulted by the epoch
+  tool-pair): fail-closed redaction for any db-reading resolver not explicitly
+  declassified (rf2-84l82t / EP-0015). The on-box listener keeps the raw
+  evidence (the leak is at off-box / epoch / MCP egress, not the local
+  listener). Tooling reads the declared inputs to avoid unnecessary whole-db
+  re-resolution and to mark the whole-db-sugar cost (EP-0015 disposition 8).
+  PASSIVE reads
   advertised as pure (`resolve-resource-scope`, subscription resolution) MUST
   call `resolve-scope*-pure` instead — they do not emit observability state
   during a read (rf2-ru73k6 F3)."

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -38,8 +38,10 @@
   shapes in [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
   (:require [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.resources.classification :as classification]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.scope-registry :as scope-registry]
+            [re-frame.resources.ssr :as ssr]
             [re-frame.resources.state :as state]
             [re-frame.resources.transport :as transport]
             [re-frame.resources.work-ledger :as work-ledger]))
@@ -368,6 +370,74 @@
 ;; the live owners, status, in-flight work-ledger links, and host-transient
 ;; in-flight handle address are the live lifecycle state.
 
+;; ---- EP-0015 tool-egress projection (rf2-0t0l3w) -------------------------
+;;
+;; `resource-cache-algebra-view` is a TOOL-facing egress boundary (Xray,
+;; re-frame2-pair-mcp, conformance fixtures). EP-0015 treats resource entries,
+;; work-ledger rows, scopes, params, and owner/cause summaries as EGRESS
+;; RECORDS, and requires projected payloads at tool boundaries (Spec 015 §10;
+;; Derivations §Resources expose process nodes — the live-resource identity
+;; case where scope/params are embedded in the node KEY / `:id` / `:output` /
+;; `:inputs` / `:work-ledger`, which a generic value-path walk cannot reach).
+;;
+;; The projection reuses the SAME resource OWNER classification the SSR /
+;; durable-egress path uses — never a tooling-private elider:
+;;   - `classification/whole-entry-disposition-for` resolves the coarse
+;;     `:sensitive?` / `:large?` root-prop claim PLUS the named-scope-resolver
+;;     derived-sensitivity inheritance against the frame (so a `{:from-db}`
+;;     scope reading a frame-sensitive `:db` input redacts even when the owner
+;;     did not declare `:sensitive?`);
+;;   - `ssr/project-scoped-key` then projects the scoped key per that
+;;     disposition — `:redact` / `:omit` replace scope + params with opaque
+;;     content-addressed `{:rf/redacted <digest>}` tokens (distinct values
+;;     stay distinct, so graph connectivity by projected key is preserved),
+;;     while `:serialize` applies the per-slot `:params-schema` marks and
+;;     otherwise rides verbatim (non-sensitive identity is preserved).
+;; The resource-id (position 1 of the 3-tuple) always survives, so a tool still
+;; sees WHICH resource each node names and edges still join nodes by the same
+;; projected key.
+
+(defn- project-key-for-egress
+  "Project a `scoped-key` for TOOL egress against the resource owner spec +
+  the `frame-id` classification (rf2-0t0l3w). Returns `[projected-key
+  disposition]`. `:redact` / `:omit` replace scope + params with opaque
+  tokens; `:serialize` projects per-slot `:params-schema` marks (a no-op when
+  none) — the resource-id always survives. Pure."
+  [scoped-key frame-id]
+  (let [resource-id (second scoped-key)
+        spec        (registry/resource-meta resource-id)
+        disposition (classification/whole-entry-disposition-for spec frame-id)]
+    [(ssr/project-scoped-key scoped-key disposition spec) disposition]))
+
+(defn- project-work-id
+  "Project the scoped key embedded in a resource work-id
+  `[:rf.work/resource <scoped-key> <generation>]` for tool egress
+  (rf2-0t0l3w). A work-id of another shape rides unchanged. Pure."
+  [work-id frame-id]
+  (if (and (vector? work-id) (= :rf.work/resource (first work-id)))
+    (assoc work-id 1 (first (project-key-for-egress (nth work-id 1) frame-id)))
+    work-id))
+
+(defn- live-work-ledger-link
+  "Build the in-flight `:work-ledger` + `:host-transient` slots for a live node,
+  PROJECTING the work-id's embedded scoped key + the record's `:resource/key`
+  for tool egress (rf2-0t0l3w) so neither leaks the raw scope/params. Returns
+  the node `acc` with both slots assoc'd."
+  [acc runtime-db work-id frame-id]
+  (let [record  (work-ledger/get-record runtime-db work-id)
+        wid'    (project-work-id work-id frame-id)
+        summary (select-keys record
+                             [:work/id :work/kind :status
+                              :resource/key :generation
+                              :transport :owners :causes])
+        rec'    (cond-> (assoc summary :work/id wid')
+                  (contains? summary :resource/key)
+                  (update :resource/key
+                          #(first (project-key-for-egress % frame-id))))]
+    (assoc acc
+           :work-ledger    {:work/id wid' :record rec'}
+           :host-transient [[:rf.http/in-flight wid']])))
+
 (defn- live-node-for
   "Build the LIVE process node for one concrete cache entry. `scoped-key` is
   `[cache-scope resource-id canonical-params]` — the entry's canonical live
@@ -377,17 +447,26 @@
   `:scoped-resource-key` kind + the entry's `:active-owners`), the entry `:status`,
   and — when an attempt is in flight — the work-ledger record summary +
   the host-transient in-flight handle address (Derivations §Output —
-  `:host-transient` in-flight work)."
-  [runtime-db scoped-key entry static-node]
-  (let [[scope resource-id params] scoped-key
-        work-id  (:current-work entry)
-        record   (when work-id (work-ledger/get-record runtime-db work-id))]
-    (cond-> {:id            scoped-key
+  `:host-transient` in-flight work).
+
+  rf2-0t0l3w: the scoped key is PROJECTED for tool egress (`project-key-for-egress`)
+  before it rides ANY identity position — the `:id`, the realized `[:scope …]`
+  / `[:param …]` inputs, the `:output` runtime-path tail, the in-flight
+  work-ledger record's `:resource/key`, and the host-transient handle address.
+  A `:sensitive?` / `:large?` / derived-sensitive resource therefore never
+  egresses its raw scope/params here (the value-path walk cannot reach them);
+  a plain resource rides verbatim."
+  [runtime-db scoped-key frame-id entry static-node]
+  (let [[proj-key _disp]           (project-key-for-egress scoped-key frame-id)
+        [proj-scope _ proj-params] proj-key
+        resource-id (second scoped-key)
+        work-id  (:current-work entry)]
+    (cond-> {:id            proj-key
              :kind          resource-superkind
              :refinement    resource-refined-kind
              :source-form   {:kind :reg-resource :id resource-id}
-             :inputs        [[:scope scope] [:param params]]
-             :output        [:runtime (state/entry-path scoped-key)]
+             :inputs        [[:scope proj-scope] [:param proj-params]]
+             :output        [:runtime (state/entry-path proj-key)]
              :storage       resource-storage
              :authority     (:authority static-node)
              :evaluation    resource-evaluation
@@ -400,14 +479,11 @@
       ;; serializable summary — the in-flight identity, owners, causes,
       ;; transport, status) AND names the host-transient in-flight handle
       ;; address (the abortable handle lives OUTSIDE durable frame-state, in
-      ;; the `[frame-id work-id]` side table — Derivations §Output).
+      ;; the `[frame-id work-id]` side table — Derivations §Output). rf2-0t0l3w:
+      ;; both are PROJECTED for tool egress (the record's `:resource/key` + the
+      ;; work-id's embedded scoped key).
       (some? work-id)
-      (assoc :work-ledger {:work/id work-id
-                           :record  (select-keys record
-                                                  [:work/id :work/kind :status
-                                                   :resource/key :generation
-                                                   :transport :owners :causes])}
-             :host-transient [[:rf.http/in-flight work-id]])
+      (live-work-ledger-link runtime-db work-id frame-id)
       ;; carry the static node's source coords / schema / doc / derive token
       ;; through to the live node (the same resource registration backs both).
       (contains? static-node :source) (assoc :source (:source static-node))
@@ -474,12 +550,20 @@
       ;; `assoc` one CEDN-distinct entry over the other (a list-params and a
       ;; vector-params entry are Clojure-= as vectors), reporting ONE node for
       ;; TWO live entries (rf2-ka2nkx).
-      (fn [acc k-id entry]
+      (fn [acc _k-id entry]
         (let [scoped-key  (:resource/key entry)
               resource-id (second scoped-key)
-              static-node (resource-algebra-view resource-id)]
-          (assoc acc k-id
-                 (live-node-for runtime-db scoped-key entry static-node))))
+              static-node (resource-algebra-view resource-id)
+              node        (live-node-for runtime-db scoped-key frame-id
+                                         entry static-node)]
+          ;; rf2-0t0l3w: re-key the returned map on the PROJECTED key's byte
+          ;; `key-id` (the node's `:id` is the projected scoped key) so the map
+          ;; key, the `:id`, and every other identity position agree and carry
+          ;; no raw secret. A non-sensitive resource projects to the SAME key,
+          ;; so its byte key-id is unchanged; a `:redact` / `:omit` resource's
+          ;; opaque content-addressed tokens stay distinct per distinct value,
+          ;; so two CEDN-distinct entries never collapse onto one map key.
+          (assoc acc (state/key-id (:id node)) node)))
       {}
       (or entries {}))))
 

--- a/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
@@ -301,6 +301,98 @@
           (is (not= (:lifecycle nv) (:lifecycle nl))
               "the two nodes carry their OWN distinct owner sets (not gated together)"))))))
 
+;; ---- EP-0015 egress redaction of the live graph snapshot (rf2-0t0l3w) ----
+;;
+;; `resource-cache-algebra-view` is a TOOL-facing egress boundary (Xray,
+;; re-frame2-pair-mcp, conformance fixtures consume it). EP-0015 treats
+;; resource entries, work-ledger rows, scopes, params, and owner/cause
+;; summaries as EGRESS RECORDS: the raw scope/params embedded in the node
+;; KEY, `:id`, `:inputs`, `:output`, and `:work-ledger :record :resource/key`
+;; cannot be reached by a generic value-path walk, so the tooling surface
+;; must project them through the resource OWNER classification BEFORE egress.
+
+(def ^:private secret "tenant-jwt-SECRET-9f3a")
+
+(defn- contains-secret?
+  "Deep-walk `v`; true iff the raw secret string appears ANYWHERE (leaf, key,
+  scope, params, work-ledger record, :output path tail)."
+  [v]
+  (boolean
+    (cond
+      (= v secret)  true
+      (map? v)      (some contains-secret? (concat (keys v) (vals v)))
+      (coll? v)     (some contains-secret? v)
+      :else         false)))
+
+(deftest live-view-redacts-sensitive-params-at-tool-egress
+  (testing "rf2-0t0l3w: a :sensitive? resource's scoped-key scope/params are
+            projected to opaque handles in EVERY identity position — the node
+            map key, :id, :inputs, :output, and the in-flight work-ledger
+            record :resource/key — while resource-id identity + connectivity
+            survive and no raw secret egresses"
+    (rf/reg-resource :secret/article
+                     (article-spec {:sensitive?    true
+                                    :params-schema [:map [:auth-token :string]]}))
+    (let [scope      [:rf.scope/tenant secret]
+          params     {:auth-token secret}
+          scoped-key (install-live-entry! :rf/default :secret/article scope params
+                                          {:owner [:route :route/article 17] :in-flight? true})
+          view       (resources-tooling/resource-cache-algebra-view :rf/default)
+          node       (first (vals view))]
+      (is (= 1 (count view)) "exactly one live node")
+      (is (some? node))
+      (testing "no raw secret anywhere in the egressed view"
+        (is (not (contains-secret? view))))
+      (testing "the resource-id identity + graph connectivity survive projection"
+        (is (= :secret/article (nth (:id node) 1))
+            "resource-id preserved in the node :id 3-tuple")
+        (is (= :secret/article (second (:resource/key (:record (:work-ledger node))))
+               )
+            "resource-id preserved in the work-ledger record :resource/key"))
+      (testing "the node MAP KEY does not embed the raw secret"
+        (is (not (contains-secret? (keys view))))))))
+
+(deftest live-view-preserves-non-sensitive-identity
+  (testing "rf2-0t0l3w guard: a NON-sensitive resource still rides its scope /
+            params verbatim (projection must not over-redact the common case)"
+    (rf/reg-resource :plain/article (article-spec))
+    (let [scope  :rf.scope/global
+          params {:slug "welcome"}
+          scoped-key (install-live-entry! :rf/default :plain/article scope params
+                                          {:status :loaded :owner [:lease :p 1]})
+          view   (resources-tooling/resource-cache-algebra-view :rf/default)
+          node   (get view (state/key-id scoped-key))]
+      (is (some? node))
+      (is (= [[:scope scope] [:param params]] (:inputs node))
+          "non-sensitive scope + params ride verbatim")
+      (is (= scoped-key (:id node)) "non-sensitive scoped key rides verbatim"))))
+
+(deftest live-view-redacts-derived-sensitive-scope
+  (testing "rf2-0t0l3w: a resource whose {:from-db <resolver>} scope derives
+            sensitivity from a frame-sensitive :db input is redacted at egress
+            EVEN when the owner did not declare :sensitive? (derived-sensitivity
+            inheritance, Spec 015 §Derived sensitivity)"
+    ;; FRAME classification: the resolver's :db input path is sensitive.
+    (rf/reg-frame :sens/frame
+                  {:doc "frame with a sensitive tenant-id"
+                   :sensitive {:app-db [[:session :tenant-id]]}})
+    ;; resolver reading the frame-sensitive path (default :inherit propagates)
+    (rf/reg-resource-scope :session/tenant
+                           {:inputs  {:tenant-id [:db [:session :tenant-id]]}
+                            :resolve (fn [{:keys [tenant-id]} _]
+                                       (when tenant-id [:rf.scope/tenant tenant-id]))})
+    ;; a tenant-scoped resource — NOT itself declared :sensitive?
+    (rf/reg-resource :derived/article
+                     (article-spec {:scope {:from-db :session/tenant}}))
+    (let [scope      [:rf.scope/tenant secret]
+          params     {:slug "x"}
+          scoped-key (install-live-entry! :sens/frame :derived/article scope params
+                                          {:status :loaded :owner [:lease :d 1]})
+          view       (resources-tooling/resource-cache-algebra-view :sens/frame)]
+      (is (= 1 (count view)) "one node")
+      (testing "the derived-sensitive scope is redacted at egress (no raw secret)"
+        (is (not (contains-secret? view)))))))
+
 ;; ---- registry semantics --------------------------------------------------
 
 (deftest cleared-resource-is-removed-from-the-static-view

--- a/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
@@ -37,6 +37,7 @@
    [re-frame.resources.route :as route]
    [re-frame.resources.state :as state]
    [re-frame.resources.subs :as r-subs]
+   [re-frame.resources.scope-registry :as scope-registry]
    [re-frame.resources.test-support]
    [re-frame.routing :as routing]
    [re-frame.schemas]
@@ -443,3 +444,72 @@
     (testing "the causal event-ensure resolution STILL emits a scope-resolved row"
       (is (pos? (count (filter #(= :t/session (:resource-id (:tags %))) rows)))
           "the traced causal boundary kept its evidence"))))
+
+;; ===========================================================================
+;; rf2-84l82t (EP-0015) — OFF-BOX egress projection of the
+;; :rf.resource/scope-resolved trace row's resolver-owned values.
+;; ===========================================================================
+
+(deftest scope-resolved-off-box-egress-redacts-resolver-values
+  ;; The resolved :input-values (raw db reads) and :scope (the derived identity
+  ;; tuple embedding them) are owner-local values the generic value-path trace
+  ;; egress walk cannot classify. project-scope-resolved-egress FAILS CLOSED:
+  ;; a db-reading resolver not explicitly declassified redacts both slots +
+  ;; stamps :sensitive? true, preserving the structural attribution slots.
+  (testing "the default (:inherit) :t/session resolver redacts its values off-box"
+    (let [tags {:resource-id  :t/session
+                :kind         :resource-scope
+                :inputs       [:username]
+                :input-values {:username "jake"}
+                :whole-db?    false
+                :scope        [:rf.scope/session {:username "jake"}]
+                :resolved-nil? false}
+          proj (scope-registry/project-scope-resolved-egress tags)]
+      (is (= :rf/redacted (:input-values proj)) "raw db reads redacted")
+      (is (= :rf/redacted (:scope proj)) "derived identity tuple redacted")
+      (is (true? (:sensitive? proj)) "row stamped sensitive for the egress gate")
+      (testing "the structural attribution slots ride verbatim"
+        (is (= :t/session (:resource-id proj)))
+        (is (= :resource-scope (:kind proj)))
+        (is (= [:username] (:inputs proj)) "the declared input NAMES survive")
+        (is (false? (:resolved-nil? proj))))
+      (testing "no raw secret survives the projection"
+        (let [secret? (fn secret? [v]
+                        (cond (= v "jake") true
+                              (map? v)  (boolean (or (some secret? (keys v))
+                                                     (some secret? (vals v))))
+                              (coll? v) (boolean (some secret? v))
+                              :else     false))]
+          (is (not (secret? proj))))))))
+
+(deftest scope-resolved-off-box-egress-public-resolver-rides-verbatim
+  ;; A resolver that explicitly DECLASSIFIES (:rf.egress/public) asserts its
+  ;; derived scope is safe to surface — the trusted, enumerable audit surface.
+  (rf/reg-resource-scope :t/public-locale
+    {:inputs  {:locale [:db [:i18n :locale]]}
+     :rf.egress/output-sensitivity :rf.egress/public
+     :resolve (fn [{:keys [locale]} _] (when locale [:rf.scope/locale {:locale locale}]))})
+  (testing "an explicitly :rf.egress/public resolver's values ride verbatim"
+    (let [tags {:resource-id  :t/public-locale
+                :kind         :resource-scope
+                :inputs       [:locale]
+                :input-values {:locale "en"}
+                :scope        [:rf.scope/locale {:locale "en"}]
+                :resolved-nil? false}
+          proj (scope-registry/project-scope-resolved-egress tags)]
+      (is (= {:locale "en"} (:input-values proj)))
+      (is (= [:rf.scope/locale {:locale "en"}] (:scope proj)))
+      (is (not (:sensitive? proj))))))
+
+(deftest scope-resolver-egress-sensitive-fails-closed-on-unregistered
+  ;; An unregistered resolver id → sensitive (fail-closed: no spec proves safe).
+  (testing "the predicate fails closed for an unknown resolver"
+    (is (true? (scope-registry/scope-resolver-egress-sensitive? :t/never-registered))))
+  (testing "the predicate is sensitive for a db-reading :inherit resolver"
+    (is (true? (scope-registry/scope-resolver-egress-sensitive? :t/session))))
+  (testing "the predicate is NOT sensitive for an explicitly :public resolver"
+    (rf/reg-resource-scope :t/public2
+      {:inputs  {:locale [:db [:i18n :locale]]}
+       :rf.egress/output-sensitivity :rf.egress/public
+       :resolve (fn [{:keys [locale]} _] (when locale [:rf.scope/locale {:locale locale}]))})
+    (is (false? (scope-registry/scope-resolver-egress-sensitive? :t/public2)))))

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -97,6 +97,20 @@
   ([frame-id scoped-key]
    (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
 
+(defn- mutation-record
+  "The serializable work-ledger record for a mutation INSTANCE's current
+  attempt — found by scanning the frame's ledger for the row whose
+  `:work/id` embeds `[:rf.mutation instance-id]`. The mutation work-id head
+  is `[:rf.work/resource [:rf.mutation instance-id] generation]`, so a row
+  scan keyed on the embedded instance key is the stable test reader (the
+  generation is runtime-allocated)."
+  ([instance-id] (mutation-record :rf/default instance-id))
+  ([frame-id instance-id]
+   (->> (vals (get-in (runtime-db frame-id) [:rf.runtime/work-ledger]))
+        (filter (fn [r] (= [:rf.mutation instance-id]
+                           (second (:work/id r)))))
+        first)))
+
 (defn- reply-success!
   ([args result] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))
   ;; EP-0010: a fixture may script the reply token's :rf.cofx to pin
@@ -1347,6 +1361,48 @@
   (testing "the accepted terminal cancellation fired the continuation"
     (is (= 1 (count @replied)))
     (is (= :cancelled (:status (second (first @replied)))))))
+
+(deftest accepted-abort-reply-settles-ledger-cancelled
+  ;; rf2-qsn30x (EP-0011): an ACCEPTED mutation abort/cancel reply
+  ;; (`{:kind :rf.http/aborted}`, which the reply substrate lowers to
+  ;; `:status :cancelled` / `:work/status :cancelled`) must settle the
+  ;; work-ledger row terminal `:cancelled` — NOT `:failed`. The ledger
+  ;; status MUST agree with the canonical reply's `:work/status`
+  ;; (Managed-Effects §Status taxonomy / §Work-status mapping). A stale
+  ;; abort still settles `:suppressed` (covered by the stale suite); this
+  ;; pins the LIVE/accepted path.
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :ac1
+                      :reply-to [:test/save-replied]}])
+  (reply-failure! @last-managed-args {:kind :rf.http/aborted :reason :user-abort})
+  (testing "the canonical reply work-status is :cancelled"
+    (is (= :cancelled (:status (second (first @replied))))))
+  (testing "the work-ledger row settled terminal :cancelled (agrees with the reply)"
+    (let [rec (mutation-record :ac1)]
+      (is (= :cancelled (:status rec)))
+      (is (= :cancelled (:work/status (second (first @replied))))
+          "the ledger status agrees with the canonical reply :work/status")))
+  (testing "the ledger outcome carries the cancel reason, not an error summary"
+    (let [rec (mutation-record :ac1)]
+      (is (= :aborted (:reason (:outcome rec))))
+      (is (nil? (:error (:outcome rec)))))))
+
+(deftest accepted-failure-reply-still-settles-ledger-failed
+  ;; rf2-qsn30x guard: a genuine (non-abort) failure reply still settles the
+  ;; ledger row `:failed` — the abort branch must NOT swallow ordinary
+  ;; failures into `:cancelled`.
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :af1
+                      :reply-to [:test/save-replied]}])
+  (reply-failure! @last-managed-args {:kind :rf.http/http-5xx :status 503})
+  (testing "the work-ledger row settled terminal :failed"
+    (is (= :failed (:status (mutation-record :af1)))))
+  (testing "the canonical reply work-status is :error"
+    (is (= :error (:status (second (first @replied)))))))
 
 (deftest stale-reply-does-not-fire-the-continuation
   ;; Validation rule 4: a STALE / superseded mutation reply fires NO

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -329,6 +329,68 @@
                (:outcome (record wid))))
         (is (nil? (work-ledger/get-handle :rf/default wid)))))))
 
+(deftest stale-aborted-event-suppressed-not-cancelled
+  ;; rf2-iu0z8t (EP-0011): the legacy `:rf.resource.internal/aborted` event
+  ;; must honour the SAME stale-suppression boundary as succeeded/failed —
+  ;; a STALE / superseded aborted event (its carried work-id + generation no
+  ;; longer correlate with the live entry) settles the row :suppressed, NOT
+  ;; an accepted :cancelled. Stale validation wins over the natural
+  ;; cancellation status (Managed-Effects §Stale suppression).
+  (rf/reg-resource :sa/article (article-spec))
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :sa/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :sa/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :sa 1]}])
+    (let [wid1 (:current-work (entry scoped-key))]
+      ;; a newer refetch supersedes (generation 2) — the gen-1 work row settles
+      ;; :suppressed (superseded) and the entry advances to generation 2.
+      (rf/dispatch-sync [:rf.resource/refetch {:resource :sa/article :scope :rf.scope/global
+                                               :params {:slug "w"}}])
+      (testing "the OLD-generation aborted event NEVER overrides the :suppressed
+                row with an accepted :cancelled (stale wins over cancellation)"
+        (rf/dispatch-sync [:rf.resource.internal/aborted
+                           {:resource/key scoped-key :work/id wid1 :generation 1}])
+        (is (= :suppressed (:status (record wid1)))
+            "the superseded row stays :suppressed, not flipped to :cancelled")
+        (is (= 2 (:generation (entry scoped-key)))
+            "the live entry's generation is untouched by the stale abort")))))
+
+(deftest cross-frame-aborted-event-rejected
+  ;; rf2-iu0z8t (EP-0011): the legacy `:rf.resource.internal/aborted` event
+  ;; must verify the carried :rf.frame/id against the receiving frame, like
+  ;; succeeded/failed (rf2-jzh5gq / rf2-eu2ifi). A cross-frame aborted event
+  ;; (payload stamped with another frame's id) is REJECTED: it can never
+  ;; settle the receiving frame's live ENTRY to an accepted cancellation
+  ;; (the durable user-visible state is the correctness boundary — the work-
+  ;; ledger row, like succeeded/failed cross-frame, lowers to :suppressed at
+  ;; the colliding work-id, never an accepted :cancelled).
+  (rf/reg-resource :cfa/article (article-spec))
+  (let [fa :cfa/frame-a
+        fb :cfa/frame-b
+        scoped-key (state/scoped-resource-key :rf.scope/global :cfa/article {:slug "w"})]
+    (rf/reg-frame fa {:doc "frame A"})
+    (rf/reg-frame fb {:doc "frame B"})
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :cfa/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :b 1]}]
+                      {:frame fb})
+    (let [wid-b      (:current-work (entry fb scoped-key))
+          before     (entry fb scoped-key)]
+      (testing "an aborted event STAMPED with frame A, dispatched into frame B,
+                does NOT abort-settle frame B's live entry (no cross-frame
+                durable write even at the same work-id / generation)"
+        ;; payload carries :rf.frame/id = fa (the wrong frame); the work-id +
+        ;; generation happen to match frame B's live attempt.
+        (rf/dispatch-sync [:rf.resource.internal/aborted
+                           {:resource/key scoped-key :work/id wid-b :generation 1
+                            :rf.frame/id fa}]
+                          {:frame fb})
+        (is (= (:status before) (:status (entry fb scoped-key)))
+            "frame B's entry status untouched by the cross-frame aborted event")
+        (is (= wid-b (:current-work (entry fb scoped-key)))
+            "frame B's :current-work pointer not cleared by the cross-frame event"))
+      (testing "the rejected cross-frame event NEVER settles an accepted
+                :cancelled work row (stale / cross-frame validation wins)"
+        (is (not= :cancelled (:status (record fb wid-b))))))))
+
 ;; ===========================================================================
 ;; 5. stale suppression is mandatory; abort is opportunistic
 ;; ===========================================================================


### PR DESCRIPTION
Review-wave findings on `implementation/resources` (EP-0011 reply-envelope + EP-0015 redaction). One surface, four beads, red→green per bead.

## EP-0011 — reply envelope

### rf2-qsn30x (P1) — mutation abort replies settle ledger `:cancelled`
`mutation_events.cljc`'s `failed-handler` unconditionally marked the work-ledger row `:failed` and stored the abort envelope as an error, even when the canonical reply lowered an `{:kind :rf.http/aborted}` failure to `:status :cancelled` / `:work/status :cancelled`. The live path now settles the row using the reply's `:work/status` (`:cancelled` for an accepted abort, `:failed` otherwise) with the abort outcome summary (`{:reason :aborted …}`, no error envelope), mirroring the resource abort path. Stale aborts still settle `:suppressed` (stale validation wins over the natural cancellation status). Coverage asserts the ledger status and the canonical reply `:work/status` agree, plus a guard that a genuine failure still settles `:failed`.

### rf2-iu0z8t (P2) — legacy aborted handler lowered through the canonical path
The registered `:rf.resource.internal/aborted` handler ad-hoc cleared the handle and marked the row `:cancelled` straight from the verification payload — no canonical reply, no `live-entry-for-reply` gate, no stale-wins boundary, no `:rf.frame/id` check. The production managed-HTTP abort already arrives as an `:rf.http/aborted` failure through `failed-handler`, so this legacy event is now lowered through the SAME path: builds the reply via `failure-reply` (synthetic `:rf.http/aborted` → `:status :cancelled`), gates on `live-entry-for-reply`, settles the live entry via `entry-abort-settled` + marks the row `:cancelled` + drains route blocking, and on a stale/cross-frame miss suppresses to `:suppressed`. Adds stale + cross-frame aborted-event coverage.

## EP-0015 — redaction

### rf2-0t0l3w (P2) — resource-cache algebra view projects scoped keys at tool egress
`resource-cache-algebra-view` (a tool-facing live-graph boundary) emitted the raw scoped key + scope/params in every identity position (node map key, `:id`, `:inputs`, `:output`, work-ledger record `:resource/key`, host-transient handle). `live-node-for` now projects each scoped key through the SAME resource owner classification the SSR path uses (`classification/whole-entry-disposition-for` + `ssr/project-scoped-key`): a `:sensitive?`/`:large?`/derived-sensitive resource has its scope+params replaced by stable opaque content-addressed tokens consistently across every identity position, while the registration `resource-id` and non-sensitive identity survive (connectivity preserved). Covers sensitive params, derived sensitive scope, an in-flight work-ledger summary, and a non-sensitive guard.

### rf2-84l82t (P2) — resolver-owned scope-resolved trace values redacted at off-box egress
The `:rf.resource/scope-resolved` trace row emits the resolver's resolved `:input-values` (raw db reads) and derived `:scope` — owner-local values the generic value-path trace egress walk is blind to once copied into tags. Adds a resource-aware egress projector the resource family owns (`scope_registry/project-scope-resolved-egress`), published as the late-bound `:resources/project-scope-resolved-egress` hook; the epoch tool-pair's off-box `:trace-events` chain consults it (gated on the off-box `:include-sensitive?` default, lifted by the trusted-local opt-in). Fail-closed for any db-reading resolver not explicitly declassified (`:output-sensitivity :rf.egress/public`); structural attribution slots survive; on-box listener keeps raw dev evidence. Covers sensitive/inherit, declassified-public, fail-closed-unregistered (unit) + an end-to-end `projected-record` integration test. The broader resource/mutation trace-family scoped-key sweep (`:resource/key`, `:removed`, rollback `:dispositions`) is filed as follow-up **rf2-8x0gfa**.

## Gates
- `npm run test:cljs` — 7736 tests / 31917 assertions green
- resources JVM — 496 tests green; epoch JVM — 343 tests green; core JVM green (incl. late-bind directory drift gate)
- `scripts/test-fast-pr.sh --no-docs` — PASS

No spec changes: `spec/Derivations.md` (§371/§850, §Tool redaction) and Spec 015 already document both EP-0015 cases — the implementation was catching up to the normative spec.