### PR TITLE
fix(core): EP-0023 inline :registrations fn-body routes through dispatch (rf2-ffc6s0)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -290,6 +290,32 @@
       (register! :cofx id meta))
     id))
 
+;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) --------------------
+;;
+;; An image's inline `:registrations` `:reg-cofx` entry carries the raw
+;; value-returning supplier fn under `:impl`. For the inline cofx to be
+;; DELIVERED through a frame-targeted cascade, the assembled generation's
+;; resolver descriptor must carry the SAME runnable slots `reg-cofx` installs
+;; — `:handler-fn` (the supplier) + the `:recordable?` / `:provided?` grade
+;; flags delivery reads. Closes the EP-0023 §Image Fragments "same runtime
+;; descriptor shape" contract for cofx. Published via late-bind (image-assembly
+;; cannot static-require this ns).
+
+(defn lower-inline-cofx
+  "Lower an inline `:reg-cofx` descriptor's raw supplier fn into the runnable
+  cofx slots `reg-cofx` installs (`:handler-fn` + the `:recordable?` /
+  `:provided?` grade flags read at delivery). `meta` is the inline entry's
+  metadata map (its `:recordable?` / `:provided?` grade is read here, mirroring
+  `reg-cofx`); `impl` is the raw value-returning supplier (nil for a provided
+  recordable fact). Returns ONLY the runnable slots so image-assembly merges
+  them onto the descriptor, preserving `:impl` + provenance."
+  [meta impl]
+  {:handler-fn  impl
+   :recordable? (boolean (:recordable? meta))
+   :provided?   (boolean (:provided? meta))})
+
+(late-bind/set-fn! :image/lower-inline-cofx lower-inline-cofx)
+
 ;; ---- :rf.cofx/requires parsing (Spec 001 §The declaration key) ------------
 ;;
 ;; `:rf.cofx/requires` is a vector of registered coeffect ids; a

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -1146,3 +1146,34 @@
   See also: `reg-event`."
   ([] (registrar/clear-kind! :event))
   ([id] (registrar/unregister! :event id)))
+
+;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) --------------------
+;;
+;; An image's inline `:registrations` `:reg-event` entry carries the raw
+;; handler fn under `:impl` (image lowering is the pure `re-frame.image`
+;; slice, which has no access to the event wrapper). For the inline handler
+;; to RUN through a frame-targeted dispatch, the assembled image generation's
+;; resolver descriptor must carry the SAME runnable slots `register-event!`
+;; installs — `:handler-fn` + the `:interceptors` chain whose tail is the
+;; `:rf/event-handler` wrapper. This lowering closes the EP-0023 §Image
+;; Fragments contract: "Both paths should lower to the same runtime descriptor
+;; shape." Published via late-bind (image-assembly cannot static-require this
+;; ns — `subs` requires `live-frame` which requires `image-assembly`, so the
+;; whole inline-lowering family rides the same forward-reference seam).
+
+(defn lower-inline-event
+  "Lower an inline `:reg-event` descriptor's raw fn body into the runnable
+  event-handler slots (`:handler-fn` + the `:interceptors` chain carrying the
+  `:rf/event-handler` wrapper) — the same shape `register-event!` stores and
+  `event-handler-meta` produces. `_meta` is the inline entry's metadata map
+  (unused for events: the descriptor already carries the inline `:metadata`,
+  and the only event-meta slot affecting the runnable chain — author-declared
+  `:interceptors` references — is an advanced inline shape out of this slice's
+  scope); `impl` is the raw handler fn. Returns ONLY the two runnable slots
+  (`{:handler-fn … :interceptors …}`) so image-assembly merges them onto the
+  descriptor, preserving `:impl` + provenance for replacement-winner
+  coordinates and dedupe."
+  [_meta impl]
+  (event-handler-meta impl))
+
+(late-bind/set-fn! :image/lower-inline-event lower-inline-event)

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -110,6 +110,28 @@
   ([] (registrar/clear-kind! :fx))
   ([id] (registrar/unregister! :fx id)))
 
