### PR TITLE
fix: EP-0023 machines-viz share-url + testbed docs + test-gate (rf2-nsfbgq, rf2-eetjmy, rf2-32siq3.44)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1276,6 +1276,20 @@ jobs:
           npx shadow-cljs compile node-test
           node out/node-test.js
 
+      # Per-namespace test-isolation gate (rf2-32siq3.44). The consolidated
+      # node-test bundle shares ONE runtime, so a test ns whose fixture forgets
+      # to install its own substrate adapter is masked: it passes whenever a
+      # sibling left an adapter installed (suite ORDERING hides a
+      # self-incomplete fixture). This step re-runs the curated EP-0023
+      # image/frame runtime-construction namespaces EACH ALONE — a fixture
+      # leaning on bundle pollution goes red standalone. Reuses the bundle the
+      # step above just compiled (no --compile).
+      - name: Per-namespace test-isolation gate self-test
+        run: node scripts/check-per-ns-isolation.cjs --self-test
+
+      - name: Per-namespace test-isolation gate
+        run: node scripts/check-per-ns-isolation.cjs
+
   js-harness-self-tests:
     name: JS harness self-tests (quiet reporters + path policy)
     runs-on: ubuntu-latest

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
+    "test:cljs-isolation": "shadow-cljs compile node-test && node scripts/check-per-ns-isolation.cjs",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",
     "test:testbed-support": "shadow-cljs compile node-test-testbed-support && node out/node-test-testbed-support.js",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",

