### PR TITLE
fix(story): static-export mount crash + cwd-robust tests + EP-0023 image/variant concept (rf2-oki92v, rf2-y0640c, rf2-fpr0b5)

### DIFF
--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -20,8 +20,8 @@
  *        the chosen port is not the one we spawned.
  *
  * 3. Drives a headless Chromium against the resolved base URL and
- *    verifies the Story shell mounted (the canonical "Select a variant
- *    or workspace" placeholder is rendered, and the chrome landmarks
+ *    verifies the Story shell mounted (the empty-state canvas
+ *    `data-test="story-canvas-empty"` is rendered, and the chrome landmarks
  *    are present).
  * 4. Verifies the first-visit help overlay is suppressed (per
  *    spec/013 §Static-mode runtime semantics — visitors arriving at a
@@ -243,12 +243,15 @@ async function smokeTest(baseUrl, diagnostics) {
   try {
     await page.goto(baseUrl, { waitUntil: 'load', timeout: 30000 });
 
-    // The shell renders the "Select a variant or workspace" placeholder
-    // when no variant / workspace is selected. The Story chrome lands
-    // around it: the sidebar lists the four counter variants + two
-    // workspaces.
+    // The shell renders its empty-state canvas ("No variant selected" +
+    // a pick-from-the-sidebar hint) when no variant / workspace is selected.
+    // The Story chrome lands around it: the sidebar lists the four counter
+    // variants + two workspaces. Asserted via the stable
+    // `data-test="story-canvas-empty"` attribute (shell.cljs) rather than the
+    // placeholder PROSE, which has drifted before — the test-id is the
+    // contract, the copy is not.
     await page
-      .getByText(/Select a variant or workspace from the sidebar/i, { exact: false })
+      .locator('[data-test="story-canvas-empty"]')
       .first()
       .waitFor({ state: 'visible', timeout: 15000 });
 

--- a/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
@@ -44,6 +44,20 @@
   (config/set-allow-sensitive-reads! false)
   (schemas/clear-schemas-by-frame!)
   (recorder/clear!)
+  ;; Disable epoch-ring recording for the duration of each story-mcp test
+  ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so a
+  ;; standalone `cd tools/story-mcp && clojure -M:test` never loads
+  ;; `re-frame.epoch` and `run-variant`'s `:narrative` projection reads an
+  ;; empty tape. Under the tools-root aggregate (`cd tools && clojure
+  ;; -M:test`) a STORY test namespace REQUIRES `re-frame.epoch`, installing
+  ;; the capture hooks process-wide — so story-mcp's `run-variant` then
+  ;; projects a full per-event narrative (each beat carries full :db /
+  ;; trace-events), ballooning the wire payload past the MCP token cap (the
+  ;; whole run-result is replaced by a `:rf.mcp/overflow` marker, failing the
+  ;; shape assertions). `(rf/configure! :epoch-history {:depth 0})` reproduces
+  ;; the artefact's own epoch-free posture: it is a core-facade knob that
+  ;; no-ops when epoch is absent and disables ring recording when present.
+  (rf/configure! :epoch-history {:depth 0})
   (story/reg-story :story.cart
     {:doc "A cart." :component :app.ui/cart :tags #{:dev :test} :args {}})
   ;; A variant carrying a REAL failing assertion (a path-equals against a
@@ -53,7 +67,12 @@
     {:doc "A failing cart variant."
      :tags #{:dev :test}
      :assertions [[:rf.assert/path-equals [:cart/total] 99]]})
-  (t))
+  (try
+    (t)
+    (finally
+      ;; Restore the shipped epoch-ring default so a story namespace running
+      ;; after this one in the aggregate sees the normal depth-50 posture.
+      (rf/configure! :epoch-history {:depth 50}))))
 
 (use-fixtures :each reset-story)
 

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -90,6 +90,21 @@
   ;; Recorder atom is per-process — clear between tests so a previous
   ;; test's captured events don't bleed in.
   (recorder/clear!)
+  ;; Disable epoch-ring recording for the duration of each story-mcp test
+  ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so a
+  ;; standalone `cd tools/story-mcp && clojure -M:test` never loads
+  ;; `re-frame.epoch` and `run-variant`'s `:narrative` projection reads an
+  ;; empty tape. Under the tools-root aggregate (`cd tools && clojure
+  ;; -M:test`) a STORY test namespace REQUIRES `re-frame.epoch`, installing
+  ;; the capture hooks process-wide — so story-mcp's `run-variant` then
+  ;; projects a full per-event narrative (each beat carries full :db /
+  ;; trace-events), ballooning the wire payload past the MCP token cap (the
+  ;; whole run-result is replaced by a `:rf.mcp/overflow` marker, failing the
+  ;; shape + elision-indicator assertions). `(rf/configure! :epoch-history
+  ;; {:depth 0})` reproduces the artefact's own epoch-free posture: it is a
+  ;; core-facade knob that no-ops when epoch is absent and disables ring
+  ;; recording when present.
+  (rf/configure! :epoch-history {:depth 0})
   ;; Fixture story + variant.
   (story/reg-story :story.button
     {:doc       "A clickable button."
@@ -145,7 +160,12 @@
       (frame-class/install! frame-id
         (frame-class/validate+extract frame-id classification-config))
       {:db db}))
-  (t))
+  (try
+    (t)
+    (finally
+      ;; Restore the shipped epoch-ring default so a story namespace running
+      ;; after this one in the aggregate sees the normal depth-50 posture.
+      (rf/configure! :epoch-history {:depth 50}))))
 
 (use-fixtures :each reset-story-and-config)
 
@@ -363,13 +383,34 @@
 ;; leaf's prose catalogue.) This deftest closes that arm.
 ;; ---------------------------------------------------------------------------
 
+(defn- artefact-root
+  "Resolve the `tools/story-mcp/` artefact root on disk, cwd-independently.
+  The per-tool `:test` alias runs from `tools/story-mcp` (a cwd-relative
+  `(io/file …)` works), but the tools-root aggregate (`tools/deps.edn :test`,
+  rf2-f2tkbt) runs from `tools/`, where a cwd-relative `spec/API.md` /
+  `../../skills/…` would miss. The repo-tree files `spec/API.md` and the
+  consuming skill leaf are NOT on the classpath (story-mcp ships only `src`
+  + `test`), so we anchor off a known classpath SOURCE resource
+  (`re_frame/story_mcp/protocol.cljc` under the `src` `:paths` root) and walk
+  its parent chain up to the artefact root. Falls back to the JVM cwd if the
+  resource is absent (e.g. a jar). Mirrors the xray guard tests' src-root
+  resolution, generalised one level up to the artefact root."
+  []
+  (let [marker (io/resource "re_frame/story_mcp/protocol.cljc")]
+    (if (and marker (= "file" (.getProtocol marker)))
+      ;; .../tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+      ;;   → protocol.cljc → story_mcp → re_frame → src → story-mcp (root)
+      (-> (io/file (.toURI marker))
+          .getParentFile .getParentFile .getParentFile .getParentFile)
+      (io/file "."))))
+
 (def ^:private story-mcp-loop-leaf
-  "The consuming skill leaf, read relative to the test JVM cwd
-  (`tools/story-mcp/`; see CI `working-directory`). Read once at
-  ns-load — if the path drifts, `slurp` throws and the drift test
-  errors loudly rather than silently passing on an empty string."
-  (delay (slurp (io/file ".." ".." "skills" "re-frame2" "references"
-                         "tooling" "story-mcp-loop.md"))))
+  "The consuming skill leaf, read relative to the `tools/story-mcp/` artefact
+  root (resolved cwd-independently via `artefact-root`). Read once at
+  ns-load — if the path drifts, `slurp` throws and the drift test errors
+  loudly rather than silently passing on an empty string."
+  (delay (slurp (io/file (artefact-root) ".." ".." "skills" "re-frame2"
+                         "references" "tooling" "story-mcp-loop.md"))))
 
 (def ^:private number-words
   "Spelled-out integers the leaf's tool-count claim may use. Keyed wide
@@ -3749,11 +3790,11 @@
           "the affected set is six tools (spec/002 §sensitive-read gate) — not three"))))
 
 (def ^:private api-md
-  "The consolidated public-API page, read relative to the test JVM cwd
-  (`tools/story-mcp/`; see CI `working-directory`). Read once at ns-load
-  — if the path drifts `slurp` throws and the drift test errors loudly
-  rather than silently passing on an empty string."
-  (delay (slurp (io/file "spec" "API.md"))))
+  "The consolidated public-API page, read relative to the `tools/story-mcp/`
+  artefact root (resolved cwd-independently via `artefact-root`). Read once
+  at ns-load — if the path drifts `slurp` throws and the drift test errors
+  loudly rather than silently passing on an empty string."
+  (delay (slurp (io/file (artefact-root) "spec" "API.md"))))
 
 (defn- api-section
   "Return the `### \\`<tool-name>\\`` section body from API.md — the text

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -396,12 +396,71 @@ no fn-slots):
  :platforms             #{:server :client}
  :substrates            #{:reagent :uix ...}
  :modes                 #{<mode-id> ...}         ; cell = (variant × mode)