+;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) --------------------
+;;
+;; An image's inline `:registrations` `:reg-fx` entry carries the raw effect
+;; handler fn under `:impl`. For the inline fx to RUN when an event handler
+;; emits it through a frame-targeted cascade, the assembled generation's
+;; resolver descriptor must carry the SAME runnable slot `reg-fx` installs —
+;; `:handler-fn` (the fx-walker reads it via `registrar/handler :fx`). Closes
+;; the EP-0023 §Image Fragments "same runtime descriptor shape" contract for
+;; fx. Published via late-bind (image-assembly cannot static-require this ns).
+
+(defn lower-inline-fx
+  "Lower an inline `:reg-fx` descriptor's raw fn body into the runnable fx slot
+  `reg-fx` installs (`:handler-fn`). `_meta` is the inline entry's metadata map
+  (unused — the descriptor already carries the inline `:metadata`; the runtime
+  `:platforms` predicate reads that map directly); `impl` is the raw
+  `(fn [ctx args] …)` handler. Returns ONLY the runnable slot so image-assembly
+  merges it onto the descriptor, preserving `:impl` + provenance."
+  [_meta impl]
+  {:handler-fn impl})
+
+(late-bind/set-fn! :image/lower-inline-fx lower-inline-fx)
+
 ;; ---- the platform predicate -----------------------------------------------
 
 (defn runs-on-platform?

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -136,6 +136,7 @@
   (:require [re-frame.image       :as image]
             [re-frame.source-store :as source-store]
             [re-frame.registrar   :as registrar]
+            [re-frame.late-bind   :as late-bind]
             [re-frame.error       :as error]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -369,6 +370,68 @@
                     descriptors
                     (image/select-descriptors image descriptors))))
         images))