--- a/implementation/scripts/check-per-ns-isolation.cjs
+++ b/implementation/scripts/check-per-ns-isolation.cjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/*
+ * Per-namespace test-isolation gate (rf2-32siq3.44).
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * `npm run test:cljs` compiles ALL `*_cljs_test` namespaces into one
+ * consolidated node-test bundle and runs them in a single process. That
+ * shares one runtime: the installed substrate adapter, the registrar, the
+ * late-bind directory, machine/trace counters — all process-global state.
+ *
+ * EP-0023 collapse made `make-frame` / `reg-frame` allocate a RUNNABLE
+ * backing record (app-db / queue / sub-cache), which needs an installed
+ * substrate adapter. A test namespace whose fixture FORGETS to install its
+ * own adapter (via `make-reset-runtime-fixture {:adapter ...}` or
+ * `rf/init!`) is still GREEN in the consolidated bundle whenever an
+ * EARLIER namespace happened to leave an adapter installed — the suite
+ * ORDERING masks a self-incomplete fixture. Run that same namespace alone
+ * and it errors with `:rf.error/no-adapter-installed`.
+ *
+ * This is the shared-node-test-bundle fragility class: a fixture that
+ * relies on bundle pollution passes the gate. The concrete instance
+ * (`live-frame-reload-cljs-test`, 11 errors standalone yet green in CI)
+ * was fixed by the sibling bead; this gate stops the CLASS from recurring.
+ *
+ * THE CHECK
+ * ---------
+ * Run each curated runtime-construction test namespace ALONE in a fresh
+ * `out/node-test.js` process (the runner's focused `--test=<ns>` selector,
+ * which already rejects a no-match selector — rf2-lbo79.1). A namespace
+ * that relies on a sibling's leaked adapter goes RED standalone, so the
+ * gate fails at the SOURCE: the self-incomplete fixture, not a victim
+ * downstream.
+ *
+ * WHY A CURATED ALLOWLIST, NOT A BLANKET SCAN
+ * -------------------------------------------
+ * Running every `*_cljs_test` ns alone would be slow (one node process
+ * each) and a naive "does this file install an adapter?" STATIC lint is
+ * unworkably noisy: `rf/init!` is BOTH a constructor AND the adapter
+ * install call, story/test helpers seat adapters through their own
+ * fixtures, and `make-frame` appears as an error-id keyword in many files
+ * that never construct a frame. So, like `check_ambient_durable_reads.py`'s
+ * durable-write suffix allowlist, this gate scopes to an EXPLICIT list of
+ * the EP-0023 image/frame runtime-construction namespaces — the lineage
+ * whose fixtures MUST self-install an adapter. Adding such a namespace is a
+ * conscious one-line edit here (and the gate then guards it).
+ *
+ * Exit 0 on PASS (every listed ns green standalone), 1 on FAIL, 2 on a
+ * setup error.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// The curated scan surface — EP-0023 image/frame runtime-construction test
+// namespaces whose fixtures MUST self-install a substrate adapter (a runnable
+// `make-frame` / `reg-frame` backing record needs one). Each is run ALONE; a
+// fixture leaning on a sibling's leaked adapter goes red standalone.
+//
+// To add a namespace: append its ns symbol (the `(ns ...)` name). Run
+// `node scripts/check-per-ns-isolation.cjs --list` to see the live set.
+// ---------------------------------------------------------------------------
+const ISOLATION_NAMESPACES = [
+  're-frame.app-value-cljs-test',
+  're-frame.app-value-install-cljs-test',
+  're-frame.conformance-corpus-cljs-test',
+  're-frame.ep0023-conformance-cljs-test',
+  're-frame.example-frame-scoping-cljs-test',
+  're-frame.frame-classification-cljs-test',
+  're-frame.frame-resolution-cljs-test',
+  're-frame.frame-teardown-report-cljs-test',
+  're-frame.live-cascade-frame-resolution-cljs-test',
+  're-frame.live-frame-cljs-test',
+  're-frame.live-frame-reload-cljs-test',
+  're-frame.migration-cljs-test',
+  're-frame.multi-frame-isolation-cljs-test',
+  're-frame.projection-cljs-test',
+  're-frame.realm-cljs-test',
+  're-frame.realm-conformance-cljs-test',
+  're-frame.router-carried-frame-cljs-test',
+];
+
+const NODE_TEST_BUNDLE = 'out/node-test.js';
+
+function implementationDir() {
+  // scripts/ lives directly under implementation/.
+  return path.resolve(__dirname, '..');
+}
+
+function compileBundle(implDir) {
+  process.stderr.write('compiling node-test bundle...\n');
+  // Hardened, shell-free spawn (per the script-spawn-policy gate): resolve
+  // shadow-cljs's JS entry-point and run it under THIS node binary, so the OS
+  // never interprets a bare `npx` / `.cmd` shim (the rf2-33vvc command-hijack
+  // class on Windows).
+  let runner;
+  try {
+    runner = require.resolve('shadow-cljs/cli/runner.js');
+  } catch (e) {
+    process.stderr.write(
+      'error: cannot resolve shadow-cljs (run `npm install` in implementation/).\n'
+    );
+    return false;
+  }
+  const r = spawnSync(process.execPath, [runner, 'compile', 'node-test'], {
+    cwd: implDir,
+    stdio: 'inherit',
+  });
+  if (r.status !== 0) {
+    process.stderr.write('error: node-test compile failed.\n');
+    return false;
+  }
+  return true;
+}
+
+function runNamespaceAlone(implDir, ns) {
+  const r = spawnSync(process.execPath, [NODE_TEST_BUNDLE, `--test=${ns}`], {
+    cwd: implDir,
+    encoding: 'utf8',
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+function main(argv) {
+  const args = new Set(argv);
+
+  if (args.has('--help') || args.has('-h')) {
+    process.stdout.write(
+      'Per-namespace test-isolation gate (rf2-32siq3.44).\n\n' +
+        'Usage:\n' +
+        '  node scripts/check-per-ns-isolation.cjs [--compile] [--list] [--self-test]\n\n' +
+        '  --compile    recompile out/node-test.js first (CI runs test:cljs ahead,\n' +
+        '               so the bundle is normally already current)\n' +
+        '  --list       print the curated namespace set and exit\n' +
+        '  --self-test  prove the gate detects a no-adapter standalone failure\n' +
+        '               and a clean pass, using a synthetic runner stub; exit\n'
+    );
+    return 0;
+  }
+
+  if (args.has('--list')) {
+    for (const ns of ISOLATION_NAMESPACES) process.stdout.write(ns + '\n');
+    return 0;
+  }
+
+  if (args.has('--self-test')) {
+    return runSelfTest();
+  }
+
+  const implDir = implementationDir();
+
+  if (args.has('--compile')) {
+    if (!compileBundle(implDir)) return 2;
+  }
+
+  const bundlePath = path.join(implDir, NODE_TEST_BUNDLE);
+  if (!fs.existsSync(bundlePath)) {
+    process.stderr.write(
+      `error: ${NODE_TEST_BUNDLE} not found. Run \`npm run test:cljs\` (or pass ` +
+        '--compile) first so the consolidated bundle exists.\n'
+    );
+    return 2;
+  }
+
+  const reds = [];
+  for (const ns of ISOLATION_NAMESPACES) {
+    process.stderr.write(`  isolating ${ns} ... `);
+    const r = runNamespaceAlone(implDir, ns);
+    if (r.status === 0) {
+      process.stderr.write('ok\n');
+    } else {
+      process.stderr.write('RED\n');
+      reds.push({ ns, ...r });
+    }
+  }
+
+  if (reds.length === 0) {
+    process.stderr.write(
+      `\nper-ns isolation: all ${ISOLATION_NAMESPACES.length} namespace(s) ` +
+        'pass standalone.\n'
+    );
+    return 0;
+  }
+
+  process.stderr.write(
+    `\n${reds.length} namespace(s) FAILED when run in isolation (they pass in ` +
+      'the consolidated bundle ONLY because a sibling left runtime state — ' +
+      'e.g. an installed adapter — behind):\n\n'
+  );
+  for (const red of reds) {
+    process.stderr.write(`  RED: ${red.ns} (exit=${red.status})\n`);
+    // Surface the tail of the diagnostic (the adapter / fixture error).
+    const tail = (red.stdout + red.stderr)
+      .split('\n')
+      .filter((l) => l.trim() !== '')
+      .slice(-6)
+      .map((l) => '      ' + l)
+      .join('\n');
+    if (tail) process.stderr.write(tail + '\n');
+  }
+  process.stderr.write(
+    '\nFix:\n  * Give the failing namespace a fixture that installs its OWN ' +
+      'substrate adapter and resets runtime state — e.g.\n' +
+      '    (use-fixtures :each\n' +
+      '      (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))\n' +
+      '  Do NOT rely on a sibling test having installed one (consolidated-bundle ' +
+      'ordering is not a contract).\n'
+  );
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Self-test — prove the gate's red/green logic with a synthetic runner stub
+// (no shadow-cljs compile required). We exercise the same exit-code contract
+// the real run depends on: a non-zero standalone exit for ONE namespace makes
+// the gate fail; an all-zero set passes.
+// ---------------------------------------------------------------------------
+function runSelfTest() {
+  let failures = 0;
+  const assert = (cond, msg) => {
+    if (cond) {
+      process.stderr.write(`self-test PASS: ${msg}\n`);
+    } else {
+      process.stderr.write(`self-test FAIL: ${msg}\n`);
+      failures += 1;
+    }
+  };
+
+  // Classify a set of synthetic {ns -> exit} runs the way main() does.
+  const classify = (runs) =>
+    Object.entries(runs)
+      .filter(([, status]) => status !== 0)
+      .map(([ns, status]) => ({ ns, status }));
+
+  // Green: every namespace exits 0 → no reds.
+  const green = classify({ a: 0, b: 0, c: 0 });
+  assert(green.length === 0, 'all-green isolation run yields zero reds (PASS)');
+
+  // Red: a self-incomplete fixture exits non-zero standalone → flagged.
+  const red = classify({ a: 0, b: 1, c: 0 });
+  assert(red.length === 1 && red[0].ns === 'b',
+    'a single standalone failure is flagged as the red namespace (FAIL path)');
+
+  // Multiple reds are all surfaced.
+  const reds = classify({ a: 1, b: 0, c: 1 });
+  assert(reds.length === 2, 'every standalone failure is surfaced, not just the first');
+
+  // The curated list is non-empty and dedup'd (a typo'd duplicate would run
+  // twice and silently weaken the signal).
+  const uniq = new Set(ISOLATION_NAMESPACES);
+  assert(ISOLATION_NAMESPACES.length > 0, 'curated namespace list is non-empty');
+  assert(uniq.size === ISOLATION_NAMESPACES.length,
+    'curated namespace list has no duplicates');
+
+  if (failures) {
+    process.stderr.write(`\n${failures} self-test failure(s).\n`);
+    return 1;
+  }
+  process.stderr.write('\nall self-tests passed.\n');
+  return 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -197,6 +197,20 @@ run "implementation JS harness helpers" "cd implementation && npm run test:scrip
 run "CLJS node integration" "cd implementation && npm run test:cljs" \
   bash -lc "cd '$repo_root/implementation' && npm run test:cljs"
 
+# Per-namespace test-isolation gate (rf2-32siq3.44).  The consolidated
+# node-test bundle shares ONE runtime, so a test ns whose fixture forgets to
+# install its own substrate adapter is masked: it passes whenever a sibling
+# left an adapter installed (suite ORDERING hides a self-incomplete fixture).
+# This gate re-runs the curated EP-0023 image/frame runtime-construction
+# namespaces EACH ALONE; a fixture leaning on bundle pollution goes red
+# standalone.  Self-test first (proves the red/green classification), then the
+# live run (reuses the bundle test:cljs just compiled).
+run "per-ns isolation self-test" "cd implementation && node scripts/check-per-ns-isolation.cjs --self-test" \
+  bash -lc "cd '$repo_root/implementation' && node scripts/check-per-ns-isolation.cjs --self-test"
+
+run "per-ns test isolation" "cd implementation && node scripts/check-per-ns-isolation.cjs" \
+  bash -lc "cd '$repo_root/implementation' && node scripts/check-per-ns-isolation.cjs"
+
 # ---- conditional markdown gates ----
 if [ "$markdown_changed" = "true" ]; then
   printf '\n--- markdown changes detected → running link/anchor gates ---\n'

--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -233,8 +233,9 @@ does not know about Xray's chrome or Story's variant runtime —
 the chart is presentation-only, so it only knows the
 `:machine-id`, `:definition`, and `:current-state` the host pulled
 and passed in, plus the two callbacks the host wired. It takes no
-`:frame-id` (that survives only as share-envelope payload
-provenance, [`API.md`](./API.md) §ShareEnvelope).
+`:frame-id` (that survives only as **optional** share-envelope payload
+provenance — an EP-0023 frame-target id, [`API.md`](./API.md)
+§ShareEnvelope).
 
 ## Surface set
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1650,7 +1650,7 @@ encoder:
 
 ```clojure
 (share/decode-share-url url)
-;; => {:rf.machines-viz.share/v "1"
+;; => {:rf.machines-viz.share/v "2"
 ;;     :rf.machines-viz.share/chart {:machine-id :auth/login-flow ...}
 ;;     :rf.machines-viz.share/created 1736000000000}
 ;; or throws :rf.machines-viz.share/decode-failed with :reason
@@ -1700,7 +1700,7 @@ nothing else. Two classes of data are structurally excluded:
 ```clojure
 (def ShareEnvelope
   [:map
-   [:rf.machines-viz.share/v      :string]   ;; encoding version, "1" at v1.0
+   [:rf.machines-viz.share/v      :string]   ;; encoding version, "2" (was "1" pre-EP-0023)
    [:rf.machines-viz.share/chart  ChartState]
    [:rf.machines-viz.share/created :int]])   ;; wall-clock ms at encode time
 
@@ -1719,7 +1719,8 @@ nothing else. Two classes of data are structurally excluded:
 (def ChartState
   [:map
    [:machine-id  keyword?]              ;; the registered machine's id
-   [:frame-id    keyword?]              ;; the registered machine's frame
+   [:frame-id   {:optional true}        ;; OPTIONAL frame-target id (v2 / EP-0023) — payload provenance only
+    keyword?]                           ;; the process-local live-frame id captured at share time; omit when unknown
    [:definition  MachineDefinition]     ;; the topology (states, transitions, guards, actions, :spawn, :spawn-all, :after)
    [:snapshot   {:optional true}        ;; the current-state configuration at share time — state CONFIGURATION only; no runtime data
     [:map {:closed true}
@@ -1750,9 +1751,22 @@ the three arms, with `:invalid-chart-state`. The viewer page mounts `MachineChar
 `:current-state` set to the snapshot's `:state` configuration (there is
 no runtime `:data` to render); the chart highlights every active leaf
 without any data-driven affordance.
-(`:frame-id` is a payload provenance field — the registered machine's
-frame at share time — not a `MachineChart` prop: the viewer hands the
-chart the `:definition` directly rather than resolving a frame.)
+(`:frame-id` is an **optional** payload-provenance field — an EP-0023
+**frame-target id**, i.e. the process-local id of the live frame the
+machine was registered against, captured at share time and decoupled
+from any (realm, frame) pairing. It is **not** a `MachineChart` prop:
+the viewer hands the chart the `:definition` directly rather than
+resolving a frame, so the viewer never reads `:frame-id` at all. A
+machine topology + active-state configuration is shareable without
+naming a live frame, so `:frame-id` is omitted when the sharer does not
+know it — a presentation-only chart (e.g. one shared straight off the
+rendered DOM seam) shares cleanly rather than fabricating a provenance
+id. `:frame-id` became optional in encoding **v2** (it was required and
+documented in pre-EP-0023 (realm, frame) terms in v1); making it
+optional is a v1→v2 share-schema change, gated behind the
+`:rf.machines-viz.share/v` bump so a v2 payload omitting `:frame-id`
+handed to a v1 decoder is refused with `:unknown-version` rather than
+silently mis-decoded — CI-enforced per the encoding-version contract.)
 
 `:source-coords` is **not a top-level key** of `ChartState`. Source
 coords live only in the operator-side `(rf/machine-meta machine-id)`

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -108,9 +108,11 @@ What does the host pass to `MachineChart` to render a chart?
   would need a live frame + a registered machine) and tied one
   presentation component to the runtime's subscription plane. The
   `:frame-id` prop never shipped on the chart (it survives only as
-  share-envelope *payload provenance*, [`API.md`](./API.md)
-  §ShareEnvelope — the registered machine's frame at share time, not a
-  `MachineChart` prop).
+  **optional** share-envelope *payload provenance*, [`API.md`](./API.md)
+  §ShareEnvelope — an EP-0023 frame-target id, i.e. the process-local id
+  of the live frame the machine was registered against at share time,
+  decoupled from any (realm, frame) pairing, and not a `MachineChart`
+  prop).
 - **Pass the snapshot directly.** The host derefs the runtime-db slot
   `[:rf.runtime/machines :snapshots <id>]` and passes the snapshot to the chart.
   Rejected — the chart loses access to the topology (states,

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -584,10 +584,12 @@
 (defn- element->chart-state
   "Project the DOM seam into the `ChartState` shape `share/encode-share-url`
   accepts. The `:frame-id` is not on the seam (the chart is
-  presentation-only and doesn't know its frame); when absent we pass
-  `:frame-id` as the machine-id so the encoder's schema is satisfied.
-  Hosts that know the frame should call `share/encode-share-url` directly
-  with the full ChartState.
+  presentation-only and doesn't know its frame). `:frame-id` is OPTIONAL
+  (v2 / EP-0023) — a topology/snapshot is shareable without naming a live
+  frame — so when no `:frame-id` is supplied we OMIT it rather than
+  fabricating a provenance id from the machine-id. A host that knows the
+  frame-target id can pass it (or call `share/encode-share-url` directly
+  with the full ChartState).
 
   `:current-state` off the seam is the chart's whole `:state` value — a
   flat keyword, a compound vector-path, or a parallel region-map (the
@@ -598,9 +600,11 @@
   [chart-element {:keys [frame-id]}]
   (let [{:keys [machine-id definition current-state]} (chart-state-of chart-element)]
     (cond-> {:machine-id machine-id
-             :frame-id   (or frame-id machine-id)
              :definition definition}
-      current-state (assoc :snapshot {:state current-state}))))
+      ;; :frame-id is OPTIONAL — include it only when the host supplied a
+      ;; frame-target id; do not fabricate one from the machine-id.
+      (some? frame-id)  (assoc :frame-id frame-id)
+      current-state     (assoc :snapshot {:state current-state}))))
 
 (defn share-url
   "Derive a share-URL from the rendered `chart-element`. Reads the
@@ -609,8 +613,9 @@
 
   `opts` is passed to `share/encode-share-url` (`{:host ...}`), and may
   also carry `:frame-id` (the chart element doesn't know its frame; a
-  host that does can supply it for payload provenance). Returns the URL
-  string."
+  host that does can supply a frame-target id for payload provenance).
+  `:frame-id` is OPTIONAL (v2 / EP-0023) — omit it to share a topology
+  that does not name a live frame. Returns the URL string."
   ([chart-element] (share-url chart-element nil))
   ([chart-element opts]
    (let [chart-state (element->chart-state chart-element opts)]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -60,8 +60,15 @@
 (def current-version
   "The encoding version emitted by this build, and the newest version
   the decoder accepts. Bumping the payload schema bumps this; older
-  decoders refuse newer payloads with `:unknown-version`."
-  "1")
+  decoders refuse newer payloads with `:unknown-version`.
+
+  v2 (EP-0023): `:frame-id` became OPTIONAL — a machine topology +
+  active-state configuration is shareable as pure data without naming a
+  live frame. v1 always carried a required `:frame-id`; a v2 payload may
+  omit it, so a v2 share-URL handed to a v1 decoder is correctly refused
+  with `:unknown-version` (the version-bump guard) rather than silently
+  mis-decoding."
+  "2")
 
 (def default-host
   "The canonical hosted viewer instance. Per Lock #7 this is a
@@ -254,9 +261,18 @@
 ;;
 ;; ChartState:
 ;;   {:machine-id keyword?
-;;    :frame-id   keyword?
+;;    :frame-id   keyword?                          ;; OPTIONAL frame-target id (v2 / EP-0023)
 ;;    :definition <MachineDefinition>
 ;;    :snapshot   {:state <state-configuration>}}  ;; OPTIONAL, {:closed true}, :state only
+;;
+;; `:frame-id` (when present) is an EP-0023 frame-target id — the
+;; process-local id of the live frame the machine was registered against,
+;; captured at share time purely as payload PROVENANCE. It is decoupled
+;; from any (realm, frame) pairing (the pre-EP-0023 model), and the viewer
+;; never resolves a frame from it (it hands the chart the `:definition`
+;; directly). A topology/snapshot is shareable without naming a live frame,
+;; so `:frame-id` is OPTIONAL (v2): a presentation-only chart that does not
+;; know its frame shares cleanly without fabricating one.
 ;;
 ;; The `:snapshot` `:state` is a STATE CONFIGURATION — one of the three
 ;; Spec 005 §Snapshot-shape arms that `MachineChart` `:current-state`
@@ -336,13 +352,16 @@
 
 (defn- valid-core-chart-state?
   "Validate the load-bearing ChartState slots (`:machine-id`,
-  `:frame-id`, `:definition`). `:snapshot` is NOT checked here — see
-  `valid-chart-state?` for the whole-shape check used at BOTH encode and
-  decode time."
+  `:definition`). `:frame-id` is OPTIONAL (v2 / EP-0023) — when present
+  it must be a keyword (a frame-target id), but a topology/snapshot is
+  shareable without naming a live frame. `:snapshot` is NOT checked here
+  — see `valid-chart-state?` for the whole-shape check used at BOTH
+  encode and decode time."
   [cs]
   (and (map? cs)
        (keyword? (:machine-id cs))
-       (keyword? (:frame-id cs))
+       (or (not (contains? cs :frame-id))
+           (keyword? (:frame-id cs)))
        (valid-definition? (:definition cs))))
 
 (def ^:private chart-state-keys
@@ -358,7 +377,8 @@
   "Validate a fully-allowlisted ChartState shape. The top-level map is
   CLOSED over `chart-state-keys` — any extra top-level key (e.g. a
   hand-edited `:source-coords` / `:data` smuggled past the encoder)
-  fails validation. `:snapshot` is optional; when present it must be
+  fails validation. `:frame-id` is OPTIONAL (v2 / EP-0023); when present
+  it must be a keyword. `:snapshot` is optional; when present it must be
   `{:state <state-configuration>}` EXACTLY (closed; `:state` only).
   Used on BOTH sides so encode/decode stay symmetric — the encoder
   validates the allowlisted chart state with this same predicate before
@@ -388,8 +408,12 @@
   [chart-state]
   (let [{:keys [machine-id frame-id definition snapshot]} chart-state]
     (cond-> {:machine-id machine-id
-             :frame-id   frame-id
              :definition (-> definition strip-meta sanitise-definition)}
+      ;; :frame-id is OPTIONAL (v2 / EP-0023): include it only when the
+      ;; caller supplied one. A presentation-only chart that does not know
+      ;; its frame shares cleanly without fabricating a provenance id.
+      (some? frame-id)
+      (assoc :frame-id frame-id)
       ;; :snapshot is allowlisted to :state ONLY — runtime :data and any
       ;; other snapshot key are dropped here structurally even if the
       ;; caller passed a full snapshot. The :state VALUE (a flat keyword,
@@ -460,7 +484,10 @@
 
   ```clojure
   {:machine-id :auth/login-flow
-   :frame-id   :app/main
+   :frame-id   :app/main           ;; OPTIONAL (v2 / EP-0023) — a
+                                   ;; frame-target id captured as payload
+                                   ;; provenance; omit it for a topology
+                                   ;; that does not name a live frame
    :definition {:initial :idle :states {...}}
    :snapshot   {:state :loading}}   ;; optional; :state ONLY (a state
                                     ;; CONFIGURATION — flat keyword,
@@ -490,9 +517,10 @@
        ;; [:rf.machines-viz.share/encode-failed] token; the fine `:reason`
        ;; keyword stays the documented tool-classification slot (API.md).
        (let [msg (str "cannot encode a share-URL: the chart state does not "
-                      "validate against the share schema (a :machine-id, "
-                      ":frame-id, :definition, or :snapshot :state is missing "
-                      "or malformed). Pass a valid ChartState.")]
+                      "validate against the share schema (a :machine-id or "
+                      ":definition is missing/malformed, :frame-id (optional) "
+                      "is non-keyword, or :snapshot :state is malformed). Pass "
+                      "a valid ChartState.")]
          (throw (ex-info (error/human-message :rf.machines-viz.share/encode-failed msg)
                          {:rf.error/id :rf.machines-viz.share/encode-failed
                           :where       'machines-viz.share/encode-share-url

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
@@ -51,6 +51,8 @@
       (is (str/includes? url "#machine="))
       (is (= :auth/login-flow (:machine-id cs)))
       (is (= definition (:definition cs)))
+      (is (not (contains? cs :frame-id))
+          "no :frame-id is fabricated off the seam (v2 / EP-0023 — frame-id is optional)")
       (is (= {:state :loading} (:snapshot cs))
           "active-state name rides as the snapshot; no :data"))))
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -85,7 +85,7 @@
       (is (= :app/main (:frame-id back)))
       (is (= idle-loading-success (:definition back)))
       (is (= {:state :loading} (:snapshot back)))
-      (is (= "1" (:rf.machines-viz.share/v env)))
+      (is (= "2" (:rf.machines-viz.share/v env)))
       (is (number? (:rf.machines-viz.share/created env))))))
 
 (deftest round-trip-parallel
@@ -468,13 +468,40 @@
 (deftest unknown-version-rejected
   (testing "a payload tagged with a newer version throws :unknown-version"
     (let [future-url (envelope->url
-                       {:rf.machines-viz.share/v       "2"
+                       {:rf.machines-viz.share/v       "3"
                         :rf.machines-viz.share/chart   chart-state
                         :rf.machines-viz.share/created 0})
           d (try (share/decode-share-url future-url)
                  (catch :default e (ex-data e)))]
       (is (= :unknown-version (:reason d)))
-      (is (= "2" (:payload-version d))))))
+      (is (= "3" (:payload-version d))))))
+
+(deftest frame-id-is-optional
+  (testing "a ChartState with no :frame-id encodes + round-trips (v2 / EP-0023)"
+    (let [cs   (dissoc chart-state :frame-id)
+          url  (share/encode-share-url cs)
+          back (:rf.machines-viz.share/chart (share/decode-share-url url))]
+      (is (not (contains? back :frame-id))
+          "no fabricated :frame-id rides the payload when none was supplied")
+      (is (= :auth/login-flow (:machine-id back)))
+      (is (= idle-loading-success (:definition back)))
+      (is (= {:state :loading} (:snapshot back))))))
+
+(deftest frame-id-when-present-must-be-keyword
+  (testing "a non-keyword :frame-id is rejected at encode with :invalid-chart-state"
+    (let [d (try (share/encode-share-url (assoc chart-state :frame-id "not-a-keyword"))
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))))))
+
+(deftest decoded-frame-id-absent-still-decodes
+  (testing "a forged v2 payload omitting :frame-id decodes cleanly (optional)"
+    (let [url  (envelope->url
+                 {:rf.machines-viz.share/v       "2"
+                  :rf.machines-viz.share/chart   (dissoc chart-state :frame-id)
+                  :rf.machines-viz.share/created 0})
+          back (:rf.machines-viz.share/chart (share/decode-share-url url))]
+      (is (not (contains? back :frame-id)))
+      (is (= :auth/login-flow (:machine-id back))))))
 
 (deftest missing-envelope-rejected
   (testing "a payload missing the envelope keys throws :missing-envelope"

--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -64,7 +64,14 @@ node, one React root at a time — `#/` the live app, `#/stories` the Story
 shell. The plumbing that switches between them (a `defonce` React-root
 handle, the tear-down-one-before-mounting-the-other dance, and the
 `hashchange` listener) is pure React-DOM-root juggling — identical across
-every testbed but for the live-app root view. It was copy-pasted across
+every testbed but for the live-app root view. That root view is not a bare
+React tree: it is a **frame-scoped subtree** — a frame, supplied by the
+consuming testbed via `frame-provider`, resolving its handlers against a
+loaded image (EP-0023 §Views). This harness sits strictly ABOVE that
+frame/image boundary — it owns the React-root + hashchange mechanics and
+treats the testbed's root view as an opaque frame subtree; it neither
+creates frames nor loads images (that is the consuming testbed's job, via
+`reg-frame` / `with-frame` / `rf/init!`). It was copy-pasted across
 six hosts (`counter_with_stories`, `login_form`, the `login` and
 `nine_states` examples, the Xray `panel_gallery` testbed, plus the template
 scaffolding), already drifting in the per-testbed boot specifics they each add.

--- a/tools/testbed-support/src/re_frame/testbed/story_host.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/story_host.cljs
@@ -11,10 +11,18 @@
   - `#/`        → the live app (the testbed's own root view).
   - `#/stories` → the Story shell mounted via `re-frame.story/mount-shell!`.
 
+  The live-app root view is not a bare React tree: it is a FRAME-SCOPED
+  SUBTREE — a frame, supplied by the consuming testbed via `frame-provider`,
+  resolving its handlers against a loaded IMAGE (EP-0023 §Views). This host
+  sits strictly ABOVE that frame/image boundary: it treats the root view as
+  an opaque frame subtree and never creates a frame or loads an image (the
+  consuming testbed does, via `reg-frame` / `with-frame` / `rf/init!`).
+
   The plumbing that switches between them — a private `app-root` atom,
   `ensure-app-root!` / `tear-down-app-root!` / `mount-app!` /
   `mount-stories!`, and the `hashchange` listener — is pure React-DOM-root
-  juggling, identical across every testbed but for the live-app root view.
+  juggling, identical across every testbed but for the live-app root view
+  (the frame subtree above).
   Five copies (`counter_with_stories`, `login_form`, the `login` and
   `nine_states` examples, plus the template scaffolding) invited drift:
   they already diverged in their `run` boot specifics (CI hooks, elision
@@ -180,6 +188,11 @@
 (defn mount-with-hash-routing!
   "Wire the live-app ↔ Story-shell hash router for `root-view` (a 0-arg
   Reagent component — pass the live-app root view, e.g. `counter-app`).
+  `root-view` is the testbed's FRAME-SCOPED subtree: a frame the consuming
+  testbed has wired (typically via `frame-provider`) that resolves its
+  handlers against a loaded IMAGE (EP-0023 §Views). This host renders it as
+  an opaque component and stays above the frame/image boundary — it neither
+  creates the frame nor loads the image.
 
   Installs the `hashchange` listener and renders the surface the current
   URL hash selects: `#/stories…` mounts the Story shell, anything else


### PR DESCRIPTION
Three EP-0023 follow-on beads on disjoint surfaces, aligning consumers to the image/frame model.

## rf2-nsfbgq (P3) — machines-viz: share-URL `:frame-id` optional + frame-target reframing
The share-URL ChartState carried a **required** `:frame-id` documented in pre-EP-0023 (realm, frame) terms ("the registered machine's frame"). The chart is presentation-only and a machine topology + active-state configuration is shareable without naming a live frame, so the export-time fabrication (`:frame-id := machine-id` when unknown) was a smell.

- `:frame-id` is now **optional** — omitted when the sharer does not know it; the DOM-seam exporter no longer fabricates one from the machine-id.
- Re-worded the `:frame-id` docs (API.md schema + provenance note, share.cljs/export.cljs docstrings, DESIGN-RATIONALE, 000-Vision) as an EP-0023 **frame-target id**: the process-local live-frame id captured at share time, decoupled from any (realm, frame) pairing; the viewer never resolves a frame from it.
- The requiredness change is a v1→v2 share-schema change, gated behind the encoding-version bump (`"1"` → `"2"`): a v2 payload omitting `:frame-id` handed to a v1 decoder is refused with `:unknown-version` (the CI-enforced version guard).
- Tests added: `frame-id-is-optional`, `frame-id-when-present-must-be-keyword`, `decoded-frame-id-absent-still-decodes`, an export no-fabrication assertion; version expectations bumped.
- machines-viz spec updated in the same PR (API.md / DESIGN-RATIONALE / 000-Vision).

## rf2-eetjmy (P4) — testbed-support: doc-currency to the frame model
README + `story_host` docstrings framed the harness as pure React-DOM-root juggling without naming the EP-0023 image/frame model. The harness sits strictly **above** the frame/image boundary (a React-root + hashchange host), so the fix notes the live-app root view is a **frame-scoped subtree** — a frame the consuming testbed supplies via `frame-provider` that resolves against a loaded image (EP-0023 §Views) — while the host neither creates frames nor loads images. Doc-only, no behavioral change.

## rf2-32siq3.44 (P3) — per-namespace test-isolation gate
The consolidated node-test bundle (`npm run test:cljs`) runs every `*_cljs_test` namespace in **one** process sharing one runtime. A test ns whose fixture forgets to install its own substrate adapter passes whenever an earlier ns left one installed — suite **ordering** masks a self-incomplete fixture (the `live-frame-reload` instance: 11 errors standalone, green in CI; fixed by the sibling bead). Run that ns alone and it errors with `:rf.error/no-adapter-installed` (the shared-node-test-bundle fragility class).

New gate `implementation/scripts/check-per-ns-isolation.cjs` re-runs a **curated allowlist** of EP-0023 image/frame runtime-construction namespaces **each alone** via the runner's focused `--test=<ns>` selector; a fixture leaning on bundle pollution goes red standalone, failing at the source. A curated allowlist (not a blanket scan / static lint) keeps it fast and false-positive-free — `rf/init!` is both a constructor and the install call, so a static "does this file install an adapter?" lint is unworkably noisy (39 false positives in a prototype). Reproduced the red (temporarily neutered the live-frame-reload adapter fixture → 14 standalone errors, exit 1), then confirmed all 17 listed namespaces pass standalone.

Wired into the canonical PR spine (`scripts/test-fast-pr.sh`) and the CI CLJS node-test job (`.github/workflows/test.yml`), reusing the bundle `test:cljs` compiles. npm script `test:cljs-isolation`; `--self-test` proves the red/green classification; `--list` prints the curated set.

## Gates
- `npm run test:cljs` — green (7816 tests, 32390 assertions, 0 failures, 0 errors) — covers machines-viz share/export + confirms the gate doesn't break the bundle.
- per-ns isolation gate — green (17/17 standalone); self-test green.
- script-spawn-policy / workflow-policy / full script-policy — green.