### PR TITLE
docs(ssr): :replace-app-db->:replace-frame-state docstring sweep + drop dead emit aliases (rf2-1i3yea)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -44,7 +44,7 @@
   rf2-3hhv5): it swaps each `<template>` fallback for its resolved subtree
   in-place and merges the per-subtree `data-rf2-suspense-hydrate` delta as
   chunks arrive, reconciling against the final `__rf_payload`
-  (`:replace-app-db`) when it lands."
+  (`:replace-frame-state`) when it lands."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]

--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -4,7 +4,7 @@
 ;; Per Spec 011 the server-side rendering and hydration surface — the
 ;; pure hiccup → HTML emitter (`render-to-string`), the structural
 ;; render-tree hash (`render-tree-hash`), the `:rf/hydrate` event with
-;; `:replace-app-db` semantics, the `:rf.server/set-status` /
+;; `:replace-frame-state` semantics, the `:rf.server/set-status` /
 ;; `:rf.server/set-header` / `:rf.server/append-header` /
 ;; `:rf.server/set-cookie` / `:rf.server/delete-cookie` /
 ;; `:rf.server/redirect` server-only fx family, the per-request HTTP

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -19,8 +19,9 @@
     - Pure hiccup → HTML emitter (HTML5 void elements, doctype prefix,
       attr/text escaping, `:tag#id.cls` parsing, registered-view
       resolution). Per Spec 011 §The render-tree → HTML emitter.
-    - `:rf/hydrate` event with `:replace-app-db` semantics; the server-
-      supplied payload's `:rf/app-db` replaces the client app-db.
+    - `:rf/hydrate` event with `:replace-frame-state` semantics; the server-
+      supplied payload's `:rf/app-db` replaces the client frame-state
+      (app-db + serializable runtime-db).
     - The six `:rf.server/*` response-shape fxs gated by `:platforms
       #{:server}`; the accumulator at `[:rf/response]` is consumed by
       the host adapter after drain. Per §HTTP response contract.

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -23,7 +23,7 @@
   `re-frame.ssr.constants/payload-script-id` id; the boot helper reads
   that SAME id (`document.getElementById`), parses the EDN with the same
   reader the server's `pr-str` round-trips through, and seeds the frame
-  via the framework's `:rf/hydrate` event (locked `:replace-app-db`
+  via the framework's `:rf/hydrate` event (locked `:replace-frame-state`
   policy, Spec 011 §The :rf/hydrate event).
 
   Before this helper every host re-implemented the same read → dispatch →
@@ -218,7 +218,7 @@
     2. HYDRATE — `dispatch-sync` `[:rf/hydrate payload]` against the
                  target frame BEFORE the first render, so the frame's
                  app-db is the server's authoritative slice when the view
-                 first evaluates (locked `:replace-app-db` policy, Spec
+                 first evaluates (locked `:replace-frame-state` policy, Spec
                  011 §The :rf/hydrate event). Skipped when there is no
                  payload (client-only first load) — the caller renders
                  against the empty app-db.

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -16,9 +16,9 @@
 
   HTML escape helpers (`escape-html`, `escape-attr`, `attr-string`) live
   in `re-frame.ssr.html-helpers` — shared with the head/meta emitter per
-  rf2-x7g10. Public-surface aliases are re-exported below so consumers
-  who `:require [re-frame.ssr.emit :as emit]` keep seeing them at
-  `emit/escape-html` / `emit/escape-attr` / `emit/attr-string`.
+  rf2-x7g10. `attr-string` is re-exported below so consumers who
+  `:require [re-frame.ssr.emit :as emit]` keep seeing it at
+  `emit/attr-string`; the emitter calls `html/escape-html` directly.
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
@@ -32,13 +32,13 @@
 
 ;; ---- shared HTML helpers (rf2-x7g10) --------------------------------------
 ;;
-;; Re-export the helpers so callers that `:require [re-frame.ssr.emit :as
-;; emit]` still resolve `emit/escape-html` etc. The producing ns is
+;; Re-export `attr-string` so callers that `:require [re-frame.ssr.emit :as
+;; emit]` still resolve `emit/attr-string`. The producing ns is
 ;; `re-frame.ssr.html-helpers` (shared with `re-frame.ssr.head.emit`); the
-;; entity-escape rules live there once.
+;; entity-escape rules live there once. `escape-html` / `escape-attr` are
+;; consumed directly via the `html/` alias — they have no `emit/`-qualified
+;; consumers (rf2-1i3yea).
 
-(def escape-html html/escape-html)
-(def escape-attr html/escape-attr)
 (def attr-string html/attr-string)
 
 ;; Per HTML5 spec, these elements are void — they self-close and have no
@@ -347,7 +347,7 @@
   ([el root-attrs]
    (cond
      (nil? el)         ""
-     (string? el)      (escape-html el)
+     (string? el)      (html/escape-html el)
      (number? el)      (str el)
      (boolean? el)     ""
      (vector? el)
@@ -495,7 +495,7 @@
          :else (str el)))
 
      (sequential? el) (emit-children el)
-     :else (escape-html el))))
+     :else (html/escape-html el))))
 
 (defn render-to-string
   "Pure hiccup → HTML string. Per Spec 011 §The render-tree → HTML

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -367,7 +367,7 @@
                     :frame    frame
                     :recovery :warned-and-replaced}))))
 
