### PR TITLE
chore(core): collapse with-new-frame throws + drop retired frame-pairs warning (rf2-a29uqh, rf2-k4xous)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -27,7 +27,6 @@
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.late-bind]
             ;; rf2-k682: routing ships in day8/re-frame2-routing.
             ;; Required here so its load-time hook + reg-sub
             ;; registrations fire before this ns's reg-route calls.
@@ -557,9 +556,12 @@
       (rf/reg-event :seed-reg-view (fn [{:keys [db]} _] {:db {:k 11}}))
       (rf/dispatch-sync [:seed-reg-view] {:frame target-frame})
       (rf/reg-sub :reg-view-test/k (fn [db _] (:k db)))
-      (when-let [clear! (re-frame.late-bind/get-fn
-                          :views/clear-plain-fn-warned-pairs!)]
-        (clear!))
+      ;; (The plain-fn-under-non-default-frame warning + its
+      ;; :views/clear-plain-fn-warned-pairs! suppression-cache reset were
+      ;; retired per EP-0002 / removed in rf2-k4xous; the warning is
+      ;; superseded by the always-on :rf.error/no-frame-context. This
+      ;; negative case now simply confirms a reg-view'd component renders
+      ;; cleanly under a non-default frame with no such warning emitted.)
       (rf/reg-view* :rf.cross-spec-10/registered-view
                     (fn registered-impl []
                       (let [_ @(rf/subscribe [:reg-view-test/k])]

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -274,25 +274,19 @@
          {:recovery :use-with-frame
           :extra    {:got bindings}})
 
-       ;; Vector but wrong arity — almost certainly a typo of the
-       ;; binding form (e.g. `[]` or `[f x y]`). Reject at compile time —
-       ;; per Spec 002 §with-frame.
-       (vector? bindings)
-       (error/throw-error!
-         :rf.error/with-new-frame-bad-binding
-         'rf/with-new-frame
-         (str "with-new-frame's binding must be [sym expr]. "
-              "Got " (count bindings) " element"
-              (when-not (= 1 (count bindings)) "s") ".")
-         {:recovery :fix-registration
-          :extra    {:got   bindings
-                     :count (count bindings)}})
-
+       ;; Anything else that isn't a 2-element `[sym expr]` vector — a
+       ;; wrong-arity vector (e.g. `[]` or `[f x y]`, almost certainly a
+       ;; typo of the binding form) OR a non-vector value. One throw for
+       ;; the whole non-`[sym expr]` class — `:rf.error/id` is the sole
+       ;; machine discriminator and `:extra {:got bindings}` already
+       ;; carries the offending value. Reject at compile time per Spec 002
+       ;; §with-frame.
        :else
        (error/throw-error!
          :rf.error/with-new-frame-bad-binding
          'rf/with-new-frame
-         "with-new-frame's binding must be a 2-element vector [sym expr]."
+         (str "with-new-frame's binding must be [sym expr]; got "
+              (pr-str bindings) ".")
          {:recovery :fix-registration
           :extra    {:got bindings}}))))
 

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -163,20 +163,21 @@
 ;; Every process-wide `defonce` warn-once cache in the adapter / views
 ;; family (`warned-non-dom-roots`, the rf2-9hoos `seen-render-keys` set,
 ;; the slim hiccup interpreter's `warned-keyword-prop` cache, and the
-;; Spec 004 `warned-plain-fn-frame-pairs` plain-fn-under-non-default-frame
-;; set) must be wiped by the standard `make-reset-runtime-fixture` between
-;; tests — otherwise a sibling test's first-encounter warning silently
-;; swallows a later test's same-key warning. The mechanism is the chained
-;; `:adapter/clear-warn-once-caches!` late-bind hook the fixture fires.
+;; React-hook spine's per-adapter source-coord cache) must be wiped by the
+;; standard `make-reset-runtime-fixture` between tests — otherwise a sibling
+;; test's first-encounter warning silently swallows a later test's same-key
+;; warning. The mechanism is the chained `:adapter/clear-warn-once-caches!`
+;; late-bind hook the fixture fires.
 ;;
