### PR TITLE
chore(resources): collapse redundant canonicalization + remove dead stale-delivery marker (rf2-rplgkw, rf2-0jpr56)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -167,7 +167,9 @@
         ;; explicit `{:params nil}` reaches the schema unchanged.
         cparams    (registry/validate+canonicalize-params
                      resource spec (state/params-present? payload) where)
-        scoped-key (state/scoped-resource-key scope resource cparams)
+        ;; rf2-rplgkw: scope (resolve-scope-for-event → canonicalize-scope) +
+        ;; cparams (validate+canonicalize-params) are ALREADY canonical.
+        scoped-key (state/scoped-resource-key* scope resource cparams)
         entry      (or (get-in runtime-db (state/entry-path scoped-key))
                        (state/empty-entry resource scoped-key))
         prior-work (:current-work entry)
@@ -1222,7 +1224,9 @@
         ;; explicit-nil-params ensure produced.
         cparams    (registry/validate+canonicalize-params
                      resource spec (state/params-present? payload) 'rf.resource/remove)
-        scoped-key (state/scoped-resource-key scope resource cparams)
+        ;; rf2-rplgkw: scope (resolve-scope-for-event → canonicalize-scope) +
+        ;; cparams (validate+canonicalize-params) are ALREADY canonical.
+        scoped-key (state/scoped-resource-key* scope resource cparams)
         entry      (get-in runtime-db (state/entry-path scoped-key))
         wid        (:current-work entry)
         transport  (when wid (:transport (work-ledger/get-record runtime-db wid)))

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -588,7 +588,9 @@
                         cparams    (registry/validate+canonicalize-params
                                      resource-id spec raw-params
                                      'rf.resource/route-entry)
-                        scoped-key (state/scoped-resource-key scope resource-id cparams)
+                        ;; rf2-rplgkw: scope (resolve-scope-for-event →
+                        ;; canonicalize-scope) + cparams already canonical.
+                        scoped-key (state/scoped-resource-key* scope resource-id cparams)
                         blocking?  (boolean (:blocking? entry))
                         ensure-ev  [:rf.resource/ensure
                                     (cond-> {:resource resource-id

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -357,6 +357,32 @@
   [x]
   (identity/canonical x))
 
+(defn- throw-non-edn!
+  "Throw the public `:rf.error/resource-non-edn-params` cache-key-boundary
+  error for `value` (a params or scope map that is not a portable CEDN-1
+  identity). The single home for the error shape, shared by `reject-non-edn!`
+  (validate-only) and `canonicalize-or-rethrow` (validate+canonicalize in one
+  walk) so the two surfaces can never drift. Never returns normally."
+  [value where kind resource-id]
+  (error/throw-error!
+    :rf.error/resource-non-edn-params
+    where
+    (str "resource " resource-id " " (name kind)
+         " is not a portable CEDN-1 EDN identity — "
+         "host / opaque values (functions, promises, "
+         "dates, DOM nodes, AbortControllers, JS "
+         "objects) and non-portable numbers (floats, "
+         "ratios, decimals, NaN/infinities, integers "
+         "outside the safe range) are rejected at the "
+         "cache-key boundary. Put every value that "
+         "affects remote identity in params as plain "
+         "portable EDN. Per Spec 016 §Resource "
+         "identity / Conventions §Canonical EDN identity.")
+    {:recovery :fix-params
+     :extra    {:resource-id resource-id
+                :kind        kind
+                :value       (pr-str value)}}))
+
 (defn reject-non-edn!
   "Throw `:rf.error/resource-non-edn-params` when `value` (a params or
   scope map) is not a portable CEDN-1 identity — a host / opaque value (fn,
@@ -369,29 +395,39 @@
 
   Preserves the public resource error category (`:rf.error/resource-non-edn-
   params`) while delegating the domain decision to the shared CEDN-1 rule
-  (`serializable-edn?` → `identity/canonical-bytes`); the underlying
-  `:rf.error/non-edn-identity` cause rides `:rf.error/cause` for diagnosis."
+  (`serializable-edn?` → `identity/canonical-bytes`).
+
+  Validate-ONLY: a caller that then needs the canonical value should call
+  `canonicalize-or-rethrow` instead, which validates AND canonicalizes in a
+  single CEDN-1 walk rather than rejecting (one walk) then canonicalizing
+  (a second walk) — `reject-non-edn!` is for the boundaries that validate but
+  carry the RAW value forward (e.g. a mutation arm that re-keys later)."
   [value where kind resource-id]
   (when-not (serializable-edn? value)
-    (error/throw-error!
-      :rf.error/resource-non-edn-params
-      where
-      (str "resource " resource-id " " (name kind)
-           " is not a portable CEDN-1 EDN identity — "
-           "host / opaque values (functions, promises, "
-           "dates, DOM nodes, AbortControllers, JS "
-           "objects) and non-portable numbers (floats, "
-           "ratios, decimals, NaN/infinities, integers "
-           "outside the safe range) are rejected at the "
-           "cache-key boundary. Put every value that "
-           "affects remote identity in params as plain "
-           "portable EDN. Per Spec 016 §Resource "
-           "identity / Conventions §Canonical EDN identity.")
-      {:recovery :fix-params
-       :extra    {:resource-id resource-id
-                  :kind        kind
-                  :value       (pr-str value)}}))
+    (throw-non-edn! value where kind resource-id))
   value)
+
+(defn canonicalize-or-rethrow
+  "Validate + canonicalize `value` in ONE CEDN-1 walk (rf2-rplgkw): return its
+  canonical EDN identity (`canonicalize`), re-throwing the public
+  `:rf.error/resource-non-edn-params` cache-key-boundary category when the
+  shared CEDN-1 rule fails it closed (`:rf.error/non-edn-identity`).
+
+  This collapses the historical `(reject-non-edn! …)` + `(canonicalize …)`
+  pair — which walked the value TWICE (once to validate via `serializable-
+  edn?` → `canonical-bytes`, once to canonicalize via `canonical`) — into a
+  single `canonical` walk, since `canonical` fails closed on EXACTLY the same
+  CEDN-1 domain `reject-non-edn!` rejects (state.cljc). Behaviour-preserving:
+  the public error category, the `where` / `kind` / `:resource-id` slots, and
+  the canonical result are identical to the two-step form. `where` / `kind`
+  (`:params` | `:scope`) name the offending boundary."
+  [value where kind resource-id]
+  (try
+    (canonicalize value)
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e
+      (if (= :rf.error/non-edn-identity (:rf.error/id (ex-data e)))
+        (throw-non-edn! value where kind resource-id)
+        (throw e)))))
 
 ;; ---- concrete-scope validation (Spec 016 §Scope resolution) ---------------
 ;;
@@ -528,21 +564,48 @@
   [scope where resource-id]
   (reject-reserved-scope-typo! scope where resource-id)
   (reject-wrapped-reserved-scope! scope where resource-id)
-  (reject-non-edn! scope where :scope resource-id)
-  (canonicalize scope))
+  ;; rf2-rplgkw: validate + canonicalize the concrete scope in ONE CEDN-1
+  ;; walk rather than rejecting (one walk) then canonicalizing (a second).
+  ;; `canonical` fails closed on exactly the host / non-portable-number
+  ;; domain `reject-non-edn!` rejects, so the public error category holds.
+  (canonicalize-or-rethrow scope where :scope resource-id))
 
 ;; ---- scoped resource key (Spec 016 §Resource identity) --------------------
