### PR TITLE
refactor(core): remove 7 zero-caller helpers + correct stale late-bind directory descriptions (rf2-ip63uo)

### DIFF
--- a/implementation/core/src/re_frame/adapter/sub_override_context.cljs
+++ b/implementation/core/src/re_frame/adapter/sub_override_context.cljs
@@ -62,21 +62,6 @@
 (when interop/debug-enabled?
   (set! (.-displayName ^js override-context) "rf2-sub-overrides"))
 
-(defn provider-element
-  "Build a React element for the override-context Provider with
-  `overrides` (a `{query-vector value}` map, or nil) as its value and
-  `children` as its child elements. Substrate-agnostic — the Reagent
-  adapter wraps it via `:>` interop, UIx/Helix via `$`.
-
-  Returns a raw React element so callers don't pay for an extra
-  `reagent.core/as-element` walk (mirrors
-  `re-frame.adapter.context/provider-element`)."
-  [overrides & children]
-  (apply React/createElement
-         (.-Provider override-context)
-         #js {:value overrides}
-         children))
-
 (defn current-overrides
   "Read the closest enclosing Provider's override map off the shared
   context object's `_currentValue` (the substrate-portable path that

--- a/implementation/core/src/re_frame/disposable.cljs
+++ b/implementation/core/src/re_frame/disposable.cljs
@@ -29,8 +29,7 @@
   follows CLJS convention for internal protocol methods: the protocol
   is a structural extension point, callers reach it through
   `re-frame.interop`'s thin wrappers (which in turn route through the
-  late-bind `:adapter/*` hook table). Users do not call these directly."
-  (:refer-clojure :exclude []))
+  late-bind `:adapter/*` hook table). Users do not call these directly.")
 
 (defprotocol IDisposable
   "Cross-substrate disposal protocol owned by re-frame. The

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -654,10 +654,6 @@
   [v]
   (and (map? v) (contains? v :rf.size/large-elided)))
 
-(defn handle?
-  [v]
-  (and (vector? v) (= :rf.elision/at (first v))))
-
 ;; ---------------------------------------------------------------------------
 ;; Derived-tree VALUE-based redaction (EP-0015 issue 2, rf2-i783h0).
 ;;

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -173,7 +173,7 @@
 (defonce ^{:doc "A MONOTONIC generation integer for the framework-standard
   registry (EP-0023 §Image — the resolved-generation cache's
   framework-standard-registration generation key leg). Bumped on every
-  `register-standard!` / `forget-standard!` / `clear-standards!` mutation; read
+  `register-standard!` / `clear-standards!` mutation; read
   by the resolved-generation cache key so a cached generation is invalidated the
   instant any standard descriptor changes. Starts at 0."
             :private true}
@@ -183,8 +183,8 @@
 (defn standard-generation
   "The framework-standard registry's MONOTONIC generation integer (EP-0023
   §Image — the resolved-generation cache key's standard-registration leg).
-  Increments on every `register-standard!` / `forget-standard!` /
-  `clear-standards!`; equal across two reads ⇒ the standard set is unchanged and
+  Increments on every `register-standard!` / `clear-standards!`; equal across
+  two reads ⇒ the standard set is unchanged and
   a sealed generation assembled then may be reused."
   []
   @standard-generation*)
@@ -204,15 +204,6 @@
     (swap! standard-registry assoc [kind id] desc)
     (swap! standard-generation* inc)
     desc))
-
-(defn forget-standard!
-  "Remove the framework-standard descriptor for `[kind id]`. Mirror of
-  `register-standard!` for the standard owner's teardown path. Bumps the
-  standard generation."
-  [kind id]
-  (swap! standard-registry dissoc [kind id])
-  (swap! standard-generation* inc)
-  nil)
 
 (defn clear-standards!
   "Reset the framework-standard registry. Test fixtures use this between cases.
@@ -1067,7 +1058,7 @@
 ;;     never handed back for another (rf2-1x2zuc). ANY reg-*/forget-*/clear on
 ;;     the active store bumps its generation leg.
 ;;   * the framework-standard generation: `standard-generation` — ANY
-;;     register-standard!/forget-standard!/clear bumps it.
+;;     register-standard!/clear bumps it.
 ;;
 ;; For the EXPLICIT-POOL arity `(assemble images descriptors)` the registered
 ;; pool is supplied directly (tests / a pre-snapshotted store), NOT read from
@@ -1317,10 +1308,3 @@
   "The set of kinds present in a sealed `generation`'s resolver. Tools use this."
   [generation]
   (:rf.gen/kinds generation))
