### PR TITLE
refactor(xray): extract replay-vector-deletes + pluralize helper; drop dead aliases/cheat-sheet row (rf2-lkehao)

### DIFF
--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -561,9 +561,10 @@ Buffer tab:
   ring. Default `200`.
 - `:cascades-retained` — count of cascades retained in each frame's
   trace ring. Mirrors
-  `re-frame.trace.tooling/default-cascades-retained` (`50`) and
-  writes through to `(rf/configure! :trace-buffer {:cascades-retained
-  N})` once the Settings UX wires the runtime knob (per rf2-43koh).
+  `re-frame.trace.tooling/default-cascades-retained` (`50`). Stored +
+  persisted only; no settings effect writes it through to the runtime
+  ring (there is no `apply-cascades-retained!` counterpart to
+  `apply-epoch-history!`, which resizes the live epoch ring on change).
   Renamed from `:trace-buffer/keep` (events) at rf2-43koh — the unit
   changed from events to cascades when Xray's separate ring was
   retired in favour of the framework's per-frame cascade-keyed rings

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1043,9 +1043,10 @@
     in the xray epoch buffer.
   - `:cascades-retained` (default 50) — count of cascades retained
     in each frame's trace ring. Mirrors
-    `re-frame.trace.tooling/default-cascades-retained` and writes
-    through to `(rf/configure! :trace-buffer {:cascades-retained N})`
-    when the Settings UX wires the runtime knob (per rf2-43koh).
+    `re-frame.trace.tooling/default-cascades-retained`. Stored +
+    persisted only; no settings effect currently writes it through to
+    the runtime ring (there is no `apply-cascades-retained!` — unlike
+    `:epoch-history`, which `apply-epoch-history!` resizes live).
     Renamed from `:trace-buffer/keep` per the rf2-3g9nw D1=a ruling:
     the unit changed from events (1000) to cascades (50) when
     Xray's separate ring was retired in favour of the framework's

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -393,6 +393,42 @@
 ;;
 ;; This is a per-vector linear walk, O(N + edits-per-vector). Pure.
 
