### PR TITLE
feat: +json media types + http query :except + nil coerce-opts tolerance (rf2-houkno, rf2-4wqxq8, rf2-iszpyg)

### DIFF
--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -56,6 +56,18 @@
     `:frame-classification/http-carriers` late-bind hook (EP-0015 HTTP
     slice, bead-plan item 8 — rf2-ppkh3v).
 
+    `:headers` is vector-only — the header denylist is immutable (a
+    default-off header would be a real leak). `:query-params` additionally
+    accepts a `{:include [..] :except [..]}` policy map (rf2-4wqxq8):
+    `:include` extends the defaults (as the legacy vector form does), and
+    `:except` SUBTRACTS denylisted names from the built-in defaults for
+    THIS frame's own dev trace — effective policy `(defaults − except) ∪
+    include`. All redaction is debug-gated trace surface (elided in
+    production), so `:except` only relaxes dev-trace friction over a
+    harmless routing/pagination key; the query defaults stay on-by-default
+    and subtractable per name. A name in both `:include` and `:except`
+    stays sensitive (`:include` wins).
+
   - **`:observability`** (`:handled-events` / `:errors`) is durable frame
     sink policy, likewise retained on the frame's `:config`. This slice
     validates its shape (each entry a map naming a `:sink` keyword);
@@ -199,31 +211,70 @@
 ;; §Privacy). Carrier names MUST be strings (header / query-param names are
 ;; strings on the wire); a non-string name fails loudly.
 
-(defn- validate-carriers!
-  "Validate one HTTP carrier-name vector (`:headers` or `:query-params`).
-  Each name must be a string; a non-string carrier fails loudly. `carrier-key`
-  names the slot for the error. Returns the (unchanged) vector, or `nil`."
-  [frame-id carrier-key names]
-  (cond
-    (nil? names) nil
-
-    (not (vector? names))
+(defn- validate-carrier-name-vector!
+  "Validate a vector of carrier names — each must be a string; a non-string
+  name fails loudly. `bad-key` locates the slot for the error message.
+  Returns the (unchanged) vector."
+  [frame-id carrier-key bad-key names]
+  (when-not (vector? names)
     (throw (classification-error
              frame-id
              (str ":sensitive :http " carrier-key ", when present, must be a "
                   "vector of carrier-name strings")
-             {:bad-key [:sensitive :http carrier-key] :bad-value names}))
+             {:bad-key bad-key :bad-value names})))
+  (doseq [n names]
+    (when-not (string? n)
+      (throw (classification-error
+               frame-id
+               (str ":sensitive :http " carrier-key " names must be "
+                    "strings (header / query-param names are strings)")
+               {:bad-key bad-key :bad-carrier n}))))
+  names)
 
-    :else
+(def ^:private query-param-policy-keys #{:include :except})
+
+(defn- validate-carriers!
+  "Validate one HTTP carrier slot (`:headers` or `:query-params`).
+
+  `:headers` accepts only a vector of carrier-name strings — the header
+  denylist is immutable (no `:except` subtraction; a default-off header
+  would be a real leak).
+
+  `:query-params` (rf2-4wqxq8) accepts EITHER:
+   - a vector of carrier-name strings — the legacy include-only form, OR
+   - a map `{:include [..] :except [..]}` — `:include` extends the defaults,
+     `:except` subtracts from the built-in defaults for this frame's own dev
+     trace. Both keys are optional; each (when present) is a vector of
+     strings; an unknown key fails loudly (closed grammar).
+
+  Each carrier name must be a string; a non-string carrier fails loudly.
+  Returns the (unchanged) value, or `nil`."
+  [frame-id carrier-key names]
+  (cond
+    (nil? names) nil
+
+    ;; rf2-4wqxq8 — query-params may carry a {:include :except} policy map.
+    (and (= :query-params carrier-key) (map? names))
     (do
-      (doseq [n names]
-        (when-not (string? n)
+      (doseq [k (keys names)]
+        (when-not (contains? query-param-policy-keys k)
           (throw (classification-error
                    frame-id
-                   (str ":sensitive :http " carrier-key " names must be "
-                        "strings (header / query-param names are strings)")
-                   {:bad-key [:sensitive :http carrier-key] :bad-carrier n}))))
-      names)))
+                   (str "unknown :sensitive :http :query-params key " k
+                        "; valid keys are :include and :except")
+                   {:bad-key [:sensitive :http :query-params k]
+                    :valid   query-param-policy-keys}))))
+      (when-some [inc (:include names)]
+        (validate-carrier-name-vector!
+          frame-id :query-params [:sensitive :http :query-params :include] inc))
+      (when-some [exc (:except names)]
+        (validate-carrier-name-vector!
+          frame-id :query-params [:sensitive :http :query-params :except] exc))
+      names)
+
+    :else
+    (validate-carrier-name-vector!
+      frame-id carrier-key [:sensitive :http carrier-key] names)))
 
 (def ^:private http-carrier-keys #{:headers :query-params})
 
@@ -485,18 +536,27 @@
 ;; point so the HTTP layer never re-derives the lower-cased form per emit.
 
 (defn http-carriers
-  "Resolve `frame-id`'s frame-local HTTP carrier extension sets from its
-  `reg-frame` `:sensitive {:http {:headers [..] :query-params [..]}}` config
-  (EP-0015 §3). Returns
+  "Resolve `frame-id`'s frame-local HTTP carrier policy from its `reg-frame`
+  `:sensitive {:http {:headers [..] :query-params ..}}` config (EP-0015 §3).
+  Returns
 
       {:headers      #{<lower-cased header name>...}
-       :query-params #{<lower-cased query-param name>...}}
+       :query-params <query-param policy>}
 
-  — the EXTENSIONS only (the immutable built-in defaults are owned by the
-  HTTP layer and unioned there). Returns `nil` when `frame-id` is nil, the
+  where the `:query-params` policy is (rf2-4wqxq8):
+   - a `#{<lower-cased name>...}` SET for the legacy include-only vector form
+     (`:query-params [\"shop_token\"]`) — names EXTEND the built-in defaults; OR
+   - a `{:include #{..} :except #{..}}` MAP for the `{:include [..] :except [..]}`
+     form — `:include` extends the defaults, `:except` subtracts from them for
+     this frame's own dev trace (`(defaults − except) ∪ include`). Empty
+     include/except sub-sets are dropped; a policy that resolves to nothing
+     (e.g. all-empty vectors) yields `nil` for `:query-params`.
+
+  `:headers` are EXTENSIONS only (the immutable built-in defaults are owned by
+  the HTTP layer and unioned there). Returns `nil` when `frame-id` is nil, the
   frame is unregistered, or the frame declares no `:sensitive :http` block —