-
-(defn generation-ids
-  "The ids registered under `kind` in a sealed `generation`. Pure."
-  [generation kind]
-  (into #{}
-        (comp (filter #(= kind (first %))) (map second))
-        (keys (:rf.gen/resolver generation))))

--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -487,16 +487,3 @@
                         (or (interceptor-ref? entry)
                             (interceptor-value? entry))))
                  chain)))
-
-;; ---- handler-meta surface (Spec 001 §Source coords, metadata, handler-meta)-
-
-(defn interceptor-handler-meta
-  "The `handler-meta :interceptor` surface — the registered interceptor's
-  metadata + source coordinate by id, looked up through the active registrar
-  (Spec 001 §Source coords, metadata, and `handler-meta`). Returns nil when no
-  interceptor is registered under `id`. The stored `:rf/interceptor-descriptor`
-  is retained on the returned meta so tooling can introspect the descriptor
-  shape; production strips the pure-documentation `:doc` per the registrar
-  policy."
-  [id]
-  (registrar/lookup interceptor-kind id))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -160,11 +160,11 @@
    {:key         :marks/add-marks
     :producer-ns 're-frame.marks
     :design-bead "rf2-vw7f5"
-    :description "Additively merge path-marks into a frame's app-db (Spec 015 §App-db marks)."}
+    :description "Additively merge path-marks into a frame's app-db (Spec 015 §App-db marks). Hook retained for the directory contract; the `add-marks` façade export was removed (frame-marks are author-declared at reg-* time, not imperatively mutated), so the underlying `re-frame.marks/add-marks` survives only as an internal / test / generated-code surface, reached by direct require — not through this late-bind hook."}
    {:key         :marks/set-marks
     :producer-ns 're-frame.marks
     :design-bead "rf2-vw7f5"
-    :description "Replace the frame's app-db mark-set wholesale (Spec 015 §App-db marks)."}
+    :description "Replace the frame's app-db mark-set wholesale (Spec 015 §App-db marks). Like `:marks/add-marks`, the `set-marks` façade export was removed; the underlying `re-frame.marks/set-marks` survives as an internal / test / generated-code surface reached by direct require, not through this hook."}
    {:key         :marks/register-marks!
     :producer-ns 're-frame.marks
     :design-bead "rf2-vw7f5"
@@ -172,11 +172,11 @@
    {:key         :marks/union-marks!
     :producer-ns 're-frame.marks
     :design-bead "rf2-w46fpt"
-    :description "UNION a mark declaration into the existing per-(kind, id) marks entry (additive merge, vs register-marks!'s full replace) — the marks-table analogue of add-marks merging into the app-db elision registry. Consumed by re-frame.machines' reg-machine :data-schema redaction bridge (EP-0005): the schema's per-slot :sensitive? / :large? paths (snapshot-rooted under [:data …]) union into the machine's :event-keyed marks so a sensitive :data slot is redacted in snapshot egress (project-machine-tags) like an app-db slot, AND a machine that also carries a manual register-marks! keeps both sets (Spec 015 §union-by-source)."}
+    :description "UNION a mark declaration into the existing per-(kind, id) marks entry (additive merge, vs register-marks!'s full replace) — the marks-table analogue of add-marks merging into the app-db elision registry. The schema's per-slot :sensitive? / :large? paths (snapshot-rooted under [:data …]) union into the machine's :event-keyed marks so a sensitive :data slot is redacted in snapshot egress (project-machine-tags) like an app-db slot, AND a machine that also carries a manual register-marks! keeps both sets (Spec 015 §union-by-source). Hook retained for the directory contract; re-frame.machines' reg-machine :data-schema bridge (EP-0005) now reaches this fn by a direct `re-frame.marks` require, not through this late-bind hook."}
    {:key         :marks/marks-for
     :producer-ns 're-frame.marks
     :design-bead "rf2-w46fpt"
-    :description "Read the registered mark declaration for a (kind, id), or nil. For an :event-kind machine id, unions the author-sourced marks with the schema-sourced marks at read time (rf2-qpibk0). Consumed by re-frame.machines' reg-machine :data-schema bridge (EP-0005)."}
+    :description "Read the registered mark declaration for a (kind, id), or nil. For an :event-kind machine id, unions the author-sourced marks with the schema-sourced marks at read time (rf2-qpibk0). Hook retained for the directory contract; re-frame.machines (snapshot / SSR trace egress, EP-0005) now calls `re-frame.marks/marks-for` by direct require, not through this late-bind hook."}
    {:key         :marks/declare-machine-schema-marks!
     :producer-ns 're-frame.marks
     :design-bead "rf2-qpibk0"
@@ -1001,11 +1001,11 @@
    {:key         :trace.tooling/register-listener!
     :producer-ns 're-frame.trace.tooling
     :design-bead "rf2-r1ciy"
-    :description "Register a trace listener. Late-bound so `re-frame.frame/fire-on-destroy-event!` can install a one-shot listener around the `:on-destroy` dispatch (to re-emit `:rf.error/handler-exception` as `:rf.error/on-destroy-handler-exception`) without forcing the tooling sibling into production CLJS bundles."}
+    :description "Register a dev-trace listener. Hook retained for the directory contract (the family is published as one rf2-r1ciy seam), but the live consumers — tests, tools, and SSR's listener registration — call `re-frame.trace.tooling/register-listener!` directly. The former `:on-destroy`-throw capture that drove this hook from `re-frame.frame/fire-on-destroy-event!` migrated to the production-survivable always-on axis (`:error-emit/register-error-listener!`) under EP-0008 / rf2-87f7fb."}
    {:key         :trace.tooling/unregister-listener!
     :producer-ns 're-frame.trace.tooling
     :design-bead "rf2-r1ciy"
-    :description "Drop a trace listener. Sibling of `:trace.tooling/register-listener!` — same rf2-r1ciy seam."}
+    :description "Drop a dev-trace listener. Sibling of `:trace.tooling/register-listener!` — same rf2-r1ciy seam; same direct-call consumers (tests / tools / SSR)."}
 
    ;; ---- re-frame.trace.tooling — per-frame trace rings (rf2-g1b2m / rf2-8uwce) ----
    ;;
