### PR TITLE
fix(core): provenance-keyed registration-collision detection + make-frame :on-create fn form (rf2-skxd6x, rf2-kzns7l)

### DIFF
--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -403,22 +403,62 @@
                          (source-coords meta) (assoc :source-coords
                                                      (source-coords meta))))))))
 
-(defn- maybe-emit-collision!
-  "Emit `:rf.warning/registration-collision` once per `(kind, id)`
-  when a re-registration swaps in a different handler-fn (different
-  in fn identity).
+(defn- collision?
+  "True when re-registering `new-meta` over `previous` is a genuine
+  cross-source COLLISION (an accidental id clash between two different
+  authoring sites) rather than a benign same-source re-eval (hot reload).
 
   Per Spec 001 §Re-registration of a different function — collision
-  warning. The existing `:rf.registry/handler-replaced` trace stays
-  intact (with `:different-fn?` tag); this warning surface is the
-  separate dev-nudge that single-source-of-truth tools surface to
-  the developer. Same suppression discipline as missing-doc — fires
-  once per `(kind, id)` to keep the dev stream readable.
+  warning: \"A re-eval of the same source file produces the same
+  `(file, line)` pair and is silent; a different file or line reassigning
+  the id surfaces `:rf.warning/registration-collision`.\" The canonical
+  identity is therefore the registration's PROVENANCE — its source-coord
+  envelope (`:ns` / `:file` / `:line`), the same provenance boundary the
+  source store keys on (`source-store.cljc`: same `(kind, id, ns)` is a
+  hot reload; a different ns for the same `(kind, id)` is the
+  image-isolation collision case).
+
+  Comparing fn IDENTITY (the prior implementation) mis-detected: a
+  same-file save-and-re-eval yields a FRESH fn instance, so identity
+  always differs and the warning fired on every hot reload — exactly the
+  false positive the spec says MUST be silent. Comparing provenance
+  instead, the same source site re-evaluates to the same `(ns, file,
+  line)` and is correctly silent.
+
+  Absent provenance on EITHER side (a programmatic / REPL `register!`
+  that bypassed the macro path — no coords captured) is NOT a collision:
+  there is no source identity to clash, and the macro-path carve-out
+  matches `maybe-emit-missing-doc!`'s `macro-path?` discipline. Returns
+  false in that case so programmatic churn stays silent."
+  [previous new-meta]
+  (let [prev-coords (source-coords previous)
+        new-coords  (source-coords new-meta)]
+    (and (some? prev-coords)
+         (some? new-coords)
+         (not= prev-coords new-coords))))
+
+(defn- maybe-emit-collision!
+  "Emit `:rf.warning/registration-collision` once per `(kind, id)`
+  when a re-registration reassigns the id from a DIFFERENT source
+  location (different `(ns, file, line)` provenance) — an accidental
+  id clash between two authoring sites, not a hot-reload re-eval of
+  the same source.
+
+  Per Spec 001 §Re-registration of a different function — collision
+  warning, the detection keys on the source-coord PROVENANCE pair, not
+  fn identity (which a same-file re-eval always changes — see
+  `collision?`). A same-source re-eval is silent; a different file/line/
+  ns reassigning the id surfaces the warning. The existing
+  `:rf.registry/handler-replaced` trace stays intact (with
+  `:different-fn?` tag) on EVERY re-registration; this warning surface is
+  the separate dev-nudge that single-source-of-truth tools surface to the
+  developer. Same suppression discipline as missing-doc — fires once per
+  `(kind, id)` to keep the dev stream readable.
 
   Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`
   for production elision (Spec 009 §Production builds)."
   [kind id previous new-meta]
-  (when (not= (:handler-fn previous) (:handler-fn new-meta))
+  (when (collision? previous new-meta)
     (let [k [kind id]]
       (when-not (contains? @collision-warned k)
         (swap! collision-warned conj k)

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -78,6 +78,25 @@
              :column 1}]
     (f)))
 
+(defn- reg-at
+  "Register an `:event` for `id` with an explicit source-coord `provenance`
+  envelope (`{:ns :file :line ...}`) and a freshly-allocated handler-fn.
+
+  The collision tests drive `registrar/register!` directly rather than the
+  `reg-event` MACRO because the macro re-captures coords from its own call
+  site `(meta &form)` — two macro calls in the test file are always on
+  different LINES, so they could never share the same provenance, which is
+  exactly the hot-reload re-eval case the rf2-skxd6x fix must keep SILENT.
+  A real hot reload lands at `register!` with the SAME `(ns, file, line)`
+  but a fresh fn instance; passing the provenance metadata explicitly here
+  reproduces that faithfully. A `nil` `provenance` reproduces the
+  programmatic / REPL path (no captured coords)."
+  ([id] (reg-at id nil))
+  ([id provenance]
+   (registrar/register! :event id
+                        (merge (or provenance {})
+                               {:handler-fn (fn [{:keys [db]} _] {:db db})}))))
+
 ;; =============================================================================
 ;; F1 — `:rf.warning/missing-doc`
 ;; =============================================================================
@@ -203,51 +222,120 @@
 
 ;; =============================================================================
 ;; F2 — `:rf.warning/registration-collision`
+;;
+;; Per Spec 001 §Re-registration of a different function — collision warning:
+;; the detection keys on the registration's source-coord PROVENANCE pair
+;; (`:ns` / `:file` / `:line`), NOT fn identity. "A re-eval of the same source
+;; file produces the same `(file, line)` pair and is silent; a different file
+;; or line reassigning the id surfaces `:rf.warning/registration-collision`."
+;;
+;; rf2-skxd6x fix: the prior implementation compared `:handler-fn` identity, so
+;; a same-file save-and-re-eval (which yields a FRESH fn instance) false-fired
+;; the warning on every hot reload — exactly the false positive the spec says
+;; MUST be silent. These tests pin the corrected provenance boundary.
 ;; =============================================================================
 
-(deftest collision-fires-on-different-fn-re-registration
-  (testing "re-registering an id with a different handler-fn emits the warning"
-    (let [recorded (record-traces! ::collision-different)]
-      (with-stamped-coords
-        (fn []
-          (rf/reg-event :collide/id {:doc "first"}  (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
-          (rf/reg-event :collide/id {:doc "second"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))))
+;; The CORE regression for rf2-skxd6x: a same-source re-eval (same coords,
+;; different fn instance) is a hot reload and MUST be silent. Driven through
+;; `registrar/register!` so the provenance can be held CONSTANT across the two
+;; registrations (the `reg-event` macro re-captures its own call-site coords,
+;; so two macro calls are always on different lines — see `reg-at`).
+
+(deftest collision-silent-on-same-source-re-eval
+  (testing "re-registering from the same (ns,file,line) with a fresh fn is a hot reload — silent"
+    (let [recorded (record-traces! ::collision-same-source)
+          coords   {:ns 're-frame.registrar-warnings-test
+                    :file "registrar_warnings_test.clj"
+                    :line 42 :column 3}]
+      ;; Two registrations from the IDENTICAL source location, each with a
+      ;; freshly-allocated handler-fn (what a save-triggered re-eval produces).
+      ;; The prior fn-identity implementation false-fired here; the provenance
+      ;; boundary keeps it silent (rf2-skxd6x).
+      (reg-at :hot/reload coords)
+      (reg-at :hot/reload coords)
+      (is (empty? (warnings-of recorded :rf.warning/registration-collision))
+          "same-source re-eval (fresh fn, same coords) must NOT warn — it's a hot reload"))))
+
+(deftest collision-fires-on-cross-provenance-reassignment
+  (testing "re-registering the id from a DIFFERENT provenance (file/line/ns) warns"
+    (let [recorded (record-traces! ::collision-cross)]
+      ;; Feature A registers :collide/id; feature B (a different file) clobbers it.
+      (reg-at :collide/id {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1})
+      (reg-at :collide/id {:ns 'feature.b :file "feature/b.cljc" :line 20 :column 1})
       (let [warns (warnings-of recorded :rf.warning/registration-collision)]
         (is (= 1 (count warns))
-            "exactly one collision warning fires on the second registration")
+            "exactly one collision warning fires on the cross-provenance reassignment")
         (let [t (:tags (first warns))]
           (is (= :event (:kind t)))
           (is (= :collide/id (:id t)))
           (is (map? (:source-coords t))
-              ":source-coords carries the NEW registration's coords")
-          ;; :previous-coords is the captured envelope of the prior reg;
-          ;; both registrations were stamped with the same coords here.
-          (is (map? (:previous-coords t))))))))
+              ":source-coords carries the NEW (feature B) registration's coords")
+          (is (= 'feature.b (:ns (:source-coords t))))
+          (is (map? (:previous-coords t))
+              ":previous-coords carries the prior (feature A) registration's coords")
+          (is (= 'feature.a (:ns (:previous-coords t)))))))))
+
+(deftest collision-fires-on-same-file-different-line
+  (testing "two registrations of the same id at different lines in one file collide"
+    (let [recorded (record-traces! ::collision-same-file-diff-line)]
+      ;; Same ns + file but a DIFFERENT line — two distinct authoring sites in
+      ;; one file accidentally reusing an id. Per the spec's `(file, line)` rule.
+      (reg-at :dup/id {:ns 're-frame.registrar-warnings-test
+                       :file "registrar_warnings_test.clj" :line 10 :column 1})
+      (reg-at :dup/id {:ns 're-frame.registrar-warnings-test
+                       :file "registrar_warnings_test.clj" :line 99 :column 1})
+      (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
+          "different line in the same file is a collision (Spec 001)"))))
+
+(deftest collision-silent-on-programmatic-path
+  (testing "programmatic register! (no captured coords) does not warn"
+    (let [recorded (record-traces! ::collision-programmatic)]
+      ;; No coords on either registration — there is no source identity to clash.
+      (reg-at :prog/id nil)
+      (reg-at :prog/id nil)
+      (is (empty? (warnings-of recorded :rf.warning/registration-collision))
+          "programmatic / REPL path has no provenance — no collision to detect"))))
 
 (deftest collision-suppressed-on-third-re-registration
-  (testing "subsequent re-registrations of the same (kind, id) do NOT re-emit"
+  (testing "subsequent cross-provenance re-registrations of the same (kind, id) do NOT re-emit"
     (let [recorded (record-traces! ::collision-suppressed)]
-      (with-stamped-coords
-        (fn []
-          (rf/reg-event :churn/id {:doc "a"} (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
-          (rf/reg-event :churn/id {:doc "b"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))
-          (rf/reg-event :churn/id {:doc "c"} (fn [{:keys [db]} _] {:db (assoc db :v 3)}))
-          (rf/reg-event :churn/id {:doc "d"} (fn [{:keys [db]} _] {:db (assoc db :v 4)}))))
+      ;; Four registrations, each from a distinct provenance — only the first
+      ;; cross-provenance reassignment warns; warn-once suppresses the rest.
+      (doseq [[ns line] [['feat.a 1] ['feat.b 2] ['feat.c 3] ['feat.d 4]]]
+        (reg-at :churn/id {:ns ns :file (str ns ".cljc") :line line :column 1}))
       (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
-          "warn-once: only the first different-fn re-registration emits"))))
+          "warn-once: only the first cross-provenance re-registration emits"))))
 
 ;; The existing `:rf.registry/handler-replaced` trace must keep firing on
 ;; EVERY re-registration (per Spec 001 §Hot-reload trace surface, rf2-6w7zn)
-;; — the collision warning is a SEPARATE surface, not a replacement.
+;; — the collision warning is a SEPARATE surface, not a replacement. Crucially,
+;; handler-replaced fires even on the SILENT same-source hot-reload path.
+
+(deftest handler-replaced-fires-on-silent-hot-reload
+  (testing "handler-replaced fires on a same-source re-eval even though collision is silent"
+    (let [recorded (record-traces! ::replaced-on-hot-reload)
+          coords   {:ns 're-frame.registrar-warnings-test
+                    :file "registrar_warnings_test.clj" :line 7 :column 1}]
+      (reg-at :hr/id coords)
+      (reg-at :hr/id coords)
+      (reg-at :hr/id coords)
+      (let [replaced (filterv (fn [ev]
+                                (and (= :rf.registry (:op-type ev))
+                                     (= :rf.registry/handler-replaced
+                                        (:operation ev))))
+                              @recorded)
+            collisions (warnings-of recorded :rf.warning/registration-collision)]
+        (is (= 2 (count replaced))
+            "handler-replaced fires on each of the two re-registrations")
+        (is (empty? collisions)
+            "no collision on a same-source hot reload (the rf2-skxd6x fix)")))))
 
 (deftest collision-warning-coexists-with-handler-replaced
   (testing "handler-replaced still fires unconditionally; collision is the dev-nudge addition"
     (let [recorded (record-traces! ::coexist)]
-      (with-stamped-coords
-        (fn []
-          (rf/reg-event :coex/id {:doc "1"} (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
-          (rf/reg-event :coex/id {:doc "2"} (fn [{:keys [db]} _] {:db (assoc db :v 2)}))
-          (rf/reg-event :coex/id {:doc "3"} (fn [{:keys [db]} _] {:db (assoc db :v 3)}))))
+      ;; Three registrations from three distinct provenances.
+      (doseq [[ns line] [['c.a 1] ['c.b 2] ['c.c 3]]]
+        (reg-at :coex/id {:ns ns :file (str ns ".cljc") :line line :column 1}))
       (let [replaced (filterv (fn [ev]
                                 (and (= :rf.registry (:op-type ev))
                                      (= :rf.registry/handler-replaced

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -207,12 +207,22 @@
 
   Required opts:
 
-    :on-create   — the event vector dispatched at frame creation. Read
-                   the Ring request map from handlers by declaring
+    :on-create   — the event dispatched at frame creation, in EITHER form:
+                     • an event VECTOR (e.g. `[:rf/server-init]`), OR
+                     • a `(fn [request] event-vector)` deriving the event
+                       from the Ring request (rf2-kzns7l). The fn is called
+                       once per request, before the drain; its result must
+                       be an event vector. Use it to fold a request-derived
+                       fact into the boot event's PAYLOAD — the replay-safe
+                       recordable boundary, e.g.
+                       `(fn [req] [:auth/server-init {:user (extract-user req)}])`
+                       (Spec 011 §Request storage substrate, durable
+                       request-derived-fact pattern).
+                   For NON-durable request reads inside a handler, declare
                    `:rf.cofx/requires [:rf.server/request]` on the
                    registration (EP-0017 — `inject-cofx` is removed) — Spec
-                   011 §Request storage substrate (rf2-afxhv) names the cofx
-                   as the canonical read surface.
+                   011 §Request storage substrate (rf2-afxhv) names that cofx
+                   as the canonical ambient read surface.
     :root-view   — either a hiccup vector (e.g. `[:app/root]`) OR a
                    0-arity fn returning hiccup. Rendered against the
                    per-request frame after the drain settles.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -321,20 +321,64 @@
       :html-attrs html-attrs
       :body-attrs body-attrs}]))
 
-(defn validate-on-create!
-  "Validate the caller's :on-create event vector and return it verbatim.
-  `:on-create` is required (per `validate-required-opts!`), so a
-  non-vector here is a programmer error — surface it as an ex-info
-  rather than letting `reg-frame` produce an obscure failure
-  downstream. Audit rf2-cegm7 A3 / rf2-j54ee."
-  [on-create]
-  (if (vector? on-create)
+(defn resolve-on-create!
+  "Resolve the caller's `:on-create` opt to the event vector dispatched at
+  per-request frame creation, given the live Ring `request`. Two accepted
+  forms (rf2-kzns7l):
+
+    1. an event VECTOR — passed through verbatim (the original contract).
+    2. a `(fn [request] event-vector)` — a 1-arity fn DERIVING the event
+       vector from the Ring request. Called EXACTLY ONCE here, before
+       `reg-frame`, with the request the host has already populated into
+       the per-request slot. The result MUST itself be an event vector,
+       validated the same way.
+
+  The fn form is the replay-safe way to fold a request-derived fact into
+  the boot event's PAYLOAD — the recordable causal boundary (Spec 011
+  §Request storage substrate, the durable request-derived-fact pattern):
+
+      :on-create (fn [req] [:auth/server-init {:user (extract-user req)}])
+
+  This is purely ADDITIVE. It is NOT a revival of the removed
+  `on-create-with-request` positional-conj helper (audit rf2-cegm7 A2 /
+  rf2-j54ee): that silently appended the WHOLE request to the caller's
+  vector (`[:rf/server-init]` → `[:rf/server-init {ring-request}]`),
+  putting the request in the wrong arg slot. Here the caller OWNS the
+  shape of the resulting event vector — only the extracted, sanitised
+  fact rides it. The ambient `:rf.server/request` cofx remains the
+  canonical surface for NON-durable request reads and is unaffected.
+
+  `:on-create` is required (per `validate-required-opts!`), which a fn
+  satisfies as a truthy value — so the form check happens here, inside
+  the per-request setup try/catch. A value that is neither a vector nor a
+  1-arity fn (or a fn whose result is not a vector) is a programmer
+  error: surface it as `:rf.error/invalid-on-create` rather than letting
+  `reg-frame` produce an obscure failure downstream."
+  [on-create request]
+  (cond
+    (vector? on-create)
     on-create
+
+    (fn? on-create)
+    (let [derived (on-create request)]
+      (if (vector? derived)
+        derived
+        (error/throw-error!
+          :rf.error/invalid-on-create
+          'rf.ssr/ssr-handler
+          (str ":on-create fn must return an event vector; the (fn [request] ...) "
+               "form derives the on-create event from the Ring request and its "
+               "result must be a vector.")
+          {:recovery :return-an-event-vector-from-the-on-create-fn
+           :extra    {:returned derived}})))
+
+    :else
     (error/throw-error!
       :rf.error/invalid-on-create
       'rf.ssr/ssr-handler
-      ":on-create must be a vector (an event vector); pass an event vector as :on-create."
-      {:recovery :supply-an-event-vector
+      (str ":on-create must be an event vector OR a (fn [request] event-vector); "
+           "pass one of those as :on-create.")
+      {:recovery :supply-an-event-vector-or-a-fn-of-the-request
        :extra    {:received on-create}})))
 
 (defn validate-required-opts!

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -184,11 +184,17 @@
       (rf/reg-frame frame-id
         (cond-> {:doc       "ssr-ring per-request frame"
                  :platform  :server
-                 ;; Audit rf2-cegm7 A2 / rf2-j54ee: pass :on-create
-                 ;; verbatim. Handlers read the request via the
-                 ;; `:rf.server/request` cofx — the spec-documented
-                 ;; canonical surface.
-                 :on-create (lifecycle/validate-on-create! on-create)}
+                 ;; Audit rf2-cegm7 A2 / rf2-j54ee: an event-VECTOR
+                 ;; `:on-create` passes through verbatim — handlers read
+                 ;; the request via the `:rf.server/request` cofx (the
+                 ;; spec-documented canonical surface for NON-durable
+                 ;; reads). rf2-kzns7l (additive): a `(fn [request]
+                 ;; event-vector)` `:on-create` is resolved HERE — the
+                 ;; request slot is already populated (set-request! above),
+                 ;; so the fn derives the event vector from the live Ring
+                 ;; request, baking a request-derived fact into the boot
+                 ;; event's PAYLOAD (the replay-safe recordable boundary).
+                 :on-create (lifecycle/resolve-on-create! on-create request)}
           fx-overrides (assoc :fx-overrides fx-overrides)
           ssr          (assoc :ssr           ssr)))
       {:frame-id frame-id}

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -672,8 +672,11 @@
   `:error-view` / `:emit-hash?` / `:version` / `:schema-digest` /
   `:content-type` plus the four trusted shell-hook opts (`:head` /
   `:body-end` / `:script-src` / `:app-element-id`, honoured by
-  `default-streaming-prefix` / `default-streaming-suffix`) — with ONE
-  exception (rf2-oq4m5):
+  `default-streaming-prefix` / `default-streaming-suffix`). `:on-create`
+  accepts BOTH forms `ssr-handler` does — an event vector OR a
+  `(fn [request] event-vector)` deriving the boot event from the Ring
+  request (rf2-kzns7l; both flow through the shared
+  `pipeline/setup-request-frame!`). One exception (rf2-oq4m5):
 
     `:html-shell` is NOT supported by the streaming path and is REJECTED
     at handler-construction time (`:rf.error/ssr-streaming-unsupported-opt`).

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -17,6 +17,7 @@
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.test-support :as ts]))
 
 ;; rf2-i3qc0 / rf2-09iktm — the canonical reset-runtime fixture is
@@ -846,6 +847,127 @@
         (handler {:uri "/b" :request-method :get})
         (is (= ["/a" "/b"] @observed)
             "each request's handler saw its own URI — no slot bleed")))))
+
+;; ===========================================================================
+;; rf2-kzns7l — :on-create accepts a (fn [request] event-vector) form
+;;
+;; Additive convenience: alongside the event-VECTOR :on-create, a 1-arity fn
+;; may DERIVE the on-create event vector from the Ring request. It is called
+;; once per request (before the drain) and its result must be an event vector.
+;; This is the ergonomic, replay-safe way to fold a request-derived fact into
+;; the boot event's PAYLOAD (the recordable causal boundary — Spec 011
+;; §Durable request-derived facts), NOT the removed positional-conj helper.
+;; ===========================================================================
+
+(defn- extract-user
+  "Stand-in for a host's auth middleware: sanitise a request cookie into a
+  wire-safe derived fact. Models the Spec 011 §Authentication / sessions
+  pattern (cookie → `{:user … :authed? …}`, never the raw cookie)."
+  [request]
+  (let [cookie (get-in request [:headers "cookie"] "")]
+    (if (str/includes? cookie "session=")
+      {:user "alice" :authed? true}
+      {:user nil :authed? false})))
+
+(deftest on-create-fn-form-derives-event-from-request
+  (testing "a (fn [request] event-vector) :on-create bakes a request-derived
+            fact into the boot event payload — the durable-fact boundary"
+    (let [seeded (atom ::not-seeded)]
+      ;; The boot handler reads the PAYLOAD (the recordable leaf), not an
+      ;; ambient cofx — the replay-safe shape.
+      (rf/reg-event :auth/server-init
+        {:platforms #{:server}}
+        (fn [{:keys [db]} [_ session]]
+          (reset! seeded session)
+          {:db (assoc db :auth session)}))
+
+      (rf/reg-view* :pages/blank-auth (fn [] [:div]))
+
+      (let [handler (ssr-ring/ssr-handler
+                      ;; The fn form: derive the event vector from the request.
+                      {:on-create (fn [req]
+                                    [:auth/server-init (extract-user req)])
+                       :root-view [:pages/blank-auth]
+                       :payload :rf.ssr.payload/whole-app-db})
+            response (handler {:uri            "/dashboard"
+                               :request-method :get
+                               :headers        {"cookie" "session=abc123"}})]
+        (is (= 200 (:status response)))
+        (is (= {:user "alice" :authed? true} @seeded)
+            "the on-create fn derived the event vector from the request and the
+             boot handler saw the sanitised fact off the event payload")))))
+
+(deftest on-create-fn-form-invoked-once-per-request-with-own-request
+  (testing "the :on-create fn is called once per request, each with its own
+            request map (no slot bleed across requests)"
+    (let [calls (atom [])]
+      (rf/reg-event :init/noted
+        {:platforms #{:server}}
+        (fn [{:keys [db]} [_ uri]]
+          {:db (assoc db :uri uri)}))
+      (rf/reg-view* :pages/blank-once (fn [] [:div]))
+
+      (let [handler (ssr-ring/ssr-handler
+                      {:on-create (fn [req]
+                                    (swap! calls conj (:uri req))
+                                    [:init/noted (:uri req)])
+                       :root-view [:pages/blank-once]
+                       :payload :rf.ssr.payload/whole-app-db})]
+        (handler {:uri "/p" :request-method :get})
+        (handler {:uri "/q" :request-method :get})
+        (is (= ["/p" "/q"] @calls)
+            "the fn fired exactly once per request, each with that request's URI")))))
+
+(deftest on-create-vector-form-still-works
+  (testing "the original event-VECTOR :on-create form is preserved verbatim"
+    (let [seen (atom false)]
+      (rf/reg-event :init/plain
+        {:platforms #{:server}}
+        (fn [{:keys [db]} _] (reset! seen true) {:db db}))
+      (rf/reg-view* :pages/blank-plain (fn [] [:div]))
+
+      (let [handler  (ssr-ring/ssr-handler
+                       {:on-create [:init/plain]
+                        :root-view [:pages/blank-plain]
+                        :payload :rf.ssr.payload/whole-app-db})
+            response (handler {:uri "/x" :request-method :get})]
+        (is (= 200 (:status response)))
+        (is (true? @seen)
+            "the vector form dispatched the boot event unchanged")))))
+
+(deftest on-create-fn-returning-non-vector-fails-closed
+  (testing "an :on-create fn whose result is NOT an event vector throws
+            :rf.error/invalid-on-create inside setup — routed to on-error 500"
+    (rf/reg-view* :pages/blank-bad (fn [] [:div]))
+    (let [handler  (ssr-ring/ssr-handler
+                     ;; Returns a map, not an event vector — programmer error.
+                     {:on-create (fn [_req] {:not "a vector"})
+                      :root-view [:pages/blank-bad]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/x" :request-method :get})]
+      (is (= 500 (:status response))
+          "the setup failure surfaces the locked default-on-error 500")
+      (is (map? response)
+          "the handler returned a Ring response — the throw was contained"))))
+
+(deftest on-create-resolve-fn-unit-contract
+  (testing "lifecycle/resolve-on-create! — vector passthrough, fn resolution,
+            and the two invalid-shape throws (unit)"
+    (let [req {:uri "/u" :headers {}}]
+      ;; Vector passes through verbatim.
+      (is (= [:e 1] (lifecycle/resolve-on-create! [:e 1] req)))
+      ;; A 1-arity fn is called with the request; its vector result is returned.
+      (is (= [:derived "/u"]
+             (lifecycle/resolve-on-create!
+               (fn [r] [:derived (:uri r)]) req)))
+      ;; A fn returning a non-vector throws invalid-on-create.
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"on-create fn must return an event vector"
+                            (lifecycle/resolve-on-create! (fn [_] {:nope true}) req)))
+      ;; A non-vector, non-fn value throws invalid-on-create.
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"on-create must be an event vector OR a"
+                            (lifecycle/resolve-on-create! '(:list-not-vector) req))))))
 
 ;; ===========================================================================
 ;; ssr-handler — :ssr opt reaches the per-request frame's :ssr metadata
@@ -2414,19 +2536,20 @@
             \"Internal error\" string).
 
             Drive the transport-failure path with a non-vector
-            `:on-create` — `validate-on-create!` throws inside
+            `:on-create` — `resolve-on-create!` throws inside
             `setup-request-frame!`'s try/catch, which surfaces the
             short-circuit on-error response. This path is the
             framework's last-resort net for setup-frame failures
             the projector can't see."
     (let [custom-body "<!DOCTYPE html><html><body>Service offline</body></html>"
           handler     (ssr-ring/ssr-handler
-                        ;; Non-vector :on-create passes the truthy
-                        ;; presence check at handler construction
-                        ;; (`validate-required-opts!`) but fails the
-                        ;; vector? check inside `validate-on-create!`,
-                        ;; which runs inside the per-request setup
-                        ;; try/catch — exactly the on-error path.
+                        ;; A list :on-create (neither a vector nor a
+                        ;; 1-arity fn) passes the truthy presence check
+                        ;; at handler construction (`validate-required-opts!`)
+                        ;; but fails the shape check inside
+                        ;; `resolve-on-create!`, which runs inside the
+                        ;; per-request setup try/catch — exactly the
+                        ;; on-error path.
                         {:on-create '(:rf/server-init)
                          :root-view [:div]
                          :payload [:x]
@@ -2492,7 +2615,7 @@
             escape as a raw container 500 with leaked internals.
 
             Setup failure is driven by a non-vector :on-create
-            (`validate-on-create!` throws inside `setup-request-frame!`,
+            (`resolve-on-create!` throws inside `setup-request-frame!`,
             which runs OUTSIDE the handler body's try/catch). The
             caller's :on-error then throws — exercising the one
             :on-error call site that the handler body's catch does not

--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -300,9 +300,9 @@ The kinds are listed in the order they appear in [§Registry model — the canon
 
 ### Re-registration of a different function — collision warning
 
-A re-registration with a *different* function (not just an updated source-coords pair on the same fn) is silent last-write-wins. This can mask collisions when two namespaces accidentally use the same id (`:save` from feature A clobbering `:save` from feature B).
+A re-registration from a *different source location* (not a same-source re-eval of the same id) is silent last-write-wins. This can mask collisions when two namespaces accidentally use the same id (`:save` from feature A clobbering `:save` from feature B).
 
-The runtime can be configured to warn at registration time when an id is reassigned to a different fn — recommend turning this on in dev. The detection compares fn identity (or, in CLJS reference, source-coord pairs from [§Source-coordinate capture](#source-coordinate-capture-cljs-reference)). A re-eval of the same source file produces the same `(file, line)` pair and is silent; a different file or line reassigning the id surfaces `:rf.warning/registration-collision`.
+The runtime can be configured to warn at registration time when an id is reassigned from a different source location — recommend turning this on in dev. The detection keys on the registration's **source-coord provenance** — its `(ns, file, line)` envelope from [§Source-coordinate capture](#source-coordinate-capture-cljs-reference) — **not** fn identity. (Comparing fn identity is wrong: a same-file save-and-re-eval allocates a *fresh* fn instance every time, so an identity comparison would fire on every hot reload — the exact false positive this rule must avoid.) A re-eval of the same source location produces the same `(ns, file, line)` provenance and is silent; a different file, line, or namespace reassigning the id surfaces `:rf.warning/registration-collision`. A programmatic / REPL registration that carries no captured provenance does not participate (there is no source identity to clash).
 
 ### How registrations interact with active machine instances
 


### PR DESCRIPTION
Two SAFE `[toomuch]` fixes from the kill-over-engineering review — both reviewed (Claude + Codex concur). One correctness fix, one additive convenience form. No guard removals.

## rf2-skxd6x (P2, bug) — provenance-keyed registration-collision detection

`registrar/maybe-emit-collision!` compared `:handler-fn` IDENTITY, so a same-file save-and-re-eval (which yields a *fresh* fn instance) false-fired `:rf.warning/registration-collision` on every hot reload — exactly the false positive Spec 001 §Re-registration of a different function says MUST be silent ("a re-eval of the same source file produces the same `(file, line)` pair and is silent").

Fix: key the detection on the registration's **source-coord provenance** (`{:ns :file :line}`) — the same provenance boundary the source store uses (same `(kind, id, ns/file/line)` = hot reload, silent; different = a genuine cross-source id clash, warn). A programmatic / REPL registration with no captured coords does not participate. The existing `:rf.registry/handler-replaced` trace still fires on every re-registration, including the silent hot-reload path.

- `registrar.cljc`: add `collision?` provenance comparator; rewrite `maybe-emit-collision!`.
- `registrar_warnings_test.clj`: regression coverage (same-source re-eval silent; cross-ns / different-file / different-line warns; programmatic silent; handler-replaced still fires on the silent path).
- `spec/001-Registration.md`: tighten the rule to provenance, not fn identity (and why identity is wrong).

## rf2-kzns7l (P3, feature) — `:on-create (fn [request] event-vector)` form

Add an additive `(fn [request] event-vector)` form to the SSR Ring adapter's `:on-create` opt, alongside the existing event-vector form. The fn is called once per request (before the drain, after the request slot is populated) and derives the boot event from the live Ring request; its result must be an event vector. This is the ergonomic, replay-safe way to fold a request-derived fact into the boot event's PAYLOAD — the recordable causal boundary (Spec 011 §Durable request-derived facts).

Scope (per the bead's reviewed ruling): **ssr-ring ONLY — NOT core reg-frame**. The load-bearing `:rf.server/request` cofx is kept intact. NOT a revival of the removed `on-create-with-request` positional-conj helper.

- `lifecycle.clj`: `validate-on-create!` → `resolve-on-create!` taking `(on-create request)` — vector passthrough; 1-arity fn called with the request, result validated; invalid shapes throw `:rf.error/invalid-on-create`.
- `pipeline.clj`: `setup-request-frame!` passes `request` to the resolver (both ssr-handler and stream-handler inherit the fn form via the shared setup).
- `ring.clj` / `streaming.clj`: document the fn form.
- `ring_test.clj`: e2e + unit coverage.

## Gates
- `implementation/core` JVM: 1810 tests, 0 failures.
- `implementation/ssr-ring` JVM: 176 tests, 0 failures.
- `npm run test:cljs`: 7857 tests, 0 failures.
- `scripts/test-fast-pr.sh`: PASS (mkdocs soft-skipped on Windows; CI runs it).
- No api-manifest / Spec-Schemas / 009 touched → no `gen --check` needed. `:rf.error/invalid-on-create` is a pre-existing error code (no new facade var).