+
+;; ---- inline-registration lowering (EP-0023 §Image Fragments, rf2-ffc6s0) ---
+;;
+;; An inline `:registrations` entry lowers (in the pure `re-frame.image` slice)
+;; to a descriptor carrying its raw fn BODY under `:impl` — inert data with NO
+;; runnable slots. A registered descriptor, by contrast, carries the RUNNABLE
+;; shape `register!` stored (`:handler-fn` + the per-kind discriminators: an
+;; event's `:interceptors` wrapper chain, a sub's `:input-kind` / `:input-signals`).
+;; So a generation built from inline `:registrations` resolved the descriptor
+;; but ran NOTHING — the cascade reads `registrar/handler` (`:handler-fn`) and
+;; an event needs `:interceptors`, neither of which an `:impl`-only descriptor
+;; carries (rf2-ffc6s0). EP-0023 §Image Fragments is explicit: "Both paths
+;; should lower to the same runtime descriptor shape."
+;;
+;; This step closes that gap: for each SELECTED descriptor that is inline
+;; (`:rf.provenance/inline`) and carries a real fn body (`:impl`), call the
+;; kind's late-bound lowering (`:image/lower-inline-<kind>`, published by
+;; `re-frame.events` / `.subs` / `.fx` / `.cofx`) with the inline `:metadata` +
+;; `:impl`, and MERGE the returned runnable slots onto the descriptor. `:impl`,
+;; the provenance coordinate, `:kind` / `:id`, and `:metadata` are PRESERVED so
+;; replacement-winner coordinates, dedupe, and introspection are unchanged; the
+;; merge only ADDS the runnable slots a registered descriptor of the same kind
+;; would carry.
+;;
+;; Late-bound (not a static require) because `image-assembly` is required by
+;; `re-frame.live-frame`, which `re-frame.subs` requires — a static require of
+;; the lowering producers would cycle. The lowering producers are core spine
+;; namespaces loaded at boot, so the hook is always published by the time any
+;; image is assembled (a `make-frame` happens at runtime, well after boot); a
+;; metadata-only inline entry (no `:impl`) and every registered descriptor pass
+;; through untouched.
+
+(defn lower-inline-descriptor
+  "Lower ONE selected descriptor into its runnable shape when it is an inline
+  descriptor carrying a real fn body (EP-0023 §Image Fragments, rf2-ffc6s0).
+  An inline descriptor (`:rf.provenance/inline`) with an `:impl` fn is merged
+  with the runnable slots its kind's late-bound lowering produces (the same
+  slots `register!` stores for a `reg-*` of that kind) — preserving `:impl`,
+  provenance, `:kind` / `:id`, and `:metadata`. A non-inline descriptor (a
+  registered or standard one), a metadata-only inline entry (no `:impl`), or a
+  kind with no published lowering hook returns UNCHANGED. Pure modulo the
+  late-bind lookup."
+  [descriptor]
+  (if (and (:rf.provenance/inline descriptor)
+           (contains? descriptor :impl))
+    (if-let [lower (late-bind/get-fn
+                     (keyword "image" (str "lower-inline-" (name (:kind descriptor)))))]
+      ;; Merge runnable slots UNDER the descriptor's own keys (the descriptor
+      ;; wins on any shared key — :impl / provenance / :kind / :id stay put;
+      ;; the lowering only contributes :handler-fn + the per-kind runtime slots).
+      (merge (lower (:metadata descriptor) (:impl descriptor)) descriptor)
+      descriptor)
+    descriptor))
+
+(defn lower-inline-descriptors
+  "Map `lower-inline-descriptor` over `descriptors` — lowering every selected
+  inline descriptor with a real fn body into its runnable shape before
+  validation + sealing (EP-0023 §Image Fragments, rf2-ffc6s0). Registered /
+  standard / metadata-only descriptors pass through untouched. Order
+  preserved (it never decides a collision winner downstream)."
+  [descriptors]
+  (mapv lower-inline-descriptor descriptors))
 
 ;; ===========================================================================
 ;; Validation — every point is FAIL-LOUD via re-frame.error/throw-error!
@@ -922,7 +985,15 @@
   (let [;; A representative image id for diagnostics (the first that carries
         ;; one); collision/winner errors also name exact coordinates.
         image-id (some :rf.image/id images)
-        selected (select-for-images images descriptors)
+        ;; Lower every selected INLINE descriptor's `:impl` fn body into its
+        ;; runnable shape (`:handler-fn` + per-kind runtime slots) so the
+        ;; sealed resolver's inline entries route through dispatch / subscribe
+        ;; identically to a `:include-ns`-selected registered descriptor
+        ;; (EP-0023 §Image Fragments — "the same runtime descriptor shape",
+        ;; rf2-ffc6s0). Registered / standard / metadata-only entries are
+        ;; unchanged; `:impl` + provenance are preserved for collision /
+        ;; replacement / dedupe (all unchanged downstream).
+        selected (lower-inline-descriptors (select-for-images images descriptors))
         standard (standard-descriptors)
         all-ds   (into (vec selected) standard)
         [rep rep-std] (replace-maps image-id images)]

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -97,6 +97,30 @@
     :producer-ns 're-frame.router
     :description "Process an event synchronously, bypassing the drain queue."}
 
