### PR TITLE
docs(template): EP-0015 classification guidance + EP-0011 HTTP reply-envelope (rf2-7i66d0, rf2-rzsxrk)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_helix/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_helix/core.cljs
@@ -27,6 +27,19 @@
   ;; `with-frame :rf/default` scope, and wraps the render in the Helix
   ;; `frame-provider` so the `use-subscribe` / `frame-handle` reads inside the
   ;; view tree resolve to `:rf/default`.
+  ;;
+  ;; The empty `{}` config is also where frame-owned EGRESS CLASSIFICATION
+  ;; lives (Spec 015 §The three-layer model). app-db SCHEMAS validate shape;
+  ;; they do NOT classify durable app-db egress — the frame does. Once your
+  ;; app-db carries sensitive paths (an `[:auth]` token) or large blobs,
+  ;; declare them here so the framework redacts/elides at every observation
+  ;; boundary (Xray, Story, error sink, off-box export):
+  ;;   (rf/reg-frame :rf/default
+  ;;     {:sensitive {:app-db [[:auth :token]]
+  ;;                  :http   {:headers ["Authorization"]}}
+  ;;      :large     {:app-db [[:documents :upload]]}})
+  ;; See README §Privacy / egress classification. HTTP response BODIES are
+  ;; classified on the request's `:decode` schema instead — see events.cljs.
   (rf/reg-frame :rf/default {})
   (rf/with-frame :rf/default
     (schema/register-schema!)

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
@@ -33,6 +33,19 @@
   ;; runs its frame-local boot work (schema attach + seed dispatch) inside a
   ;; `with-frame :rf/default` scope, and wraps the render in a `frame-provider`
   ;; so every in-tree dispatch/subscribe resolves to `:rf/default`.
+  ;;
+  ;; The empty `{}` config is also where frame-owned EGRESS CLASSIFICATION
+  ;; lives (Spec 015 §The three-layer model). app-db SCHEMAS validate shape;
+  ;; they do NOT classify durable app-db egress — the frame does. Once your
+  ;; app-db carries sensitive paths (an `[:auth]` token) or large blobs,
+  ;; declare them here so the framework redacts/elides at every observation
+  ;; boundary (Xray, Story, error sink, off-box export):
+  ;;   (rf/reg-frame :rf/default
+  ;;     {:sensitive {:app-db [[:auth :token]]
+  ;;                  :http   {:headers ["Authorization"]}}
+  ;;      :large     {:app-db [[:documents :upload]]}})
+  ;; See README §Privacy / egress classification. HTTP response BODIES are
+  ;; classified on the request's `:decode` schema instead — see events.cljs.
   (rf/reg-frame :rf/default {})
   (rf/with-frame :rf/default
     ;; Frame-local schema attach — must run under a live frame scope (it

--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -108,6 +108,26 @@
 ;; [Spec 014 §`:rf.http/managed`](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)).
 ;; Adopt it as-is when your app starts talking to an HTTP backend:
 ;;
+;; The `(:rf/reply msg)` / `{:kind :success|:failure …}` payload this
+;; handler reads is managed-HTTP **public compatibility sugar** — NOT the
+;; framework-wide managed-async model. Every managed-HTTP completion
+;; lowers internally onto re-frame2's
+;; [uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/Managed-Effects.md#the-uniform-reply-envelope)
+;; (Managed-Effects property 9; rationale record
+;; [EP-0011](https://github.com/day8/re-frame2/blob/main/docs/EP/EP-0011-uniform-async-reply-envelope.md)):
+;; one canonical reply map with a single closed `:status`
+;; (`:ok` / `:error` / `:cancelled`; `:stale` is suppressed before app
+;; delivery and never reaches this handler), `:value` / `:error`,
+;; `:work/id`, and `:completed-at`. `:on-success` / `:on-failure` and the
+;; co-located `(:rf/reply msg)` form are sugar that lowers to the
+;; framework target `:rf/reply-to` and reshapes the canonical reply back
+;; into the `{:kind …}` payload below — so the event shape is preserved
+;; exactly. Do NOT read `{:kind …}` as the general async contract: any
+;; non-HTTP managed-async surface you build reports completion through the
+;; same envelope's `:status` / `:value` / `:error` / `:completed-at`
+;; directly, with mandatory stale suppression. See
+;; [Spec 014 §Lowering onto the uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md#lowering-onto-the-uniform-reply-envelope).
+;;
 ;;   1. Require `[re-frame.http-managed]` at app boot — that's the load-
 ;;      time side-effect that registers the `:rf.http/managed` fx and
 ;;      publishes the call-site helpers. Without it, dispatching the fx
@@ -139,7 +159,8 @@
     (fn [{:keys [db]} [_ msg]]
       (cond
         ;; Success branch — server returned `{"delta": N}` (decoded
-        ;; per :decode :auto).
+        ;; per :decode :auto; see the :decode classification note on the
+        ;; request below).
         (some-> msg :rf/reply :kind (= :success))
         {:db (-> db
                  (update :counter/value + (:delta (:value (:rf/reply msg))))
@@ -166,6 +187,16 @@
         :else
         {:db (assoc db :counter/status :loading :counter/error nil)
          :fx [[:rf.http/managed
+               ;; `:decode :auto` is the simple, non-sensitive case — fine
+               ;; for this public counter response. A real body that
+               ;; carries secrets (tokens, credentials, session material)
+               ;; or is large should use a `:decode` SCHEMA and classify
+               ;; per-slot with `:sensitive?` / `:large?` Malli props: the
+               ;; body is a transient payload owned by its request's
+               ;; `:decode` schema (NOT the frame). An unschematized body
+               ;; is whole-sensitive (fail-closed) — off-box traces/captures
+               ;; omit it unless classified projection is requested. See
+               ;; [Spec 015 §HTTP response bodies](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md#http-response-bodies).
                {:request {:method :get :url "/api/counter"}
                 :decode  :auto
                 :retry   {:on           #{:rf.http/transport

--- a/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
@@ -24,7 +24,15 @@
    Schemas validate **in dev** (and on JVM unless production-hardened);
    the validation check elides automatically under `:advanced`
    `goog.DEBUG=false` builds — schema attachments stay in source but
-   cost nothing in production hot paths."
+   cost nothing in production hot paths.
+
+   A schema validates **shape**; it does NOT classify durable app-db
+   egress. Whether an app-db path is sensitive or large — and therefore
+   redacted/elided at observation boundaries (Xray, Story, traces,
+   off-box export) — is FRAME-owned policy declared on `reg-frame`, not
+   re-attached here (Spec 015 §Schemas describe shape, not durable app-db
+   egress policy: one owner, one route). See `core.cljs` (where the frame
+   is registered) and README §Privacy / egress classification."
   (:require [re-frame.core :as rf]))
 
 ;; --- Whole-app-db schema ---------------------------------------------------

--- a/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
@@ -27,6 +27,19 @@
   ;; `with-frame :rf/default` scope, and wraps the render in the UIx
   ;; `frame-provider` so the `use-subscribe` / `frame-handle` reads inside the
   ;; view tree resolve to `:rf/default`.
+  ;;
+  ;; The empty `{}` config is also where frame-owned EGRESS CLASSIFICATION
+  ;; lives (Spec 015 §The three-layer model). app-db SCHEMAS validate shape;
+  ;; they do NOT classify durable app-db egress — the frame does. Once your
+  ;; app-db carries sensitive paths (an `[:auth]` token) or large blobs,
+  ;; declare them here so the framework redacts/elides at every observation
+  ;; boundary (Xray, Story, error sink, off-box export):
+  ;;   (rf/reg-frame :rf/default
+  ;;     {:sensitive {:app-db [[:auth :token]]
+  ;;                  :http   {:headers ["Authorization"]}}
+  ;;      :large     {:app-db [[:documents :upload]]}})
+  ;; See README §Privacy / egress classification. HTTP response BODIES are
+  ;; classified on the request's `:decode` schema instead — see events.cljs.
   (rf/reg-frame :rf/default {})
   (rf/with-frame :rf/default
     (schema/register-schema!)

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -437,12 +437,108 @@ Schema validation elides automatically under `:advanced`
 `goog.DEBUG=false` builds — registrations stay in source but cost
 nothing in production hot paths.
 
+### Privacy / egress classification — declare it on the frame
+
+re-frame2 makes runtime state highly observable: one trace stream feeds
+Xray (default-on in dev — see above), Story (ships in release if you opt
+in), the dev error sink (logs to the console), and any off-box monitor
+or export you wire later. That observability is a productivity feature
+**and** a privacy surface — an auth token, a session id, a partner
+credential, or a multi-megabyte upload can cross a framework-mediated
+observation boundary and land in a record that is shown in a panel,
+handed to an LLM tool, or shipped off-box. The classification model
+([Spec 015 §The three-layer model](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md))
+exists so the framework can redact / elide those values at egress.
+
+**App-db schemas validate shape; they do NOT classify egress.** The
+`schema.cljs` schema above says what app-db *looks like*; it says nothing
+about which paths are sensitive or large. Egress classification for
+**durable app-db paths** is owned by the **frame**, declared on
+`reg-frame` — never re-attached to a schema. (Spec 015 deliberately keeps
+one route per fact: frame config owns durable app-db classification;
+schemas own shape — see
+[§Schemas describe shape, not durable app-db egress policy](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md#schemas-describe-shape-not-durable-app-db-egress-policy).)
+
+The starter counter has nothing sensitive, so its `reg-frame` config is
+the empty `{}`. As soon as you add auth/API data to app-db — say an
+`[:auth]` slice with a token, or a `[:documents]` slice that holds a
+large upload — declare it on the frame where the counter registers
+`:rf/default` in `core.cljs`:
+
+```clojure
+;; core.cljs — replace (rf/reg-frame :rf/default {}) with the
+;; classification config once your app-db carries sensitive/large paths.
+(rf/reg-frame :rf/default
+  {;; Durable app-db paths whose VALUES must never reach an observation
+   ;; surface. They project to :rf/redacted at every egress boundary.
+   :sensitive {:app-db [[:auth :token]
+                        [:auth :refresh-token]]
+               ;; Frame-local HTTP carrier names (headers / query params)
+               ;; that carry secret material on this app's requests.
+               :http   {:headers      ["Authorization"]
+                        :query-params ["api_key"]}}
+   ;; Durable app-db paths too large to ship whole — they project to
+   ;; :rf.size/large-elided (sensitive wins over large).
+   :large     {:app-db [[:documents :upload]]}})
+```
+
+Real values still flow through events → handlers → app-db → subs → views
+unchanged — projection runs **only** at the observation boundary, and the
+whole dev trace stream rides the `goog.DEBUG` gate, so there is no
+happy-path runtime cost.
+
+For **HTTP response bodies**, classification rides the request's
+`:decode` schema, not the frame (the body is a transient payload owned by
+its request) — see the HTTP section below.
+
 ### HTTP — closed failure-category set and a single `:on-failure` branch
 
 `events.cljs` ships a commented-out `:rf.http/managed` handler showing
 the canonical call shape per
 [Spec 014 §`:rf.http/managed`](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md).
 Uncomment and adapt when your app starts talking to a backend.
+
+**The `(:rf/reply msg)` / `{:kind :success|:failure …}` payload in the
+example is managed-HTTP public compatibility sugar — not the
+framework-wide managed-async model.** Every managed-HTTP completion
+lowers internally onto the framework's
+[uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/Managed-Effects.md#the-uniform-reply-envelope)
+(Managed-Effects property 9; the rationale record is
+[EP-0011](https://github.com/day8/re-frame2/blob/main/docs/EP/EP-0011-uniform-async-reply-envelope.md)):
+one canonical reply map with a single **closed** `:status`, `:value` /
+`:error`, `:work/id`, and `:completed-at`. The HTTP outcomes map onto it
+as:
+
+| HTTP compat `:kind` | Envelope `:status` | Carries |
+|---|---|---|
+| `:success` | `:ok` | `:value` (decoded body), `:work/id`, `:completed-at` |
+| `:failure` (any `:rf.http/*`) | `:error` | `:error` map with `:kind`, `:work/status` (`:failed` / `:timed-out`) |
+| abort | `:cancelled` | `:cancelled? true`, `:cancel/reason`, `:rf.http/aborted` under `:error` |
+| superseded / late | `:stale` | **never delivered to your app target** — stale replies are suppressed before dispatch |
+
+`:rf.http/managed` accepts `:on-success` / `:on-failure` (and the
+co-located `(:rf/reply msg)` form) as sugar that lowers to the framework
+target `:rf/reply-to`; both reshape the canonical reply back into the
+public `{:kind …}` payload, so the event shape in the exemplar is exactly
+what your handler sees. Full lowering contract:
+[Spec 014 §Lowering onto the uniform reply envelope](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md#lowering-onto-the-uniform-reply-envelope).
+**Do not read the `{:kind …}` payload as the general async model** — any
+non-HTTP managed-async surface you build (machines, resources, timers)
+reports completion through the same envelope's `:status` / `:value` /
+`:error` / `:completed-at` directly, with mandatory stale suppression.
+
+**Response-body classification — `:decode :auto` is the simple,
+non-sensitive case.** The exemplar decodes with `:decode :auto`, which is
+fine for a public counter response. A real response body that carries
+secrets (login / refresh tokens, partner credentials, opaque session
+material) or is large should use a **`:decode` schema** and classify
+per-slot with `:sensitive?` / `:large?` Malli props — the body is a
+transient payload owned by its request's `:decode` schema (not the frame;
+see the Privacy section above). An **unschematized body is
+whole-sensitive (fail-closed)**: off-box production traces and captures
+omit it entirely unless a classified projection is explicitly requested.
+See
+[Spec 015 §HTTP response bodies](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md#http-response-bodies).
 
 Two distinctive postures land in the example:
 

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -136,7 +136,8 @@
 
         ;; -- Best-practice surface in events.cljs + schema.cljs (rf2-48mij) --
         (let [events-text (slurp (io/file root "src/acme/my_app/events.cljs"))
-              schema-text (slurp (io/file root "src/acme/my_app/schema.cljs"))]
+              schema-text (slurp (io/file root "src/acme/my_app/schema.cljs"))
+              core-text   (slurp (io/file root "src/acme/my_app/core.cljs"))]
           (is (.contains events-text "register-listener!")
               "events.cljs registers an error-sink trace listener
                (errors-are-events-too best-practice)")
@@ -160,7 +161,59 @@
           (is (.contains schema-text "reg-app-schema")
               "schema.cljs registers a whole-app-db schema")
           (is (.contains schema-text "CounterDb")
-              "schema.cljs ships the CounterDb Malli schema"))
+              "schema.cljs ships the CounterDb Malli schema")
+
+          ;; -- EP-0011: HTTP exemplar names the uniform reply envelope
+          ;;    lowering + the compat-sugar distinction (rf2-rzsxrk) --
+          ;; The exemplar must say the (:rf/reply msg)/{:kind …} payload is
+          ;; managed-HTTP public compatibility SUGAR that lowers onto the
+          ;; framework-wide uniform reply envelope, and must name the
+          ;; canonical :status/:value/:work/id/:completed-at facts — so a
+          ;; future edit cannot re-teach the compat payload as the general
+          ;; managed-async model.
+          (is (.contains events-text "compatibility sugar")
+              "events.cljs HTTP exemplar marks the (:rf/reply msg)/{:kind …}
+               payload as managed-HTTP public compatibility sugar (EP-0011;
+               not the general async model — rf2-rzsxrk)")
+          (is (.contains events-text "uniform reply envelope")
+              "events.cljs HTTP exemplar names the framework-wide uniform
+               reply envelope the compat payload lowers onto (EP-0011 —
+               rf2-rzsxrk)")
+          (is (.contains events-text ":rf/reply-to")
+              "events.cljs HTTP exemplar names :rf/reply-to as the framework
+               target the :on-success/:on-failure sugar lowers to (EP-0011 —
+               rf2-rzsxrk)")
+          (is (.contains events-text ":completed-at")
+              "events.cljs HTTP exemplar names the canonical :completed-at
+               reply fact (EP-0011 — rf2-rzsxrk)")
+
+          ;; -- EP-0015: events.cljs decode-body classification guidance
+          ;;    (rf2-7i66d0) --
+          ;; The :decode :auto exemplar must say it is the simple
+          ;; non-sensitive case and point real bodies at a :decode SCHEMA
+          ;; with :sensitive? / :large? props + the unschematized
+          ;; fail-closed posture, so the scaffold cannot drift back to the
+          ;; pre-EP-0015 "decode :auto is the whole story" framing.
+          (is (.contains events-text ":sensitive?")
+              "events.cljs decode note names per-slot :sensitive? schema
+               props for sensitive HTTP response bodies (EP-0015 — rf2-7i66d0)")
+          (is (.contains events-text "fail-closed")
+              "events.cljs decode note states an unschematized HTTP body is
+               whole-sensitive / fail-closed (EP-0015 — rf2-7i66d0)")
+
+          ;; -- EP-0015: frame-owned classification pointer at the reg-frame
+          ;;    site + schema-is-shape-not-egress note (rf2-7i66d0) --
+          ;; core.cljs must point the user at frame-owned egress
+          ;; classification where it registers :rf/default, and schema.cljs
+          ;; must state that schemas validate shape, NOT durable app-db
+          ;; egress (the one-owner-one-route rule).
+          (is (.contains core-text ":sensitive")
+              "core.cljs points at frame-owned :sensitive egress
+               classification at the reg-frame site (EP-0015 — rf2-7i66d0)")
+          (is (.contains schema-text "does NOT classify durable app-db")
+              "schema.cljs states a schema validates shape and does NOT
+               classify durable app-db egress (frame owns that — EP-0015;
+               rf2-7i66d0)"))
 
         ;; -- package.json sanity --
         (let [pj-text (slurp (io/file root "package.json"))]
@@ -219,6 +272,71 @@
                 "README documents the naming-conventions rules")
             (is (.contains readme-text "spec/Conventions.md")
                 "README links to spec/Conventions.md for the normative catalogue"))
+
+          ;; -- README EP-0015 privacy/egress classification (rf2-7i66d0) --
+          ;; The README must carry a concise privacy/egress section that
+          ;; distinguishes app-db schemas (shape) from frame-owned durable
+          ;; classification (:sensitive / :large on reg-frame), and shows
+          ;; where sensitive/large app-db paths + frame-local HTTP carrier
+          ;; names are declared. Scope the assertions to that section so an
+          ;; honest mention elsewhere can't satisfy them weakly.
+          (let [readme-text (slurp (io/file root "README.md"))
+                priv-start  (.indexOf readme-text "### Privacy / egress classification")
+                priv-end    (let [i (.indexOf readme-text "\n### " (inc priv-start))]
+                              (if (neg? i) (count readme-text) i))
+                priv-sec    (subs readme-text (max 0 priv-start) priv-end)]
+            (is (not (neg? priv-start))
+                "README has a Privacy / egress classification section
+                 (EP-0015 — rf2-7i66d0)")
+            (is (.contains priv-sec "do NOT classify egress")
+                "README privacy section states app-db schemas validate shape
+                 and do NOT classify egress (EP-0015 — rf2-7i66d0)")
+            (is (.contains priv-sec "reg-frame")
+                "README privacy section shows classification declared on
+                 reg-frame (frame-owned durable classification — EP-0015;
+                 rf2-7i66d0)")
+            (is (and (.contains priv-sec ":sensitive")
+                     (.contains priv-sec ":large"))
+                "README privacy section names :sensitive and :large
+                 frame-owned classification keys (EP-0015 — rf2-7i66d0)")
+            (is (.contains priv-sec "spec/015-Data-Classification.md")
+                "README privacy section links Spec 015 for the normative
+                 classification model (EP-0015 — rf2-7i66d0)"))
+
+          ;; -- README EP-0011 HTTP reply-envelope lowering (rf2-rzsxrk) --
+          ;; The README HTTP section must name the lowering: the {:kind …}
+          ;; payload is managed-HTTP compatibility sugar over the uniform
+          ;; reply envelope, mapping HTTP outcomes onto canonical :status
+          ;; values (:ok/:error/:cancelled; :stale suppressed). Scope to the
+          ;; HTTP section.
+          (let [readme-text (slurp (io/file root "README.md"))
+                http-start  (.indexOf readme-text "### HTTP")
+                http-end    (let [i (.indexOf readme-text "\n### " (inc http-start))]
+                              (if (neg? i) (count readme-text) i))
+                http-sec    (subs readme-text (max 0 http-start) http-end)]
+            (is (not (neg? http-start))
+                "README has an HTTP section")
+            (is (.contains http-sec "compatibility sugar")
+                "README HTTP section marks the {:kind …} payload as
+                 managed-HTTP public compatibility sugar (EP-0011 —
+                 rf2-rzsxrk)")
+            (is (.contains http-sec "uniform reply envelope")
+                "README HTTP section names the uniform reply envelope the
+                 compat payload lowers onto (EP-0011 — rf2-rzsxrk)")
+            (is (and (.contains http-sec ":ok")
+                     (.contains http-sec ":cancelled")
+                     (.contains http-sec ":stale"))
+                "README HTTP section maps HTTP outcomes onto the canonical
+                 :status values incl. :stale suppression (EP-0011 —
+                 rf2-rzsxrk)")
+            (is (.contains http-sec "Managed-Effects.md")
+                "README HTTP section links Managed-Effects.md for the uniform
+                 reply envelope contract (EP-0011 — rf2-rzsxrk)")
+            ;; EP-0015 HTTP-body classification also lives in the HTTP
+            ;; section — the :decode :auto / schema-prop posture.
+            (is (.contains http-sec ":sensitive?")
+                "README HTTP section names :decode-schema :sensitive? props
+                 for sensitive response bodies (EP-0015 — rf2-7i66d0)"))
 
           ;; -- README substrate-invariant badges (rf2-sufwn) --
           (let [readme-text (slurp (io/file root "README.md"))]


### PR DESCRIPTION
Fixes two P2 template-surface beads aligning the deps-new scaffold with the landed EP-0015 (frame-owned egress classification) and EP-0011 (uniform async reply envelope) models. Verified against the landed template; counter app stays mark-free.

## rf2-7i66d0 — EP-0015 classification guidance (BUG)
The scaffold registered the app frame with an empty `(rf/reg-frame :rf/default {})` and a whole-app-db schema, with no pointer at where durable egress classification belongs once an app adds auth/API data to observable app-db, Xray, Story, logs, or off-box export.

- **README** gains a `### Privacy / egress classification` section: app-db schemas validate shape; durable app-db egress classification (`:sensitive` / `:large` + frame-local HTTP carrier names) is frame-owned on `reg-frame` — one owner, one route (Spec 015 §Schemas describe shape).
- **core.cljs (Reagent / UIx / Helix)** carry a worked `:sensitive` / `:large` reg-frame config sketch at the frame-registration site.
- **schema.cljs** docstring states a schema validates shape and does NOT classify durable app-db egress.
- **HTTP body classification**: the `:decode :auto` exemplar is marked as the simple non-sensitive case; real bodies should use a `:decode` schema with per-slot `:sensitive?` / `:large?` props, unschematized body = whole-sensitive / fail-closed (Spec 015 §HTTP response bodies).

## rf2-rzsxrk — EP-0011 HTTP reply-envelope alignment
The HTTP exemplar taught only the public `(:rf/reply msg)` / `{:kind :success|:failure}` payload without the canonical-envelope context EP-0011 requires tools/examples to surface.

- **events.cljs** + **README HTTP section** now state the `{:kind …}` payload is managed-HTTP public compatibility sugar that lowers onto the framework-wide uniform reply envelope, name the closed `:status` taxonomy (`:ok` / `:error` / `:cancelled`; `:stale` suppressed before app delivery), `:value` / `:error`, `:work/id`, `:completed-at`, and the `:rf/reply-to` lowering target. Both explicitly say the compat payload is NOT the framework-wide managed-async model.

## Tests
Focused guards added in `template_test.clj` pin the EP-0011 lowering / sugar distinction and the EP-0015 classification guidance in the emitted events.cljs / README / core.cljs / schema.cljs so they cannot drift back to the pre-EP story.

## Gates
- `tools/template` JVM tests: 39 tests, 521 assertions, 0 failures.
- `scripts/test-fast-pr.sh`: green (core JVM + all JS harness/policy gates).
- `implementation` `npm run test:cljs`: 7807 tests, 32349 assertions, 0 failures.