-;; This defect class has now bitten four times: rf2-4edk (the original
-;; source-coord cache), rf2-9hoos (seen-render-keys), rf2-qy6cl (the slim
-;; keyword-prop cache), and rf2-z79p8 (the plain-fn pairs cache — the 4th
-;; straggler). Each fix was the SAME one-liner: chain the clear-fn. The
-;; pattern is fragile because there is no single chokepoint and nothing
-;; asserts the set of `defonce` warn-once caches equals the set of clears
-;; in the chain — a 5th cache can be added with a bare `defonce` + a
-;; standalone clear-fn and silently escape the fixture.
+;; This defect class bit four times before the chokepoint landed: rf2-4edk
+;; (the original source-coord cache), rf2-9hoos (seen-render-keys), rf2-qy6cl
+;; (the slim keyword-prop cache), and rf2-z79p8 (a since-retired plain-fn
+;; pairs cache — its warning is gone per EP-0002, removed in rf2-k4xous).
+;; Each fix was the SAME one-liner: chain the clear-fn. The pattern was
+;; fragile because there was no single chokepoint and nothing asserted the
+;; set of `defonce` warn-once caches equals the set of clears in the chain —
+;; a cache could be added with a bare `defonce` + a standalone clear-fn and
+;; silently escape the fixture.
 ;;
 ;; `register-warn-once-clear-fn!` is that chokepoint: it both (a) chains
 ;; the clear-fn into `:adapter/clear-warn-once-caches!` and (b) records

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -865,9 +865,6 @@
     :description "Install the substrate-specific hiccup emitter for SSR. Chained — every loaded React-shaped adapter contributes its own install step so a single SSR ns-load auto-wires every adapter's render-to-string slot."}
 
    ;; ---- re-frame.views (CLJS, rf2-4edk warn-once chain) ---------------------
-   {:key         :views/clear-plain-fn-warned-pairs!
-    :producer-ns 're-frame.views.warn-once
-    :description "Clear the warned-plain-fn-frame-pairs cache (warn-once-clear chain / test isolation; rf2-z79p8). The warning this cache once gated is retired per EP-0002 (rf2-7yqn39) — the cache is retained only as a governed member of the :adapter/clear-warn-once-caches! chain."}
    {:key         :views/reading-render-key
     :producer-ns 're-frame.views
     :design-bead "rf2-vh1k3"
@@ -889,7 +886,7 @@
                    re-frame.adapter.uix]
     :chained?    true
     :design-bead "rf2-4edk"
