### PR TITLE
refactor(test-runner): remove producer-less [rf-sensitive] redaction layer (rf2-bvru0a)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -450,70 +450,6 @@
       (flush [])
       (close []))))
 
-;; ----------------------------------------------------------------------
-;; Test-output diagnostic projection boundary (EP-0015, rf2-j49rb3).
-;;
-;; This runner is the SHARED test-output sink for the whole repo's suites,
-;; including warning-heavy privacy suites. EP-0015 makes projection
-;; centralized at log / test-output boundaries: a sink replays
-;; already-projected records, never raw owner-local payloads. The buffered
-;; stderr ring is opaque bytes from ANY namespace, so the sink cannot
-;; path-classify it; what it CAN — and per EP-0015 MUST — do is be an
-;; explicit projection boundary that fails closed for owner-local payloads
-;; a producer wraps in the framework sensitive convention.
-;;
-;; The convention is value-free egress (the `re-frame.mcp-base.sensitive`
-;; rf2-el9sw rule, generalized to test output): a producer that has an
-;; owner-local payload it must NOT let reach a CI / test log wraps it in the
-;; `[rf-sensitive] … [/rf-sensitive]` sentinel. The sink redacts the wrapped
-;; payload to the `:rf/redacted` sentinel at replay — the PROJECTED evidence
-;; (the surrounding diagnostic text + the redaction marker) survives, the raw
-;; payload does not. Content with no marker is treated as already-projected
-;; and replayed verbatim (the upstream producer is responsible for projecting
-;; before it hits the wire, per EP-0015's "sinks receive projected records").
-
-;; The framework redaction sentinel (`re-frame.privacy/redacted-sentinel`),
-;; spelled as a literal here so this test-only artefact stays decoupled from
-;; core (it has NO dep on `implementation/core` — see deps.edn — and its own
-;; tests run UNDER this runner, so a core require would couple the sink to the
-;; framework runtime it is meant to observe). Kept in lockstep with
-;; `re-frame.privacy/redacted-sentinel` by convention.
-(def ^:private privacy-redacted :rf/redacted)
-
-(def ^:private sensitive-open  "[rf-sensitive]")
-(def ^:private sensitive-close "[/rf-sensitive]")
-
-(defn project-diagnostic
-  "Project one buffered test-output diagnostic string for replay (EP-0015,
-  rf2-j49rb3). Any payload wrapped in the `[rf-sensitive] … [/rf-sensitive]`
-  owner-local convention is redacted to the `:rf/redacted` sentinel so the
-  raw payload never reaches the replayed CI / test log; the projected
-  evidence around it survives. Idempotent and value-free on the redacted
-  span. Content with no marker passes through unchanged (already-projected
-  upstream). The single named test-output projection seam — a stricter sink
-  policy installs here."
-  [^String s]
-  (if (and s (.contains s sensitive-open))
-    (loop [acc (StringBuilder.) i 0]
-      (let [open (.indexOf s sensitive-open i)]
-        (if (neg? open)
-          (.toString (.append acc (.substring s i)))
-          (let [after-open (+ open (.length sensitive-open))
-                close      (.indexOf s sensitive-close after-open)]
-            (if (neg? close)
-              ;; Unterminated marker — fail closed: redact to end of string
-              ;; rather than risk leaking a payload whose terminator was
-              ;; trimmed off the ring or split across a flush.
-              (-> acc
-                  (.append (.substring s i open))
-                  (.append (str privacy-redacted))
-                  (.toString))
-              (recur (-> acc
-                         (.append (.substring s i open))
-                         (.append (str privacy-redacted)))
-                     (+ close (.length sensitive-close))))))))
-    s))
-
 (defn- install-summary-replay-hook!
   "Install a `clojure.test/report :summary` override that REPLAYS the
   buffered stderr (`sb`) to `real-err` when the run is RED, then delegates
@@ -531,7 +467,7 @@
   The replay goes to the REAL stderr (the `*err*` ring is still bound at
   this point, so we must NOT use `*err*`/`println` here or the replay
   would feed straight back into the buffer).  Each captured chunk is
-  written verbatim; a header marks it as a red-run replay so it is
+  written VERBATIM; a header marks it as a red-run replay so it is
   distinguishable from the reporter's own stdout, mirroring the CLJS
   replay's `[test-quiet]` prefix.  On green the buffer is simply dropped
   (never written)."
@@ -541,18 +477,12 @@
       (let [{:keys [fail error]} m]
         (when (and (pos? (+ (or fail 0) (or error 0)))
                    (pos? (.length sb)))
-          ;; EP-0015 (rf2-j49rb3): replay the buffered stderr through the
-          ;; test-output projection seam, never raw — an owner-local payload a
-          ;; producer wrapped in the `[rf-sensitive]` convention is redacted to
-          ;; the `:rf/redacted` sentinel here, so it does not reach the CI /
-          ;; test log; the projected diagnostic evidence around it survives.
-          (let [captured  (.toString sb)
-                projected (project-diagnostic captured)]
+          (let [captured (.toString sb)]
             (.write real-err
-                    (str "\n[test-quiet] buffered stderr (projected) replayed"
+                    (str "\n[test-quiet] buffered stderr replayed"
                          " because the run was RED:\n"))
-            (.write real-err projected)
-            (when-not (.endsWith projected "\n")
+            (.write real-err captured)
+            (when-not (.endsWith captured "\n")
               (.write real-err "\n"))
             (.flush real-err))))
       ;; Delegate to the prior :summary so the canonical

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -66,73 +66,22 @@
                (subvec buf' (- n warn-buffer-cap))
                buf')))))
 
-;; Test-output diagnostic projection boundary (EP-0015, rf2-j49rb3) — the
-;; CLJS-node counterpart of the JVM runner's `project-diagnostic`. This node
-;; runner is the shared CLJS test-output sink for warning-heavy privacy
-;; suites; EP-0015 makes it an explicit projection boundary that replays
-;; already-projected records, never raw owner-local payloads. The buffered
-;; `console.warn` args are opaque values from ANY namespace, so the sink
-;; cannot path-classify them; what it MUST do is fail closed for an
-;; owner-local payload a producer wraps in the framework sensitive
-;; convention. A string arg containing `[rf-sensitive] … [/rf-sensitive]`
-;; has the wrapped payload redacted to the `:rf/redacted` sentinel; a
-;; non-string arg that is itself marked sensitive is redacted wholesale.
-
-(def ^:private sensitive-open  "[rf-sensitive]")
-(def ^:private sensitive-close "[/rf-sensitive]")
-(def ^:private privacy-redacted
-  ;; `re-frame.privacy/redacted-sentinel`, spelled literally so this
-  ;; test-only ns stays decoupled from core (it requires no core ns and runs
-  ;; the core tests under itself). Kept in lockstep by convention.
-  :rf/redacted)
-
-(defn project-diagnostic
-  "Project one buffered `console.warn` arg for replay (EP-0015, rf2-j49rb3).
-  A string carrying the `[rf-sensitive] … [/rf-sensitive]` owner-local
-  convention has the wrapped payload (or the tail, if unterminated — fail
-  closed) redacted to the `:rf/redacted` sentinel; the projected evidence
-  around it survives. Non-string / non-marked args pass through (the
-  upstream producer projects before egress). The single named CLJS
-  test-output projection seam."
-  [arg]
-  (if (and (string? arg) (str/includes? arg sensitive-open))
-    (let [tail-redacted
-          ;; A bare opener with no closer fails closed: redact from the
-          ;; opener to end of string.
-          (loop [s arg]
-            (let [open (str/index-of s sensitive-open)]
-              (if (nil? open)
-                s
-                (let [after-open (+ open (count sensitive-open))
-                      close      (str/index-of s sensitive-close after-open)]
-                  (if (nil? close)
-                    (str (subs s 0 open) privacy-redacted)
-                    (recur (str (subs s 0 open)
-                                privacy-redacted
-                                (subs s (+ close (count sensitive-close))))))))))]
-      tail-redacted)
-    arg))
-
 (defn- replay-buffered-warnings!
   "Replay the buffered warnings to stderr, prefixed so they are
   distinguishable from the test reporter's own stdout output.  Called
   from the `:end-run-tests` reporter ONLY on a red run, restoring the
   diagnostic context the green-path quieting withheld.
 
-  EP-0015 (rf2-j49rb3): each buffered arg is replayed through the
-  `project-diagnostic` seam — never raw — so an owner-local payload a
-  producer wrapped in the `[rf-sensitive]` convention is redacted before it
-  reaches the CI / test log."
+  Each buffered arg is replayed VERBATIM."
   []
   (let [buffered @warn-buffer]
     (when (seq buffered)
       (binding [*print-fn* (fn [s] (js/process.stderr.write s))]
         (println (str "[test-quiet] " (count buffered)
                       " console.warn message(s) buffered during this run"
-                      " (projected, replayed because the run was RED):"))
+                      " (replayed because the run was RED):"))
         (doseq [args buffered]
-          (apply println "[test-quiet] console.warn:"
-                 (map project-diagnostic args)))))))
+          (apply println "[test-quiet] console.warn:" args))))))
 
 ;; The stub carries a `re-frame.test-quiet/silenced` marker property so it
 ;; is IDENTIFIABLE: a contract test can assert the live `console.warn` is