+   ;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) -------------------
+   ;; `re-frame.image-assembly` lowers an image's inline `:registrations` fn
+   ;; bodies (`:impl`) into the runnable descriptor shape per kind so they route
+   ;; through dispatch identically to a `:include-ns`-selected registration
+   ;; (EP-0023 §Image Fragments — "the same runtime descriptor shape"). Each
+   ;; kind's ns publishes its lowering; image-assembly cannot static-require any
+   ;; of them (subs requires live-frame requires image-assembly → cycle).
+   {:key         :image/lower-inline-event
+    :producer-ns 're-frame.events
+    :design-bead "rf2-ffc6s0"
+    :description "Lower an inline :reg-event descriptor's :impl fn body into the runnable event-handler slots (:handler-fn + the :interceptors chain carrying the :rf/event-handler wrapper) so an image's inline event routes through a frame-targeted dispatch. Consumed by re-frame.image-assembly during assembly."}
+   {:key         :image/lower-inline-sub
+    :producer-ns 're-frame.subs
+    :design-bead "rf2-ffc6s0"
+    :description "Lower an inline :reg-sub descriptor's :impl computation fn into the runnable layer-1 (:input-kind :db) sub slots (:handler-fn + :input-kind + :input-signals) so an image's inline sub computes through a frame-targeted subscribe. Consumed by re-frame.image-assembly during assembly."}
+   {:key         :image/lower-inline-fx
+    :producer-ns 're-frame.fx
+    :design-bead "rf2-ffc6s0"
+    :description "Lower an inline :reg-fx descriptor's :impl fn body into the runnable fx slot (:handler-fn) so an image's inline fx runs when an event handler emits it. Consumed by re-frame.image-assembly during assembly."}
+   {:key         :image/lower-inline-cofx
+    :producer-ns 're-frame.cofx
+    :design-bead "rf2-ffc6s0"
+    :description "Lower an inline :reg-cofx descriptor's :impl supplier fn into the runnable cofx slots (:handler-fn + the :recordable? / :provided? grade flags) so an image's inline cofx is delivered through a frame-targeted cascade. Consumed by re-frame.image-assembly during assembly."}
+
    ;; ---- re-frame.subs --------------------------------------------------------
    {:key         :subs/subscribe-once
     :producer-ns 're-frame.subs

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1493,6 +1493,37 @@
 
 (late-bind/set-fn! :subs/subscribe-once subscribe-once)
 
+;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) --------------------
+;;
+;; An image's inline `:registrations` `:reg-sub` entry carries the raw
+;; computation fn under `:impl`. For the inline sub to COMPUTE through a
+;; frame-targeted subscribe, the assembled generation's resolver descriptor
+;; must carry the SAME runnable slots `reg-sub` installs — `:handler-fn` +
+;; the `:input-kind` / `:input-signals` discriminators the sub-cache reads.
+;; The inline tuple `[id metadata body]` carries exactly ONE body fn and no
+;; `:<-` chain, so the lowered shape is the layer-1 app-db reader (`:input-kind
+;; :db`), the only sub shape expressible inline (a `:<-` static / parametric
+;; sub needs the chain / two-fn form `reg-sub` parses, which the inline tuple
+;; cannot carry). Closes the EP-0023 §Image Fragments "same runtime descriptor
+;; shape" contract for subs. Published via late-bind (image-assembly cannot
+;; static-require this ns — subs requires live-frame requires image-assembly).
+
+(defn lower-inline-sub
+  "Lower an inline `:reg-sub` descriptor's raw computation fn into the runnable
+  layer-1 (`:input-kind :db`) sub slots `reg-sub` installs (`:handler-fn` +
+  `:input-kind :db` + empty `:input-signals`). `_meta` is the inline entry's
+  metadata map (unused — the descriptor already carries the inline `:metadata`,
+  and an inline tuple cannot express the `:<-` chain that would change the
+  input kind); `impl` is the raw `(fn [db query-v] …)` computation. Returns
+  ONLY the runnable slots so image-assembly merges them onto the descriptor,
+  preserving `:impl` + provenance."
+  [_meta impl]
+  {:handler-fn    impl
+   :input-kind    :db
+   :input-signals []})
+
+(late-bind/set-fn! :image/lower-inline-sub lower-inline-sub)
+
 ;; ---- JVM-side convenience aliases (rf2-bmzq0) ----------------------------
 ;;
 ;; On the JVM we preserve the legacy `re-frame.subs/<name>` shape for

--- a/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
@@ -380,6 +380,87 @@
               "event-first opts form still routes the object target byte-identically"))))))
 
 ;; ===========================================================================
