### PR TITLE
feat(xray): EP-0023 true frame seating + EP-0015 spec vocab (rf2-32siq3.36, rf2-jt88ga)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -485,7 +485,7 @@ labels; the underlying paths now live under the runtime-db partition's
 | `:rf/spawned` | `[:rf.runtime/machines :spawned]` | machine runtime | Declarative-`:spawn` / `:spawn-all` spawn registry — `<parent-id> → {<invoke-id> <slot>}` for the destroy-cascade walker. |
 | `:rf/route` | `[:rf.runtime/routing :current]` | routing runtime | The current route slice `{:route-id :params :query :transition :error}`. |
 | `:rf/pending-navigation` | `[:rf.runtime/routing :pending-navigation]` | routing runtime | Pending-navigation slot populated when a `:can-leave` guard rejects; cleared by `:rf.route/continue` / `:rf.route/cancel`. |
-| `:rf/elision` | `[:rf.runtime/elision]` | elision runtime | Wire-elision declaration registry — `{:declarations {<path> {:large? :hint :source}} :sensitive-declarations {<path> {:sensitive? :hint :source}}}`. Populated at boot from `:large? true` / `:sensitive? true` schema slots; consulted by `rf/elide-wire-value` at every wire-boundary emit. Schemas are the only nomination path. |
+| `:rf/elision` | `[:rf.runtime/elision]` | elision runtime | Wire-elision declaration registry — `{:declarations {<path> {:large? :hint :source}} :sensitive-declarations {<path> {:sensitive? :hint :source}}}`. Hydrated at `reg-frame` time from the **frame-owned** `:sensitive {:app-db …}` / `:large {:app-db …}` path-map declarations (installed by `re-frame.frame-classification` under `:source :frame`, Spec 015 §Frame-owned durable classification); consulted by `rf/elide-wire-value` at every wire-boundary emit. Durable app-db classification is frame-owned, NOT a schema-slot route — per [Spec 015 §Schemas describe shape](../../../spec/015-Data-Classification.md), a `reg-app-schema` `{:sensitive? true}` slot prop is no longer a nomination path into this registry (machine `:data-schema` props and schema-validation-failure redaction are separate, schema-owned surfaces). |
 
 Conventions is the canonical home; this table is the panel-facing
 projection. The `runtime-areas` lookup in `app_db_diff_helpers.cljc`
@@ -532,10 +532,15 @@ questions.
 
 Per [Spec 015 §Data Classification](../../../spec/015-Data-Classification.md)
 and [Security §Epoch privacy posture](../../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress),
-an app-supplied epoch `:redact-fn` may substitute the `:rf/redacted`
-sentinel into `:db-before` / `:db-after` to keep sensitive material out
-of recorded records. When the underlying value at a redacted path
-actually changed across a cascade, the structural diff correctly sees
+the panel renders the projected view of an epoch, and any value that the
+observed frame declared `:sensitive` is substituted by the `:rf/redacted`
+sentinel through **egress projection** (`project-egress` keyed on the
+observed frame) — never by mutating the stored record. Per Spec 015 §6
+(Epoch projection — no storage-side mutation), raw epoch records remain
+in-process and the legacy storage-side `(rf/configure! :epoch-history
+{:redact-fn …})` hook is gone; projection at the export / on-box-render
+boundary is the normal answer. When the underlying value at a redacted
+path actually changed across a cascade, the structural diff correctly sees
 `:rf/redacted` = `:rf/redacted` and emits no row — the elision
 contract is preserved (per `diff/engine.cljc` §Sentinel-aware
 modified handling). The developer is left with an empty diff and no