--- a/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
@@ -26,14 +26,7 @@
   (when armed?
     ;; A stray runtime warning of exactly the class the green-path stub
     ;; withholds. It must survive to the RED output via the buffer replay.
-    (js/console.warn "RED-WARN-FIXTURE-MARKER diagnostic context")
-    ;; EP-0015 (rf2-j49rb3): a diagnostic carrying an owner-local payload
-    ;; wrapped in the `[rf-sensitive]` convention. The red-replay projection
-    ;; seam must redact the wrapped span to the `:rf/redacted` sentinel — the
-    ;; surrounding evidence (`PROJ-EVIDENCE-MARKER`) survives, the raw payload
-    ;; (`SUPER-SECRET-TOKEN`) does NOT reach the CI / test log.
-    (js/console.warn
-      "PROJ-EVIDENCE-MARKER token=[rf-sensitive]SUPER-SECRET-TOKEN[/rf-sensitive] end"))
+    (js/console.warn "RED-WARN-FIXTURE-MARKER diagnostic context"))
   ;; GREEN unless armed: the consolidated whole-suite run keeps passing.
   (is (or (not armed?) (= :expected :actual))
       "armed fixture fails so the run is RED and the buffer replays"))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -779,45 +779,9 @@
               (str "the buffered stderr must be REPLAYED on a RED run"
                    " (rf2-nrk066); got\n--- stdout ---\n" out
                    "\n--- stderr ---\n" err))