-    :description "Chained reset of EVERY adapter/views warn-once defonce cache the standard make-reset-runtime-fixture must wipe between tests. Per rf2-z79p8 every contributor enrols through the single governance chokepoint re-frame.late-bind/register-warn-once-clear-fn! (which chains the clear-fn here AND records it in the warn-once-clear governance registry). Members: re-frame.views.warn-once's warned-non-dom-roots + warned-plain-fn-frame-pairs (the rf2-z79p8 4th straggler), re-frame.views's rf2-9hoos seen-render-keys (:mount? discriminator), the React-hook spine's per-adapter source-coord cache (re-frame.substrate.spine, used by helix/uix), and the slim hiccup interpreter's warned-keyword-prop (re-frame.adapter.reagent-slim, rf2-qy6cl). The warn-once-clear governance assertion enumerates the registry and proves each member is wiped by this chain so a future 5th cache cannot silently escape the fixture."}
+    :description "Chained reset of EVERY adapter/views warn-once defonce cache the standard make-reset-runtime-fixture must wipe between tests. Per rf2-z79p8 every contributor enrols through the single governance chokepoint re-frame.late-bind/register-warn-once-clear-fn! (which chains the clear-fn here AND records it in the warn-once-clear governance registry). Members: re-frame.views.warn-once's warned-non-dom-roots, re-frame.views's rf2-9hoos seen-render-keys (:mount? discriminator), the React-hook spine's per-adapter source-coord cache (re-frame.substrate.spine, used by helix/uix), and the slim hiccup interpreter's warned-keyword-prop (re-frame.adapter.reagent-slim, rf2-qy6cl). The warn-once-clear governance assertion enumerates the registry and proves each member is wiped by this chain so a future cache cannot silently escape the fixture. (A 5th member, warned-plain-fn-frame-pairs, was removed in rf2-k4xous once its warning was retired per EP-0002.)"}
    {:key         :adapter/current-frame
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -184,7 +184,6 @@
 (def format-source-coord source-coord/format-source-coord)
 
 (def clear-warned-non-dom-roots! warn-once/clear-warned-non-dom-roots!)
-(def clear-plain-fn-warned-pairs! warn-once/clear-plain-fn-warned-pairs!)
 
 ;; The React-context object is consumed by `reg-view*` below (the
 ;; `:contextType` static-field) and by the warn-once helpers in

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -1,25 +1,16 @@
 (ns re-frame.views.warn-once
-  "Warn-once caches and detection helpers for the Reagent-side views ns.
+  "Warn-once cache and detection helpers for the Reagent-side views ns.
   Re-frame.views re-exports the publicly-referenced surface
-  (`clear-warned-non-dom-roots!`, `clear-plain-fn-warned-pairs!`).
+  (`clear-warned-non-dom-roots!`).
 
-  Two warn-once caches live here:
-
-  1. Non-DOM-root warning (Spec 006 §Source-coord annotation,
-     documented exemption). When a reg-view'd component returns a
-     non-DOM root (fn/class component or React Fragment) the source-
-     coord walk skips the annotation and emits a one-shot
-     console.warn per id. The `warned-non-dom-roots` defonce holds
-     the per-process set; `make-reset-runtime-fixture` clears it via the
-     chained `:adapter/clear-warn-once-caches!` hook.
-
-  2. Plain-fn-under-non-default-frame suppression cache (`warned-plain-fn-
-     frame-pairs`). The warning this cache once gated is RETIRED — see the
-     section below — but the cache itself is retained as a governed member
-     of the warn-once-clear chain (rf2-z79p8): it is one of the empirical
-     example caches the warn-once-clear governance gate arms/fires/asserts
-     against, proving the canonical `:adapter/clear-warn-once-caches!`
-     chain wipes every enrolled cache between tests."
+  One warn-once cache lives here: the non-DOM-root warning (Spec 006
+  §Source-coord annotation, documented exemption). When a reg-view'd
+  component returns a non-DOM root (fn/class component or React Fragment)
+  the source-coord walk skips the annotation and emits a one-shot
+  console.warn per id. The `warned-non-dom-roots` defonce holds the
+  per-process set; `make-reset-runtime-fixture` clears it via the chained
+  `:adapter/clear-warn-once-caches!` hook (enrolled through the governance
+  chokepoint `register-warn-once-clear-fn!`, rf2-z79p8)."
   (:require [re-frame.late-bind :as late-bind]))
 
 ;; ---- non-DOM-root warning ------------------------------------------------
@@ -53,81 +44,27 @@
              "§Source-coord annotation: pair tools fall back to :rf/id "
              "for non-DOM roots).")))))
 
