### PR TITLE
fix(story): self-contained static export + share-url variant hydration (rf2-8l0ffk, rf2-8q35fw)

### DIFF
--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -103,6 +103,14 @@ function flushDiagnostics(diagnostics) {
   console.error('--------------------------------');
 }
 
+// A sentinel absolute checkout root, injected as RF2_TESTBED_PROJECT_ROOT
+// into the static build's environment. The static export MUST NOT consume
+// this env var (the dev-testbed `repo-root` goog-define is not seeded for the
+// :story-static/* build), so this string must NOT survive into the emitted
+// bundle or manifest. `assertNoSentinelLeak` below enforces that.
+const PROJECT_ROOT_SENTINEL =
+  'C:/Users/rf2-static-leak-sentinel/code/should-not-be-bundled';
+
 function runBuild(diagnostics) {
   // Use process.execPath directly without shell:true — on Windows the
   // installed node.exe path commonly contains spaces ("Program Files"),
@@ -110,11 +118,18 @@ function runBuild(diagnostics) {
   // argv pass-through verbatim.
   const script = path.join(__dirname, 'story-build.cjs');
   diagnostics.add(`Process: ${process.execPath} ${script}`);
+  // Inject the sentinel checkout root the same way a dev launcher would
+  // (`RF2_TESTBED_PROJECT_ROOT`). The static-export build deliberately does
+  // NOT seed `re-frame.testbed.config/repo-root` from this env var, so the
+  // sentinel must not appear anywhere in the published artifact — the
+  // self-containment contract (a published bundle carries no build-machine
+  // checkout path). `assertNoSentinelLeak` verifies it post-build.
   const result = spawnSync(process.execPath, [script], {
     cwd: IMPL_ROOT,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, RF2_TESTBED_PROJECT_ROOT: PROJECT_ROOT_SENTINEL },
   });
   if (result.stdout) addChunk(diagnostics, '[story-build:stdout] ', result.stdout);
   if (result.stderr) addChunk(diagnostics, '[story-build:stderr] ', result.stderr, 'stderr');
@@ -125,6 +140,31 @@ function runBuild(diagnostics) {
     throw new Error(`story-build.cjs failed (exit ${result.status})`);
   }
   diagnostics.add(`story-build.cjs exited ${result.status}`);
+}
+
+// Static-export self-containment: scan the emitted bundle + manifest for the
+// build-time RF2_TESTBED_PROJECT_ROOT sentinel. The published export must
+// carry NO ambient machine-local checkout path baked in. The advanced bundle
+// inlines goog-define string constants, so a regression that re-seeds
+// `re-frame.testbed.config/repo-root` from the env var would surface here as
+// the sentinel string embedded in main.js.
+function assertNoSentinelLeak(diagnostics) {
+  const filesToScan = ['main.js', 'manifest.json', 'index.html'];
+  for (const fileName of filesToScan) {
+    const p = path.join(OUT_DIR, fileName);
+    if (!fs.existsSync(p)) continue;
+    const contents = fs.readFileSync(p, 'utf8');
+    if (contents.includes(PROJECT_ROOT_SENTINEL)) {
+      throw new Error(
+        `static-export self-containment violated: the build-machine checkout ` +
+          `sentinel ("${PROJECT_ROOT_SENTINEL}") leaked into ${fileName}. The ` +
+          `:story-static/* build must NOT seed re-frame.testbed.config/repo-root ` +
+          `from RF2_TESTBED_PROJECT_ROOT — a published bundle carries no ` +
+          `machine-local checkout path.`,
+      );
+    }
+    diagnostics.add(`Sentinel-leak scan clean: ${fileName}`);
+  }
 }
 
 // Resolve the port via the shared harness primitive: prefer DEFAULT_PORT
@@ -286,6 +326,16 @@ async function smokeTest(baseUrl, diagnostics) {
       flushDiagnostics(diagnostics);
       process.exit(1);
     }
