### PR TITLE
fix(machines-viz): preserve + teach error-final completion status (rf2-202epv, rf2-g89c97)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -170,14 +170,36 @@ scoping + §3.1 G9).
 > property, Spec 005:2840) is *out* of this affordance — it belongs to a
 > separate all-finals output decision if it earns one.
 >
-> **Text emitters (mermaid / SCXML) carry no error-final distinction.**
-> Mermaid's `[*]` terminal and SCXML's `<final>` element have no
-> first-class error-terminal concept — the error-final ring is a
-> visual-chart affordance only. Both emitters render an `:error?` final
-> identically to a success final (`[*]` / `<final>`); the round-trip is
-> lossless on `:final?` but does **not** preserve `:error?`. This is by
-> design: the chart surfaces a re-frame2-specific routing distinction the
-> portable text formats cannot represent.
+> **Text emitters (mermaid / SCXML) preserve the error-final distinction.**
+> The error-final KIND is **not** chart-only trivia: it is the machine
+> **completion status** the framework acts on. Under EP-0011 a child that
+> finishes via an `:error?` final lowers to the uniform reply envelope as
+> `:status :error` and routes the spawning parent's `:spawn` **`:on-error`**,
+> while a plain `:final?` child completes `:status :ok` and routes
+> **`:on-done`**. Collapsing the two terminal kinds on a text round-trip
+> would silently turn an error completion into a success one — EP-0011
+> reply-envelope semantic drift, not a harmless visual caveat. So both
+> emitters carry the distinction, each in the idiom of its format:
+>
+> - **SCXML** has no first-class error-terminal element, so the bit rides a
+>   re-frame2-specific custom attribute — `<final … data_rf_error_final="true"/>`
+>   — exactly the `data_*` carrier posture the action-name round-trip
+>   (`data_rf_action`) already uses. An ordinary SCXML consumer ignores the
+>   unknown `data_*` attribute (the export stays consumable), while the
+>   re-frame2 import recovers `:error? true` from it. The round-trip is
+>   therefore **lossless on both `:final?` and `:error?`**.
+> - **Mermaid** has no error-terminal glyph, and its emitter is one-way
+>   (there is no `mermaid->spec`). Rather than collapse an `:error?` final
+>   into a plain success terminal, the emitter **visibly marks** it with a
+>   `note right of <error-final>` naming the error-terminal completion
+>   (`:status :error` / parent `:on-error`) — the same `note` idiom the
+>   action-only completion and history-default annotations use. A success
+>   `:final?` terminal carries no such note.
+>
+> The chart's error-hue outer ring (above) is the *canvas* counterpart of
+> the same distinction; the SCXML attribute and the Mermaid note are its
+> text-surface counterparts. All three keep the re-frame2 completion-status
+> routing visible rather than letting the portable formats erase it.
 
 ### 1.5 Event labels
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -2147,8 +2147,23 @@ local Ollama / Xray's chat seam / re-frame2-pair-mcp).
 ;;     :states  {:idle    {:on {:login :loading}}
 ;;               :loading {:on {:ok :success :err :failed}}
 ;;               :success {:final? true}
-;;               :failed  {:final? true}}}
+;;               ;; EP-0011 — :err is a FAILURE terminal, so it carries
+;;               ;; :error? true: the machine completes :status :error and
+;;               ;; routes a spawning parent's :on-error (vs the success
+;;               ;; terminal's :status :ok / :on-done). A non-error terminal
+;;               ;; stays a plain {:final? true}.
+;;               :failed  {:final? true :error? true}}}
 ```
+
+The system prompt (`ai/system-prompt`) teaches this distinction: a
+terminal that represents the machine *failing* (a load error, an auth
+rejection, a payment decline) is `{:final? true :error? true}`; a
+successful terminal stays `{:final? true}`. An ordinary in-flow error
+state the user can retry from is **not** terminal at all (it keeps
+running), so it carries neither bit. This keeps a generated child
+machine's completion **status** (Spec 005 §`:final?` /
+[EP-0011](../../../spec/005-StateMachines.md)) honest — a failure
+outcome does not silently complete as a success.
 
 ### Contract
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -94,8 +94,9 @@
   Public Var so callers can audit the wording, compose multi-turn
   chats around it, or fork it. Changes to this string are part of
   the public contract — bumping the prompt's behaviour expectations
-  (\"always include `:final?` states for terminal outcomes\") is a
-  semver-relevant change."
+  (\"always include `:final?` states for terminal outcomes\";
+  \"mark FAILURE terminals `:error? true`\") is a semver-relevant
+  change."
   (str/join "\n"
     ["You are an assistant that generates re-frame2 state-machine specs."
      ""
@@ -105,7 +106,7 @@
      "   :states  {:idle    {:on {:start :loading}}"
      "             :loading {:on {:ok :success :err :failed}}"
      "             :success {:final? true}"
-     "             :failed  {:final? true}}}"
+     "             :failed  {:final? true :error? true}}}"
      ""
      "Conventions:"
      ""
@@ -119,7 +120,18 @@
      "  :initial (for compound states), and :states (a child map)."
      "- A transition value may be a target keyword (:loading) or a"
      "  map with :target + optional :guard (:auth-ok?) and :action."
-     "- :final? true marks a terminal state."
+     "- :final? true marks a terminal state — the machine has finished."
+     "- :error? true (only on a :final? terminal) marks a FAILURE"
+     "  terminal. A non-error :final? terminal completes :status :ok"
+     "  and routes a spawning parent's :on-done; an :error? terminal"
+     "  completes :status :error and routes the parent's :on-error"
+     "  instead. So if an outcome means the machine FAILED (a load"
+     "  error, an auth rejection, a payment decline), give that"
+     "  terminal {:final? true :error? true}; a successful outcome"
+     "  stays {:final? true}. Do NOT mark an ordinary in-flow error UI"
+     "  state that the user can retry from (it keeps running, so it is"
+     "  not :final? at all) — :error? is only for a terminal that ends"
+     "  the machine in failure."
      "- For compound states, nest :states and provide a child"
      "  :initial."
      "- For parallel regions, use {:type :parallel :regions {...}}"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -660,6 +660,36 @@
                    (concat self child))))
        (remove nil?)))
 
+(defn- render-error-final-notes
+  "EP-0011 — visibly mark every `:final? true :error? true` ERROR terminal
+  (compound-aware). Spec 005 §`:final?` lets a final leaf carry `:error?
+  true`: a child finishing via an error final lowers to the uniform reply
+  envelope as `:status :error` and routes the spawning parent's `:spawn`
+  `:on-error` (vs a plain final's `:status :ok` / `:on-done`). This is a
+  re-frame2 routing distinction the FRAMEWORK acts on, not decoration.
+
+  Mermaid's `[*]` terminal has no error-terminal glyph, so — same posture
+  as the action-only / history annotations — the distinction is surfaced
+  visibly via a `note right of <error-final>` rather than collapsing into a
+  plain success terminal. A plain `:final?` (success) terminal carries NO
+  such note. (The chart canvas paints the error-hue ring; the SCXML emitter
+  carries `data_rf_error_final`; this is the Mermaid surface's counterpart.)"
+  [root-path states]
+  (mapcat
+    (fn [[state-id state-node]]
+      (let [state-path (conj (vec root-path) state-id)
+            self       (when (and (:final? state-node) (:error? state-node))
+                         [(str "  note right of " (sanitise-id state-path))
+                          ;; EP-0011 — names the completion KIND + the
+                          ;; parent routing it drives, so a reader sees this
+                          ;; is not a success terminal.
+                          "    error terminal — completes :status :error (parent :on-error)"
+                          "  end note"])
+            child      (when (:states state-node)
+                         (render-error-final-notes state-path (:states state-node)))]
+        (concat self child)))
+    states))
+
 (defn- render-state-alias
   [state-path label depth]
   (let [indent (apply str (repeat depth "  "))]
@@ -772,6 +802,10 @@
                                fallback-edges)
         edge-lines     (map render-edge edges)
         final-lines    (render-final-edges root-path states)
+        ;; EP-0011 — mark error-final terminals (`:final? true :error? true`)
+        ;; so their `:status :error` / parent `:on-error` routing is not
+        ;; silently collapsed into a plain success terminal.
+        error-final-notes (render-error-final-notes root-path states)
         compound-lines (render-compound-blocks root-path states 1)
         ;; rf2-ay42f — a COMPOUND whose `:on-done` is action-only
         ;; (target-less) has no sibling arrow to draw; render its
@@ -796,6 +830,7 @@
                compound-lines
                edge-lines
                final-lines
+               error-final-notes
                on-done-notes
                internal-notes
                root-fallback-notes))))
@@ -865,6 +900,14 @@
         final-lines (mapcat (fn [[region-id {:keys [states]}]]
                               (render-final-edges [region-id] states))
                             regions)
+        ;; EP-0011 — mark error-final terminals inside any region so the
+        ;; `:status :error` / parent `:on-error` routing is not silently
+        ;; collapsed into a plain success terminal (matches the flat/
+        ;; compound emitter).
+        error-final-notes
+        (mapcat (fn [[region-id {:keys [states]}]]
+                  (render-error-final-notes [region-id] states))
+                regions)
         ;; rf2-ay42f — a COMPOUND inside a region whose `:on-done` is
         ;; action-only renders the same completion note the flat/compound
         ;; emitter and the parallel-root use (no sibling arrow to draw).
@@ -897,6 +940,7 @@
                ["  }"]
                edge-lines
                final-lines
+               error-final-notes
                region-on-done-notes
                region-internal-notes
                root-internal-notes

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -550,22 +550,53 @@
        (str (indent-str depth) "</history>")]
       [(str (indent-str depth) "<history " attrs "/>")])))
 
+;; EP-0011 — the re-frame2-specific carrier for an ERROR-terminal final
+;; state. Spec 005 §`:final?` lets a `:final?` leaf carry `:error? true` (an
+;; error terminal that routes the spawning parent's `:spawn` `:on-error` and
+;; completes `:status :error`, vs a plain final's `:on-done` / `:status :ok`).
+;; W3C SCXML's `<final>` has no error-terminal concept, so — like
+;; `data_rf_action` — the bit rides a custom `data_*` attribute (underscore
+;; key, so `parse-attrs`' `(\w+)` pattern recovers it; can never collide with
+;; a real W3C SCXML attribute). The emitter writes it on the `<final>`
+;; element when `:error? true`; the parser recovers it back to `:error?`.
+;; Ordinary SCXML consumers ignore an unknown `data_*` attribute, so the
+;; export stays consumable while the completion-status distinction survives.
+(def ^:private error-final-attr "data_rf_error_final")
+
 (defn- emit-state
   "Emit a `<state>` (or `<final>`) block for one state-node. `path` is
   the absolute path (root → this state) used to emit unique xsd:IDs and
   to qualify transition targets (rf2-mnp93.7).
 
   rf2-m285a — a `:type :history` child of this state is emitted as a W3C
-  `<history>` element (`emit-history`), NOT a nested `<state>`."
+  `<history>` element (`emit-history`), NOT a nested `<state>`.
+
+  EP-0011 — a `:final? true :error? true` leaf is an ERROR terminal; its
+  `<final>` carries the `data_rf_error_final=\"true\"` carrier so the
+  completion-status distinction survives the round-trip (see
+  `error-final-attr`)."
   [path state-node depth]
