### PR TITLE
fix(errors): route all throw-sites through human-message helper + corpus-driven gate (rf2-6bb3pg)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,6 +343,32 @@ jobs:
       - name: Verify durable-write namespaces carry no ambient world read (EP-0010)
         run: python scripts/check_ambient_durable_reads.py --verbose
 
+      # Thrown-error human-message corpus gate (rf2-6bb3pg, Spec 009 §The
+      # thrown-error shape / rf2-vvixub). rf2-vvixub flipped the contract: a
+      # framework thrown-error's `ex-message` is a HUMAN sentence + trailing
+      # `[:rf.error/<id>]` token, never the bare stringified discriminator
+      # keyword (`:rf.error/id` ex-data is the SOLE machine discriminator). The
+      # original conformance test (thrown_error_message_conformance_cljs_test)
+      # is a CURATED allow-list — it exercises a handful of central sites
+      # in-process, so a new/never-converted `(ex-info ":rf.error/…")` site is
+      # invisible to it (rf2-6bb3pg found 70+ such sites). This gate is the
+      # corpus replacement: a source scan that fails on ANY framework
+      # `(ex-info …)` whose MESSAGE position is a bare `:rf.*` discriminator
+      # keyword (literal string, `(str :rf.*)`, `(str error-kw/error-id)`, or
+      # `(str (:rf.error/id <map>))`). It scopes to the ex-info FIRST argument,
+      # so a `:rf.error/…` keyword as a :reason value / ex-data slot / trace
+      # arg never fires; `;`-comments are masked. Pure Python stdlib. Self-test
+      # first (proves it FIRES on each bare-keyword shape + stays GREEN on the
+      # conformant counterparts), then the live scan asserts implementation/
+      # framework source is clean. Hosted in this always-on PR-spine python job
+      # so a keyword-only thrown message blocks the merge regardless of which
+      # surface a PR touches. See scripts/check_thrown_error_messages.py.
+      - name: Self-test the thrown-error human-message gate
+        run: python scripts/check_thrown_error_messages.py --self-test --verbose
+
+      - name: Verify framework source carries no keyword-only thrown message (rf2-vvixub)
+        run: python scripts/check_thrown_error_messages.py --verbose
+
   # PR-time gate for README link drift (rf2-br5u7). Source: the
   # rf2-oavap README sweep used a local `ai/link-sweep-v2.py` audit
   # that flagged 5 issues — 3 real, 2 false-positives caused by GitHub

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -84,15 +84,16 @@
     ;; the raw tree — this throw escapes through React's render path into
     ;; error boundaries / host logs, and the hiccup can carry app-owned
     ;; sensitive/large values that path-based projection cannot recover.
-    (throw (ex-info ":rf.error/as-element-fn-unregistered"
-             {:rf.error/id    :rf.error/as-element-fn-unregistered
-              :where          'reagent2.impl.component/->react-element
-              :recovery       :no-recovery
-              :reason         (str "reagent2.impl.template/as-element was not"
-                                   " registered before render. Require"
-                                   " reagent2.impl.template (or reagent2.core)"
-                                   " so its ns-load wires the as-element seam.")
-              :hiccup/summary (diag/value-summary hiccup)}))))
+    (let [reason (str "reagent2.impl.template/as-element was not"
+                      " registered before render. Require"
+                      " reagent2.impl.template (or reagent2.core)"
+                      " so its ns-load wires the as-element seam.")]
+      (throw (ex-info (str reason " [:rf.error/as-element-fn-unregistered]")
+               {:rf.error/id    :rf.error/as-element-fn-unregistered
+                :where          'reagent2.impl.component/->react-element
+                :recovery       :no-recovery
+                :reason         reason
+                :hiccup/summary (diag/value-summary hiccup)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dynamic var: in-flight component instance
@@ -138,18 +139,19 @@
   [spec]
   (let [unsupported (vec (remove cap-keys (keys spec)))]
     (when (seq unsupported)
-      (throw
-        (ex-info ":rf.error/create-class-key-unsupported"
-          {:rf.error/id    :rf.error/create-class-key-unsupported
-           :where          'reagent2.core/create-class
-           :recovery       :no-recovery
-           :reason         (str "create-class accepts a 7-key cap. "
-                                "Unsupported: " (pr-str unsupported) ". "
-                                "Migrate to the supported keys, restructure "
-                                "via :on-create / :on-destroy events, or "
-                                "switch to the bridge adapter day8/re-frame2-reagent.")
-           :keys           unsupported
-           :supported-keys cap-keys}))))
+      (let [reason (str "create-class accepts a 7-key cap. "
+                        "Unsupported: " (pr-str unsupported) ". "
+                        "Migrate to the supported keys, restructure "
+                        "via :on-create / :on-destroy events, or "
+                        "switch to the bridge adapter day8/re-frame2-reagent.")]
+        (throw
+          (ex-info (str reason " [:rf.error/create-class-key-unsupported]")
+            {:rf.error/id    :rf.error/create-class-key-unsupported
+             :where          'reagent2.core/create-class
+             :recovery       :no-recovery
+             :reason         reason
+             :keys           unsupported
+             :supported-keys cap-keys})))))
   spec)
 
 ;; ---------------------------------------------------------------------------
@@ -526,7 +528,7 @@
                       ;; never carry the whole spec map. A spec can carry
                       ;; app-owned closures/data; the throw is captured by
                       ;; host logs before path-based projection runs.
-                      (throw (ex-info ":rf.error/create-class-missing-render"
+                      (throw (ex-info "create-class spec is missing the required :reagent-render fn. [:rf.error/create-class-missing-render]"
                                {:rf.error/id  :rf.error/create-class-missing-render
                                 :where        'reagent2.core/create-class
                                 :recovery     :no-recovery

--- a/implementation/adapters/reagent/test/re_frame/adapter_render_to_string_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_to_string_cljs_test.cljs
@@ -74,8 +74,8 @@
                           (catch :default e e))]
           (is (some? thrown)
               "render-to-string threw when no emitter was installed")
-          (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
-              "ex-message names the error keyword")
+          (is (= :rf.error/no-hiccup-emitter-bound (:rf.error/id (ex-data thrown)))
+              "ex-data :rf.error/id carries the canonical discriminator")
           (let [data (ex-data thrown)]
             (is (some? data)
                 "the thrown value carries ex-data")

--- a/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
@@ -78,9 +78,9 @@
                    (catch :default e e))]
       (is (some? thrown)
           "rf/init! with a keyword raises")
-      (is (= ":rf.error/no-adapter-specified"
-             (some-> thrown ex-message))
-          "ex-message carries the :rf.error/no-adapter-specified tag")
+      (is (= :rf.error/no-adapter-specified
+             (some-> thrown ex-data :rf.error/id))
+          "ex-data :rf.error/id carries the :rf.error/no-adapter-specified discriminator")
       (let [data (ex-data thrown)]
         (is (= :reagent (:received data))
             "ex-data echoes the offending keyword")))

--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -37,7 +37,8 @@
 
   Builtins: :inc :dec :+ :- :* :/ :identity :conj :assoc :dissoc
             :item-amount :count"
-  (:require [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -97,12 +98,12 @@
                                                     :recovery :no-recovery}))
                    :else          (count x)))
     :item-amount (fn [item] (* (:qty item) (:price item)))
-    (throw (ex-info ":rf.error/conformance-unknown-fn-builtin"
-                    {:rf.error/id :rf.error/conformance-unknown-fn-builtin
-                     :where    'rf/conformance-eval
-                     :recovery :no-recovery
-                     :reason   (str "unknown :fn builtin " k)
-                     :builtin  k}))))
+    (error/throw-error!
+      :rf.error/conformance-unknown-fn-builtin
+      'rf/conformance-eval
+      (str "unknown :fn builtin " k)
+      {:recovery :no-recovery
+       :extra    {:builtin k}})))
 
 ;; ---- value resolver -------------------------------------------------------
 
@@ -298,14 +299,14 @@
 
               :noop acc
 
-              (throw (ex-info ":rf.error/conformance-unknown-before-op"
-                              {:rf.error/id :rf.error/conformance-unknown-before-op
-                               :where    'rf/conformance-eval
-                               :recovery :no-recovery
-                               :reason   "unknown :before DSL op"
-                               :op       step
-                               :allowed  #{:assoc-in-request
-                                           :dispatch :noop}})))))
+              (error/throw-error!
+                :rf.error/conformance-unknown-before-op
+                'rf/conformance-eval
+                "unknown :before DSL op"
+                {:recovery :no-recovery
+                 :extra    {:op      step
+                            :allowed #{:assoc-in-request
+                                       :dispatch :noop}}}))))
         chain-ctx
         steps))))
 
@@ -441,12 +442,12 @@
     :reduce-input ctx
     :db-get    ctx
 
-    (throw (ex-info ":rf.error/conformance-unknown-dsl-op"
-                    {:rf.error/id :rf.error/conformance-unknown-dsl-op
-                     :where    'rf/conformance-eval
-                     :recovery :no-recovery
-                     :reason   "unknown DSL op"
-                     :op       step}))))
+    (error/throw-error!
+      :rf.error/conformance-unknown-dsl-op
+      'rf/conformance-eval
+      "unknown DSL op"
+      {:recovery :no-recovery
+       :extra    {:op step}})))
 
 (defn realise-event-db-handler
   "DSL → an event-db handler fn (db, event) → new-db.

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -3061,12 +3061,13 @@
   "Raise `:rf.error/no-adapter-specified` with a consistent reason
   string. Factored out of `init!`'s nil-check and not-map-check."
   [received]
-  (throw (ex-info ":rf.error/no-adapter-specified"
-                  (cond-> {:where    'rf/init!
-                           :expected "adapter spec map"
-                           :recovery :no-recovery
-                           :reason   "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter)."}
-                    (some? received) (assoc :received received)))))
+  (error/throw-error!
+    :rf.error/no-adapter-specified
+    'rf/init!
+    "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter)."
+    {:recovery :no-recovery
+     :extra    (cond-> {:expected "adapter spec map"}
+                 (some? received) (assoc :received received))}))
 
 (defn init!
   "Idempotent boot — installs a substrate adapter. Pass the adapter spec
@@ -3121,12 +3122,13 @@
   [p]
   (if (#{:server :client} p)
     (do (interop/set-platform! p) nil)
-    (throw (ex-info ":rf.error/invalid-platform"
-                    {:where    'rf/init-platform
-                     :expected "one of #{:server :client}"
-                     :received p
-                     :recovery :no-recovery
-                     :reason   "rf/init-platform takes the platform keyword directly — :server or :client per Spec 011 §Effect handling on the server."}))))
+    (error/throw-error!
+      :rf.error/invalid-platform
+      'rf/init-platform
+      "rf/init-platform takes the platform keyword directly — :server or :client per Spec 011 §Effect handling on the server."
+      {:recovery :no-recovery
+       :extra    {:expected "one of #{:server :client}"
+                  :received p}})))
 
 ;; ---- feature inspection (rf2-3nbl5.5, API-governance G5) ------------------
 ;;

--- a/implementation/core/src/re_frame/core_artefact.cljc
+++ b/implementation/core/src/re_frame/core_artefact.cljc
@@ -77,7 +77,8 @@
   Convention: each `core_<artefact>.cljc` declares a private
   `<artefact>-artefact` at the top of the file and threads it through
   every `defwrapper` spec."
