### PR TITLE
test(conformance): EP-0011 reply-envelope coverage (event/reply/mcp/derivation) (rf2-lve3qj, rf2-p41683, rf2-mrfvg2, rf2-cxpa87)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -578,6 +578,23 @@
   ;; [cache-scope resource-id canonical-params] — a concrete live fact id.
   [[:rf.scope/global] :article/by-slug {:slug "a1"}])
 
+;; EP-0011 (rf2-cxpa87) — the resource attempt's generation. The canonical
+;; resource work-id is the FAMILY tuple `[:rf.work/resource <scoped-key>
+;; <generation>]` (`re-frame.resources.work-ledger/resource-work-id`), NOT a
+;; scalar. Managed-Effects §Work-id correlation: ledger-backed async work
+;; carries ONE `:work/id` per attempt, and the resource family's head is
+;; `:rf.work/resource`. The previous fixture used a SCALAR `3` and a
+;; non-issuance `:status :pending`, which let this cross-family graph tier pass
+;; while accepting a non-canonical work-id shape + a status the real issuance
+;; row never writes — so it failed to protect the one-attempt-one-:work/id rule
+;; or the work-ledger status vocabulary in the graph projection.
+(def ^:private k3-generation 3)
+(def ^:private k3-work-id
+  ;; The canonical resource work-id tuple — `[:rf.work/resource <scoped-key>
+  ;; <generation>]`, exactly what `resources.work-ledger/resource-work-id`
+  ;; mints at issuance.
+  [:rf.work/resource k3-scoped-key k3-generation])
+
 (defn- k3-live-contributors
   "Contributors whose subs / resources / routes live-fns return the realized
   shapes a `[:article/page \"a1\"]` materialization + a route-owned fetch
@@ -621,8 +638,14 @@
                     :lifecycle   {:kind :scoped-resource-key
                                   :owners #{[:route :route/article k3-nav-token]}}
                     :status      :loading
-                    :work-ledger {:work/id 3
-                                  :record  {:work/id 3 :status :pending
+                    ;; EP-0011 (rf2-cxpa87) — the in-flight work-ledger link
+                    ;; carries the CANONICAL resource work-id TUPLE and the
+                    ;; REAL non-terminal issuance status (`:running`, in
+                    ;; `work-ledger/non-terminal-statuses`), matching the row
+                    ;; `re-frame.resources.work-ledger/work-record` writes — not
+                    ;; a scalar id / non-issuance `:pending`.
+                    :work-ledger {:work/id k3-work-id
+                                  :record  {:work/id k3-work-id :status :running
                                             :resource/key k3-scoped-key}}}})}
    ;; the LIVE route slice with its realized owner.
    :routes
@@ -662,8 +685,30 @@
         (is (= #{[:route :route/article k3-nav-token]}
                (get-in res [:lifecycle :owners]))
             "the live owner set is composed through verbatim")
