### PR TITLE
docs(reply): document obsolete-target suppression as HTTP-specific by-design (rf2-wwfn7q)

### DIFF
--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -56,7 +56,33 @@
   threaded in); this ns never reads a clock. Trace summaries route every
   wire-bearing slot through the shared `re-frame.reply/trace-summary`
   (which calls `re-frame.elision/elide-wire-value`) — never a
-  family-private elider (Managed-Effects §Tracing)."
+  family-private elider (Managed-Effects §Tracing).
+
+  ## Why there is no `target-obsolete?` gate here (rf2-wwfn7q)
+
+  HTTP carries an `actor-destroy-target-obsolete?` predicate
+  (`re-frame.http-reply`) that lowers a destroyed-actor reply to `:stale`/
+  `:suppressed` (rather than `:cancelled`) when the reply TARGET names the
+  destroyed actor. Machines have NO counterpart, **by design** — obsolete-
+  target suppression is HTTP-specific. HTTP is the only EP-0011 surface that
+  RE-DISPATCHES a reply at a caller-supplied event target (its `:on-failure`
+  / origin-event head, which can name the actor or an ordinary app event), so
+  TARGET-identity obsolescence is only definable there.
+
+  A machine cancel is not a re-dispatch at a caller-supplied target: it is a
+  TERMINAL completion/correlation row (`cancelled-actor-reply` — no `:value`,
+  no dispatch, no caller target) that closes the work-ledger row as
+  `:cancelled`. Machines already model obsolescence, but split by SEMANTICS,
+  not target-identity: the LATE-OBSOLETE-arrival `:stale` cases are
+  `stale-spawn-reply` (child finishes after the parent is gone),
+  `stale-join-child-reply` (join child reports after the join resolved), and
+  `after-stale-reply` (an `:after` timer fires after an epoch/path mismatch);
+  PROACTIVE teardown is recorded as the `:cancelled` `cancelled-actor-reply`.
+  Forcing HTTP's `target == actor` gate onto `cancelled-actor-reply` would
+  blur those two genuinely distinct facts. All surfaces still route through
+  the shared `re-frame.reply/suppress` and spell `:cancelled` identically —
+  uniform where it matters; the obsolescence DETERMINATION is correctly
+  surface-specific."
   (:require [re-frame.reply :as reply]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/resources/src/re_frame/resources/reply.cljc
+++ b/implementation/resources/src/re_frame/resources/reply.cljc
@@ -68,7 +68,32 @@
   threads it in); this namespace never reads a clock. Trace summaries route
   every wire-bearing slot through the shared `re-frame.reply/trace-summary`
   (which calls `re-frame.elision/elide-wire-value`) — never a family-private