-  (:require [re-frame.late-bind]))
+  (:require [re-frame.error :as error]
+            [re-frame.late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -163,12 +164,12 @@
      (let [attrs (cond
                    (map? docstring-or-attrs)    docstring-or-attrs
                    (string? docstring-or-attrs) {:doc docstring-or-attrs}
-                   :else (throw (ex-info ":rf.error/defwrapper-bad-args"
-                                         {:rf.error/id :rf.error/defwrapper-bad-args
-                                          :where       'defwrapper
-                                          :recovery    :fix-registration
-                                          :reason      "defwrapper's second argument must be a docstring or an attr-map"
-                                          :got         docstring-or-attrs})))
+                   :else (error/throw-error!
+                           :rf.error/defwrapper-bad-args
+                           'defwrapper
+                           "defwrapper's second argument must be a docstring or an attr-map"
+                           {:recovery :fix-registration
+                            :extra    {:got docstring-or-attrs}}))
            attrs (cond-> attrs
                    (:arglists spec) (assoc :arglists (:arglists spec)))
            spec    (update spec :where #(or % (list 'quote (symbol "rf" (str name-sym)))))

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -28,7 +28,8 @@
   File naming uses the flat dash-form (per Conventions; rf2-2vbm):
   CLJS `goog.provide` for `re-frame.core` overwrites its parent
   object, which would wipe a previously-loaded `re-frame.core.X`."
-  (:require [re-frame.source-coords :as source-coords]))
+  (:require [re-frame.error :as error]
+            [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -173,12 +174,12 @@
      [sym]
      (let [v (ns-resolve (find-ns 're-frame.core) sym)]
        (when (nil? v)
-         (throw (ex-info ":rf.error/defreg-macro-bad-delegate"
-                         {:rf.error/id :rf.error/defreg-macro-bad-delegate
-                          :where       'defreg-macro
-                          :recovery    :fix-registration
-                          :reason      (str "defreg-macro cannot resolve delegate symbol " sym " in re-frame.core")
-                          :sym         sym})))
+         (error/throw-error!
+           :rf.error/defreg-macro-bad-delegate
+           'defreg-macro
+           (str "defreg-macro cannot resolve delegate symbol " sym " in re-frame.core")
+           {:recovery :fix-registration
+            :extra    {:sym sym}}))
        (symbol (str (.ns ^clojure.lang.Var v))
                (str (.sym ^clojure.lang.Var v))))))
 

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -16,7 +16,8 @@
 
   The expander helpers stay plain CLJ fns so CLJS test files can also
   exercise them JVM-side."
-  (:require [re-frame.source-coords :as source-coords]))
+  (:require [re-frame.error :as error]
+            [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -114,19 +115,18 @@
                              :rf/id
                              :file :line :column :source :end-line :end-column)]
        (when (nil? parsed)
-         (throw (ex-info
-                  ":rf.error/reg-view-bad-args"
-                  {:rf.error/id    :rf.error/reg-view-bad-args
-                   :where          'rf/reg-view
-                   :recovery       :fix-registration
-                   :reason         (str "reg-view's second argument must be an args vector "
-                                        "(defn-shape: (reg-view sym [args] body)). Got "
-                                        (describe-reg-view-bad-second-arg (first more))
-                                        ". For runtime registration, use "
-                                        "(re-frame.core/reg-view* :id render-fn).")
-                   :sym            sym
-                   :got            (first more)
-                   :args-after-sym (vec more)})))
+         (error/throw-error!
+           :rf.error/reg-view-bad-args
+           'rf/reg-view
+           (str "reg-view's second argument must be an args vector "
+                "(defn-shape: (reg-view sym [args] body)). Got "
+                (describe-reg-view-bad-second-arg (first more))
+                ". For runtime registration, use "
+                "(re-frame.core/reg-view* :id render-fn).")
+           {:recovery :fix-registration
+            :extra    {:sym            sym
+                       :got            (first more)
+                       :args-after-sym (vec more)}}))
        (let [{:keys [docstring args body]} parsed
              form-tag (reagent-slim-form-tag body)
              def-form (if docstring
@@ -234,15 +234,14 @@
      [frame-id body]
      (cond
        (vector? frame-id)
-       (throw (ex-info
-                ":rf.error/with-frame-vector-form"
-                {:rf.error/id :rf.error/with-frame-vector-form
-                 :where       'rf/with-frame
-                 :recovery    :use-with-new-frame
-                 :reason      (str "with-frame pins to an existing frame-id (keyword). "
-                                   "Got a vector — did you mean `with-new-frame`, "
-                                   "which evals, binds, runs, and destroys?")
-                 :got         frame-id}))
+       (error/throw-error!
+         :rf.error/with-frame-vector-form
+         'rf/with-frame
+         (str "with-frame pins to an existing frame-id (keyword). "
+              "Got a vector — did you mean `with-new-frame`, "
+              "which evals, binds, runs, and destroys?")
+         {:recovery :use-with-new-frame
+          :extra    {:got frame-id}})
 
        :else
        `(binding [re-frame.frame/*current-frame* ~frame-id]
@@ -266,39 +265,36 @@
        ;; Common mistake: passed a keyword instead of `[sym expr]`. The
        ;; caller meant `with-frame` (pin form). Reject loudly.
        (keyword? bindings)
-       (throw (ex-info
-                ":rf.error/with-new-frame-keyword-form"
-                {:rf.error/id :rf.error/with-new-frame-keyword-form
-                 :where       'rf/with-new-frame
-                 :recovery    :use-with-frame
-                 :reason      (str "with-new-frame evals, binds, runs, and destroys. "
-                                   "Got a keyword — did you mean `with-frame`, "
-                                   "which pins to an existing frame-id?")
-                 :got         bindings}))
+       (error/throw-error!
+         :rf.error/with-new-frame-keyword-form
+         'rf/with-new-frame
+         (str "with-new-frame evals, binds, runs, and destroys. "
+              "Got a keyword — did you mean `with-frame`, "
+              "which pins to an existing frame-id?")
+         {:recovery :use-with-frame
+          :extra    {:got bindings}})
 
        ;; Vector but wrong arity — almost certainly a typo of the
        ;; binding form (e.g. `[]` or `[f x y]`). Reject at compile time —
        ;; per Spec 002 §with-frame.
        (vector? bindings)
-       (throw (ex-info
-                ":rf.error/with-new-frame-bad-binding"
-                {:rf.error/id :rf.error/with-new-frame-bad-binding
-                 :where       'rf/with-new-frame
-                 :recovery    :fix-registration
-                 :reason      (str "with-new-frame's binding must be [sym expr]. "
-                                   "Got " (count bindings) " element"
-                                   (when-not (= 1 (count bindings)) "s") ".")
-                 :got         bindings
-                 :count       (count bindings)}))
+       (error/throw-error!
+         :rf.error/with-new-frame-bad-binding
+         'rf/with-new-frame
+         (str "with-new-frame's binding must be [sym expr]. "
+              "Got " (count bindings) " element"
+              (when-not (= 1 (count bindings)) "s") ".")
+         {:recovery :fix-registration
+          :extra    {:got   bindings
+                     :count (count bindings)}})
 
        :else
-       (throw (ex-info
-                ":rf.error/with-new-frame-bad-binding"
-                {:rf.error/id :rf.error/with-new-frame-bad-binding
-                 :where       'rf/with-new-frame
-                 :recovery    :fix-registration
-                 :reason      "with-new-frame's binding must be a 2-element vector [sym expr]."
-                 :got         bindings})))))
+       (error/throw-error!
+         :rf.error/with-new-frame-bad-binding
+         'rf/with-new-frame
+         "with-new-frame's binding must be a 2-element vector [sym expr]."
+         {:recovery :fix-registration
+          :extra    {:got bindings}}))))
 
 #?(:clj
    (defn expand-frame-bound-fn

--- a/implementation/core/src/re_frame/error.cljc
+++ b/implementation/core/src/re_frame/error.cljc
@@ -132,6 +132,26 @@
   ([error-id where-sym reason opts]
    (throw (thrown-ex-info error-id where-sym reason opts))))
 
+(defn ex-info-from-data
+  "Build a canonical thrown-error `ex-info` whose ex-data is the ALREADY-BUILT
+  `data` map verbatim, deriving the human message from the map's own
+  `:rf.error/id` + `:reason` slots (Spec 009 §The thrown-error shape).
+
+  The companion to `thrown-ex-info` for the sites that build a SHARED ex-data
+  payload up front — reused by both a throw and a trace-emit / final-boundary
+  emit (e.g. `re-frame.frame`'s `no-frame-context-payload`,
+  `re-frame.events`'s `legacy-runtime-root-ex-data`) — so the two surfaces
+  carry an IDENTICAL map. Those sites cannot route the BUILD through
+  `thrown-ex-info` without forking the shared payload; this helper lets them
+  keep the one payload and still emit the human message instead of the bare
+  `(str (:rf.error/id data))` keyword the message position used to carry.
+
+  `data` MUST carry `:rf.error/id` and SHOULD carry `:reason`; the message is
+  `(human-message (:rf.error/id data) (:reason data))`. ex-data is `data`
+  unchanged."
+  [data]
+  (ex-info (human-message (:rf.error/id data) (:reason data)) data))
+
 (defn keyword-only-message?
   "Conformance predicate (rf2-vvixub): true when `message` is a bare
   stringified `:rf.error/…` keyword — i.e. the OLD keyword-only message

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -37,6 +37,7 @@
             [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.late-bind :as late-bind]
             [re-frame.cofx :as cofx]
+            [re-frame.error :as error]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -82,16 +83,15 @@
   swallow: a malformed chain cannot be honoured and must not be silently
   dropped or coerced."
   [reg-fn-name id value reason]
-  (throw (ex-info
-           ":rf.error/reg-event-bad-interceptors"
-           {:rf.error/id :rf.error/reg-event-bad-interceptors
-            :where       'rf/reg-event
-            :reg-fn      reg-fn-name
-            :id          id
-            :recovery    :fix-registration
-            :reason      reason
-            :got         value
-            :expected    "a vector of interceptor references (e.g. [:auth/required [:rf.interceptor/path [:cart]]])"})))
+  (error/throw-error!
+    :rf.error/reg-event-bad-interceptors
+    'rf/reg-event
+    reason
+    {:recovery :fix-registration
+     :extra    {:reg-fn   reg-fn-name
+                :id       id
+                :got      value
+                :expected "a vector of interceptor references (e.g. [:auth/required [:rf.interceptor/path [:cart]]])"}}))
 
 (defn- throw-inline-interceptor-removed!
   "Raise `:rf.error/inline-interceptor-removed` (ex-info) at registration when a
@@ -103,23 +103,21 @@
   not at first dispatch. Mirrors the dispatch-time
   `interceptor-registry/resolve-chain` rejection with the same error id."
   [reg-fn-name id value offending]
-  (throw (ex-info
-           ":rf.error/inline-interceptor-removed"
-           {:rf.error/id :rf.error/inline-interceptor-removed
-            :where       'rf/reg-event
-            :reg-fn      reg-fn-name
-            :id          id
-            :recovery    :fix-registration
-            :reason
-            (str reg-fn-name " for `" id "` carried an INLINE interceptor value `"
-                 (pr-str offending) "` in its metadata `:interceptors` chain. "
-                 "Interceptor chains are reference-only (EP-0022): register the "
-                 "interceptor with `rf/reg-interceptor` and reference it by id — "
-                 "a bare keyword `:my/ic` or an `[id arg]` 2-vector "
-                 "(e.g. `[:rf.interceptor/path [:cart]]`).")
-            :got         value
-            :offending   offending
-            :expected    "a vector of interceptor references (keyword ids / [id arg] vectors)"})))
+  (error/throw-error!
+    :rf.error/inline-interceptor-removed
+    'rf/reg-event
+    (str reg-fn-name " for `" id "` carried an INLINE interceptor value `"
+         (pr-str offending) "` in its metadata `:interceptors` chain. "
+         "Interceptor chains are reference-only (EP-0022): register the "
+         "interceptor with `rf/reg-interceptor` and reference it by id — "
+         "a bare keyword `:my/ic` or an `[id arg]` 2-vector "
+         "(e.g. `[:rf.interceptor/path [:cart]]`).")
+    {:recovery :fix-registration
+     :extra    {:reg-fn    reg-fn-name
+                :id        id
+                :got       value
+                :offending offending
+                :expected  "a vector of interceptor references (keyword ids / [id arg] vectors)"}}))
 
 (defn- validate-meta-interceptors!
   "Validate the metadata-map `:interceptors` value at registration. The value
@@ -245,22 +243,21 @@
   [reg-fn-name id meta interceptors]
   (when (and (attaches-validate-at-boundary-interceptor? interceptors)
              (not (and (map? meta) (contains? meta :schema))))
-    (throw (ex-info ":rf.error/at-boundary-missing-schema"
-                    {:rf.error/id :rf.error/at-boundary-missing-schema
-                     :where    'rf/reg-event
-                     :reg-fn   reg-fn-name
-                     :id       id
-                     :reason
-                     (str reg-fn-name " for `" id "` attaches the "
-                          "`:rf.schema/at-boundary` interceptor but the "
-                          "registration carries no `:schema` metadata. "
-                          "The boundary interceptor cannot validate "
-                          "without a schema and is structurally "
-                          "meaningless without one. Either attach a "
-                          "`:schema` to the metadata-map "
-                          "(recommended) or remove the boundary "
-                          "interceptor from metadata `:interceptors`.")
-                     :recovery :no-recovery})))
+    (error/throw-error!
+      :rf.error/at-boundary-missing-schema
+      'rf/reg-event
+      (str reg-fn-name " for `" id "` attaches the "
+           "`:rf.schema/at-boundary` interceptor but the "
+           "registration carries no `:schema` metadata. "
+           "The boundary interceptor cannot validate "
+           "without a schema and is structurally "
+           "meaningless without one. Either attach a "
+           "`:schema` to the metadata-map "
+           "(recommended) or remove the boundary "
+           "interceptor from metadata `:interceptors`.")
+      {:recovery :no-recovery
+       :extra    {:reg-fn reg-fn-name
+                  :id     id}}))
   nil)
 
 ;; ---- effect-map shape policing (Spec migration M-8) -----------------------
@@ -558,8 +555,7 @@
   emits in-band rather than throwing, so the drain is not aborted."
   [app-db event]
   (when (legacy-runtime-root? app-db)
-    (throw (ex-info ":rf.error/legacy-runtime-root"
-                    (legacy-runtime-root-ex-data event))))
+    (throw (error/ex-info-from-data (legacy-runtime-root-ex-data event))))
   app-db)
 
 (defn- commit-fx-effects
@@ -766,23 +762,21 @@
   Loud-fail at registration per Conventions §No silent swallow — the
   interceptor would otherwise be silently dropped and never run."
   [reg-fn-name slot offending args]
-  (throw (ex-info
-           ":rf.error/reg-event-bare-interceptor"
-           {:rf.error/id :rf.error/reg-event-bare-interceptor
-            :where       'rf/reg-event
-            :reg-fn      reg-fn-name
-            :slot        slot
-            :recovery    :fix-registration
-            :reason
-            (str reg-fn-name " received a BARE interceptor in the " (name slot)
-                 " slot; the interceptor chain belongs in metadata "
-                 "`:interceptors` and MUST be a vector. A bare interceptor map "
-                 "would be silently dropped (never run). Wrap it: `("
-                 reg-fn-name " id {:interceptors [the-interceptor]} handler)` "
-                 "— not `(" reg-fn-name " id the-interceptor handler)`.")
-            :got         offending
-            :expected    "metadata-map with :interceptors (e.g. {:interceptors [:my/ic]})"
-            :args        args})))
+  (error/throw-error!
+    :rf.error/reg-event-bare-interceptor
+    'rf/reg-event
+    (str reg-fn-name " received a BARE interceptor in the " (name slot)
+         " slot; the interceptor chain belongs in metadata "
+         "`:interceptors` and MUST be a vector. A bare interceptor map "
+         "would be silently dropped (never run). Wrap it: `("
+         reg-fn-name " id {:interceptors [the-interceptor]} handler)` "
+         "— not `(" reg-fn-name " id the-interceptor handler)`.")
+    {:recovery :fix-registration
+     :extra    {:reg-fn   reg-fn-name
+                :slot     slot
+                :got      offending
+                :expected "metadata-map with :interceptors (e.g. {:interceptors [:my/ic]})"
+                :args     args}}))
 
 (defn- normalise-args
   "Accept the two documented shapes for the variadic tail of `reg-event`:
@@ -804,23 +798,21 @@
           (bare-interceptor-map? middle)
           (throw-bare-interceptor! reg-fn-name :middle middle args)
           (map? middle)    [middle handler]
-          :else            (throw (ex-info
-                                    ":rf.error/reg-event-bad-middle-slot"
-                                    {:rf.error/id :rf.error/reg-event-bad-middle-slot
-                                     :where       'rf/reg-event
-                                     :recovery    :fix-registration
-                                     :reason      "the middle slot of a reg-event call must be a metadata-map (e.g. {:doc \"...\" :interceptors [:my/ic]}); the positional interceptor vector is retired"
-                                     :args        args
-                                     :got         middle
-                                     :expected    "metadata-map (e.g. {:doc \"...\" :interceptors [:my/ic]})"}))))
-    (throw (ex-info
-             ":rf.error/reg-event-bad-arity"
-             {:rf.error/id :rf.error/reg-event-bad-arity
-              :where       'rf/reg-event
-              :recovery    :fix-registration
-              :reason      "reg-event expects (id handler) or (id metadata handler); put interceptor chains in metadata :interceptors"
-              :args        args
-              :count       (count args)}))))
+          :else            (error/throw-error!
+                             :rf.error/reg-event-bad-middle-slot
+                             'rf/reg-event
+                             "the middle slot of a reg-event call must be a metadata-map (e.g. {:doc \"...\" :interceptors [:my/ic]}); the positional interceptor vector is retired"
+                             {:recovery :fix-registration
+                              :extra    {:args     args
+                                         :got      middle
+                                         :expected "metadata-map (e.g. {:doc \"...\" :interceptors [:my/ic]})"}})))
+    (error/throw-error!
+      :rf.error/reg-event-bad-arity
+      'rf/reg-event
+      "reg-event expects (id handler) or (id metadata handler); put interceptor chains in metadata :interceptors"
+      {:recovery :fix-registration
+       :extra    {:args  args
+                  :count (count args)}})))
 
 (defn- merge-form-source
   "Merge `*pending-form-source*` into `m` under `:rf.handler/source`
@@ -1101,12 +1093,12 @@
     (trace/emit-error! error-kw
                        (cond-> {:recovery :no-recovery :reason reason}
                          (some? id) (assoc :id id)))
-    (throw (ex-info (str error-kw)
-                    (cond-> {:rf.error/id error-kw
-                             :where       where
-                             :recovery    :no-recovery
-                             :reason      reason}
-                      (some? id) (assoc :id id))))))
+    (error/throw-error!
+      error-kw
+      where
+      reason
+      {:recovery :no-recovery
+       :extra    (cond-> {} (some? id) (assoc :id id))})))
 
 (defn ^:no-doc reg-event-db
   "REMOVED in EP-0018 (no alias). Calling `reg-event-db` is the hard error

--- a/implementation/core/src/re_frame/features.cljc
+++ b/implementation/core/src/re_frame/features.cljc
@@ -51,7 +51,8 @@
   (via `late-bind/require-fn!`); every artefact-missing error in the
   framework carries the same copy-pasteable require/coordinate this
   table holds."
-  (:require [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -184,28 +185,28 @@
   (let [entry (get feature-registry feature)]
     (cond
       (nil? entry)
-      (throw (ex-info ":rf.error/unknown-feature"
-                      {:rf.error/id :rf.error/unknown-feature
-                       :where       'rf/require-feature!
-                       :feature     feature
-                       :known       (vec (sort (keys feature-registry)))
-                       :recovery    :no-recovery
-                       :reason      (str feature " is not a known optional feature. "
-                                         "Known features: "
-                                         (vec (sort (keys feature-registry))) ".")}))
+      (error/throw-error!
+        :rf.error/unknown-feature
+        'rf/require-feature!
+        (str feature " is not a known optional feature. "
+             "Known features: "
+             (vec (sort (keys feature-registry))) ".")
+        {:recovery :no-recovery
+         :extra    {:feature feature
+                    :known   (vec (sort (keys feature-registry)))}})
 
       (feature-loaded? feature)
       true
 
       :else
       (let [{:keys [maven require]} entry]
-        (throw (ex-info ":rf.error/feature-not-loaded"
-                        {:rf.error/id :rf.error/feature-not-loaded
-                         :where       'rf/require-feature!
-                         :feature     feature
-                         :maven       maven
-                         :require-ns  require
-                         :recovery    :no-recovery
-                         :reason      (str "The " feature " feature's implementation artefact "
-                                           "is not on the classpath. Add " maven
-                                           " to deps and (require '" require ") at app boot.")}))))))
+        (error/throw-error!
+          :rf.error/feature-not-loaded
+          'rf/require-feature!
+          (str "The " feature " feature's implementation artefact "
+               "is not on the classpath. Add " maven
+               " to deps and (require '" require ") at app boot.")
+          {:recovery :no-recovery
+           :extra    {:feature    feature
+                      :maven      maven
+                      :require-ns require}})))))

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -400,7 +400,14 @@
   ([operation extra]
    (merge {:rf.error/id :rf.error/no-frame-context
            :operation   operation
-           :recovery    :supply-frame}
+           :recovery    :supply-frame
+           :reason      (str "a frame-scoped " (name operation) " ran with no frame "
+                             "context — no carried frame stamp and no established "
+                             "scope. Frame identity is carried, not found: declare "
+                             "your root frame (rf/reg-frame) and run the operation "
+                             "inside that scope (with-frame / a frame-provider), or "
+                             "pass an explicit {:frame <id>}. Per Spec 002 §The error "
+                             "and its ladder.")}
           ;; Capture-site ancestry off the in-scope handler scope: the
           ;; cascade's dispatch-id correlates a stampless continuation back
           ;; to the cascade that captured the callback. nil outside any
@@ -516,11 +523,11 @@
                     :frame-provider
                     {:where where :recovery :supply-frame})]
       (emit-no-frame-context! payload)
-      (throw (ex-info (str (:rf.error/id payload)) payload)))
+      (throw (error/ex-info-from-data payload)))
     :else
     (let [payload (bad-frame-provider-arg-payload frame-kw {:where where})]
       (emit-bad-frame-provider-arg! payload)
-      (throw (ex-info (str (:rf.error/id payload)) payload)))))
+      (throw (error/ex-info-from-data payload)))))
 
 (defn require-current-frame!
   "Return the frame stamp (id) the in-effect scope carries, or raise/emit
@@ -551,7 +558,7 @@
    (or (resolve-current-frame)
        (let [payload (no-frame-context-payload operation extra)]
          (emit-no-frame-context! payload)
-         (throw (ex-info (str (:rf.error/id payload)) payload))))))
+         (throw (error/ex-info-from-data payload))))))
 
 (defn require-frame-stamp!
   "Operation-time companion to `require-current-frame!` (EP-0002, Spec 002
@@ -578,7 +585,7 @@
    (or frame-id
        (let [payload (no-frame-context-payload operation extra)]
          (emit-no-frame-context! payload)
-         (throw (ex-info (str (:rf.error/id payload)) payload))))))
+         (throw (error/ex-info-from-data payload))))))
 
 ;; ---- lookup ---------------------------------------------------------------
 

--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -97,6 +97,7 @@
   (`:my-app.sinks/datadog`) are NOT framework-claimed."
   (:require [clojure.string :as str]
             [re-frame.elision :as elision]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.path :as path]
@@ -123,13 +124,12 @@
   and MAY carry `:rf.error/cause` (the inner `:rf.error/id` of a wrapped
   path error — kept distinct so it never clobbers this error's own id)."
   [frame-id reason extras]
-  (ex-info (str :rf.error/bad-frame-classification)
-           (merge {:rf.error/id :rf.error/bad-frame-classification
-                   :where       'rf/reg-frame
-                   :recovery    :fix-frame-classification
-                   :frame       frame-id
-                   :reason      reason}
-                  extras)))
+  (error/thrown-ex-info
+    :rf.error/bad-frame-classification
+    'rf/reg-frame
+    reason
+    {:recovery :fix-frame-classification
+     :extra    (merge {:frame frame-id} extras)}))
 
 ;; ---- path validation (EP-0012 :rf/path) ----------------------------------
 ;;