@@ -1073,10 +1073,13 @@
    ;;
    ;; The three hooks let `re-frame.epoch/settle!` reach the aggregator
    ;; (`:trace.cascade/capture-for-epoch!`) without requiring the
-   ;; cascade ns, and let Xray's Reactive panel publish / withdraw its
-   ;; focus predicate (`set-focus-predicate!` / `clear-focus-predicate!`)
-   ;; through the same registry the rest of the substrate uses. The
-   ;; cascade ns is JVM-autoloaded from `re-frame.core` only; CLJS
+   ;; cascade ns; the focus-predicate pair (`set-focus-predicate!` /
+   ;; `clear-focus-predicate!`) publishes the install / withdraw surface
+   ;; through the same registry the rest of the substrate uses. (No Xray
+   ;; consumer ships against the focus-predicate hooks today — the only
+   ;; in-tree caller is the core `trace_cascade_captured_test`, which
+   ;; drives the aggregator directly via `re-frame.trace.cascade/<name>`.)
+   ;; The cascade ns is JVM-autoloaded from `re-frame.core` only; CLJS
    ;; production builds DCE the ns so the hooks are simply unbound on
    ;; the prod side.
    {:key         :trace.cascade/capture-for-epoch!
@@ -1086,11 +1089,11 @@
    {:key         :trace.cascade/set-focus-predicate!
     :producer-ns 're-frame.trace.cascade
     :design-bead "rf2-931pm"
-    :description "Install the predicate the aggregator consults at end-of-epoch (`(fn [frame-id epoch-id event-id] truthy?)`). Xray's Reactive panel calls this at mount."}
+    :description "Install the predicate the aggregator consults at end-of-epoch (`(fn [frame-id epoch-id event-id] truthy?)`). Hook published for a focus-publishing consumer to drive at mount; no Xray consumer ships against it today — the only in-tree caller is the core `trace_cascade_captured_test`, which calls `re-frame.trace.cascade/set-focus-predicate!` directly."}
    {:key         :trace.cascade/clear-focus-predicate!
     :producer-ns 're-frame.trace.cascade
     :design-bead "rf2-931pm"
-    :description "Restore the no-op default focus predicate (no epoch focused). Xray's Reactive panel calls this on unmount."}
+    :description "Restore the no-op default focus predicate (no epoch focused). Withdraw counterpart of `:trace.cascade/set-focus-predicate!`; same no-Xray-consumer status — only the core `trace_cascade_captured_test` calls `re-frame.trace.cascade/clear-focus-predicate!` directly."}
 
    ;; NOTE (rf2-7pgiz): `:subs/resolve-sub-override` — the SUBSTITUTIVE
    ;; dev-only sub-override seam consulted by `re-frame.subs/subscribe`