-;; ---- plain-fn-under-non-default-frame warning — RETIRED (EP-0002) --------
-;;
-;; The `:rf.warning/plain-fn-under-non-default-frame-once` warning is RETIRED
-;; (Spec 009 §Error event catalogue, the strikethrough row), superseded by the
-;; always-on `:rf.error/no-frame-context` error per EP-0002 (rf2-69r7ui). The
-;; old contract: a plain Reagent fn (not registered via `reg-view`, so without
-;; the `^{:contextType frame-context}` metadata `reg-view` attaches) cannot
-;; read the surrounding React-context frame, so its `(rf/subscribe ...)` /
-;; `(rf/dispatch ...)` fell through to `:rf/default` — and a now-deleted helper
-;; emitted a once-per-pair warning about the silent fall-through.
-;;
-;; Under EP-0002 there is NO `:rf/default` floor. A plain fn that cannot read
-;; the context resolves to nil (the no-provider sentinel coerces to nil), and
-;; `frame/require-current-frame!` — which `subs/subscribe` and the dispatch
-;; envelope call BEFORE anything else — raises the always-on
-;; `:rf.error/no-frame-context` and HALTS the operation. That loud error IS
-;; the sharper diagnostic the warning used to soften. So the warning's firing
-;; case (plain fn under a non-default provider, no `with-frame`) became
-;; UNREACHABLE — the throw happened first — leaving the helper a structural
-;; no-op contradicting the catalogue's RETIRED ruling. rf2-7yqn39 deleted the
-;; dead emit site, the helper, its `:views/maybe-warn-plain-fn-under-non-
-;; default-frame!` late-bind hook, the `subs/subscribe` call site, and the
-;; `re-frame.views` re-export.
-;;
-;; The `warned-plain-fn-frame-pairs` suppression cache and its
-;; `clear-plain-fn-warned-pairs!` clear-fn are RETAINED — not for the retired
-;; warning, but as a governed member of the warn-once-clear chain (rf2-z79p8).
-;; They enrol through `register-warn-once-clear-fn!` below so the warn-once-
-;; clear governance gate (`re-frame.warn-once-clear-governance-{cljs-,}test`)
-;; can arm/fire/assert that the canonical `:adapter/clear-warn-once-caches!`
-;; chain wipes every enrolled cache between tests.
-
-(defonce ^:private warned-plain-fn-frame-pairs
-  ;; Set of `[component-id frame-id]` pairs. Retained as a governed member of
-  ;; the warn-once-clear chain (rf2-z79p8); the warning it once gated is
-  ;; retired (see the section above).
-  (atom #{}))
-
-(defn clear-plain-fn-warned-pairs!
-  "Reset the warn-once suppression cache. Retained as the clear-fn the
-  warn-once-clear governance chain (rf2-z79p8) drives — see the RETIRED
-  section above and `register-warn-once-clear-fn!` below."
-  []
-  (reset! warned-plain-fn-frame-pairs #{})
-  nil)
-
-;; Publish the clear-fn through the late-bind hook table so re-frame.subs
-;; (a leaf namespace, .cljc, JVM-runnable) and the governance chain can
-;; reach it without statically requiring this CLJS-only ns. JVM builds
-;; never load this file; the lookup returns nil there. Per re-frame.late-bind
-;; §Hook keys.
-(late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
-                   clear-plain-fn-warned-pairs!)
-
-;; Enrol BOTH warn-once `defonce` caches this ns owns into the chained
+;; Enrol the `warned-non-dom-roots` cache into the chained
 ;; `:adapter/clear-warn-once-caches!` hook, via the canonical governance
 ;; chokepoint `late-bind/register-warn-once-clear-fn!` (rf2-z79p8). Each
 ;; adapter (helix, uix), the slim hiccup interpreter, re-frame.views, and
-;; this ns all contribute a clear-step; `make-reset-runtime-fixture`
-;; invokes the top of the chain and every contributor's reset runs. The
-;; chokepoint also records each cache in the warn-once-clear governance
-;; registry so the governance assertion proves the chain wipes it.
+;; this ns contribute a clear-step; `make-reset-runtime-fixture` invokes
+;; the top of the chain and every contributor's reset runs. The chokepoint
+;; also records the cache in the warn-once-clear governance registry so the
+;; governance assertion proves the chain wipes it.
 ;;
-;;   1. `warned-non-dom-roots` — the rf2-4edk source-coord / non-DOM-root
-;;      cache.
-;;   2. `warned-plain-fn-frame-pairs` — the rf2-z79p8 4th straggler (its
-;;      warning is now retired, but it stays a governed chain member).
+;; (The retired `warned-plain-fn-frame-pairs` suppression cache — the
+;; rf2-z79p8 4th straggler — was removed in rf2-k4xous: its warning
+;; `:rf.warning/plain-fn-under-non-default-frame-once` is RETIRED per
+;; EP-0002 (rf2-7yqn39 deleted the emit site, helper, hook, call site and
+;; re-export, superseding it with the always-on `:rf.error/no-frame-context`
+;; error). It was kept SOLELY as a governance test subject; the three live
+;; probe-carrying caches — `warned-non-dom-roots` here, `seen-render-keys`
+;; in re-frame.views, and the spine's per-adapter source-coord cache — still
+;; exercise the arm/fire/assert-empty governance proof, so removing it loses
+;; zero coverage.)
 (late-bind/register-warn-once-clear-fn!
   {:label    :views/warned-non-dom-roots
    :clear-fn clear-warned-non-dom-roots!
    :arm      (fn [] (swap! warned-non-dom-roots conj ::governance-sentinel))
    :armed?   (fn [] (contains? @warned-non-dom-roots ::governance-sentinel))})
-
-(late-bind/register-warn-once-clear-fn!
-  {:label    :views/warned-plain-fn-frame-pairs
-   :clear-fn clear-plain-fn-warned-pairs!
-   :arm      (fn [] (swap! warned-plain-fn-frame-pairs conj ::governance-sentinel))
-   :armed?   (fn [] (contains? @warned-plain-fn-frame-pairs ::governance-sentinel))})

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -207,6 +207,20 @@
             ":rf.error/id is the canonical discriminator")
         (is (re-find #"binding must be \[sym expr\]"
                      (:reason (ex-data e)))
+            ":reason carries the structured explanation"))
+      ;; Non-vector binding (e.g. a bare symbol) — same collapsed
+      ;; non-`[sym expr]` throw (rf2-a29uqh: one throw for the whole class).
+      (let [e (try (expand 'not-a-vector '((do nil))) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "a non-vector binding must throw")
+        (is (= :rf.error/with-new-frame-bad-binding (:rf.error/id (ex-data e)))
+            ":rf.error/id is the canonical discriminator (shared with the wrong-arity case)")
+        (is (= :fix-registration (:recovery (ex-data e)))
+            ":recovery is :fix-registration")
+        (is (= 'not-a-vector (:got (ex-data e)))
+            ":extra {:got bindings} carries the offending value")
+        (is (re-find #"binding must be \[sym expr\]"
+                     (:reason (ex-data e)))
             ":reason carries the structured explanation")))))
 
 ;; ===========================================================================

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -340,14 +340,12 @@
   (let [_m (views/first-render?! [:probe/unmounted 1])]
     nil)
   (views/clear-seen-render-keys!)