+;; 8b. INLINE :registrations FN-BODY ROUTES THROUGH DISPATCH (rf2-ffc6s0)
+;;     — the EP-0023 gap: an image built from inline `:registrations` with a
+;;     REAL fn body must wire that handler into the dispatch / subscribe /
+;;     fx / cofx path identically to a `:include-ns`-selected registration.
+;;     Before the fix the inline body lowered ONLY to `:impl` (inert data),
+;;     so a frame-targeted dispatch resolved the descriptor but ran nothing
+;;     (`registrar/handler` reads `:handler-fn`, an event needs `:interceptors`).
+;;     EP-0023 §Image Fragments: "Both paths should lower to the same runtime
+;;     descriptor shape."
+;; ===========================================================================
+
+(deftest inline-registrations-event-fn-body-runs-through-dispatch
+  (testing "an image built from INLINE :registrations with a REAL event fn body
+            runs that handler END-TO-END under a frame-targeted dispatch — the
+            inline body lowers to the same runnable descriptor shape a
+            :include-ns-selected handler carries (rf2-ffc6s0)"
+    (rf/reg-frame :inline/main {:doc "inline-image counter frame"})
+    ;; A GLOBAL handler the cascade would (wrongly) run if it resolved through
+    ;; the global registrar — present so the assertion proves the IMAGE ran.
+    (rf/reg-event :counter/inc
+      (fn [{:keys [db]} _] {:db (assoc db :written-by :global)}))
+    (let [img (image/image
+                {:id :inline/counter
+                 :registrations
+                 {:reg-event [[:counter/inc {:doc "Increment via inline body."}
+                               (fn [{:keys [db]} _]
+                                 {:db (assoc db :written-by :inline :hit true)})]]}})]
+      ;; No explicit pool needed — inline descriptors are selected because the
+      ;; image was supplied, not from the source store.
+      (lf/make-frame {:id :inline/main :images [img]} [])
+      (rf/dispatch-sync [:counter/inc] {:frame :inline/main})
+      (let [db (rf/app-db-value :inline/main)]
+        (is (true? (:hit db))
+            "the INLINE fn body actually executed — app-db mutated")
+        (is (= :inline (:written-by db))
+            "the inline body ran, not the global handler"))
+      (is (nil? registrar/*generation*)
+          "the generation binding did NOT leak past the cascade"))))
+
+(deftest inline-registrations-sub-fn-body-runs-through-subscribe
+  (testing "an image built from INLINE :registrations with a REAL layer-1 sub
+            fn body computes that sub END-TO-END under a frame-targeted
+            subscribe (rf2-ffc6s0)"
+    (rf/reg-frame :inline/main {:doc "inline-image counter frame"})
+    (rf/reg-sub :counter/value (fn [_db _] :global))
+    (let [img (image/image
+                {:id :inline/counter
+                 :registrations
+                 {:reg-event [[:counter/inc {}
+                               (fn [{:keys [db]} _]
+                                 {:db (update db :count (fnil inc 0))})]]
+                  :reg-sub   [[:counter/value {:doc "Current counter value."}
+                               (fn [db _] (:count db 0))]]}})]
+      (lf/make-frame {:id :inline/main :images [img] :initial-db {:count 0}} [])
+      (rf/dispatch-sync [:counter/inc] {:frame :inline/main})
+      (rf/dispatch-sync [:counter/inc] {:frame :inline/main})
+      (is (= 2 @(rf/subscribe :inline/main [:counter/value]))
+          "the INLINE sub body computed over the frame's own app-db, not the
+           global sub")
+      (is (nil? registrar/*generation*)
+          "the generation binding did NOT leak past the build"))))
+
+(deftest inline-registrations-fx-fn-body-runs-through-cascade
+  (testing "an image built from INLINE :registrations with a REAL fx fn body
+            runs that effect END-TO-END when an inline event handler emits it
+            (rf2-ffc6s0)"
+    (rf/reg-frame :inline/main {:doc "inline-image fx frame"})
+    (let [fired (atom [])
+          img (image/image
+                {:id :inline/fx
+                 :registrations
+                 {:reg-event [[:do/it {}
+                               (fn [_ _] {:fx [[:my/side-effect {:n 7}]]})]]
+                  :reg-fx    [[:my/side-effect {}
+                               (fn [_ctx args] (swap! fired conj args))]]}})]
+      (lf/make-frame {:id :inline/main :images [img]} [])
+      (rf/dispatch-sync [:do/it] {:frame :inline/main})
+      (is (= [{:n 7}] @fired)
+          "the INLINE fx handler ran — its fn body executed with the emitted args"))))
+
+;; ===========================================================================
 ;; 9. rf/reload-images! ON THE FACADE (EP-0023 collapse slice 2, rf2-32siq3.32)
 ;;    — the public hot-reload export swaps a frame's whole image composition
 ;;    while PRESERVING FRAME MEMORY (app-db continues; only the generation moves)


### PR DESCRIPTION
## Summary

Closes the EP-0023 gap surfaced during rf2-fpr0b5: an image built from inline `:registrations` with a **real fn body** did not route through dispatch — only `:include-ns` (registered) images were verified end-to-end.

An inline `:registrations` entry lowered (in the pure `re-frame.image` slice) only to `:impl` — inert data with no runnable slots. A frame resolving that image **found** the descriptor but **ran nothing**: the cascade reads `registrar/handler` (`:handler-fn`), and an event additionally needs its `:interceptors` wrapper chain — neither of which an `:impl`-only descriptor carries. So `dispatch-sync [:counter/inc] {:frame f}` left app-db unchanged (neither the inline nor the global handler fired).

EP-0023 §Image Fragments is explicit: **"Both paths should lower to the same runtime descriptor shape."** This makes that true.

## Fix

- Each kind's ns publishes a late-bound inline-lowering fn (`:image/lower-inline-{event,sub,fx,cofx}`) that turns a raw `:impl` body into the runnable slots `register!` stores:
  - **event** → `:handler-fn` + the `:rf/event-handler` interceptor wrapper chain (via `event-handler-meta`)
  - **sub** → layer-1 `:db` reader slots (`:handler-fn` + `:input-kind :db` + `:input-signals []` — the only sub shape an inline tuple can express)
  - **fx** → `:handler-fn`
  - **cofx** → `:handler-fn` + `:recordable?` / `:provided?` grade flags
- `re-frame.image-assembly/assemble*` lowers every selected **inline** descriptor carrying a fn body before validation + sealing, **merging** the runnable slots onto the descriptor while preserving `:impl` / provenance / `:kind` / `:id` / `:metadata` (so collision detection, replacement-winner coordinates, dedupe, and introspection are all unchanged).
- Late-bound (not a static require) because `image-assembly` is required by `live-frame`, which `subs` requires — a static require of the lowering producers would cycle. The lowering producers are core spine namespaces loaded at boot, so the hook is always published by assembly time.

## Red → green evidence

Three new regression cases in `live_cascade_frame_resolution_cljs_test` (inline event dispatch, inline sub subscribe, inline fx cascade). Before the fix all three FAILED (app-db unchanged / sub returns nil / fx never fired); after, all green.

## Gates

- `npm run test:cljs` — 7851 tests / 32499 assertions, 0 failures
- core `image-assembly` + `ep0023-conformance` + `late-bind-drift` JVM — 83 tests / 881 assertions, 0 failures
- events / cofx / fx JVM suites — 136 tests / 666 assertions, 0 failures
- full fast-pr spine — see CI

## Spec

EP-0023 already carries the normative contract (§Image Fragments: "the same runtime descriptor shape"); no new error ids / instrumentation ops / schemas. No hot-zone spec edit needed.