--- a/implementation/core/src/re_frame/observability.cljc
+++ b/implementation/core/src/re_frame/observability.cljc
@@ -138,12 +138,6 @@
   (reset! sinks {})
   nil)
 
-(defn registered-sink-ids
-  "Return the set of currently-registered sink ids. Introspection surface
-  (Xray's observability panel) — pure (modulo the registry read)."
-  []
-  (set (keys @sinks)))
-
 ;; ---- routing --------------------------------------------------------------
 ;;
 ;; The default egress profile when a sink entry omits `:rf.egress/profile`.

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -13,7 +13,7 @@
   hot fast path — `emit!` / `emit-error!` / `*handler-scope*` and the
   bracket macros. The public-tooling surface (`register-listener!` /
   `unregister-listener!` / `clear-listeners!` / `trace-buffer` /
-  `clear-trace-buffer!` / `configure-trace-buffer!` / `configure`) and
+  `clear-trace-buffer!` / `configure-trace-buffer!`) and
   the buffer + listener state live in the sibling
   `re-frame.trace.tooling`, which is loaded only when a test fixture,
   tool, or dev preload requires it.
@@ -487,4 +487,3 @@
 (def trace-buffer           trace-tooling/trace-buffer)
 (def clear-trace-buffer!    trace-tooling/clear-trace-buffer!)
 (def configure-trace-buffer! trace-tooling/configure-trace-buffer!)
-(def configure              trace-tooling/configure)

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -2,7 +2,7 @@
   "Trace tooling sibling of `re-frame.trace` — carries the public
   dev-tooling surface (`register-listener!` / `unregister-listener!` /
   `clear-listeners!` / `trace-buffer` / `clear-trace-buffer!` /
-  `configure-trace-buffer!` / `configure`) and the per-frame
+  `configure-trace-buffer!`) and the per-frame
   cascade-keyed trace rings + listener state.
 
   ## Per-frame trace rings (rf2-g1b2m / rf2-8uwce)
@@ -689,15 +689,6 @@
               rings
               rings))))
   nil)
-
-(defn configure
-  "Generic config dispatch. Recognises :trace-buffer; future config knobs
-  add cases here. Per Spec 009 §Per-frame trace rings
-  (`(rf/configure! :trace-buffer {:cascades-retained N})`)."
-  [k opts]
-  (case k
-    :trace-buffer (configure-trace-buffer! opts)
-    nil))
 
 ;; ---- delivery hook ------------------------------------------------------
 ;;


### PR DESCRIPTION
Implements **rf2-ip63uo** — DELICATE kernel vestigial cleanup (from the gtnfro core review). Removes the 7 grep-verified zero-caller helpers + 1 empty-ns no-op, and corrects 3 stale late-bind directory descriptions whose cited consumers have migrated. The underlying late-bound fns are KEPT (live via direct calls); only their directory descriptions are corrected so the late-bind-drift-test authority holds. No out-of-scope items touched.

## Removals (each re-verified zero-caller via repo-wide `git grep` over tracked files)

