### PR TITLE
chore(scripts): EP-0011 reply-vocab + EP-0015 privacy-drift guards + stale-registrar/epoch cleanup (rf2-uhew69, rf2-1zjkn8, rf2-khf6qm, rf2-ba0eum)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -329,6 +329,71 @@
               {:kind :reg-cofx-contract :facet label}))
           reg-cofx-required-phrases)))
 
+;; ---------------------------------------------------------------------------
+;; EP-0015 :rf.egress/* closed-enum pin (rf2-1zjkn8).
+;;
+;; The var-resolution reconcile above is blind to the EP-0015 KEYWORD
+;; vocabulary, and the keyword-drift guard (projection/ep0015-…) only catches
+;; RETIRED profile spellings reappearing. It cannot catch the CLOSED enum
+;; silently SHRINKING — a member dropped from its owner row in
+;; spec/Conventions.md would let docs/spec regress with the gate green. This
+;; positive pin asserts every closed `:rf.egress/*` member is present on the
+;; owner row, the same shape as the reg-cofx contract pin: pin the small,
+;; settled, closed set's PRESENCE (a member that vanished has drifted).
+;; ---------------------------------------------------------------------------
+
+(def ^:private conventions-md-file
+  (delay (io/file gen/repo-root "spec" "Conventions.md")))
+
+(def ^:private egress-closed-enum
+  "The closed EP-0015 `:rf.egress/*` vocabulary the owner row
+   (spec/Conventions.md `:rf.egress/*` reserved-namespace row) MUST carry: the
+   six-member projection-profile enum (EP-0015 issue 3) plus the
+   `:rf.egress/output-sensitivity` declassification key and its closed
+   three-value set (EP-0015 issue 9). A member missing from the row is enum
+   drift (the closed set silently shrank)."
+  [":rf.egress/off-box-observability"
+   ":rf.egress/off-box-tool"
+   ":rf.egress/local-redacted"
+   ":rf.egress/local-raw"
+   ":rf.egress/ssr-hydration"
+   ":rf.egress/public-error"
+   ":rf.egress/output-sensitivity"
+   ":rf.egress/inherit"
+   ":rf.egress/sensitive"
+   ":rf.egress/public"])
+
+(defn- egress-enum-row-text
+  "The full raw text of the spec/Conventions.md `:rf.egress/*` reserved-
+   namespace row (the `| ... |` table line whose first cell is
+   `` `:rf.egress/*` ``), or nil if absent. The whole pipe-delimited line is
+   returned so the pin asserts every closed member is named on the one row."
+  []
+  (with-open [r (io/reader @conventions-md-file)]
+    (->> (line-seq r)
+         (some (fn [line]
+                 (when (re-find #"^\s*\|\s*`:rf\.egress/\*`\s*\|" line) line))))))
+
+(defn egress-enum-problems
+  "Pure closed-enum pin (rf2-1zjkn8 — extracted so the EP-0015 `:rf.egress/*`
+   enum contract is unit-testable with a synthetic row). Given the raw
+   `:rf.egress/*` owner row line (or nil), return the seq of problem maps for
+   any missing closed member, plus a guard problem when the row is absent.
+
+   INTENTIONALLY positive (require each closed member's presence) rather than
+   a denylist — the closed set is small and settled, so pinning its presence
+   is the sound drift gate: a row that lost a member has drifted."
+  [row-line]
+  (if (nil? row-line)
+    [{:kind :egress-row-missing
+      :detail (str "spec/Conventions.md has no `:rf.egress/*` reserved-namespace "
+                   "row — the EP-0015 closed projection-profile enum is "
+                   "unaccounted for")}]
+    (keep (fn [member]
+            (when-not (str/includes? row-line member)
+              {:kind :egress-member-missing :member member}))
+          egress-closed-enum)))
+
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
    every API.md var-row resolves to a manifest row with a MATCHING tier;
@@ -356,13 +421,24 @@
         ;; cannot see the row's signature/contract prose drift back to the
         ;; stale v1 ctx-transform shape. Pin the load-bearing EP-0017 phrases.
         cofx-probs (reg-cofx-contract-problems (reg-cofx-row-text))
+        api-md-lines (with-open [r (io/reader @api-md-file)]
+                       (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r))))
         ;; EP-0017 keyword-drift guard (rf2-tawage): the var-row reconcile is
         ;; blind to stale `:rf.world/inputs` keyword vocabulary creeping into
         ;; API.md prose outside an explicit retirement/rename mention.
-        kw-probs   (projection/ep0017-keyword-drift-problems
-                     "spec/API.md"
-                     (with-open [r (io/reader @api-md-file)]
-                       (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r)))))]
+        ;; EP-0011 (rf2-uhew69) + EP-0015 (rf2-1zjkn8) add the reply-envelope
+        ;; (`:stale-key` / bare `:work-id`) and egress-profile (retired
+        ;; `:rf.egress/on-box-*` / `trusted-local-*`) keyword guards over the
+        ;; same API.md prose, all on the same retirement-marker discipline.
+        kw-probs   (concat
+                     (projection/ep0017-keyword-drift-problems "spec/API.md" api-md-lines)
+                     (projection/ep0011-reply-vocab-drift-problems "spec/API.md" api-md-lines)
+                     (projection/ep0015-privacy-vocab-drift-problems "spec/API.md" api-md-lines))
+        ;; EP-0015 closed-enum pin (rf2-1zjkn8): the keyword-drift guard above
+        ;; only catches RETIRED spellings reappearing — it cannot see the
+        ;; closed `:rf.egress/*` enum silently SHRINK on its owner row in
+        ;; spec/Conventions.md. Pin every closed member's presence positively.
+        egress-probs (egress-enum-problems (egress-enum-row-text))]
     (cond
       ;; Vacuity-floor violation: extraction collapsed — refuse a green.
       floor
@@ -388,11 +464,24 @@
 
       (seq kw-probs)
       (do (binding [*out* *err*]
-            (println "DRIFT: spec/API.md reintroduced stale EP-0017 keyword vocabulary.")
-            (println ":rf.world/inputs was renamed to the flat :rf.cofx map (no alias);")
-            (println "a mention must be an explicit retirement/rename reference. Problems:")
-            (doseq [{:keys [file line detail]} kw-probs]
-              (println (format "  %s:%d  %s" file line detail))))
+            (println "DRIFT: spec/API.md reintroduced stale keyword vocabulary.")
+            (println "A retired keyword (EP-0017 :rf.world/inputs, EP-0011 :stale-key /")
+            (println ":work-id, or EP-0015 retired :rf.egress/* profile form) appears outside")
+            (println "an explicit retirement/rename reference. Problems:")
+            (doseq [{:keys [file line raw detail]} kw-probs]
+              (println (format "  %s:%d  `%s`  %s" file line raw detail))))
+          false)
+
+      (seq egress-probs)
+      (do (binding [*out* *err*]
+            (println "DRIFT: spec/Conventions.md `:rf.egress/*` row lost a closed-enum member.")
+            (println "The closed EP-0015 projection-profile enum (six profiles +")
+            (println ":rf.egress/output-sensitivity + its three-value set) must be named in")
+            (println "full on the owner row. Missing:")
+            (doseq [{:keys [kind member detail]} egress-probs]
+              (case kind
+                :egress-row-missing    (println (str "  " detail))
+                :egress-member-missing (println (format "  MISSING closed member: %s" member)))))
           false)
 
       (empty? problems)

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
@@ -95,10 +95,12 @@
         var-problems (reconcile {:references   references
                                  :core-vars    core-vars
                                  :scoped-allow scoped-allow})
-        ;; EP-0017 keyword-drift guard (rf2-tawage): the var-resolution
-        ;; reconcile above cannot see stale `:rf.world/inputs` keyword
-        ;; vocabulary creeping back into teaching prose. Fold the keyword
-        ;; scan in so a reintroduction goes RED here too.
+        ;; Keyword-drift guards (rf2-tawage / rf2-uhew69 / rf2-1zjkn8): the
+        ;; var-resolution reconcile above cannot see stale EP-0017
+        ;; `:rf.world/inputs`, EP-0011 reply-envelope (`:stale-key` / bare
+        ;; `:work-id`), or EP-0015 egress-profile keyword vocabulary creeping
+        ;; back into teaching prose. Fold the keyword scan in so a
+        ;; reintroduction goes RED here too.
         kw-problems  (proj/keyword-drift-problems-over-files files)
         problems     (concat var-problems kw-problems)]
     (proj/report-with-floor! "docs/guide/" (count references) min-references problems)))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -276,14 +276,165 @@
                               ":rf.error/world-inputs-renamed error on the line)")}))))
         lines))
 
+;; ---------------------------------------------------------------------------
+;; EP-0011 reply-envelope vocabulary-drift guard (rf2-uhew69).
+;;
+;; The var-resolution projection checks scope to PUBLIC-VAR references and
+;; cannot see the EP-0011 reply-envelope KEYWORD vocabulary at all (`rg` over
+;; the scripts surface found no `:work/id`, `:stale-key`, or reply-status
+;; vocabulary). EP-0011 settled one canonical attempt identity — namespaced
+;; `:work/id` — and explicitly RETIRED two near-duplicate spellings
+;; ([EP-0007] one-name-per-fact):
+;;
+;;   - `:stale-key` — the retired second stale-suppression key. EP-0011 keys
+;;     stale suppression on `:work/id`; `:stale-key` is dropped (no synonym).
+;;   - bare hyphenated `:work-id` — the unqualified spelling that survived in
+;;     resource / mutation internal reply events; EP-0011 lowered them all to
+;;     the qualified `:work/id`. (`:work-id` legitimately survives ONLY inside
+;;     an `:rf.observe/*` correlation example, where it is a string-valued
+;;     correlation-id projection, not the reply-map attempt identity.)
+;;
+;; A teaching/spec surface that reintroduces `:stale-key` or bare `:work-id`
+;; as live reply-envelope vocabulary has drifted, while every var-resolution
+;; check stays green. This guard closes that gap with a targeted KEYWORD scan,
+;; mirroring the EP-0017 guard above: a stale keyword is flagged UNLESS the
+;; line ALSO carries a retirement/rename/migration marker (the spec's own
+;; retirement prose always names `:work/id` as the canonical replacement) or,
+;; for `:work-id`, an `:rf.observe`/`:correlation` context marker.
+;; ---------------------------------------------------------------------------
+
+(def ^:private work-id-retirement-markers
+  "Same-line tokens that mark a `:stale-key` / bare `:work-id` mention as a
+   legitimate retirement / rename / correlation reference rather than fresh
+   stale reply-envelope vocabulary. The canonical replacement key `:work/id`
+   and the [EP-0007] one-name-per-fact citation are the strongest markers; the
+   prose words cover narrative migration mentions; `:rf.observe` /
+   `:correlation` mark the one legitimate non-EP-0011 surface where a bare
+   `:work-id` correlation-id projection survives."
+  [":work/id"
+   "ep-0007" "one-name-per-fact" "one name per fact"
+   ":rf.observe" ":correlation"
+   "retired" "renamed" "removed" "dropped" "superseded" "synonym" "migrat"])
+
+(defn ep0011-reply-vocab-drift-problems
+  "Return a seq of EP-0011 reply-envelope vocabulary-drift problem maps for
+   `lines` (a seq of `[line-no text]`), tagged with `file` (repo-relative).
+   Flags each `:stale-key` or bare hyphenated `:work-id` mention NOT
+   accompanied on its line by a retirement / rename / correlation marker (see
+   `work-id-retirement-markers`).
+
+   The bare-`:work-id` match is anchored on a NON-`/` boundary so it never
+   fires on the canonical namespaced `:work/id` (the `/` after `work` makes it
+   `:work/id`, not `:work-id`).
+
+   Pure over the supplied lines so the contract is unit-testable with
+   synthetic inputs (rf2-uhew69)."
+  [file lines]
+  (let [;; `:work-id` (hyphen) but NOT `:work/id` (slash). Trailing boundary
+        ;; keeps `:work-id-foo` from matching as the bare identity key.
+        work-id-re #":work-id(?![/a-zA-Z0-9*!?<>=._+-])"]
+    (keep (fn [[n text]]
+            (let [lc       (str/lower-case text)
+                  approved (some #(str/includes? lc (str/lower-case %))
+                                 work-id-retirement-markers)
+                  stale    (cond
+                             (str/includes? text ":stale-key")  ":stale-key"
+                             (re-find work-id-re text)           ":work-id")]
+              (when (and stale (not approved))
+                {:file file :line n :raw stale
+                 :detail (str "stale EP-0011 reply-envelope vocabulary — the "
+                              "canonical attempt identity is the namespaced "
+                              ":work/id; " stale " is a retired near-duplicate "
+                              "([EP-0007] one-name-per-fact). A mention must be "
+                              "an explicit retirement/rename reference (name "
+                              ":work/id on the line) or, for :work-id, an "
+                              ":rf.observe/:correlation projection context")})))
+          lines)))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 privacy / egress vocabulary-drift guard (rf2-1zjkn8).
+;;
+;; The var-resolution projection checks are blind to EP-0015's keyword
+;; vocabulary. EP-0015 renamed two early `:rf.egress/*` profile spellings for
+;; axis consistency and the OLD keyword forms must never reappear as live
+;; vocabulary:
+;;
+;;   - `:rf.egress/on-box-hidden-sensitive` → renamed to `:rf.egress/local-redacted`
+;;   - `:rf.egress/trusted-local-raw`       → renamed to `:rf.egress/local-raw`
+;;
+;; These retired keyword profile forms appear only in the superseded EP-0015
+;; proposal doc (not a scanned surface); reintroducing either into a teaching
+;; / spec / skills surface is drift while the var-resolution checks stay green.
+;;
+;; SCOPE DISCIPLINE. The match is on the RETIRED `:rf.egress/`-prefixed
+;; keyword FORMS only — NOT the bare English adjectives "on-box" /
+;; "trusted-local", which remain current trust-boundary descriptors
+;; (`:rf.egress/local-raw` IS "trusted local operator"). A mention carrying a
+;; retirement/rename marker on the same line (the proposal-doc rename rows
+;; name the replacement) is approved. The closed six-member profile enum and
+;; the `:rf.egress/output-sensitivity` value set are PINNED positively by
+;; `ep0015-egress-enum-problems` over the spec/Conventions.md owner row.
+;; ---------------------------------------------------------------------------
+
+(def ^:private egress-profile-retirement-markers
+  "Same-line tokens that mark a retired `:rf.egress/*` profile-form mention as
+   a legitimate rename reference. The replacement profile keywords and the
+   rename prose words approve a line; one carrying NONE is fresh stale
+   vocabulary."
+  [":rf.egress/local-redacted" ":rf.egress/local-raw"
+   "renamed" "rename" "retired" "removed" "superseded" "earlier" "migrat"])
+
+(def ^:private retired-egress-profiles
+  "The retired `:rf.egress/*` profile keyword FORMS EP-0015 renamed away for
+   axis consistency (each followed by its current replacement, for the report)."
+  {":rf.egress/on-box-hidden-sensitive" ":rf.egress/local-redacted"
+   ":rf.egress/trusted-local-raw"       ":rf.egress/local-raw"})
+
+(defn ep0015-privacy-vocab-drift-problems
+  "Return a seq of EP-0015 privacy/egress vocabulary-drift problem maps for
+   `lines` (a seq of `[line-no text]`), tagged with `file` (repo-relative).
+   Flags each retired `:rf.egress/*` profile keyword form NOT accompanied on
+   its line by a rename / retirement marker (see
+   `egress-profile-retirement-markers`).
+
+   Pure over the supplied lines so the contract is unit-testable with
+   synthetic inputs (rf2-1zjkn8)."
+  [file lines]
+  (keep (fn [[n text]]
+          (let [lc       (str/lower-case text)
+                approved (some #(str/includes? lc (str/lower-case %))
+                               egress-profile-retirement-markers)
+                stale    (some (fn [[retired _]]
+                                 (when (str/includes? text retired) retired))
+                               retired-egress-profiles)]
+            (when (and stale (not approved))
+              {:file file :line n :raw stale
+               :detail (str "stale EP-0015 egress-profile keyword — " stale
+                            " was renamed to " (get retired-egress-profiles stale)
+                            " for axis consistency; the retired form must only "
+                            "appear in an explicit rename/retirement reference")})))
+        lines))
+
 (defn keyword-drift-problems-over-files
-  "Run `ep0017-keyword-drift-problems` over every file in `files` (io/file
-   seq), returning the concatenated problem seq with repo-relative `:file`
-   tags. The driver projection checks fold this into their problem list so a
-   keyword-drift reintroduction goes RED alongside any var-resolution drift."
+  "Run the keyword-drift guards over every file in `files` (io/file seq),
+   returning the concatenated problem seq with repo-relative `:file` tags. The
+   driver projection checks fold this into their problem list so a keyword /
+   vocabulary reintroduction goes RED alongside any var-resolution drift.
+
+   Folds in three guards over the same scanned surfaces:
+     - EP-0017 `:rf.world/inputs` keyword drift (rf2-tawage);
+     - EP-0011 reply-envelope vocabulary drift — retired `:stale-key` /
+       bare `:work-id` attempt-identity spellings (rf2-uhew69);
+     - EP-0015 egress-profile vocabulary drift — retired
+       `:rf.egress/on-box-hidden-sensitive` / `:rf.egress/trusted-local-raw`
+       profile keyword forms (rf2-1zjkn8)."
   [files]
   (mapcat (fn [^java.io.File f]
-            (ep0017-keyword-drift-problems (repo-relative f) (numbered-lines f)))
+            (let [rel   (repo-relative f)
+                  lines (numbered-lines f)]
+              (concat (ep0017-keyword-drift-problems rel lines)
+                      (ep0011-reply-vocab-drift-problems rel lines)
+                      (ep0015-privacy-vocab-drift-problems rel lines))))
           files))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
@@ -69,11 +69,12 @@
                                {:file file :line line :raw raw
                                 :detail "no re-frame.core manifest row"}))
                            results)
-        ;; EP-0017 keyword-drift guard (rf2-tawage): scan the SAME checked
-        ;; skill files (the migration skill is already excluded above, where
-        ;; the retired keyword legitimately appears) for stale
-        ;; `:rf.world/inputs` vocabulary reintroduced outside an explicit
-        ;; retirement/rename mention.
+        ;; Keyword-drift guards (rf2-tawage / rf2-uhew69 / rf2-1zjkn8): scan
+        ;; the SAME checked skill files (the migration skill is already excluded
+        ;; above, where retired vocabulary legitimately appears) for stale
+        ;; EP-0017 `:rf.world/inputs`, EP-0011 reply-envelope (`:stale-key` /
+        ;; bare `:work-id`), and EP-0015 egress-profile vocabulary reintroduced
+        ;; outside an explicit retirement/rename mention.
         kw-problems  (proj/keyword-drift-problems-over-files files)
         problems     (concat var-problems kw-problems)]
     (proj/report-with-floor! "skills/ (excl. re-frame-migration)"

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -250,3 +250,60 @@
       (is (some? row) "spec/API.md must carry a `reg-cofx` var-row")
       (is (empty? (c/reg-cofx-contract-problems row))
           "live drift: spec/API.md reg-cofx row lost an EP-0017 contract facet"))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 :rf.egress/* closed-enum pin (rf2-1zjkn8).
+;;
+;; The keyword-drift guard catches RETIRED spellings reappearing; this pin
+;; catches the closed `:rf.egress/*` enum silently SHRINKING on its owner row
+;; in spec/Conventions.md. A member dropped from the row must go RED.
+;; ---------------------------------------------------------------------------
+
+(def ^:private good-egress-row
+  "A synthetic `:rf.egress/*` owner row naming every closed member (a trimmed
+   paraphrase of the live spec/Conventions.md row)."
+  (str "| `:rf.egress/*` | closed six-member profile enum: "
+       ":rf.egress/off-box-observability, :rf.egress/off-box-tool, "
+       ":rf.egress/local-redacted, :rf.egress/local-raw, "
+       ":rf.egress/ssr-hydration, :rf.egress/public-error. Plus "
+       ":rf.egress/output-sensitivity and its value set :rf.egress/inherit / "
+       ":rf.egress/sensitive / :rf.egress/public. | 015 |"))
+
+(deftest egress-good-row-has-no-enum-problems
+  (testing "a row naming every closed member passes the enum pin"
+    (is (empty? (c/egress-enum-problems good-egress-row)))))
+
+(deftest egress-shrunk-row-flags-missing-members
+  (testing "a row that dropped a profile member and the declassification value
+            set is flagged on every missing member"
+    (let [shrunk (str "| `:rf.egress/*` | profiles: "
+                      ":rf.egress/off-box-observability, :rf.egress/off-box-tool, "
+                      ":rf.egress/local-redacted, :rf.egress/local-raw, "
+                      ":rf.egress/ssr-hydration. | 015 |")
+          probs  (c/egress-enum-problems shrunk)
+          missing (set (map :member probs))]
+      (is (pos? (count probs)) "the shrunk enum row must be flagged")
+      (is (every? #(= :egress-member-missing (:kind %)) probs))
+      (is (contains? missing ":rf.egress/public-error"))
+      (is (contains? missing ":rf.egress/output-sensitivity"))
+      (is (contains? missing ":rf.egress/inherit")))))
+
+(deftest egress-missing-row-is-flagged
+  (testing "an absent :rf.egress/* owner row is a contract problem, not a pass"
+    (let [probs (c/egress-enum-problems nil)]
+      (is (= 1 (count probs)))
+      (is (= :egress-row-missing (:kind (first probs)))))))
+
+(deftest egress-live-row-pins-clean
+  (testing "the committed spec/Conventions.md :rf.egress/* row carries the full
+            closed EP-0015 enum (the CI contract)"
+    (let [row (#'c/egress-enum-row-text)]
+      (is (some? row) "spec/Conventions.md must carry a `:rf.egress/*` row")
+      (is (empty? (c/egress-enum-problems row))
+          "live drift: spec/Conventions.md :rf.egress/* row lost a closed member"))))
+
+(deftest live-api-md-check-with-new-guards-passes
+  (testing "the committed tree passes the full api-md-check including the new
+            EP-0011/EP-0015 keyword guards + the egress-enum pin (no false +)"
+    (is (true? (c/check!))
+        "live drift: api-md-check failed with the EP-0011/EP-0015 guards wired")))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -28,14 +28,15 @@
 ;; A minimal synthetic manifest reproducing the EXACT ambiguity the real
 ;; manifest has: the bare var `adapter` carried for four namespaces, three
 ;; of them at tier :adapter and one (SSR) at :implementation. Plus an
-;; intentionally-bare var (`reg-event-db`) for the bare-row path.
+;; intentionally-bare var (`reg-event` — the EP-0018 one-form public event
+;; registrar) for the bare-row path.
 (def ^:private synthetic-rows
   [{:namespace "re-frame.adapter.reagent" :var "adapter" :tier :adapter}
    {:namespace "re-frame.adapter.uix"     :var "adapter" :tier :adapter}
    {:namespace "re-frame.adapter.helix"   :var "adapter" :tier :adapter}
    {:namespace "re-frame.ssr"             :var "adapter" :tier :implementation}
    {:namespace "re-frame.http"            :var "get"     :tier :advanced}
-   {:namespace "re-frame.core"            :var "reg-event-db" :tier :front-porch}])
+   {:namespace "re-frame.core"            :var "reg-event" :tier :front-porch}])
 
 (defn- problems-for
   "Run `reconcile` over `api-rows` against the synthetic manifest, with the
@@ -121,8 +122,8 @@
   (testing "a bare row resolves if ANY manifest row with that bare name
             carries the stated tier"
     (is (empty? (problems-for
-                  [{:var "reg-event-db" :qualifier nil :tier :front-porch
-                    :line 1 :raw "reg-event-db"}])))
+                  [{:var "reg-event" :qualifier nil :tier :front-porch
+                    :line 1 :raw "reg-event"}])))
     (testing "and an unmanifested bare name is flagged unless allowlisted"
       (is (= 1 (count (problems-for
                         [{:var "story-view" :qualifier nil :tier :tooling
@@ -136,8 +137,8 @@
   (testing "a bare row whose stated tier no manifest row with that name
             carries is a tier-mismatch"
     (let [problems (problems-for
-                     [{:var "reg-event-db" :qualifier nil :tier :tooling
-                       :line 1 :raw "reg-event-db"}])]
+                     [{:var "reg-event" :qualifier nil :tier :tooling
+                       :line 1 :raw "reg-event"}])]
       (is (= 1 (count problems)))
       (is (= :tier-mismatch (:kind (first problems))))
       (is (= #{:front-porch} (:manifest-tiers (first problems)))))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -29,8 +29,8 @@
 (deftest no-duplicates-yields-empty
   (testing "a manifest with distinct [namespace var] keys has no duplicates"
     (is (empty? (gen/duplicate-rows
-                  [{:namespace "re-frame.core" :var "reg-event-db" :tier :front-porch}
-                   {:namespace "re-frame.core" :var "subscribe"    :tier :front-porch}
+                  [{:namespace "re-frame.core" :var "reg-event"  :tier :front-porch}
+                   {:namespace "re-frame.core" :var "subscribe"  :tier :front-porch}
                    {:namespace "re-frame.adapter.uix" :var "adapter" :tier :adapter}])))))
 
 (deftest duplicate-within-cljs-only-detected

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
@@ -110,3 +110,89 @@
       (is (pos? (count guide-files)))
       (is (empty? (proj/keyword-drift-problems-over-files guide-files))
           "live drift: a docs/guide file reintroduced stale :rf.world/inputs"))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0011 reply-envelope vocabulary-drift guard (rf2-uhew69).
+;;
+;; EP-0011 settled the namespaced `:work/id` as the one attempt identity and
+;; retired the near-duplicate `:stale-key` and bare hyphenated `:work-id`
+;; spellings ([EP-0007] one-name-per-fact). The guard flags a retired spelling
+;; reintroduced WITHOUT a same-line retirement/correlation marker.
+;; ---------------------------------------------------------------------------
+
+(deftest ep0011-flags-fresh-stale-key
+  (testing "a fresh :stale-key mention with no retirement marker is flagged"
+    (let [probs (proj/ep0011-reply-vocab-drift-problems
+                  "spec/API.md"
+                  [[7 "Suppress on a `:stale-key` `[:resource k gen]` head."]])]
+      (is (= 1 (count probs)))
+      (is (= ":stale-key" (:raw (first probs))))
+      (is (re-find #":work/id" (:detail (first probs)))))))
+
+(deftest ep0011-flags-fresh-bare-work-id
+  (testing "a fresh bare :work-id (hyphen) mention with no marker is flagged"
+    (let [probs (proj/ep0011-reply-vocab-drift-problems
+                  "docs/guide/x.md"
+                  [[3 "The reply map carries a `:work-id` attempt identity."]])]
+      (is (= 1 (count probs)))
+      (is (= ":work-id" (:raw (first probs)))))))
+
+(deftest ep0011-canonical-work-id-not-flagged
+  (testing "the canonical namespaced :work/id is NOT a bare :work-id match"
+    (is (empty? (proj/ep0011-reply-vocab-drift-problems
+                  "x.md"
+                  [[1 "The attempt identity is `:work/id` (one attempt, one id)."]])))))
+
+(deftest ep0011-allows-retirement-mentions
+  (testing "a retired spelling on a line that names :work/id or the EP-0007
+            rule, or sits in an :rf.observe/:correlation context, is approved"
+    (is (empty? (proj/ep0011-reply-vocab-drift-problems
+                  "spec/Managed-Effects.md"
+                  [[1 "Stale suppression keys on :work/id; the separate :stale-key is dropped."]
+                   [2 "No :stale-key-style synonym (EP-0007: one-name-per-fact)."]
+                   [3 ":correlation {:work-id \"w-77\" :dispatch-id \"d-91\"}"]
+                   [4 "The unqualified :work-id is retired in favour of :work/id."]])))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 egress-profile vocabulary-drift guard (rf2-1zjkn8).
+;;
+;; EP-0015 renamed two early `:rf.egress/*` profile spellings; the retired
+;; keyword forms must not reappear as live vocabulary outside a rename mention.
+;; ---------------------------------------------------------------------------
+
+(deftest ep0015-flags-retired-profile-form
+  (testing "a fresh retired :rf.egress/on-box-hidden-sensitive form is flagged"
+    (let [probs (proj/ep0015-privacy-vocab-drift-problems
+                  "docs/guide/x.md"
+                  [[9 "Set the profile to :rf.egress/on-box-hidden-sensitive for dev."]])]
+      (is (= 1 (count probs)))
+      (is (= ":rf.egress/on-box-hidden-sensitive" (:raw (first probs))))
+      (is (re-find #":rf.egress/local-redacted" (:detail (first probs))))))
+  (testing "the retired :rf.egress/trusted-local-raw form is flagged too"
+    (is (= 1 (count (proj/ep0015-privacy-vocab-drift-problems
+                      "skills/x.md"
+                      [[1 "Use :rf.egress/trusted-local-raw for the operator."]]))))))
+
+(deftest ep0015-allows-rename-mentions
+  (testing "a retired form on a line naming the replacement or 'renamed' is OK"
+    (is (empty? (proj/ep0015-privacy-vocab-drift-problems
+                  "spec/API.md"
+                  [[1 ":rf.egress/on-box-hidden-sensitive was renamed to :rf.egress/local-redacted."]
+                   [2 "The earlier :rf.egress/trusted-local-raw spelling is retired."]])))))
+
+(deftest ep0015-current-egress-names-not-flagged
+  (testing "the current :rf.egress/local-redacted / local-raw names are NOT drift,
+            and the bare English adjectives on-box / trusted-local are not either"
+    (is (empty? (proj/ep0015-privacy-vocab-drift-problems
+                  "x.md"
+                  [[1 "Local dev defaults to :rf.egress/local-redacted; raw is :rf.egress/local-raw."]
+                   [2 "A trusted-local operator on-box may opt into raw."]])))))
+
+(deftest keyword-drift-over-files-folds-all-three-guards-clean-on-live
+  (testing "the live docs/guide surface carries no EP-0011/EP-0015 stale
+            vocabulary either (the folded driver stays clean). docs/guide has
+            no migration-skill exclusion, so the whole tree must be clean."
+    (let [guide (proj/markdown-files (proj/repo-file "docs" "guide"))]
+      (is (pos? (count guide)))
+      (is (empty? (proj/keyword-drift-problems-over-files guide))
+          "live drift: a docs/guide file reintroduced stale reply/egress vocabulary"))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -252,13 +252,20 @@ const DEV_ONLY_SENTINELS = [
   // must elide in production.
   { source: 're-frame.epoch/on-frame-destroyed! (rf.epoch.cb/silenced-on-frame-destroy)',
     sentinel: 'rf.epoch.cb/silenced-on-frame-destroy' },
-  // re-frame.epoch — :rf.warning/epoch-redact-fn-exception (rf2-wp70d).
-  // Emitted by maybe-redact when an installed :redact-fn throws.
-  // Every consumer of maybe-redact (settle!, perform-replace-app-db!
-  // via replace-app-db!'s if-not gate, on-frame-destroyed!) sits
-  // inside the universal `interop/debug-enabled?` gate, so this
-  // string literal must elide in :advanced + goog.DEBUG=false.
-  { source: 're-frame.epoch/maybe-redact (rf.warning/epoch-redact-fn-exception)',
+  // re-frame.epoch — :rf.warning/epoch-redact-fn-exception (rf2-wp70d,
+  // EP-0015 issue 6 rf2-ba0eum). EP-0015 RULED storage-side `:redact-fn`
+  // mutation removed: the `:redact-fn` advanced override is now
+  // PROJECTION-SIDE only — it runs at the OFF-BOX egress boundary inside
+  // `re-frame.epoch.tool-pair/projected-record`, AFTER the frame/profile
+  // `re-frame.projection/project-egress` projection, never at storage
+  // time (settle! / replace-app-db! / on-frame-destroyed! deliver the
+  // raw record UNMUTATED). The warning is emitted by
+  // `re-frame.epoch.assembly/apply-redact-fn` when an installed
+  // projection-side :redact-fn throws; the emit body sits inside the
+  // universal `interop/debug-enabled?` gate (the projection helper is
+  // itself gated), so this string literal must elide in :advanced +
+  // goog.DEBUG=false.
+  { source: 're-frame.epoch.assembly/apply-redact-fn (rf.warning/epoch-redact-fn-exception, projection-side)',
     sentinel: 'rf.warning/epoch-redact-fn-exception' },
   // re-frame.views — :rf.view/render trace op (Spec 004 §Render-tree
   // primitives, rf2-piag / rf2-t5tx). Emitted by the reg-view*
@@ -444,9 +451,12 @@ const DEV_ONLY_SENTINELS = [
   // fragment must NOT survive in production bundles.
   { source: 're-frame.core/{dispatch,subscribe,inject-cofx} (rf.trace/call-site stamping)',
     sentinel: 'rf.trace/call-site' },
-  // re-frame.core/reg-event-{db,fx,ctx} — handler form-source capture
-  // (Spec 009 §`:rf.handler/source`, Xray Spec 021 §11.2 B.7 stretch,
-  // rf2-xgfuy). The defreg-event-macro emission wraps the bound source
+  // re-frame.core/reg-event — handler form-source capture (Spec 009
+  // §`:rf.handler/source`, Xray Spec 021 §11.2 B.7 stretch, rf2-xgfuy).
+  // EP-0018 collapsed public event registration to the ONE `reg-event`
+  // macro (the per-kind `reg-event-{db,fx,ctx}` forms are removed —
+  // calling them is a hard error). The defreg-event-macro emission wraps
+  // the bound source
   // string in `(if interop/debug-enabled? ~src-string nil)` and the
   // events/merge-form-source body is gated on `interop/debug-enabled?`.
   // Under :advanced + goog.DEBUG=false, Closure constant-folds both


### PR DESCRIPTION
Review-wave fixes on the `implementation/scripts/` surface (one worker, one surface). All four are lint/drift-guard/vocabulary alignments to the landed EP-0011 reply-envelope and EP-0015 data-classification models.

## rf2-uhew69 — EP-0011 reply-envelope vocabulary drift guard
The api-manifest projection checks scope to public-VAR references and were blind to EP-0011 reply-envelope KEYWORD vocabulary. Added `ep0011-reply-vocab-drift-problems` (in `projection.clj`) flagging the retired `:stale-key` and bare hyphenated `:work-id` attempt-identity spellings (canonical is the namespaced `:work/id`, per EP-0007 one-name-per-fact), on the same same-line-retirement-marker discipline as the existing EP-0017 `:rf.world/inputs` guard. Allows `:rf.observe`/`:correlation` projection contexts (where a bare `:work-id` correlation-id legitimately survives); anchored so it never matches the canonical `:work/id`.

## rf2-1zjkn8 — EP-0015 privacy-vocabulary drift guard
Added `ep0015-privacy-vocab-drift-problems` flagging the retired `:rf.egress/*` profile keyword forms (`:rf.egress/on-box-hidden-sensitive`, `:rf.egress/trusted-local-raw`) that EP-0015 renamed to `:rf.egress/local-redacted` / `local-raw`, allowing rename mentions and scoped to the keyword forms (not the still-current English adjectives). Added a positive closed-enum pin (`egress-enum-problems` in `api-md-check`) over the `spec/Conventions.md` `:rf.egress/*` owner row: every closed member (six profiles + `:rf.egress/output-sensitivity` + its three-value set) must be named, so the enum cannot silently shrink. Both keyword guards are folded into `keyword-drift-problems-over-files`, so `doc-guide-check` + `skills-check` pick them up, and into `api-md-check` over spec/API.md.

## rf2-khf6qm — remove stale retired event-registrar fixtures
EP-0018 collapsed public event registration to the one `reg-event` macro. Updated the positive api-manifest fixtures (`api_md_check_test` synthetic rows + bare-row/tier-mismatch tests, `gen_test` no-duplicates fixture) to use the live `reg-event` front-porch var instead of the retired `reg-event-db`. Relabelled the `check-elision.cjs` handler form-source-capture comment to the one `reg-event` macro. Retired registrar names now remain under `scripts/` only in the explicit removal/migration checks (reagent-slim removed-stub guard, doc-guide file-scoped removed-name allowlist) — matching the bead's grep acceptance.

## rf2-ba0eum — projection-side epoch redact-fn elision sentinel
EP-0015 ruled storage-side `:redact-fn` mutation removed. Retargeted the `:rf.warning/epoch-redact-fn-exception` sentinel in `check-elision.cjs` from the stale storage-side `maybe-redact` framing (settle! / replace-app-db! / on-frame-destroyed!) to its actual projection-side boundary — emitted by `re-frame.epoch.assembly/apply-redact-fn` inside `projected-record`, after `project-egress`. The sentinel string remains valid; only the source/comment changed.

## Gates
- api-manifest reconciler test suite: **56 tests, 118 assertions, 0 failures** (new unit tests pin the synthetic positive/negative contracts + live-tree-clean assertions).
- All check-mains (api-md-check, doc-guide-check, skills-check) green on the live committed tree — no false positives from the new guards.
- `scripts/test-fast-pr.sh` spine green (core JVM, script-policy, script-helpers, dev-testbed, CLJS node integration 7752 tests / 31971 assertions / 0 failures).