@@ -557,26 +562,28 @@ count is 0.
 threads an exact `:rf.epoch/redacted-modified-paths-count` integer on
 the epoch record (per
 [Spec-Schemas §`:rf/epoch-record`](../../../spec/Spec-Schemas.md#rfepoch-record)).
-Computed inside `re-frame.epoch.assembly/build-record` from raw
-db-before / db-after values BEFORE the `:redact-fn` runs — parallel to
+Computed inside `re-frame.epoch.assembly/build-record` from the raw,
+in-process db-before / db-after values (no storage-side mutation runs;
+projection happens only at egress / render) — parallel to
 the `:rf.epoch/sensitive?` rollup. A path `P` counts in the framework's
 figure when:
 
-1. `P` is schema-declared sensitive (`[:rf.runtime/elision :sensitive-declarations]`
+1. `P` is frame-declared sensitive (`[:rf.runtime/elision :sensitive-declarations]`
    in the runtime-db partition, EP-0001 rf2-vzld77,
-   populated from `{:sensitive? true}` per-slot schema props per
-   [Spec 015](../../../spec/015-Data-Classification.md)).
+   hydrated from the frame's `:sensitive {:app-db …}` path-map declarations
+   under `:source :frame` per
+   [Spec 015 §Frame-owned durable classification](../../../spec/015-Data-Classification.md)).
 2. `(not= (get-in db-before P) (get-in db-after P))` — value-equality
-   on the raw (pre-redact-fn) dbs.
+   on the raw (unprojected) in-process dbs.
 
 This is the **exact** count of declared-sensitive paths that mutated
 this cascade. Xray reads it directly from the record; no walk, no
 heuristic.
 
 **Heuristic fallback (rf2-bz1cl).** Records that lack the egress slot
-(legacy snapshots, hand-rolled test fixtures, hosts with no schema
-layer that produces a sensitive-declarations registry) fall back to a
-Xray-side heuristic — paths `P` where:
+(legacy snapshots, hand-rolled test fixtures, hosts whose frames declared
+no `:sensitive {:app-db …}` classification, so no sensitive-declarations
+registry exists) fall back to a Xray-side heuristic — paths `P` where:
 
 1. `(= :rf/redacted (get-in db-before P))`, AND
 2. `(= :rf/redacted (get-in db-after  P))`, AND

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1027,7 +1027,7 @@ The category table below is retained as the canonical **"what counts as an issue
 |---|---|---|
 | **JS exceptions** | uncaught errors; React lifecycle exceptions; promise rejections at handler scope | red; full stack-trace in the Epoch panel's "Exception Thrown" block |
 | **Schema violations** | Malli registration on app-db / event-args / sub-output | yellow; offending path + expected vs actual in the Epoch EFFECT HANDLERS step |
-| **Sensitive-data warnings** | `:rf/redacted` paths that escaped via `console.error` before marking applied · per-marking-site mark-misses (an `add-marks` / `set-marks` path pointing to nothing — typo detection) | magenta; marker-aware so the warning itself doesn't leak the value |
+| **Sensitive-data warnings** | `:rf/redacted` paths that escaped via `console.error` before classification applied · per-declaration classification-misses (a frame `:sensitive {:app-db …}` / registration `:sensitive` path pointing at nothing — typo detection) | magenta; marker-aware so the warning itself doesn't leak the value |
 | **Hydration mismatches** | SSR-only; mismatched server/client tree | yellow; node path + server vs client text |
 | **Perf-budget overruns** | cascades exceeding configured perf budget | orange; actual vs budget + cascade-id |
 | **App console errors/warns** | host app's `console.error` / `console.warn` calls (captured via hook) | dim grey (advisory); raw text |
@@ -1669,7 +1669,7 @@ Xray CONSUMES the contract specified in [spec/015-Data-Classification](../../../
 
 | Sentinel | Xray renders | Drillable? | Hover tooltip discloses | Click affordance |
 |---|---|---|---|---|
-| `:rf/redacted` (bare) | `[● REDACTED 1]` magenta | NO | Path of redaction · mark source (`add-marks` / `set-marks` / event-handler / sub / fx / cofx / machine / flow) · local count | One-way disclosure of STRUCTURE only (path + source). **NO "reveal value" button.** **NO fetch handle.** The value is GONE at the source. |
+| `:rf/redacted` (bare) | `[● REDACTED 1]` magenta | NO | Path of redaction · mark owner (frame / event-handler / sub / fx / cofx / machine / flow / resource) · local count | One-way disclosure of STRUCTURE only (path + owner). **NO "reveal value" button.** **NO fetch handle.** The value is GONE at the source. |
 | `:rf/redacted {:bytes N}` | `[● REDACTED · N bytes]` magenta | NO | Same as above + size | Same as above; size disclosed (helps debug "is the redacted thing big enough to be the problem?") |
 | `:rf.size/large-elided {:path [...] :bytes N :type <kw> :reason :schema :hint "…" :handle [:rf.elision/at <path>]}` | `[● ELIDED · N bytes]` yellow | YES | Path · mark source · byte size · `:hint` text · `:type` (`:map`/`:vector`/`:set`/`:string`/`:scalar`) | Popover with `:hint` text + **"Fetch full value" button**. Fetch routes via `get-path` per [Tool-Pair.md](../../../spec/Tool-Pair.md) (round-trips the marker's `:handle`). Size-warned via confirm modal when bytes > threshold (default 100KB). |
 
@@ -1723,21 +1723,23 @@ Without the modal, large drill-ins can blow out the renderer and degrade INP. Th
 
 - **No "reveal redacted value" button.** Ever. The only path to seeing sensitive payloads is the host-level opt-in `(xray-config/configure! {:rf.xray/egress-profile :rf.egress/local-raw})` — the EP-0015 trusted-local per-`(tool, frame)` reveal grain, a deliberate code-level act gating FUTURE events. The walker drops the value before the trace bus buffers it; the value is unrecoverable at render time. Drop-and-forget is the contract.
 - **No fetch button for `:rf/redacted`.** Distinguishes from `:rf.size/large-elided`. The two sentinels MUST have different affordances.
-- **No schema-based marking** (rejected per [spec/015](../../../spec/015-Data-Classification.md)). Xray renders sentinels from the seven first-class marking sites only.
 
-### The seven first-class marking sites (framework contract; Xray consumes)
+### The owner-classification model (framework contract; Xray consumes)
 
-Per [spec/015-Data-Classification](../../../spec/015-Data-Classification.md):
+Per [spec/015-Data-Classification §The ownership split](../../../spec/015-Data-Classification.md) — classification is attached to whoever owns the data shape. This **supersedes** the earlier "seven first-class marking sites" framing and the public `add-marks` / `set-marks` app-db surface. Xray consumes the resulting sentinels; it renders them identically regardless of owner.
 
-1. **Event handler** (`reg-event`) — `{:sensitive [paths]}` on the registration map.
-2. **App-db** (per frame) — `(rf/add-marks <frame-id> {path mark, ...})` (additive merge) or `(rf/set-marks <frame-id> {path mark, ...})` (replace wholesale).
-3. **Subscription** — output marking via `{:sensitive [paths]}` or whole-output `{:sensitive? true/false}` override. Default = propagate from sensitive input paths.
+1. **Frame** (`reg-frame`) — durable frame-wide facts classified by the frame's `:sensitive {:app-db …}` / `:large {:app-db …}` path maps (and `:sensitive {:http {…}}` carriers). This is the durable app-db classification path; schema-attached app-db classification and the imperative `add-marks` / `set-marks` surface are removed.
+2. **Event handler** (`reg-event`) — `{:sensitive [paths]}` on the registration map (event-arg transient payloads).
+3. **Subscription** — output classification via `{:sensitive [paths]}` and the closed `:rf.egress/output-sensitivity` declassification claim (`:rf.egress/inherit` default · `:rf.egress/sensitive` force-mark · `:rf.egress/public` declassify). Sensitivity propagates from sensitive input paths unless declassified.
 4. **Effect** (`reg-fx`) — input marking on the fx-args.
 5. **Coeffect** (`reg-cofx`) — injection marking.
-6. **State machine** (`reg-machine`) — `:data` slot path marking.
-7. **Flow** (`reg-flow`) — output marking + propagation override.
+6. **State machine** (`reg-machine`) — schema-first `:data` slot props (`:sensitive?` / `:large?` on the `:data-schema`; EP-0005 composition, not the frame path-map mechanism).
+7. **Flow** (`reg-flow`) — output marking + the same `:rf.egress/output-sensitivity` declassification claim subs honour.
+8. **Resource / mutation** (`reg-resource` / `reg-mutation`) — durable runtime-subsystem state classified by per-slot `:sensitive?` / `:large?` props on the `:data-schema` / `:params-schema` (the shared EP-0005 schema mechanism).
 
-Xray's renderer is the same regardless of which site marked the value — it sees the sentinel and renders per the table above. The mark site is disclosed in the hover tooltip so the user can trace "where did this redaction come from?" without revealing the value itself.
+Schemas describe **shape**, not durable app-db egress policy: a `reg-app-schema` `{:sensitive? true}` slot prop is **not** a route into app-db classification (Spec 015 §Schemas describe shape). Per-slot schema props are the classification surface only for the owners whose natural declaration is a schema (machines, resources, HTTP bodies).
+
+Xray's renderer is the same regardless of which owner marked the value — it sees the sentinel and renders per the table above. The mark owner is disclosed in the hover tooltip so the user can trace "where did this redaction come from?" without revealing the value itself.
 
 ---
 

--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -273,18 +273,41 @@ the target's registration set.
 > Xray runs in its own frame. Xray inspects the target frame. That keeps the
 > inspection tool from becoming part of the thing being inspected.
 
-**Scope (honest claim, rf2-32siq3.35).** What is realized today is the
-**CONSTRUCT-and-PROVE** half: Xray builds its OWN real `rf/image` (a separate
-registration-set value) and the implementation **proves** it
-registration-disjoint from a target frame's image. The running Xray shell is
-NOT yet SEATED in a frame built from that image via `rf/make-frame` — Xray
-still runs on the ambient registrar like any other surface. Actually seating
-Xray in its own frame is deferred follow-up (**rf2-32siq3.36**). So the claim is
-"Xray's instruction set is a separate image, provably non-overlapping with the
-target's" — the image VALUE plus the proven disjointness — not the full "Xray
-runs in its own frame" runtime. With the strengthened proof (below) the
-**isolation** claim is true; only the "runs-in-its-own-frame" claim is scoped
-down to construct-and-prove.
+**Scope (runtime self-seating shipped as a callable; production-singleton flip
+deferred).** The dogfood now has a working RUNTIME arm: Xray
+builds its OWN real `rf/image` (a separate registration-set value), the
+implementation **proves** it registration-disjoint from a target frame's image,
+AND `image_view_reads/seat-xray-frame!` **SEATS a running Xray frame built from
+that image** via `rf/make-frame {:images [(xray-image)]}` — true runtime
+self-seating in genuine registration ISOLATION (the seated frame resolves ONLY
+Xray's `:rf.xray/*` registrations plus the framework standards the assembly
+unions into every generation, not the shared default registrar). This is the
+literal `(rf/make-frame {:id … :images [(xray-image)] …})` shape the EP names,
+shipped as a tested, callable seam.
+
+The seating preserves the `:rf.trace/frame-no-emit?` gate that keeps
+Xray's own reactivity out of the trace ring it inspects: `make-frame` is the
+EP-0023 OBJECT constructor and honours only the frame-creation opts (`:images` /
+`:id` / `:initial-db` / …), rejecting the record-config flag, so the gate is set
+directly through `re-frame.trace/set-frame-no-emit!` (the same canonical seam
+`reg-frame` routed it through) — asserted on every seat / re-seat. The seating is
+idempotent: `make-frame {:id …}` is fail-loud on a duplicate live `:id`, so a
+re-open / hot-reload / repeated testbed mount finds the frame already live
+(`xray-frame-seated?`) and skips the re-create, re-asserting only the gate.
+
+**What is deferred.** The default production-singleton mount path
+(`mount/ensure-xray-frame!`) is NOT yet flipped onto `seat-xray-frame!`; it keeps
+the legacy realm seating (`reg-frame {:rf.trace/frame-no-emit? true}`) for now.
+The blocker is the image selector grain: `xray-image`'s `day8.re-frame2-xray.**`
+glob sweeps in Xray's OWN `*-cljs-test` namespaces in any dev/test build that
+loads them, and those tests co-register `:rf.xray/*` ids (e.g.
+`[:fx :rf.editor/open]` from both `open-in-editor` and `open-in-editor-cljs-test`)
+— so assembling the image fails loud (`:rf.error/image-duplicate-id`) under the
+node-test build. The seating-core seam is therefore exercised against an explicit
+descriptor pool (deterministic, no test-ns sweep), and the production flip waits
+on a test-namespace-excluding image selector. The disjointness claim is true and
+proven (below) regardless; only the default-singleton flip is scoped to a
+follow-on.
 
 Xray therefore models its registration set as a **separate image**, NOT as
 shared registration state:
@@ -371,9 +394,10 @@ does not flip `:images?` (there is no image content to show).
 - `panels/image_view_reads.cljs` — the READ-TIME fail-soft live read seam
   (`live-frames` · `resolve-descriptor` · `image-view-data`) over the EP-0023
   core surfaces (`re-frame.live-frame` / `re-frame.image` /
-  `re-frame.image-assembly`), PLUS the Xray-as-its-own-image constructor
-  (`xray-image` · `xray-image-id` · `xray-source-glob` · `resolver-keyset` ·
-  `application-resolver-keyset` · `xray-image-isolated-from?`).
+  `re-frame.image-assembly`), PLUS the Xray-as-its-own-image constructor +
+  SEATING (`xray-image` · `xray-image-id` · `xray-source-glob` ·
+  `resolver-keyset` · `application-resolver-keyset` · `xray-image-isolated-from?`
+  · `xray-frame-seated?` · `seat-xray-frame!`).
   `resolver-keyset` is the full `[kind id]`-keyset reader (every resolved
   registration, framework standards included — what the FRAMES section
   displays); `application-resolver-keyset` is the application-owned subset
@@ -381,13 +405,26 @@ does not flip `:images?` (there is no image content to show).
   every generation — rf2-32siq3.41) that the disjointness predicate compares;
   `xray-image-isolated-from?` assembles both images and compares those
   application-owned keysets (live-store + explicit-pool arities, fail-soft to a
-  conservative `false`). Xray may require these core
+  conservative `false`). `seat-xray-frame!` is the TRUE runtime seating
+  (EP-0023 §Xray Beside The Target): `rf/make-frame {:id frame-id :images
+  [(xray-image)]}` (live-store + explicit-pool arities) +
+  `re-frame.trace/set-frame-no-emit!` for the
+  trace gate, guarded by `xray-frame-seated?` (a live-frame registry probe) for
+  idempotency on re-seat. Xray may require these core
   namespaces directly — bundle isolation forbids `implementation/` requiring
   from `tools/`, not the reverse, the same pattern Xray uses for
-  `re-frame.frame` / `re-frame.registrar`. (The read seam's fail-soft is
-  READ-TIME robustness, not absent-core-surface tolerance: the core EP-0023
-  namespaces are hard-`:require`d, so an old core fails at LOAD before the
-  try/catch.)
+  `re-frame.frame` / `re-frame.registrar` / `re-frame.trace`. (The read seam's
+  fail-soft is READ-TIME robustness, not absent-core-surface tolerance: the core
+  EP-0023 namespaces are hard-`:require`d, so an old core fails at LOAD before
+  the try/catch.) `seat-xray-frame!` + `xray-frame-seated?` are covered by
+  `image_view_reads_cljs_test` (seats against an explicit pool; asserts the
+  seated frame resolves ONLY Xray's app-owned ids, the trace-no-emit gate is
+  set, and re-seat is idempotent — no duplicate-`:id` throw).
+- `mount.cljs/ensure-xray-frame!` — currently keeps the legacy realm seating
+  (`reg-frame {:rf.trace/frame-no-emit? true}`) for the production singleton.
+  The flip onto `seat-xray-frame!` waits on a test-namespace-excluding image
+  selector (the `day8.re-frame2-xray.**` glob sweeps Xray's own `*-cljs-test`
+  registrations in dev/test builds → a fail-loud assembly collision); see §8.1.
 - `panels/module_view.cljs` — extended with the FRAMES section (`frame-row` ·
   `descriptor-rows` · `frames-section-body`) + the `:rf.xray/image-view` sub.
 - Tests: `panels/image_view_helpers_cljs_test.cljc` (the generation/image

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -822,8 +822,10 @@ panel-side trace collector + `snapshot-from-rings` honour via
 `config/suppress-sensitive?` (rf2-to36uj).
 
 `egress-value` also takes an optional `:path` — the **absolute** app-db
-path the value sits at. The framework's schema-declared sensitive / large
-declarations are keyed by absolute path, so a slice egress'd in isolation
+path the value sits at. The framework's frame-owned app-db sensitive / large
+declarations (the `:sensitive {:app-db …}` / `:large {:app-db …}` path maps
+declared on `reg-frame`, Spec 015 §Frame-owned durable classification) are
+keyed by absolute path, so a slice egress'd in isolation
 (a `:path`-scoped `get-app-db` read, or one changed-path slice from
 `get-app-db-diff`) MUST tell the walker where the slice lives or the
 declaration won't match and the raw leaf would cross the boundary
@@ -848,8 +850,8 @@ which writes the copied value to the system clipboard via the
 `:rf.xray.fx/copy-to-clipboard` fx — an off-box sink. The event routes the
 value through `egress-value` **before** the clipboard write, pinned to the
 **observed** frame (`[:focus :frame]`, falling back to `:target-frame`) so
-that frame's own schema declarations govern — a `{:sensitive? true}` slot
-copies as `:rf/redacted`, a `{:large? true}` blob as `:rf.size/large-elided`,
+that frame's own classification governs — a slot the frame declared
+`:sensitive` copies as `:rf/redacted`, a `:large` slot as `:rf.size/large-elided`,
 fail-closed (mirroring the snapshot's `with-frame` pinning, rf2-mxzgg).
 The sibling `:rf.xray/copy-path-to-clipboard` copies only the path vector
 (key names, no values), so it is not a value-egress site and is not
@@ -863,7 +865,7 @@ gate is reachable only through the runtime accessors.
 |---|---|---|---|
 | `get-trace-buffer` | `get-trace-buffer` | `{:ok? true :events <vec> :count <n>}` | `trace-tooling/trace-buffer` — filtered slice of the trace stream. Filter keys are the canonical Spec 009 vocabulary (`:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`). Whole `:sensitive? true` events are default-SUPPRESSED before value-scrubbing — the envelope is dropped unless `{:include-sensitive? true}` (rf2-to36uj). |
 | `get-epoch-history` | `get-epoch-history` | `{:ok? true :frame <id> :epochs <vec> :count <n>}` | `rf/epoch-history` per-frame vector of `:rf/epoch-record`, each routed through `egress-record` → `projected-record`. `:include-sensitive?` / `:include-large?` opt the **app-db** partition's privacy / size posture back in; the frame-state `:rf.db/runtime` partition stays `:rf/redacted` unless a trusted-local caller also passes `:include-runtime-db? true` (rf2-5w06uu). |
-| `get-app-db` | `get-app-db` | `{:ok? true :frame <id> :path <vec> :value <edn>}` | `rf/app-db-value` (optionally scoped by `:path`). The `:value` routes through `egress-value`; when `:path` is supplied the absolute path is threaded into the walker so a scoped slice elides against schema-declared sensitive / large paths — fail-closed, symmetric with the whole-db read and the `get-app-db-diff` slices (rf2-a96xq). |
+| `get-app-db` | `get-app-db` | `{:ok? true :frame <id> :path <vec> :value <edn>}` | `rf/app-db-value` (optionally scoped by `:path`). The `:value` routes through `egress-value`; when `:path` is supplied the absolute path is threaded into the walker so a scoped slice elides against the frame-owned `:sensitive` / `:large` app-db declarations — fail-closed, symmetric with the whole-db read and the `get-app-db-diff` slices (rf2-a96xq). |
 | `get-app-db-diff` | `get-app-db-diff` | `{:ok? true :frame <id> :epoch-id <uuid> :diff {:added [{:path :value}] :removed [{:path :value}] :changed [{:path :before :after}]}}` | Projects the changed-paths slice diff between a named epoch's `:db-before` + `:db-after` via the canonical Editscript-A* engine (`diff.engine/project`). Only the changed paths' slices egress — each `:value` / `:before` / `:after` routed through `egress-value`, never two whole app-db snapshots (rf2-uv2q2). Heavier nested-diff projection lives MCP-side. |
 | `get-machine-state` | `get-machine-state` | `{:ok? true :frame <id> :machine-id <kw> :state <live-state-path> :snapshot {:state :data :tags …} :spec <registered-definition>}` | The LIVE FSM position — reads the machine's snapshot from the frame's **runtime-db partition** at `[:rf.runtime/machines :snapshots <machine-id>]` (EP-0001 rf2-vzld77 — machine snapshots are durable runtime-db state; the same slot the Machine Inspector's `:rf.xray/machine-snapshots` sub + the framework resolver read). `:state` is the running state-path (a region→state map for a `:parallel` machine — Spec 005), NOT derived from the static spec; the registered definition is returned separately under `:spec`. A registered-but-not-yet-started machine has no live snapshot — `:state` / `:snapshot` are `nil` and `:reason` is `:not-yet-started` (still `:ok? true`). **Partition-aware off-box redaction (rf2-jj1xer · Mike ruling #14):** `:state` / `:snapshot` are RUNTIME-DB state, so they egress through `egress-runtime-db-value` and are REDACTED to `:rf/redacted` off-box by default; a trusted-local caller opts in with `:include-runtime-db? true` (the inner walk then honours per-slot sensitive / large declarations). `:spec` is a static registry value (not runtime-db), so it egresses through `egress-value` regardless of the runtime-db opt-in. |
 | `get-machine-list` | `get-machine-list` | `{:ok? true :machines <map> :count <n>}` | `rf/machines` — map keyed by machine-id. |

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -368,6 +368,12 @@
   calls are surgical no-ops on the frame side and (per each hook's own
   idempotency contract) no-ops on the hook side.
 
+  EP-0023 §Xray Beside The Target (rf2-32siq3.36): the true image-loaded
+  seating (`rf/make-frame {:images [(xray-image)]}`) ships as the proven,
+  tested `image-view-reads/seat-xray-frame!` callable, but is NOT yet flipped
+  onto this default singleton path — see the body for the test-namespace-
+  collision blocker that gates the flip.
+
   ## `frame-id` arg (rf2-lnluk)
 
   Defaults to `shell/default-frame-id` (`:rf/xray`) — the production
@@ -451,6 +457,19 @@
    ;; the frame-scoped sibling of the handler-scoped `:rf.trace/no-
    ;; emit?`; the framework's `reg-frame` honours it on every (re-)
    ;; registration so the gate survives hot-reload.
+   ;;
+   ;; EP-0023 §Xray Beside The Target (rf2-32siq3.36) — true image-loaded
+   ;; SEATING of this singleton via `image-reads/seat-xray-frame!` (the
+   ;; `rf/make-frame {:images [(xray-image)]}` path) is SHIPPED + proven as a
+   ;; callable, tested seating-core, but is NOT yet flipped onto this default
+   ;; production-singleton path. The `day8.re-frame2-xray.**` image glob sweeps
+   ;; in Xray's OWN `*-cljs-test` namespaces in any dev/test build that loads
+   ;; them, colliding on shared `:rf.xray/*` ids (e.g. `[:fx :rf.editor/open]`
+   ;; co-registered by `open-in-editor` + `open-in-editor-cljs-test`) → a
+   ;; fail-loud `:rf.error/image-duplicate-id` at assembly. Flipping the
+   ;; singleton needs a test-ns-excluding image selector (a follow-on); until
+   ;; then the singleton keeps the legacy realm seating below, while
+   ;; `seat-xray-frame!` is the proven runtime self-seating callable.
    (rf/reg-frame frame-id {:rf.trace/frame-no-emit? true})
    (doseq [{:keys [handler]} @first-mount-hooks]
      (handler frame-id))))

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -141,14 +141,14 @@
 ;;
 ;; ## Why the egress runs inside `(rf/with-frame tf …)`
 ;;
-;; `egress-value` (→ `elide-wire-value`) resolves the schema-declared
-;; sensitive / large declarations from `frame/current-frame` when no
+;; `egress-value` (→ `elide-wire-value`) resolves the frame-owned
+;; sensitive / large app-db declarations from `frame/current-frame` when no
 ;; explicit `:frame` opt is passed. The snapshot reads the FOCUSED
 ;; frame's db (`tf`), which is NOT necessarily the frame the fx fires
 ;; in (the palette dispatches against `:rf/xray`). Pinning the current
 ;; frame to `tf` for the egress makes the walker match `tf`'s OWN
 ;; declarations — so a host frame's `[:auth :token]` redacts against
-;; the host frame's schema, not the (empty) Xray-frame declarations.
+;; the host frame's classification, not the (empty) Xray-frame declarations.
 ;; Fail-closed: a frame with no declarations still emits the raw value
 ;; only when that frame declared nothing sensitive, exactly as the
 ;; per-frame contract intends.

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs
@@ -62,6 +62,7 @@
             [re-frame.live-frame :as live-frame]
             [re-frame.image :as image]
             [re-frame.image-assembly :as image-assembly]
+            [re-frame.trace :as trace]
             [day8.re-frame2-xray.panels.image-view-helpers :as h]))
 
 ;; ===========================================================================