+ :images                [(rf/image {...}) ...]   ; EP-0023 behaviour-variant images — see §Behaviour-variant images
  :xray-panel           <panel-kw>               ; (rf2-v1ach) default Xray panel for the RHS embed
  :xray                 {:open?  <bool>          ;   per-story Xray preset — see §Xray preset slot
                          :panel  <panel-kw>      ;   preset: auto-select this panel on mount
                          :filters {...}
                          :focus   {...}}}
 ```
+
+### `:images` — behaviour-variant images (EP-0023)
+
+`:images` is the variant's **behaviour-variant** surface, per
+[EP-0023 §Stories](../../../docs/EP/EP-0023-image-loaded-frames.md) — the
+graduated rule: **use another frame for a STATE variant; use another image
+for a BEHAVIOUR variant.** A state variant changes only its starting memory
+(`:setup` / `:db-seed` / `:args`) while resolving behaviour against the same
+registrations; a behaviour variant changes WHICH registrations its frame runs.
+
+Each entry is an **image VALUE** built by the framework constructor
+`re-frame.core/image` — an inert, PURE selected-registration-set value (see
+[spec/API.md §App values and composition](../../../spec/API.md) and
+EP-0023 §Image). An image selects registrations by provenance namespace
+(`:include-ns ["app.checkout.v2" "app.shared.**"]`), supplies inline
+`:registrations`, declares `:replace` winners for collisions, and carries an
+optional `:id`:
+
+```clojure
+(reg-variant :story.checkout/legacy-flow
+  {:doc    "Checkout under the v1 pricing rules."
+   :images [(rf/image {:id :checkout/v1 :include-ns ["app.checkout.v1"]})]
+   :setup  [[:checkout/init]]})
+
+(reg-variant :story.checkout/new-flow
+  {:doc    "SAME story, SAME events — but the v2 pricing image."
+   :images [(rf/image {:id :checkout/v2 :include-ns ["app.checkout.v2"]})]
+   :setup  [[:checkout/init]]})
+```
+
+Both variants dispatch the SAME event ids; the runtime resolves each
+variant's behaviour through ITS OWN image, so `:checkout/init` (and every
+sub / fx the cascade touches) means different things in the two frames —
+without the global-clobber anti-pattern (no process-wide `reg-event`
+mutation between runs). The runtime threads `:images` into `rf/make-frame`
+at frame allocation (a live frame object carrying the resolved, sealed image
+generation registered under the variant id); the framework's
+`call-with-frame-resolution` routes every `{:frame variant-id}` dispatch
+through that generation ([spec/002 Dispatch resolution chain](../../../spec/002-Frames.md)
+/ EP-0023 §Frame-derived live registration resolution).
+
+A variant with NO `:images` resolves against the shared default registrar
+exactly as before (absence-is-default) — the slot is opt-in and changes
+nothing for ordinary state variants.
+
+**Validation is the framework's.** Story does not fork image validation: a
+non-image entry, a zero-match `:include-ns` glob (a typo / forgotten require
+/ stale ns), or a malformed `:replace` map FAILS LOUDLY at frame creation
+(`:rf.error/invalid-image` / `:rf.error/image-zero-match` /
+`:rf.error/image-missing-reference`). The variant body schema admits
+`:images` as a loose vector; the rigorous shape is owned by `rf/image` and
+`re-frame.image-assembly/assemble` — one source of truth, mirroring the
+`:sensitive` / `:large` precedent.
+
+The resolved image ids are reported back: the run-result map carries an
+`:images` slot (when the variant declared images) and the variant frame-meta
+carries `:rf/images` (read via `re-frame.story.frames/variant-image-ids`), so
+Test mode / MCP / Xray can surface WHICH behaviour set ran.
 
 ### `:script` — the public phase-4 surface (rf2-5x1wt.11)
 

--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -23,6 +23,39 @@ At variant-unmount the runtime calls `(rf/destroy-frame! variant-id)`.
 Hot-reload preserves the side-table; a re-registration of the same
 variant calls `reset-frame!` and re-runs the lifecycle.
 
+### Behaviour-variant images (EP-0023)
+
+When a variant declares `:images` (see
+[001-Authoring.md §`:images`](001-Authoring.md)), `frames/allocate!` ALSO
+registers a live frame **object** under the variant id carrying the resolved,
+sealed image generation, per
+[EP-0023 §Stories](../../../docs/EP/EP-0023-image-loaded-frames.md):
+
+1. `(rf/make-frame {:id variant-id :images [<image> …]})` — creates the
+   backing runnable record AND the live frame object whose
+   `:rf.frame/generation` is the assembled, sealed generation the images
+   resolve to. Runs FIRST so the framework's image validation fails loud at
+   frame creation.
+2. `(rf/reg-frame variant-id {…story config…})` — SURGICAL-UPDATES that
+   record's config with the Story preset / `:fx-overrides` / classification /
+   `:rf/images` (the image ids, for tooling read-back), preserving the
+   freshly-made app-db. The live frame object (in the separate live-frame
+   registry) is untouched.
+
+The framework's `call-with-frame-resolution` then routes every
+`{:frame variant-id}` dispatch — event-handler lookup, declared cofx, the
+whole fx walk — through the variant frame's OWN image generation rather than
+the shared default registrar (EP-0023 §Frame-derived live registration
+resolution). Two variants reusing the SAME global event/sub id under
+DIFFERENT images resolve it to their own image's descriptor — **behaviour
+variant -> image**, with NO global-registrar clobber between runs.
+
+A variant with no `:images` skips `make-frame` entirely and resolves against
+the shared default registrar exactly as before (absence-is-default). The
+resolved image ids are reported on the run-result `:images` slot and on the
+variant frame-meta `:rf/images` slot
+(`re-frame.story.frames/variant-image-ids`).
+
 ### Machine lifecycle on variant unmount
 
 When `destroy-variant!` fires, any

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -540,14 +540,26 @@
   validates + installs them atomically as part of frame creation, BEFORE
   `:on-create`. Story does not fork the classification validation; a
   malformed declaration FAILS LOUDLY at `reg-frame` time."
-  [variant-id fx-overrides {:keys [sensitive large]}]
+  [variant-id fx-overrides {:keys [sensitive large image-ids]}]
   (cond-> {:doc        (str "Variant frame for " variant-id ".")
            :preset     :story
            :rf/story?  true
            :rf/variant variant-id}
     (seq fx-overrides) (assoc :fx-overrides fx-overrides)
     (some? sensitive)  (assoc :sensitive sensitive)
-    (some? large)      (assoc :large large)))
+    (some? large)      (assoc :large large)
+    ;; EP-0023 §Stories — report the IMAGE ids this behaviour-variant frame
+    ;; resolves behaviour against, on frame-meta, so Test mode / MCP / Xray can
+    ;; surface which behaviour set ran (rf2-fpr0b5 item 4). The actual image
+    ;; GENERATION is attached to the live frame object by `rf/make-frame` in
+    ;; `allocate!`; this slot carries the authored ids for tooling read-back.
+    (seq image-ids)    (assoc :rf/images (vec image-ids))))
+
+(defn- image-id
+  "The id of an `rf/image` value — its `:rf.image/id` slot, or nil for an
+  anonymous image (valid for local stories per EP-0023 §Public API)."
+  [image]
+  (:rf.image/id image))
 
 (defn allocate!
   "Create the variant's frame, register fx-override stubs, run
@@ -586,12 +598,47 @@
           ;; the events-only classification (rf2-043cm) doesn't depend
           ;; on the file's declaration order.
           v-body         (registrar/handler-meta :variant variant-id)
+          ;; EP-0023 §Stories — the variant's behaviour-variant IMAGES (the
+          ;; `rf/image` registration-set values its frame resolves behaviour
+          ;; against). A vector of image VALUES; nil/empty for an ordinary
+          ;; state variant (which resolves against the shared default
+          ;; registrar). rf2-fpr0b5.
+          images         (:images v-body)
           ;; rf2-bsk1d9 — thread the variant's EP-0015 frame-owned
           ;; `:sensitive` / `:large` classification onto the reg-frame config.
-          config-map     (variant-frame-config variant-id fx-overrides
-                                                (select-keys v-body [:sensitive :large]))
+          ;; rf2-fpr0b5 — plus the image ids (for frame-meta tooling read-back).
+          config-map     (variant-frame-config
+                           variant-id fx-overrides
+                           (assoc (select-keys v-body [:sensitive :large])
+                                  :image-ids (keep image-id images)))
           events-only?   (loaders/events-only-variant? v-body decorator-stack)]
-      ;; Allocate the frame.
+      ;; EP-0023 §Stories / §Frame-derived live registration resolution
+      ;; (rf2-fpr0b5 item 1) — when the variant declares behaviour-variant
+      ;; `:images`, register a live frame OBJECT under the SAME id carrying the
+      ;; resolved, sealed image GENERATION. `process-event!`'s
+      ;; `call-with-frame-resolution` then routes the whole cascade
+      ;; (event-handler lookup, cofx, fx) for any `{:frame variant-id}`
+      ;; dispatch through THIS frame's image generation rather than the global
+      ;; registrar — so two variants reuse the SAME global id with DIFFERENT
+      ;; meanings ("behavior variant -> image", EP-0023 §Stories). Image-less
+      ;; variants skip this and resolve against the shared default registrar
+      ;; exactly as before (absence-is-default). The framework's `rf/image` /
+      ;; assembly own all validation — a malformed image or a zero-match
+      ;; `:include-ns` glob FAILS LOUDLY here at frame creation.
+      ;;
+      ;; ORDER: `make-frame` FIRST — it creates the backing runnable record
+      ;; (with an empty config) under `variant-id`. The `reg-frame` below then
+      ;; SURGICAL-UPDATES that record's config with the full Story config
+      ;; (preset / fx-overrides / classification / `:rf/images`) while
+      ;; preserving the freshly-made app-db. Doing `reg-frame` first then
+      ;; `make-frame` would let `make-frame`'s backing `reg-frame …{}` clobber
+      ;; the Story config back to empty. The live-frame OBJECT (carrying the
+      ;; generation) lives in a SEPARATE registry, untouched by `reg-frame`.
+      (when (seq images)
+        (rf/make-frame {:id variant-id :images (vec images)}))
+      ;; Allocate / configure the frame (the EP-0013 runnable record carrying
+      ;; app-db / sub-cache / queue). Surgical-update when `make-frame` already
+      ;; created the backing record above.
       (rf/reg-frame variant-id config-map)
       ;; rf2-043cm — drive the lifecycle by variant shape. Events-only
       ;; variants jump straight to :ready (no skeleton ever shows);
@@ -883,6 +930,15 @@
   (->> (rf/frame-ids)
        (filter variant-frame?)
        set))
+
+(defn variant-image-ids
+  "Return the vector of behaviour-variant IMAGE ids a variant frame resolves
+  behaviour against (EP-0023 §Stories, rf2-fpr0b5), or nil for an ordinary
+  state variant that resolves against the shared default registrar. Reads the
+  `:rf/images` slot `allocate!` stamps onto frame-meta. The companion read for
+  Test mode / MCP / Xray to surface WHICH behaviour set ran."
+  [frame-id]
+  (:rf/images (rf/frame-meta frame-id)))
 
 ;; ---- variant-body lookup convenience -------------------------------------
 

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -678,13 +678,20 @@
                     :unmet               unmet
                     :app-db              (or app-db {})
                     :elapsed-ms          (- (interop/now-ms) start-ms)})]
-    (merge unified
-           {:frame           variant-id
-            :rendered-hiccup nil       ;; Stage 4 fills this in
-            :snapshot        snapshot
-            :decorators      decorator-stack
-            :effective-args  effective-args
-            :lifecycle       (loaders/current-state variant-id)})))
+    (cond-> (merge unified
+                   {:frame           variant-id
+                    :rendered-hiccup nil       ;; Stage 4 fills this in
+                    :snapshot        snapshot
+                    :decorators      decorator-stack
+                    :effective-args  effective-args
+                    :lifecycle       (loaders/current-state variant-id)})
+      ;; EP-0023 §Stories (rf2-fpr0b5 item 4) — surface the behaviour-variant
+      ;; IMAGE ids the run resolved behaviour against, so Test mode / MCP /
+      ;; Xray can show WHICH behaviour set ran. Present only for a behaviour
+      ;; variant (one that declared `:images`); omitted for an ordinary state
+      ;; variant resolving against the shared default registrar.
+      (seq (frames/variant-image-ids variant-id))
+      (assoc :images (frames/variant-image-ids variant-id)))))
 
 (defn- resolve-runner-selection
   "Normalize the run `opts` and SELECT the runner for `plan` (rf2-baah3 —

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -942,7 +942,27 @@
     ;; spec/015 §Frame-owned durable classification, fail-fast). Story does
     ;; not fork that validation — one source of truth.
     [:sensitive             {:optional true} [:map-of :keyword :any]]
-    [:large                 {:optional true} [:map-of :keyword :any]]]
+    [:large                 {:optional true} [:map-of :keyword :any]]
+    ;; EP-0023 §Stories — "behavior variant -> image". A variant declares the
+    ;; IMAGE(s) (the `rf/image` registration-set values) its frame resolves
+    ;; behaviour against, so two variants reuse the SAME global event/sub id
+    ;; with DIFFERENT meanings by mounting under different images. Each entry
+    ;; is an `rf/image` VALUE (built by `re-frame.core/image` —
+    ;; `{:include-ns […] :registrations {…} :replace {…} :id …}`); the runtime
+    ;; threads `:images` into `rf/make-frame` at frame allocation
+    ;; (`frames/allocate!`), and the framework resolves them into ONE sealed
+    ;; image generation the variant frame resolves registration lookups
+    ;; through (EP-0023 §Frame-derived live registration resolution).
+    ;;
+    ;; Loose `:vector` here on purpose, mirroring the `:sensitive` / `:large`
+    ;; precedent above: the framework's `re-frame.core/image` constructor +
+    ;; `re-frame.image-assembly/assemble` own the rigorous shape validation
+    ;; (a non-image entry, a zero-match `:include-ns` glob, a malformed
+    ;; `:replace` map all FAIL LOUDLY at frame-creation time). Story does not
+    ;; fork that validation — one source of truth. A state variant uses the
+    ;; SAME image with different `:setup` / `:db-seed`; only a BEHAVIOUR
+    ;; variant declares different `:images`.
+    [:images                {:optional true} [:vector :any]]]
    ;; rf2-5x1wt.11 — setup-surface mutual-exclusion. `:setup` is the
    ;; public spelling, `:events` the transitional one; an author picks
    ;; ONE during migration. Mixing both is a schema-level error so the

--- a/tools/story/test/re_frame/story/meta_fixtures_test.cljc
+++ b/tools/story/test/re_frame/story/meta_fixtures_test.cljc
@@ -45,14 +45,31 @@
        scan must skip itself or it would flag its own illustrative prose."
        "meta_fixtures_test.cljc")
 
+     (defn- test-root
+       "Resolve `tools/story/test/` on disk, cwd-independently. The per-tool
+       `:test` alias runs from `tools/story` (a cwd-relative `(io/file
+       \"test\")` works), but the tools-root aggregate (`tools/deps.edn
+       :test`, rf2-f2tkbt) runs from `tools/`, where a bare `test` would miss.
+       `test` is a classpath `:extra-paths` root, so this meta-check's own
+       source file is a classpath resource on the JVM regardless of cwd; its
+       parent chain up to the `test`-root anchors the walk. Falls back to the
+       cwd-relative path if the resource is absent. Mirrors the xray guard
+       tests' src-root pattern."
+       []
+       (let [marker (io/resource "re_frame/story/meta_fixtures_test.cljc")]
+         (if (and marker (= "file" (.getProtocol marker)))
+           ;; .../test/re_frame/story/meta_fixtures_test.cljc → up to .../test
+           (-> (io/file (.toURI marker)) .getParentFile .getParentFile .getParentFile)
+           (io/file "test"))))
+
      (defn- cljc-test-files
        "Walk `test/` and return every `.cljc` file as a `java.io.File`,
        excluding this meta-check (which quotes the forbidden form in its
-       own docs/message). The classpath element `test` resolves to the same
-       directory whether tests run via `clojure -M:test` from `tools/story`
-       or under the top-level build, mirroring `story-substrate-isolation-test`."
+       own docs/message). The root is resolved via `test-root` so the walk is
+       cwd-independent (per-tool `clojure -M:test` AND the tools-root
+       aggregate), mirroring `story-substrate-isolation-test`."
        []
-       (let [root (io/file "test")]
+       (let [root (test-root)]
          (when (.isDirectory root)
            (->> (file-seq root)
                 (filter #(.isFile ^java.io.File %))

--- a/tools/story/test/re_frame/story/test_helpers/image_behaviour_v1.cljc
+++ b/tools/story/test/re_frame/story/test_helpers/image_behaviour_v1.cljc
@@ -1,0 +1,21 @@
+(ns re-frame.story.test-helpers.image-behaviour-v1
+  "Behaviour-variant IMAGE fixture v1 (EP-0023 §Stories, rf2-fpr0b5).
+
+  Registers the SAME event id `:img.counter/step` as the v2 sibling but with a
+  DIFFERENT meaning: v1 adds 1. A behaviour-variant test selects this namespace
+  into a variant's `:images` via `(rf/image {:include-ns
+  [\"re-frame.story.test-helpers.image-behaviour-v1\"]})` so the variant frame
+  resolves `:img.counter/step` to THIS handler — proving 'behavior variant ->
+  image': two variants reuse the same global id with different behaviour purely
+  by mounting under different images.
+
+  The id is namespaced under `:img.counter/*` (NOT a reserved `:rf.*` root) per
+  the feature-modularity id-prefix convention."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-event
+  :img.counter/step
+  (fn [{:keys [db]} _]
+    {:db (-> db
+             (update :n (fnil + 0) 1)
+             (assoc :behaviour :v1-add-one))}))

--- a/tools/story/test/re_frame/story/test_helpers/image_behaviour_v2.cljc
+++ b/tools/story/test/re_frame/story/test_helpers/image_behaviour_v2.cljc
@@ -1,0 +1,16 @@
+(ns re-frame.story.test-helpers.image-behaviour-v2
+  "Behaviour-variant IMAGE fixture v2 (EP-0023 §Stories, rf2-fpr0b5).
+
+  Sibling of `image-behaviour-v1`: registers the SAME event id
+  `:img.counter/step` but adds 100 (the DIFFERENT behaviour). Selected into a
+  variant's `:images` via `(rf/image {:include-ns
+  [\"re-frame.story.test-helpers.image-behaviour-v2\"]})`. See the v1 sibling's
+  docstring for the 'behavior variant -> image' rationale."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-event
+  :img.counter/step
+  (fn [{:keys [db]} _]
+    {:db (-> db
+             (update :n (fnil + 0) 100)
+             (assoc :behaviour :v2-add-hundred))}))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -37,7 +37,12 @@
             [re-frame.story.frames    :as frames]
             [re-frame.story.identity  :as ident]
             [re-frame.story.loaders   :as loaders]
-            [re-frame.story.runtime   :as runtime]))
+            [re-frame.story.runtime   :as runtime]
+            ;; EP-0023 behaviour-variant image fixtures (rf2-fpr0b5): two
+            ;; namespaces register the SAME event id with DIFFERENT meanings;
+            ;; a variant's `:images` `:include-ns` selects one or the other.
+            [re-frame.story.test-helpers.image-behaviour-v1]
+            [re-frame.story.test-helpers.image-behaviour-v2]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
@@ -781,6 +786,70 @@
       (is (= :story.run/v        (-> r :snapshot :variant-id)))
       (is (string?               (-> r :snapshot :content-hash))))
     (story/destroy-variant! :story.run/v)))
