### PR TITLE
fix(machines-viz): emit canonical :rf.size/large-elided sentinel (rf2-vny8p4)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -73,7 +73,7 @@ registry).
 | `:machine-data` | no | `nil` | rf2-qo5xy; rf2-q129z8; rf2-3q4k5b. CLJS map fed into the Context BAND in the ROOT-CONTAINER frame header (was a top-left corner panel pre-q129z8). Host projection: either live `:data` (key→value) or the **static context shape** (key→type-caption, via Xray's `static-context-shape`), which is **declared over inferred** — authoritative off a `:data-schema` when present, else inferred from one `:data` sample (rf2-3q4k5b). `nil` / empty → no band. See [§Context band](#context-band-rf2-qo5xy-rf2-q129z8--now-in-the-frame-header). |
 | `:machine-data-inferred?` | no | `true` | rf2-5tz9p; rf2-3q4k5b. Provenance gate for the Context-band badge. When `true` (default) the band shows a subtle `inferred from :data` badge — a type shape **inferred** from one sample of the definition's `:data`, **not** a declared schema and **not** the live runtime `:data`. When `false` the inferred badge is **dropped** and a positive `declared` badge shows instead; hosts pass `false` when feeding live `:data` **values** OR an AUTHORITATIVE shape off a `:data-schema` (rf2-3q4k5b · EP-0005). Ignored when no band renders. See [§Context band](#context-band-rf2-qo5xy-rf2-q129z8--now-in-the-frame-header). |
 | `:machine-data-sensitive` | no | `#{}` | rf2-27e38h · EP-0015. A SET of Context-band keys whose VALUES are redacted to `:rf/redacted` before they reach the DOM (and therefore the SVG/PNG/clipboard export). The host derives it from the machine's `:data-schema` `:sensitive?` slot props. See [§Context-band egress contract](#context-band-egress-contract--local-redacted-by-default-rf2-27e38h--ep-0015). |
-| `:machine-data-large` | no | `#{}` | rf2-27e38h · EP-0015. A SET of Context-band keys whose values are elided to a content-FREE `:rf/large {:bytes N}` form before export. Unmarked over-cap values elide too; sensitive wins over large. |
+| `:machine-data-large` | no | `#{}` | rf2-27e38h · EP-0015. A SET of Context-band keys whose values are elided to the canonical content-FREE `:rf.size/large-elided` marker before export. Unmarked over-cap values elide too; sensitive wins over large. |
 | `:machine-data-raw?` | no | `false` | rf2-27e38h · EP-0015. The explicit trusted-local (`:rf.egress/local-raw`) opt-in. `true` skips Context-band redaction and serialises raw values — an operator act for a developer inspecting their own process. Default `false` keeps the band local-redacted. |
 | `:testid` | no | `"rf-mv-chart"` | Root wrapper `data-testid` so tests + hosts can find the chart. |
 
@@ -641,7 +641,7 @@ them) via two optional props:
 | Prop | Default | Meaning |
 |------|---------|---------|
 | `:machine-data-sensitive` | `#{}` | A SET of band keys whose VALUES are redacted to the `:rf/redacted` sentinel before they reach the DOM/export. |
-| `:machine-data-large` | `#{}` | A SET of band keys whose values are elided to a content-FREE `:rf/large {:bytes N}` form (size diagnostic only — no content head). An unmarked value over a defensive char cap is elided too. |
+| `:machine-data-large` | `#{}` | A SET of band keys whose values are elided to the canonical content-FREE `:rf.size/large-elided` marker (size diagnostic only — no content head). An unmarked value over a defensive char cap is elided too. |
 | `:machine-data-raw?` | `false` | The explicit **trusted-local** (`:rf.egress/local-raw`) opt-in. When `true`, redaction is skipped and the raw values are painted/serialised. An operator act, for a developer inspecting their own process. |
 
 Sensitive **wins over** large (the EP-0015 ordering). The redaction
@@ -659,7 +659,7 @@ question: **the host MAY pass raw live `:data` and declare the
 sensitive/large slots; the chart applies the local-redacted projection
 itself.** A host that has already projected its own values may pass an
 empty classification (the values are then treated as non-sensitive). The