-  the common case, so the redactor's per-frame lookup allocates nothing when
-  a frame carries no carrier policy. Names are lower-cased for the
+  the common case, so the redactor's per-frame lookup allocates nothing when a
+  frame carries no carrier policy. Names are lower-cased for the
   case-insensitive wire match. Pure (modulo the registry read)."
   [frame-id]
   (when frame-id
@@ -507,7 +567,18 @@
                         (when (seq names)
                           (into #{} (map str/lower-case) names)))
                 hs (->set (:headers http))
-                qs (->set (:query-params http))]
+                raw-qs (:query-params http)
+                qs (if (map? raw-qs)
+                     ;; {:include :except} policy map — lower-case both sub-sets,
+                     ;; drop empties, and collapse to nil when nothing remains.
+                     (let [inc (->set (:include raw-qs))
+                           exc (->set (:except raw-qs))]
+                       (when (or inc exc)
+                         (cond-> {}
+                           inc (assoc :include inc)
+                           exc (assoc :except exc))))
+                     ;; legacy include-only vector → plain extension set
+                     (->set raw-qs))]
             (when (or hs qs)
               (cond-> {}
                 hs (assoc :headers hs)

--- a/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
@@ -219,6 +219,47 @@
       (is (= [:sensitive :http :query-params] (:bad-key data)))
       (is (= 42 (:bad-carrier data))))))
 