--- a/implementation/core/src/re_frame/identity.cljc
+++ b/implementation/core/src/re_frame/identity.cljc
@@ -50,7 +50,8 @@
 
   Pure namespace — no runtime state, no trace. `.cljc` so the JVM test
   sweep exercises the encoder cross-host."
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            [re-frame.error :as error])
   #?(:clj (:import [java.util UUID]
                    [java.util Date]
                    [java.time Instant ZoneOffset]
@@ -74,13 +75,13 @@
   the CEDN-1 domain fails the WHOLE identity closed — never a host-string
   fallback (Conventions §Canonical EDN identity)."
   [value reason]
-  (throw (ex-info (str :rf.error/non-edn-identity)
-                  {:rf.error/id :rf.error/non-edn-identity
-                   :where       'rf.identity/canonical
-                   :recovery    :encode-as-portable-edn
-                   :reason      reason
-                   :bad-value   value
-                   :bad-type    (str (type value))})))
+  (error/throw-error!
+    :rf.error/non-edn-identity
+    'rf.identity/canonical
+    reason
+    {:recovery :encode-as-portable-edn
+     :extra    {:bad-value value
+                :bad-type  (str (type value))}}))
 
 ;; ---- safe-integer range --------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -64,6 +64,7 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
             [re-frame.identity :as identity]
+            [re-frame.error :as error]
             [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -103,28 +104,28 @@
 
 (defn- throw-invalid-interceptor!
   [id descriptor reason]
-  (throw (ex-info ":rf.error/invalid-interceptor"
-                  {:rf.error/id :rf.error/invalid-interceptor
-                   :where       'rf/reg-interceptor
-                   :id          id
-                   :recovery    :fix-registration
-                   :reason      reason
-                   :got         descriptor
-                   :expected    "one of {:before f} / {:after f} / {:before f :after g} / {:factory f}"})))
+  (error/throw-error!
+    :rf.error/invalid-interceptor
+    'rf/reg-interceptor
+    reason
+    {:recovery :fix-registration
+     :extra    {:id       id
+                :got      descriptor
+                :expected "one of {:before f} / {:after f} / {:before f :after g} / {:factory f}"}}))
 
 (defn- throw-interceptor-id-mismatch!
   [id descriptor value-id]
-  (throw (ex-info ":rf.error/invalid-interceptor"
-                  {:rf.error/id :rf.error/invalid-interceptor
-                   :where       'rf/reg-interceptor
-                   :id          id
-                   :recovery    :fix-registration
-                   :reason      (str "reg-interceptor for `" id "` received an interceptor "
-                                     "VALUE carrying `:id " value-id "`, which does NOT match "
-                                     "the positional registration id `" id "`. The migration "
-                                     "boundary requires the value's `:id` (when present) to "
-                                     "match the registration id.")
-                   :got         descriptor})))
+  (error/throw-error!
+    :rf.error/invalid-interceptor
+    'rf/reg-interceptor
+    (str "reg-interceptor for `" id "` received an interceptor "
+         "VALUE carrying `:id " value-id "`, which does NOT match "
+         "the positional registration id `" id "`. The migration "
+         "boundary requires the value's `:id` (when present) to "
+         "match the registration id.")
+    {:recovery :fix-registration
+     :extra    {:id  id
+                :got descriptor}}))
 
 ;; ---- registration ---------------------------------------------------------
 
@@ -282,39 +283,39 @@
 
 (defn- throw-unregistered-interceptor!
   [ref id]
-  (throw (ex-info ":rf.error/unregistered-interceptor"
-                  {:rf.error/id :rf.error/unregistered-interceptor
-                   :where       'rf/resolve-interceptor-ref
-                   :ref         ref
-                   :id          id
-                   :recovery    :fix-registration
-                   :reason      (str "interceptor reference `" (pr-str ref) "` names id `"
-                                     id "`, which is not registered. Register it with "
-                                     "`reg-interceptor` before referencing it from an "
-                                     "event/frame `:interceptors` chain.")})))
+  (error/throw-error!
+    :rf.error/unregistered-interceptor
+    'rf/resolve-interceptor-ref
+    (str "interceptor reference `" (pr-str ref) "` names id `"
+         id "`, which is not registered. Register it with "
+         "`reg-interceptor` before referencing it from an "
+         "event/frame `:interceptors` chain.")
+    {:recovery :fix-registration
+     :extra    {:ref ref
+                :id  id}}))
 
 (defn- throw-factory-arity!
   [ref id reason]
-  (throw (ex-info ":rf.error/interceptor-factory-arity"
-                  {:rf.error/id :rf.error/interceptor-factory-arity
-                   :where       'rf/resolve-interceptor-ref
-                   :ref         ref
-                   :id          id
-                   :recovery    :fix-registration
-                   :reason      reason})))
+  (error/throw-error!
+    :rf.error/interceptor-factory-arity
+    'rf/resolve-interceptor-ref
+    reason
+    {:recovery :fix-registration
+     :extra    {:ref ref
+                :id  id}}))
 
 (defn- throw-invalid-ref!
   [ref]
-  (throw (ex-info ":rf.error/invalid-interceptor-ref"
-                  {:rf.error/id :rf.error/invalid-interceptor-ref
-                   :where       'rf/resolve-interceptor-ref
-                   :ref         ref
-                   :recovery    :fix-registration
-                   :reason      (str "interceptor chain entry `" (pr-str ref) "` is neither a "
-                                     "keyword id nor an `[id arg]` 2-vector reference. "
-                                     "Interceptor chains are reference-only (EP-0022): register "
-                                     "the interceptor with `reg-interceptor` and reference it by id.")
-                   :expected    "a keyword id or an [id arg] vector"})))
+  (error/throw-error!
+    :rf.error/invalid-interceptor-ref
+    'rf/resolve-interceptor-ref
+    (str "interceptor chain entry `" (pr-str ref) "` is neither a "
+         "keyword id nor an `[id arg]` 2-vector reference. "
+         "Interceptor chains are reference-only (EP-0022): register "
+         "the interceptor with `reg-interceptor` and reference it by id.")
+    {:recovery :fix-registration
+     :extra    {:ref      ref
+                :expected "a keyword id or an [id arg] vector"}}))
 
 (defn- throw-inline-interceptor-removed!
   "Raise `:rf.error/inline-interceptor-removed` (ex-info) for an INLINE
@@ -327,18 +328,18 @@
   registered with `reg-interceptor` and referenced by id. Loud-fail at chain
   assembly rather than a silent no-op (Conventions §No silent swallow)."
   [entry]
-  (throw (ex-info ":rf.error/inline-interceptor-removed"
-                  {:rf.error/id :rf.error/inline-interceptor-removed
-                   :where       'rf/resolve-chain
-                   :entry       entry
-                   :recovery    :fix-registration
-                   :reason      (str "an event/frame `:interceptors` chain carried an INLINE "
-                                     "interceptor value `" (pr-str entry) "`. Interceptor "
-                                     "chains are reference-only (EP-0022): register the "
-                                     "interceptor with `reg-interceptor` and reference it by id "
-                                     "— a bare keyword `:my/ic` or an `[id arg]` 2-vector "
-                                     "(e.g. `[:rf.interceptor/path [:cart]]`).")
-                   :expected    "a keyword id or an [id arg] vector reference"})))
+  (error/throw-error!
+    :rf.error/inline-interceptor-removed
+    'rf/resolve-chain
+    (str "an event/frame `:interceptors` chain carried an INLINE "
+         "interceptor value `" (pr-str entry) "`. Interceptor "
+         "chains are reference-only (EP-0022): register the "
+         "interceptor with `reg-interceptor` and reference it by id "
+         "— a bare keyword `:my/ic` or an `[id arg]` 2-vector "
+         "(e.g. `[:rf.interceptor/path [:cart]]`).")
+    {:recovery :fix-registration
+     :extra    {:entry    entry
+                :expected "a keyword id or an [id arg] vector reference"}}))
 
 (defn- resolve-factory
   "Resolve a parameterized `[id arg]` ref against its registered `:factory`

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -38,6 +38,7 @@
   classification is authored on the frame. The former
   schema→app-db-egress route is gone post-EP-0015 §8.)"
   (:require [re-frame.elision :as elision]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -148,13 +149,12 @@
   merges the offending-value slot (`:bad-value` for a non-vector whole,
   `:bad-entries` for malformed entries)."
   [mark-key reason extras]
-  (ex-info (str :rf.error/bad-marks)
-           (merge {:rf.error/id :rf.error/bad-marks
-                   :where       'rf/reg-marks
-                   :recovery    :fix-registration
-                   :reason      reason
-                   :bad-key     mark-key}
-                  extras)))
+  (error/thrown-ex-info
+    :rf.error/bad-marks
+    'rf/reg-marks
+    reason
+    {:recovery :fix-registration
+     :extra    (merge {:bad-key mark-key} extras)}))
 
 (defn- coerce-paths
   "Normalise a `:sensitive` / `:large` declaration value to a vector of
@@ -634,17 +634,17 @@
                  (case mark
                    :sensitive [(conj s p) l]
                    :large     [s (conj l p)]
-                   (throw (ex-info (str :rf.error/bad-marks)
-                                   {:rf.error/id :rf.error/bad-marks
-                                    :where       'rf/add-marks
-                                    :recovery    :fix-mark-value
-                                    :reason      (str "an app-db mark value must be one of "
-                                                      (pr-str app-db-mark-values)
-                                                      " — :sensitive redacts the value, :large "
-                                                      "emits a size marker")
-                                    :bad-path    path
-                                    :bad-mark    mark
-                                    :valid       app-db-mark-values})))))
+                   (error/throw-error!
+                     :rf.error/bad-marks
+                     'rf/add-marks
+                     (str "an app-db mark value must be one of "
+                          (pr-str app-db-mark-values)
+                          " — :sensitive redacts the value, :large "
+                          "emits a size marker")
+                     {:recovery :fix-mark-value
+                      :extra    {:bad-path path
+                                 :bad-mark mark
+                                 :valid    app-db-mark-values}}))))
              [[] []]
              path->mark))
 

--- a/implementation/core/src/re_frame/path.cljc
+++ b/implementation/core/src/re_frame/path.cljc
@@ -58,6 +58,7 @@
   so the JVM test sweep exercises the algebra without the CLJS runtime."
   (:refer-clojure :exclude [get])
   (:require [clojure.core :as core]
+            [re-frame.error :as error]
             [re-frame.identity :as identity])
   #?(:clj (:import [java.util UUID Date]
                    [java.time Instant])))
@@ -406,11 +407,14 @@
                 (let [param (nth seg 1)]
                   (if (contains? bindings param)
                     (core/get bindings param)
-                    (throw (ex-info (str :rf.error/missing-path-param)
-                                    {:rf.error/id :rf.error/missing-path-param
-                                     :where       'rf.path/instantiate
-                                     :recovery    :supply-binding
-                                     :param       param
-                                     :bad-path    path}))))
+                    (error/throw-error!
+                      :rf.error/missing-path-param
+                      'rf.path/instantiate
+                      (str "the :rf/path template references parameter " (pr-str param)
+                           " but no binding was supplied for it; provide a binding for "
+                           "every [:rf.path/param …] segment when instantiating the path.")
+                      {:recovery :supply-binding
+                       :extra    {:param    param
+                                  :bad-path path}})))
                 seg))
             path))))

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -62,7 +62,8 @@
   whole `(reg-event-X :id {:doc \"…\"} …)` form-source under
   `goog.DEBUG=false` (the elision-probe `:probe/cs-event` sentinel
   covers it); the strip here pins the *handler-meta* absence."
-  (:require [re-frame.interop       :as interop]
+  (:require [re-frame.error         :as error]
+            [re-frame.interop       :as interop]
             [re-frame.late-bind     :as late-bind]
             [re-frame.source-coords :as source-coords]
             [re-frame.source-store  :as source-store]))
@@ -489,13 +490,13 @@
   surface — `(rf2-6w7zn)`."
   [kind id metadata]
   (when-not (valid-kind? kind)
-    (throw (ex-info ":rf.error/unknown-registry-kind"
-                    {:rf.error/id :rf.error/unknown-registry-kind
-                     :where       'rf/register-handler
-                     :recovery    :fix-registration
-                     :reason      (str "unknown registry kind " kind " — not one of the registered registry kinds")
-                     :kind        kind
-                     :id          id})))
+    (error/throw-error!
+      :rf.error/unknown-registry-kind
+      'rf/register-handler
+      (str "unknown registry kind " kind " — not one of the registered registry kinds")
+      {:recovery :fix-registration
+       :extra    {:kind kind
+                  :id   id}}))
   ;; Always-on error-coord parallel registry (rf2-3un2g §Production
   ;; elision). When a public reg-* macro is on the stack `*pending-coords*`
   ;; carries the captured coord-map (slim in CLJS prod — no `:column`).

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -15,6 +15,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
+            [re-frame.error :as error]
             [re-frame.error-emit :as error-emit]
             [re-frame.events :as events]
             [re-frame.cofx :as cofx]
@@ -512,13 +513,13 @@
   "Throw `:rf.error/interceptor-override-invalid` (Spec 002 §`:interceptor-
   overrides` / §Error model) for a malformed override map key or replacement."
   [k v reason]
-  (throw (ex-info ":rf.error/interceptor-override-invalid"
-                  {:rf.error/id :rf.error/interceptor-override-invalid
-                   :where       :rf.interceptor/overrides
-                   :recovery    :fix-overrides
-                   :reason      reason
-                   :key         k
-                   :replacement v})))
+  (error/throw-error!
+    :rf.error/interceptor-override-invalid
+    :rf.interceptor/overrides
+    reason
+    {:recovery :fix-overrides
+     :extra    {:key         k
+                :replacement v}}))
 
 (defn- override-replacement
   "Resolve an `:interceptor-overrides` replacement VALUE to an executable

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -156,13 +156,13 @@
   the `[:rf.interceptor/path <path-vector>]` ref carries a non-vector or
   otherwise malformed path argument."
   [path-vector reason]
-  (throw (ex-info ":rf.error/path-interceptor-bad-path"
-                  {:rf.error/id :rf.error/path-interceptor-bad-path
-                   :where       :rf.interceptor/path
-                   :recovery    :fix-path
-                   :reason      reason
-                   :got         path-vector
-                   :expected    "an EDN vector naming a concrete app-db path, e.g. [:cart :items]"})))
+  (error/throw-error!
+    :rf.error/path-interceptor-bad-path
+    :rf.interceptor/path
+    reason
+    {:recovery :fix-path
+     :extra    {:got      path-vector
+                :expected "an EDN vector naming a concrete app-db path, e.g. [:cart :items]"}}))
 
 (defn standard-path-interceptor
   "Build the framework-standard `:rf.interceptor/path` interceptor focusing the

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -33,6 +33,7 @@
   This is the only disposal algorithm — there are no pluggable lifecycle
   policies, no deferred-grace timer, no batched dispose."
   (:require [re-frame.registrar :as registrar]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.live-frame :as live-frame]
             [re-frame.substrate.adapter :as adapter]
@@ -106,14 +107,13 @@
         meta  (if meta? (first args) {})
         rest-args (if meta? (next args) args)
         bad!  (fn [reason received]
-                (throw (ex-info
-                         ":rf.error/reg-sub-bad-args"
-                         {:rf.error/id :rf.error/reg-sub-bad-args
-                          :where       'rf/reg-sub
-                          :recovery    :fix-registration
-                          :reason      reason
-                          :id          id
-                          :received    received})))]
+                (error/throw-error!
+                  :rf.error/reg-sub-bad-args
+                  'rf/reg-sub
+                  reason
+                  {:recovery :fix-registration
+                   :extra    {:id       id
+                              :received received}}))]
     (loop [chain []
            remaining rest-args]
       (cond
@@ -381,11 +381,11 @@
   reactive cache path and the pure `compute-sub` path."
   [input-return]
   (let [bad! (fn [reason]
-               (throw (ex-info
-                        ":rf.error/sub-input-fn-bad-return"
-                        {:rf.error/id :rf.error/sub-input-fn-bad-return
-                         :returned    input-return
-                         :reason      reason})))]
+               (error/throw-error!
+                 :rf.error/sub-input-fn-bad-return
+                 'rf/subscribe
+                 reason
+                 {:extra {:returned input-return}}))]
     (cond
       (not (vector? input-return))
       (bad! (str "input-fn must return a vector of query vectors; got "

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -809,9 +809,11 @@
       ;; ex-data is captured by SSR/static-export error handlers and
       ;; host logs before the record projector can classify it, and a
       ;; hiccup tree can carry app-owned sensitive/large values.
-      (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                      {:reason              "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
-                       :render-tree/summary (rf-error/diag-value-summary render-tree)})))))
+      (rf-error/throw-error!
+        :rf.error/no-hiccup-emitter-bound
+        'rf/render-to-string
+        "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
+        {:extra {:render-tree/summary (rf-error/diag-value-summary render-tree)}}))))
 
 ;; ---- context provider — substrate-agnostic CORE ---------------------------
 ;;

--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -163,6 +163,7 @@
     `cljs.test/async`). Replaces incidental fixed-sleep waits when the
     post-condition is observable in view-state or app-db."
   (:require [clojure.string :as str]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             #?(:clj  [clojure.test :as ctest]
                :cljs [cljs.test :as ctest :include-macros true]))
@@ -439,23 +440,19 @@
         (is (= 1 (:n (app-db-value :rf/default)))))"
   [node event-key & args]
   (when-not (vector? node)
-    (throw (ex-info ":rf.error/invoke-handler-bad-node"
-                    {:rf.error/id :rf.error/invoke-handler-bad-node
-                     :where     'rf/invoke-handler
-                     :recovery  :no-recovery
-                     :reason    "invoke-handler's node must be a hiccup vector"
-                     :node      node
-                     :event-key event-key})))
+    (error/throw-error! :rf.error/invoke-handler-bad-node
+                        'rf/invoke-handler
+                        "invoke-handler's node must be a hiccup vector"
+                        {:extra {:node      node
+                                 :event-key event-key}}))
   (let [h (extract-handler node event-key)]
     (when-not (fn? h)
-      (throw (ex-info ":rf.error/invoke-handler-missing"
-                      {:rf.error/id :rf.error/invoke-handler-missing
-                       :where     'rf/invoke-handler
-                       :recovery  :no-recovery
-                       :reason    (str "invoke-handler found no handler fn under " event-key)
-                       :node      node
-                       :event-key event-key
-                       :handler   h})))
+      (error/throw-error! :rf.error/invoke-handler-missing
+                          'rf/invoke-handler
+                          (str "invoke-handler found no handler fn under " event-key)
+                          {:extra {:node      node
+                                   :event-key event-key
+                                   :handler   h}}))
     (apply h args)))
 
 ;; ---------------------------------------------------------------------------
@@ -606,15 +603,13 @@
   []
   (if-let [view *current-root-view*]
     (apply view *current-root-view-args*)
-    (throw (ex-info
-             ":rf.error/no-root-view"
-             {:rf.error/id :rf.error/no-root-view
-              :where    'rf/expect-text
-              :recovery :no-recovery
-              :reason   (str "expect-text / wait-until called outside a "
-                             "`with-app-fixture` body, OR the fixture did not "
-                             "supply :root-view. Pass an explicit tree as the "
-                             "first arg, or set :root-view in the fixture opts.")}))))
+    (error/throw-error!
+      :rf.error/no-root-view
+      'rf/expect-text
+      (str "expect-text / wait-until called outside a "
+           "`with-app-fixture` body, OR the fixture did not "
+           "supply :root-view. Pass an explicit tree as the "
+           "first arg, or set :root-view in the fixture opts."))))
 
 (defn- coerce-testid-string
   "Allow testids supplied as keywords (`:counter-display`) at the call
@@ -626,13 +621,11 @@
     (keyword? testid) (name testid)
     (string?  testid) testid
     :else
-    (throw (ex-info ":rf.error/testid-bad-arg"
-                    {:rf.error/id :rf.error/testid-bad-arg
-                     :where    'rf/find-by-testid
-                     :recovery :no-recovery
-                     :reason   (str "testid must be a keyword or string, got "
-                                    (pr-str testid))
-                     :testid   testid}))))
+    (error/throw-error! :rf.error/testid-bad-arg
+                        'rf/find-by-testid
+                        (str "testid must be a keyword or string, got "
+                             (pr-str testid))
+                        {:extra {:testid testid}})))
 
 (defn expect-text
   "Assert that the hiccup node carrying `:data-testid testid` has
@@ -699,14 +692,12 @@
   the canonical `:rf.error/id :rf.error/wait-until-timeout` discriminator
   (per Spec 009) regardless of runtime."
   [label elapsed-ms]
-  (ex-info ":rf.error/wait-until-timeout"
-           {:rf.error/id :rf.error/wait-until-timeout
-            :where       'rf/wait-until
-            :recovery    :no-recovery
-            :reason      (str "wait-until timed out"
-                              (when label (str " — " label)))
-            :elapsed-ms  elapsed-ms
-            :label       label}))
+  (error/thrown-ex-info :rf.error/wait-until-timeout
+                        'rf/wait-until
+                        (str "wait-until timed out"
+                             (when label (str " — " label)))
+                        {:extra {:elapsed-ms elapsed-ms
+                                 :label      label}}))
 
 #?(:clj
    (defn- jvm-wait-until-pred

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -97,6 +97,7 @@
     timer-semantics tests — those should keep their sleep and annotate
     that intent locally (the sleep IS the contract under test)."
   (:require [re-frame.registrar :as registrar]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             ;; The flows / schemas / machines / routing / http-managed /
             ;; epoch artefacts ship in separate Maven coordinates and are
@@ -747,14 +748,12 @@
   :rf.error/poll-until-timeout` discriminator (per Spec 009) works on
   either runtime."
   [label elapsed-ms]