@@ -126,17 +127,14 @@
   PURE: `rf/image` is data, not registration (no realm, no registrar, no side
   effect).
 
-  This is the CONSTRUCT-and-PROVE half of the dogfooding the EP names: Xray
-  builds its OWN registration-set value (a SEPARATE image, not shared
-  registration state) and `xray-image-isolated-from?` proves it
-  registration-disjoint from a target frame's image. The returned image value
-  is Xray's instruction set; it never mixes with a target frame's image, and
-  the target frame is inspected as DATA through the live-read fns. To SEAT a
-  running Xray in a frame built from this image one would construct
-  `(rf/make-frame {:id :rf.xray/main :images [(xray-image)] :initial-db
-  {:rf.xray/target <target-frame-id>}})` — that seating is deferred follow-up
-  (rf2-32siq3.36); what this fn realizes is the image VALUE and (via the
-  isolation predicate) the proven disjointness, not the seated runtime.
+  This is the registration-set value the dogfooding seats: Xray builds its OWN
+  registration-set value (a SEPARATE image, not shared registration state),
+  `xray-image-isolated-from?` proves it registration-disjoint from a target
+  frame's image, and `seat-xray-frame!` SEATS a running Xray frame on it (true
+  runtime self-seating — Xray runs in its own image-loaded frame, not the legacy
+  shared registrar). The returned image value is Xray's instruction set; it
+  never mixes with a target frame's image, and the target frame is inspected as
+  DATA through the live-read fns.
 
   Returns the normalized inert image value (`:rf.image/id` /
   `:rf.image/include-ns` / …)."