+;; rf2-4wqxq8 — :query-params accepts a {:include [..] :except [..]} policy map
+;; (an additive frame-local subtraction path) in addition to the legacy vector.
+
+(deftest query-params-policy-map-accepted-and-validated
+  (testing "rf2-4wqxq8 — a well-formed {:include :except} :query-params map is accepted"
+    (rf/reg-frame :app/qp-policy-ok
+      {:sensitive {:http {:query-params {:include ["shop_token"]
+                                         :except  ["token"]}}}})
+    (is (= {:include ["shop_token"] :except ["token"]}
+           (get-in (rf/frame-meta :app/qp-policy-ok)
+                   [:sensitive :http :query-params]))
+        "the policy map rides the frame config verbatim"))
+  (testing "an unknown key inside the :query-params policy map fails loudly"
+    (let [data (bad-classification-ex
+                 #(rf/reg-frame :app/qp-policy-badkey
+                    {:sensitive {:http {:query-params {:include ["x"] :bogus ["y"]}}}}))]
+      (is (= :rf.error/bad-frame-classification (:rf.error/id data)))
+      (is (= [:sensitive :http :query-params :bogus] (:bad-key data)))))
+  (testing "a non-string name inside :include / :except fails loudly with a precise bad-key"
+    (let [data (bad-classification-ex
+                 #(rf/reg-frame :app/qp-policy-badinc
+                    {:sensitive {:http {:query-params {:include [42]}}}}))]
+      (is (= [:sensitive :http :query-params :include] (:bad-key data)))
+      (is (= 42 (:bad-carrier data))))
+    (let [data (bad-classification-ex
+                 #(rf/reg-frame :app/qp-policy-badexc
+                    {:sensitive {:http {:query-params {:except [:kw]}}}}))]
+      (is (= [:sensitive :http :query-params :except] (:bad-key data)))
+      (is (= :kw (:bad-carrier data)))))
+  (testing "a non-vector :include sub-value fails loudly"
+    (let [data (bad-classification-ex
+                 #(rf/reg-frame :app/qp-policy-nonvec
+                    {:sensitive {:http {:query-params {:include "not-a-vector"}}}}))]
+      (is (= [:sensitive :http :query-params :include] (:bad-key data)))))
+  (testing "the header denylist stays vector-only (no policy-map form)"
+    (let [data (bad-classification-ex
+                 #(rf/reg-frame :app/hdr-policy-rejected
+                    {:sensitive {:http {:headers {:include ["X-Foo"]}}}}))]
+      (is (= [:sensitive :http :headers] (:bad-key data))
+          "a {:include ...} map is not a valid :headers value (immutable denylist)"))))
+
 (deftest fail-loud-on-bad-observability-entry
   (testing "an :observability entry without a :sink keyword fails loudly"
     (let [data (bad-classification-ex

--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -89,14 +89,41 @@
   [body-text]
   (and (string? body-text) (str/blank? body-text)))
 
+(defn- json-media-type?
+  "rf2-houkno — RFC 6839 / IANA structured-syntax-suffix aware JSON
+  media-type predicate. Strips parameters (the `;charset=…` tail) and the
+  type prefix, then accepts a subtype of exactly `json` OR any subtype
+  carrying the `+json` structured-syntax suffix. This recognises mainstream
+  vendor JSON media types — `application/vnd.api+json` (JSON:API),
+  `application/ld+json` (JSON-LD), `application/vnd.github+json` — that a
+  bare `(str/includes? ct \"application/json\")` substring check wrongly
+  rejected (a real footgun against correct servers).
+
+  Examples that match: `application/json`, `application/json; charset=utf-8`,
+  `application/vnd.api+json`, `application/ld+json`, `text/json`.
+  Examples that do NOT: `application/edn`, `text/plain`, `application/xml`."
+  [content-type]
+  (when (string? content-type)
+    (let [;; drop parameters (`; charset=…`, `; boundary=…`), trim, lower-case
+          essence (-> content-type (str/split #";") first str/trim str/lower-case)
+          ;; subtype is the part after the first "/"; tolerate a missing "/"
+          subtype (let [idx (str/index-of essence "/")]
+                    (if idx (subs essence (inc idx)) essence))]
+      (boolean
+        (or (= "json" subtype)
+            (str/ends-with? subtype "+json"))))))
+
 (defn- sniff-decoder
-  "Per Spec 014 §`:auto`: sniff the response Content-Type header."
+  "Per Spec 014 §`:auto`: sniff the response Content-Type header.
+  rf2-houkno — JSON sniffing recognises RFC 6839 `+json` structured-syntax
+  suffix media types (e.g. `application/vnd.api+json`) via `json-media-type?`,
+  not just a bare `application/json` substring."
   [content-type]
   (let [ct (some-> content-type str/lower-case)]
     (cond
-      (and ct (str/includes? ct "application/json")) :json
-      (and ct (str/starts-with? ct "text/"))         :text
-      :else                                          :blob)))
+      (json-media-type? content-type)        :json
+      (and ct (str/starts-with? ct "text/")) :text
+      :else                                  :blob)))
 
 (defn- json-content-type?
   "rf2-upexd.2 — does the response declare a JSON Content-Type? The
@@ -107,10 +134,16 @@
   JSON-eligible — many JSON APIs omit the header, and rejecting them
   would be a regression; only a Content-Type that is PRESENT and
   declares a NON-JSON MIME is rejected as a clear contract violation
-  rather than silently JSON-parsing (and failing) a non-JSON body."
+  rather than silently JSON-parsing (and failing) a non-JSON body.
+
+  rf2-houkno — JSON eligibility now honours RFC 6839 `+json` structured-
+  syntax suffix media types (e.g. `application/vnd.api+json`,
+  `application/ld+json`) via `json-media-type?`, not just a bare
+  `application/json` substring — those carry valid JSON bodies by
+  construction and were wrongly rejected as non-JSON before."
   [content-type]
   (or (nil? content-type)
-      (some-> content-type str/lower-case (str/includes? "application/json"))))
+      (json-media-type? content-type)))
 
 (def ^:private binary-decode-kinds
   "Decode modes whose result is a native binary/structured Fetch body

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -106,26 +106,46 @@
     "hmac"})
 
 (defn sensitive-query-param?
-  "Predicate: is `param-name` in the merged query-param denylist (built-in
-  defaults ∪ the emitting frame's `frame-extras`)? Case-insensitive.
+  "Predicate: is `param-name` sensitive under the emitting frame's effective
+  query-param policy? Case-insensitive.
 
-  `frame-extras` is the frame-local carrier extension set — a set of
-  lower-cased param names resolved from the emitting frame's
-  `:sensitive {:http {:query-params [..]}}` policy (EP-0015 §3), or `nil`
-  when the frame declares none. The built-in defaults always apply; the
-  frame set EXTENDS them.
+  `frame-policy` is the frame-local query-param carrier policy resolved from
+  the emitting frame's `:sensitive {:http {:query-params ..}}` config
+  (EP-0015 §3), or `nil` when the frame declares none. Two shapes are
+  accepted (rf2-4wqxq8):
 
-  Per rf2-ydp66 — short-circuits via `contains?` lookups on the source
-  sets rather than building a fresh union per call. The URL redactor calls
-  this once per query-string param; two `contains?` ops on small sets are
-  O(1) and allocate nothing."
+   - a **set** of lower-cased names — the legacy include-only extension set
+     (`:query-params [\"shop_token\"]`). The built-in defaults always apply;
+     the set EXTENDS them.
+   - a **policy map** `{:include #{..} :except #{..}}` — `:include` extends
+     the defaults (as above); `:except` SUBTRACTS from the immutable
+     built-in defaults for THIS frame's own dev trace. The effective policy
+     is `(defaults − except) ∪ include`. A name in BOTH wins as sensitive
+     (`:include` takes precedence over `:except`) — declaring a name
+     sensitive is never overridden by also excepting it.
+
+  The `:except` path is a frame-local DEV-TRACE subtraction only (all
+  redaction is debug-gated trace surface, elided entirely in production);
+  it lets a frame stop redacting a harmless routing/pagination key/token in
+  its OWN local trace. The immutable header denylist and the on-by-default
+  query defaults are unchanged — `:except` is opt-in per name.
+
+  Per rf2-ydp66 — short-circuits via `contains?` lookups on the source sets
+  rather than building a fresh union per call."
   ([param-name] (sensitive-query-param? param-name nil))
-  ([param-name frame-extras]
+  ([param-name frame-policy]
    (boolean
      (when (string? param-name)
-       (let [lowered (str/lower-case param-name)]
-         (or (contains? default-query-param-denylist lowered)
-             (and frame-extras (contains? frame-extras lowered))))))))
+       (let [lowered (str/lower-case param-name)
+             ;; Normalise both accepted shapes to [include except].
+             [include except] (if (map? frame-policy)
+                                [(:include frame-policy) (:except frame-policy)]
+                                [frame-policy nil])
+             included? (and include (contains? include lowered))]
+         ;; :include wins over :except (declaring sensitive is never undone).
+         (or included?
+             (and (contains? default-query-param-denylist lowered)
+                  (not (and except (contains? except lowered))))))))))
 
 (defn- percent-decode-name
   "rf2-065xo — percent-decode a query-param NAME for denylist comparison
@@ -165,17 +185,19 @@
   sensitive. The redactor consults the decoded form so an encoded auth
   token is denied just like its plain spelling.
 
-  `frame-extras` is the emitting frame's frame-local query-param carrier
-  extension set (EP-0015 §3), or `nil` for defaults-only.
+  `frame-policy` is the emitting frame's frame-local query-param carrier
+  policy (EP-0015 §3) — a legacy include-only set OR a
+  `{:include #{..} :except #{..}}` map (rf2-4wqxq8) — or `nil` for
+  defaults-only. Threaded verbatim to `sensitive-query-param?`.
 
   Decode is comparison-only and total: a malformed escape decodes to
   `nil`, so matching falls back to the raw name and never throws."
   ([param-name] (sensitive-query-param-name? param-name nil))
-  ([param-name frame-extras]
+  ([param-name frame-policy]
    (boolean
-     (or (sensitive-query-param? param-name frame-extras)
+     (or (sensitive-query-param? param-name frame-policy)
          (when-let [decoded (percent-decode-name param-name)]
-           (sensitive-query-param? decoded frame-extras))))))
+           (sensitive-query-param? decoded frame-policy))))))
 
 ;; ---- URL query-string redaction (rf2-2p8wr) -------------------------------
 