+
+(defn scoped-resource-key*
+  "TRUSTED scoped-key constructor (rf2-rplgkw): assemble the scoped resource
+  key vector `[scope resource-id params]` from scope + params that are
+  ALREADY canonical — it does NOT re-canonicalize. Use this on the resolution
+  hot paths (sub / event / route) where the scope arrived through
+  `canonicalize-scope` and the params through `validate+canonicalize-params`,
+  both of which already return the canonical value; canonicalizing again here
+  re-proves an established invariant (`canonical` is idempotent) for pure
+  overhead, and a resource sub re-runs this on every frame-state change before
+  output memoization. Per Spec 016 §Canonicalization rule: canonicalization
+  happens ONCE at the scope/params resolution boundary.
+
+  CONTRACT: callers MUST pass already-canonical scope + params. Direct
+  internal / test callers handed RAW values should use the defensive
+  `scoped-resource-key` (below), which canonicalizes."
+  [scope resource-id params]
+  [scope resource-id params])
 
 (defn scoped-resource-key
   "Build the canonical scoped resource key
   `[canonical-scope resource-id canonical-params]` — the cache key, the
   request-correlation token payload, and the unit Xray / SSR enumerate.
 
-  Both the scope and the params are canonicalized under the SAME rule
-  (`canonicalize`), so key order in either map never affects identity, and
-  the scope is part of the key (the same params in different scopes can't
-  supersede each other). Per Spec 016 §Resource identity. Assumes scope +
-  params are already validated serializable EDN (`reject-non-edn!`).
+  DEFENSIVE: canonicalizes both scope and params under the SAME rule
+  (`canonicalize`) before assembling the key, so key order in either map never
+  affects identity, and the scope is part of the key (the same params in
+  different scopes can't supersede each other). Per Spec 016 §Resource
+  identity. Use this for direct internal / test callers handed RAW (not yet
+  canonical) scope / params, and for the mutation map-form-target boundary
+  (which validates serializability separately, then canonicalizes here). The
+  resolution hot paths (sub / event / route) instead use the trusted
+  `scoped-resource-key*` — their scope / params are ALREADY canonical
+  (`canonicalize-scope` + `validate+canonicalize-params`), so re-canonicalizing
+  here is pure overhead on a per-reaction path (rf2-rplgkw).
 
   The returned vector is the kind-PRESERVING canonical identity (a list value
   stays a list, distinct from a vector — rf2-wgutc2). It is NO LONGER used
@@ -556,7 +619,7 @@
   rf2-wgutc2 introduced is preserved end-to-end, and the `=`-collapse is closed
   at the map-keying layer where it actually occurred."
   [scope resource-id params]
-  [(canonicalize scope) resource-id (canonicalize params)])
+  (scoped-resource-key* (canonicalize scope) resource-id (canonicalize params)))
 
 (defn prior-loaded-sibling-key
   "Find the prior loaded SIBLING key to project under `:keep-previous?`

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -111,7 +111,10 @@
         ;; schema unchanged).
         cparams (registry/validate+canonicalize-params
                   resource spec (state/params-present? payload) 'rf.resource/subscribe)]
-    (state/scoped-resource-key scope resource cparams)))
+    ;; rf2-rplgkw: scope + cparams are ALREADY canonical (resolve-scope-for-sub
+    ;; → canonicalize-scope; validate+canonicalize-params), so use the trusted
+    ;; constructor — a resource sub re-runs this on every frame-state change.
+    (state/scoped-resource-key* scope resource cparams)))
 
 ;; ---- dev-mode scope-mismatch warning (Spec 016 §Subscription-side scope
 ;; ---- resolution — likely-mismatch dev warning) ----------------------------

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -131,6 +131,54 @@
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
           (state/reject-non-edn! {:f (fn [])} 'test :params :r/x)))))
 
+;; rf2-rplgkw — the redundant scope/params re-canonicalization on the resource
+;; sub re-key hot path is collapsed: a trusted `scoped-resource-key*` for
+;; already-canonical inputs (the sub / event / route resolution paths feed it
+;; values that already passed canonicalize-scope + validate+canonicalize-params)
+;; and a single-walk `canonicalize-or-rethrow` folding the reject-non-edn! +
+;; canonicalize pair inside canonicalize-scope. Behaviour MUST be preserved.
+(deftest trusted-scoped-key-matches-defensive-on-canonical-input
+  (testing "scoped-resource-key* (no re-canonicalize) yields the SAME key as
+            the defensive scoped-resource-key when handed ALREADY-canonical
+            scope + params — the dedup is behaviour-preserving"
+    (let [cscope  (state/canonicalize {:tenant "acme" :user "u-42"})
+          cparams (state/canonicalize {:slug "x" :rev 1})
+          trusted (state/scoped-resource-key* cscope :article/by-slug cparams)
+          defens  (state/scoped-resource-key cscope :article/by-slug cparams)]
+      (is (= defens trusted) "same key vector")
+      (is (= (state/key-id defens) (state/key-id trusted)) "same byte key-id")))
+  (testing "the defensive constructor still canonicalizes RAW (key-order-
+            varying) input to the same identity scoped-resource-key* produces
+            from the canonical value — so RAW direct/test/mutation callers keep
+            working"
+    (let [raw-a (state/scoped-resource-key {:user "u-42" :tenant "acme"}
+                                           :article/by-slug {:rev 1 :slug "x"})
+          raw-b (state/scoped-resource-key {:tenant "acme" :user "u-42"}
+                                           :article/by-slug {:slug "x" :rev 1})]
+      (is (= raw-a raw-b) "key-order spellings collapse via the defensive path")
+      (is (= raw-a (state/scoped-resource-key*
+                     (state/canonicalize {:tenant "acme" :user "u-42"})
+                     :article/by-slug
+                     (state/canonicalize {:rev 1 :slug "x"})))
+          "the trusted path on the canonical value matches the defensive path"))))
+
+(deftest canonicalize-or-rethrow-folds-validate-and-canonicalize
+  (testing "on conforming input it returns the SAME value as canonicalize"
+    (is (= (state/canonicalize {:b 2 :a 1})
+           (state/canonicalize-or-rethrow {:a 1 :b 2} 'test :scope :r/x))
+        "canonical result is identical to the two-step (reject + canonicalize)")
+    (is (= :rf.scope/global
+           (state/canonicalize-or-rethrow :rf.scope/global 'test :scope :r/x))
+        "the bare global scope keyword canonicalizes to itself"))
+  (testing "a host / opaque value re-throws the SAME public
+            :rf.error/resource-non-edn-params category reject-non-edn! threw"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
+          (state/canonicalize-or-rethrow {:f (fn [])} 'test :scope :r/x)))
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
+          (state/canonicalize-or-rethrow {:ratio 1.5} 'test :params :r/x)))))
+
 ;; rf2-wgutc2 (EP-0012 correctness review item 1): resource params + scopes
 ;; use the SHARED CEDN-1 identity rule (`re-frame.identity/canonical`), not a
 ;; resource-local dialect. This closes three divergences the prior


### PR DESCRIPTION
From the "kill over-engineering" `[toomuch]` review. Two SAFE beads on `implementation/resources`; one fixed, one reported-not-removed after verification.

## rf2-rplgkw (P2) — DONE: collapse redundant scope/params re-canonicalization

Resource subs are reg-frame-state-subs, so `resolve-scoped-key` re-runs on every frame-state change (before output memoization). It canonicalized scope (`canonicalize-scope`) and params (`validate+canonicalize-params`), then `scoped-resource-key` re-canonicalized **both again** — pure overhead, since `canonical` is idempotent and fails closed on the same CEDN-1 domain as `reject-non-edn!`.

- Added `state/scoped-resource-key*` — a trusted constructor that assembles the key vector **without** re-canonicalizing, for already-canonical inputs.
- Redefined the defensive `state/scoped-resource-key` in terms of it; kept it for direct internal/test callers and the mutation map-form-target boundary (which validates serializability separately, then canonicalizes here).
- Switched the four already-canonical resolution call-sites (sub / ensure / remove / route-entry) to `scoped-resource-key*`.
- Added `state/canonicalize-or-rethrow`: validate + canonicalize in **one** CEDN-1 walk (re-throwing the public `:rf.error/resource-non-edn-params` category), folding the `reject-non-edn!` + `canonicalize` pair inside `canonicalize-scope`. `reject-non-edn!` is retained (direct callers + the params path, where Malli must run on the raw value between reject and canonicalize, so the pair is not adjacent there).

Behaviour-preserving: new tests assert `scoped-resource-key*` matches the defensive constructor on canonical input, and that `canonicalize-or-rethrow` matches `canonicalize` on good input and throws the same error category on a host/non-portable value.

## rf2-0jpr56 (P3) — REPORTED, NOT REMOVED (per the bead's own guard)

The bead said: *"VERIFY truly private + unused (grep all readers) before deleting — if anything consumes it, report instead of removing."* It is **not** unused. Grep found real consumers:

- **PRODUCTION:** `routing/src/re_frame/routing/nav_token.cljc` threads a reply `:target` through `route-reply/suppress`; the target's `::stale-authority` capability authorizes framework/tool stale delivery at the production routing surface.
- **TESTS (functional):** `routing_nav_token_test.clj:741-772` exercises that production path — authorized framework/tool target RECEIVES the stale reply; unauthorized app target FAILS LOUD. Plus `routing_reply_test.clj`, `timer_probe_conformance`, `event_reply_envelope_conformance`, and core `reply_test.cljc`.
- **SPEC CONTRACT:** `Managed-Effects.md:117` + `Spec-Schemas.md:2978` normatively require app targets MUST NOT opt into stale delivery, *enforced via the framework-private stale-authority capability*.

`with-stale-authority` / `stale-authority?` are public framework fns (only `stale-authority-key` is `^:private`). The marker is a live capability boundary that GRANTS authorized framework/tool stale delivery AND fails app overreach loud. Deleting it would silently let app targets opt into stale delivery, remove a production routing authorization path, and require relaxing a normative spec contract — a behaviour change, not a behaviour-preserving dead-marker removal. Kept unchanged; bead updated with the finding.

## Gates
- Resources JVM (`clojure -M:test`): 499 tests, 2074 assertions, 0 failures
- `npm run test:cljs`: 7862 tests, 32567 assertions, 0 failures/errors
- `sh scripts/test-fast-pr.sh`: PASS (full CLJS gate + per-ns isolation)