-          (is (str/includes? err "buffered stderr (projected) replayed because the run was RED")
-              (str "the replay must be labelled (and marked PROJECTED — EP-0015"
-                   " rf2-j49rb3) so it is distinguishable from the reporter's"
-                   " own output; got stderr:\n" err)))))))
-
-(deftest red-replay-projects-sensitive-owner-local-payload
-  (testing "EP-0015 (rf2-j49rb3): a buffered diagnostic carrying an
-            owner-local payload wrapped in the `[rf-sensitive]` convention is
-            PROJECTED on red replay — the raw payload is redacted to the
-            `:rf/redacted` sentinel, while the surrounding diagnostic evidence
-            survives. The test-output sink is an explicit projection boundary;
-            it must not replay raw owner-local payloads to the CI / test log."
-    (with-fixture-dir
-      (fn [dir]
-        ;; A failing test whose stderr diagnostic embeds a secret wrapped in
-        ;; the owner-local sensitive convention. The sink must redact the
-        ;; wrapped span and keep the structural evidence either side.
-        (write-fixture! dir "red_projected_fixture_test" "red-projected-fixture-test"
-                        (str "(deftest a-sensitive-warning-and-failing-test"
-                             " (binding [*out* *err*]"
-                             "   (println \"DRIFT-EVIDENCE-MARKER token=[rf-sensitive]SUPER-SECRET-TOKEN[/rf-sensitive] end\"))"
-                             " (is (= :exp :act)))"))
-        (let [{:keys [exit out err]} (run-runner dir)]
-          (is (= 1 exit)
-              (str "the sensitive-warning-and-failing suite is red; must exit 1;"
-                   " got " exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
-          ;; PROJECTED EVIDENCE survives: the surrounding diagnostic text and
-          ;; the redaction sentinel reach the replayed stderr.
-          (is (str/includes? err "DRIFT-EVIDENCE-MARKER")
-              (str "the projected diagnostic evidence must survive the red"
-                   " replay; got stderr:\n" err))
-          (is (str/includes? err ":rf/redacted")
-              (str "the redacted span must surface as the :rf/redacted"
-                   " sentinel; got stderr:\n" err))
-          ;; RAW OWNER-LOCAL PAYLOAD does NOT leak to stdout OR stderr.
-          (is (not (str/includes? (str out err) "SUPER-SECRET-TOKEN"))
-              (str "the raw owner-local payload must NOT reach the replayed"
-                   " CI / test log (EP-0015 rf2-j49rb3); got"
-                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err)))))))
+          (is (str/includes? err "buffered stderr replayed because the run was RED")
+              (str "the replay must be labelled so it is distinguishable from"
+                   " the reporter's own output; got stderr:\n" err)))))))
 
 ;; ----------------------------------------------------------------------
 ;; Subprocess-harness pipe-deadlock regression — rf2-spzkgo.

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -521,38 +521,6 @@
             (str "a green run must emit ONLY the canonical summary lines;"
                  " got:\n" (str/join "\n" non-blank)))))))
 