@@ -228,14 +250,16 @@
   verbatim in the rebuilt pair — only the value is replaced (decoding is
   comparison-only).
 
-  `frame-extras` is the emitting frame's frame-local query-param carrier
-  extension set (EP-0015 §3), or `nil` for defaults-only."
-  [pair force-all? frame-extras]
+  `frame-policy` is the emitting frame's frame-local query-param carrier
+  policy (EP-0015 §3) — a legacy include-only set OR a
+  `{:include #{..} :except #{..}}` map (rf2-4wqxq8) — or `nil` for
+  defaults-only."
+  [pair force-all? frame-policy]
   (let [eq-idx (str/index-of pair "=")
         [pname _pvalue] (if eq-idx
                           [(subs pair 0 eq-idx) (subs pair (inc eq-idx))]
                           [pair nil])]
-    (if (or force-all? (sensitive-query-param-name? pname frame-extras))
+    (if (or force-all? (sensitive-query-param-name? pname frame-policy))
       (str pname "=" redacted-url-token)
       pair)))
 
@@ -252,17 +276,21 @@
   (e.g. `?api_key=SECRET&page=2` → `?api_key=:rf/redacted&page=2`).
   Fragment portion (`#…`) preserved verbatim.
 
-  `frame-extras` is the emitting frame's frame-local query-param carrier
-  extension set (EP-0015 §3), or `nil` for defaults-only — it UNIONS onto
-  the immutable built-in denylist for the always-on (`sensitive?` false)
-  redaction.
+  `frame-policy` is the emitting frame's frame-local query-param carrier
+  policy (EP-0015 §3), or `nil` for defaults-only. Accepts a legacy
+  include-only set (UNIONed onto the immutable built-in denylist) OR a
+  `{:include #{..} :except #{..}}` map (rf2-4wqxq8) whose `:except` set
+  SUBTRACTS from the built-in defaults for this frame's own dev trace —
+  effective policy `(defaults − except) ∪ include`. Applies to the
+  always-on (`sensitive?` false) redaction; a `sensitive?`-true request
+  still redacts EVERY param regardless of policy.
 
   Returns `[redacted-url any-redacted?]` where `any-redacted?` is true
   iff at least one param value was redacted (the caller uses this to
   decide whether to stamp `:sensitive?` per the denylist-is-signal
   rule). Nil / non-string / no-query inputs return `[url-str false]`."
   ([url-str sensitive?] (redact-url-query-string url-str sensitive? nil))
-  ([url-str sensitive? frame-extras]
+  ([url-str sensitive? frame-policy]
    (cond
      (not (string? url-str))
      [url-str false]
@@ -282,7 +310,7 @@
                changed?   (volatile! false)
                pairs      (str/split query #"&")
                redacted   (mapv (fn [p]
-                                  (let [out (redact-query-param p force-all? frame-extras)]
+                                  (let [out (redact-query-param p force-all? frame-policy)]
                                     (when-not (identical? out p)
                                       (vreset! changed? true))
                                     out))
@@ -300,5 +328,5 @@
   (which use `redact-url-query-string` directly for the flag). No
   production caller invokes this single-value wrapper."
   ([url-str sensitive?] (first (redact-url-query-string url-str sensitive? nil)))
-  ([url-str sensitive? frame-extras]
-   (first (redact-url-query-string url-str sensitive? frame-extras))))
+  ([url-str sensitive? frame-policy]
+   (first (redact-url-query-string url-str sensitive? frame-policy))))

--- a/implementation/http/test/re_frame/http_decode_test.clj
+++ b/implementation/http/test/re_frame/http_decode_test.clj
@@ -187,6 +187,85 @@
              :decode-supplied? true
              :max-decoded-keys 2})))))
 