+(defn- replay-vector-deletes
+  "Replay Editscript's `:-` edits against a live `survivors` list of
+  ORIGINAL before-indices and return `{:removed :survivors}`.
+
+  Editscript applies `:-` edits SEQUENTIALLY against a progressively-
+  shrinking sequence: each `:-` at edit-index `i` removes the element
+  CURRENTLY occupying index `i`, AFTER all prior `:-` at this parent have
+  already been applied. A contiguous tail deletion therefore repeats the
+  SAME edit-index (`[1 2 3] → [1]` ⇒ `[[1] :-] [[1] :-]`), and a scattered
+  deletion uses post-shift indices (`[:a :b :c :d] → [:a :c]` ⇒ `[[1] :-]
+  [[2] :-]`). These are NOT stable before-indices.
+
+  `survivors` starts as `(range before-len)`. For each delete edit-index
+  `i` in Editscript order we record `survivors[i]` into `:removed` (in
+  removal order) then splice it out, so what remains in `:survivors` are
+  the before-indices of all surviving elements in after-order. An out-of-
+  range edit-index (should not happen for well-formed Editscript output)
+  is skipped rather than crashing the projection. Pure.
+
+  Used by both `shift-suffixes-for-vector` (`:survivors`) and
+  `resolve-vector-removals` (`:removed`)."
+  [before-len delete-idxs]
+  (loop [survivors  (vec (range before-len))
+         [i & more] delete-idxs
+         removed    []]
+    (if (nil? i)
+      {:removed removed :survivors survivors}
+      (if (and (>= i 0) (< i (count survivors)))
+        (recur (into (subvec survivors 0 i)
+                     (subvec survivors (inc i)))
+               more
+               (conj removed (nth survivors i)))
+        ;; Defensive: a malformed out-of-range edit-index is skipped
+        ;; rather than crashing the projection.
+        (recur survivors more removed)))))
+
 (defn- shift-suffixes-for-vector
   "Given an after-vector's length + the per-position edits Editscript
   emitted at this vector's path, return a map
@@ -443,17 +479,7 @@
         ;; Step 1+2 — replay the `:-` deletes against the survivor list of
         ;; original before-indices, removing the post-shift slot each time.
         survivors-after-deletes
-        (loop [survivors  (vec (range before-len))
-               [i & more] delete-edit-idxs]
-          (if (nil? i)
-            survivors
-            (recur (if (and (>= i 0) (< i (count survivors)))
-                     (into (subvec survivors 0 i)
-                           (subvec survivors (inc i)))
-                     ;; Defensive: a malformed out-of-range edit-index is
-                     ;; skipped rather than crashing the projection.
-                     survivors)
-                   more)))
+        (:survivors (replay-vector-deletes before-len delete-edit-idxs))
         ;; Step 3 — splice insert-markers (nil) at each `:+` after-index so
         ;; the slot vector aligns position-for-position with the after-vector.
         slots
@@ -854,21 +880,7 @@
   `{:before-index :before-value}` in before-index order. Pure."
   [edits bvec]
   (let [edit-idxs (mapv (fn [e] (peek (first e))) edits)
-        recovered (loop [survivors (vec (range (count bvec)))
-                         [i & more] edit-idxs
-                         acc        []]
-                    (if (nil? i)
-                      acc
-                      (if (and (>= i 0) (< i (count survivors)))
-                        (let [orig (nth survivors i)]
-                          (recur (into (subvec survivors 0 i)
-                                       (subvec survivors (inc i)))
-                                 more
-                                 (conj acc orig)))
-                        ;; Defensive: an out-of-range edit-index (should not
-                        ;; happen for well-formed Editscript output) is
-                        ;; skipped rather than crashing the projection.
-                        (recur survivors more acc))))]
+        recovered (:removed (replay-vector-deletes (count bvec) edit-idxs))]
     (->> recovered
          sort
          (mapv (fn [orig] {:before-index orig

--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -67,21 +67,6 @@
   ;; tone; `:success`/`:error` are the reference's green/red tokens.
   (case mode :in (:success tokens) :out (:error tokens)))
 
-(defn- format-pattern
-  "Render the pill's pattern text. Keywords render with their leading
-  `:`; strings render verbatim. nil / blank falls back to `<empty>`
-  so a partially-saved pill is still visually addressable.
-
-  Kept for back-compat call sites; new code routes through
-  `typed/pill-label` so each kind picks its own format."
-  [pattern]
-  (cond
-    (nil? pattern)              "<empty>"
-    (keyword? pattern)          (str pattern)
-    (and (string? pattern)
-         (seq pattern))         pattern
-    :else                       "<empty>"))
-
 (defn- pill-kind
   "Read the pill's `:kind` slot, canonicalising via the typed-
   predicate ns so legacy `{:pattern …}` pills surface as

--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_helpers.cljc
@@ -79,7 +79,8 @@
     - Cross-frame causality — single-cascade-anchor scope only.
     - Multi-anchor merging — each call returns ONE cascade. The subs
       pick which anchor to focus (focused-machine or focused-event)."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.common-helpers :as common]))
 
 ;; ---- canonical operation sets -------------------------------------------
 
@@ -510,17 +511,14 @@
       "No cancellation cascade in the trace window."
 
       (= :no-aborts (:empty-kind cascade))
-      (str teardowns " child destroyed"
-           (when (not= 1 teardowns) "s")
+      (str teardowns " " (common/pluralize teardowns "child destroyed")
            " · 0 effects aborted")
 
       :else
       (str/join " · "
-                (cond-> [(str teardowns " child"
-                              (when (not= 1 teardowns) "ren")
+                (cond-> [(str teardowns " " (common/pluralize teardowns "child" "ren")
                               " destroyed")
-                         (str aborts " effect"
-                              (when (not= 1 aborts) "s")
+                         (str aborts " " (common/pluralize aborts "effect")
                               " aborted")]
                   elapsed-s (conj (str elapsed-s " elapsed")))))))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/common_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/common_helpers.cljc
@@ -88,6 +88,21 @@
 
 ;; ---- formatting ---------------------------------------------------------
 
+(defn pluralize
+  "Return `noun` with its plural suffix appended iff `n` is not exactly 1.
+
+  The canonical English-count pluralizer shared across every panel
+  helper that renders a `<count> <noun>` summary — `1 descriptor` vs
+  `2 descriptors`, `1 row` vs `0 rows`. Returns the NOUN only (no count),
+  so callers compose it as `(str n \" \" (pluralize n \"descriptor\"))`.
+
+  The 2-arg form appends `\"s\"`. The 3-arg form takes an explicit
+  `plural-suffix` for irregular nouns (e.g. `(pluralize n \"child\"
+  \"ren\")` → `child` / `children`). Pure; JVM-runnable."
+  ([n noun] (pluralize n noun "s"))
+  ([n noun plural-suffix]
+   (str noun (when (not= 1 n) plural-suffix))))
+
 (defn format-time-hms
   "Render `t` (ms-since-epoch) as `HH:MM:SS.mmm`. Pure-ish — uses the
   platform Date constructor. Canonical shared formatter — the trace,

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -68,6 +68,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
+            [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.format :as fmt]
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
@@ -5258,7 +5259,7 @@
                 (pos? m)
                 (str m " unmounted")
                 :else
-                (str n " view" (when (not= 1 n) "s") " re-rendered"))]
+                (str n " " (common/pluralize n "view") " re-rendered"))]
     [:div {:data-testid "rf-xray-epoch-step-views"
            :data-step-kw "views"}
      (numbered-circle step-number :VIEWS)

--- a/tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc
@@ -55,7 +55,8 @@
   helper. A frame object / generation / image is presented as the inert data
   it already is — `make-frame` returns an inert map and `assemble` seals an
   inert generation (EP-0023 §Image — \"an image is data, not registration\")."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.common-helpers :as common]))
 
 ;; ===========================================================================
 ;; Generation projection — an image as its `[kind id]` descriptor set
@@ -256,8 +257,8 @@
   generation): `N descriptors · K kinds`. Pure `data -> string`;
   JVM-testable."
   [{:keys [descriptor-count kinds] :as _image}]
-  (str descriptor-count " descriptor" (when (not= 1 descriptor-count) "s")
-       " · " (count kinds) " kind" (when (not= 1 (count kinds)) "s")))
+  (str descriptor-count " " (common/pluralize descriptor-count "descriptor")
+       " · " (count kinds) " " (common/pluralize (count kinds) "kind")))
 
 (def no-images-caption
   "The calm empty-state caption the image/frame sections render when NO live

--- a/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
@@ -305,9 +305,11 @@
 
 (defn- has-http-op?
   "True when any event in `events` is a `:rf.http/*` or `:http/*`
-  trace. Both namespaces are surfaced by the managed-HTTP substrate
-  (`:rf.http/` is the canonical Spec 009 prefix; `:http/` is the
-  legacy alias still in use by some adapters)."
+  trace. `:rf.http/` is the canonical Spec 009 prefix emitted by the
+  managed-HTTP substrate; the bare `:http/` branch is fixture-only
+  (exercised by the l2-timeline test fixtures, not emitted by any
+  real adapter) — kept defensively so a host that hand-rolls the bare
+  prefix still classifies."
   [events]
   (boolean
    (some (fn [ev]

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -93,6 +93,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panels.module-view-helpers :as h]
             [day8.re-frame2-xray.panels.image-view-helpers :as ih]
             [day8.re-frame2-xray.panels.image-view-reads :as image-reads]
@@ -211,8 +212,7 @@
   [module-row]
   (let [{:keys [registration-kinds registration-count]} module-row]
     (if (seq registration-kinds)
-      (str registration-count " descriptor"
-           (when (not= 1 registration-count) "s")
+      (str registration-count " " (common/pluralize registration-count "descriptor")
            " (" (str/join " · " (map name registration-kinds)) ")")
       "no registrations")))
 
@@ -255,7 +255,7 @@
               :style       realm-id-style}
        (str realm)]
       [:span {:style realm-meta-style}
-       (str "· " frame-count " frame" (when (not= 1 frame-count) "s"))]]
+       (str "· " frame-count " " (common/pluralize frame-count "frame"))]]
      (when (seq frames)
        [:div {:data-testid (str "rf-xray-module-view-realm-" rid-name "-frames")
               :style       realm-frames-style}

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
@@ -62,7 +62,8 @@
   pure data → data projection (realm address-space assembly, the
   module-row shape, the single/multi-realm classification) lives here so
   it runs under the JVM unit-test target (`clojure -M:test`)."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.common-helpers :as common]))
 
 ;; ---- realm / frame address space (EP-0013 disposition 3) ----------------
 
@@ -320,4 +321,4 @@
   "A one-line plain-language summary for a realm row — `<realm-id> · N
   frame(s)`. Pure data → string; JVM-testable."
   [{:keys [realm frame-count] :as _realm-row}]
-  (str realm " · " frame-count " frame" (when (not= 1 frame-count) "s")))
+  (str realm " · " frame-count " " (common/pluralize frame-count "frame")))

--- a/tools/xray/src/day8/re_frame2_xray/panels/overflow_indicator.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/overflow_indicator.cljc
@@ -62,8 +62,7 @@
                      :color       (:text-secondary tokens)
                      :margin-right "4px"}}
       (str "+" hidden-count)]
-     " row"
-     (when (not= 1 hidden-count) "s")
+     (str " " (common/pluralize hidden-count "row"))
      " hidden — narrow the filter or selection to see more."]))
 
 (defn capped-list

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -750,8 +750,7 @@
             ["Esc"          "Close modal / collapse popover / focus event list"]
             ["Ctrl+K / ⌘K"  "Command palette"]
             ["Ctrl+F"       "Find within active tab"]
-            ["o"            "Popout (window.open whole shell)"]
-            ["c"            "Causality popover (from any tab)"]]}
+            ["o"            "Popout (window.open whole shell)"]]}
    {:group "Ribbon nav cluster"
     :rows  [["j"     "Back one event (◀)"]
             ["k"     "Forward one event (▶)"]
@@ -882,10 +881,10 @@
 ;;   `settings/effects.cljs §apply-epoch-history!`). Slot stays under
 ;;   `:general` for back-compat with the persisted settings shape;
 ;;   only the popup home moved here (rf2-pu9sb).
-;; * Cascades retained (slot `:buffer :cascades-retained`) — wired to
-;;   the framework's per-frame trace ring depth via
-;;   `(rf/configure! :trace-buffer {:cascades-retained N})` (rf2-43koh
-;;   consumer substrate).
+;; * Cascades retained (slot `:buffer :cascades-retained`) — stored +
+;;   persisted only. No settings effect writes it through to the
+;;   framework's per-frame trace ring (there is no
+;;   `apply-cascades-retained!` counterpart to `apply-epoch-history!`).
 ;; * App-db inspector collapse threshold (slot
 ;;   `:buffer :app-db/inspector-collapse-threshold`) — stored for the
 ;;   inspector layer.

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -124,6 +124,7 @@
             [day8.re-frame2-xray.filters.pills :as filter-pills]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as app-db-segment-inspector]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cancellation-cascade]
@@ -935,8 +936,7 @@
   (when (pos? redacted-count)
     [:span {:data-testid "rf-xray-redacted-indicator"
             :title       (str "Spec 009 §Privacy: " redacted-count
-                              " sensitive trace event"
-                              (when (not= 1 redacted-count) "s")
+                              " " (common/pluralize redacted-count "sensitive trace event")
                               " suppressed by default. Set "
                               ":rf.xray/egress-profile :rf.egress/local-raw "
                               "via (xray-config/configure! ...) to "
@@ -1752,7 +1752,7 @@
                    :color       (:text-primary tokens)}}
      [:span {:data-testid "rf-xray-filters-hidden-count"
              :style {:font-weight 500 :color (:warning tokens) :white-space "nowrap"}}
-      (str hidden " event" (when (not= 1 hidden) "s") " filtered out")]]))
+      (str hidden " " (common/pluralize hidden "event") " filtered out")]]))
 
 (rf/reg-view events-ribbon
   "L1.5 **events ribbon** (bar-2) — reconciled to the Figma-Make surface

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/instances_jump.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/instances_jump.cljs
@@ -51,9 +51,6 @@
      (dispatch-fn [:rf.xray/select-machine-id machine-id]))
    nil))
 
-;; Back-compat alias for direct callers / tests that used the old name.
-(def dispatch-jump! dispatch-jump-via)
-
 (defn dispatch-jump-sync!
   "Test-only synchronous variant. Production code paths through the
   async `dispatch-jump-via` because UI clicks are inherently async;

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -537,10 +537,13 @@
 
 (def missing-sentinel
   "Marker for a `:before` / `:after` slot that does not exist in its
-  side of the diff. Public so the `children-of-pair` / `diff-pair-count`
-  walkers can thread it without colliding with a real `nil` slot. The
-  CLASSIFIER side of the diff (which op to attach to each leaf) lives
-  in `day8.re-frame2-xray.diff.engine` per rf2-n2jig."
+  side of the diff. The `children-of-pair` / `diff-pair-count` walkers
+  thread this same `::missing` keyword (they live in THIS ns, so they
+  don't need it to be public). It stays public only so the
+  edn-inspector tests can assert the walker triples against the exact
+  sentinel value — distinct from `engine/missing-sentinel`
+  (`:day8.re-frame2-xray.diff.engine/missing`), which is the CLASSIFIER
+  side's marker per rf2-n2jig. Never collides with a real `nil` slot."
   ::missing)
 
 ;; ---- per-op token tables ------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs
@@ -196,7 +196,7 @@
           (is (fn? (th/extract-handler jump-chip :on-click))
               "jump chip carries no :on-click handler — the JUMP is wired but never fires")
           ;; Drive the production handler synchronously. The chip's own
-          ;; on-click calls `dispatch-jump!` (async); the test variant
+          ;; on-click calls `dispatch-jump-via` (async); the test variant
           ;; `dispatch-jump-sync!` is the same dispatcher with
           ;; `dispatch-sync` semantics — the canonical seam panel_cljs_test
           ;; uses to assert post-dispatch state without an event-queue flush.


### PR DESCRIPTION
Implements **rf2-lkehao** — tools/xray dedup + vestigial cleanup (from c3p9bp/5hbyki review).

## DEDUP
- **D1** Extracted a private `replay-vector-deletes [before-len delete-idxs] -> {:removed :survivors}` in `diff/engine.cljc`. `shift-suffixes-for-vector` consumes `:survivors`; `resolve-vector-removals` consumes `:removed`. Correctness-critical, byte-identical replay — pinned `engine_cljs_test` + `diff_engine_consistency` before AND after (1229 tests / 5580 assertions, unchanged both runs).
- **D2** Added `(pluralize n noun [plural-suffix])` to `panels/common_helpers.cljc`; replaced 12 inline `(when (not= 1 n) "s")` sites across `image_view_helpers`, `module_view` / `module_view_helpers`, `overflow_indicator`, `cancellation_cascade_helpers` (the `child`/`children` case uses the 3-arg `"ren"` form), `epoch/view`, `shell`. All rendered strings byte-identical.

## VESTIGIAL
- **V1** Deleted dead `dispatch-jump!` back-compat alias (`instances_jump.cljs`); fixed the stale test comment (the chip on-click actually calls `dispatch-jump-via`).
- **V2** Deleted dead private `format-pattern` (`pills.cljs`).
- **V3** Deleted dead `["c" "Causality popover (from any tab)"]` cheat-sheet row (`settings/view.cljs`) — `spec/007 §Retired keys` already documents `c` as unused (Causality dropped, rf2-y0z5b), and no `c` keybinding handler exists.
- **V5** Fixed contradicted docstrings:
  - `:cascades-retained` is **stored + persisted only** (no `apply-cascades-retained!` wire-through) — corrected in `config.cljc`, `settings/view.cljs`, and `spec/015-Configuration.md`.
  - `l2_timeline` `:http/` branch is **fixture-only** (exercised by the l2-timeline test fixtures, not emitted by any real adapter), not a "legacy alias still in use by some adapters".
  - `edn_inspector` `missing-sentinel` docstring corrected to state the real reason it stays public.

### Deviation note
The bead asked to make `edn_inspector` `missing-sentinel` `^:private`. It is **kept public**: the `edn_inspector_cljs_test` suite pins `ei/missing-sentinel` (~15 refs) and these assert the exact walker-triple sentinel value (distinct from `engine/missing-sentinel`). Making it private breaks the CLJS gate. The false "Public so the same-ns walkers can thread it" justification was the actual smell — corrected in the docstring instead.

**V4 Buffer knobs untouched** (separate decision bead rf2-5u03ig).

## Quality gates
\`\`\`
cd implementation && npm run test:cljs && npm run test:bundle-isolation
# + tools/xray JVM: clojure -M:test in tools/xray
\`\`\`
- xray JVM (`clojure -M:test`): **1229 tests / 5580 assertions, 0 failures, 0 errors** (identical before + after D1 — byte-identity proof)
- `npm run test:cljs`: **7860 tests / 32552 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation`: **PASS** (22 artefact entries; 40 internal sentinels absent; uix/helix/reagent-free PASS)

### Spec update
Per the standing rule: `spec/015-Configuration.md` updated for the V5 `:cascades-retained` fix. D1 needs no spec change — `spec/004-App-DB-Diff.md §shift-suffix` already documents that both channels "use the same replay" (D1 makes that literal in code). `pluralize` / `replay-vector-deletes` are internal private helpers with no spec surface.