-  ;; The plain-fn-under-non-default-frame WARNING is retired (EP-0002;
-  ;; superseded by the always-on :rf.error/no-frame-context — rf2-7yqn39
-  ;; deleted the dead emit). The `warned-plain-fn-frame-pairs` suppression
-  ;; cache and its `clear-plain-fn-warned-pairs!` clear-fn are retained only
-  ;; as a governed member of the warn-once-clear chain (rf2-z79p8). Touch the
-  ;; clear-fn so the warn-once ns body stays in the reachability graph for
-  ;; the elision check.
-  (views/clear-plain-fn-warned-pairs!))
+  ;; Touch the surviving warn-once clear-fn so the warn-once ns body stays
+  ;; in the reachability graph for the elision check. (The retired
+  ;; `warned-plain-fn-frame-pairs` cache + `clear-plain-fn-warned-pairs!`
+  ;; were removed in rf2-k4xous — their warning is retired per EP-0002,
+  ;; superseded by the always-on :rf.error/no-frame-context.)
+  (views/clear-warned-non-dom-roots!))
 
 ;; ---- Spec 005 §Source-coord stamping — reg-machine macro (rf2-8bp3) -------
 

--- a/implementation/core/test/re_frame/warn_once_clear_governance_cljs_test.cljs
+++ b/implementation/core/test/re_frame/warn_once_clear_governance_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.warn-once-clear-governance-cljs-test
   "Governance gate for the adapter/views warn-once `defonce` cache class
-  (rf2-z79p8) — the class that has now bitten FOUR times:
+  (rf2-z79p8) — the class that bit FOUR times before the chokepoint landed:
 
     * rf2-4edk  — `warned-non-dom-roots` (the source-coord / non-DOM-root
                   cache) was left out of the fixture-reset chain.
@@ -8,7 +8,9 @@
     * rf2-qy6cl — the slim hiccup interpreter's `warned-keyword-prop`.
     * rf2-z79p8 — `warned-plain-fn-frame-pairs` (the Spec 004 plain-fn-
                   under-non-default-frame suppression set) — the 4th
-                  straggler, chained by THIS change.
+                  straggler. That cache has since been REMOVED (rf2-k4xous):
+                  its warning is retired per EP-0002, and the three live
+                  probe-carrying caches below still exercise the same gate.
 
   Each recurrence was the SAME defect: a process-wide `defonce` warn-once
   cache whose clear-fn was published standalone but NEVER chained into the
@@ -52,7 +54,6 @@
             ;; registry at ns-load:
             ;;   re-frame.views          → seen-render-keys
             ;;   re-frame.views.warn-once → warned-non-dom-roots
-            ;;                              + warned-plain-fn-frame-pairs
             ;;   re-frame.adapter.uix     → the React-hook spine's per-
             ;;                              adapter source-coord cache
             ;;                              (make-react-adapter enrols it)
@@ -67,20 +68,18 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private expected-labels
-  "Every warn-once cache of the rf2-4edk/9hoos/qy6cl/z79p8 class that MUST
-  be enrolled in the registry (and therefore chained). A 5th cache that
+  "Every warn-once cache of the rf2-4edk/9hoos/qy6cl class that MUST be
+  enrolled in the registry (and therefore chained). A new cache that
   forgets to enrol trips the source-enumeration JVM assertion; one that
   enrols under a new label lands here once Mike/the reviewer adds it."
   #{:views/warned-non-dom-roots