+;; ---- rf2-houkno: +json vendor media types (RFC 6839 suffix) ---------------
+;;
+;; The JSON gate (`json-content-type?` for schema eligibility + `sniff-decoder`
+;; for `:auto`) previously keyed on a bare `(str/includes? ct "application/json")`
+;; substring, so mainstream vendor JSON types — application/vnd.api+json
+;; (JSON:API), application/ld+json (JSON-LD), application/vnd.github+json —
+;; were wrongly rejected (schema path) or mis-sniffed to :blob (:auto path)
+;; even though the body is valid JSON. rf2-houkno accepts subtype "json" OR
+;; the "+json" structured-syntax suffix (RFC 6839 / IANA), parameter-stripped.
+
+(deftest schema-decode-accepts-vendor-plus-json-media-types
+  (testing "rf2-houkno — a schema :decode over a body whose Content-Type
+            carries the RFC 6839 `+json` suffix (vnd.api+json, ld+json,
+            vnd.github+json) decodes as JSON rather than being rejected
+            as `:rf.error/http-schema-non-json-content-type`"
+    (doseq [ct ["application/vnd.api+json"
+                "application/ld+json"
+                "application/vnd.github+json"
+                "application/vnd.api+json; charset=utf-8"]]
+      (is (= {:title "hello" :id 42}
+             (decode/decode-response-body
+               {:body-text "{\"title\":\"hello\",\"id\":42}"
+                :headers   {"content-type" ct}
+                :decode    [:map [:title :string] [:id :int]]
+                :decode-supplied? true}))
+          (str "vendor +json media type should decode as JSON: " ct)))))
+
+(deftest schema-decode-still-rejects-genuine-non-json-content-type
+  (testing "rf2-houkno — the present-non-JSON reject guard is KEPT: a
+            schema :decode over an application/edn / text/plain response
+            still raises the clear MIME-mismatch error (not a misleading
+            Malli string-validation failure)"
+    (doseq [ct ["application/edn" "text/plain" "application/xml"]]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf.error/http-schema-non-json-content-type"
+            (decode/decode-response-body
+              {:body-text "{\"title\":\"hello\"}"
+               :headers   {"content-type" ct}
+               :decode    [:map [:title :string]]
+               :decode-supplied? true}))
+          (str "genuine non-JSON media type must still reject: " ct)))))
+
+(deftest auto-sniff-resolves-plus-json-to-json
+  (testing "rf2-houkno — :auto sniffing of a `+json` suffix Content-Type
+            resolves to :json (parses the body) rather than mis-sniffing
+            to :blob"
+    (doseq [ct ["application/vnd.api+json"
+                "application/ld+json"
+                "application/vnd.github+json; charset=utf-8"]]
+      (is (= {:ok true}
+             (decode/decode-response-body
+               {:body-text        "{\"ok\":true}"
+                :headers          {"content-type" ct}
+                :decode           :auto
+                :decode-supplied? false
+                :request-id       :req-pj
+                :handler-id       :handler/pj
+                :url              "https://example.test/pj"}))
+          (str "vendor +json media type should auto-sniff to :json: " ct)))))
+
+(deftest json-media-type-predicate-edge-cases
+  (testing "rf2-houkno — the JSON media-type predicate accepts json subtype
+            + +json suffix (parameter-stripped) and rejects genuine non-JSON"
+    (let [json-media-type? @#'decode/json-media-type?]
+      (is (true?  (json-media-type? "application/json")))
+      (is (true?  (json-media-type? "application/json; charset=utf-8")))
+      (is (true?  (json-media-type? "APPLICATION/JSON")))
+      (is (true?  (json-media-type? "text/json")))
+      (is (true?  (json-media-type? "application/vnd.api+json")))
+      (is (true?  (json-media-type? "application/ld+json")))
+      (is (true?  (json-media-type? "application/vnd.github+json; charset=utf-8")))
+      (is (false? (json-media-type? "application/edn")))
+      (is (false? (json-media-type? "text/plain")))
+      (is (false? (json-media-type? "application/xml")))
+      ;; a subtype that merely CONTAINS "json" but is not json / +json
+      (is (false? (json-media-type? "application/jsonrequest")))
+      (is (nil?   (json-media-type? nil))))))
+
 ;; ---- G4: :rf.warning/decode-defaulted dev emission ------------------------
 ;;
 ;; Spec 014 §`:auto`. The warning fires when the user did NOT supply

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -379,6 +379,59 @@
     (is (not (url/sensitive-query-param? :keyword)))
     (is (not (url/sensitive-query-param? 42)))))
 