-  (ex-info ":rf.error/poll-until-timeout"
-           {:rf.error/id :rf.error/poll-until-timeout
-            :where       'rf/poll-until
-            :recovery    :no-recovery
-            :reason      (str "poll-until timed out"
-                              (when label (str " — " label)))
-            :elapsed-ms  elapsed-ms
-            :label       label}))
+  (error/thrown-ex-info :rf.error/poll-until-timeout
+                        'rf/poll-until
+                        (str "poll-until timed out"
+                             (when label (str " — " label)))
+                        {:extra {:elapsed-ms elapsed-ms
+                                 :label      label}}))
 
 #?(:clj
    (defn poll-until

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -179,7 +179,7 @@
     (let [thrown (try (render-to-string [:div] {}) nil
                       (catch :default e e))]
       (is (some? thrown) "render-to-string threw post-dispose")
-      (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
+      (is (= :rf.error/no-hiccup-emitter-bound (:rf.error/id (ex-data thrown)))
           "the emitter slot was cleared by dispose-adapter!"))))
 
 (defn assert-clear-warn-idempotent-post-dispose
@@ -1008,8 +1008,8 @@
           thrown (try (render-to-string tree {}) nil
                       (catch :default e e))]
       (is (some? thrown) "render-to-string threw when no emitter was installed")
-      (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
-          "ex-message names the error keyword")
+      (is (= :rf.error/no-hiccup-emitter-bound (:rf.error/id (ex-data thrown)))
+          ":rf.error/id names the canonical error discriminator")
       (let [data (ex-data thrown)]
         (is (some? data) "the thrown value carries ex-data")
         (is (string? (:reason data)) ":reason key is a string")

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -225,9 +225,9 @@
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown)
           "rf/init! with nil raises")
-      (is (= ":rf.error/no-adapter-specified"
-             (some-> thrown ex-message))
-          "ex-message carries the :rf.error/no-adapter-specified tag"))
+      (is (= :rf.error/no-adapter-specified
+             (:rf.error/id (ex-data thrown)))
+          "ex-data carries the :rf.error/no-adapter-specified tag"))
     (is (nil? (adapter/current-adapter))
         "the failed init! did NOT install any adapter")))
 
@@ -239,8 +239,8 @@
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown)
           "rf/init! with a keyword raises — keyword form is not supported")
-      (is (= ":rf.error/no-adapter-specified"
-             (some-> thrown ex-message))
+      (is (= :rf.error/no-adapter-specified
+             (:rf.error/id (ex-data thrown)))
           "the thrown exception carries the :rf.error/no-adapter-specified tag")
       (let [data (ex-data thrown)]
         (is (= :reagent (:received data))

--- a/implementation/core/test/re_frame/core_contract_guards_test.clj
+++ b/implementation/core/test/re_frame/core_contract_guards_test.clj
@@ -77,8 +77,6 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex)
           "an unknown kind throws an ex-info")
-      (is (= ":rf.error/unknown-registry-kind" (.getMessage ^Exception ex))
-          "message is the stringified canonical error keyword")
       (let [data (ex-data ex)]
         (is (= :rf.error/unknown-registry-kind (:rf.error/id data))
             ":rf.error/id is the canonical discriminator")
@@ -177,7 +175,6 @@
                (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex)
           "a malformed reg-sub tail throws an ex-info")
-      (is (= ":rf.error/reg-sub-bad-args" (.getMessage ^Exception ex)))
       (let [data (ex-data ex)]
         (is (= :rf.error/reg-sub-bad-args (:rf.error/id data)))
         (is (= 'rf/reg-sub (:where data)))

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -162,7 +162,6 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/reg-event-bad-middle-slot" (ex-message ex)))
       (let [data (ex-data ex)]
         (is (= :rf.error/reg-event-bad-middle-slot (:rf.error/id data)))
         (is (= 'rf/reg-event (:where data)))
@@ -187,7 +186,6 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/reg-event-bad-arity" (ex-message ex)))
       (is (= :rf.error/reg-event-bad-arity (:rf.error/id (ex-data ex))))
       (is (re-find #"interceptor chains in metadata :interceptors" (:reason (ex-data ex)))))))
 
@@ -202,7 +200,6 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/reg-event-bad-interceptors" (ex-message ex)))
       (let [data (ex-data ex)]
         (is (= :rf.error/reg-event-bad-interceptors (:rf.error/id data)))
         (is (= "reg-event" (:reg-fn data)))
@@ -224,7 +221,7 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/reg-event-bad-interceptors" (ex-message ex)))
+      (is (= :rf.error/reg-event-bad-interceptors (:rf.error/id (ex-data ex))))
       (is (re-find #"reference" (:reason (ex-data ex))))))
 
   (testing "EP-0022 reference-only flip: an INLINE interceptor value in a chain throws inline-interceptor-removed"
@@ -234,7 +231,6 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/inline-interceptor-removed" (ex-message ex)))
       (let [data (ex-data ex)]
         (is (= :rf.error/inline-interceptor-removed (:rf.error/id data)))
         (is (= "reg-event" (:reg-fn data)))
@@ -252,7 +248,7 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/inline-interceptor-removed" (ex-message ex)))))
+      (is (= :rf.error/inline-interceptor-removed (:rf.error/id (ex-data ex))))))
 
   (testing "EP-0022: a bare-keyword ref to an UNREGISTERED interceptor throws unregistered-interceptor"
     (let [ex (try (rf/reg-event :test.0adhqs/bad-ref
@@ -261,7 +257,6 @@
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/unregistered-interceptor" (ex-message ex)))
       (is (= :rf.error/unregistered-interceptor (:rf.error/id (ex-data ex))))))
 
   (testing "the malformed rejection happens BEFORE the registry slot is written"
@@ -548,9 +543,8 @@
                nil
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/reg-event-bad-arity" (ex-message ex))
-          "message is the stringified discriminator kw")
-      (is (= :rf.error/reg-event-bad-arity (:rf.error/id (ex-data ex))))
+      (is (= :rf.error/reg-event-bad-arity (:rf.error/id (ex-data ex)))
+          ":rf.error/id is the canonical discriminator")
       (is (re-find #"reg-event expects" (:reason (ex-data ex)))
           ":reason names the arity error")))
   (testing "two-arg middle slot that is neither a map nor a vector throws"
@@ -561,7 +555,6 @@
                nil
                (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex))
-      (is (= ":rf.error/reg-event-bad-middle-slot" (ex-message ex)))
       (is (= :rf.error/reg-event-bad-middle-slot (:rf.error/id (ex-data ex))))
       (is (re-find #"metadata-map" (:reason (ex-data ex)))))))
 

--- a/implementation/core/test/re_frame/frame_resolver_test.clj
+++ b/implementation/core/test/re_frame/frame_resolver_test.clj
@@ -94,8 +94,6 @@
                    nil
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown) "require-current-frame! throws outside any scope")
-      (is (= ":rf.error/no-frame-context" (some-> thrown ex-message))
-          "ex-message carries the :rf.error/no-frame-context tag")
       (let [data (ex-data thrown)]
         (is (= :rf.error/no-frame-context (:rf.error/id data))
             "ex-data carries the canonical :rf.error/id discriminator")

--- a/implementation/core/test/re_frame/init_platform_test.clj
+++ b/implementation/core/test/re_frame/init_platform_test.clj
@@ -124,7 +124,7 @@
                     (catch clojure.lang.ExceptionInfo e e))]
         (is (some? ex)
             (str "(rf/init-platform " (pr-str bad) ") raised"))
-        (is (= ":rf.error/invalid-platform" (ex-message ex)))
+        (is (= :rf.error/invalid-platform (:rf.error/id (ex-data ex))))
         (is (= :no-recovery (:recovery (ex-data ex))))
         (is (= 'rf/init-platform (:where (ex-data ex))))
         (is (= bad (:received (ex-data ex)))))))

--- a/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
@@ -17,6 +17,17 @@
   asserts the central builder + every CENTRAL per-surface site routed
   through it (rf2-vvixub PR) emits the canonical message.
 
+  CORPUS BACKSTOP (rf2-6bb3pg): this suite exercises the BUILDER
+  PREDICATES + a curated set of central sites in-process, so a NEW or
+  never-converted `(ex-info \":rf.error/…\")` site elsewhere is invisible
+  to it. The whole-tree anti-regression sweep is now
+  `scripts/check_thrown_error_messages.py` — a source scan (run by
+  `scripts/test-fast-pr.sh`) that fails on ANY framework `(ex-info …)`
+  whose message position is a bare `:rf.*` discriminator keyword. That
+  corpus gate, not this allow-list, is what guarantees the rollout can't
+  silently regress; this suite proves the BUILDER and predicates the
+  corpus gate's contract rests on are themselves correct.
+
   Dual-runtime: the ns ends in `-cljs-test` so it rides the always-on
   `:node-test` gate (`npm run test:cljs`); cognitect-test-runner also
   discovers the `.cljc` on the JVM (`clojure -M:test`). Pure data — no

--- a/implementation/http/src/re_frame/http_transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http_transport_cljs.cljc
@@ -19,6 +19,7 @@
   `:cljs` reader branch). Keeping the conditionals local to the adapter is
   the rf2-hp772l contract: the shared loop carries no CLJS interop."
   (:require [clojure.string         :as str]
+            [re-frame.error         :as error]
             [re-frame.http-decode   :as decode]
             [re-frame.http-encoding :as encoding]
             [re-frame.http-privacy  :as privacy]
@@ -244,24 +245,25 @@
                                       (fn []
                                         (try (.abort internal-controller "timeout")
                                              (catch :default _ nil))
-                                        (reject (ex-info ":rf.error/http-timeout"
-                                                         {:rf.error/id      :rf.error/http-timeout
-                                                          :where            ':rf.http/managed
-                                                          :recovery         :no-recovery
-                                                          :reason           (str "the request exceeded its " timeout-ms "ms timeout and was aborted")
-                                                          ;; co-stamp the registry-hook signal the
-                                                          ;; downstream classifier branches on
-                                                          :rf.http/timeout? true
-                                                          ;; rf2-6ecc6 — a MEASURED wall-clock delta
-                                                          ;; (whole ms, monotonic where available),
-                                                          ;; not the synthetic `timeout-ms` constant.
-                                                          ;; The setTimeout fires at ~`timeout-ms`, so
-                                                          ;; this is `>= :limit-ms` by the scheduling
-                                                          ;; margin — the SAME semantics the JVM path
-                                                          ;; reports via `System/nanoTime`, closing the
-                                                          ;; prior cross-host `:elapsed-ms` divergence.
-                                                          :elapsed-ms       (js/Math.round (- (now-ms) started-ms))
-                                                          :limit-ms         timeout-ms})))
+                                        (reject (error/thrown-ex-info
+                                                  :rf.error/http-timeout
+                                                  ':rf.http/managed
+                                                  (str "the request exceeded its " timeout-ms "ms timeout and was aborted")
+                                                  {:recovery :no-recovery
+                                                   :extra
+                                                   {;; co-stamp the registry-hook signal the
+                                                    ;; downstream classifier branches on
+                                                    :rf.http/timeout? true
+                                                    ;; rf2-6ecc6 — a MEASURED wall-clock delta
+                                                    ;; (whole ms, monotonic where available),
+                                                    ;; not the synthetic `timeout-ms` constant.
+                                                    ;; The setTimeout fires at ~`timeout-ms`, so
+                                                    ;; this is `>= :limit-ms` by the scheduling
+                                                    ;; margin — the SAME semantics the JVM path
+                                                    ;; reports via `System/nanoTime`, closing the
+                                                    ;; prior cross-host `:elapsed-ms` divergence.
+                                                    :elapsed-ms       (js/Math.round (- (now-ms) started-ms))
+                                                    :limit-ms         timeout-ms}})))
                                       timeout-ms)))))
            promise
            (-> (js/Promise.race #js [attempt-promise timeout-promise])

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -36,7 +36,8 @@
   Overflow throws `:rf.error/id :rf.error/malformed-json` with
   `:cause :too-many-keys` — the `:rf.http/managed` cascade classifies
   this as `:rf.http/decode-failure`."
-  #?(:clj  (:require [cheshire.core :as cheshire])))
+  (:require [re-frame.error :as error]
+            #?(:clj [cheshire.core :as cheshire])))
 
 ;; rf2-b45uc — reflection warnings ON. This ns carries the other
 ;; non-trivial JVM interop in the http surface (Cheshire's
@@ -71,13 +72,13 @@
   Carries `:rf.error/id :rf.error/malformed-json` + `:cause :too-many-keys`
   + the configured `:limit`."
   [max-keys]
-  (ex-info ":rf.error/malformed-json"
-           {:rf.error/id :rf.error/malformed-json
-            :where       'rf.http/json-parse
-            :recovery    :no-recovery
-            :reason      (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
-            :cause       :too-many-keys
-            :limit       max-keys}))
+  (error/thrown-ex-info
+    :rf.error/malformed-json
+    'rf.http/json-parse
+    (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
+    {:recovery :no-recovery
+     :extra    {:cause :too-many-keys
+                :limit max-keys}}))
 
 (defn json-parse
   "JSON string → Clojure data with keyword keys for object keys. JVM

--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -59,6 +59,7 @@
   surface is re-frame2's own (EP-0017 §Rationale — Why consumer attachment
   for machines)."
   (:require [re-frame.cofx :as cofx]
+            [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.machines.grammar :as grammar]
             [re-frame.registrar :as registrar]
@@ -113,23 +114,21 @@
   §Consumer attachment §Inline callbacks cannot declare requirements +
   Spec 009 §Error catalogue."
   [where detail]
-  (throw (ex-info
-           ":rf.error/machine-cofx-requires-inline"
-           (merge {:rf.error/id :rf.error/machine-cofx-requires-inline
-                   :where       'rf/reg-machine
-                   :recovery    :no-recovery
-                   :reason
-                   (str ":rf.cofx/requires may be declared ONLY on a NAMED "
-                        ":guards / :actions entry map (the "
-                        "`{:rf.cofx/requires [...] :fn (fn [...] ...)}` form) "
-                        "— never on an inline callback. A fact-consuming "
-                        "guard / action must be a named entry so the declared "
-                        "diet sits with the code that can be checked against "
-                        "it (Spec 005 §Consumer attachment). Move the inline "
-                        "fn into the machine's :guards / :actions map and "
-                        "declare :rf.cofx/requires on its entry. Found at: "
-                        where ".")}
-                  detail))))
+  (error/throw-error!
+    :rf.error/machine-cofx-requires-inline
+    'rf/reg-machine
+    (str ":rf.cofx/requires may be declared ONLY on a NAMED "
+         ":guards / :actions entry map (the "
+         "`{:rf.cofx/requires [...] :fn (fn [...] ...)}` form) "
+         "— never on an inline callback. A fact-consuming "
+         "guard / action must be a named entry so the declared "
+         "diet sits with the code that can be checked against "
+         "it (Spec 005 §Consumer attachment). Move the inline "
+         "fn into the machine's :guards / :actions map and "
+         "declare :rf.cofx/requires on its entry. Found at: "
+         where ".")
+    {:recovery :no-recovery
+     :extra    detail}))
 
 (defn- check-no-inline-requires!
   "Reject `:rf.cofx/requires` anywhere it cannot be honoured. `v` is a

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -22,6 +22,7 @@
       action-failure projection, finalize delegation (in
       `lifecycle-fx.finalize`)."
   (:require [re-frame.cofx :as cofx]
+            [re-frame.error :as error]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -748,25 +749,23 @@
   ;; direct path stays legal for it.
   (when (and (:data-schema machine)
              (not *in-registration-home?*))
-    (throw (ex-info
-             ":rf.error/machine-schema-requires-reg-machine"
-             {:rf.error/id :rf.error/machine-schema-requires-reg-machine
-              :where       'rf-machines/make-machine-handler
-              :recovery    :use-reg-machine
-              :reason
-              (str "make-machine-handler was handed a machine spec carrying a "
-                   ":data-schema via the bare (reg-event id meta "
-                   "(make-machine-handler spec)) direct path. That path stamps "
-                   "neither the :rf/machine? / :rf/machine registration "
-                   "metadata (so the :data-schema validates NOTHING) NOR the "
-                   ":sensitive? / :large? redaction marks (so a sensitive :data "
-                   "slot egresses RAW to the trace bus / AI-MCP). Register the "
-                   "machine through reg-machine / reg-machine* — and when the "
-                   "machine ALSO validates its outer event vector, use the "
-                   "event-:schema arity: (reg-machine id {:schema EventSchema} "
-                   "machine) or (reg-machine* id machine {:schema EventSchema}). "
-                   "These run both side-effects.")
-              :data-schema (:data-schema machine)})))
+    (error/throw-error!
+      :rf.error/machine-schema-requires-reg-machine
+      'rf-machines/make-machine-handler
+      (str "make-machine-handler was handed a machine spec carrying a "
+           ":data-schema via the bare (reg-event id meta "
+           "(make-machine-handler spec)) direct path. That path stamps "
+           "neither the :rf/machine? / :rf/machine registration "
+           "metadata (so the :data-schema validates NOTHING) NOR the "
+           ":sensitive? / :large? redaction marks (so a sensitive :data "
+           "slot egresses RAW to the trace bus / AI-MCP). Register the "
+           "machine through reg-machine / reg-machine* — and when the "
+           "machine ALSO validates its outer event vector, use the "
+           "event-:schema arity: (reg-machine id {:schema EventSchema} "
+           "machine) or (reg-machine* id machine {:schema EventSchema}). "
+           "These run both side-effects.")
+      {:recovery :use-reg-machine
+       :extra    {:data-schema (:data-schema machine)}}))
   ;; Per rf2-f9tu — `build-initial-snapshot` runs lazily INSIDE the
   ;; returned handler, not at registration time. The initial-state
   ;; computation reaches through `:initial` / `:states` / `:regions`;
@@ -1029,16 +1028,15 @@
   at read time — so the schema-vs-manual composition is order-independent."
   [machine-id machine opts]
   (when (or (contains? opts :rf/machine?) (contains? opts :rf/machine))
-    (throw (ex-info
-             ":rf.error/machine-reserved-meta-in-opts"
-             {:rf.error/id :rf.error/machine-reserved-meta-in-opts
-              :where       'rf-machines/reg-machine*
-              :recovery    :drop-reserved-keys
-              :reason      (str "reg-machine opts must not carry the "
-                                "framework-owned :rf/machine? / :rf/machine "
-                                "keys — the registration home stamps them.")
-              :machine-id  machine-id
-              :opts        opts})))
+    (error/throw-error!
+      :rf.error/machine-reserved-meta-in-opts
+      'rf-machines/reg-machine*
+      (str "reg-machine opts must not carry the "
+           "framework-owned :rf/machine? / :rf/machine "
+           "keys — the registration home stamps them.")
+      {:recovery :drop-reserved-keys
+       :extra    {:machine-id machine-id
+                  :opts       opts}}))
   ;; Per rf2-s83iu: install a per-machine region-machine cache before
   ;; the machine value is threaded through the handler closure and
   ;; published to the registrar. Re-registration replaces the machine

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -25,7 +25,8 @@
   `walk-state-nodes` yields `[state-key state-node]` pairs for every
   node under `:states`, recursing through `:states` maps; used by the
   top-level dispatch."
-  (:require [re-frame.machines.grammar :as grammar]
+  (:require [re-frame.error :as error]
+            [re-frame.machines.grammar :as grammar]
             [re-frame.machines.parallel :as parallel]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -54,12 +55,8 @@
   `:guard`)."
   ([error-kw reason] (validation-error error-kw reason nil))
   ([error-kw reason extras]
-   (ex-info (str error-kw)
-            (merge {:rf.error/id error-kw
-                    :where       'rf/reg-machine
-                    :recovery    :fix-registration
-                    :reason      reason}
-                   extras))))
+   (error/thrown-ex-info error-kw 'rf/reg-machine reason
+                         {:recovery :fix-registration :extra extras})))
 
 (defn- ref-resolves?
   "Mirror of the runtime resolver `transition/chase-ref` (rf2-ylpnn): a

--- a/implementation/machines/test/re_frame/after_delay_validation_test.clj
+++ b/implementation/machines/test/re_frame/after_delay_validation_test.clj
@@ -45,7 +45,7 @@
   (testing "an :after key of -1 fails registration with :rf.error/machine-bad-after-delay"
     (let [thrown (registration-throws? :adv/neg (mk-machine -1))]
       (is (some? thrown) "negative :after delay SHOULD throw at registration")
-      (is (= ":rf.error/machine-bad-after-delay" (.getMessage thrown))
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))
           "error category names the bad-after-delay contract")
       (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))
           "ex-data :rf.error/id carries the discriminator")

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -50,7 +50,7 @@
                        :other {}}}
           thrown (registration-throws? :rf.nested-validation/top-on-guard m)]
       (is (some? thrown) "top-level :on :guard misuse SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-guard contract")
       (is (= :no-such-guard (:guard (ex-data thrown)))
           "ex-data carries the offending guard keyword"))))