-  (let [{:keys [final? initial states on after always on-done]} state-node
+  (let [{:keys [final? error? initial states on after always on-done]} state-node
         id-str (qualified-id path)
         tag    (if final? "final" "state")
         attrs  (cond-> (str "id=\"" (escape-xml-attr id-str) "\"")
                  (and (not final?) initial)
                  ;; rf2-mnp93.7 — `initial` references a CHILD by its
                  ;; unique qualified id (the child's absolute path).
-                 (str " initial=\"" (escape-xml-attr (qualified-id (conj (vec path) initial))) "\""))
+                 (str " initial=\"" (escape-xml-attr (qualified-id (conj (vec path) initial))) "\"")
+                 ;; EP-0011 — a `:final? true :error? true` leaf is an ERROR
+                 ;; terminal: it lowers to the uniform reply envelope as
+                 ;; `:status :error` and routes the spawning parent's
+                 ;; `:spawn` `:on-error` (vs a plain final's `:status :ok` /
+                 ;; `:on-done`). W3C SCXML's `<final>` has no error-terminal
+                 ;; concept, so the bit rides the re-frame2-specific
+                 ;; `data_rf_error_final` custom attribute (same carrier
+                 ;; posture as `data_rf_action`) — ordinary SCXML consumers
+                 ;; ignore it; the import side recovers `:error?` from it so
+                 ;; the completion STATUS does not silently collapse to
+                 ;; success.
+                 (and final? error?)
+                 (str " " error-final-attr "=\"true\""))
         children
         (concat
           (emit-transitions-for-on on path (inc depth))
@@ -1331,6 +1362,14 @@
         state-id   (abs-path->local-key abs-path)
         base       (cond-> {}
                      (= "final" tag) (assoc :final? true)
+                     ;; EP-0011 — recover the error-terminal KIND from the
+                     ;; re-frame2 carrier (`emit-state`). Only meaningful on
+                     ;; a `<final>`; the parent's `:on-error` vs `:on-done`
+                     ;; routing (`:status :error` vs `:status :ok`) depends
+                     ;; on this bit surviving the round-trip.
+                     (and (= "final" tag)
+                          (= "true" (get attrs error-final-attr)))
+                     (assoc :error? true)
                      ;; rf2-mnp93.7 — `initial` references a child by its
                      ;; qualified id; the re-frame2 `:initial` is the
                      ;; child's LOCAL key (last segment).

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
@@ -91,6 +91,28 @@
     (is (str/includes? ai/system-prompt ":regions"))))
 
 ;; ---------------------------------------------------------------------------
+;; EP-0011 — error-final completion status (rf2-g89c97)
+;;
+;; Spec 005 §:final? lets a terminal carry `:error? true` — an error final
+;; lowers to the uniform reply envelope as `:status :error` and routes the
+;; spawning parent's `:spawn` `:on-error` (vs a plain final's `:status :ok` /
+;; `:on-done`). The system prompt must teach `:error? true` for terminal
+;; FAILURE outcomes so a generated child machine doesn't silently encode a
+;; failure as a success completion.
+
+(deftest system-prompt-teaches-error-final
+  (testing "system-prompt teaches :error? true for terminal failure /
+            error outcomes, distinct from plain :final? success terminals"
+    (is (str/includes? ai/system-prompt ":error?")
+        "the prompt names the :error? terminal marker")
+    ;; The canonical example must encode a failure terminal as an error
+    ;; final — `{:final? true :error? true}` — not a plain success final.
+    (is (re-find #":error\?\s+true" ai/system-prompt)
+        "the prompt shows :error? true on a terminal")
+    (is (str/includes? ai/system-prompt ":on-error")
+        "the prompt ties the error terminal to the parent's :on-error routing")))
+
+;; ---------------------------------------------------------------------------
 ;; generate-machine — happy paths
 
 (deftest generate-with-fenced-clojure-response-returns-spec

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -411,3 +411,51 @@
       ;; SCXML — a target-less <transition> (already faithful pre-fix).
       (is (= 1 (scxml-internal-transition-count m))
           "scxml emits the target-less machine-level <transition>"))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0011 — error-final terminal KIND surfaces in ALL THREE emitters.
+;;
+;; Spec 005 §:final? lets a `:final?` leaf carry `:error? true`: a child
+;; finishing via an error final lowers to the uniform reply envelope as
+;; `:status :error` and routes the spawning parent's `:spawn` `:on-error`
+;; (vs a plain final's `:status :ok` / `:on-done`). The KIND must not
+;; collapse silently on any surface: the chart paints the error-hue ring,
+;; the SCXML emitter carries `data_rf_error_final` (lossless round-trip),
+;; and the Mermaid emitter notes the error terminal.
+
+(def success-and-error-finals-machine
+  {:initial :running
+   :states  {:running {:on {:ok :ok :boom :boom}}
+             :ok      {:final? true}
+             :boom    {:final? true :error? true}}})
+
+(deftest error-final-kind-surfaced-by-all-three-emitters
+  (testing "EP-0011 — an :error? final reads distinctly from a success
+            final in chart, mermaid, AND SCXML; a plain :final? does not
+            pick up the error KIND"
+    ;; CHART — the layout node carries :error? (gated on :final?).
+    (let [nodes  (:nodes (layout/project-definition success-and-error-finals-machine))
+          by-lbl (into {} (map (juxt :label identity) nodes))]
+      (is (true?  (:error? (get by-lbl "boom"))) "chart flags the error final")
+      (is (false? (:error? (get by-lbl "ok")))   "chart leaves the success final plain")
+      (is (false? (:error? (get by-lbl "running"))) "a non-final node is never error"))
+    ;; MERMAID — the error final gets a note; the success final does not.
+    (let [out (mermaid-body success-and-error-finals-machine)]
+      (is (str/includes? out "ok --> [*]")   "success terminal renders plainly")
+      (is (str/includes? out "boom --> [*]") "error terminal renders the edge")
+      (is (str/includes? out "note right of boom") "error terminal carries a note")
+      (is (not (str/includes? out "note right of ok"))
+          "success terminal carries no error note"))
+    ;; SCXML — the error final carries the carrier attr AND round-trips :error?.
+    (let [out  (scxml/spec->scxml success-and-error-finals-machine)
+          back (scxml/scxml->spec out)]
+      (is (str/includes? out "<final id=\"boom\" data_rf_error_final=\"true\"")
+          "scxml carries the error-final attribute")
+      (is (str/includes? out "<final id=\"ok\"")
+          "scxml emits the success final as a plain <final>")
+      (is (= success-and-error-finals-machine back)
+          "scxml round-trips the error-final spec exactly")
+      (is (true? (get-in back [:states :boom :error?]))
+          "the error terminal reconstructs :error? true")
+      (is (nil? (get-in back [:states :ok :error?]))
+          "the success terminal carries no :error? bit"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -127,6 +127,42 @@
       (is (str/includes? out "success --> [*]"))
       (is (str/includes? out "failed --> [*]")))))
 
+;; ---------------------------------------------------------------------------
+;; Error-final terminal KIND — EP-0011 reply-envelope completion status.
+;;
+;; Spec 005 §:final? lets a `:final?` leaf carry `:error? true`. A child
+;; finishing via an `:error?` final completes as `:status :error` (vs a plain
+;; final's `:status :ok`) and routes the spawning parent's `:on-error`
+;; instead of `:on-done`. Mermaid's `[*]` terminal has no error-terminal
+;; glyph, so — same posture as the action-only / history annotations — the
+;; emitter surfaces the distinction visibly via a `note` on the error final
+;; rather than letting it collapse into a plain success terminal.
+
+(def success-and-error-finals-machine
+  "Two terminals of distinct KIND: a plain success final + an `:error?`
+  error final."
+  {:initial :running
+   :states  {:running {:on {:ok :ok :boom :boom}}
+             :ok      {:final? true}
+             :boom    {:final? true :error? true}}})
+
+(deftest emit-marks-error-final-distinctly
+  (testing "an :error? final is visibly marked (a `note` annotation tying
+            it to the EP-0011 :status :error / parent :on-error routing);
+            a success final renders as a plain `state --> [*]` terminal
+            with no such note"
+    (let [out (m/emit success-and-error-finals-machine)]
+      (is (str/includes? out "ok --> [*]")
+          "the success final renders the plain terminal edge")
+      (is (str/includes? out "boom --> [*]")
+          "the error final still renders the terminal edge")
+      (is (str/includes? out "note right of boom")
+          "the error final carries a note marking the error terminal")
+      (is (str/includes? out "error terminal")
+          "the note text names the error-terminal completion")
+      (is (not (str/includes? out "note right of ok"))
+          "the success final carries NO error-terminal note"))))
+
 (deftest emit-includes-omission-caveat-by-default
   (testing "the `:after` + `:spawn-all` omission caveat lands at the top"
     (let [out (m/emit idle-loading-success-error)]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -486,6 +486,57 @@
       (is (not (str/includes? out "done.state"))))))
 
 ;; ---------------------------------------------------------------------------
+;; Error-final terminal KIND — EP-0011 reply-envelope completion status.
+;;
+;; Spec 005 §:final? lets a `:final?` leaf carry `:error? true` — an ERROR
+;; terminal. This is not decorative: a child finishing via an `:error?` final
+;; lowers to the uniform reply envelope as `:status :error` (vs a plain
+;; `:final?` child's `:status :ok`) and routes the spawning parent's `:spawn`
+;; `:on-error` instead of `:on-done`. The completion KIND the framework acts
+;; on must therefore survive the text round-trip — collapsing it silently
+;; turns an error completion into a success one.
+;;
+;; W3C SCXML's `<final>` has no first-class error-terminal concept, so — like
+;; the action-name carrier (`data_rf_action`) — the bit rides a re-frame2-
+;; specific `data_rf_error_final="true"` custom attribute, which ordinary
+;; SCXML consumers ignore.
+
+(def success-and-error-finals-machine
+  "Two terminals of distinct KIND: a plain success final + an `:error?`
+  error final. Mirrors the chart-projection fixture so the two surfaces
+  cover the same terminal-kind distinction."
+  {:initial :running
+   :states  {:running {:on {:ok :ok :boom :boom}}
+             :ok      {:final? true}
+             :boom    {:final? true :error? true}}})
+
+(deftest emit-error-final-carries-error-attribute
+  (testing "an :error? final emits the re-frame2 carrier
+            data_rf_error_final=\"true\" on its <final>; a success final
+            does NOT (the bit is the EP-0011 completion status, not decor)"
+    (let [out (scxml/spec->scxml success-and-error-finals-machine)]
+      (is (str/includes? out "<final id=\"boom\" data_rf_error_final=\"true\"")
+          "the error final carries the error-terminal carrier attribute")
+      (is (str/includes? out "<final id=\"ok\"")
+          "the success final still renders as a plain <final>")
+      (is (not (str/includes? out "<final id=\"ok\" data_rf_error_final"))
+          "the success final carries NO error-terminal attribute"))))
+
+(deftest round-trip-error-final-preserves-status
+  (testing "an :error? final round-trips its :error? bit (the parent's
+            :on-error vs :on-done routing must not silently collapse to
+            success); a plain :final? stays plain"
+    (let [spec success-and-error-finals-machine
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "the error-final spec round-trips exactly")
+      (is (true? (get-in back [:states :boom :error?]))
+          "the error terminal reconstructs as :error? true")
+      (is (true? (get-in back [:states :boom :final?]))
+          "the error terminal is still :final?")
+      (is (nil? (get-in back [:states :ok :error?]))
+          "the success terminal carries no :error? bit"))))
+
+;; ---------------------------------------------------------------------------
 ;; Parallel-ROOT :on / :after ancestor fallback (rf2-656ivk / rf2-m3otj2)
 ;;
 ;; A `:type :parallel` ROOT may declare its OWN `:on` (the ancestor fallback,


### PR DESCRIPTION
## What

EP-0011 / Spec 005 make a spawned child's completion status depend on the terminal KIND: a plain `:final?` child completes `:status :ok` and routes the spawning parent's `:spawn :on-done`, while an `:error?` final completes `:status :error` and routes `:on-error`. That bit is the completion status the framework acts on — not decoration. The machines-viz text-emitter surfaces (SCXML, Mermaid) silently collapsed an error completion into a success one, and the AI-generation prompt taught failure terminals without the `:error?` bit.

## Changes

**rf2-202epv — preserve error-final completion status in the text emitters**
- **SCXML** (`scxml.cljc`): emit + parse a re-frame2-specific carrier attribute `data_rf_error_final="true"` on `<final>` (same `data_*` posture as the existing `data_rf_action` action carrier). Ordinary SCXML consumers ignore the unknown attribute; the round-trip is now lossless on both `:final?` and `:error?`.
- **Mermaid** (`mermaid.cljc`, one-way — no parser): visibly mark an error final with a `note right of <state>` naming the `:status :error` / parent `:on-error` routing, via the existing `note` idiom. Success finals stay plain `[*]` terminals. Wired into both the flat/compound and parallel emit bodies.

**rf2-g89c97 — teach AI generation about error-final completions**
- **AI-generate** (`ai_generate.cljc`): the system prompt now teaches `:error? true` for terminal FAILURE outcomes, drawing the distinction between a success terminal (`{:final? true}`), a failure terminal (`{:final? true :error? true}` → `:status :error` / parent `:on-error`), and an ordinary in-flow error UI state the user can retry from (not terminal at all). Canonical example + `spec/API.md` example updated to encode the failure terminal as `{:final? true :error? true}`.

**Docs**
- `spec/001-Topology-Parity.md`: the "text emitters carry no error-final distinction" passage is rewritten — it no longer frames the loss as harmless visual-chart trivia; it ties the distinction to EP-0011 completion status and parent `:on-done` vs `:on-error` routing, and documents the SCXML carrier + Mermaid note.
- `spec/API.md`: AI-generate example + surrounding prose.

**Tests (red→green)**
- SCXML: error-final carrier emit + lossless round-trip of `:error?`.
- Mermaid: error-final note present; success final stays plain.
- AI-generate: system prompt teaches `:error?` / `:on-error`.
- Cross-emitter agreement: one fixture asserts chart + Mermaid + SCXML all surface success vs error terminals distinctly so the two kinds cannot collapse silently.

## Spec sync (standing rule)

`tools/xray/spec/*` unchanged because the error-final text-emitter contract lives wholly in `tools/machines-viz/spec/` (`001-Topology-Parity.md` + `API.md`, both updated). `tools/xray/spec/` carries no error-final / SCXML-carrier / Mermaid-emitter contract to keep in sync (the Machine-Inspector spec has no error-final or text-emitter round-trip content).

## Gates
- `tools/machines-viz` JVM tests: 550 tests, 0 failures.
- `npm run test:cljs` (node runtime): 7784 tests, 0 failures.
- `scripts/test-fast-pr.sh`: PASS (tests + markdown link/anchor/EP gates; mkdocs soft-skipped on Windows, CI runs it).