+  }
+
+  // 2b. Static-export self-containment: the build ran with a sentinel
+  //     RF2_TESTBED_PROJECT_ROOT; assert it did NOT leak into the bundle.
+  try {
+    assertNoSentinelLeak(diagnostics);
+  } catch (err) {
+    console.error(err.message || err);
+    flushDiagnostics(diagnostics);
+    process.exit(1);
   }
 
   // 3. Publish the ownership token BEFORE spawning http-server.

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1576,15 +1576,20 @@
   {:target           :browser
    :output-dir       "out/story-static/counter-with-stories"
    :asset-path       "."
-   ;; rf2-5dphw — the build-env project-root define rides alongside the
-   ;; static-mode? define here (see :examples/two-frame-isolation for the
-   ;; mechanism). In a published static export the open-in-editor chip is
-   ;; effectively dev-only, so the slot is harmless; seeding it keeps the
-   ;; static entry structurally identical to the dev entry.
+   ;; Static-export self-containment: the static build does NOT seed the
+   ;; `re-frame.testbed.config/repo-root` goog-define from
+   ;; `RF2_TESTBED_PROJECT_ROOT`. That env-derived define is for DEV testbeds
+   ;; (it powers the open-in-editor chip's absolute-path resolution under
+   ;; `shadow-cljs watch`). Inlining it into an `:advanced` static bundle
+   ;; would bake the BUILD machine's checkout root (often a `C:/Users/<name>/`
+   ;; home path) into a publishable artifact as a string constant. The
+   ;; published export is dev-tool-free, so only `static-mode? true` rides
+   ;; here; the open-in-editor project-root stays nil (and the framework
+   ;; guard in `re-frame.story.config/set-project-root!` fails closed under
+   ;; static mode regardless). A downstream consumer that genuinely wants a
+   ;; deep-link-to-editor static site opts in explicitly in their own entry.
    :compiler-options {:closure-defines
-                      {re-frame.story.config/static-mode? true
-                       re-frame.testbed.config/repo-root
-                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+                      {re-frame.story.config/static-mode? true}}
    :modules          {:main {:init-fn counter-with-stories.story-static/run}}}
 
   ;; Pattern-WebSocket worked example (rf2-yf97). Canonical worked

--- a/tools/story/spec/013-Static-Build.md
+++ b/tools/story/spec/013-Static-Build.md
@@ -72,6 +72,57 @@ custom downstream build mirroring its `:closure-defines`) sets it to
 `true`. On the JVM the flag is a plain `const` def of `false` so JVM
 tests always operate against the dev-flavoured branch.
 
+### Self-containment: no ambient project-root
+
+A published export must be **self-contained** — it carries no path,
+token, or state derived from the machine that built it. The
+open-in-editor project-root is the one dev-time affordance that could
+otherwise leak such a path:
+
+- The dev testbeds resolve their open-in-editor project-root from the
+  build environment (`re-frame.testbed.config/resolve-project-root`,
+  seeded by the `RF2_TESTBED_PROJECT_ROOT` env var via a
+  `re-frame.testbed.config/repo-root` goog-define). That root is an
+  absolute checkout path — frequently a `C:/Users/<name>/…` home path.
+- A `vscode://`/`cursor://`/`idea://` URI does **not** resolve from a
+  published HTML page anyway, so the affordance is dev-only on a static
+  site.
+
+So the static export is fail-closed on this slot, at two layers:
+
+1. **Build:** the `:story-static/*` build does **not** seed
+   `re-frame.testbed.config/repo-root` from `RF2_TESTBED_PROJECT_ROOT`.
+   Its only `:closure-define` is `static-mode? true`. The `:advanced`
+   compiler inlines goog-define string constants, so omitting the seed
+   keeps the build-machine checkout path out of the bundle string-table
+   entirely. The static entry-point ns
+   (`counter_with_stories/story_static.cljs`) correspondingly passes no
+   `:rf.story/project-root` to `configure!`.
+2. **Runtime:** `re-frame.story.config/set-project-root!` is fail-closed
+   under `static-mode?` — a passed root is ignored (the slot stays
+   `nil`; open-in-editor degrades to the documented missing-root no-op)
+   unless the host has explicitly opted in via
+   `re-frame.story.config/set-allow-static-project-root!`. This is the
+   framework-level guard that protects **every** downstream static
+   export regardless of what its entry-point's `configure!` passes.
+
+A host that genuinely wants a published site to deep-link back into the
+author's editor (an internal docs deploy where the baked absolute root
+is acceptable) flips the opt-in deliberately:
+
+```clojure
+(re-frame.story.config/set-allow-static-project-root! true)   ; before configure!
+(story/configure! {:rf.story/project-root "/abs/checkout/root"})
+```
+
+The opt-in is **distinct** from the dev testbed root helper — passing
+`resolve-project-root`'s result into a static export is exactly the
+accidental-leak case the guard closes.
+
+The sanity test (`npm run test:story-static`, below) builds with a
+sentinel `RF2_TESTBED_PROJECT_ROOT` and asserts the sentinel appears in
+neither `main.js`, `manifest.json`, nor `index.html`.
+
 ## Build target
 
 A new shadow-cljs build, mirroring the per-example pattern under