@@ -65,7 +65,7 @@
                        :other {}}}
           thrown (registration-throws? :rf.nested-validation/top-on-action m)]
       (is (some? thrown) "top-level :on :action misuse SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-action" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-action (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-action contract")
       (is (= :no-such-action (:action (ex-data thrown)))
           "ex-data carries the offending action keyword"))))
@@ -171,7 +171,7 @@
           thrown (registration-throws? :rf.nested-validation/top-always-singlemap-guard m)]
       (is (some? thrown)
           "single-map :always :guard misuse SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-guard contract")
       (is (= :no-such-guard (:guard (ex-data thrown)))
           "ex-data carries the offending guard keyword"))))
@@ -187,7 +187,7 @@
           thrown (registration-throws? :rf.nested-validation/top-always-singlemap-action m)]
       (is (some? thrown)
           "single-map :always :action misuse SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-action" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-action (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-action contract")
       (is (= :no-such-action (:action (ex-data thrown)))
           "ex-data carries the offending action keyword"))))
@@ -294,7 +294,7 @@
           thrown (registration-throws? :rf.nested-validation/par-on-guard m)]
       (is (some? thrown)
           "parallel-region :on :guard misuse SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-guard contract"))))
 
 (deftest parallel-region-on-action-keyword-unresolved
@@ -312,7 +312,7 @@
           thrown (registration-throws? :rf.nested-validation/par-on-action m)]
       (is (some? thrown)
           "parallel-region :on :action misuse SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-action" (.getMessage thrown))))))
+      (is (= :rf.error/machine-unresolved-action (:rf.error/id (ex-data thrown)))))))
 
 (deftest parallel-region-entry-action-keyword-unresolved
   (testing "Parallel region :entry referencing an unregistered action fails registration"
@@ -400,7 +400,7 @@
              :states  {:checking {:always [{:guard :ready? :target :checking}]}}}
           thrown (registration-throws? :rf.always-self-loop/kw m)]
       (is (some? thrown) "same-state :always self-loop SHOULD throw at registration")
-      (is (= ":rf.error/machine-always-self-loop" (.getMessage thrown))
+      (is (= :rf.error/machine-always-self-loop (:rf.error/id (ex-data thrown)))
           "error category names the self-loop contract")
       (is (= :checking (:state (ex-data thrown)))
           "ex-data carries the declaring state-keyword"))))
@@ -411,7 +411,7 @@
              :states  {:spin {:always [{:target :spin}]}}}
           thrown (registration-throws? :rf.always-self-loop/no-guard m)]
       (is (some? thrown) "guard-less self-target SHOULD throw")
-      (is (= ":rf.error/machine-always-self-loop" (.getMessage thrown))))))
+      (is (= :rf.error/machine-always-self-loop (:rf.error/id (ex-data thrown)))))))
 
 (deftest always-internal-no-target-permitted
   (testing "an internal :always (no :target, just :action) is the canonical
@@ -457,7 +457,7 @@
                                                            :target [:outer :inner]}]}}}}}
           thrown (registration-throws? :rf.always-self-loop/vec m)]
       (is (some? thrown) "vector self-target SHOULD throw")
-      (is (= ":rf.error/machine-always-self-loop" (.getMessage thrown)))
+      (is (= :rf.error/machine-always-self-loop (:rf.error/id (ex-data thrown))))
       (is (= :inner (:state (ex-data thrown)))
           "ex-data names the declaring leaf state"))))
 
@@ -468,7 +468,7 @@
              :states  {:checking {:always {:guard :ready? :target :checking}}}}
           thrown (registration-throws? :rf.always-self-loop/single m)]
       (is (some? thrown) "single-map :always self-loop SHOULD throw")
-      (is (= ":rf.error/machine-always-self-loop" (.getMessage thrown))))))
+      (is (= :rf.error/machine-always-self-loop (:rf.error/id (ex-data thrown)))))))
 
 (deftest always-sibling-target-permitted
   (testing "an :always targeting a DIFFERENT sibling registers cleanly (control)"
@@ -492,7 +492,7 @@
                          :states  {:x {}}}}}
           thrown (registration-throws? :rf.always-self-loop/region m)]
       (is (some? thrown) "region :always self-loop SHOULD throw at registration")
-      (is (= ":rf.error/machine-always-self-loop" (.getMessage thrown))))))
+      (is (= :rf.error/machine-always-self-loop (:rf.error/id (ex-data thrown)))))))
 
 ;; ---- compound state missing :initial rejected (rf2-boryv) ----------------
 ;;
@@ -509,7 +509,7 @@
                                  :settings  {}}}}}     ;; no :initial — rejected
           thrown (registration-throws? :rf.missing-initial/top m)]
       (is (some? thrown) "compound state without :initial SHOULD throw")
-      (is (= ":rf.error/machine-compound-state-missing-initial" (.getMessage thrown))
+      (is (= :rf.error/machine-compound-state-missing-initial (:rf.error/id (ex-data thrown)))
           "error category names the missing-initial contract")
       (is (= :authenticated (:state (ex-data thrown)))
           "ex-data carries the compound state-keyword"))))
@@ -521,7 +521,7 @@
                                :states  {:mid {:states {:leaf {}}}}}}}  ;; :mid compound, no :initial
           thrown (registration-throws? :rf.missing-initial/nested m)]
       (is (some? thrown) "nested compound state without :initial SHOULD throw")
-      (is (= ":rf.error/machine-compound-state-missing-initial" (.getMessage thrown)))
+      (is (= :rf.error/machine-compound-state-missing-initial (:rf.error/id (ex-data thrown))))
       (is (= :mid (:state (ex-data thrown)))
           "ex-data names the offending nested compound state"))))
 
@@ -599,7 +599,7 @@
           thrown (registration-throws? :rf.ylpnn/guard-dangling-tail m)]
       (is (some? thrown)
           "a dangling multi-hop guard chain MUST throw at registration")
-      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-guard contract")
       (is (= :a (:guard (ex-data thrown)))
           "ex-data names the head ref the author wrote"))))
@@ -615,7 +615,7 @@
           thrown (registration-throws? :rf.ylpnn/action-dangling-tail m)]
       (is (some? thrown)
           "a dangling multi-hop action chain MUST throw at registration")
-      (is (= ":rf.error/machine-unresolved-action" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-action (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-action contract")
       (is (= :a (:action (ex-data thrown)))
           "ex-data names the head ref the author wrote"))))
@@ -633,7 +633,7 @@
           thrown (registration-throws? :rf.ylpnn/guard-cycle m)]
       (is (some? thrown)
           "a cyclic guard indirection MUST throw at registration (not loop)")
-      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-guard contract"))))
 
 ;; ---- transition :target shape + resolution (rf2-w84jv) -------------------
@@ -655,7 +655,7 @@
           thrown (registration-throws? :rf.w84jv/scalar-target m)]
       (is (some? thrown)
           "a scalar :target SHOULD throw at registration, not at dispatch")
-      (is (= ":rf.error/machine-bad-target" (.getMessage thrown))
+      (is (= :rf.error/machine-bad-target (:rf.error/id (ex-data thrown)))
           "error category names the bad-target contract")
       (is (= 42 (:target (ex-data thrown)))
           "ex-data carries the offending target"))))
@@ -668,7 +668,7 @@
           thrown (registration-throws? :rf.w84jv/missing-vector-target m)]
       (is (some? thrown)
           "an unresolved vector :target SHOULD throw at registration, not commit an invalid snapshot at dispatch")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-target contract")
       (is (= [:missing] (:target (ex-data thrown)))
           "ex-data carries the offending target"))))
@@ -681,7 +681,7 @@
           thrown (registration-throws? :rf.w84jv/missing-kw-target m)]
       (is (some? thrown)
           "an unresolved keyword :target SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))
           "error category names the unresolved-target contract")
       (is (= :nowhere (:target (ex-data thrown)))))))
 