-;; ---- handler fns for the six :rf.server/* fxs ----------------------------
+;; ---- handler fns for the seven :rf.server/* fxs --------------------------
 
 (defn set-status-fx
   "Handler fn for `:rf.server/set-status`. Last-write-wins; multi-write

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -44,7 +44,7 @@
 
   - `build-final-payload` — after every continuation has drained,
     constructs the canonical `:rf/hydration-payload`. The client
-    `:rf/hydrate`s against this with `:replace-app-db` semantics — the
+    `:rf/hydrate`s against this with `:replace-frame-state` semantics — the
     final payload wins, deltas were speculative.
 
   All three are pure-ish helper fns; the host adapter (`ssr-ring/streaming`)
@@ -629,7 +629,7 @@
 (defn build-final-payload
   "After every continuation has drained, construct the canonical
   `:rf/hydration-payload` for the `__rf_payload` final chunk. The
-  client `:rf/hydrate`s against this with `:replace-app-db` semantics
+  client `:rf/hydrate`s against this with `:replace-frame-state` semantics
   — the final payload wins, deltas were speculative.
 
   Mirrors `re-frame.ssr.ring.payload/build-payload`'s shape so the

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -46,7 +46,7 @@
       speculative state.
 
   When the final `__rf_payload` lands, the bootstrap (`ssr/hydrate!`)
-  dispatches `:rf/hydrate` with `:replace-app-db` semantics — the
+  dispatches `:rf/hydrate` with `:replace-frame-state` semantics — the
   deltas were speculative, the final payload is the correctness lock.
   `install!` reconciles by disconnecting its observer once it sees the
   final-payload node, so no stray delta can race the canonical state.


### PR DESCRIPTION
## rf2-1i3yea — SSR doc-hygiene

SOURCE/COMMENT/dead-alias only. No behaviour change. spec/011 is NOT touched (the six->seven server-fx count there is a separate deferred hot-zone follow-up, sequenced after #4532).

### (1) `:replace-app-db` -> `:replace-frame-state`
Retired the old vocab across 6 ssr docstrings + 1 deps comment, plus ssr-ring:
- `implementation/ssr/src/re_frame/ssr.cljc` (also reworded "replaces the client app-db" -> "replaces the client frame-state (app-db + serializable runtime-db)")
- `implementation/ssr/src/re_frame/ssr/boot.cljc` (x2)
- `implementation/ssr/src/re_frame/ssr/streaming.cljc` (x2)
- `implementation/ssr/src/re_frame/ssr/streaming/client.cljs`
- `implementation/ssr/deps.edn`
- `implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj`

The shipped contract event is `:replace-frame-state`.

### (2) `six` -> `seven` `:rf.server/*` fxs
`response.cljc` section comment. Seven `*-fx` handlers ship: set-status, set-header, append-header, set-cookie, delete-cookie, redirect, safe-redirect (the seventh, rf2-zfm8v).

### (3) Drop dead emit re-export aliases
`emit.cljc` — dropped `(def escape-html …)` + `(def escape-attr …)`. Zero `emit/`-qualified consumers across the repo (verified via `git grep`; only `.beads/issues.jsonl` + the ns docstring referenced them).
- `escape-attr` was fully unused.
- `escape-html` had two internal call sites in `emit-element` — inlined to `html/escape-html` so the public alias surface is removed with no behaviour change.
- `attr-string` kept (live: `emit/attr-string` consumed by `streaming.cljc` + tests).

Docstring + section comment updated to match.

## Quality gates
```
cd implementation && npm run test:cljs
# Ran 7860 tests containing 32552 assertions. 0 failures, 0 errors.

cd implementation/ssr && clojure -M:test
# Ran 366 tests containing 1465 assertions. 0 failures, 0 errors.

cd implementation/ssr-ring && clojure -M:test
# Ran 165 tests containing 755 assertions. 0 failures, 0 errors.
```
mkdocs not installed locally; no `docs/` or `spec/` files are touched, so the strict docs build is unaffected (CI covers it).

Closes rf2-1i3yea.