@@ -170,8 +221,11 @@ npm run test:story-static
 Driven by [`implementation/scripts/check-story-static.cjs`](../../../implementation/scripts/check-story-static.cjs).
 The script:
 
-1. Runs `story-build.cjs` (compile + stage + manifest).
-2. Asserts `index.html`, `main.js`, `manifest.json` are all present.
+1. Runs `story-build.cjs` (compile + stage + manifest) **with a sentinel
+   `RF2_TESTBED_PROJECT_ROOT`** in the build environment.
+2. Asserts `index.html`, `main.js`, `manifest.json` are all present, and
+   that the sentinel checkout path leaked into **none** of them
+   (static-export self-containment — see §Self-containment above).
 3. Spawns `http-server` over the output directory on port 8040.
 4. Drives headless Chromium against `http://127.0.0.1:8040/` and
    verifies:

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -288,13 +288,78 @@
   project-root
   (atom nil))
 
+;; ---- static-export project-root posture (rf2: static-export self-containment)
+;;
+;; The project-root is a DEV-time affordance: it turns a classpath-relative
+;; source-coord into an absolute on-disk path so the open-in-editor chip can
+;; launch the author's editor (`vscode://file/<root>/<file>...`). On a
+;; PUBLISHED static export (`story:build`, `static-mode?` true) that absolute
+;; path is (a) useless — a custom `editor://` URI does not resolve from a
+;; published HTML page — and (b) a leak — it bakes the BUILD machine's
+;; checkout root (often `C:/Users/<name>/...`) into a publicly-served bundle
+;; and into every rendered open-chip `href`.
+;;
+;; So in static mode the project-root is FAIL-CLOSED: `set-project-root!`
+;; ignores it (the slot stays nil; open-in-editor degrades to the same no-op
+;; the spec already documents for a missing root) UNLESS a host has made the
+;; explicit, static-export-aware opt-in below. The opt-in is DISTINCT from the
+;; dev testbed root helper (`re-frame.testbed.config/resolve-project-root`):
+;; that helper exists to wire dev testbeds, and a static export passing its
+;; result is exactly the accidental-leak case this guard closes. A host that
+;; genuinely wants a "published site that links back into the author's editor"
+;; (e.g. an internal docs deploy) flips this opt-in deliberately.
+;;
+;; This is a runtime guard. The static build ALSO drops the `RF2_TESTBED_
+;; PROJECT_ROOT` → `repo-root` goog-define seed (see implementation/
+;; shadow-cljs.edn :story-static/*), so no ambient checkout STRING is inlined
+;; into the advanced bundle in the first place; this guard is the framework-
+;; level defence that protects every downstream static export regardless of
+;; what its entry-point's `configure!` passes.
+
+(defonce
+  ^{:doc "Atom: has a host explicitly opted in to an absolute project-root in
+         static-export mode? Default `false` (fail-closed). When false,
+         `set-project-root!` ignores any project-root under
+         `static-mode?` so a published bundle never bakes a build-machine
+         checkout path into its open-in-editor URIs. A host that wants a
+         published site to deep-link back into its own editor sets this true
+         via `set-allow-static-project-root!` BEFORE `configure!`."}
+  allow-static-project-root?
+  (atom false))
+
+(defn set-allow-static-project-root!
+  "Opt a static-export build IN to an absolute project-root (rf2 static-export
+  self-containment). Default is OFF — in `static-mode?` the open-in-editor
+  project-root is fail-closed so a published bundle ships no build-machine
+  checkout path. Call this (with `true`) BEFORE `configure!` only when the
+  published site is meant to deep-link back into the author's editor and the
+  baked absolute root is acceptable. Has no effect outside static mode
+  (the dev project-root path is unguarded). `nil` resets to off."
+  [allow?]
+  (reset! allow-static-project-root? (boolean allow?))
+  nil)
+
+(defn allow-static-project-root?*
+  "Return whether the static-export project-root opt-in is on."
+  []
+  @allow-static-project-root?)
+
 (defn set-project-root!
   "Replace the project-root prefix. Accepts a string (the on-disk root,
   typically the directory above the classpath source-paths, joined to
   source-coords via `/`), or `nil` (clears the prefix). Story's
-  `configure!` calls this."
+  `configure!` calls this.
+
+  Fail-closed in static-export mode: under `static-mode?` a non-nil
+  project-root is IGNORED (the slot stays nil) unless the host has opted in
+  via `set-allow-static-project-root!`. This stops a published `story:build`
+  bundle from baking the build machine's checkout root into its
+  open-in-editor URIs (rf2 static-export self-containment). Dev builds
+  (`static-mode?` false) are unaffected."
   [p]
-  (reset! project-root (when (and (string? p) (seq p)) p))
+  (let [suppress? (and static-mode? (not @allow-static-project-root?))]
+    (reset! project-root
+            (when (and (not suppress?) (string? p) (seq p)) p)))
   nil)
 
 (defn get-project-root
@@ -738,14 +803,15 @@
   any other config mutation) in one test cannot leak into the next.
 
   Resets, in declaration order:
-  - `global-args`           → `{}`     (Layer 1 of args resolution)
-  - `global-decorators`     → `[]`
-  - `editor`                → `:vscode`
-  - `project-root`          → `nil`
-  - `frame-egress-profiles` → `{}`     (per-(tool,frame) overrides cleared —
-                                        reset directly, no toggle-off fire)
-  - `session-egress-profile`→ `:rf.egress/local-redacted`
-  - `suppressed-counters`   → `{}`
+  - `global-args`                 → `{}`     (Layer 1 of args resolution)
+  - `global-decorators`           → `[]`
+  - `editor`                      → `:vscode`
+  - `project-root`                → `nil`
+  - `allow-static-project-root?`  → `false`  (fail-closed static opt-in)
+  - `frame-egress-profiles`       → `{}`     (per-(tool,frame) overrides cleared —
+                                              reset directly, no toggle-off fire)
+  - `session-egress-profile`      → `:rf.egress/local-redacted`
+  - `suppressed-counters`         → `{}`
 
   Deliberately leaves `toggle-off-callbacks` intact — those are
   load-time module registrations, not per-test state (per rf2-6ez1u)."
@@ -754,6 +820,7 @@
   (reset! global-decorators [])
   (reset! editor :vscode)
   (reset! project-root nil)
+  (reset! allow-static-project-root? false)
   (reset! frame-egress-profiles {})
   (reset! session-egress-profile default-egress-profile)
   (reset! suppressed-counters {})

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -49,3 +49,25 @@
            (share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
     (is (= {:label "Shared" :count 7}
            (share/parse-overrides-param "{:label \"Shared\", :count 7}")))))
+
+(deftest scenario-overrides-token-roundtrips-with-spaced-string-value
+  (testing "the browser-decoded `overrides=` token the share-url-hydrates
+            scenario drives (`{:label \"Shared Label\"}`) parses as a kept
+            override, not a dropped one. A space-bearing string value is the
+            case that exposed the stale pre-rf2-j0hwf `label:\"...\"` wire
+            form (it was classified :dropped), so this pins the EDN-map form."
+    (let [decoded "{:label \"Shared Label\"}"
+          parsed  (share/parse-overrides-param* decoded)]
+      (is (= {:label "Shared Label"} (:overrides parsed))
+          "the spaced-string override is kept")
+      (is (= [] (:dropped parsed))
+          "nothing is dropped — the EDN-map wire form reads cleanly")
+      ;; The URL the scenario sends carries the js/encodeURIComponent form
+      ;; (space → %20, not +); URLSearchParams.get decodes it back to the
+      ;; EDN-map string above. Round-trip the encoder to lock the contract.
+      (let [token (share/build-overrides-token {:label "Shared Label"})]
+        (is (string? token))
+        (is (= {:label "Shared Label"}
+               (share/parse-overrides-param
+                 (js/decodeURIComponent token)))
+            "the CLJS-encoded token round-trips through URLSearchParams-style decode")))))

--- a/tools/story/test/re_frame/story_static_build_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_static_build_cljs_test.cljs
@@ -195,3 +195,64 @@
            (story/variants-of :story.static.seed)))
     (is (= [[:probe/init]]
            (:events (story/variant->edn :story.static.seed/probe))))))
+
+;; ===========================================================================
+;; STATIC-EXPORT SELF-CONTAINMENT — open-in-editor project-root fails closed
+;; ===========================================================================
+;;
+;; A published `story:build` export must not bake the build machine's
+;; checkout root (a `C:/Users/<name>/...`-style absolute path) into its
+;; open-in-editor URIs. The project-root is a DEV-time affordance; under
+;; `static-mode?` `config/set-project-root!` fails closed — a passed root is
+;; ignored (the slot stays nil) unless a host explicitly opts in via
+;; `config/set-allow-static-project-root!`. The dev path (static-mode? false)
+;; is unaffected. This is the compile-level counterpart to the release-mode
+;; sentinel-leak check in `npm run test:story-static`.
+
+(def ^:private sentinel-root
+  "A sentinel absolute checkout root that must NEVER survive into the
+  static-export project-root slot. Shaped like a real build-machine home
+  path so the assertion is meaningful."
+  "C:/Users/leak-sentinel/code/my-app")
+
+(deftest static-mode-suppresses-project-root-by-default
+  (testing "under static-mode?, a passed project-root is ignored — the
+            open-in-editor slot stays nil so no build-machine checkout path
+            leaks into a published bundle's editor URIs"
+    (config/reset-all!)
+    (with-redefs [config/static-mode? true]
+      (config/set-project-root! sentinel-root)
+      (is (nil? (config/get-project-root))
+          "static mode fails closed — the sentinel root is not retained"))
+    (config/reset-all!)))
+
+(deftest static-mode-opt-in-restores-project-root
+  (testing "a host that explicitly opts in via set-allow-static-project-root!
+            keeps the root in static mode — the escape hatch for a published
+            site that deep-links back into the author's editor"
+    (config/reset-all!)
+    (with-redefs [config/static-mode? true]
+      (config/set-allow-static-project-root! true)
+      (config/set-project-root! sentinel-root)
+      (is (= sentinel-root (config/get-project-root))
+          "with the explicit opt-in the root is retained even in static mode"))
+    (config/reset-all!)))
+
+(deftest dev-mode-project-root-unaffected
+  (testing "with static-mode? false (the dev build) the project-root is set
+            verbatim — the guard narrows ONLY static exports, never dev"
+    (config/reset-all!)
+    (is (false? config/static-mode?) "node-test build is dev-flavoured")
+    (config/set-project-root! sentinel-root)
+    (is (= sentinel-root (config/get-project-root))
+        "dev builds keep the root — open-in-editor resolves absolute paths")
+    (config/reset-all!)))
+
+(deftest reset-all-clears-static-opt-in
+  (testing "config/reset-all! restores the static project-root opt-in to its
+            fail-closed default so a test that flips it cannot leak into the
+            next test"
+    (config/set-allow-static-project-root! true)
+    (config/reset-all!)
+    (is (false? (config/allow-static-project-root?*))
+        "opt-in is back to fail-closed after reset-all!")))

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -264,9 +264,18 @@ module.exports = {
 
     await scenario(page, 'share-url-hydrates-variant-modes-and-props', async () => {
       await primeHelpDismissed(page);
+      // rf2-j0hwf switched the `overrides=` wire form from the legacy
+      // `key:value` token to a single pr-str-printed EDN map
+      // (`{:label "Shared Label"}`), percent-encoded as one token. This URL
+      // carries that current form: `URLSearchParams.get("overrides")` decodes
+      // `%7B%3Alabel%20%22Shared%20Label%22%7D` back to `{:label "Shared Label"}`,
+      // which `share/parse-overrides-param*` reads as a map and keeps (the
+      // `:label` key is declared by `:story.counter/loaded`). The pre-rf2-j0hwf
+      // `label:"Shared Label"` token no longer parses as EDN and was being
+      // classified `:dropped`, tripping the degraded-mode banner.
       await gotoStory(
         page,
-        '/counter-with-stories/?variant=story.counter%2Floaded&modes=Mode.app%2Fdark&overrides=label%3A%22Shared%20Label%22#/stories',
+        '/counter-with-stories/?variant=story.counter%2Floaded&modes=Mode.app%2Fdark&overrides=%7B%3Alabel%20%22Shared%20Label%22%7D#/stories',
       );
 
       await waitForCanvas(page, ':story.counter/loaded');

--- a/tools/story/testbeds/counter_with_stories/story_static.cljs
+++ b/tools/story/testbeds/counter_with_stories/story_static.cljs
@@ -29,10 +29,7 @@
             ;; Source the stories ns so all `reg-*` calls fire on namespace
             ;; load. The variant bodies reference views / events / subs by
             ;; id; the stories ns transitively requires them.
-            [counter-with-stories.stories]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
-            ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config]))
+            [counter-with-stories.stories]))
 
 (defn ^:export run
   "Mount the Story shell at `#app`. Idempotent on hot-reload (which
@@ -45,22 +42,21 @@
   ;; stories ns, whose first `reg-*` call auto-installed the canonical
   ;; vocabulary per rf2-p1ydc (audit D-2 / rf2-y8gag).
   ;; Story global configuration — pinned defaults a published docs site
-  ;; can ship with. Locale defaults to :en; the editor preference
-  ;; doesn't matter because the open-in-editor affordance is dev-only
-  ;; (file:// hrefs in a published site are not actionable).
+  ;; can ship with. Locale defaults to :en.
   ;;
-  ;; rf2-r1uod — `:project-root` is plumbed here for parity with
-  ;; the dev-flavoured `core.cljs` entry. In a published static build
-  ;; the open-in-editor chip is effectively dev-only (custom URI
-  ;; schemes don't resolve from a published HTML page), so the slot
-  ;; is harmless in this entry; mirroring the dev entry's wiring
-  ;; keeps the two `run` fns structurally identical and makes future
-  ;; "live-on-static" experiments (e.g. a published site that links
-  ;; back into the author's editor) trivial.
-  ;; rf2-5dphw — project-root derived from the build env (see
-  ;; `re-frame.testbed.config`), not a hardcoded personal path.
-  (story/configure! {:rf.story/global-args  {:locale :en}
-                     :rf.story/project-root (testbed-config/resolve-project-root "tools/story/testbeds")})
+  ;; NO `:rf.story/project-root` here. The project-root is a DEV-time
+  ;; affordance — it builds an absolute on-disk `editor://` URI for the
+  ;; open-in-editor chip, which (a) doesn't resolve from a published HTML
+  ;; page and (b) would bake the BUILD machine's checkout root into a
+  ;; publicly-served bundle. A static export must be self-contained, so it
+  ;; does NOT inherit the dev testbed root helper
+  ;; (`re-frame.testbed.config/resolve-project-root`, which is for dev
+  ;; testbeds) — and the framework guard in `re-frame.story.config/
+  ;; set-project-root!` fails closed in `static-mode?` regardless. A
+  ;; downstream "published site that links back into the author's editor"
+  ;; opts in explicitly via `config/set-allow-static-project-root!` +
+  ;; passing a root; this canonical export does not.
+  (story/configure! {:rf.story/global-args {:locale :en}})
   ;; Seed the live-app's :count slot so any embedded `counter-card`
   ;; view that renders under the variant canvas starts from a
   ;; deterministic value rather than `nil`.


### PR DESCRIPTION
Fixes two P2 story beads (EP-0015 review findings cohort).

## rf2-8q35fw — share-url variant hydration drops the override

The `share-url-hydrates-variant-modes-and-props` browser scenario drove a
stale `overrides=label:"Shared Label"` token — the pre-rf2-j0hwf `key:value`
wire form. rf2-j0hwf switched the `overrides=` payload to a single
pr-str-printed EDN map (`{:label "Shared Label"}`), so the legacy token no
longer parses as EDN: `parse-overrides-edn-map` classified the whole token
`:dropped`, and the runtime rendered the degraded-mode banner ("1 override
from this URL no longer apply — variant args refactored?") instead of
applying the label.

**Root cause:** stale test URL, not a hydration regression. The
hydration/classification path is correct — the existing CLJS e2e
`valid-substrate-and-overrides-still-hydrate` already pins the EDN-map form,
and `:story.counter/loaded` declares `:label`. The scenario URL (authored at
#1214) was never updated when the wire format changed.

**Fix:** update the scenario to the current wire form
(`overrides=%7B%3Alabel%20%22Shared%20Label%22%7D`, which `URLSearchParams`
decodes to `{:label "Shared Label"}`) + a CLJS codec regression pinning that
the spaced-string override round-trips kept-not-dropped, keeping the scenario
URL in sync with the codec.

**Red→green verified:** with the stale origin URL, `npm run
test:story-feature-load` reproduces the bead's exact failure; with the
EDN-map URL it greens.

## rf2-8l0ffk — static export must not inherit testbed-support project-root

The static-export path wired the dev testbed-support project-root helper into
a publishable bundle: the `:story-static/*` build seeded
`re-frame.testbed.config/repo-root` from `RF2_TESTBED_PROJECT_ROOT`, and the
static entry passed `resolve-project-root` into `configure!`. A caller with
that env set while building could bake a machine-local checkout path (often a
`C:/Users/<name>/...` home path) into the static artifact and into rendered
open-in-editor `editor://` hrefs.

**Fix — fail-closed at two layers:**

1. **Build:** the `:story-static/*` build no longer seeds `repo-root` from
   the env var (only `static-mode? true` rides). The advanced compiler
   inlines goog-define string constants, so omitting the seed keeps the
   checkout path out of the bundle string-table entirely. The static
   entry-point passes no `:rf.story/project-root`.
2. **Runtime:** `config/set-project-root!` is fail-closed under
   `static-mode?` — a passed root is ignored (slot stays nil; open-in-editor
   degrades to the documented missing-root no-op) unless the host explicitly
   opts in via `config/set-allow-static-project-root!`. Protects every
   downstream static export regardless of its entry's `configure!`.

Dev builds (`static-mode?` false) are unaffected. `check-story-static.cjs`
now builds with a sentinel `RF2_TESTBED_PROJECT_ROOT` and asserts it leaked
into none of main.js / manifest.json / index.html (verified locally — clean).
CLJS regressions pin the fail-closed / opt-in / dev-unaffected / reset-all
contracts. spec/013 §Self-containment documents the posture.

## Gates
- story JVM tests: 1704 tests / 6305 assertions, 0 failures
- `npm run test:cljs`: 7812 tests / 32358 assertions, 0 failures
- `scripts/test-fast-pr.sh`: PASS
- `npm run test:bundle-isolation`: PASS
- `npm run test:story-feature-load`: 0 failures (share-url scenario green; red→green proven)
- `npm run test:story-static` sentinel-leak scan: clean (main.js / manifest.json / index.html)

## Follow-ups filed (pre-existing, out of scope)
- rf2-oki92v (P2): static-export bundle throws `pageerror: jj` at mount — shell never renders. Reproduced on clean origin/main; predates this work. `test:story-static` is a nightly expensive gate, off the PR critical path.
- rf2-xjd2mi (P3): static bundle bakes absolute source-coord `:file` paths (a distinct mechanism from the project-root leak fixed here).