@@ -698,7 +698,7 @@
           thrown (registration-throws? :rf.w84jv/cross-level-kw m)]
       (is (some? thrown)
           "a keyword target reaching past the immediate parent level SHOULD throw")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))))))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))))))
 
 (deftest after-unresolved-target-rejected-at-registration
   (testing "an :after entry whose :target is unresolved is rejected at registration (rf2-w84jv)"
@@ -708,7 +708,7 @@
           thrown (registration-throws? :rf.w84jv/after-target m)]
       (is (some? thrown)
           "an unresolved :after :target SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))))))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))))))
 
 (deftest on-done-unresolved-target-rejected-at-registration
   (testing "a compound's :on-done whose :target is unresolved is rejected at registration (rf2-w84jv)"
@@ -719,7 +719,7 @@
           thrown (registration-throws? :rf.w84jv/on-done-target m)]
       (is (some? thrown)
           "an unresolved compound :on-done :target SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))))))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))))))
 
 (deftest spawn-on-error-unresolved-target-rejected-at-registration
   (testing "a :spawn :on-error whose :target is unresolved is rejected at registration (rf2-w84jv)"
@@ -730,7 +730,7 @@
           thrown (registration-throws? :rf.w84jv/spawn-on-error-target m)]
       (is (some? thrown)
           "an unresolved :spawn :on-error :target SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))))))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))))))
 
 (deftest parallel-region-unresolved-target-rejected-at-registration
   (testing "an unresolved :target inside a parallel REGION is rejected at registration (rf2-w84jv)"
@@ -743,7 +743,7 @@
           thrown (registration-throws? :rf.w84jv/region-target m)]
       (is (some? thrown)
           "an unresolved region :target SHOULD throw at registration")
-      (is (= ":rf.error/machine-unresolved-target" (.getMessage thrown))))))
+      (is (= :rf.error/machine-unresolved-target (:rf.error/id (ex-data thrown)))))))
 
 (deftest valid-targets-register-cleanly
   (testing "well-formed resolvable targets (keyword sibling, vector absolute, :same-state, history pseudo-state) register cleanly (control) (rf2-w84jv)"

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -50,6 +50,7 @@
   install. The `:rf.resource/*` event handlers carry the behaviour;
   loading this namespace registers the whole family."
   (:require [re-frame.cofx :as cofx]
+            [re-frame.error :as error]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
@@ -217,18 +218,18 @@
   lookup returns `nil` only for a genuinely absent entry."
   [{:keys [frame] :as opts}]
   (when (nil? frame)
-    (throw (ex-info ":rf.error/no-frame-context"
-                    {:rf.error/id :rf.error/no-frame-context
-                     :where       'rf/resource-state
-                     :recovery    :pass-frame
-                     :reason      (str "resource-state requires an explicit :frame "
-                                       "introspection target. A frameless call would "
-                                       "pass nil through to the runtime-db lookup and "
-                                       "return nil — indistinguishable from a genuinely "
-                                       "absent entry. Pass {:resource … :scope … "
-                                       ":params … :frame <frame-id>}. Per Spec 016 "
-                                       "§Introspection / EP-0002.")
-                     :opts        (dissoc opts :frame)})))
+    (error/throw-error!
+      :rf.error/no-frame-context
+      'rf/resource-state
+      (str "resource-state requires an explicit :frame "
+           "introspection target. A frameless call would "
+           "pass nil through to the runtime-db lookup and "
+           "return nil — indistinguishable from a genuinely "
+           "absent entry. Pass {:resource … :scope … "
+           ":params … :frame <frame-id>}. Per Spec 016 "
+           "§Introspection / EP-0002.")
+      {:recovery :pass-frame
+       :extra    {:opts (dissoc opts :frame)}}))
   (let [;; EP-0016 D3 slice 3: a `{:from-db <id>}` scope on the introspection
         ;; target resolves against the frame's app-db value (the same db the
         ;; reactive sub resolves against), so `resource-state` and a live
@@ -272,18 +273,18 @@
   explicit frame lookup returns `nil` only for a genuinely absent instance."
   [{:keys [instance frame] :as opts}]
   (when (nil? frame)
-    (throw (ex-info ":rf.error/no-frame-context"
-                    {:rf.error/id :rf.error/no-frame-context
-                     :where       'rf/mutation-state
-                     :recovery    :pass-frame
-                     :reason      (str "mutation-state requires an explicit :frame "
-                                       "introspection target. A frameless call would "
-                                       "pass nil through to the runtime-db lookup and "
-                                       "return nil — indistinguishable from a genuinely "
-                                       "absent instance. Pass {:instance … "
-                                       ":frame <frame-id>}. Per EP-0003 §Mutations / "
-                                       "EP-0002.")
-                     :opts        (dissoc opts :frame)})))
+    (error/throw-error!
+      :rf.error/no-frame-context
+      'rf/mutation-state
+      (str "mutation-state requires an explicit :frame "
+           "introspection target. A frameless call would "
+           "pass nil through to the runtime-db lookup and "
+           "return nil — indistinguishable from a genuinely "
+           "absent instance. Pass {:instance … "
+           ":frame <frame-id>}. Per EP-0003 §Mutations / "
+           "EP-0002.")
+      {:recovery :pass-frame
+       :extra    {:opts (dissoc opts :frame)}}))
   (let [runtime-db (frame/frame-runtime-db-value frame)]
     (get-in runtime-db (mstate/instance-path instance))))
 

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -61,6 +61,7 @@
   `live-entry-for-reply`). Terminal rows are pruned on the linked entry's
   next successful transition, retaining a bounded per-key tail for Xray."
   (:require [clojure.set :as set]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.reply :as rreply]
@@ -843,19 +844,19 @@
         ;; set). Cross-scope is the only scope-agnostic path and must be
         ;; opted into explicitly. Per Spec 016 §Invalidation.
         _          (when (and (not cross-scope?) (nil? scope))
-                     (throw (ex-info ":rf.error/resource-invalidate-scope-required"
-                                     {:rf.error/id :rf.error/resource-invalidate-scope-required
-                                      :where       'rf.resource/invalidate-tags
-                                      :recovery    :fix-scope
-                                      :reason      (str "a scoped :rf.resource/invalidate-tags MUST "
-                                                        "supply an explicit :scope. A missing scope "
-                                                        "is fail-closed (it would silently match "
-                                                        "nothing — or the wrong nil-scope set — "
-                                                        "rather than the intended scope). To "
-                                                        "invalidate the tags in EVERY scope, opt in "
-                                                        "explicitly with :cross-scope? true. Per Spec "
-                                                        "016 §Invalidation.")
-                                      :tags        tags})))
+                     (error/throw-error!
+                       :rf.error/resource-invalidate-scope-required
+                       'rf.resource/invalidate-tags
+                       (str "a scoped :rf.resource/invalidate-tags MUST "
+                            "supply an explicit :scope. A missing scope "
+                            "is fail-closed (it would silently match "
+                            "nothing — or the wrong nil-scope set — "
+                            "rather than the intended scope). To "
+                            "invalidate the tags in EVERY scope, opt in "
+                            "explicitly with :cross-scope? true. Per Spec "
+                            "016 §Invalidation.")
+                       {:recovery :fix-scope
+                        :extra    {:tags tags}}))
         ;; AUDITED ESCAPE — cross-scope MUST carry :cause (rf2-7r8kgd, Spec 016
         ;; §The cross-scope lattice). :cross-scope? true can stale / refetch
         ;; data across every user, tenant, story frame, and SSR request, so it
@@ -864,21 +865,21 @@
         ;; unaudited sweep. (The mutation engine always stamps
         ;; :cause [:mutation id instance]; this guards the direct public entry.)
         _          (when (and cross-scope? (nil? cause))
-                     (throw (ex-info ":rf.error/resource-cross-scope-cause-required"
-                                     {:rf.error/id :rf.error/resource-cross-scope-cause-required
-                                      :where       'rf.resource/invalidate-tags
-                                      :recovery    :fix-cause
-                                      :reason      (str "a :cross-scope? true :rf.resource/invalidate-tags "
-                                                        "MUST carry :cause evidence. Cross-scope is the "
-                                                        "AUDITED escape — it can stale or refetch data "
-                                                        "across every user, tenant, story frame, and SSR "
-                                                        "request, so the runtime records WHY the cache "
-                                                        "reached outside the mutation's own resolved "
-                                                        "scope (a privacy-relevant trace, EP-0015). A "
-                                                        "cross-scope invalidation with no :cause is "
-                                                        "rejected — never a silent unaudited sweep. Per "
-                                                        "Spec 016 §The cross-scope lattice.")
-                                      :tags        tags})))
+                     (error/throw-error!
+                       :rf.error/resource-cross-scope-cause-required
+                       'rf.resource/invalidate-tags
+                       (str "a :cross-scope? true :rf.resource/invalidate-tags "
+                            "MUST carry :cause evidence. Cross-scope is the "
+                            "AUDITED escape — it can stale or refetch data "
+                            "across every user, tenant, story frame, and SSR "
+                            "request, so the runtime records WHY the cache "
+                            "reached outside the mutation's own resolved "
+                            "scope (a privacy-relevant trace, EP-0015). A "
+                            "cross-scope invalidation with no :cause is "
+                            "rejected — never a silent unaudited sweep. Per "
+                            "Spec 016 §The cross-scope lattice.")
+                       {:recovery :fix-cause
+                        :extra    {:tags tags}}))
         ;; route the concrete scope through the SHARED validation path
         ;; (rf2-hosnba, rf2-lzv9xc): rejects reserved-namespace typos +
         ;; host / non-EDN scope values, rejects the wrapped [:rf.scope/global]

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -18,7 +18,8 @@
   registrars read as one family; the params-validation + (optional) scope
   resolution reuse the resource registry's pluggable late-bound Malli
   validator and canonicalization."