-(deftest red-replay-projects-sensitive-owner-local-payload
-  (testing "EP-0015 (rf2-j49rb3): a buffered console.warn carrying an
-            owner-local payload wrapped in the `[rf-sensitive]` convention is
-            PROJECTED on red replay — the raw payload is redacted to the
-            `:rf/redacted` sentinel, while the surrounding diagnostic evidence
-            survives. The CLJS test-output sink is an explicit projection
-            boundary; it must not replay raw owner-local payloads."
-    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
-          {status :status stdout :stdout stderr :stderr err :error
-           timed-out? :timed-out?}
-          (spawn-runner [(str "--test=" red-ns)]
-                        {:env {:RF2_TQ_RED_WARN_FIXTURE "1"}})
-          combined (str stdout stderr)]
-      (is (nil? err)
-          (str "spawning the real runner must not error; got: " (pr-str err)))
-      (is (not timed-out?) "the armed fixture run must not time out")
-      (is (and (number? status) (not (zero? status)))
-          (str "the armed fixture is RED; must exit NONZERO; got " status
-               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
-      ;; PROJECTED EVIDENCE survives the red replay.
-      (is (str/includes? combined "PROJ-EVIDENCE-MARKER")
-          (str "the projected diagnostic evidence must survive the red replay;"
-               " got\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
-      (is (str/includes? combined ":rf/redacted")
-          (str "the redacted span must surface as the :rf/redacted sentinel;"
-               " got\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
-      ;; RAW OWNER-LOCAL PAYLOAD does NOT leak.
-      (is (not (str/includes? combined "SUPER-SECRET-TOKEN"))
-          (str "the raw owner-local payload must NOT reach the replayed CI /"
-               " test log (EP-0015 rf2-j49rb3); got\n--- stdout ---\n" stdout
-               "\n--- stderr ---\n" stderr)))))
-
 ;; ----------------------------------------------------------------------
 ;; Shared spawn timeout/output policy (rf2-8dfq5j.3).
 ;;


### PR DESCRIPTION
@
## Summary

Removes the test-quiet `[rf-sensitive] … [/rf-sensitive]` text-marker redaction layer from both quiet runners. The marker was **producer-less**: a `git grep` over tracked files (excl `.beads`) for `rf-sensitive` hit ONLY the two runner sources, their two contract tests, and the one fixture — zero hits in `spec/`, `docs/`, or `implementation/core/`. The redact branch in `project-diagnostic` only fired on the marker, so on real input only the pass-through branch ever ran (dead-on-real-input).

The real privacy primitive is different in kind: `re-frame.privacy/redacted-sentinel` = `:rf/redacted` is a DATA VALUE substituted by path at the framework egress seams (`elide-wire-value`/`project-egress`), where sinks receive already-projected structured records — never wrapped in `[rf-sensitive]` text and written to stderr/console.warn. The test runner is a TRUSTED in-process surface, not the MCP/network egress boundary, so the layer redacted a wire shape that never reaches the wire.

Implements bead **rf2-bvru0a** (Mike-recorded ruling: ACCEPT Option A; Claude + Codex concur on the identical slice).

## What changed

- **`runner.clj`** (JVM): deleted `project-diagnostic`, the `sensitive-open`/`sensitive-close` consts + the `privacy-redacted` literal, and the EP-0015 comment blocks. `install-summary-replay-hook!` now writes the captured stderr VERBATIM; header is `[test-quiet] buffered stderr replayed because the run was RED:` (dropped the "(projected)" wording).
- **`shadow_node.cljs`** (CLJS node): deleted `project-diagnostic`, the marker/sentinel consts, and the EP-0015 comment block. `replay-buffered-warnings!` now applies `println` to the buffered args VERBATIM; header dropped the "(projected,)" wording. (`clojure.string` require kept — still used by the unknown-selector guard.)
- **Tests**: deleted the two `[rf-sensitive]` contract tests (`red-replay-projects-sensitive-owner-local-payload` in both the JVM contract test and the CLJS shadow-node test). Updated the KEEP `red-run-replays-buffered-stderr` label assertion to match the new verbatim header. In the CLJS fixture, deleted ONLY the `[rf-sensitive]`-bearing `console.warn` (+ comment); the `RED-WARN-FIXTURE-MARKER` warn that drives the process-boundary red-replay regression is kept.

Net: 5 files, +12 / -208.

## Residue check (zero remaining `rf-sensitive`)

`git grep -n "rf-sensitive" -- :!.beads` → **no matches**. (The two `privacy-redacted-data-never-raw` hits in `tools/xray/` are the unrelated framework `:rf/redacted` data-value privacy test, explicitly distinguished from this text marker in the bead.)

`git grep "projected|project-diagnostic|sensitive-open|sensitive-close" -- implementation/test-quiet` → **no matches**.

## KEEP items — UNTOUCHED, each regression-backed

- **Banner filter** (`runner.clj`, rf2-lbo79.2) — unchanged.
- **stderr/console.warn buffering + red-replay mechanics** (rf2-nrk066 / rf2-8dfq5j.2) — only the redaction step in the replay was removed; buffer ring, red-only replay, green-drop, and the `[test-quiet] console.warn:` label all unchanged; the red-replay regression tests pass.
- **Strict green-output + unknown-arg guard** (`shadow_node.cljs` `execute-cli`, rf2-14nojy.1/rf2-spzkgo) — unchanged; the false-green selector guard tests pass.

## Quality gates

- `clojure -M:test` (JVM quiet-runner contract tests, self-spawns the real runner): **Ran 23 tests / 83 assertions. 0 failures, 0 errors.**
- `npm run test:cljs` (CLJS node-test, includes the test-quiet CLJS contract + red-replay + strict-green tests): **Ran 7860 tests / 32561 assertions. 0 failures, 0 errors.**
- `npm run test:script-policy && npm run test:script-helpers` (the CI "JS harness self-tests (quiet reporters + path policy)" gate): **all passed.**
- `npm run test:browser` — **skipped**: the change touches only the JVM + CLJS-node quiet sinks (`runner.clj`, `shadow_node.cljs`); the `:browser-test` build does not import `shadow_node.cljs`/`project-diagnostic` (confirmed by the residue grep), so browser test reporting is unaffected.
@