-    :views/warned-plain-fn-frame-pairs
     :views/seen-render-keys
     :adapter/warned-non-dom-roots          ;; the React-hook spine's per-adapter cache
     :reagent-slim/warned-keyword-prop})
 
 (deftest registry-enrols-every-named-cache-of-the-class
   (testing "the warn-once-clear governance registry enrols every named
-            cache of the rf2-z79p8 class (incl. the 4th straggler
-            :views/warned-plain-fn-frame-pairs)"
+            cache of the rf2-z79p8 class"
     (let [enrolled (set (map :label @late-bind/warn-once-clear-registry))
           missing  (set/difference expected-labels enrolled)]
       (is (empty? missing)
@@ -134,45 +133,15 @@
                  "will not re-arm it between tests."))))))
 
 ;; ---------------------------------------------------------------------------
-;; Re-arm of warned-plain-fn-frame-pairs — the 4th straggler (rf2-z79p8)
+;; A representative live cache the contrast assertions can drive
 ;; ---------------------------------------------------------------------------
 
-(defn- plain-fn-entry []
-  (some (fn [e] (when (= :views/warned-plain-fn-frame-pairs (:label e)) e))
-        @late-bind/warn-once-clear-registry))
-
-(deftest plain-fn-cache-re-arms-via-the-chain
-  (testing "the warned-plain-fn-frame-pairs cache (Spec 004 plain-fn-under-
-            non-default-frame suppression set) re-arms when the chained
-            :adapter/clear-warn-once-caches! hook fires — the rf2-z79p8 fix.
-            Before this change the cache was NOT chained, so the standard
-            fixture left a sibling test's pair in the set and a later same-
-            pair warning was silently swallowed. This drives the REAL cache
-            through the REAL chain via its registry probes (the production
-            seam), mirroring the chained-clear re-arm in
-            template_keyword_prop_warn_once_clear_cljs_test (rf2-qy6cl) and
-            assert-chained-clear-warn-once-empties-cache (rf2-e54wc)."
-    (let [{:keys [arm armed?]} (plain-fn-entry)
-          chain (late-bind/get-fn :adapter/clear-warn-once-caches!)]
-      (is (and (fn? arm) (fn? armed?))
-          "the plain-fn cache is enrolled with arm/armed? probes")
-      ;; Phase 1 — a pair is recorded (the production code does this the
-      ;; first time a plain fn warns; once recorded the SAME pair is
-      ;; suppressed). Simulate via the production arm seam.
-      (arm)
-      (is (true? (boolean (armed?)))
-          "phase 1: the pair is in the suppression set (a same-pair warning would now be swallowed)")
-      ;; The chained fixture-reset hook fires (what make-reset-runtime-
-      ;; fixture does between every test).
-      (chain)
-      ;; Phase 2 — the cache is empty again: the same pair would warn
-      ;; AFRESH, no longer swallowed. This is the re-arm the 4th straggler
-      ;; was missing before rf2-z79p8.
-      (is (false? (boolean (armed?)))
-          (str "phase 2: AFTER the chained :adapter/clear-warn-once-caches! "
-               "hook fires, the warned-plain-fn-frame-pairs cache MUST be "
-               "empty so the same pair warns again (it was silently "
-               "swallowed before rf2-z79p8 chained this cache)")))))
+(defn- a-probed-live-entry
+  "Any registry entry that carries :arm / :armed? probes — a real,
+  properly-enrolled cache the empirical arm/fire/assert-empty logic can
+  drive. Used as the positive contrast in the negative-proof test below."
+  []
+  (first (probed-entries)))
 
 ;; ---------------------------------------------------------------------------
 ;; Negative proof — the gate has teeth (a registered-but-unchained cache
@@ -211,7 +180,7 @@
           ;; And confirm that, by contrast, a properly-enrolled cache IS
           ;; cleared by the same chain fire (so the gate distinguishes the
           ;; two — it isn't vacuously green).
-          (let [{real-arm :arm real-armed? :armed?} (plain-fn-entry)]
+          (let [{real-arm :arm real-armed? :armed?} (a-probed-live-entry)]
             (real-arm)
             ;; fire again so both synthetic and the real cache see the chain
             (chain)

--- a/implementation/core/test/re_frame/warn_once_clear_governance_test.clj
+++ b/implementation/core/test/re_frame/warn_once_clear_governance_test.clj
@@ -10,21 +10,20 @@
   would chain it WITHOUT recording it in the registry, re-opening the
   rf2-4edk/9hoos/qy6cl/z79p8 defect class the CLJS gate can no longer see).
 
-  Two assertions:
+  SINGLE CHOKEPOINT assertion — no source file other than
+  `re-frame.late-bind` itself (which DEFINES the chokepoint) may call
+  `(chain-fn! :adapter/clear-warn-once-caches! ...)` directly. Every
+  contributor goes through `register-warn-once-clear-fn!` (core/views) or
+  `install-clear-warn-once-step!` (the spine/adapter seam, itself a thin
+  delegator). This guarantees enrolment-and-chaining are atomic: you
+  cannot chain without registering.
 
-    1. SINGLE CHOKEPOINT — no source file other than `re-frame.late-bind`
-       itself (which DEFINES the chokepoint) may call
-       `(chain-fn! :adapter/clear-warn-once-caches! ...)` directly. Every
-       contributor goes through `register-warn-once-clear-fn!` (core/views)
-       or `install-clear-warn-once-step!` (the spine/adapter seam, itself a
-       thin delegator). This guarantees enrolment-and-chaining are atomic:
-       you cannot chain without registering.
-
-    2. ENROLMENT COVERAGE — every standalone warn-once clear-fn the
-       adapter/views family publishes as a `clear-*warned*!`-shaped
-       late-bind hook (the historical straggler shape — a `defonce` cache
-       with a hand-published clear-fn) is routed through the chokepoint
-       somewhere in source.
+  (A second assertion once enumerated standalone `clear-*warned*!`-shaped
+  late-bind hooks — the historical straggler shape, a `defonce` cache with
+  a hand-published clear-fn — and checked each was routed through the
+  chokepoint. The last such hook, `:views/clear-plain-fn-warned-pairs!`,
+  was removed in rf2-k4xous once its warning was retired per EP-0002, so
+  that shape no longer exists in source and the assertion had no subject.)
 
   Walks the same source tree as `re-frame.late-bind-drift-test`.")
 
@@ -89,72 +88,3 @@
                "rf2-4edk/9hoos/qy6cl/z79p8 defect class. Route through the "
                "chokepoint:\n  "
                (str/join "\n  " (sort offenders)))))))