-sentinels render as content-free text (`🔒 :rf/redacted`, `… :rf/large
+sentinels render as content-free text (`🔒 :rf/redacted`, `… :rf.size/large-elided
 {:bytes N}`) in both the band and any export.
 
 #### Legacy paradigm sections below

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
@@ -28,9 +28,9 @@
   local-redacted display map BEFORE it reaches the DOM:
 
     - a key declared **sensitive** projects to the sentinel `:rf/redacted`;
-    - a **large** value projects to `:rf/large {:bytes N}` (size
-      diagnostic preserved; NO content head — a head fragment would leak
-      into the export);
+    - a **large** value projects to the canonical `:rf.size/large-elided`
+      marker (size diagnostic preserved; NO content head — a head fragment
+      would leak into the export);
     - sensitive WINS over large (the EP-0015 ordering);
     - everything else passes through unchanged.
 
@@ -109,6 +109,38 @@
   [v]
   (count (pr-str v)))
 
+(defn- value-type
+  "Coarse type tag for the `:rf.size/large-elided` marker payload.
+  Mirrors `re-frame.marks/value-type` (inlined — this ns carries no
+  dependency on the core runtime graph)."
+  [v]
+  (cond
+    (map? v)    :map
+    (vector? v) :vector
+    (set? v)    :set
+    (string? v) :string
+    :else       :scalar))
+
+(defn- large-marker
+  "Build the canonical content-FREE `:rf.size/large-elided` marker for a
+  large context VALUE `v` at single-key path `[k]`. Mirrors the SHAPE of
+  `re-frame.marks/large-marker` (a single-key map `{:rf.size/large-elided
+  {…}}`) so the projected map is recognised by every consumer of the
+  framework's large-elision vocabulary (e.g. xray's `large-sentinel?`,
+  mcp-base's `count-elided-markers`) — inlined because machines-viz is
+  intentionally JVM-portable / plain-data and cannot `:require` the core
+  elision namespace.
+
+  Content-free: carries only the size diagnostic (`:bytes`/`:type`) and
+  provenance (`:path`/`:reason`), never a content head, preserving the
+  export-safety property."
+  [k v]
+  {:rf.size/large-elided
+   {:path   [k]
+    :bytes  (printed-size v)
+    :type   (value-type v)
+    :reason :schema}})
+
 ;; ---------------------------------------------------------------------------
 ;; Projection
 
@@ -117,7 +149,7 @@
 
     - sensitive (key ∈ `sensitive`)  → `:rf/redacted`
     - large (key ∈ `large`, OR printed size > `large-char-cap`)
-                                      → `:rf/large {:bytes N}` (no head)
+                                      → `:rf.size/large-elided` marker (no head)
     - otherwise                       → `v` unchanged
 
   Sensitive WINS over large (EP-0015). Returns the value to render."
@@ -127,7 +159,7 @@
     (contains? sensitive k) :rf/redacted
     (or (contains? large k)
         (> (printed-size v) large-char-cap))
-    [:rf/large {:bytes (printed-size v)}]
+    (large-marker k v)
     :else v))
 
 (defn redact-context
@@ -147,14 +179,15 @@
 
 (defn display-string
   "The display TEXT the band paints for a (possibly redacted) value `v`.
-  `:rf/redacted` and the `:rf/large` rich form render as stable,
-  content-FREE sentinels so they read clearly in the chart AND in any
-  serialised export. Everything else renders via `pr-str` (the prior
-  behaviour)."
+  `:rf/redacted` and the canonical `:rf.size/large-elided` marker render
+  as stable, content-FREE sentinels so they read clearly in the chart AND
+  in any serialised export. Everything else renders via `pr-str` (the
+  prior behaviour)."
   [v]
   (cond
     (= :rf/redacted v) "🔒 :rf/redacted"
-    (and (vector? v) (= :rf/large (first v)) (map? (second v)))
-    (let [bytes (:bytes (second v))]
-      (str "… :rf/large" (when bytes (str " {:bytes " bytes "}"))))
+    (and (map? v) (contains? v :rf.size/large-elided))
+    (let [bytes (:bytes (:rf.size/large-elided v))]
+      (str "… :rf.size/large-elided"
+           (when bytes (str " {:bytes " bytes "}"))))
     :else (pr-str v)))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_cljs_test.cljc
@@ -45,19 +45,22 @@
     (is (= :rf/redacted (r/redact-value :tok "hunter2" {:sensitive #{:tok}})))))
 
 (deftest redact-value-large-becomes-elided-no-head
-  (testing "a large key elides to :rf/large {:bytes N} with NO content head"
+  (testing "a large key elides to the canonical :rf.size/large-elided marker with NO content head"
     (let [big (apply str (repeat 50 "x"))
           out (r/redact-value :blob big {:large #{:blob}})]
-      (is (vector? out))
-      (is (= :rf/large (first out)))
-      (is (number? (:bytes (second out))))
-      (is (not (contains? (second out) :head)) "no content head leaks"))))
+      (is (map? out))
+      (is (contains? out :rf.size/large-elided))
+      (let [body (:rf.size/large-elided out)]
+        (is (number? (:bytes body)))
+        (is (= [:blob] (:path body)) "path is the single context key")
+        (is (= :string (:type body)))
+        (is (not (contains? body :head)) "no content head leaks")))))
 
 (deftest redact-value-large-heuristic-fires-for-unmarked-big-value
   (testing "an unmarked value over the char cap is still elided as large"
     (let [big (apply str (repeat 1000 "y"))
           out (r/redact-value :unmarked big {})]
-      (is (= :rf/large (first out)) "defensive size guard fires"))))
+      (is (contains? out :rf.size/large-elided) "defensive size guard fires"))))
 
 (deftest redact-value-sensitive-wins-over-large
   (testing "a key that is BOTH sensitive and large redacts as sensitive"
@@ -93,9 +96,10 @@
       (is (str/includes? s ":rf/redacted")))))
 
 (deftest display-string-large-shows-size-not-content
-  (testing ":rf/large renders size only, never the content"
-    (let [s (r/display-string [:rf/large {:bytes 4096}])]
-      (is (str/includes? s ":rf/large"))
+  (testing ":rf.size/large-elided renders size only, never the content"
+    (let [s (r/display-string {:rf.size/large-elided {:bytes 4096 :path [:blob]
+                                                      :type :string :reason :schema}})]
+      (is (str/includes? s ":rf.size/large-elided"))
       (is (str/includes? s "4096"))
       (is (not (str/includes? s "xxxx")) "no content head"))))
 

--- a/tools/story/spec/000-Vision.md
+++ b/tools/story/spec/000-Vision.md
@@ -162,7 +162,7 @@ Story participates in the framework's path-level data-classification
 contract ([spec/015-Data-Classification.md](../../../spec/015-Data-Classification.md)).
 Story is **not** a separate observation surface that needs its own
 classification machinery — it consumes the framework's existing
-sentinels (`:rf/redacted`, `:rf/large`) and propagation graph at the
+sentinels (`:rf/redacted`, `:rf.size/large-elided`) and propagation graph at the
 boundaries it owns.
 
 The posture is normative across Story's surfaces:

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -69,7 +69,7 @@ Story core returns **marks-as-data**: the registered bodies and
 per-frame snapshots travel unchanged across the read primitives
 above, with `:sensitive` / `:large` declarations carried alongside as
 declarative metadata. The wire-elision substitution to `:rf/redacted`
-/ `:rf/large` happens at the **MCP jar's egress boundary**, NOT in
+/ `:rf.size/large-elided` happens at the **MCP jar's egress boundary**, NOT in
 Story core — every tool-response payload the MCP jar emits is passed
 through `re-frame.elision/elide-wire-value` before it crosses the
 JSON-RPC wire (per


### PR DESCRIPTION
## What

The machines-viz Context-band local-redacted projection
(`chart/context_redaction.cljc`) emitted a dead `:rf/large {:bytes N}`
vector for a large machine-`:data` slot. `:rf/large` is a sentinel the
framework **no longer emits** and no consumer recognises:

- `tools/xray/.../edn_inspector` `large-sentinel?` explicitly pins
  `{:rf/large …}` as a NON-match (pre-alpha, no shim).
- mcp-base `count-elided-markers` keys only on `:rf.size/large-elided`,
  so a machines-viz large value would never be counted.

The canonical large-elision marker (re-frame.elision / marks.cljc /
mcp-base) is the single-key map `{:rf.size/large-elided {…}}`.

## Change

- `redact-value` now builds the canonical content-FREE
  `:rf.size/large-elided` marker via a new inline `large-marker` helper
  (carrying `:path`/`:bytes`/`:type`/`:reason`), mirroring the SHAPE of
  `re-frame.marks/large-marker`. Inlined — machines-viz is intentionally
  JVM-portable / plain-data and cannot `:require` the core elision graph
  (the bead's stated constraint). The projected map is now recognised by
  every consumer of the framework's large-elision vocabulary, closing the
  future-consumer-sees-unknown-marker gap.
- `display-string` recognises the map-form marker and renders content-FREE
  text, preserving the export-safety property.
- Updates the test, docstrings, `tools/machines-viz/spec/API.md` rows, and
  the two `tools/story/spec/*` references that taught the dead `:rf/large`
  spelling as the framework sentinel.

Note: the rich `:rf/large {:bytes N :head …}` display form documented in
`spec/015-Data-Classification.md` is a SEPARATE, intentional surface-render
form (distinct from the low-level walker's `:rf.size/large-elided` marker)
and is correctly left unchanged — this fix targets only the dead
projected-data spelling in machines-viz.

## Gates

- `tools/machines-viz` `clojure -M:test` — 550 tests / 1927 assertions, 0 failures (re-run post-rebase).
- `implementation` `npm run test:cljs` — 7840 tests / 32465 assertions, 0 failures.
- `scripts/test-fast-pr.sh` — green (markdown link/anchor gates ran on the .md edits; mkdocs --strict soft-skipped locally, CI runs it).

Spec updated in the same PR per the machines-viz/xray shared-spec standing rule.