@@ -229,3 +227,77 @@
        (empty? (set/intersection (application-resolver-keyset xray-gen)
                                  (application-resolver-keyset target-gen))))
      (catch :default _ false))))
+
+(defn xray-frame-seated?
+  "True iff a live frame is already registered under `frame-id` in the EP-0023
+  process-local live-frame registry — the idempotency probe `seat-xray-frame!`
+  reads to avoid the fail-loud duplicate-`:id` gate on re-seat (re-open,
+  hot-reload, repeated testbed mount). Pure read of the registry snapshot."
+  [frame-id]
+  (some? (live-frame/live-frame frame-id)))
+
+(defn seat-xray-frame!
+  "SEAT a running Xray frame in its OWN EP-0023 image-loaded frame — the TRUE
+  runtime dogfood (EP-0023 §Xray Beside The Target, rf2-32siq3.36). This is the
+  runtime counterpart to `xray-image` (the image VALUE) and
+  `xray-image-isolated-from?` (the proven disjointness): Xray runs in genuine
+  registration ISOLATION from the inspected target — its `:rf.xray/*`
+  registrations are resolved through the frame's OWN sealed image generation
+  (built from `(xray-image)`), never the shared default registrar.
+
+  Replaces the legacy realm seating (`reg-frame frame-id {:rf.trace/frame-no-
+  emit? true}`), which produced the shell frame against the process-global
+  registrar and relied on id-collision-avoidance. Here the frame resolves ONLY
+  Xray's image (plus the framework-standard registrations the assembly unions
+  into every generation) — the EP's literal `(rf/make-frame {:id … :images
+  [(xray-image)] …})` shape.
+
+  ## Idempotency
+
+  `make-frame {:id …}` is fail-loud on a duplicate live `:id` (EP-0023 §Id
+  Spaces — `:rf.error/live-frame-id-conflict`), so the seating runs ONLY when
+  `frame-id` is not already live (`xray-frame-seated?`). A re-open / hot-reload /
+  repeated testbed mount that finds the frame already seated SKIPS the
+  `make-frame` and just re-asserts the trace-emission gate below (the per-frame
+  app-db seeding is the caller's idempotent first-mount-hook chain, not this
+  fn's job).
+
+  ## Trace-emission gate (rf2-2qaqh — preserved)
+
+  `make-frame` is the EP-0023 OBJECT constructor: it honours only the
+  frame-creation opts (`:images` / `:id` / `:initial-db` / …) and would reject
+  the record-config `:rf.trace/frame-no-emit?` flag. That flag is frame-scoped
+  trace state owned by `re-frame.trace`, keyed by frame-id independently of the
+  generation, so it is set DIRECTLY via `trace/set-frame-no-emit!` — the same
+  canonical seam `reg-frame` routes the flag through. Asserted on EVERY call
+  (seat or re-seat) so a hot-reload never drops the gate that keeps Xray's own
+  reactive substrate from flooding the trace ring it inspects.
+
+  `frame-id` is the shell frame id (`:rf/xray` for the production singleton, a
+  distinct id for a second testbed shell). Two arities mirror the other EP-0023
+  seams here:
+
+    (seat-xray-frame! frame-id)
+      seat against the LIVE source store (the production runtime: where
+      `register-xray-handlers!` registers Xray's `:rf.xray/*` instruction set).
+
+    (seat-xray-frame! frame-id pool)
+      seat against an EXPLICIT descriptor `pool` (the deterministic test/harness
+      form `make-frame`'s 2-arity takes — does not depend on what the live store
+      carries).
+
+  Returns the live frame OBJECT on a fresh seat, or nil on a re-seat skip."
+  ([frame-id] (seat-xray-frame! frame-id ::live))
+  ([frame-id pool]
+   (let [already? (xray-frame-seated? frame-id)
+         opts {:id frame-id :images [(xray-image)]}
+         obj (when-not already?
+               (if (= pool ::live)
+                 (live-frame/make-frame opts)
+                 (live-frame/make-frame opts pool)))]
+     ;; Frame-scoped trace gate (rf2-2qaqh): mark the shell frame a tool /
+     ;; inspector frame so its own `:rf.sub/run` / `:rf.view/render` reactivity
+     ;; does NOT flood the shared trace ring it inspects. Independent of the
+     ;; image generation, so set on both fresh seat and re-seat.
+     (trace/set-frame-no-emit! frame-id true)
+     obj)))

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -291,7 +291,9 @@
       (egress-value v {:include-sensitive? true}) ; opt back in
 
   Optional `:path` — the ABSOLUTE app-db path the value sits at. The
-  framework's schema-declared sensitive / large declarations are keyed
+  framework's frame-owned app-db sensitive / large declarations (the
+  `:sensitive {:app-db …}` / `:large {:app-db …}` path maps on `reg-frame`,
+  Spec 015 §Frame-owned durable classification) are keyed
   by absolute path, so a SLICE egress'd in isolation (e.g. one
   changed-path slice from `get-app-db-diff`, or a `:path`-scoped
   `get-app-db` read) must tell the walker where the slice lives or the
@@ -638,8 +640,8 @@
   scoped by `:path`. Routes through `elide-wire-value` (MUST-inventory
   row #19 — direct-read privacy posture). When `:path` is supplied the
   absolute path is threaded into the egress walker so a scoped slice is
-  elided against schema-declared sensitive / large paths (keyed by
-  absolute path) — fail-closed, symmetric with the whole-db read and
+  elided against the frame-owned `:sensitive` / `:large` app-db declarations
+  (keyed by absolute path) — fail-closed, symmetric with the whole-db read and
   the `get-app-db-diff` slices (rf2-a96xq). Returns
   `{:ok? true :frame <id> :path <vec> :value <edn>}` or
   `{:ok? false :reason :no-frame-resolved}`."
@@ -655,8 +657,9 @@
           :frame fid
           :path  (vec path)
           ;; Thread the ABSOLUTE app-db `:path` into the egress walker so
-          ;; a `:path`-scoped slice is elided against schema-declared
-          ;; sensitive / large paths (keyed by absolute path) — without
+          ;; a `:path`-scoped slice is elided against the frame-owned
+          ;; `:sensitive` / `:large` app-db declarations (keyed by absolute
+          ;; path) — without
           ;; it the walker starts the sliced value at root `[]` and a
           ;; declaration registered for e.g. `[:auth :password]` never
           ;; matches a direct read of `{:path [:auth :password]}`, leaking
@@ -695,8 +698,9 @@
   trust-boundary override the sibling accessors expose, and the resolved
   `:frame` so every slice projects under that frame's classification
   (EP-0015 frame-owned egress, rf2-5b2ct2) rather than the ambient scope.
-  Each slice is egress'd at its ABSOLUTE leaf `:path` so schema-declared
-  sensitive / large paths still match against the isolated slice."
+  Each slice is egress'd at its ABSOLUTE leaf `:path` so the frame-owned
+  `:sensitive` / `:large` app-db declarations still match against the
+  isolated slice."
   [before after egress-opts]
   (let [{:keys [flat-rows]} (diff-engine/project before after)
         egress-at (fn [v path] (egress-value v (assoc egress-opts :path path)))]

--- a/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
@@ -443,7 +443,7 @@
 ;; `:rf.xray.palette.fx/snapshot-app-db` fx, which reads the focused
 ;; frame's app-db and ships it to TWO off-box sinks: `console.log` and
 ;; `navigator.clipboard.writeText`. Pre-rf2-mxzgg it shipped the RAW
-;; `(rf/app-db-value tf)` — a schema-declared sensitive slot
+;; `(rf/app-db-value tf)` — a frame-declared sensitive slot
 ;; (`{:auth {:password "shh"}}`) crossed both sinks unredacted. The fix
 ;; routes the value through `runtime/egress-value` (the same fail-closed
 ;; projection `get-app-db` uses) FIRST, so the off-box payload carries
@@ -542,7 +542,7 @@
       (let [payload (first @(:console sinks))]
         (is (some? payload) "the console.log sink received a payload")
         (is (= :rf/redacted (get-in payload [:auth :password]))
-            "console payload redacts the schema-declared sensitive slot")
+            "console payload redacts the frame-declared sensitive slot")
         (is (not= "hunter2" (get-in payload [:auth :password]))
             "the raw secret never crosses the console off-box sink")
         (is (= "ada" (get-in payload [:auth :username]))
@@ -558,8 +558,8 @@
 
 (deftest snapshot-app-db-size-elides-large-slot-on-both-off-box-sinks
   ;; rf2-mxzgg — size minimisation rides the same safe-egress default
-  ;; (polarity parity with the runtime accessors): a schema-declared
-  ;; `:large?` slot is replaced with the `:rf.size/large-elided` marker.
+  ;; (polarity parity with the runtime accessors): a frame-declared
+  ;; `:large` slot is replaced with the `:rf.size/large-elided` marker.
   (setup!)
   (let [sinks (capture-snapshot-sinks!)]
     (try
@@ -578,7 +578,7 @@
       (let [payload (first @(:console sinks))]
         (is (some? payload) "the console.log sink received a payload")
         (is (contains? (get-in payload [:blob :payload]) :rf.size/large-elided)
-            "console payload size-elides the schema-declared large slot")
+            "console payload size-elides the frame-declared large slot")
         (is (not= {:big "value"} (get-in payload [:blob :payload]))
             "the raw large value never crosses the console off-box sink"))
       (finally ((:restore sinks))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -425,7 +425,7 @@
     captured))
 
 (deftest copy-value-redacts-sensitive-slot
-  (testing "rf2-uo0rc.2 — a copied value carrying a schema-declared
+  (testing "rf2-uo0rc.2 — a copied value carrying a frame-declared
             sensitive slot is REDACTED before it reaches the clipboard fx;
             the raw secret never crosses the off-box boundary"
     (registry/register-xray-handlers!)
@@ -453,8 +453,8 @@
             "non-sensitive sibling survives the copy")))))
 
 (deftest copy-value-size-elides-large-slot
-  (testing "rf2-uo0rc.2 — a copied value carrying a schema-declared
-            :large? slot is size-elided before it reaches the clipboard fx"
+  (testing "rf2-uo0rc.2 — a copied value carrying a frame-declared
+            :large slot is size-elided before it reaches the clipboard fx"
     (registry/register-xray-handlers!)
     (frame/reg-frame :rf/default {})
     (frame/reg-frame :rf/xray {})

--- a/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
@@ -23,14 +23,27 @@
             [re-frame.image :as image]
             [re-frame.live-frame :as live-frame]
             [re-frame.image-assembly :as image-assembly]
+            [re-frame.trace :as trace]
             [day8.re-frame2-xray.panels.image-view-reads :as reads]))
 
 ;; Each case starts from a clean live-frame registry so an `:id` from one case
 ;; never collides with the next (EP-0023 §Id Spaces — a frame id is unique in
-;; the process-local registry).
+;; the process-local registry). The frame-no-emit gate (rf2-2qaqh) lives in a
+;; persistent `re-frame.trace` set that `clear-live-frames!` does NOT touch, so
+;; the seating cases also clear the shell ids they exercise so each starts
+;; un-gated.
+(def ^:private seat-test-frame-ids
+  [:rf.xray/seat-a :rf.xray/seat-b :rf.xray/seat-c])
+
 (use-fixtures :each
-  {:before #(live-frame/clear-live-frames!)
-   :after  #(live-frame/clear-live-frames!)})
+  {:before (fn []
+             (live-frame/clear-live-frames!)
+             (doseq [fid seat-test-frame-ids]
+               (trace/set-frame-no-emit! fid false)))
+   :after  (fn []
+             (live-frame/clear-live-frames!)
+             (doseq [fid seat-test-frame-ids]
+               (trace/set-frame-no-emit! fid false)))})
 
 ;; A target image + a target frame, built against an EXPLICIT descriptor pool
 ;; (so the test does not depend on the live source store carrying any host
@@ -201,3 +214,52 @@
           "resolves to the target image's descriptor, not Xray's"))
     (testing "a nil generation is fail-soft → nil (no throw)"
       (is (nil? (reads/resolve-descriptor nil :event :counter/inc))))))
+
+;; ---- TRUE runtime self-seating (EP-0023 §Xray Beside The Target) ----------
+;;
+;; rf2-32siq3.36 — the dogfood's runtime arm: Xray SEATS a running frame in its
+;; OWN image-loaded frame (built from `(xray-image)`), so its registrations are
+;; resolved through that frame's OWN sealed generation in genuine registration
+;; isolation — not the shared default registrar. These cases exercise the seating
+;; against an EXPLICIT pool (deterministic, no dependence on the live store) and
+;; assert the trace-emission gate + idempotency the production singleton relies on.
+
+(deftest seat-xray-frame-seats-in-its-own-image
+  (testing "seat-xray-frame! seats a LIVE frame whose resolved generation carries
+            Xray's OWN registrations (the frame runs Xray's image, not the shared
+            registrar) — the true runtime dogfood"
+    (let [obj (reads/seat-xray-frame! :rf.xray/seat-a xray-pool)
+          kids (reads/application-resolver-keyset (:rf.frame/generation obj))]
+      (is (some? obj) "a fresh seat returns the live frame object")
+      (is (= :rf.xray/seat-a (:rf.frame/id obj)) "registered under the shell id")
+      (is (true? (reads/xray-frame-seated? :rf.xray/seat-a))
+          "the frame is now live in the EP-0023 registry")
+      (is (contains? kids [:event :rf.xray/refresh])
+          "the seated frame resolves Xray's OWN [kind id] through its image")
+      (is (every? (fn [[_ id]] (= "rf.xray" (namespace id))) kids)
+          "the seated frame resolves ONLY Xray's app-owned ids — registration
+           isolation from any inspected target"))))
+
+(deftest seat-xray-frame-sets-the-trace-no-emit-gate
+  (testing "seat-xray-frame! marks the shell frame trace-disabled (rf2-2qaqh) so
+            Xray's own reactivity does not flood the ring it inspects — preserved
+            across the make-frame seating that cannot carry the record-config flag"
+    (is (false? (trace/frame-trace-disabled? :rf.xray/seat-b))
+        "not gated before seating")
+    (reads/seat-xray-frame! :rf.xray/seat-b xray-pool)
+    (is (true? (trace/frame-trace-disabled? :rf.xray/seat-b))
+        "seating sets the frame-no-emit gate")))
+
+(deftest seat-xray-frame-is-idempotent
+  (testing "a re-seat (re-open / hot-reload / repeated testbed mount) finds the
+            frame already live and SKIPS the fail-loud duplicate-:id make-frame,
+            re-asserting only the trace gate — no throw"
+    (let [first-obj (reads/seat-xray-frame! :rf.xray/seat-c xray-pool)]
+      (is (some? first-obj) "first seat creates the frame")
+      ;; A second call must NOT throw :rf.error/live-frame-id-conflict.
+      (let [second-obj (reads/seat-xray-frame! :rf.xray/seat-c xray-pool)]
+        (is (nil? second-obj) "re-seat is a skip (returns nil), not a re-create")
+        (is (true? (reads/xray-frame-seated? :rf.xray/seat-c))
+            "the frame stays live")
+        (is (true? (trace/frame-trace-disabled? :rf.xray/seat-c))
+            "the trace gate is re-asserted on the re-seat")))))

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -723,7 +723,7 @@
 
 (deftest egress-value-redacts-sensitive-on-the-safe-default-path
   (testing "`egress-value` with no opts (the SHORT path) redacts a
-            schema-declared sensitive slot — the off-box defaults are
+            frame-declared sensitive slot — the off-box defaults are
             baked in so a forwarder author never re-derives the opts"
     (seed-sensitive-schema!)
     (let [out (runtime/egress-value {:auth {:username "ada" :password "shh"}})]
@@ -918,8 +918,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; (11b) PATH-SCOPED get-app-db threads the absolute :path into the egress
-;;       walker so a scoped slice elides against schema-declared
-;;       sensitive / large paths (rf2-a96xq).
+;;       walker so a scoped slice elides against the frame-owned
+;;       sensitive / large app-db declarations (rf2-a96xq).
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Before the fix the scoped read called `egress-value` WITHOUT the
@@ -941,7 +941,7 @@
       {:large {:app-db [[:blob :payload]]}})))
 
 (deftest get-app-db-path-scoped-redacts-sensitive-leaf-by-default
-  (testing "a PATH-scoped get-app-db over a schema-declared sensitive
+  (testing "a PATH-scoped get-app-db over a frame-declared sensitive
             leaf redacts by default — the absolute :path is threaded into
             the egress walker so the [:auth :password] declaration
             matches the scoped slice (rf2-a96xq: fail-closed)"
@@ -981,7 +981,7 @@
           ":include-sensitive? true ⇒ the raw leaf is revealed at the scoped path"))))
 
 (deftest get-app-db-path-scoped-elides-large-leaf-by-default
-  (testing "a PATH-scoped get-app-db over a schema-declared :large? leaf
+  (testing "a PATH-scoped get-app-db over a frame-declared :large leaf
             emits the :rf.size/large-elided marker by default, and reveals
             the raw value only on {:include-large? true} (rf2-a96xq:
             symmetric size minimisation on the scoped path)"
@@ -1061,7 +1061,7 @@
 
 (deftest get-app-db-diff-redacts-sensitive-slices
   (testing "`get-app-db-diff` routes each changed-path slice through
-            egress-value — a schema-declared sensitive slot that changed
+            egress-value — a frame-declared sensitive slot that changed
             redacts in the :changed bucket (rf2-uv2q2 privacy)"
     (let [epoch-id (record-epoch-via-reset!
                      {:auth {:username "ada" :password "old-pw"}}
@@ -1092,7 +1092,7 @@
             through-wire-elision invariant with no exceptions"
     (seed-sensitive-schema!)
     ;; Register an event whose registration-metadata carries a
-    ;; value-bearing slot at the schema-declared sensitive path. We use
+    ;; value-bearing slot at the frame-declared sensitive path. We use
     ;; the registrar directly (not the `reg-event` macro, which emits its
     ;; own metadata and would not let us plant the slot) so the meta map
     ;; itself carries `{:auth {:password ...}}`. `egress-value` walks the
@@ -1120,7 +1120,7 @@
 
 (defn- register-handler-with-sourcey-coord!
   "Register an event whose registration metadata carries a `:source-coord`
-  whose value sits at the schema-declared sensitive path. We use the
+  whose value sits at the frame-declared sensitive path. We use the
   registrar directly (not the `reg-event` macro, which emits its own
   metadata) so the `:source-coord` slot we plant survives to
   `rf/handler-meta` verbatim. `egress-value` walks the source-coord value


### PR DESCRIPTION
Two EP-0023 follow-on beads on the tools/xray surface.

## rf2-jt88ga — Xray specs/comments aligned to the EP-0015 owner-classification model

Xray's normative docs + runtime comments still taught the pre-EP-0015 model:
app-db sensitive/large nominated via schema slots only, storage-side epoch
`:redact-fn` mutation, and the "seven first-class marking sites" framing with
public `add-marks`/`set-marks` and `:sensitive? true/false` subscription
overrides. Spec 015 supersedes that.

- **004-App-DB-Diff**: `:rf/elision` registry hydrated from frame-owned
  `:sensitive {:app-db …}` / `:large {:app-db …}` path maps, NOT schema slots;
  the redacted-paths-modified chip is projection-side (export/render), not the
  removed storage-side `:redact-fn`; count semantics read frame-declared paths.
- **API.md**: `egress-value :path`, `get-app-db`, copy-to-clipboard accessors
  describe frame-owned app-db declarations.
- **018-Event-Spine**: replaced "seven first-class marking sites" with the
  EP-0015 owner-classification model (frame / event / sub / fx / cofx / machine
  / flow / resource); dropped public `add-marks`/`set-marks` and the
  `:sensitive? true/false` override; subs/flows use the closed
  `:rf.egress/output-sensitivity` declassification vocabulary; "owner" not "site".
- **runtime.cljs / palette/events.cljs** comments + **test docstrings**:
  frame-owned/frame-declared, not schema-declared (the test helpers already
  install frame-owned classification; prose only).

Acceptance grep clean: `schema slots` / `only nomination path` / `redact-fn`
(storage-side) / `:sensitive? true/false` / `:sensitive false` leave only
intentional removal/historical notes. Remaining `schema-declared` hits are the
render-args walk, which is genuinely schema-driven (a schema-owned transient
surface, correct under EP-0015).

## rf2-32siq3.36 — true image-loaded frame seating, shipped as a proven callable

EP-0023 §Xray Beside The Target's runtime arm. `image_view_reads/seat-xray-frame!`
seats a running Xray frame in its OWN image-loaded frame via
`(rf/make-frame {:images [(xray-image)]})` — genuine registration isolation, the
literal EP shape. Sets the `:rf.trace/frame-no-emit?` gate via
`re-frame.trace/set-frame-no-emit!` (make-frame is the object constructor and
rejects the record-config flag); idempotent on re-seat (`xray-frame-seated?`).
Tested: seated frame resolves ONLY Xray's app-owned ids, gate is set, re-seat is
a no-throw skip.

**Deferred (filed rf2-rjml45): the production-singleton flip.**
`mount/ensure-xray-frame!` keeps the legacy `reg-frame` seating. Blocker
(reproduced — 50 node-test errors when the singleton was flipped): the
`day8.re-frame2-xray.**` image glob sweeps Xray's OWN `*-cljs-test` namespaces in
dev/test builds, and those tests co-register `:rf.xray/*` ids (e.g.
`[:fx :rf.editor/open]`) → fail-loud `:rf.error/image-duplicate-id` at assembly.
Flipping the singleton needs a test-namespace-excluding image selector. The
seating-core seam + its disjointness proof stand independently.

The facade dependency (`.32`/`.48`) is already satisfied: `rf/make-frame` is the
EP-0023 object constructor accepting `:images`.

## Gates
- `npm run test:cljs` — green (0 failures, 0 errors; +101 assertions from the new seating tests)
- `npm run test:xray-feature-gate` — green (15 scenarios, 0 failures; all builds 0 warnings)
- `scripts/test-fast-pr.sh` — PASS (CLJS + markdown link/anchor gates; mkdocs soft-skipped locally, CI runs it)