-        (is (= 3 (get-in res [:work-ledger :work/id]))
-            "the in-flight work-ledger link is composed through")))
+        ;; EP-0011 (rf2-cxpa87) — the composed work-ledger link carries the
+        ;; CANONICAL resource work-id TUPLE (not a scalar), with the
+        ;; `:rf.work/resource` family head, and the REAL non-terminal issuance
+        ;; status. Assert the tuple head + status explicitly so a regression to
+        ;; a scalar id / a non-issuance status (`:pending`) goes RED here.
+        (is (= k3-work-id (get-in res [:work-ledger :work/id]))
+            "the in-flight work-ledger link is the canonical work-id tuple, composed through")
+        (is (= :rf.work/resource (first (get-in res [:work-ledger :work/id])))
+            "the work-id tuple head is the :rf.work/resource family head (one-attempt-one-:work/id)")
+        (is (= k3-scoped-key (second (get-in res [:work-ledger :work/id])))
+            "the work-id tuple carries the concrete scoped-key")
+        (is (= k3-generation (nth (get-in res [:work-ledger :work/id]) 2))
+            "the work-id tuple embeds the attempt generation")
+        (is (= k3-work-id (get-in res [:work-ledger :record :work/id]))
+            "the work-ledger RECORD carries the same canonical work-id tuple")
+        (is (= :running (get-in res [:work-ledger :record :status]))
+            "the work-ledger record status is the real non-terminal issuance status :running (not :pending)")
+        ;; The old SCALAR-`:work-id` spelling MUST be absent from the composed
+        ;; node — Managed-Effects uses the `:work/id` (namespaced) key, never a
+        ;; bare `:work-id`.
+        (is (not (contains? (:work-ledger res) :work-id))
+            "the composed work-ledger uses :work/id, never the old bare :work-id spelling")
+        (is (not (contains? (get-in res [:work-ledger :record]) :work-id))
+            "the work-ledger record uses :work/id, never the old bare :work-id spelling")))
     (testing "the REALIZED route-owned resource edge (rf2-k0meap.1) resolves
               the static :parametric marker into a concrete edge: live route
               → concrete [:resource scoped-key], :param role"

--- a/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
@@ -1,0 +1,191 @@
+(ns re-frame.event-reply-envelope-conformance-cljs-test
+  "EP-0011 reply-envelope DISPATCH event-model conformance (rf2-lve3qj).
+
+  ## Why this tier
+
+  EP-0011 / Managed-Effects property 9: a managed async completion is an
+  ordinary CAUSAL EVENT — one `:rf/reply-to` target completed with one
+  canonical reply map, appended as the FINAL event argument, then
+  dispatched through the normal event pipeline. `implementation/event-
+  conformance` is the umbrella regression-lock on the PUBLIC event model
+  (the one-form `reg-event` contract, EP-0017 recordable coeffects, EP-0023
+  dispatch isolation), but it carried no EP-0011-shaped reply event case.
+
+  The pure reply substrate (`re-frame.reply`) is pinned in
+  `reply-conformance/` (the cross-family vocabulary + functor-law tiers),
+  and each family's reply slice is pinned in its `*-reply-lowering-*` suite.
+  But NONE of those prove, in this public event-model umbrella surface, that
+  a completed `:rf/reply-to` event is HANDLED by the single public
+  `reg-event` path with the reply map visible as the final argument and
+  ordinary coeffects/effects behaviour. A future event-model regression
+  could keep the pure reply substrate green while drifting that integration
+  contract — and this surface would not catch it.
+
+  ## What this tier proves
+
+  A canonical reply map (`:status` + `:value`/`:error`, `:work/id`,
+  `:work/kind`, `:work/status`, `:rf.frame/id`, `:completed-at`) is built,
+  a `:rf/reply-to` target is COMPLETED with `re-frame.reply/complete`, and
+  the resulting event is dispatched through the PUBLIC `rf/dispatch-sync` /
+  `reg-event` pipeline. The handler — an ordinary `reg-event` — sees the
+  full event vector with the reply map in FINAL position, reads the
+  canonical reply facts off it, and commits ordinary effects (`{:db …}`).
+  No retired `reg-event-db` / `reg-event-fx` / `reg-event-ctx`, no callback,
+  no ad-hoc `:work-id` vocabulary is introduced — the reply event is just an
+  event.
+
+  `.cljc`, dual-runtime: the shadow-cljs `:node-test` build
+  (`npm run test:cljs`, ns matches `cljs-test$`) AND the JVM
+  `clojure -M:test` runner both pick it up. Harness mirrors the sibling
+  model-conformance suite — the shared `make-reset-runtime-fixture` wraps
+  every body in `(with-frame :rf/default …)` so ambient `dispatch-sync`
+  resolves.
+
+  Canonical contract: `spec/Managed-Effects.md` §The uniform reply envelope
+  + §Reply delivery is an ordinary causal event (property 9) + EP-0018 §The
+  one-form event model."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.reply :as reply]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; A CANONICAL reply map — the uniform envelope a managed-async family lowers
+;; its completion onto (Managed-Effects §The reply map). It validates against
+;; the shared `re-frame.reply/validate-reply` (asserted below), so this is the
+;; SAME shape a real HTTP / resource completion carries — not a synthetic stub.
+;; ---------------------------------------------------------------------------
+
+(def ^:private completed-at-ms 1781078400456)
+
+(def ^:private canonical-reply
+  {:status       :ok
+   :value        {:article {:id 42 :title "Welcome"}}
+   :work/id      [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1]
+   :work/kind    :resource
+   :work/status  :completed
+   :rf.frame/id  :rf/default
+   :completed-at completed-at-ms})
+
+;; ---------------------------------------------------------------------------
+;; (1) A completed :rf/reply-to event is an ORDINARY reg-event dispatch — the
+;;     reply map rides as the FINAL argument and the single public reg-event
+;;     handler sees the full event vector + commits ordinary effects.
+;; ---------------------------------------------------------------------------
+
+(deftest reply-completion-is-an-ordinary-reg-event-dispatch
+  (testing "EP-0011 property 9: a managed async completion is a CAUSAL EVENT —
+            re-frame.reply/complete appends the canonical reply map as the final
+            arg of the :rf/reply-to target, and that event is handled by the
+            ONE public reg-event path with normal coeffects-in / effects-out"
+    (is (reply/valid-reply? canonical-reply)
+        (str "the fixture reply must be a canonical uniform envelope: "
+             (reply/validate-reply canonical-reply)))
+    (let [seen-event (atom ::unset)
+          seen-cofx  (atom ::unset)
+          ;; The :rf/reply-to target — the public short form (an event-vector
+          ;; prefix). A family hands this to the substrate; it is data.
+          target     [:article/loaded {:id 42}]]
+      (rf/reg-sub :evt-reply/last-title (fn [db _] (:title db)))
+      (rf/reg-event :article/loaded
+        (fn [coeffects event]
+          ;; The handler is an ordinary reg-event — coeffects IN, effects OUT.
+          (reset! seen-event event)
+          (reset! seen-cofx coeffects)
+          (let [reply (peek event)]
+            ;; Commit an ordinary {:db …} effect derived from the reply value.
+            {:db (assoc (:db coeffects) :title (get-in reply [:value :article :title]))})))
+
+      ;; Build the completed event via the SHARED substrate helper, then
+      ;; dispatch it through the PUBLIC pipeline — exactly the path a family's
+      ;; completion reducer drives.
+      (let [completed (reply/complete target canonical-reply)]
+        (is (= [:article/loaded {:id 42} canonical-reply] completed)
+            "complete appends the reply map as the FINAL event argument")
+        (rf/dispatch-sync completed))
+
+      (testing "the reg-event handler saw the FULL event vector with the reply in final position"
+        (is (= [:article/loaded {:id 42} canonical-reply] @seen-event)
+            "the handler's event arg is the completed vector, reply map last")
+        (let [delivered (peek @seen-event)]
+          (testing "the canonical reply facts are preserved on the delivered event arg"
+            (is (= :ok (:status delivered))             ":status preserved")
+            (is (= {:article {:id 42 :title "Welcome"}} (:value delivered)) ":value preserved")
+            (is (nil? (:error delivered))               "no :error on an :ok reply")
+            (is (= [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1]
+                   (:work/id delivered))                ":work/id tuple preserved")
+            (is (= :rf.work/resource (first (:work/id delivered)))
+                ":work/id head is the family head")
+            (is (= :resource (:work/kind delivered))    ":work/kind preserved")
+            (is (= :completed (:work/status delivered)) ":work/status preserved")
+            (is (= :rf/default (:rf.frame/id delivered)) ":rf.frame/id preserved")
+            (is (= completed-at-ms (:completed-at delivered)) ":completed-at (EP-0017) preserved")
+            (is (contains? reply/statuses (:status delivered))
+                ":status is in the ONE closed status vocabulary")
+            (is (contains? reply/work-statuses (:work/status delivered))
+                ":work/status is in the ONE closed work-status vocabulary"))))
+
+      (testing "the reply event got ORDINARY event-model semantics — a coeffects
+                map IN (the reg-event-fx shape), not a bare db, and the {:db …}
+                effect committed"
+        (is (map? @seen-cofx)         "the handler received the coeffects MAP")
+        (is (contains? @seen-cofx :db) "`:db` delivered IN the coeffects map")
+        (is (= :rf/default (:rf.frame/id @seen-cofx))
+            "the ambient frame id is delivered as :rf.frame/id")
+        (is (= "Welcome" @(rf/subscribe [:evt-reply/last-title]))
+            "the {:db …} effect derived from the reply value committed")))))
+
+;; ---------------------------------------------------------------------------
+;; (2) A STALE reply (the suppression boundary) is ALSO an ordinary reg-event
+;;     dispatch when the framework/tool authority opts into delivery — the
+;;     canonical :status :stale envelope rides as the final arg, MUTATES NO app
+;;     value, and is read off the event like any other reply. (The app-target
+;;     non-delivery default is the families'/runtime's job; this tier proves the
+;;     EVENT-MODEL shape of a delivered stale envelope, the same single path.)
+;; ---------------------------------------------------------------------------
+
+(deftest a-stale-reply-envelope-is-also-an-ordinary-event
+  (testing "EP-0011 §Stale suppression — the canonical :status :stale envelope is
+            an ordinary causal event when delivered (framework/tool authority):
+            it rides as the final arg, carries NO :value, and the one reg-event
+            path reads it off the event"
+    (let [target  (reply/with-stale-authority [:article/loaded {:id 42}])
+          ;; The substrate's suppress boundary produces the canonical stale
+          ;; reply; a framework/tool target opts into delivery so the event is
+          ;; actually dispatchable (an app target's stale reply is NOT delivered
+          ;; — that non-delivery is enforced elsewhere; here we exercise the
+          ;; delivered-event SHAPE).
+          carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
+          current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
+          {:keys [reply]} (reply/suppress
+                            (assoc target :dispatch-stale? true)
+                            carried current
+                            {:work/id     (:work/id carried)
+                             :work/kind   :resource
+                             :rf.frame/id :rf/default})
+          seen-event (atom ::unset)]
+      (is (reply/valid-reply? reply)
+          (str "the suppressed reply must be a canonical stale envelope: "
+               (reply/validate-reply reply)))
+      (rf/reg-event :article/loaded
+        (fn [coeffects event]
+          (reset! seen-event event)
+          ;; A stale reply MUST mutate no app state — the handler is a no-op db
+          ;; write (an ordinary effects map).
+          {:db (:db coeffects)}))
+      (let [completed (reply/complete (assoc target :dispatch-stale? true) reply)]
+        (rf/dispatch-sync completed))
+      (let [delivered (peek @seen-event)]
+        (is (= :stale (:status delivered))    "the delivered envelope is :status :stale")
+        (is (= :suppressed (:work/status delivered)) ":work/status :suppressed")
+        (is (true? (:stale? delivered))       "the :stale? marker rides")
+        (is (some? (:stale/reason delivered)) "a :stale/reason rides")
+        (is (not (contains? delivered :value))
+            "a stale reply carries NO :value — it mutates no app state")
+        (is (contains? reply/statuses (:status delivered))
+            ":stale is in the ONE closed status vocabulary")))))

--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -1,0 +1,337 @@
+(ns re-frame.reply-egress-projection-conformance-cljs-test
+  "EP-0015 reply-envelope EGRESS-projection conformance (rf2-p41683).
+
+  ## The gap this closes
+
+  The sibling reply-conformance tiers prove the EP-0011 RAW reply
+  vocabulary / functor laws: the cross-family table asserts raw `:value` /
+  `:error` envelope slots + the data-only / no-host-handle invariants
+  (`reply-vocab-conformance`), and the functor suite proves relocated
+  completions preserve the raw appended reply (`reply-functor-law`). NONE of
+  them exercises the EP-0015 EGRESS boundary for reply envelopes — none
+  calls `re-frame.reply/trace-summary` or `re-frame.core/project-egress`
+  under an off-box profile.
+
+  Why it matters: Spec 015 + Managed-Effects require EVERY managed-effect
+  trace / tool / log boundary to project wire-bearing reply slots through
+  the SHARED elider. Reply `:value` / `:error` / `:correlation` / `:meta`
+  can carry owner-local HTTP / resource / mutation / machine / route data,
+  including schema-marked `:sensitive?` / `:large?` response bodies and
+  failure payloads. Without a reply-conformance guard a family can keep
+  passing the raw envelope-shape tests while drifting to raw owner-local
+  data at trace / tool / off-box boundaries.
+
+  ## What this tier proves (the bead's enumerated legs)
+
+    1. wire-bearing reply slots are projected by the SHARED elider before
+       trace / tool / log egress — `trace-summary` routes `:value` / `:error`
+       / `:correlation` / `:meta` through `elide-wire-value`, and
+       `project-egress` routes a reply tree through the same walker; identity
+       facts (`:work/id` / `:status` / `:rf.frame/id` / timestamps) ride
+       VERBATIM;
+    2. sensitive + large markings are honored, with SENSITIVE winning over
+       large at a both-marked path;
+    3. frame is supplied from the carried reply / frame stamp, and a
+       missing / unresolved frame FAILS CLOSED (the whole value redacts —
+       NOT a fall-through to `:rf/default` or a raw pass-through);
+    4. off-box profiles do NOT expose raw response bodies / failure payloads
+       unless a classified projection explicitly permits it (`:local-raw`);
+    5. relocated / completed reply targets do not create an UNPROJECTED
+       durable / tool / log representation of the raw reply envelope — the
+       relocated target's durable projection strips the ephemeral accumulator
+       and the completed reply egress projects the wire slots.
+
+  Pure-fn + live-frame conformance over `re-frame.reply` (`trace-summary`,
+  `complete`, `map-target`, `durable-target`) and `re-frame.core`
+  (`project-egress`) against a frame whose elision registry classifies reply
+  value / error sub-paths. Lives in the cross-artefact `reply-conformance/`
+  surface alongside the vocab + functor tiers.
+
+  `.cljc`, dual-runtime: the shadow-cljs `:node-test` build
+  (`npm run test:cljs`, ns matches `cljs-test$`) AND the JVM
+  `clojure -M:test` runner both pick it up.
+
+  Canonical contract: `spec/015-Data-Classification.md` §`project-egress`
+  + `spec/Managed-Effects.md` §Tracing (the data-only trace summary)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.privacy :as privacy]
+            [re-frame.projection :as projection]
+            [re-frame.reply :as reply]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The frame whose elision registry classifies reply wire sub-paths. The
+;; declarations are app-db PATHS; the egress walk is SEEDED with the matching
+;; `:path` offset so the reply slot's internal coordinates align with the
+;; declaration (the same seed-path mechanism `project-egress` uses for a
+;; direct-read value at a `:path`).
+;;
+;;   [:token]      → SENSITIVE  (a bearer token in a response body)
+;;   [:blob]       → LARGE      (a large response body)
+;;   [:secret-big] → SENSITIVE *and* LARGE (the both-marked path — sensitive
+;;                                must WIN)
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-id :reply-egress/main)
+
+(def ^:private big-string
+  ;; > the 16384-byte default threshold so an UNDECLARED large would auto-detect
+  ;; too; here [:blob] is DECLARED large so the marker is deterministic.
+  (apply str (repeat 40000 \x)))
+
+(defn- mk-frame! []
+  (rf/reg-frame frame-id
+    {:sensitive {:app-db [[:token] [:secret-big]]}
+     :large     {:app-db [[:blob] [:secret-big]]}}))
+
+;; A reply `:value` body whose leaves sit at the declared coordinates (seeded
+;; via `:path []`, so `[:token]` / `[:blob]` / `[:secret-big]` are the walk
+;; coordinates).
+(defn- reply-body []
+  {:token      "bearer-SECRET-do-not-ship"
+   :blob       big-string
+   :secret-big big-string
+   :public     {:count 3}})
+
+(def ^:private work-id
+  [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1])
+
+(def ^:private completed-at-ms 1781078400456)
+
+(defn- ok-reply []
+  {:status       :ok
+   :value        (reply-body)
+   :work/id      work-id
+   :work/kind    :resource
+   :work/status  :completed
+   :rf.frame/id  frame-id
+   :completed-at completed-at-ms})
+
+(defn- error-reply []
+  ;; The failure payload's wire-bearing leaves sit at the declared coordinates
+  ;; (`[:token]` sensitive, `[:blob]` large) — seeded via `:path []`, the same
+  ;; alignment the success `:value` body uses — so the shared elider classifies
+  ;; them. The structural family facts (`:kind` / `:status`) are NOT at a
+  ;; declared path and ride verbatim.
+  {:status      :error
+   :error       {:kind   :rf.http/http-5xx
+                 :status 503
+                 :token  "bearer-SECRET-do-not-ship"
+                 :blob   big-string}
+   :work/id     work-id
+   :work/kind   :resource
+   :work/status :failed
+   :rf.frame/id frame-id})
+
+(defn- redacted? [v] (= privacy/redacted-sentinel v))
+(defn- large-marker? [v] (and (map? v) (contains? v :rf.size/large-elided)))
+
+;; ---------------------------------------------------------------------------
+;; (1) trace-summary routes EVERY wire-bearing slot through the SHARED elider;
+;;     identity facts ride verbatim.
+;; ---------------------------------------------------------------------------
+
+(deftest trace-summary-projects-wire-slots-through-the-shared-elider
+  (testing "Managed-Effects §Tracing — trace-summary elides :value / :error /
+            :correlation / :meta through the SHARED elide-wire-value walker
+            (frame from the carried stamp), keeping identity facts verbatim"
+    (mk-frame!)
+    (let [reply   (assoc (ok-reply)
+                         :correlation {:token "corr-SECRET"}
+                         :meta        {:blob big-string})
+          summary (reply/trace-summary reply {:frame frame-id})]
+      (testing "the SENSITIVE reply-value leaf is redacted by the shared elider"
+        (is (redacted? (get-in summary [:value :token]))
+            ":value sensitive leaf redacted"))
+      (testing "the LARGE reply-value leaf is elided to the shared marker"
+        (is (large-marker? (get-in summary [:value :blob]))
+            ":value large leaf elided to a marker"))
+      (testing "the unmarked sibling rides through"
+        (is (= 3 (get-in summary [:value :public :count]))))
+      (testing "the :correlation + :meta wire slots are ALSO projected"
+        (is (redacted? (get-in summary [:correlation :token]))
+            ":correlation sensitive leaf redacted")
+        (is (large-marker? (get-in summary [:meta :blob]))
+            ":meta large leaf elided"))
+      (testing "identity / correlation facts ride VERBATIM (never elided)"
+        (is (= work-id (:work/id summary))         ":work/id verbatim")
+        (is (= :ok (:status summary))              ":status verbatim")
+        (is (= :resource (:work/kind summary))     ":work/kind verbatim")
+        (is (= :completed (:work/status summary))  ":work/status verbatim")
+        (is (= frame-id (:rf.frame/id summary))    ":rf.frame/id verbatim")
+        (is (= completed-at-ms (:completed-at summary)) ":completed-at verbatim")))))
+
+(deftest trace-summary-projects-the-error-failure-payload
+  (testing "a failure reply's :error map carries owner-local response data — its
+            wire-bearing sub-slots are projected through the shared elider too
+            (the failure payload is NOT exempt from egress projection)"
+    (mk-frame!)
+    (let [summary (reply/trace-summary (error-reply) {:frame frame-id})]
+      (is (redacted? (get-in summary [:error :token]))
+          "a sensitive leaf inside the :error response body is redacted")
+      (is (large-marker? (get-in summary [:error :blob]))
+          "a large leaf inside the :error response body is elided")
+      ;; The error's structural family facts (the :kind / :status) ride — they
+      ;; are not at a declared sensitive/large path.
+      (is (= :rf.http/http-5xx (get-in summary [:error :kind]))
+          "the family error :kind rides (not a declared wire path)")
+      (is (= 503 (get-in summary [:error :status]))
+          "the family error :status rides (not a declared wire path)")
+      (is (= work-id (:work/id summary)) ":work/id verbatim on an error reply"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) SENSITIVE wins over LARGE at a both-marked path.
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-wins-over-large-at-a-both-marked-reply-slot
+  (testing "EP-0015 — a reply value leaf declared BOTH :sensitive? and :large?
+            REDACTS (sensitive wins), it never large-elides to a marker"
+    (mk-frame!)
+    (let [summary (reply/trace-summary (ok-reply) {:frame frame-id})]
+      (is (redacted? (get-in summary [:value :secret-big]))
+          "the both-marked leaf is REDACTED, not large-elided")
+      (is (not (large-marker? (get-in summary [:value :secret-big])))
+          "sensitive wins — no large marker at the both-marked path"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) frame from the carried stamp; missing / unresolved frame FAILS CLOSED.
+;; ---------------------------------------------------------------------------
+
+(deftest egress-frame-resolves-from-the-carried-stamp-and-fails-closed-when-unresolved
+  (testing "the projection frame is supplied from the carried reply / frame
+            stamp; an UNRESOLVED frame fails closed (whole value redacted) —
+            never a raw pass-through, never :rf/default"
+    (mk-frame!)
+    ;; The carried frame is KNOWN+LIVE → the policy applies (sensitive redacts).
+    (let [known (reply/trace-summary (ok-reply) {:frame frame-id})]
+      (is (redacted? (get-in known [:value :token]))
+          "a KNOWN carried frame applies its sensitive policy"))
+    ;; A frame stamp that names a NEVER-REGISTERED frame is unresolvable. The
+    ;; shared elider fails CLOSED — the whole wire slot conservatively redacts
+    ;; rather than shipping the raw body under no policy.
+    (let [unresolved (reply/trace-summary (ok-reply) {:frame :reply-egress/ghost})]
+      (is (redacted? (:value unresolved))
+          "an UNRESOLVED carried frame fails closed — the whole :value slot redacts")
+      (is (not= "bearer-SECRET-do-not-ship" (get-in unresolved [:value :token]))
+          "the raw token NEVER ships under an unresolved frame")
+      ;; Identity facts still ride (they are not wire slots).
+      (is (= work-id (:work/id unresolved))
+          ":work/id still rides verbatim — only the wire slots fail closed"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) off-box profiles do NOT expose raw bodies; an explicit classified
+;;     projection (:local-raw) does. Driven through the record-level
+;;     `project-egress` boundary (EP-0015 §10/§11).
+;; ---------------------------------------------------------------------------
+
+(deftest off-box-project-egress-redacts-the-reply-body-and-local-raw-exposes-it
+  (testing "EP-0015 §10/§11 — the reply value projected through the record-level
+            project-egress boundary: off-box profiles redact sensitive + elide
+            large; only an explicit :local-raw (a classified projection) exposes
+            the raw response body"
+    (mk-frame!)
+    (doseq [p [:rf.egress/off-box-observability
+               :rf.egress/off-box-tool
+               :rf.egress/local-redacted]]
+      (let [out (rf/project-egress (reply-body)
+                  {:frame frame-id :rf.egress/profile p})]
+        (is (redacted? (get-in out [:token]))
+            (str p ": the sensitive reply-body leaf is redacted off-box"))
+        (is (large-marker? (get-in out [:blob]))
+            (str p ": the large reply-body leaf is elided off-box"))
+        (is (= 3 (get-in out [:public :count]))
+            (str p ": the unmarked sibling passes through"))))
+    (testing ":rf.egress/local-raw (the explicit classified projection) exposes the raw body"
+      (let [out (rf/project-egress (reply-body)
+                  {:frame frame-id :rf.egress/profile :rf.egress/local-raw})]
+        (is (= "bearer-SECRET-do-not-ship" (get-in out [:token]))
+            "trusted-local sees the raw token")
+        (is (= big-string (get-in out [:blob]))
+            "trusted-local sees the raw large body")))))
+
+(deftest off-box-project-egress-fails-closed-on-an-unresolved-frame
+  (testing "EP-0015 / Spec 015 §Direct reads — project-egress for an
+            UNRESOLVED carried frame fails closed (the whole reply body
+            redacts); it never synthesises :rf/default or ships the raw body.
+            (Naming a never-registered frame is the genuine fail-closed case —
+            a frame stamp alone is not policy-bearing unless it RESOLVES to a
+            live frame.)"
+    (let [out (rf/project-egress (reply-body)
+                {:frame :reply-egress/ghost :rf.egress/profile :rf.egress/off-box-tool})]
+      (is (redacted? out)
+          "an unresolved-frame off-box egress conservatively redacts the whole reply body")
+      (is (not= "bearer-SECRET-do-not-ship" (get-in out [:token]))
+          "the raw token NEVER ships under an unresolved frame"))))
+
+;; ---------------------------------------------------------------------------
+;; (5) a relocated / completed reply target does not create an UNPROJECTED
+;;     durable / tool / log representation of the raw reply envelope.
+;; ---------------------------------------------------------------------------
+
+(deftest a-relocated-reply-target-has-no-unprojected-durable-representation
+  (testing "EP-0011/EP-0015 — a relocated (map-target) reply target carries the
+            ephemeral accumulator (NOT data-only); its DURABLE projection strips
+            it and is data-only, so a stored continuation / ledger row / replay
+            log never durably captures a function or a host handle"
+    (let [relayed (reply/map-target (fn [event] [:parent/relay event])
+                                    [:article/loaded {:id 42}])]
+      (is (false? (reply/data-only-target? relayed))
+          "a relocated target is NOT data-only (it carries the ::post accumulator)")
+      (let [durable (reply/durable-target relayed)]
+        (is (true? (reply/data-only-target? durable))
+            "the durable projection strips the accumulator — data-only, safe to persist")))))
+
+(deftest a-completed-reply-events-wire-slots-project-before-egress
+  (testing "the COMPLETED reply event (the dispatched continuation) still carries
+            the raw reply as its final arg in-memory; before that event crosses a
+            trace / tool / log boundary its wire slots MUST be projected — the
+            shared trace-summary over the appended reply is the egress product,
+            and it redacts the sensitive body (no unprojected raw representation
+            reaches off-box)"
+    (mk-frame!)
+    (let [target    [:article/loaded {:id 42}]
+          completed (reply/complete target (ok-reply))
+          ;; The appended reply rides as the final arg in-memory (raw, by
+          ;; design — the reducer needs it). The EGRESS product is the
+          ;; trace-summary projection of that reply.
+          delivered (peek completed)
+          summary   (reply/trace-summary delivered {:frame frame-id})]
+      (is (= [:article/loaded {:id 42} (ok-reply)] completed)
+          "the completed event carries the raw reply as its final arg in-memory")
+      (is (redacted? (get-in summary [:value :token]))
+          "the EGRESS projection of the appended reply redacts the sensitive body")
+      (is (large-marker? (get-in summary [:value :blob]))
+          "the egress projection elides the large body")
+      (is (= work-id (:work/id summary))
+          "identity facts still ride on the egress product"))))
+
+;; ---------------------------------------------------------------------------
+;; ADVERSARIAL CONTROL — the gate above is only as strong as its ability to
+;; FAIL when a family bypasses the shared elider. Prove that a RAW reply (the
+;; pre-projection in-memory shape) DOES carry the sensitive body, so the
+;; redaction assertions above would go RED if trace-summary stopped projecting.
+;; ---------------------------------------------------------------------------
+
+(deftest control-the-raw-reply-carries-the-sensitive-body-before-projection
+  (testing "the raw reply body (no projection) carries the sensitive token + the
+            large blob verbatim — so the projection assertions are non-trivial:
+            if trace-summary / project-egress stopped eliding, the sensitive
+            body would survive to egress (the exact leak this gate guards)"
+    (mk-frame!)
+    (let [reply (ok-reply)]
+      (is (= "bearer-SECRET-do-not-ship" (get-in reply [:value :token]))
+          "the RAW reply carries the sensitive token (pre-projection)")
+      (is (= big-string (get-in reply [:value :blob]))
+          "the RAW reply carries the large blob (pre-projection)")
+      ;; And the SHARED elider, applied directly, is what removes it — proving
+      ;; trace-summary delegates to elide-wire-value, not a private elider.
+      (let [direct (elision/elide-wire-value (:value reply) {:frame frame-id})]
+        (is (redacted? (get-in direct [:token]))
+            "elide-wire-value (the shared walker) is what redacts — same result trace-summary produces")))))

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -92,6 +92,53 @@ This test is the conformance gate. It asserts:
   (`ResultEnvelope`, `CascadeBundle`) stays co-located with its tests.
 - `indicator_field_test.clj`, `slot_name_test.clj`, `verb_vocab_test.clj`
   — independent cross-MCP vocabulary surfaces (pre-existing).
+- `reply_envelope_test.clj` — the EP-0011 reply-envelope TRACE-egress
+  vocabulary gate (rf2-mrfvg2). See §EP-0011 coverage boundary below.
+
+## EP-0011 reply-envelope coverage boundary (rf2-mrfvg2)
+
+`reply_envelope_test.clj` pins the additive `:rf.reply/*` trace vocabulary
+an MCP consumer reads off a `trace-window` / cascade-bundle `:trace-events`
+reply-envelope row — the EP-0011 uniform reply envelope is named among
+Tool-Pair's record-shaped off-box egress
+([`spec/Tool-Pair.md`](../../re-frame2-pair-mcp/spec) §`project-egress`),
+and Managed-Effects property 9 requires managed-async families to emit trace
+rows FROM reply-envelope facts. Before this gate, `tools/mcp-conformance`
+validated only the MCP wrapper / cascade envelope + a counter dispatch — no
+managed-async reply-envelope trace CONTENT.
+
+It pins, in the same schema + fixture + source-pin + near-miss shape as the
+wrapper markers above:
+
+- a canonical Malli schema (`ReplyEnvelopeTraceRow`) for the MCP-visible
+  reply-envelope trace row: the additive `:rf.reply/status` /
+  `:rf.reply/work-id` / `:rf.reply/work-status` keys, the canonical bare
+  `:work/id` join key (which MUST equal `:rf.reply/work-id`), and the
+  carried/current stale-suppression correlation gate;
+- fixtures matching the REAL production emissions (HTTP
+  `:rf.http/stale-suppressed`, resource `:rf.resource/stale-suppressed`,
+  machine), so a tag-map drift trips the gate;
+- a SOURCE-text pin that the additive `:rf.reply/*` keys appear as DATA in
+  the production emit sites (HTTP transport, resources events, machine
+  transition, routing nav-token) — so a substrate / family rename trips the
+  gate even though the literals live in `implementation/`, not in
+  re-frame2-pair-mcp;
+- a near-miss anti-pin so a snake_case / pluralised / predicate spelling
+  fails;
+- schema fail-closed checks for a scalar (non-tuple) work-id, an
+  off-vocabulary status / work-status, and a dropped required reply key.
+
+**What it does NOT cover (complementarity, not duplication):** it does not
+re-validate the whole managed-effect suite. Family-internal correctness +
+the runtime trace emission live in the per-family `*-reply-lowering-*` suites
+and the resources / machines runtime tests; the cross-family reply
+VOCABULARY consistency lives in `implementation/reply-conformance`; the
+EP-0015 reply egress projection lives there too; Xray's consumer-side reply
+panel is `tools/xray`. This gate is narrowly the MCP-egress-visible contract
+that those `:rf.reply/*` keys reach a `trace-window` / `subscribe` consumer
+un-renamed. The live `subscribe` end-to-end path
+(`test/live-re-frame2-pair-subscribe.cjs`) is the runtime counterpart; this
+JVM gate is the cheap, hermetic vocabulary pin.
 
 ## Adding a new cross-MCP marker — which files to touch
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
@@ -1,0 +1,352 @@
+(ns re-frame.mcp-conformance.reply-envelope-test
+  "EP-0011 reply-envelope TRACE-EGRESS wire-vocabulary gate (rf2-mrfvg2).
+
+  ## Why this gate
+
+  EP-0011 is not only a runtime / Xray concern. Managed-Effects property 9
+  requires managed async families to emit trace rows FROM reply-envelope
+  facts, and Tool-Pair's off-box egress contract names the EP-0011 uniform
+  reply envelope among the record-shaped tool egress
+  (spec/Tool-Pair.md §`project-egress` record-shaped egress).
+  `tools/mcp-conformance` is the client-side MCP gate for re-frame2-pair-mcp's
+  `trace-window` / `subscribe` surfaces — the off-box delivery path over the
+  authoritative per-frame trace rings (Tool-Pair §Reading the per-frame
+  trace ring). But the surface validated only the MCP wrapper / cascade
+  envelope and a simple counter dispatch — it pinned NO managed-async
+  reply-envelope trace content. `rg \"EP-0011|reply-envelope|rf\\.reply\"
+  tools/mcp-conformance` returned no matches before this gate.
+
+  This is the wire-vocab counterpart to the live-`subscribe` end-to-end
+  path: a pure-JVM schema + fixture + source-pin gate (the same shape as
+  `cascade_bundle_test` / the `canonical-markers` table) that pins the
+  ADDITIVE `:rf.reply/*` trace vocabulary an MCP consumer reads off a
+  `trace-window` / cascade-bundle `:trace-events` row, so a rename / drop /
+  near-miss of the MCP-visible reply-envelope keys FAILS in
+  `tools/mcp-conformance`.
+
+  ## The wire vocabulary this pins
+
+  Family completion / stale-suppression trace rows stamp the canonical
+  reply facts ADDITIVELY (Xray spec 013 §One work/reply vocabulary +
+  Managed-Effects §Tracing). The MCP-visible reply-envelope trace row
+  carries, alongside its bespoke family facts:
+
+    - `:rf.reply/status`      — the closed reply `:status` (the row's
+                                outcome; `:stale` on a suppression).
+    - `:rf.reply/work-id`     — the `[:rf.work/* …]` attempt-identity tuple.
+    - `:rf.reply/work-status` — the operational `:work/status`
+                                (`:suppressed` on a stale row).
+    - `:rf.reply/carried` / `:rf.reply/current` — the carried-vs-current
+                                stale-suppression correlation gate.
+    - `:work/id`              — the canonical BARE join key (the same tuple)
+                                Xray's uniform work/reply grouping reads.
+
+  An MCP consumer normalizes BOTH the canonical bare keys (`:work/id` /
+  `:status` / `:work/status`) AND the additive `:rf.reply/*` spelling
+  (preferring the canonical, falling back to `:rf.reply/*`), so a row
+  carrying only the additive vocabulary is still joined by `:work/id`.
+
+  ## The gate shape (mirrors the per-marker pattern)
+
+    1. A canonical Malli schema for one reply-envelope trace row.
+    2. Fixtures matching the REAL production emissions (HTTP
+       `:rf.http/stale-suppressed`, resource `:rf.resource/stale-suppressed`,
+       machine `:rf.machine/done`) so a fixture drift trips the gate.
+    3. A SOURCE-text pin asserting the additive `:rf.reply/*` keys appear as
+       DATA in the production emit sites (so a substrate / family rename
+       trips this gate even though the literals live in the implementation
+       tree, not in re-frame2-pair-mcp).
+    4. A near-miss anti-pin so a rename to a snake_case / pluralised /
+       predicate spelling FAILS.
+
+  Coverage boundary: this gate pins the reply-envelope trace VOCABULARY
+  visible to MCP consumers — the keys + their shapes. It does NOT
+  re-validate the whole managed-effect suite (the runtime / resources /
+  Xray tests own family-internal correctness + the live emission); it is
+  the MCP-egress-visible contract that those keys reach a `trace-window` /
+  `subscribe` consumer un-renamed. See README §EP-0011 coverage boundary."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [malli.core :as m]
+            [malli.error :as me]
+            [re-frame.mcp-conformance.fixtures :as fx]))
+
+;; ---------------------------------------------------------------------------
+;; The closed reply vocabularies — mirrored from re-frame.reply as literal
+;; data (the wire-vocab gate never :requires the substrate; it consumes the
+;; WIRE facts, the same posture Xray's reply-envelope panel takes per spec
+;; 013 §One work/reply vocabulary). A substrate drift that changed these sets
+;; would also drift the production emissions the source-pin below tracks.
+;; ---------------------------------------------------------------------------
+
+(def ^:private reply-statuses
+  "The closed reply `:status` vocabulary (Managed-Effects §Status taxonomy)."
+  #{:ok :partial :error :cancelled :stale})
+
+(def ^:private work-statuses
+  "The closed `:work/status` vocabulary (Managed-Effects §Status taxonomy)."
+  #{:completed :failed :timed-out :suppressed :cancelled})
+
+(defn- work-id-tuple?
+  "True when `v` is a canonical `[:rf.work/* …]` attempt-identity tuple — a
+  non-empty vector whose head is an `:rf.work/`-namespaced keyword. EP-0011
+  one-attempt-one-:work/id: the work-id is a family-headed tuple, never a
+  scalar."
+  [v]
+  (and (vector? v)
+       (seq v)
+       (keyword? (first v))
+       (= "rf.work" (namespace (first v)))))
+
+;; ---------------------------------------------------------------------------
+;; The canonical reply-envelope trace-row schema. OPEN map — every emission
+;; rides its bespoke family facts ALONGSIDE the additive `:rf.reply/*`
+;; vocabulary (the row is NOT a single-key wrapper; it is a trace event's tag
+;; map). The load-bearing contract is the additive `:rf.reply/*` keys + the
+;; canonical bare `:work/id` join key + their shapes.
+;; ---------------------------------------------------------------------------
+
+(def ReplyEnvelopeTraceRow
+  "The MCP-visible reply-envelope trace-row shape (Managed-Effects §Tracing,
+  Xray spec 013 §One work/reply vocabulary). OPEN — additive bespoke family
+  facts (`:resource/key`, `:rf.machine/done`, `:recovery`, …) compose without
+  a schema bump.
+
+  Required additive reply-envelope slots (the MCP-visible contract):
+    :rf.reply/status      — closed reply `:status`.
+    :rf.reply/work-id     — `[:rf.work/* …]` attempt-identity tuple.
+    :rf.reply/work-status — closed `:work/status`.
+    :work/id              — the canonical BARE join key (== :rf.reply/work-id).
+
+  Optional (present on a stale-suppression row):
+    :rf.reply/carried / :rf.reply/current — the carried-vs-current gate.
+    :rf.reply/stale-reason — why the completion was suppressed."
+  [:map
+   {:closed false}
+   [:rf.reply/status      [:enum :ok :partial :error :cancelled :stale]]
+   [:rf.reply/work-id     [:and :any [:fn work-id-tuple?]]]
+   [:rf.reply/work-status [:enum :completed :failed :timed-out :suppressed :cancelled]]
+   [:work/id              [:and :any [:fn work-id-tuple?]]]
+   [:rf.reply/carried     {:optional true} [:maybe :any]]
+   [:rf.reply/current     {:optional true} [:maybe :any]]
+   [:rf.reply/stale-reason {:optional true} [:maybe :any]]])
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — the REAL production emission shapes. Each mirrors a landed
+;; `trace/emit!` call so a drift in the production tag map (a dropped key, a
+;; renamed key, a scalar work-id) trips this gate.
+;; ---------------------------------------------------------------------------
+
+(def ^:private http-stale-suppressed-fixture
+  "Mirrors `re-frame.http-transport`'s `:rf.http/stale-suppressed` emit — a
+  superseded HTTP request suppressed for a fresh one (carried = superseded
+  work-id, current = superseding work-id)."
+  {:rf.reply/status       :stale
+   :rf.reply/work-status  :suppressed
+   :rf.reply/stale-reason :rf.reply/correlation-mismatch
+   :rf.reply/work-id      [:rf.work/http :article/by-id 1 1]
+   :work/id               [:rf.work/http :article/by-id 1 1]
+   :work/kind             :http
+   :rf.reply/carried      [:rf.work/http :article/by-id 1 1]
+   :rf.reply/current      [:rf.work/http :article/by-id 2 1]
+   :recovery              :superseded-by-fresh-request
+   :frame                 :app/main})
+
+(def ^:private resource-stale-suppressed-fixture
+  "Mirrors `re-frame.resources.events`'s `:rf.resource/stale-suppressed`
+  emit — the bespoke resource facts PLUS the additive reply vocabulary."
+  {:rf.frame/id           :app/main
+   :resource/key          [:rf.scope/global :article/by-slug {:slug "w"}]
+   :work/id               [:rf.work/resource [:rf.scope/global :article/by-slug {:slug "w"}] 4]
+   :generation            4
+   :outcome               :superseded
+   :rf.reply/status       :stale
+   :rf.reply/work-status  :suppressed
+   :rf.reply/work-id      [:rf.work/resource [:rf.scope/global :article/by-slug {:slug "w"}] 4]
+   :rf.reply/stale-reason :resource/generation-mismatch
+   :rf.reply/correlation  {:generation {:carried 4 :current 5}}
+   :rf.reply/carried      {:work/id [:rf.work/resource [:rf.scope/global :article/by-slug {:slug "w"}] 4] :generation 4}
+   :rf.reply/current      {:work/id [:rf.work/resource [:rf.scope/global :article/by-slug {:slug "w"}] 5] :generation 5}})
+
+(def ^:private machine-stale-suppressed-fixture
+  "Mirrors a machine transition stale-suppression emit carrying the additive
+  reply vocabulary (`:rf.machine/transition.cljc`)."
+  {:rf.reply/status      :stale
+   :rf.reply/work-id     [:rf.work/machine :auth/flow#1]
+   :rf.reply/work-status :suppressed
+   :work/id              [:rf.work/machine :auth/flow#1]
+   :work/kind            :machine
+   :rf.machine/done      false})
+
+(def ^:private all-fixtures
+  {:http     http-stale-suppressed-fixture
+   :resource resource-stale-suppressed-fixture
+   :machine  machine-stale-suppressed-fixture})
+
+;; ---------------------------------------------------------------------------
+;; The MCP-visible reply-envelope keys this gate pins.
+;; ---------------------------------------------------------------------------
+
+(def ^:private reply-envelope-keys
+  "The additive `:rf.reply/*` trace keys an MCP consumer reads off a
+  reply-envelope trace row. A rename / drop of any of these breaks the
+  uniform work/reply join an MCP consumer performs."
+  [:rf.reply/status
+   :rf.reply/work-id
+   :rf.reply/work-status
+   :rf.reply/carried
+   :rf.reply/current])
+
+;; ---------------------------------------------------------------------------
+;; The production emit sites where the additive `:rf.reply/*` keys MUST appear
+;; as DATA. A family / substrate rename trips the source-pin even though the
+;; literals live in the implementation tree (not in re-frame2-pair-mcp) — the
+;; same posture the cross-MCP marker pins take against `mcp-base/vocab.cljc`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private emit-source-files
+  "Per-family source files emitting the additive `:rf.reply/*` reply-envelope
+  trace vocabulary. The keyword is `pr-str`'d and grepped against the file
+  text AFTER `strip-comments-and-strings` neuters docstring/comment mentions."
+  ["implementation/http/src/re_frame/http_transport.cljc"
+   "implementation/resources/src/re_frame/resources/events.cljc"
+   "implementation/machines/src/re_frame/machines/transition.cljc"
+   "implementation/routing/src/re_frame/routing/nav_token.cljc"])
+
+(defn- near-miss-variants
+  "Near-miss spellings of a `:rf.reply/*` key a rename MUST NOT slip through:
+  snake_case name, ns-dots→underscores, pluralised, predicate form."
+  [k]
+  (let [s   (pr-str k)
+        ns* (namespace k)
+        nm  (name k)]
+    (cond-> []
+      (str/includes? nm "-")
+      (conj (str ":" ns* "/" (str/replace nm #"-" "_")))
+      (str/includes? ns* ".")
+      (conj (str ":" (str/replace ns* #"\." "_") "/" nm))
+      true
+      (into [(str s "s") (str s "?")]))))
+
+;; ===========================================================================
+;; (1) Schema conformance — every production-shaped fixture validates.
+;; ===========================================================================
+
+(deftest reply-envelope-fixtures-conform-to-schema
+  (doseq [[family fixture] all-fixtures]
+    (is (m/validate ReplyEnvelopeTraceRow fixture)
+        (str family " reply-envelope trace fixture failed schema validation:\n"
+             (me/humanize (m/explain ReplyEnvelopeTraceRow fixture))))))
+
+(deftest reply-envelope-row-pins-the-closed-vocabularies
+  (testing "every fixture's :rf.reply/status is in the closed reply-status set
+            and its :rf.reply/work-status is in the closed work-status set"
+    (doseq [[family fixture] all-fixtures]
+      (is (contains? reply-statuses (:rf.reply/status fixture))
+          (str family " :rf.reply/status " (:rf.reply/status fixture)
+               " is not in the closed reply-status vocabulary " reply-statuses))
+      (is (contains? work-statuses (:rf.reply/work-status fixture))
+          (str family " :rf.reply/work-status " (:rf.reply/work-status fixture)
+               " is not in the closed work-status vocabulary " work-statuses)))))
+
+(deftest reply-envelope-work-id-is-a-canonical-tuple-and-the-bare-join-key-agrees
+  (testing "the :rf.reply/work-id is a canonical [:rf.work/* …] tuple and the
+            bare :work/id join key carries the SAME tuple (one-attempt-one-id —
+            an MCP consumer joins on the bare :work/id)"
+    (doseq [[family fixture] all-fixtures]
+      (is (work-id-tuple? (:rf.reply/work-id fixture))
+          (str family " :rf.reply/work-id is not a canonical [:rf.work/* …] tuple"))
+      (is (work-id-tuple? (:work/id fixture))
+          (str family " bare :work/id join key is not a canonical tuple"))
+      (is (= (:rf.reply/work-id fixture) (:work/id fixture))
+          (str family " :rf.reply/work-id and the bare :work/id join key DISAGREE "
+               "— an MCP consumer that joins on :work/id would lose this row")))))
+
+(deftest stale-rows-carry-the-suppression-correlation-and-reason
+  (testing "a stale-suppression row pins :work/status :suppressed + the
+            carried/current correlation gate + a stale reason (the
+            stale/cancelled outcome fields the bead names)"
+    (doseq [family [:http :resource]
+            :let [fixture (all-fixtures family)]]
+      (is (= :stale (:rf.reply/status fixture))
+          (str family " suppression row is :rf.reply/status :stale"))
+      (is (= :suppressed (:rf.reply/work-status fixture))
+          (str family " suppression row is :rf.reply/work-status :suppressed"))
+      (is (some? (:rf.reply/carried fixture))
+          (str family " suppression row carries :rf.reply/carried correlation"))
+      (is (some? (:rf.reply/current fixture))
+          (str family " suppression row carries :rf.reply/current correlation")))))
+
+;; ===========================================================================
+;; (2) Schema FAILS CLOSED on a renamed / dropped / scalar near-miss — the
+;;     gate is only as strong as its ability to reject the regression shapes.
+;; ===========================================================================
+
+(deftest schema-rejects-a-scalar-work-id
+  (testing "a scalar (non-tuple) :rf.reply/work-id is rejected — EP-0011
+            one-attempt-one-:work/id requires the family-headed tuple"
+    (is (not (m/validate ReplyEnvelopeTraceRow
+                         (assoc http-stale-suppressed-fixture
+                                :rf.reply/work-id 3
+                                :work/id 3)))
+        "a scalar work-id MUST fail the schema")))
+
+(deftest schema-rejects-an-out-of-vocabulary-status
+  (testing "an off-vocabulary :rf.reply/status / :rf.reply/work-status is
+            rejected (the enum is closed)"
+    (is (not (m/validate ReplyEnvelopeTraceRow
+                         (assoc http-stale-suppressed-fixture :rf.reply/status :done)))
+        "a :rf.reply/status outside the closed set MUST fail")
+    (is (not (m/validate ReplyEnvelopeTraceRow
+                         (assoc http-stale-suppressed-fixture :rf.reply/work-status :running)))
+        "a :rf.reply/work-status outside the closed set MUST fail")))
+
+(deftest schema-rejects-a-dropped-required-reply-key
+  (testing "a row missing a required additive reply key (a near-miss rename
+            that drops the canonical spelling) fails — an MCP consumer would
+            lose the status / work-id / grouping"
+    (doseq [k [:rf.reply/status :rf.reply/work-id :rf.reply/work-status :work/id]]
+      (is (not (m/validate ReplyEnvelopeTraceRow (dissoc http-stale-suppressed-fixture k)))
+          (str "a row missing " k " MUST fail the schema")))))
+
+;; ===========================================================================
+;; (3) SOURCE-text pin — the additive `:rf.reply/*` keys appear as DATA in the
+;;     production emit sites. A family / substrate rename trips this gate.
+;; ===========================================================================
+
+(deftest reply-envelope-keys-are-emitted-as-data-in-the-production-sites
+  (testing "each additive :rf.reply/* key appears as DATA (not a docstring /
+            comment) in at least one production emit site — so a rename of the
+            MCP-visible reply-envelope vocabulary trips this gate"
+    (let [stripped (map (comp fx/strip-comments-and-strings fx/read-source) emit-source-files)]
+      (doseq [k reply-envelope-keys
+              :let [literal (pr-str k)]]
+        (is (some #(str/includes? % literal) stripped)
+            (str "the reply-envelope key " literal " is not emitted as DATA in any "
+                 "production site " (vec emit-source-files) " — a rename of the "
+                 "MCP-visible reply-envelope vocabulary slipped past the gate"))))))
+
+(deftest the-bare-work-id-join-key-is-emitted-alongside-the-reply-vocabulary
+  (testing "the canonical bare :work/id join key is emitted in the production
+            reply-envelope emit sites — an MCP consumer joins reply rows by it"
+    (let [stripped (map (comp fx/strip-comments-and-strings fx/read-source) emit-source-files)]
+      (is (some #(str/includes? % (pr-str :work/id)) stripped)
+          ":work/id (the bare canonical join key) must be emitted as DATA"))))
+
+;; ===========================================================================
+;; (4) Near-miss anti-pin — a snake_case / pluralised / predicate / dotted-ns
+;;     spelling of a reply-envelope key MUST NOT appear in any emit site.
+;; ===========================================================================
+
+(deftest no-near-miss-spelling-of-a-reply-envelope-key-appears-in-the-sources
+  (testing "no near-miss spelling (snake_case, pluralised, predicate,
+            ns-dots→underscores) of a :rf.reply/* key appears in any
+            production emit site — a rename to a near-miss form must FAIL"
+    (let [sources (into {} (map (juxt identity fx/read-source)) emit-source-files)]
+      (doseq [k reply-envelope-keys
+              variant (near-miss-variants k)
+              [file text] sources]
+        (is (not (re-find (fx/variant-regex variant) text))
+            (str "near-miss spelling " variant " of " (pr-str k)
+                 " appears in " file " — a reply-envelope key rename to a "
+                 "near-miss form slipped through"))))))


### PR DESCRIPTION
Adds EP-0011 reply-envelope conformance coverage across 4 disjoint conformance surfaces. Asserts against the LANDED reply-envelope vocabulary (`:rf.reply/*`, `:work/id`, `:status`, `:work/status`). All 4 beads were OPEN + unclaimed at start.

## rf2-lve3qj — event-conformance: reply-envelope dispatch event-model coverage
New dual-runtime tier `event_reply_envelope_conformance_cljs_test.cljc`. Builds a canonical reply envelope (`:status`, `:value`, `:work/id` tuple, `:work/kind`, `:work/status`, `:rf.frame/id`, `:completed-at`), completes a `:rf/reply-to` target via `re-frame.reply/complete`, dispatches through the public `rf/dispatch-sync` / `reg-event` path, and asserts the reply map is the final event arg with all canonical facts preserved + ordinary `{:db …}` effects. A second case proves a delivered `:status :stale` envelope is the same single event-model path (no `:value`). No retired `reg-event-{db,fx,ctx}` / callback / ad-hoc `:work-id` vocabulary.

## rf2-p41683 — reply-conformance: lock EP-0015 reply-envelope egress projection
New tier `reply_egress_projection_conformance_cljs_test.cljc`. Against a frame classifying reply value/error sub-paths, asserts the bead's enumerated legs: wire-bearing slots (`:value`/`:error`/`:correlation`/`:meta`) projected by the SHARED `elide-wire-value` walker before trace egress (`trace-summary`) and through `project-egress`, identity facts verbatim; sensitive wins over large; frame from carried stamp + unresolved-frame fail-closed (never `:rf/default`, never raw); off-box profiles redact/elide, only `:local-raw` exposes; relocated target's durable projection strips the ephemeral accumulator; completed reply event's egress product redacts the sensitive body. Plus an adversarial control proving the raw reply carries the sensitive body pre-projection.

## rf2-mrfvg2 — mcp-conformance: pin EP-0011 reply-envelope trace egress vocabulary
New wire-vocab gate `reply_envelope_test.clj` (schema + fixture + source-pin + near-miss shape). Canonical `ReplyEnvelopeTraceRow` Malli schema pinning `:rf.reply/status` / `:rf.reply/work-id` / `:rf.reply/work-status` + the bare `:work/id` join key (must equal `:rf.reply/work-id`) + the carried/current stale gate; fixtures matching the real HTTP/resource/machine stale-suppression emissions; a source-text pin that the `:rf.reply/*` keys appear as DATA in the production emit sites (http transport, resources events, machine transition, routing nav-token); a near-miss anti-pin + schema fail-closed checks (scalar work-id, off-vocab status, dropped required key). Documents the EP-0011 coverage boundary in `wire-vocab/README.md`.

## rf2-cxpa87 — derivation-conformance: canonical resource work-id tuple in live fixture
Fixed the k3 live-resource graph fixture: replaced the scalar `:work/id 3` + non-issuance `:status :pending` with the canonical resource work-id TUPLE `[:rf.work/resource <scoped-key> <generation>]` (what `resources.work-ledger/resource-work-id` mints), the real non-terminal issuance status `:running`, and explicit tuple head/scoped-key/generation + status assertions. Added a guard that the old bare `:work-id` spelling is absent in the composed node + record.

## Quality gates (all green)
- `npm run test:cljs` — 7763 tests / 32047 assertions, 0 failures
- `scripts/test-fast-pr.sh` — PASS (incl. markdown link/anchor gates; mkdocs soft-skipped on Windows)
- JVM tiers: derivation-conformance 21/374, event-conformance 55/189, reply-conformance 28/373, mcp-conformance wire-vocab 93/922 — all 0 failures

Each bead is a separate commit.