| # | Item | Grep proof |
|---|------|------------|
| 1 | `interceptor_registry.cljc` `interceptor-handler-meta` | `git grep interceptor-handler-meta` → only the defn line (+ the bead in `.beads`). Zero callers. |
| 2 | `image_assembly.cljc` `forget-standard!` | `git grep forget-standard!` → only the defn + 3 doc enumerations (now corrected). Zero call sites. |
| 3 | `image_assembly.cljc` `generation-ids` | `git grep generation-ids` → only the defn line. Zero callers. (`generation-kinds`, which HAS test callers, kept.) |
| 4 | `trace/tooling.cljc` `configure` + its re-export `trace.cljc` `(def configure …)` | `git grep` for `(configure …)` fn-calls / `trace-tooling/configure` → only doc strings + the def/defn. The real path is `core/configure!` (`core.cljc:2989`) routing `:trace-buffer` straight to the `:trace.tooling/configure-trace-buffer!` hook (`core.cljc:3017`), bypassing this generic dispatch dup. Zero callers. |
| 5 | `elision.cljc` `handle?` | `git grep -w handle?` → only the defn; other hits (`host-handle?`, `host-asserts-own-handle?`) are distinct symbols. Zero callers. (`marker?`, kept, is out of scope.) |
| 6 | `observability.cljc` `registered-sink-ids` | `git grep registered-sink-ids` → only the defn line. Zero callers. |
| 7 | `adapter/sub_override_context.cljs` `provider-element` (the **DEAD** one) | `git grep provider-element` → no `sub-override-context/provider-element` call anywhere. The story tool requires the ns but consumes only `ovr-ctx/override-context` + `ovr-ctx/current-overrides`; it builds its own Provider inline (`sub_overrides.cljc:243`). The **LIVE** `adapter/context.cljs:65 provider-element` is **untouched**. Zero callers. |

**Trivial no-op:** dropped the empty `(:refer-clojure :exclude [])` on `disposable.cljs`.

**Necessary follow-on doc cleanups for the removed fns** (so source no longer names deleted fns): trimmed `forget-standard!` from 3 doc enumerations in `image_assembly.cljc`; trimmed `configure` from the public-surface docstrings in `trace.cljc` + `trace/tooling.cljc`.

## Doc-in-code corrections (`late_bind/directory.cljc` descriptions — underlying fns kept)

- **`:trace.tooling/register-listener!` / `unregister-listener!`** — old text claimed `frame/fire-on-destroy-event!` installs a one-shot listener via this hook. That `:on-destroy`-throw capture **migrated to `:error-emit/register-error-listener!`** (EP-0008 / rf2-87f7fb; confirmed at `frame.cljc:1777-1778` + `error_emit.cljc:431`). Corrected to: live consumers are tests / tools / SSR calling `re-frame.trace.tooling/<name>` directly.
- **`:marks/union-marks!` / `marks-for` / `add-marks` / `set-marks`** — old text said "Consumed by re-frame.machines' reg-machine bridge" via the hook. Machines now reaches these by a **direct `re-frame.marks` require** (`machines/ssr.cljc:52,89`); no `get-fn` consumer of these keys exists anywhere. `add/set` façade exports were removed (now internal/test/generated-code surfaces). Descriptions corrected.
- **`:trace.cascade/set-focus-predicate!` / `clear-focus-predicate!`** — old text claimed "Xray's Reactive panel calls this at mount/unmount". **No Xray consumer exists**; the only in-tree caller is the core `trace_cascade_captured_test`. Block comment + both descriptions corrected.

## Out of scope (NOT touched — need separate ruling)
`derivation/graph.cljc` `node-id`, `subs.cljc` + `subs/tooling.cljc` case-defaults, `marks.cljc` `clear-app-db-marks!`, `subs/cache.cljc` `unsubscribe!` 2-arity, `views.cljs` `mint-instance-token!`, `router_transducer.cljc` (design scaffold). Verified no out-of-scope file appears in the diff.

## Quality gates (all green)
```
cd implementation/core && clojure -M:test
  → Ran 1804 tests, 7852 assertions, 0 failures, 0 errors (includes late-bind-drift-test)
cd implementation && npm run test:cljs
  → Ran 7860 tests, 32552 assertions, 0 failures, 0 errors
npm run test:elision
  → PASS: production 41/41 absent; EP-0023 1/1 provenance-survives + 1/1 assembly-DCE; control 41/41 present
cd implementation/scripts/api-manifest && clojure -M -m re-frame.api-manifest.gen --check
  → OK: spec/api-manifest.edn in sync (510 public vars)
```
**api-manifest:** none of the 7 removed fns are manifest rows (the probe covers the public-API namespaces — `re-frame.core`, adapters, epoch, flows, … — not the internal kernel namespaces these helpers live in), so no regeneration was needed; `--check` is in sync.