-
-;; ---------------------------------------------------------------------------
-;; 2. Enrolment coverage — every published clear-*warned* hook is chokepointed
-;; ---------------------------------------------------------------------------
-
-(def ^:private clear-warned-hook-re
-  "Match a late-bind publication of a `clear-…warned…`-shaped clear-fn —
-  the historical straggler shape (a standalone hand-published clear-fn for
-  a warn-once cache). e.g. `(late-bind/set-fn! :views/clear-plain-fn-warned-pairs! …`."
-  #"\(late-bind/set-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/clear-[a-zA-Z0-9!?*+\-]*warned[a-zA-Z0-9!?*+\-]*)")
-
-(defn- published-clear-warned-hooks
-  "Map of `clear-*warned*` hook-key → producing-ns-sym across all source."
-  []
-  (into {}
-        (for [^java.io.File f (source-files)
-              :let [content (slurp f)
-                    ns-sym  (ns-name-of content)]
-              k (->> (re-seq clear-warned-hook-re content)
-                     (map (comp keyword #(subs % 1) second)))]
-          [k ns-sym])))
-
-(defn- files-routing-through-chokepoint
-  "Source whose content references the chokepoint or its spine seam by the
-  name of a clear-fn — used as a coarse 'this cache is wired in' signal."
-  []
-  (->> (source-files)
-       (map (fn [^java.io.File f] [(.getPath f) (slurp f)]))
-       (into {})))
-
-(deftest every-clear-warned-hook-is-routed-through-the-chokepoint
-  (testing "every standalone clear-*warned* warn-once clear-fn the
-            adapter/views family publishes is also wired into the chain via
-            the chokepoint (rf2-z79p8) — so it is enrolled in the registry
-            and the CLJS gate covers it"
-    (let [hooks      (published-clear-warned-hooks)
-          all-source (vals (files-routing-through-chokepoint))
-          ;; A clear-fn is 'wired' if SOME source file enrols it through
-          ;; the chokepoint or the spine seam. We match on the unqualified
-          ;; fn name (the symbol after the last `/` in the hook key, minus
-          ;; the `clear-`/`!` decoration is too lossy — instead match the
-          ;; fn-name token the clear-fn is defined under, which by
-          ;; convention is the hook key's local name).
-          enrol-tokens ["register-warn-once-clear-fn!"
-                        "install-clear-warn-once-step!"]
-          chokepoint-source (filter (fn [s]
-                                      (some #(str/includes? s %) enrol-tokens))
-                                    all-source)]
-      (is (seq hooks)
-          "sanity: at least one clear-*warned* hook is published in source")
-      (is (seq chokepoint-source)
-          "sanity: the chokepoint / spine seam is referenced in source")
-      ;; For each published clear-*warned* hook, its local fn name should
-      ;; appear in a chokepoint-routing source file. The hook key's local
-      ;; name mirrors the clear-fn symbol (e.g.
-      ;; :views/clear-plain-fn-warned-pairs! ↔ clear-plain-fn-warned-pairs!).
-      (let [unrouted
-            (for [[hook-key _producer] hooks
-                  :let [fn-name (name hook-key)]
-                  :when (not (some #(str/includes? % fn-name) chokepoint-source))]
-              hook-key)]
-        (is (empty? unrouted)
-            (str "These clear-*warned* warn-once clear-fns are published as "
-                 "standalone late-bind hooks but their fn-name is NOT "
-                 "referenced at any chokepoint (register-warn-once-clear-fn! "
-                 "/ install-clear-warn-once-step!) call site — they may be "
-                 "stragglers NOT wired into the fixture chain (the "
-                 "rf2-z79p8 defect class):\n  "
-                 (str/join "\n  " (sort (map str unrouted)))))))))


### PR DESCRIPTION
@
Two SAFE `[toomuch]` simplifications on `implementation/core` from the "kill over-engineering" review. Both behaviour-preserving; no live guard removed.

## rf2-a29uqh — collapse the two `with-new-frame` bad-binding throws into one

`expand-with-new-frame` (`core_reg_view_macro.cljc`) had THREE throw sites / two error ids: the keyword-form hint, plus `:rf.error/with-new-frame-bad-binding` thrown TWICE — once on the wrong-arity-vector branch (with `(count)`/pluralisation) and an identical-id `:else`. Collapsed both non-`[sym expr]` cases into one `:else` throw of the same id.

- KEPT: the normatively-promised `:rf.error/with-new-frame-keyword-form` keyword->with-frame compile-time hint (untouched).
- Loses nothing: `:rf.error/id` is the sole machine discriminator (tests/tools branch on it, never the byte-exact message); the offending value is still in `:extra {:got bindings}`; the dropped `:count` slot and the per-arity pluralised message are unreferenced anywhere.
- Test: extended `with-new-frame-rejects-vector-bindings-with-wrong-arity` with a non-vector `:else` case (asserts shared id + `:recovery` + `:got` + reason).

## rf2-k4xous — drop the retired `warned-plain-fn-frame-pairs` warn-once cache

Its warning (`:rf.warning/plain-fn-under-non-default-frame-once`) was retired per EP-0002 (rf2-7yqn39 deleted the emit site/helper/hook/call-site/re-export, superseding it with the always-on `:rf.error/no-frame-context`). The cache was kept SOLELY as a governance test subject — a structural no-op with no production reader.

Removed: the cache, its clear-fn, the `re-frame.views` facade export, the `:views/clear-plain-fn-warned-pairs!` late-bind publication, the late-bind directory entry, and the `register-warn-once-clear-fn!` enrolment.

KEPT intact (the governance machinery guarding a 4×-recurring defect class): the `register-warn-once-clear-fn!` chokepoint, `warn-once-clear-registry`, `install-clear-warn-once-step!`, and the JVM single-chokepoint source-enumeration assertion. The arm/fire/assert-empty proof still runs against the three LIVE probe-carrying caches (`warned-non-dom-roots`, `seen-render-keys`, the spine per-adapter source-coord cache) — zero coverage lost.

Also: removed the now-subjectless dedicated `plain-fn-cache-re-arms-via-the-chain` CLJS test (the generic chain-wipes-every-enrolled-cache test covers re-arm for all live probed caches) and the JVM enrolment-coverage assertion (its subject shape — standalone `clear-*warned*` `set-fn!` hooks — no longer exists in source); repointed the negative-proof contrast to any live probed cache; updated the vestigial cross-spec negative case + elision-probe reachability touch to the surviving clear-fn.

## Gates
- `npm run test:cljs` — 7859 tests / 32554 assertions, 0 failures
- core JVM (`clojure -M:test`) — 1810 tests / 7874 assertions, 0 failures
- `scripts/test-fast-pr.sh` — PASS (incl. per-ns isolation + late-bind drift)
@