-  (:require [re-frame.late-bind :as late-bind]
+  (:require [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.classification :as classification]
             [re-frame.resources.mutation-runtime :as mstate]
@@ -49,12 +50,12 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-mutation` validation failure."
   [error-id where reason extra]
-  (ex-info (str error-id)
-           (merge {:rf.error/id error-id
-                   :where       where
-                   :recovery    :fix-registration
-                   :reason      reason}
-                  extra)))
+  (error/thrown-ex-info
+    error-id
+    where
+    reason
+    {:recovery :fix-registration
+     :extra    extra}))
 
 (defn- validate-mutation-spec!
   "Fail loudly at the authoring boundary when a mutation spec omits the

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -33,7 +33,8 @@
   shape, and the PURE patch / populate transition over resource entries
   (the mutation success handler applies them); the swaps over these
   paths live in `re-frame.resources.mutation-events`."
-  (:require [re-frame.resources.state :as state]))
+  (:require [re-frame.error :as error]
+            [re-frame.resources.state :as state]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -664,14 +665,14 @@
   for an invalid mutation patch / populate TARGET scoped key. `arm`
   (`:patches` | `:populates`) names the offending mutation-spec arm."
   [where arm reason target extra]
-  (ex-info ":rf.error/mutation-invalid-target"
-           (merge {:rf.error/id :rf.error/mutation-invalid-target
-                   :where       where
-                   :arm         arm
-                   :recovery    :fix-mutation-target
-                   :reason      reason
-                   :target      (pr-str target)}
-                  extra)))
+  (error/thrown-ex-info
+    :rf.error/mutation-invalid-target
+    where
+    reason
+    {:recovery :fix-mutation-target
+     :extra    (merge {:arm    arm
+                       :target (pr-str target)}
+                      extra)}))
 
 ;; ---- map-form exact target (EP-0016 Rider 2 / slice 6) --------------------
 ;;
@@ -837,24 +838,24 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)
   for a non-serializable mutation INSTANCE id."
   [instance-id where]
-  (ex-info ":rf.error/mutation-non-serializable-instance-id"
-           {:rf.error/id :rf.error/mutation-non-serializable-instance-id
-            :where       where
-            :recovery    :fix-instance-id
-            :reason      (str "a mutation instance id must be serializable EDN "
-                              "(a scalar — keyword / string / number — or an "
-                              "EDN collection recursively built from such); got "
-                              (pr-str instance-id) ". The instance id is stored "
-                              "in runtime-db, the work-ledger work id, and the "
-                              "reply payloads — all durable + trace-visible + "
-                              "epoch / restore-safe — so it follows the same "
-                              "serializable-identity discipline as resource "
-                              "params and scopes. Host / opaque values "
-                              "(functions, promises, dates, DOM nodes, "
-                              "AbortControllers, JS objects, atoms) are "
-                              "rejected. Per EP-0003 §Mutations / Spec 016 "
-                              "§Resource identity.")
-            :instance-id (pr-str instance-id)}))
+  (error/thrown-ex-info
+    :rf.error/mutation-non-serializable-instance-id
+    where
+    (str "a mutation instance id must be serializable EDN "
+         "(a scalar — keyword / string / number — or an "
+         "EDN collection recursively built from such); got "
+         (pr-str instance-id) ". The instance id is stored "
+         "in runtime-db, the work-ledger work id, and the "
+         "reply payloads — all durable + trace-visible + "
+         "epoch / restore-safe — so it follows the same "
+         "serializable-identity discipline as resource "
+         "params and scopes. Host / opaque values "
+         "(functions, promises, dates, DOM nodes, "
+         "AbortControllers, JS objects, atoms) are "
+         "rejected. Per EP-0003 §Mutations / Spec 016 "
+         "§Resource identity.")
+    {:recovery :fix-instance-id
+     :extra    {:instance-id (pr-str instance-id)}}))
 
 (defn validate-instance-id!
   "Fail-closed: reject a non-serializable mutation INSTANCE id BEFORE it is
@@ -904,14 +905,14 @@
   CLOSED at settle time (before any invalidation dispatch), never a silent
   no-op — an author who returns garbage from `:invalidates` learns loudly."
   [where reason raw extra]
-  (ex-info ":rf.error/mutation-invalid-invalidation"
-           (merge {:rf.error/id :rf.error/mutation-invalid-invalidation
-                   :where       where
-                   :arm         :invalidates
-                   :recovery    :fix-invalidates
-                   :reason      reason
-                   :invalidates (pr-str raw)}
-                  extra)))
+  (error/thrown-ex-info
+    :rf.error/mutation-invalid-invalidation
+    where
+    reason
+    {:recovery :fix-invalidates
+     :extra    (merge {:arm         :invalidates
+                       :invalidates (pr-str raw)}
+                      extra)}))
 
 (defn- normalize-one-descriptor
   "Normalize ONE descriptor map into the canonical shape

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -24,7 +24,8 @@
   data-lifecycle events (`:rf.resource/remove` / `:rf.resource/release-owner`
   / `:rf.resource/clear-scope`) remain the in-cascade, scope/instance-grained
   disposal surfaces."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.classification :as classification]
@@ -116,12 +117,12 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-resource` validation failure."
   [error-id where reason extra]
-  (ex-info (str error-id)
-           (merge {:rf.error/id error-id
-                   :where       where
-                   :recovery    :fix-registration
-                   :reason      reason}
-                  extra)))
+  (error/thrown-ex-info
+    error-id
+    where
+    reason
+    {:recovery :fix-registration
+     :extra    extra}))
 
 (defn- validate-resource-spec!
   "Fail loudly at the authoring boundary when a resource spec omits the

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -77,7 +77,8 @@
   the handler's coeffect db (the pre-transition causal input) and pass it to
   `:rf.resource/clear-scope` concretely. Per Spec 016 §`clear-scope` resolves
   the concrete scope from the coeffect db (EP-0016 issue 7)."
-  (:require [re-frame.marks :as marks]
+  (:require [re-frame.error :as error]
+            [re-frame.marks :as marks]
             [re-frame.path :as path]
             [re-frame.registrar :as registrar]
             [re-frame.resources.state :as state]
@@ -120,12 +121,12 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-resource-scope` validation failure."
   [error-id where reason extra]
-  (ex-info (str error-id)
-           (merge {:rf.error/id error-id
-                   :where       where
-                   :recovery    :fix-registration
-                   :reason      reason}
-                  extra)))
+  (error/thrown-ex-info
+    error-id
+    where
+    reason
+    {:recovery :fix-registration
+     :extra    extra}))
 
 ;; ---- validation ----------------------------------------------------------
 

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -15,7 +15,8 @@
   `:rf.runtime/work-ledger`. Both are reserved runtime-db keys (per
   [Conventions §Reserved runtime-db keys]) — allocated lazily, per-frame
   isolated, never an app-db location."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.identity :as identity]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -372,24 +373,24 @@
   `:rf.error/non-edn-identity` cause rides `:rf.error/cause` for diagnosis."
   [value where kind resource-id]
   (when-not (serializable-edn? value)
-    (throw (ex-info ":rf.error/resource-non-edn-params"
-                    {:rf.error/id :rf.error/resource-non-edn-params
-                     :where       where
-                     :recovery    :fix-params
-                     :reason      (str "resource " resource-id " " (name kind)
-                                       " is not a portable CEDN-1 EDN identity — "
-                                       "host / opaque values (functions, promises, "
-                                       "dates, DOM nodes, AbortControllers, JS "
-                                       "objects) and non-portable numbers (floats, "
-                                       "ratios, decimals, NaN/infinities, integers "
-                                       "outside the safe range) are rejected at the "
-                                       "cache-key boundary. Put every value that "
-                                       "affects remote identity in params as plain "
-                                       "portable EDN. Per Spec 016 §Resource "
-                                       "identity / Conventions §Canonical EDN identity.")
-                     :resource-id resource-id
-                     :kind        kind
-                     :value       (pr-str value)})))
+    (error/throw-error!
+      :rf.error/resource-non-edn-params
+      where
+      (str "resource " resource-id " " (name kind)
+           " is not a portable CEDN-1 EDN identity — "
+           "host / opaque values (functions, promises, "
+           "dates, DOM nodes, AbortControllers, JS "
+           "objects) and non-portable numbers (floats, "
+           "ratios, decimals, NaN/infinities, integers "
+           "outside the safe range) are rejected at the "
+           "cache-key boundary. Put every value that "
+           "affects remote identity in params as plain "
+           "portable EDN. Per Spec 016 §Resource "
+           "identity / Conventions §Canonical EDN identity.")
+      {:recovery :fix-params
+       :extra    {:resource-id resource-id
+                  :kind        kind
+                  :value       (pr-str value)}}))
   value)
 
 ;; ---- concrete-scope validation (Spec 016 §Scope resolution) ---------------
@@ -462,19 +463,19 @@
   [scope where resource-id]
   (when (and (vector? scope)
              (contains? reserved-concrete-scopes (first scope)))
-    (throw (ex-info ":rf.error/resource-invalid-scope"
-                    {:rf.error/id :rf.error/resource-invalid-scope
-                     :where       where
-                     :recovery    :fix-scope
-                     :reason      (str "resource " resource-id " was reached with a "
-                                       "scope " (pr-str scope) " — a reserved "
-                                       ":rf.scope/* concrete scope wrapped in a "
-                                       "vector. The global scope IS the bare keyword "
-                                       ":rf.scope/global; supply it bare, not as the "
-                                       "singleton [:rf.scope/global]. Per Spec 016 "
-                                       "§Scope resolution.")
-                     :resource-id resource-id
-                     :scope       scope})))
+    (error/throw-error!
+      :rf.error/resource-invalid-scope
+      where
+      (str "resource " resource-id " was reached with a "
+           "scope " (pr-str scope) " — a reserved "
+           ":rf.scope/* concrete scope wrapped in a "
+           "vector. The global scope IS the bare keyword "
+           ":rf.scope/global; supply it bare, not as the "
+           "singleton [:rf.scope/global]. Per Spec 016 "
+           "§Scope resolution.")
+      {:recovery :fix-scope
+       :extra    {:resource-id resource-id
+                  :scope       scope}}))
   scope)
 
 (defn reject-reserved-scope-typo!
@@ -488,23 +489,23 @@
   unchanged when it conforms."
   [scope where resource-id]
   (when (reserved-scope-typo? scope)
-    (throw (ex-info ":rf.error/resource-invalid-scope"
-                    {:rf.error/id :rf.error/resource-invalid-scope
-                     :where       where
-                     :recovery    :fix-scope
-                     :reason      (str "resource " resource-id " was reached with a "
-                                       "scope " (pr-str scope) " in the framework-"
-                                       "reserved :rf.scope/* namespace that is not a "
-                                       "valid concrete scope. The only concrete "
-                                       "reserved scope is :rf.scope/global; "
-                                       ":rf.scope/from-caller is a registration "
-                                       "policy (the use site supplies the concrete "
-                                       "scope), and any other :rf.scope/* keyword is "
-                                       "a typo. A framework-namespace typo MUST fail "
-                                       "closed rather than become a silent wrong "
-                                       "cache scope. Per Spec 016 §Scope resolution.")
-                     :resource-id resource-id
-                     :scope       scope})))
+    (error/throw-error!
+      :rf.error/resource-invalid-scope
+      where
+      (str "resource " resource-id " was reached with a "
+           "scope " (pr-str scope) " in the framework-"
+           "reserved :rf.scope/* namespace that is not a "
+           "valid concrete scope. The only concrete "
+           "reserved scope is :rf.scope/global; "
+           ":rf.scope/from-caller is a registration "
+           "policy (the use site supplies the concrete "
+           "scope), and any other :rf.scope/* keyword is "
+           "a typo. A framework-namespace typo MUST fail "
+           "closed rather than become a silent wrong "
+           "cache scope. Per Spec 016 §Scope resolution.")
+      {:recovery :fix-scope
+       :extra    {:resource-id resource-id
+                  :scope       scope}}))
   scope)
 
 (defn canonicalize-scope

--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -12,7 +12,8 @@
 
   Per the rf2-icrxv cohesion-split audit (Phase-2 Option C): PATTERN
   seam — template compile + match-against."
-  (:require [re-frame.routing.url :as url]))
+  (:require [re-frame.error :as error]
+            [re-frame.routing.url :as url]))
 
 ;; ---- registration ---------------------------------------------------------
 
@@ -58,14 +59,14 @@
   ;; the pattern at registration), :recovery + :reason complete the
   ;; required slots. Per-site :route-id / :pattern / :index merge on top.
   [route-id pattern reason index]
-  (throw (ex-info ":rf.error/invalid-route-pattern"
-                  (cond-> {:rf.error/id :rf.error/invalid-route-pattern
-                           :where       'rf/reg-route
-                           :recovery    :no-recovery
-                           :reason      reason
-                           :route-id    route-id
-                           :pattern     pattern}
-                    (some? index) (assoc :index index)))))
+  (error/throw-error!
+    :rf.error/invalid-route-pattern
+    'rf/reg-route
+    reason
+    {:recovery :no-recovery
+     :extra    (cond-> {:route-id route-id
+                        :pattern  pattern}
+                 (some? index) (assoc :index index))}))
 
 (defn- valid-route-name? [s]
   (boolean (and (seq s) (re-matches route-name-re s))))

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -903,7 +903,7 @@
                  nil
                  (catch clojure.lang.ExceptionInfo e e))]
         (is (some? ex) (str pattern " should be rejected"))
-        (is (= ":rf.error/invalid-route-pattern" (ex-message ex)))
+        (is (= :rf.error/invalid-route-pattern (:rf.error/id (ex-data ex))))
         (is (= route-id (:route-id (ex-data ex))))
         (is (= pattern (:pattern (ex-data ex))))
         (is (some? (:reason (ex-data ex)))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/human_message_builder.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/human_message_builder.cljc
@@ -1,0 +1,11 @@
+(ns fixture.negative.human-message-builder
+  "NEGATIVE fixture: the conformant shape — (ex-info (human-message …) …).
+  The message is DERIVED from a human reason + the token, so it is never a
+  bare keyword. MUST stay green."
+  (:require [re-frame.error :as error]))
+
+(defn boom [error-id reason x]
+  (throw (ex-info (error/human-message error-id reason)
+                  {:rf.error/id error-id
+                   :reason      reason
+                   :bad         x})))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/inline_human_token_slim.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/inline_human_token_slim.cljc
@@ -1,0 +1,11 @@
+(ns fixture.negative.inline-human-token-slim
+  "NEGATIVE fixture: the bundle-isolated reagent-slim shape — it CANNOT
+  :require re-frame.error, so it hand-rolls a human sentence + the trailing
+  [:rf.error/<id>] token inline. MUST stay green (it LEADS with a string
+  literal of human text, not a bare keyword).")
+
+(defn boom [x]
+  (throw (ex-info "reagent2 create-class requires a :render fn (or :reagent-render); add one to the spec map. [:rf.error/create-class-missing-render]"
+                  {:rf.error/id :rf.error/create-class-missing-render
+                   :reason      "create-class requires a :render fn"
+                   :bad         x})))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_as_reason_value.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_as_reason_value.cljc
@@ -1,0 +1,11 @@
+(ns fixture.negative.keyword-as-reason-value
+  "NEGATIVE fixture: a :rf.error/… keyword appearing as an ex-data VALUE (here
+  the :rf.error/id slot) while the MESSAGE is a human sentence. Only the
+  ex-info FIRST argument is the message; ex-data keywords are sanctioned. MUST
+  stay green.")
+
+(defn boom [x]
+  (throw (ex-info "a perfectly human sentence [:rf.error/foo]"
+                  {:rf.error/id :rf.error/foo
+                   :cause       :rf.error/inner
+                   :bad         x})))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_in_comment.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_in_comment.cljc
@@ -1,0 +1,13 @@
+(ns fixture.negative.keyword-in-comment
+  "NEGATIVE fixture: the retired bad shape mentioned in `;;` line comments.
+  Mirrors re-frame.error's rationale comment, which literally quotes the
+  retired forms. Comments are masked, so MUST stay green."
+  (:require [re-frame.error :as error]))
+
+;; The retired hand-rolled forms made the keyword the WHOLE message:
+;;   (ex-info ":rf.error/foo" {…})
+;;   (ex-info (str error-kw) {…})
+;;   (ex-info (str (:rf.error/id payload)) payload)
+;; All route through the central builder now.
+(defn boom [error-id reason]
+  (error/throw-error! error-id 'rf/x reason))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_in_docstring.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_in_docstring.cljc
@@ -1,0 +1,16 @@
+(ns fixture.negative.keyword-in-docstring
+  "NEGATIVE fixture: a docstring that NAMES :rf.error/… keywords and describes
+  the thrown-error contract in prose, without reproducing an `(ex-info …)`
+  message-position bad byte sequence. The gate anchors on `(ex-info` + the bad
+  first argument, so prose naming a keyword (a :rf.error/… mention, or talk of
+  the OLD message shape) never fires. MUST stay green."
+  (:require [re-frame.error :as error]))
+
+(defn boom
+  "Throw the canonical :rf.error/no-frame-context error. The retired form put
+  the discriminator keyword (e.g. :rf.error/no-frame-context) into the message
+  position; this routes through the central builder so the message is a human
+  sentence carrying the [:rf.error/<id>] token instead. See Spec 009 §The
+  thrown-error shape."
+  [reason]
+  (error/throw-error! :rf.error/no-frame-context 'rf/x reason))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_in_exdata.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/keyword_in_exdata.cljc
@@ -1,0 +1,11 @@
+(ns fixture.negative.keyword-in-exdata
+  "NEGATIVE fixture: a (str :rf.error/…) appearing NOT in ex-info message
+  position — here building an ex-data diagnostic string. The patterns anchor
+  on `(ex-info (str :rf.error/…`, so a bare `(str :rf.error/…)` elsewhere is
+  sanctioned. MUST stay green.")
+
+(defn diagnostic [x]
+  (let [label (str :rf.error/some-category)]
+    {:rf.error/id :rf.error/some-category
+     :label       label
+     :bad         x}))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/str_concat_human_text.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/str_concat_human_text.cljc
@@ -1,0 +1,11 @@
+(ns fixture.negative.str-concat-human-text
+  "NEGATIVE fixture: a (str …) message that CONCATENATES the keyword token
+  with human text — the hand-rolled inline conformant shape (reagent-slim).
+  This LEADS with a human sentence, so it is NOT a bare keyword. MUST stay
+  green: the (str …) form opens with a string literal, not a bare keyword.")
+
+(defn boom [x]
+  (throw (ex-info (str "as-element fn is unregistered; install an adapter "
+                       "before rendering. [" :rf.error/as-element-fn-unregistered "]")
+                  {:rf.error/id :rf.error/as-element-fn-unregistered
+                   :bad x})))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/throw_error_bang.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/throw_error_bang.cljc
@@ -1,0 +1,12 @@
+(ns fixture.negative.throw-error-bang
+  "NEGATIVE fixture: the canonical builder call — error/throw-error! — never
+  touches `ex-info` at the call site, so there is nothing to flag. MUST stay
+  green."
+  (:require [re-frame.error :as error]))
+
+(defn boom [x]
+  (error/throw-error!
+    :rf.error/no-adapter-installed
+    'rf/init!
+    "rf/init! cannot continue because no adapter is installed; require an adapter ns and install it before boot."
+    {:extra {:bad x}}))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/literal_keyword_multiline.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/literal_keyword_multiline.cljc
@@ -1,0 +1,11 @@
+(ns fixture.positive.literal-keyword-multiline
+  "POSITIVE fixture: the bare-keyword message on the line AFTER (ex-info —
+  the common wrapped shape a line-local scan would miss.")
+
+(defn boom [x]
+  (throw
+    (ex-info
+      ":rf.error/resource-non-edn-params"
+      {:rf.error/id :rf.error/resource-non-edn-params
+       :reason "a human sentence"
+       :bad x})))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/literal_keyword_string.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/literal_keyword_string.cljc
@@ -1,0 +1,9 @@
+(ns fixture.positive.literal-keyword-string
+  "POSITIVE fixture: a bare :rf.error/… keyword STRING LITERAL as the
+  ex-info message — the retired keyword-only shape (rf2-vvixub).")
+
+(defn boom [x]
+  (throw (ex-info ":rf.error/no-frame-context"
+                  {:rf.error/id :rf.error/no-frame-context
+                   :reason "a human sentence"
+                   :bad x})))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/str_error_id_var.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/str_error_id_var.cljc
@@ -1,0 +1,11 @@
+(ns fixture.positive.str-error-id-var
+  "POSITIVE fixture: (str error-id) as the ex-info message — the resources
+  registration-error helper-clone shape (registry / mutation-registry /
+  scope-registry) that bound the keyword as `error-id`.")
+
+(defn registration-error [error-id where reason extra]
+  (ex-info (str error-id)
+           (merge {:rf.error/id error-id
+                   :where       where
+                   :reason      reason}
+                  extra)))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/str_error_kw_var.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/str_error_kw_var.cljc
@@ -1,0 +1,10 @@
+(ns fixture.positive.str-error-kw-var
+  "POSITIVE fixture: (str error-kw) as the ex-info message — the machines /
+  events helper-clone shape that centralised the regression into a builder
+  parameter named `error-kw`.")
+
+(defn validation-error [error-kw reason extras]
+  (ex-info (str error-kw)
+           (merge {:rf.error/id error-kw
+                   :reason      reason}
+                  extras)))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/str_id_of_payload.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/str_id_of_payload.cljc
@@ -1,0 +1,7 @@
+(ns fixture.positive.str-id-of-payload
+  "POSITIVE fixture: (str (:rf.error/id payload)) as the ex-info message —
+  the frame.cljc payload-throw shape that pulls the discriminator off a
+  pre-built payload map and stringifies it.")
+
+(defn boom [payload]
+  (throw (ex-info (str (:rf.error/id payload)) payload)))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/str_literal_keyword.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/str_literal_keyword.cljc
@@ -1,0 +1,9 @@
+(ns fixture.positive.str-literal-keyword
+  "POSITIVE fixture: (str :rf.error/…) as the ex-info message — the per-surface
+  helper-clone shape (marks.cljc / identity.cljc / path.cljc / etc.).")
+
+(defn boom [x]
+  (throw (ex-info (str :rf.error/bad-marks)
+                  {:rf.error/id :rf.error/bad-marks
+                   :reason "a human sentence"
+                   :bad x})))

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""rf2-vvixub thrown-error HUMAN-MESSAGE contract — corpus-driven CI gate.
+
+Spec 009 §The thrown-error shape rules the framework thrown-error message
+contract (rf2-vvixub):
+
+  1. `(ex-message e)` is a human-actionable one-line sentence (the public
+     concept + the expected fix + key context). It is NOT the bare
+     stringified `:rf.error/<id>` discriminator keyword.
+  2. `:rf.error/id` (ex-data) is the SOLE canonical machine discriminator;
+     tools and tests branch on it, never on the message.
+  3. The message is stable in MEANING, not bytes.
+  4. The message carries a trailing `[:rf.error/<id>]` greppability token.
+
+`re-frame.error/throw-error!` / `re-frame.error/thrown-ex-info` are the
+canonical builders: they DERIVE the message from `:reason` + the token, so a
+keyword-only message is impossible to emit. The per-feature artefacts route
+their throws through them (directly, or via thin helpers like
+`flows.registry/flow-error`, `routing.registry/route-error`).
+
+WHY THIS GATE EXISTS (the rf2-6bb3pg finding)
+
+The original conformance test
+(`implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc`)
+is a CURATED allow-list: it `:require`s a handful of namespaces and exercises
+those sites directly. A NEW (or never-converted) `(ex-info ":rf.error/…" …)`
+site is invisible to it. rf2-6bb3pg found 50+ such sites still shipping the
+bare keyword as `ex-message` — the exact regression rf2-vvixub abolished —
+that CI could not see. This gate replaces the allow-list with a CORPUS SWEEP
+that fails on ANY framework `(ex-info …)` whose MESSAGE position is a bare
+`:rf.*` discriminator keyword, so the rollout cannot silently regress.
+
+It mirrors the source-scanning drift guards already in this tree
+(`check_retired_spellings.py` / `check_ambient_durable_reads.py` /
+the EP-0011 reply-vocab + EP-0015 privacy-vocab projection guards): a
+comment/string-masked scan over framework source, a `--self-test` fixture
+mode that proves the gate FIRES on each bad shape and stays GREEN on the
+conformant counterparts, and a fix hint.
+
+THE FLAGGED SHAPE (the bare-keyword MESSAGE — `ex-info`'s FIRST argument)
+
+The contract violation is entirely about the FIRST argument of `ex-info`
+(the message). A conformant site passes a human sentence there — usually
+`(human-message …)` / `(error/human-message …)`, or a builder
+(`thrown-ex-info` / `throw-error!` / `flow-error` / `route-error` / …) that
+derives it. A NON-conformant site passes a bare error keyword:
+
+  (a) a `:rf.*` keyword STRING LITERAL:        (ex-info ":rf.error/foo" …)
+  (b) `(str <literal :rf.* keyword>)`:         (ex-info (str :rf.error/foo) …)
+  (c) `(str <error-keyword-named var>)`:        (ex-info (str error-kw) …)
+                                                (ex-info (str error-id) …)
+  (d) `(str (:rf.error/id <map>))`:             (ex-info (str (:rf.error/id payload)) …)
+
+All four render `ex-message` as exactly the stringified discriminator
+keyword — the OLD shape. Forms (c)/(d) are the per-surface helper clones
+(`registration-error`, `validation-error`, `raise-removed-reg-event!`, the
+frame.cljc payload throws) that centralised the regression rather than
+fixing it; they still ship the bare keyword and are equally caught.
+
+We detect on the `ex-info` FIRST ARGUMENT only, so a `:rf.error/foo` keyword
+appearing as a `:reason` value, an ex-data slot, a trace-emit arg, or inside
+a docstring/comment never fires — those are sanctioned.
+
+SCAN SURFACE
+
+Framework source under `implementation/` — `.clj` / `.cljc` / `.cljs`. The
+default excludes `test/` trees (a test that asserts the old shape is gone, or
+constructs a `(ex-info ":rf.error/…")` to exercise a predicate, legitimately
+names it). `tools/` is bundle-isolated dev tooling and `examples/` is
+consumer-shaped, so neither is framework source for this gate. The one
+framework artefact that CANNOT `:require` `re-frame.error` (the
+bundle-isolated `reagent-slim` adapter) hand-rolls a human sentence inline —
+so it too must clear the gate, and it is under `implementation/`.
+
+Exit code:
+    0  no bare-keyword thrown-error message in framework source
+    1  at least one (results printed file:line)
+    2  invocation / setup error
+
+Dependency-light — Python stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+# --------------------------------------------------------------------------
+# Scan surface
+# --------------------------------------------------------------------------
+
+DEFAULT_SCAN_DIR = "implementation"
+
+_SOURCE_SUFFIXES = (".clj", ".cljc", ".cljs")
+
+_EXCLUDE_DIR_NAMES = frozenset({
+    "node_modules",
+    "target",
+    "out",
+    ".shadow-cljs",
+    ".git",
+    ".beads",
+    ".cpcache",
+})
+
+# `test` / `tests` dirs are excluded by default (see module docstring): a test
+# may legitimately construct a bare-keyword ex-info to exercise a predicate, or
+# assert the old shape is gone. `--include-tests` lifts the exclusion (the
+# self-test fixtures rely on this — their files live under fixture dirs).
+_TEST_DIR_NAMES = frozenset({"test", "tests"})
+
+
+# --------------------------------------------------------------------------
+# The bare-keyword MESSAGE patterns (ex-info's FIRST argument)
+# --------------------------------------------------------------------------
+#
+# Every pattern anchors on `(ex-info` + optional whitespace + the bad first
+# argument. The trailing whitespace/`)` after the keyword token ensures we
+# matched the WHOLE message argument, not a longer expression that merely
+# starts with the keyword (e.g. `(ex-info (str :rf.error/x " context") …)` —
+# a `str` that CONCATENATES the keyword with human text is NOT a bare-keyword
+# message and is intentionally not flagged).
+#
+# The `:rf\.[a-z]` namespace match covers every reserved discriminator root
+# (`:rf.error/…`, `:rf.ssr/…`, …) without firing on app keywords.
+
+# (a) A bare `:rf.*` keyword STRING LITERAL as the message.
+#     (ex-info ":rf.error/foo" …)   — the quotes are part of the match so a
+#     `:rf.error/foo` used as a non-message arg never fires here.
+_LITERAL_STRING_RE = re.compile(
+    r"""\(\s*ex-info\s+"(:rf\.[a-z][\w.-]*/[\w.*+!?<>=-]+)"\s*"""
+)
+
+# (b) (str <literal :rf.* keyword>) as the message.
+#     (ex-info (str :rf.error/foo) …)
+_STR_LITERAL_KW_RE = re.compile(
+    r"\(\s*ex-info\s+\(\s*str\s+(:rf\.[a-z][\w.-]*/[\w.*+!?<>=-]+)\s*\)"
+)
+
+# (c) (str <error-keyword-named var>) as the message. The var name is the
+#     load-bearing signal it holds a discriminator keyword: the per-surface
+#     helper clones bind the keyword as `error-kw` / `error-id` /
+#     `error-keyword`. Scoped to those exact names so a `(str some-human-var)`
+#     never fires.
+_STR_ERR_VAR_RE = re.compile(
+    r"\(\s*ex-info\s+\(\s*str\s+(error-kw|error-id|error-keyword|err-kw|err-id)\s*\)"
+)
+
+# (d) (str (:rf.error/id <map>)) as the message — pull the discriminator off a
+#     payload map and stringify it. The frame.cljc payload throws use this.
+_STR_ID_OF_MAP_RE = re.compile(
+    r"\(\s*ex-info\s+\(\s*str\s+\(\s*:rf\.error/id\s+[\w.*+!?<>=/-]+\s*\)\s*\)"
+)
+
+_PATTERNS = (
+    ("literal-keyword-string", _LITERAL_STRING_RE),
+    ("str-literal-keyword", _STR_LITERAL_KW_RE),
+    ("str-error-keyword-var", _STR_ERR_VAR_RE),
+    ("str-id-of-payload", _STR_ID_OF_MAP_RE),
+)
+
+
+class Finding(NamedTuple):
+    path: Path
+    line: int
+    kind: str
+    snippet: str
+
+
+# --------------------------------------------------------------------------
+# Clojure-comment masking
+# --------------------------------------------------------------------------
+#
+# `(ex-info (str error-kw) …)` and `(ex-info ":rf.error/…")` appear in PROSE:
+# the `re-frame.error` rationale comment literally quotes the retired
+# `(ex-info (str error-kw) …)` shape, and docstrings reference
+# `:rf.error/…` ex-infos. Those are documentation, not reintroduced code.
+#
+# We mask `;`-to-EOL comments (length-preserving). We DO NOT mask "..." string
+# literals — pattern (a) MUST see the `":rf.error/…"` literal message string,
+# which is itself a string literal. A `:rf.error/…` mention inside an unrelated
+# docstring cannot match any pattern (none of the patterns match a `:rf.*`
+# keyword that is not the immediate `ex-info` first argument), so leaving
+# string contents visible is safe — and (a) requires it. Multi-line docstrings
+# that happen to contain the literal text `(ex-info ":rf.error/…"` would be a
+# false positive, but that exact byte sequence does not occur in any docstring
+# (a docstring describing the OLD shape spells it `(ex-info (str error-kw) …)`,
+# which is a `;;` comment in re-frame.error and is masked).
+
+_LINE_COMMENT_RE = re.compile(r";.*$")
+
+
+def _mask_comments(text: str) -> list[str]:
+    """Return per-line content with `;`-to-EOL comments blanked.
+
+    Length-preserving so 1-based line numbers and reported snippets line up
+    with the source. A `;` inside a "..." string literal is NOT a comment, so
+    we track string state to avoid blanking a `;` that lives in a string (rare,
+    but e.g. a reason sentence with a semicolon). Backslash-escaped quotes do
+    not toggle string state.
+    """
+    masked: list[str] = []
+    in_string = False
+    for raw in text.splitlines():
+        out = []
+        i = 0
+        n = len(raw)
+        while i < n:
+            c = raw[i]
+            if in_string:
+                if c == "\\" and i + 1 < n:
+                    out.append(raw[i:i + 2])
+                    i += 2
+                    continue
+                if c == '"':
+                    in_string = False
+                out.append(c)
+                i += 1
+                continue
+            if c == '"':
+                in_string = True
+                out.append(c)
+                i += 1
+                continue
+            if c == ";":
+                # Comment to EOL — blank length-preserving and stop the line.
+                out.append(" " * (n - i))
+                i = n
+                continue
+            out.append(c)
+            i += 1
+        masked.append("".join(out))
+    return masked
+
+
+# --------------------------------------------------------------------------
+# File iteration
+# --------------------------------------------------------------------------
+
+
+def _iter_source_files(scan_root: Path, include_tests: bool) -> Iterable[Path]:
+    """Yield framework source files under scan_root."""
+    if scan_root.is_file():
+        if scan_root.suffix in _SOURCE_SUFFIXES:
+            yield scan_root
+        return
+    for path in sorted(scan_root.rglob("*")):
+        if path.suffix not in _SOURCE_SUFFIXES:
+            continue
+        parts = set(path.relative_to(scan_root).parts)
+        if parts & _EXCLUDE_DIR_NAMES:
+            continue
+        if not include_tests and (parts & _TEST_DIR_NAMES):
+            continue
+        yield path
+
+
+# --------------------------------------------------------------------------
+# Per-file scan
+# --------------------------------------------------------------------------
+#
+# The four patterns can span lines (a builder call wrapped across newlines), so
+# we run them over the WHOLE masked text and map each match back to its 1-based
+# line number. `(ex-info\n  ":rf.error/…"` is a real shape (most converted /
+# unconverted sites put the message on the line after `(ex-info`), so a
+# line-local scan would miss them.
+
+
+def _line_of_offset(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _scan_text(path: Path, text: str) -> list[Finding]:
+    masked = "\n".join(_mask_comments(text))
+    raw_lines = text.splitlines()
+
+    def raw_snippet(line_no: int) -> str:
+        return raw_lines[line_no - 1].strip() if 0 <= line_no - 1 < len(raw_lines) else ""
+
+    findings: list[Finding] = []
+    for kind, pat in _PATTERNS:
+        for m in pat.finditer(masked):
+            line_no = _line_of_offset(masked, m.start())
+            findings.append(Finding(path, line_no, kind, raw_snippet(line_no)))
+    # De-dup (a single site cannot match two patterns, but guard anyway).
+    seen = set()
+    unique: list[Finding] = []
+    for f in findings:
+        key = (f.path, f.line, f.kind)
+        if key not in seen:
+            seen.add(key)
+            unique.append(f)
+    return sorted(unique, key=lambda f: (str(f.path), f.line))
+
+
+def scan(scan_root: Path, include_tests: bool = False) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in _iter_source_files(scan_root, include_tests):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        findings.extend(_scan_text(path, text))
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+_FIX_HINT = (
+    "These sites ship a BARE `:rf.error/…` keyword as `ex-message` — the OLD "
+    "shape rf2-vvixub abolished (Spec 009 §The thrown-error shape). Route each "
+    "through the canonical builder so the message LEADS with a human sentence "
+    "and TRAILS with the `[:rf.error/<id>]` token:\n"
+    "  * an artefact that can `:require re-frame.error`:\n"
+    "      (error/throw-error! :rf.error/<id> 'rf/<where> \"<human sentence>\" {:extra {...}})\n"
+    "    or build-without-throwing via `error/thrown-ex-info`. A per-surface\n"
+    "    helper (flow-error / route-error / registration-error / …) should\n"
+    "    DELEGATE its message to `error/thrown-ex-info` rather than\n"
+    "    `(ex-info (str error-id) …)`.\n"
+    "  * the bundle-isolated reagent-slim adapter (cannot :require\n"
+    "    re-frame.error): hand-roll the same shape inline —\n"
+    "      (ex-info (str \"<human sentence> [\" :rf.error/<id> \"]\") {:rf.error/id … :reason … …})\n"
+    "  The `:reason` sentence usually already exists in the ex-data; reuse it."
+)
+
+
+def _report(findings: list[Finding], repo_root: Path) -> None:
+    sys.stderr.write(
+        f"\n{len(findings)} bare-keyword thrown-error message(s) found in "
+        "framework source (rf2-vvixub / Spec 009 §The thrown-error shape):\n\n"
+    )
+    for f in findings:
+        try:
+            rel = f.path.relative_to(repo_root)
+        except ValueError:
+            rel = f.path
+        rel_str = str(rel).replace("\\", "/")
+        sys.stderr.write(f"  {f.kind}: {rel_str}:{f.line}\n      {f.snippet}\n")
+    sys.stderr.write(f"\nFix:\n  {_FIX_HINT}\n")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "rf2-vvixub: fail on a framework `(ex-info …)` whose message is a "
+            "bare `:rf.*` discriminator keyword (the retired keyword-only shape)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Path to the repo root. Defaults to the script's grandparent.",
+    )
+    parser.add_argument(
+        "--scan-dir",
+        default=None,
+        help=(
+            "Directory (relative to repo-root) to scan. Defaults to "
+            f"'{DEFAULT_SCAN_DIR}'."
+        ),
+    )
+    parser.add_argument(
+        "--include-tests",
+        action="store_true",
+        help=(
+            "Scan test/ trees too. Off by default — a test may construct a "
+            "bare-keyword ex-info to exercise a predicate."
+        ),
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print progress to stderr."
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Run the bundled fixture-based self-tests in "
+            "scripts/_test_fixtures/check_thrown_error_messages/ and exit."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests(verbose=args.verbose)
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    if not (repo_root / "mkdocs.yml").is_file():
+        sys.stderr.write(
+            f"error: {repo_root} does not look like the re-frame2 repo root "
+            "(no mkdocs.yml). Pass --repo-root explicitly.\n"
+        )
+        return 2
+
+    scan_root = repo_root / (args.scan_dir or DEFAULT_SCAN_DIR)
+    if not scan_root.exists():
+        sys.stderr.write(f"error: scan dir {scan_root} does not exist.\n")
+        return 2
+
+    if args.verbose:
+        n = sum(1 for _ in _iter_source_files(scan_root, args.include_tests))
+        rel = str(scan_root.relative_to(repo_root)).replace("\\", "/")
+        sys.stderr.write(
+            f"scanning {n} framework source file(s) under {rel} "
+            f"(tests {'included' if args.include_tests else 'excluded'})...\n"
+        )
+
+    findings = scan(scan_root, include_tests=args.include_tests)
+    if findings:
+        _report(findings, repo_root)
+        return 1
+    if args.verbose:
+        sys.stderr.write(
+            "no bare-keyword thrown-error messages in framework source.\n"
+        )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Self-tests (fixture-driven) — prove the gate FIRES on each bad shape and
+# stays GREEN on every conformant counterpart.
+# --------------------------------------------------------------------------
+
+_SELF_TEST_FIXTURE_ROOT = (
+    Path(__file__).resolve().parent
+    / "_test_fixtures"
+    / "check_thrown_error_messages"
+)
+
+
+def _run_self_tests(verbose: bool = False) -> int:
+    cases: list[tuple[str, int]] = [
+        # (fixture-file relative to fixture-root, expected finding count)
+        # --- positives: each bare-keyword message shape must FIRE ---
+        ("positive/literal_keyword_string.cljc",     1),
+        ("positive/literal_keyword_multiline.cljc",  1),
+        ("positive/str_literal_keyword.cljc",        1),
+        ("positive/str_error_kw_var.cljc",           1),
+        ("positive/str_error_id_var.cljc",           1),
+        ("positive/str_id_of_payload.cljc",          1),
+        # --- negatives: every conformant counterpart must stay GREEN ---
+        ("negative/human_message_builder.cljc",      0),
+        ("negative/throw_error_bang.cljc",           0),
+        ("negative/str_concat_human_text.cljc",      0),
+        ("negative/keyword_as_reason_value.cljc",    0),
+        ("negative/keyword_in_exdata.cljc",          0),
+        ("negative/keyword_in_comment.cljc",         0),
+        ("negative/keyword_in_docstring.cljc",       0),
+        ("negative/inline_human_token_slim.cljc",    0),
+    ]
+
+    failures = 0
+    for fixture, expected in cases:
+        path = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not path.is_file():
+            sys.stderr.write(
+                f"self-test FAIL: fixture {fixture!r} missing at {path}\n"
+            )
+            failures += 1
+            continue
+        got = len(scan(path, include_tests=True))
+        if got == expected:
+            if verbose:
+                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} expected findings={expected}, "
+                f"got {got}\n"
+            )
+            failures += 1
+
+    if failures:
+        sys.stderr.write(f"\n{failures} self-test failure(s).\n")
+        return 1
+    if verbose:
+        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -169,6 +169,21 @@ run "retired-spelling gate self-test" "python scripts/check_retired_spellings.py
 run "retired-spelling gate (EP-0007)" "python scripts/check_retired_spellings.py --verbose" \
   python "$repo_root/scripts/check_retired_spellings.py" --verbose
 
+# Thrown-error human-message corpus gate (rf2-6bb3pg, Spec 009 §The thrown-error
+# shape / rf2-vvixub): a framework `(ex-info …)` whose MESSAGE is a bare
+# `:rf.*` discriminator keyword is the keyword-only shape rf2-vvixub abolished —
+# a CI failure, not a doc note. Replaces the curated allow-list conformance
+# test (thrown_error_message_conformance_cljs_test) with a CORPUS sweep so a
+# new/never-converted keyword-only throw-site cannot ride back in invisibly.
+# Self-test first (proves it FIRES on each bare-keyword shape + stays GREEN on
+# the conformant counterparts), then the live scan asserts framework source is
+# clean.  See scripts/check_thrown_error_messages.py.
+run "thrown-error message gate self-test" "python scripts/check_thrown_error_messages.py --self-test" \
+  python "$repo_root/scripts/check_thrown_error_messages.py" --self-test
+
+run "thrown-error message gate (rf2-vvixub)" "python scripts/check_thrown_error_messages.py --verbose" \
+  python "$repo_root/scripts/check_thrown_error_messages.py" --verbose
+
 # EP-0010 §Validation/Conformance ambient-durable-read gate (rf2-f2t151): a
 # direct ambient host read (clock / RNG / browser fact) written into a DURABLE
 # frame-state field inside a durable-write namespace (resource reducers,


### PR DESCRIPTION
Completes the **rf2-vvixub** thrown-error human-message rollout and replaces the curated allow-list conformance test with a **corpus-driven gate** so it cannot silently regress (rf2-6bb3pg).

## Problem
rf2-vvixub flipped the contract (Spec 009 §The thrown-error shape): a framework thrown-error's `ex-message` is a human sentence + trailing `[:rf.error/<id>]` token, never the bare stringified discriminator keyword. But the rollout was half-done — **72 `(ex-info …)` sites across 34 files** still shipped the bare keyword as the message. The bead enumerated ~42 via `git grep '(ex-info ":rf'`; the new corpus gate found **30 more** the grep missed: the multi-line `(ex-info\n ":rf…"` form, and the `(str …)` variants — `(str :rf.error/…)`, `(str error-kw)` / `(str error-id)` (per-surface helper clones), and `(str (:rf.error/id payload))` (shared-payload throws). All four shapes render `ex-message` as exactly the stringified keyword — the same regression.

The old conformance test (`thrown_error_message_conformance_cljs_test`) is a curated allow-list exercising a few central sites in-process, so CI couldn't see any of these.

## Part 1 — route every site through the human-message builder (72 sites)
- Direct throws → `error/throw-error!`; build-don't-throw sites (passed to `reject`/returned) → `error/thrown-ex-info`.
- Per-surface helper clones (`flow-error`/`route-error`/`registration-error`/`validation-error`/`raise-removed-reg-event!`) now **delegate** their message to the builder instead of `(ex-info (str error-id) …)`.
- **Shared pre-built ex-data payloads** (frame `no-frame-context`, events `legacy-runtime-root` — reused by both a throw AND a trace/boundary emit) route through a new `error/ex-info-from-data`, which derives the message from the map's own `:rf.error/id` + `:reason` **without forking the shared payload**. Added `:reason` to `no-frame-context-payload`; added a human `:reason` to the path `missing-path-param` + spine `no-hiccup-emitter` throws (which had none).
- **reagent-slim** (bundle-isolated, cannot `:require re-frame.error`) hand-rolls the human sentence + token inline.
- ex-data is preserved verbatim everywhere — only the message changes. (Two core sites — `no-adapter-specified`, `invalid-platform` — now also carry the canonical `:rf.error/id` slot they previously omitted.)

## Part 2 — corpus-driven gate
`scripts/check_thrown_error_messages.py` — a source scan (mirrors `check_retired_spellings.py`) that fails on **ANY** framework `(ex-info …)` whose message position is a bare `:rf.*` discriminator keyword (all 4 shapes). Anchors on the `ex-info` **first argument**, masks `;`-comments, so a `:rf.error/…` keyword used as a `:reason`/ex-data/trace value never fires. `--self-test` mode with **6 positive + 8 negative fixtures**. Wired into `scripts/test-fast-pr.sh` and `.github/workflows/test.yml` (self-test + live scan).

### Red → green
- **RED** on the pre-fix tree: **72 findings across 34 files**.
- **GREEN** after the conversions: 0 findings.
- Self-test: all 14 fixtures pass (proves it fires on each bad shape, stays green on the conformant counterparts incl. the inline reagent-slim shape + `(str "human" :kw "]")` concat).

## Test migration (vvixub pattern)
Exact-equality message assertions `(= ":rf.error/foo" (ex-message ex))` across core / machines / routing / reagent tests migrated to branch on `(:rf.error/id (ex-data ex))`. `thrown-with-msg?` regex assertions left intact (the new message still contains the `[:rf.error/<id>]` token).

## Gates run (all green)
- corpus gate: RED-before (72) → GREEN-after; self-test 14/14
- JVM: core (1798 tests), resources (496), machines (774), routing (297), http (443) — 0 failures
- CLJS node `npm run test:cljs`: 7848 tests / 32493 assertions — 0 failures

Closes rf2-6bb3pg.