+
+;; ===========================================================================
+;; EP-0023 BEHAVIOUR-VARIANT IMAGES (rf2-fpr0b5)
+;; ===========================================================================
+
+(deftest behaviour-variant-images-resolve-same-id-differently
+  (testing "EP-0023 §Stories — two variants declaring DIFFERENT `:images`
+            resolve the SAME event id `:img.counter/step` to DIFFERENT
+            behaviour. The image's `:include-ns` selects which namespace's
+            registration the variant frame resolves against; the runtime
+            attaches the resolved generation via `rf/make-frame` in
+            `allocate!`, and `process-event!`'s frame-resolution routes the
+            dispatch through it. This is 'behavior variant -> image' end-to-end."
+    ;; The fixture's `registrar/clear-all!` wipes the helper namespaces'
+    ;; top-level `reg-event`s from the source store, so re-run their loads
+    ;; before building the selecting images (a zero-match `:include-ns` fails
+    ;; loud by design).
+    (require 're-frame.story.test-helpers.image-behaviour-v1 :reload)
+    (require 're-frame.story.test-helpers.image-behaviour-v2 :reload)
+    ;; Variant A mounts under the v1 image (adds 1).
+    (story/reg-variant :story.img/v1
+      {:images [(rf/image {:id :img/behaviour-v1
+                           :include-ns ["re-frame.story.test-helpers.image-behaviour-v1"]})]
+       :events [[:img.counter/step]]})
+    ;; Variant B mounts under the v2 image (adds 100) — SAME event id.
+    (story/reg-variant :story.img/v2
+      {:images [(rf/image {:id :img/behaviour-v2
+                           :include-ns ["re-frame.story.test-helpers.image-behaviour-v2"]})]
+       :events [[:img.counter/step]]})
+    (let [ra (async/deref-blocking (story/run-variant :story.img/v1) 5000)
+          rb (async/deref-blocking (story/run-variant :story.img/v2) 5000)]
+      (is (= 1 (-> ra :app-db :n))
+          "variant under the v1 image ran the add-one handler")
+      (is (= :v1-add-one (-> ra :app-db :behaviour)))
+      (is (= 100 (-> rb :app-db :n))
+          "variant under the v2 image ran the add-hundred handler — SAME id,
+           DIFFERENT behaviour, resolved through the variant frame's own image")
+      (is (= :v2-add-hundred (-> rb :app-db :behaviour)))
+      ;; item 4 — the result reports WHICH behaviour set ran.
+      (is (= [:img/behaviour-v1] (:images ra))
+          "the result surfaces the resolved behaviour-variant image ids")
+      (is (= [:img/behaviour-v2] (:images rb))))
+    (story/destroy-variant! :story.img/v1)
+    (story/destroy-variant! :story.img/v2)))
+
+(deftest behaviour-variant-image-ids-on-frame-meta
+  (testing "EP-0023 — a behaviour variant's image ids land on frame-meta
+            (`frames/variant-image-ids`); a state variant (no `:images`)
+            reports none and resolves against the shared default registrar."
+    (require 're-frame.story.test-helpers.image-behaviour-v1 :reload)
+    (story/reg-variant :story.img/meta
+      {:images [(rf/image {:id :img/behaviour-v1
+                           :include-ns ["re-frame.story.test-helpers.image-behaviour-v1"]})]
+       :events [[:img.counter/step]]})
+    (story/reg-variant :story.img/state-only
+      {:events []})
+    (frames/allocate! :story.img/meta (story/resolve-decorators :story.img/meta))
+    (frames/allocate! :story.img/state-only (story/resolve-decorators :story.img/state-only))
+    (is (= [:img/behaviour-v1] (frames/variant-image-ids :story.img/meta))
+        "behaviour variant carries its image ids on frame-meta")
+    (is (nil? (frames/variant-image-ids :story.img/state-only))
+        "a state-only variant carries no :rf/images slot")
+    (frames/destroy! :story.img/meta)
+    (frames/destroy! :story.img/state-only)))
 
 (deftest run-variant-with-loaders-and-events
   (testing "run-variant drains loaders before events"

--- a/tools/story/test/re_frame/story_substrate_isolation_test.clj
+++ b/tools/story/test/re_frame/story_substrate_isolation_test.clj
@@ -27,13 +27,28 @@
 
 ;; ----- helpers ------------------------------------------------------------
 
+(defn- src-root
+  "Resolve `tools/story/src/` on disk, cwd-independently. The per-tool
+  `:test` alias runs from `tools/story` (a cwd-relative `(io/file \"src\")`
+  works), but the tools-root aggregate (`tools/deps.edn :test`, rf2-f2tkbt)
+  runs from `tools/`, where a bare `src` would miss. `src` is a classpath
+  `:paths` root, so a known story source (`re_frame/story.cljc`) is a
+  classpath resource on the JVM regardless of cwd; its `src`-relative parent
+  chain is the src-root. Falls back to the cwd-relative path if the resource
+  is absent (e.g. a jar). Mirrors the xray guard tests' `src-root`."
+  []
+  (let [marker (io/resource "re_frame/story.cljc")]
+    (if (and marker (= "file" (.getProtocol marker)))
+      ;; .../src/re_frame/story.cljc → up to .../src
+      (-> (io/file (.toURI marker)) .getParentFile .getParentFile)
+      (io/file "src"))))
+
 (defn- src-files
   "Walk tools/story/src/ and return every .cljc / .cljs / .clj file as
-  a `java.io.File`. The classpath element `src` resolves to the same
-  directory whether tests run via `clojure -M:test` from `tools/story`
-  or via the top-level shadow build."
+  a `java.io.File`, resolving the src root via `src-root` so the walk is
+  cwd-independent (per-tool `clojure -M:test` AND the tools-root aggregate)."
   []
-  (let [root (io/file "src")]
+  (let [root (src-root)]
     (when (.isDirectory root)
       (->> (file-seq root)
            (filter #(.isFile ^java.io.File %))
@@ -89,7 +104,7 @@
 
   (testing "the substrate enum still advertises :reagent + :uix + :helix
 (consumer-app registration surface — keyword refs only, not requires)"
-    (let [enum-file (io/file "src/re_frame/story/schemas.cljc")
+    (let [enum-file (io/file (src-root) "re_frame" "story" "schemas.cljc")
           body      (slurp enum-file)]
       (is (str/includes? body ":reagent"))
       (is (str/includes? body ":uix"))

--- a/tools/story/testbeds/counter_with_stories/story_static.cljs
+++ b/tools/story/testbeds/counter_with_stories/story_static.cljs
@@ -57,10 +57,18 @@
   ;; opts in explicitly via `config/set-allow-static-project-root!` +
   ;; passing a root; this canonical export does not.
   (story/configure! {:rf.story/global-args {:locale :en}})
-  ;; Seed the live-app's :count slot so any embedded `counter-card`
-  ;; view that renders under the variant canvas starts from a
-  ;; deterministic value rather than `nil`.
-  (rf/dispatch-sync [:counter/initialise 5])
+  ;; NO shell-level `(rf/dispatch-sync [:counter/initialise 5])` here.
+  ;; A bare global dispatch carries no frame context, and per EP-0002 the
+  ;; runtime never synthesises a `:rf/default` frame — so the router throws
+  ;; `:rf.error/no-frame-context` at `build-envelope`, which under `:advanced`
+  ;; minified to the `jj` pageerror that aborted the mount and left the shell
+  ;; unrendered (rf2-oki92v). The seed was also redundant: every counter
+  ;; variant renders inside its OWN isolated variant frame and seeds its
+  ;; `:count` slot via that variant's `:setup [[:counter/initialise N]]`
+  ;; (stories.cljs). There is no shell-level live-counter view to seed — this
+  ;; entry mounts only the Story shell — so the dispatch had no legitimate
+  ;; target. Frames are isolated contexts; the static shell holds no app-db
+  ;; of its own to seed.
   ;; Mount the Story shell directly onto `#app`. No hash routing — this
   ;; ns is the static-export entry only, the SPA lives in core.cljs.
   (story/mount-shell! (js/document.getElementById "app")))


### PR DESCRIPTION
Fixes three beads on the `tools/story` surface (one worker, sequential on one branch). Rebased off latest `origin/main`.

## rf2-y0640c (P3, bug) — tools-root aggregate: story/story-mcp cwd failures
The `cd tools && clojure -M:test` aggregate had pre-existing story/story-mcp failures (both suites pass standalone). Two distinct cwd-coupled causes:
1. **cwd-relative file resolution** — four guard/drift tests read repo-tree files via a bare cwd-relative `(io/file "src"…)` / `"test"` / `"spec/API.md"` / `"../../skills/…"`, which resolve from `tools/<tool>` standalone but miss under the `tools/` aggregate cwd. Re-anchored each off a known classpath resource walking to the src / test / artefact root (the xray guard-test pattern), with a cwd fallback.
2. **epoch-load-coupled narrative overflow** — story-mcp ships no epoch dep, so standalone its `run-variant` `:narrative` reads an empty tape. Under the aggregate a story test `require`s `re-frame.epoch`, installing the capture hooks process-wide, so story-mcp's `run-variant` then projects a full narrative that blows the MCP token cap (the result is replaced by an `:rf.mcp/overflow` marker, failing shape/elision assertions). The story-mcp run fixtures now disable epoch-ring recording for the test duration (`rf/configure! :epoch-history {:depth 0}`, restored after) — reproducing the artefact's own epoch-free posture; no-ops cleanly when epoch is absent.

## rf2-oki92v (P2, bug) — static export throws at mount (pageerror 'jj')
The advanced static-export bundle threw an uncaught `ExceptionInfo` `:rf.error/no-frame-context` (minified to `jj`) at mount; the shell never rendered. Deminified via a pseudo-names build: the throw was `re-frame.router/build-envelope` rejecting a bare global `(rf/dispatch-sync [:counter/initialise 5])` in `story_static.cljs` — a frameless dispatch, and per EP-0002 the runtime never synthesises a `:rf/default` frame. The seed was also redundant (variants seed their own `:count` in their own isolated frames via `:setup`; the static entry mounts only the shell). Removed it. Also re-anchored the static-export smoke (`check-story-static.cjs`) on the stable `data-test="story-canvas-empty"` attribute — it was waiting on a stale placeholder string. `test:story-static` smoke now green.

## rf2-fpr0b5 (P2, feature) — EP-0023 behaviour-variant image concept (core)
Gives Story the missing "behavior variant -> image" concept (EP-0023, graduated). Lands the **core** (items 1 + 4):
- **Authoring**: optional `:images` slot on the Variant body — a vector of `rf/image` values. Loose-vector; the framework's `rf/image` + image-assembly own validation (mirrors the `:sensitive`/`:large` precedent).
- **Routing**: `frames/allocate!` threads `:images` into `rf/make-frame` so the variant frame resolves behaviour through its own sealed image generation; `call-with-frame-resolution` routes every `{:frame variant-id}` dispatch through it. Two variants reuse the SAME global id with DIFFERENT meanings — no global-registrar clobber. Image-less variants are unchanged (absence-is-default).
- **Reporting**: run-result `:images` + frame-meta `:rf/images` (`frames/variant-image-ids`).
- Tests: two behaviour-variant image fixtures + JVM tests proving end-to-end differentiated resolution; spec `001`/`002` documented.

**Deferred to follow-ups** (the bead's items 2/3/5, each independent + lower-priority): rf2-6g9mt2 (EP-0013 realm-surface collapse + realm-docstring update), rf2-vttk98 (stub fx/events into the variant image). Also filed rf2-ffc6s0: a **core-engine gap** found during this work — inline `:registrations` with a real fn body don't yet route through dispatch (only the `:include-ns` path is verified end-to-end); Story's image slot works for `:include-ns` images.

## Gates
- story (1717) + story-mcp (284) standalone green
- tools aggregate `cd tools && clojure -M:test` (3509) green
- `npm run test:cljs` (7840) green
- `test:story-static` smoke green
- `scripts/test-fast-pr.sh` green