+;; rf2-4wqxq8 — frame-local query-param policy MAP {:include :except}: a frame
+;; can SUBTRACT a built-in default (relaxing its OWN dev-trace friction over a
+;; harmless routing/pagination key) while still extending with :include. The
+;; effective policy is (defaults − except) ∪ include; :include wins over :except.
+
+(deftest query-param-policy-except-subtracts-a-default
+  (testing "rf2-4wqxq8 — :except removes a built-in default for this frame"
+    (let [policy {:except #{"token"}}]
+      ;; the excepted default is no longer sensitive
+      (is (not (url/sensitive-query-param? "token" policy)))
+      (is (not (url/sensitive-query-param? "TOKEN" policy)))
+      ;; other defaults still apply
+      (is (url/sensitive-query-param? "api_key" policy))
+      (is (url/sensitive-query-param? "signature" policy))
+      ;; without the policy the default still redacts (subtraction is frame-local)
+      (is (url/sensitive-query-param? "token")))))
+
+(deftest query-param-policy-include-and-except-compose
+  (testing "rf2-4wqxq8 — :include extends defaults; :except subtracts; both compose"
+    (let [policy {:include #{"shop_token"} :except #{"token"}}]
+      (is (url/sensitive-query-param? "shop_token" policy)) ; included extension
+      (is (not (url/sensitive-query-param? "token" policy))) ; excepted default
+      (is (url/sensitive-query-param? "api_key" policy))     ; untouched default
+      (is (not (url/sensitive-query-param? "page" policy)))))) ; never sensitive
+
+(deftest query-param-policy-include-wins-over-except
+  (testing "rf2-4wqxq8 — a name in BOTH :include and :except stays sensitive"
+    (let [policy {:include #{"token"} :except #{"token"}}]
+      (is (url/sensitive-query-param? "token" policy)
+          "declaring a name sensitive is never undone by also excepting it"))))
+
+(deftest query-param-policy-empty-map-is-defaults-only
+  (testing "rf2-4wqxq8 — an empty policy map behaves like defaults-only"
+    (is (url/sensitive-query-param? "api_key" {}))
+    (is (not (url/sensitive-query-param? "page" {})))))
+
+(deftest redact-url-policy-except-leaves-default-param-visible
+  (testing "rf2-4wqxq8 — end-to-end: :except keeps a default param's value
+            visible in the frame's own dev trace"
+    (let [policy {:except #{"token"}}
+          [url any?] (url/redact-url-query-string
+                       "https://api.example.com/list?token=abc&api_key=SECRET&page=2"
+                       false policy)]
+      ;; token is excepted → visible; api_key still a default → redacted
+      (is (= "https://api.example.com/list?token=abc&api_key=:rf/redacted&page=2" url))
+      (is (true? any?)))
+    (testing "a sensitive? request still redacts EVERY param regardless of :except"
+      (let [policy {:except #{"token"}}
+            [url _] (url/redact-url-query-string
+                      "https://api.example.com/list?token=abc&page=2"
+                      true policy)]
+        (is (= "https://api.example.com/list?token=:rf/redacted&page=:rf/redacted" url))))))
+
 ;; ---- 9. redact-url-query-string (rf2-2p8wr) -------------------------------
 
 (deftest redact-url-denylist-replaces-sensitive-values
@@ -700,3 +753,38 @@
       (let [tags {:url "https://api.example.com/x?shop_token=abc&page=2"}
             out  (privacy/prepare-emit-tags tags false)]
         (is (= "https://api.example.com/x?shop_token=abc&page=2" (:url out)))))))
+
+;; rf2-4wqxq8 — frame-local :query-params {:include :except} policy map.
+
+(deftest frame-http-carriers-resolves-policy-map
+  (testing "rf2-4wqxq8 — the :query-params {:include :except} map form lowers
+            to a {:include #{..} :except #{..}} policy (sub-sets lower-cased)"
+    (rf/reg-frame :app/qp-policy
+      {:sensitive {:http {:query-params {:include ["Shop_Token"]
+                                         :except  ["Token" "Sig"]}}}})
+    (let [carriers (privacy/frame-http-carriers :app/qp-policy)
+          qp       (:query-params carriers)]
+      (is (= #{"shop_token"} (:include qp)))
+      (is (= #{"token" "sig"} (:except qp))))
+    (testing "the legacy vector form still resolves to a plain set"
+      (rf/reg-frame :app/qp-legacy
+        {:sensitive {:http {:query-params ["shop_token"]}}})
+      (is (= #{"shop_token"} (:query-params (privacy/frame-http-carriers :app/qp-legacy)))))
+    (testing "a policy map of all-empty vectors resolves :query-params to nil"
+      (rf/reg-frame :app/qp-empty
+        {:sensitive {:http {:query-params {:include [] :except []}}}})
+      (is (nil? (:query-params (privacy/frame-http-carriers :app/qp-empty)))))))
+
+(deftest prepare-emit-tags-honours-frame-query-param-except
+  (testing "rf2-4wqxq8 — a frame-local :except keeps a built-in default param
+            VISIBLE in the frame's own dev trace (subtraction is frame-local)"
+    (rf/reg-frame :app/qp-except
+      {:sensitive {:http {:query-params {:except ["token"]}}}})
+    (let [tags {:url "https://api.example.com/x?token=abc&api_key=SECRET&page=2"}
+          out  (privacy/prepare-emit-tags tags false {:frame :app/qp-except})]
+      (is (= "https://api.example.com/x?token=abc&api_key=:rf/redacted&page=2" (:url out))
+          "excepted default visible; non-excepted default still redacted"))
+    (testing "without the frame the default param redacts as usual"
+      (let [tags {:url "https://api.example.com/x?token=abc&page=2"}
+            out  (privacy/prepare-emit-tags tags false)]
+        (is (= "https://api.example.com/x?token=:rf/redacted&page=2" (:url out)))))))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -59,12 +59,22 @@
 
 (defn coerce-opts
   "Permit the keyword-only sugar `(app-schemas frame-id)` and the
-  opts-map form `(app-schemas {:frame frame-id})`. Every zero-arity
-  caller (`app-schema-at`, `app-schema-meta-at`, `app-schemas`,
-  `app-schemas-digest`) supplies `{}` explicitly — `nil` is not a
-  permitted argument."
+  opts-map form `(app-schemas {:frame frame-id})`.
+
+  rf2-iszpyg — a `nil` argument coerces to `{}` (the empty-opts shape),
+  identical to the no-arg arity's behaviour: it means \"no override —
+  resolve the frame from the carried-invariant scope\". Every read /
+  registration entry point already passes `{}` in its zero-arity
+  (`app-schema-at`, `app-schema-meta-at`, `app-schemas`,
+  `app-schemas-digest`, `reg-app-schemas`), so `nil` only arrives from an
+  explicit `(app-schemas nil)` by a trusted in-process caller. Unlike the
+  nil-PATH hazard (a non-sequential path poisons the `get-in` validation
+  hot path), a nil OPTS has no downstream hazard — it just delegates frame
+  resolution to scope, exactly as the no-arg arity does — so accepting it
+  removes a footgun rather than masking a defect."
   [opts-or-frame-id]
   (cond
+    (nil?     opts-or-frame-id) {}
     (keyword? opts-or-frame-id) {:frame opts-or-frame-id}
     (map?     opts-or-frame-id) opts-or-frame-id
     :else

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -115,11 +115,19 @@
            (storage/coerce-opts {:frame :tenant/a :other :thing})))
     (is (= {} (storage/coerce-opts {})))))
 
+(deftest coerce-opts-accepts-nil-as-empty-opts
+  (testing "rf2-iszpyg — nil coerces to {} (the empty-opts shape), identical
+            to the no-arg arity: it means 'no override, resolve the frame
+            from scope'. A nil OPTS has no analogue to the nil-PATH hazard,
+            so accepting it removes a footgun for a trusted in-process caller."
+    (is (= {} (storage/coerce-opts nil)))))
+
 (deftest coerce-opts-throws-on-bad-arg
   (testing "Per rf2-yv62u — a non-keyword, non-map argument throws
-            :rf.error/bad-app-schemas-arg. nil, numbers, strings,
-            vectors all fail."
-    (doseq [bad-arg [nil 42 "frame-a" [:a :b] :well/-actually-keyword-is-ok]]
+            :rf.error/bad-app-schemas-arg. numbers, strings, vectors all
+            fail. (rf2-iszpyg — nil is now accepted as {}; see
+            coerce-opts-accepts-nil-as-empty-opts.)"
+    (doseq [bad-arg [42 "frame-a" [:a :b] :well/-actually-keyword-is-ok]]
       (cond
         ;; keywords pass — exclude from the throw-loop sentinel above.
         (keyword? bad-arg)

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -1225,7 +1225,7 @@ The privacy surface has four declaration surfaces, none of them a process-global
 |---|---|---|
 | Built-in header denylist | A closed, **immutable** set of always-sensitive header names ([§1](#1-header-denylist-always-on)). No frame can remove one. | framework default (`re-frame.http-privacy-headers`) |
 | Built-in query-param denylist | A closed, **immutable** set of always-sensitive query-param names ([§2](#2-query-param-denylist-always-on)). | framework default (`re-frame.http-url`) |
-| Frame-local carriers | App-specific sensitive header / query-param names, declared on the **frame** via `:sensitive {:http {:headers [..] :query-params [..]}}` ([§Frame-local carriers](#frame-local-carriers-ep-0015-3)). The frame extension set **unions** onto the built-in defaults for the emitting frame. | `reg-frame` metadata (`re-frame.frame-classification`) |
+| Frame-local carriers | App-specific sensitive header / query-param names, declared on the **frame** via `:sensitive {:http {:headers [..] :query-params [..]}}` ([§Frame-local carriers](#frame-local-carriers-ep-0015-3)). The frame extension set **unions** onto the built-in defaults for the emitting frame. `:query-params` also accepts a `{:include [..] :except [..]}` policy map whose `:except` set **subtracts** a built-in default for that frame's own dev trace (rf2-4wqxq8); `:headers` has no `:except` form. | `reg-frame` metadata (`re-frame.frame-classification`) |
 | Per-request `:sensitive?` | The coarse per-call / per-request flag ([§3](#3-per-request--per-call-sensitive)) that redacts a single request's body / params / all URL params wholesale. | the `:rf.http/managed` args map |
 
 Response **bodies** are classified separately, per-slot, via the request's `:decode` schema ([§Response-body classification](#response-body-classification-ep-0015-5)).
@@ -1290,6 +1290,16 @@ The built-in denylist is **immutable** — no frame can remove a name. Apps exte
 ```
 
 The frame extension set is lower-cased and **unions** onto the immutable built-in defaults for traces emitted from that frame; matching is case-insensitive.
+
+**Frame-local subtraction — `{:include :except}` (rf2-4wqxq8).** `:query-params` additionally accepts a policy map so a frame can stop redacting a *harmless* routing/pagination name (e.g. a `token` that is a CSRF/page token, not an auth secret) in its **own** dev trace, where the broad bare-name default produces friction:
+
+```clojure
+(rf/reg-frame :app/main
+  {:sensitive {:http {:query-params {:include ["shop_token"]   ; extend defaults
+                                     :except  ["token"]}}}})    ; subtract a default
+```
+
+The effective policy is **`(defaults − except) ∪ include`** — `:include` extends the built-in defaults (identical to the bare vector form), `:except` removes the named defaults for that frame. A name in **both** `:include` and `:except` stays sensitive (`:include` wins — declaring a name sensitive is never undone by also excepting it). The subtraction is **frame-local and dev-trace-only**: all redaction is debug-gated trace surface and elides entirely in production, so `:except` only relaxes dev-trace friction — it never affects a production bundle. The header denylist (§1) has **no** `:except` form (a default-off header would be a real leak), and the query defaults stay **on-by-default**, subtractable only per explicitly-named param. Malformed shapes (unknown key inside the policy map, non-string name, non-vector sub-value) **fail loudly at frame registration**.
 
 Matching is **percent-decoding-aware**: a query-param name is compared against the denylist in both its raw spelling **and** its percent-decoded form, so an encoded denylisted name (`?api%5Fkey=…` for `api_key`, `?%61ccess_token=…` for `access_token`, an app-declared `?shop%5Ftoken=…`) is redacted just like its plain spelling. The decode is comparison-only — the rebuilt URL preserves the original raw name verbatim and replaces only the value. A malformed percent-escape decodes to nothing and falls back to the raw-name match; redaction is total and never throws.
 

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -221,7 +221,7 @@ Pass a Malli schema as `:decode`:
 
 The fx:
 1. Reads the response body as text.
-2. **JSON-parses the body.** The schema path is **JSON-only**: the runtime wires Malli's `json-transformer` for the decode step, so a schema rides a JSON body by construction. A response that *declares* a non-JSON Content-Type (e.g. `application/edn`, `text/plain`) under a schema `:decode` is a contract mismatch and classifies as `:rf.http/decode-failure` with a `:rf.error/http-schema-non-json-content-type` discriminator — the diagnostic names the MIME mismatch rather than masking it as a schema-validation failure. A **missing/absent** Content-Type is JSON-eligible (many JSON APIs omit the header); only a *present non-JSON* MIME is rejected. (Non-JSON wire formats under a schema are out of v1 scope — decode the body yourself with a `:decode` fn and validate downstream if you need EDN/other MIMEs.)
+2. **JSON-parses the body.** The schema path is **JSON-only**: the runtime wires Malli's `json-transformer` for the decode step, so a schema rides a JSON body by construction. JSON eligibility follows the [RFC 6839](https://www.rfc-editor.org/rfc/rfc6839) / IANA structured-syntax-suffix rule — a Content-Type whose subtype is `json` **or** carries the `+json` suffix is JSON (so mainstream vendor types `application/vnd.api+json` (JSON:API), `application/ld+json` (JSON-LD), `application/vnd.github+json` are accepted, parameters such as `;charset=utf-8` stripped). A response that *declares* a non-JSON Content-Type (e.g. `application/edn`, `text/plain`) under a schema `:decode` is a contract mismatch and classifies as `:rf.http/decode-failure` with a `:rf.error/http-schema-non-json-content-type` discriminator — the diagnostic names the MIME mismatch rather than masking it as a schema-validation failure. A **missing/absent** Content-Type is JSON-eligible (many JSON APIs omit the header); only a *present non-JSON* MIME is rejected. (Non-JSON wire formats under a schema are out of v1 scope — decode the body yourself with a `:decode` fn and validate downstream if you need EDN/other MIMEs.)
 3. Validates / coerces with Malli's `decode` against the schema (using the `json-transformer`).
 4. Hands the decoded value to `:accept`.
 
@@ -252,7 +252,7 @@ Full control. Throwing inside this fn (on a 2xx response — it doesn't run on n
 ### `:auto` (default)
 
 Sniff the response Content-Type header:
-- `application/json*` → `:json`.
+- subtype `json` or a `+json` structured-syntax suffix ([RFC 6839](https://www.rfc-editor.org/rfc/rfc6839)) → `:json` (e.g. `application/json`, `application/vnd.api+json`, `application/ld+json`, parameters stripped).
 - `text/*` → `:text`.
 - otherwise → `:blob`.
 

--- a/spec/015-Data-Classification.md
+++ b/spec/015-Data-Classification.md
@@ -140,7 +140,7 @@ Semantics:
 - Frame classification is installed **atomically as part of frame creation**, before `:on-create` runs.
 - Re-registering a frame **replaces** frame-owned classification using ordinary frame-metadata replacement semantics (no additive merge — the declaration *is* the frame's policy).
 - `:sensitive :app-db` and `:large :app-db` entries are `:rf/path` values ([EP-0012](../docs/EP/EP-0012-path-optics-and-canonical-forms.md)).
-- `:sensitive :http :headers` and `:sensitive :http :query-params` are **frame-local extensions** to the immutable built-in framework defaults; built-in HTTP carrier names remain immutable framework defaults that no frame can remove.
+- `:sensitive :http :headers` and `:sensitive :http :query-params` are **frame-local extensions** to the immutable built-in framework defaults; built-in HTTP carrier names remain immutable framework defaults that no frame can remove. `:query-params` additionally accepts a `{:include [..] :except [..]}` policy map (rf2-4wqxq8) whose `:except` set **subtracts** built-in defaults for that frame's own (dev-only, debug-gated) trace — effective policy `(defaults − except) ∪ include`, `:include` winning a tie; `:headers` has no `:except` form (a default-off header would be a real leak). See [014-HTTPRequests §Frame-local carriers](014-HTTPRequests.md#frame-local-carriers-ep-0015-3).
 - **Sensitive wins over large.** A path that is both sensitive and large redacts as sensitive and does **not** emit a large marker that could leak path, size, digest, or fetch-handle information.
 - Malformed paths, unknown classification keys, and non-string HTTP carrier names **fail loudly at frame registration** (fail-fast, not silent-ignore).
 


### PR DESCRIPTION
Three SAFE `[toomuch]` simplification beads from the kill-over-engineering review. All widen acceptance / add tolerance; none removes a validation or security guard. Two disjoint surfaces (http + core/schema, no shared files).

## rf2-houkno (P2, http) — accept RFC 6839 `+json` vendor media types in decode
Replaces the bare `(str/includes? ct "application/json")` JSON gate in `sniff-decoder` + `json-content-type?` (`http_decode.cljc`) with a parameter-stripping `json-media-type?` predicate that accepts subtype `json` OR the `+json` structured-syntax suffix (RFC 6839 / IANA). Mainstream vendor JSON types — `application/vnd.api+json` (JSON:API), `application/ld+json` (JSON-LD), `application/vnd.github+json` — now decode as JSON under both `:auto` sniffing and schema-driven `:decode` instead of being rejected/mis-sniffed. KEEPS the present-non-JSON reject guard (`application/edn`, `text/plain`) and its tests. Spec 014 decode + `:auto` sniff sections updated.

## rf2-4wqxq8 (P3, http) — frame-local query-param `:except` subtraction
`:sensitive {:http {:query-params ...}}` now accepts a `{:include [..] :except [..]}` policy map alongside the legacy include-only vector. Effective policy is `(defaults − except) ∪ include`; `:include` wins a tie. Lets a frame stop redacting a harmless routing/pagination key/token in its OWN dev trace (all redaction is debug-gated trace surface, elided in production) without removing the on-by-default query defaults. KEEPS immutable: the header denylist (no `:except` form) and the on-by-default (subtractable) query defaults. `sensitive-query-param?` accepts both the legacy set and the new map shape; `http-carriers` normalises the map form while the legacy vector still resolves to a plain set. Malformed policy maps fail loud at registration. Spec 014/015 updated.

## rf2-iszpyg (P3, schema) — accept `nil` opts as `{}` in coerce-opts
Adds `(nil? opts-or-frame-id) {}` as the first cond clause in `coerce-opts` (`storage.cljc`). `nil` now means the same as `{}` / the no-arg arity — "resolve the frame from scope" — rather than throwing `:rf.error/bad-app-schemas-arg`. Applies to all surfaces sharing `coerce-opts` (reads via `coerce->frame-id` + the digest path; registration opts). Problem A (the `reg-app-schemas` bulk pair-seq coercion) deliberately NOT changed — the bulk first-arg stays map-only and still rejects `nil` with `:rf.error/bad-app-schemas-batch` (the rf2-naihn1 false-green guard).

## Tests / gates
- New red→green tests on each surface: `+json` decode + sniff (http_decode_test), `:except` policy predicate/resolution/end-to-end (http_privacy_test), policy-map validation (frame_classification_cljs_test), `nil`-opts coercion (schemas_storage_test).
- http JVM suite: 454 tests green. schemas JVM suite: 316 tests green. core frame-classification: green.
- `npm run test:cljs`: 7860 tests, 0 failures.
- `scripts/test-fast-pr.sh`: green (incl. markdown link/anchor gates for the spec edits).