### PR TITLE
chore(story): human ex-message for unknown-egress-profile throw (rf2-lhnftt)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -892,12 +892,24 @@
     ;; coercing to the default. `nil` resets to the redacting default.
     (when (and (some? egress-profile)
                (not (config/known-egress-profile? egress-profile)))
-      (throw (ex-info ":rf.error/unknown-egress-profile"
-                      {:rf.error/id :rf.error/unknown-egress-profile
-                       :where       'rf.story/configure!
-                       :recovery    :use-a-known-profile
-                       :profile     egress-profile
-                       :valid       config/egress-profiles})))
+      ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape:
+      ;; a human sentence + the trailing `[:rf.error/<id>]` token as the
+      ;; ex-message, with `:rf.error/id` the sole machine discriminator.
+      ;; The central `re-frame.error` builder is NOT used here — `tools/`
+      ;; is bundle-isolated and MUST NOT `:require re-frame.*`, so the shape
+      ;; is hand-rolled inline (mirroring reagent-slim's same constraint).
+      (let [msg (str "configure! got an unknown :rf.story/egress-profile: "
+                     (pr-str egress-profile)
+                     " — known profiles are " (pr-str config/egress-profiles) ". "
+                     "Use one of the known profiles, or `nil` to reset to the "
+                     "redacting default. [:rf.error/unknown-egress-profile]")]
+        (throw (ex-info msg
+                        {:rf.error/id :rf.error/unknown-egress-profile
+                         :where       'rf.story/configure!
+                         :recovery    :use-a-known-profile
+                         :reason      msg
+                         :profile     egress-profile
+                         :valid       config/egress-profiles}))))
     (config/set-egress-profile! egress-profile))
   nil)
 

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -166,10 +166,24 @@
 
 (deftest configure!-rejects-unknown-egress-profile
   (testing "an unknown profile keyword raises :rf.error/unknown-egress-profile (closed enum)"
-    (is (thrown-with-msg?
-          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
-          #"unknown-egress-profile"
-          (story/configure! {:rf.story/egress-profile :rf.egress/not-a-profile})))
+    (let [e (try
+              (story/configure! {:rf.story/egress-profile :rf.egress/not-a-profile})
+              nil
+              (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
+      (is (some? e) "expected ex-info to be thrown")
+      ;; Canonical thrown-error shape: a human sentence carrying the offending
+      ;; profile + the trailing `[:rf.error/<id>]` token — NOT the bare keyword
+      ;; string.
+      (let [msg #?(:clj (.getMessage ^Exception e) :cljs (ex-message e))]
+        (is (re-find #":rf.egress/not-a-profile" msg)
+            "the message names the unknown profile the author passed")
+        (is (re-find #"known profiles are" msg)
+            "the message enumerates the known profiles")
+        (is (re-find #"\[:rf.error/unknown-egress-profile\]" msg)
+            "the message ends with the machine-readable error token"))
+      (let [data (ex-data e)]
+        (is (= :rf.error/unknown-egress-profile (:rf.error/id data)))
+        (is (= 'rf.story/configure! (:where data)))))
     (is (= :rf.egress/local-redacted (config/get-egress-profile))
         "the rejected call left the profile at the redacting default")))
 


### PR DESCRIPTION
## What

tools/story `configure!` carried a SECOND bare-keyword throw — the twin of the just-fixed `:rf.error/unknown-story-config-key` (#4521 / r2redv). The `:rf.story/egress-profile` validation branch threw an `ex-info` whose **message** was the bare keyword string `":rf.error/unknown-egress-profile"`; the actionable detail (the offending profile + the known set) lived only in data slots, so a bare `(.getMessage e)` gave the author nothing.

## Change

- `tools/story/src/re_frame/story.cljc` — hand-roll the canonical thrown-error shape inline (a human sentence naming the bad profile and enumerating the known profiles, ending with the trailing `[:rf.error/unknown-egress-profile]` machine token), exactly mirroring how the sibling fix handled `:rf.error/unknown-story-config-key` in the same function. `tools/` is bundle-isolated and cannot `:require re-frame.error`, so the shape is hand-rolled (the reagent-slim pattern). `:rf.error/id` stays the sole discriminator; the new sentence is also mirrored into `:reason`.
- `tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc` — strengthen the pinning test from a bare token-substring regex to asserting the human message (offending profile + known set + trailing token) plus the `:rf.error/id` / `:where` data slots.

## Gates

- story JVM tests (`clojure -M:test`): 1705 tests, 6311 assertions, 0 failures / 0 errors.
- `npm run test:cljs`: 7861 tests, 32567 assertions, 0 failures / 0 errors (this `.cljc` pinning test runs under CLJS too).
- `sh scripts/test-fast-pr.sh`: green through the spine (its CLJS node integration step also passes after `npm install`).