-  elider (Managed-Effects §Tracing)."
+  elider (Managed-Effects §Tracing).
+
+  ## Why there is no `target-obsolete?` gate here (rf2-wwfn7q)
+
+  HTTP carries an `actor-destroy-target-obsolete?` predicate
+  (`re-frame.http-reply`) that lowers a destroyed-actor reply to `:stale`/
+  `:suppressed` (rather than `:cancelled`) when the reply TARGET names the
+  destroyed actor. Resources and mutations have NO counterpart, **by
+  design** — obsolete-target suppression is HTTP-specific. HTTP is the only
+  EP-0011 surface that RE-DISPATCHES a reply at a caller-supplied event
+  target (its `:on-failure` / origin-event head), so TARGET-identity
+  obsolescence is only definable there.
+
+  Resource / mutation reply targets are framework-INTERNAL
+  (`:rf.resource.internal/*` / `:rf.mutation.internal/*`), never a caller-
+  supplied app event, so obsolescence is gated on WORK-ID + GENERATION
+  ENTRY-LIVENESS, not target-identity. `live-entry-for-reply`
+  (`re-frame.resources.events`) verifies the live entry's `:current-work` ==
+  the reply's `:work/id` AND its `:generation` == the reply's `:generation`;
+  it returns nil for a cross-frame / stale / superseded / vanished reply,
+  which is then suppressed through `stale-reply` (a destroyed / aborted
+  attempt whose entry is still live lowers to `:cancelled` via
+  `failure-reply`, and its public error target does NOT run). All surfaces
+  still route through the shared `re-frame.reply/suppress` and spell
+  `:cancelled` identically — uniform where it matters; the obsolescence
+  DETERMINATION is correctly surface-specific."
   (:require [re-frame.reply :as reply]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/spec/Managed-Effects.md
+++ b/spec/Managed-Effects.md
@@ -224,7 +224,7 @@ If validation fails:
 
 ### Cancellation
 
-Cancellation is represented as **data**, not as the absence of a reply. Explicit user cancellation that is still live MAY dispatch a `:status :cancelled` reply (with `:cancelled? true` and `:cancel/reason`); supersession cancellation should usually suppress the old app reply as `:status :stale`/`:suppressed`. Actor-destroy cancellation is delivered by the owning surface and completes through this same envelope: `:status :cancelled` when the actor-bound target is still meaningful, `:status :stale`/`:suppressed` when teardown made the target obsolete before delivery.
+Cancellation is represented as **data**, not as the absence of a reply. Explicit user cancellation that is still live MAY dispatch a `:status :cancelled` reply (with `:cancelled? true` and `:cancel/reason`); supersession cancellation should usually suppress the old app reply as `:status :stale`/`:suppressed`. Actor-destroy cancellation is delivered by the owning surface and completes through this same envelope: `:status :cancelled` when the actor-bound target is still meaningful, `:status :stale`/`:suppressed` when teardown made the target obsolete before delivery. The *obsolete-target* check itself is surface-specific by design: HTTP needs an explicit target-identity gate (`actor-destroy-target-obsolete?`) because it alone re-dispatches a reply at a caller-supplied event target; resources/mutations gate obsolescence on work-id/generation entry-liveness, and machines split late-obsolete arrivals into separate semantic `:stale` paths — so none of the sibling surfaces needs HTTP's predicate.
 
 ### Causal completion metadata
 


### PR DESCRIPTION
Implements accepted bead **rf2-wwfn7q** per Mike's ruling: DOCUMENT the obsolete-target stale-suppression asymmetry as by-design. Do NOT generalize HTTP's `actor-destroy-target-obsolete?` predicate. Doc-only.

## The ruling, in one line
HTTP is the only EP-0011 surface that re-dispatches a reply at a **caller-supplied event target**, so TARGET-identity obsolescence is only definable there. Machines and resources already detect obsolescence with gates suited to their surface — they don't need HTTP's predicate, and importing it would be less precise.

## Changes (comments + one spec sentence only — zero behaviour change)

**1. `implementation/machines/src/re_frame/machines/reply.cljc`** — header note:
> HTTP carries an `actor-destroy-target-obsolete?` predicate that lowers a destroyed-actor reply to `:stale`/`:suppressed` when the reply TARGET names the destroyed actor. Machines have NO counterpart, **by design** — obsolete-target suppression is HTTP-specific. A machine cancel is not a re-dispatch at a caller-supplied target: it is a TERMINAL completion/correlation row (`cancelled-actor-reply` — no `:value`, no dispatch, no caller target) that closes the work-ledger row as `:cancelled`. Machines model obsolescence split by SEMANTICS, not target-identity: late-obsolete arrivals are `stale-spawn-reply` / `stale-join-child-reply` / `after-stale-reply`; proactive teardown is the `:cancelled` `cancelled-actor-reply`. All surfaces still route through the shared `re-frame.reply/suppress` and spell `:cancelled` identically — the obsolescence DETERMINATION is correctly surface-specific.

**2. `implementation/resources/src/re_frame/resources/reply.cljc`** — header note:
> Resources/mutations have NO `target-obsolete?` counterpart, **by design**. Resource/mutation reply targets are framework-INTERNAL (`:rf.resource.internal/*` / `:rf.mutation.internal/*`), never a caller-supplied app event, so obsolescence is gated on WORK-ID + GENERATION ENTRY-LIVENESS, not target-identity. `live-entry-for-reply` verifies the live entry's `:current-work` == reply `:work/id` AND `:generation` == reply `:generation`, returning nil (→ `stale-reply` suppression) for a cross-frame/stale/superseded/vanished reply. All surfaces route through the shared `re-frame.reply/suppress` and spell `:cancelled` identically.

**3. `spec/Managed-Effects.md` §Cancellation (line 227)** — one clarifying sentence:
> The *obsolete-target* check itself is surface-specific by design: HTTP needs an explicit target-identity gate (`actor-destroy-target-obsolete?`) because it alone re-dispatches a reply at a caller-supplied event target; resources/mutations gate obsolescence on work-id/generation entry-liveness, and machines split late-obsolete arrivals into separate semantic `:stale` paths — so none of the sibling surfaces needs HTTP's predicate.

## Quality gates
```
$ python -m mkdocs build --strict   # docs gate (rm -rf docs/spec && cp -r spec docs/spec first)
INFO    -  Documentation built in 12.93 seconds
EXIT=0   (no WARNING/ERROR/Aborted lines)

$ npm run test:cljs                 # confirm no behaviour change
Ran 7861 tests containing 32567 assertions.
0 failures, 0 errors.
```

Confirmed **zero behaviour change** — comments + one spec sentence only.
