### PR TITLE
refactor(story): dedup reg-variant codegen + status descriptors; drop dead test-only helpers (rf2-8fr3yd)

### DIFF
--- a/tools/story/src/re_frame/story/author_expectations.cljc
+++ b/tools/story/src/re_frame/story/author_expectations.cljc
@@ -471,13 +471,8 @@
                     doc     (conj [:doc (pr-str doc)])
                     extends (conj [:extends (pr-str extends)])
                     true    (conj [:assertions (pr-assertions-vector merged)])
-                    true    (conj [:tags (pr-str #{:test})]))
-        body-str  (->> body-keys
-                       (map (fn [[k v]] (str k " " v)))
-                       (str/join "\n   "))]
-    (str "(" alias "/reg-variant "
-         (pr-str (or variant-id :story.expectations/example))
-         "\n  {" body-str "})")))
+                    true    (conj [:tags (pr-str #{:test})]))]
+    (pred/reg-variant-form alias (or variant-id :story.expectations/example) body-keys)))
 
 ;; ===========================================================================
 ;; DEFAULT NEW-VARIANT ID

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -634,13 +634,15 @@
       (run-toggle-off-callbacks! nil)))
   nil)
 
-;; ---- legacy single-knob shims (deprecated; tests + back-compat) ----------
+;; ---- legacy single-knob shim (deprecated; configure! + tests) ------------
 ;;
-;; The pre-rf2-6z4znr single process-global surface (`set-egress-profile!` /
-;; `get-egress-profile` / the no-arg `include-sensitive?`) is retained as a
-;; thin shim over the session-pin so existing test fixtures and the
-;; `configure!` path keep working. These operate on the SESSION-PIN, never on
-;; a per-frame override — the per-frame act is `set-frame-egress-profile!`.
+;; The pre-rf2-6z4znr single process-global setter (`set-egress-profile!`) is
+;; retained as a thin shim over the session-pin so the `configure!` session-
+;; default path + existing fixtures keep working. It operates on the SESSION-
+;; PIN, never on a per-frame override — the per-frame act is
+;; `set-frame-egress-profile!`. To READ the session-pin, deref
+;; `session-egress-profile`; for a frame's effective profile use
+;; `resolve-egress-profile`.
 
 (defn set-egress-profile!
   "DEPRECATED single-knob shim (rf2-6z4znr): sets the SESSION-PIN profile.
@@ -650,26 +652,16 @@
   [profile]
   (set-session-egress-profile! profile))
 
-(defn get-egress-profile
-  "Return the current SESSION-PIN profile (the tool-UX default for frames
-  with no per-frame override). For a specific frame's effective profile use
-  `resolve-egress-profile`."
-  []
-  @session-egress-profile)
-
 (defn include-sensitive?
   "True iff the profile resolved for `frame-id` reveals sensitive values
   (i.e. resolves to `:rf.size/include-sensitive? true`). Every Story trace
   listener consults this (via `suppress-sensitive?`) — passing the frame the
   event / recording targets — to decide whether a `:sensitive?` event is
   shown or redacted. Frame-scoped (EP-0015 issue 7): revealing one frame
-  never reveals another. Fail-closed by default.
-
-  The no-arg arity reads the session-pin and is retained for back-compat
-  surfaces (DOM capture's element-level redaction, legacy callers); prefer
-  the `frame-id` arity at every per-event seam."
-  ([] (include-sensitive? nil))
-  ([frame-id] (profile-includes-sensitive? (resolve-egress-profile frame-id))))
+  never reveals another. Fail-closed by default. Pass `nil` to resolve
+  against the session-pin (a frameless / unknown-frame seam)."
+  [frame-id]
+  (profile-includes-sensitive? (resolve-egress-profile frame-id)))
 
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top

--- a/tools/story/src/re_frame/story/predicates.cljc
+++ b/tools/story/src/re_frame/story/predicates.cljc
@@ -18,6 +18,19 @@
   (the `:rf.assert/*` family)."
   "rf.assert")
 
+(def assertion-glyph
+  "Canonical assertion-outcome glyph map — the single source of truth for
+  the three assertion verdicts shared by the assertion strip, the test-
+  mode result table, and the step-through scrubber (rf2-8fr3yd). `:skip`
+  is an assertion-level verdict distinct from `theme.status/:cannot-run`
+  (which is a runner-tier status), so it is NOT a `theme.status` descriptor
+  — this is the assertion vocabulary, not the tool-wide status vocabulary.
+  Consumers supply their own fallback for non-assertion ticks (`:event`,
+  unknown). Pure data."
+  {:pass "✓"
+   :fail "✗"
+   :skip "⊘"})
+
 (defn parent-story-id
   "Derive a variant's parent story id by stripping the variant's name
   per /spec/007-Stories.md §Canonical id grammar — a variant id `:story.foo/bar`
@@ -70,6 +83,49 @@
   (review-dialog) just for this 4-line helper."
   [prefix]
   (str "\n" (apply str (repeat (count prefix) \space))))
+
+(defn reg-variant-envelope
+  "Wrap an already-rendered body string in the `(<alias>/reg-variant <id>
+  { … })` form-envelope every codegen builder emits. Pure data → string.
+
+  `body-str` renders verbatim between the body braces (the opening `{`
+  sits two spaces in under the form's opening paren). The eight Story
+  codegen builders share this wrapper; they differ only in how each
+  assembles `body-str` (Shape-A builders via `reg-variant-form` below;
+  play-export / view-state / schema-form via their own body shape).
+
+  Byte-identical to the hand-rolled envelope the builders previously
+  carried (rf2-8fr3yd). Builders that derive a default id or alias resolve
+  those at the call site and pass the resolved values in."
+  [alias variant-id body-str]
+  (str "(" alias "/reg-variant "
+       (pr-str variant-id)
+       "\n  {" body-str "})"))
+
+(defn reg-variant-form
+  "Render a `(<alias>/reg-variant <id> { … })` form whose body is a list
+  of `[key value-string]` pairs — the Shape-A codegen path shared by
+  save-variant / recorder / author-expectations / promotion. Pure data →
+  string.
+
+  Each pair renders as `key value-string` (`key` prints verbatim — a
+  keyword as `:foo`; `value-string` is already-rendered EDN), one per
+  line, the continuation aligned three spaces under the body's opening
+  `{`:
+
+      (reg-variant-form \"story\" :story.saved/x [[:extends \":story/a\"]
+                                                  [:args \"{}\"]])
+      ;; => \"(story/reg-variant :story.saved/x\\n  {:extends :story/a\\n   :args {}})\"
+
+  Byte-identical to the hand-rolled builders (rf2-8fr3yd). Lives in the
+  predicates leaf so every producer can `:require` it without cycle risk
+  (they already `:require` `indent-after` from here)."
+  [alias variant-id body-keys]
+  (reg-variant-envelope
+    alias variant-id
+    (->> body-keys
+         (map (fn [[k v]] (str k " " v)))
+         (str/join "\n   "))))
 
 ;; ---- predicate-symbol resolution -----------------------------------------
 

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -293,13 +293,8 @@
         body-keys   (cond-> []
                       doc     (conj [:doc (pr-str doc)])
                       extends (conj [:extends (pr-str extends)])
-                      true    (conj [:script script-map-str]))
-        body-str    (->> body-keys
-                         (map (fn [[k v]] (str k " " v)))
-                         (str/join "\n   "))]
-    (str "(" alias "/reg-variant "
-         (pr-str (or variant-id :story.recorded/example))
-         "\n  {" body-str "})")))
+                      true    (conj [:script script-map-str]))]
+    (pred/reg-variant-form alias (or variant-id :story.recorded/example) body-keys)))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: canonical assertion vocabulary

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -510,6 +510,4 @@
         body-str (->> body
                       (map (fn [[k v]] (str k v)))
                       (str/join "\n  "))]
-    (str "(" alias "/reg-variant "
-         (pr-str variant-id)
-         "\n  {" body-str "})")))
+    (pred/reg-variant-envelope alias variant-id body-str)))

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -318,13 +318,8 @@
   (let [body-keys (cond-> []
                     doc     (conj [:doc (pr-str doc)])
                     extends (conj [:extends (pr-str extends)])
-                    true    (conj [:args (pr-args-map (or args {}))]))
-        body-str  (->> body-keys
-                       (map (fn [[k v]] (str k " " v)))
-                       (str/join "\n   "))]
-    (str "(" alias "/reg-variant "
-         (pr-str (or variant-id :story.saved/example))
-         "\n  {" body-str "})")))
+                    true    (conj [:args (pr-args-map (or args {}))]))]
+    (pred/reg-variant-form alias (or variant-id :story.saved/example) body-keys)))
 
 ;; ---------------------------------------------------------------------------
 ;; Default-id derivation + dialog state shape

--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -54,6 +54,7 @@
             [reagent.core :as r]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.author-expectations :as author]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.ui.test-mode.pure :as tm-pure]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
@@ -269,10 +270,9 @@
    :skip (:glyph-skip styles)})
 
 (def status-glyph
-  "Status-glyph map. Public so tests can pin the shape."
-  {:pass "✓"
-   :fail "✗"
-   :skip "⊘"})
+  "Status-glyph map — the shared assertion-outcome vocabulary
+  (`predicates/assertion-glyph`). Public so tests can pin the shape."
+  pred/assertion-glyph)
 
 ;; ---- rendering ------------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/promotion.cljc
+++ b/tools/story/src/re_frame/story/ui/promotion.cljc
@@ -57,6 +57,7 @@
   `save-variant` + the substrate's `promote-run-artifact!`)."
   (:require [clojure.string :as str]
             [re-frame.story.artifact  :as artifact]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.promotion :as promotion]
             ;; `review-dialog` is `.cljc` — its pure transitions
             ;; (`default-variant-id-with-prefix` / `parse-variant-id-string`)
@@ -199,13 +200,8 @@
                         (keep (fn [k]
                                 (when (contains? body k)
                                   [k (pr-str (get body k))])))
-                        vec)
-        body-str   (->> body-keys
-                        (map (fn [[k v]] (str k " " v)))
-                        (str/join "\n   "))]
-    (str "(story/reg-variant "
-         (pr-str variant-id)
-         "\n  {" body-str "})")))
+                        vec)]
+    (pred/reg-variant-form "story" variant-id body-keys)))
 
 ;; ===========================================================================
 ;; CLJS-ONLY: the capture store

--- a/tools/story/src/re_frame/story/ui/schema_form.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_form.cljc
@@ -65,7 +65,8 @@
   (:require [clojure.string :as str]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
-            [re-frame.story.malli-schema :as msu]))
+            [re-frame.story.malli-schema :as msu]
+            [re-frame.story.predicates :as pred]))
 
 ;; ===========================================================================
 ;; PURE: scalar-schema → widget descriptor (flat shapes only)
@@ -336,11 +337,14 @@
   ([source-variant-id query-v value]
    (override-snippet source-variant-id query-v value false))
   ([source-variant-id query-v value from-edn?]
-   (let [v-str (pp-value value 20)]
-     (str "(story/reg-variant " (pr-str source-variant-id) "-pinned\n"
-          "  {:extends " (pr-str source-variant-id) "\n"
-          "   :sub-overrides {" (pr-str query-v) " " v-str "}})\n"
-          ";; pins " (pr-str query-v)
+   (let [v-str    (pp-value value 20)
+         pinned-id (keyword (namespace source-variant-id)
+                            (str (name source-variant-id) "-pinned"))]
+     (str (pred/reg-variant-envelope
+            "story" pinned-id
+            (str ":extends " (pr-str source-variant-id) "\n"
+                 "   :sub-overrides {" (pr-str query-v) " " v-str "}"))
+          "\n;; pins " (pr-str query-v)
           " for design exploration — lowest fidelity, never proof of sub logic."
           (when from-edn?
             "\n;; value entered as raw EDN (the output schema was not flat-renderable).")))))

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -71,6 +71,7 @@
             [re-frame.story.egress :as egress]
             [re-frame.story.malli-schema :as msu]
             [re-frame.story.plan :as plan]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.review-dialog :as review-dialog]
             [re-frame.story.share :as share]
@@ -307,9 +308,8 @@
                 vid
                 {:active-modes   (:active-modes shell)
                  :cell-overrides (get-in shell [:cell-overrides vid])})]
-      (str "(story/reg-variant " (pr-str vid) "\n"
-           "  {:extends " (pr-str vid) "\n"
-           "   :args " (pr-str eff) "})"))))
+      (pred/reg-variant-form "story" vid [[:extends (pr-str vid)]
+                                          [:args (pr-str eff)]]))))
 
 ;; ---- styling -------------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/sidebar_signals.cljc
+++ b/tools/story/src/re_frame/story/ui/sidebar_signals.cljc
@@ -41,7 +41,8 @@
   No signal is fabricated: a chip appears only when the variant body (or
   the run record) carries the data behind it."
   (:require [re-frame.story.plan         :as plan]
-            [re-frame.story.requirements :as requirements]))
+            [re-frame.story.requirements :as requirements]
+            [re-frame.story.theme.status :as status]))
 
 ;; ===========================================================================
 ;; AXIS 1 — STATUS
@@ -58,26 +59,23 @@
 ;; spec/018 §7.1 'SHOULD … after … exists' work).
 
 (def status-order
-  "Canonical render order for the status signal (spec/018 §12.6). `:running`
-  is the in-flight transient between `:pending` and a verdict. `:error` is a
-  tool/runtime/schema problem, DISTINCT from a failed expectation (`:fail`).
-  `:blocked` / `:dirty` / `:redacted` are the additional signal states the
-  spec names; they ride this axis as data lands."
-  [:pass :fail :cannot-run :error :running :pending :blocked :dirty :redacted])
+  "Canonical render order for the status signal — the shared
+  `theme.status/order` (spec/018 §12.6, the single status vocabulary).
+  `:running` is the in-flight transient between `:pending` and a verdict;
+  `:error` is a tool/runtime/schema problem DISTINCT from a failed
+  expectation (`:fail`); `:blocked` / `:dirty` / `:redacted` are the
+  additional signal states the spec names. Derived (not re-encoded) so the
+  sidebar can never drift from the tool-wide order (rf2-8fr3yd)."
+  status/order)
 
 (def status-labels
-  "Pure data → data: the compact chip label per status keyword (spec/018
-  §12.6 — pending / pass / fail / error / cannot-run / blocked / dirty /
-  redacted MUST be distinguishable in text, not only colour)."
-  {:pass       "pass"
-   :fail       "fail"
-   :cannot-run "cannot-run"
-   :error      "error"
-   :running    "running"
-   :pending    "pending"
-   :blocked    "blocked"
-   :dirty      "dirty"
-   :redacted   "redacted"})
+  "Pure data → data: the compact chip label per status keyword. Derived
+  from `theme.status/descriptors` — the single source of truth for the
+  status vocabulary (spec/018 §12.6 — pending / pass / fail / error /
+  cannot-run / blocked / dirty / redacted MUST be distinguishable in text,
+  not only colour). Single-sourced (not re-encoded) so the sidebar chip
+  label can never drift from the canonical status label (rf2-8fr3yd)."
+  (into {} (map (fn [[k d]] [k (:label d)])) status/descriptors))
 
 (defn status-signal
   "Pure data → data: the single status chip for a variant given its run

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
@@ -38,6 +38,7 @@
   variant frame) but not the variant's authoring shape — same posture
   as the Re-run button (spec/009)."
   (:require [reagent.core                                  :as r]
+            [re-frame.story.predicates                     :as pred]
             [re-frame.story.ui.test-mode.stepper-pure      :as pure]
             [re-frame.story.ui.test-mode.stepper-state     :as state]
             [re-frame.story.ui.test-mode.stepper-styles    :refer [styles]]))
@@ -51,12 +52,9 @@
   (case position
     :current "▶"
     :pending "○"
-    :done    (case outcome
-               :pass  "✓"
-               :fail  "✗"
-               :skip  "⊘"
-               :event "•"
-               "•")
+    ;; Done rows show the shared assertion-outcome glyph
+    ;; (`predicates/assertion-glyph`); :event + unknown fall to the bullet.
+    :done    (get pred/assertion-glyph outcome "•")
     "·"))
 
 (defn- outcome-style [{:keys [outcome]}]

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -205,15 +205,11 @@
     (:tick-event styles)))
 
 (defn- step-glyph
-  "Compact glyph for a tick: ✓ / ✗ / ⊘ for assertion outcomes, · for
-  plain events. Pure-data; doesn't reach into ratoms."
+  "Compact glyph for a tick: ✓ / ✗ / ⊘ for assertion outcomes (the shared
+  `predicates/assertion-glyph` vocabulary), · for plain events / unknown.
+  Pure-data; doesn't reach into ratoms."
   [status]
-  (case status
-    :pass  "✓"
-    :fail  "✗"
-    :skip  "⊘"
-    :event "·"
-    "·"))
+  (get pred/assertion-glyph status "·"))
 
 (defn- scrubber-section
   "Step-through scrubber (rf2-lc36w). One tick per play event with

--- a/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
@@ -43,6 +43,7 @@
   closure DCEs the lot."
   (:require [re-frame.story.ui.test-mode.pure        :as pure]
             [re-frame.story.ui.test-mode.state       :as state]
+            [re-frame.story.theme.status :as status]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
 
@@ -109,11 +110,12 @@
                  :color      (:warning colors/tokens)
                  :font-style "italic"}})
 
-(def ^:private status-pill
-  {:pass       {:bg (:success-bg colors/tokens) :fg (:success colors/tokens) :glyph "✓" :label "pass"}
-   :fail       {:bg (:danger-bg colors/tokens)  :fg (:danger colors/tokens)  :glyph "✗" :label "fail"}
-   :error      {:bg (:danger-bg colors/tokens)  :fg (:danger colors/tokens)  :glyph "✖" :label "error"}
-   :cannot-run {:bg (:warning-bg colors/tokens) :fg (:warning colors/tokens) :glyph "⊘" :label "cannot-run"}})
+;; Deliberate glyph override: this pane marks `:error` with a HEAVY cross
+;; (✖) rather than the shared `theme.status` descriptor's `!`, so a browser-
+;; tier executor error reads as a hard failure-of-the-check (not a soft
+;; warning) inline in the result row. Colour + the other three glyphs derive
+;; from the shared status vocabulary (rf2-8fr3yd dedup).
+(def ^:private error-glyph "✖")
 
 (def ^:private kind-title
   {:visual         "Visual snapshot"
@@ -123,9 +125,13 @@
 
 (defn- pill
   "The status pill for one browser-tier row — pass / fail / error, plus the
-  distinct THIRD `:cannot-run` state (spec/018 §12.6)."
+  distinct THIRD `:cannot-run` state (spec/018 §12.6). Colour + glyph derive
+  from the shared `theme.status` descriptor (the single status vocabulary),
+  with a deliberate heavy-cross `:error` glyph override (see `error-glyph`).
+  Unmapped statuses degrade to the descriptor's neutral fallback."
   [status]
-  (let [{:keys [bg fg glyph label]} (get status-pill status (:fail status-pill))]
+  (let [{:keys [bg fg glyph]} (status/descriptor status)
+        glyph (if (= status :error) error-glyph glyph)]
     [:span {:style       {:padding        "2px 8px"
                           :border-radius  "8px"
                           :background     bg
@@ -136,7 +142,7 @@
                           :letter-spacing "0.4px"}
             :data-test   "story-va-status-pill"
             :data-status (name status)}
-     (str glyph " " label)]))
+     (str glyph " " (name status))]))
 
 (defn- findings-list
   "Render an a11y findings list (structural or axe) readably — the finding

--- a/tools/story/src/re_frame/story/ui/view_state.cljc
+++ b/tools/story/src/re_frame/story/ui/view_state.cljc
@@ -90,6 +90,7 @@
   never invoke it and closure DCEs the lot (same contract as the rest of
   the Story UI). The pure `.cljc` helpers carry no DOM / Reagent dep."
   (:require [re-frame.story.plan :as plan]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.ui.schema-validation :as schema-validation]
             ;; `clojure.string` is consumed ONLY by the `:cljs` render
             ;; helpers (`str/join` in the provenance lines); the pure
@@ -391,10 +392,11 @@
                  ":setup   [[:dispatch [:your/setup-event {}]]] ; real events — proves handlers + app-db"
                  :db-seed
                  ":db-seed {} ; schema-checked direct app-db seed — fill the validated state shape")]
-    (str "(story/reg-variant " (pr-str new-id) "\n"
-         "  {:extends " (pr-str source-variant-id) "\n"
-         "   " slot "})\n"
-         ";; upgrade of " (pr-str source-variant-id)
+    (str (pred/reg-variant-envelope
+           "story" new-id
+           (str ":extends " (pr-str source-variant-id) "\n"
+                "   " slot))
+         "\n;; upgrade of " (pr-str source-variant-id)
          " — drop :sub-overrides; the artifact stays a variant.")))
 
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -127,8 +127,8 @@
 
 (deftest suppress-sensitive?-default-suppresses
   (testing "by default (:rf.egress/local-redacted) sensitive events are suppressed"
-    (is (= :rf.egress/local-redacted (config/get-egress-profile)))
-    (is (false? (config/include-sensitive?)))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile))
+    (is (false? (config/include-sensitive? nil)))
     (is (true?  (config/suppress-sensitive?
                   (sensitive-dispatch-event :v/x [:auth/login])))))
   (testing "non-sensitive events are never suppressed"
@@ -138,8 +138,8 @@
 (deftest suppress-sensitive?-opts-out-under-local-raw
   (testing "under :rf.egress/local-raw, sensitive events are NOT suppressed"
     (config/set-egress-profile! :rf.egress/local-raw)
-    (is (= :rf.egress/local-raw (config/get-egress-profile)))
-    (is (true? (config/include-sensitive?)))
+    (is (= :rf.egress/local-raw @config/session-egress-profile))
+    (is (true? (config/include-sensitive? nil)))
     (is (false? (config/suppress-sensitive?
                   (sensitive-dispatch-event :v/x [:auth/login])))))
   (testing "non-sensitive events remain unsuppressed regardless of profile"
@@ -149,19 +149,19 @@
 
 (deftest configure!-wires-egress-profile
   (testing "story/configure! routes :rf.story/egress-profile to the config atom"
-    (is (= :rf.egress/local-redacted (config/get-egress-profile)) "default is local-redacted")
+    (is (= :rf.egress/local-redacted @config/session-egress-profile) "default is local-redacted")
     (story/configure! {:rf.story/egress-profile :rf.egress/local-raw})
-    (is (= :rf.egress/local-raw (config/get-egress-profile))
+    (is (= :rf.egress/local-raw @config/session-egress-profile)
         "opt-in flips the profile to the trusted-local boundary")
-    (is (true? (config/include-sensitive?)))
+    (is (true? (config/include-sensitive? nil)))
     (story/configure! {:rf.story/egress-profile :rf.egress/local-redacted})
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "passing local-redacted narrows back")
-    (is (false? (config/include-sensitive?))))
+    (is (false? (config/include-sensitive? nil))))
   (testing "configure! without the key leaves the profile untouched"
     (config/set-egress-profile! :rf.egress/local-raw)
     (story/configure! {:rf.story/editor :cursor})
-    (is (= :rf.egress/local-raw (config/get-egress-profile))
+    (is (= :rf.egress/local-raw @config/session-egress-profile)
         "the unrelated key didn't reset the profile")))
 
 (deftest configure!-rejects-unknown-egress-profile
@@ -184,20 +184,20 @@
       (let [data (ex-data e)]
         (is (= :rf.error/unknown-egress-profile (:rf.error/id data)))
         (is (= 'rf.story/configure! (:where data)))))
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "the rejected call left the profile at the redacting default")))
 
 (deftest set-egress-profile!-fail-closed-defaults
   (testing "set-egress-profile! resets nil + non-member values to the fail-closed default"
     (config/set-egress-profile! :rf.egress/local-raw)
     (config/set-egress-profile! nil)
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "nil resets to the redacting default")
     (config/set-egress-profile! :rf.egress/local-raw)
     (config/set-egress-profile! :not-a-profile)
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "a non-member value coerces fail-closed (defence-in-depth)")
-    (is (false? (config/include-sensitive?)))))
+    (is (false? (config/include-sensitive? nil)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Suppressed-events counter

--- a/tools/story/test/re_frame/story/test_support_test.clj
+++ b/tools/story/test/re_frame/story/test_support_test.clj
@@ -201,14 +201,14 @@
     (config/add-global-decorator! [:some/global-decorator])
     ;; sanity: the mutations landed
     (is (= {:theme :dark} (config/get-global-args)))
-    (is (= :rf.egress/local-raw (config/get-egress-profile)))
+    (is (= :rf.egress/local-raw @config/session-egress-profile))
     ;; …then reset and assert the pristine load-time defaults.
     (config/reset-all!)
     (is (= {}      (config/get-global-args))      "global-args → {}")
     (is (= []      (config/get-global-decorators)) "global-decorators → []")
     (is (= :vscode (config/get-editor))           "editor → :vscode")
     (is (nil?      (config/get-project-root))     "project-root → nil")
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "egress-profile → :rf.egress/local-redacted")
     (is (= 0       (config/suppressed-count :some.variant/x))
         "suppressed-counters → {}")))
@@ -227,7 +227,7 @@
       (config/set-egress-profile! :rf.egress/local-raw)
       (config/reset-all!)
       (try
-        (is (= :rf.egress/local-redacted (config/get-egress-profile))
+        (is (= :rf.egress/local-redacted @config/session-egress-profile)
             "the profile was restored to its redacting default")
         (is (zero? @fired)
             "reset-all! restored the profile without firing the toggle-off hook")
@@ -247,7 +247,7 @@
     (is (= {} (config/get-global-args))
         "global-args is the pristine {} default — no sibling test leaked a
          configure! into this one")
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "egress-profile is the pristine :rf.egress/local-redacted default")
     ;; A variant with NO args resolves to exactly the empty global layer.
     (story/reg-variant :story.cfg/probe-a {:tags #{:test}})
@@ -268,7 +268,7 @@
             (config/reset-all! ran in the fixture between them) (rf2-6ez1u)"
     (is (= {} (config/get-global-args))
         "config-isolation-a's leaked global-args did NOT survive the reset")
-    (is (= :rf.egress/local-redacted (config/get-egress-profile))
+    (is (= :rf.egress/local-redacted @config/session-egress-profile)
         "config-isolation-a's egress-profile widening did NOT survive the reset")
     (story/reg-variant :story.cfg/probe-b {:tags #{:test}})
     (is (= {} (story/resolve-args :story.cfg/probe-b))

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -636,7 +636,7 @@
   restoring the prior value afterwards (the assertions fixture does not
   reset it, so a `set-egress-profile!` must be unwound by hand)."
   [profile thunk]
-  (let [prev (config/get-egress-profile)]
+  (let [prev @config/session-egress-profile]
     (config/set-egress-profile! profile)
     (try (thunk)
          (finally (config/set-egress-profile! prev)))))


### PR DESCRIPTION
Implements **rf2-8fr3yd** (tools/story dedup + vestigial cleanup, from the d046hn/fev99v read-only review).

## DEDUP
1. **reg-variant form-envelope** — extracted into `predicates/reg-variant-envelope` (raw `body-str`) + `predicates/reg-variant-form` (Shape-A `[k v]` body-keys, joined `"\n   "`). All 8 hand-rolled builders now route through it: save-variant, recorder, author-expectations, promotion (3-space `reg-variant-form`); play-export (2-space `reg-variant-envelope`); share (`reg-variant-form`); view-state + schema-form (`reg-variant-envelope` + their trailing comments). **Paste output is byte-identical** — verified via REPL spot-check of all 8 + the JVM/CLJS gates. schema-form's `<id>-pinned` id is reconstructed as a keyword (proven byte-identical across namespaced/unqualified/dotted/special-char ids).
2. **visual-a11y-view** — colour + glyph now derive from `theme.status/descriptor`; the deliberate heavy-cross `:error` glyph (`✖` vs the shared `!`) is preserved as an explicit, documented constant. `:cannot-run` ground converges to the canonical neutral (the local `:warning-bg` was the drift the shared layer exists to kill).
3. **assertion-glyph** — new shared `predicates/assertion-glyph` `{:pass "✓" :fail "✗" :skip "⊘"}`; consumed by assertion-strip / stepper-view / test-mode view. `:skip` stays an assertion verdict distinct from `theme.status/:cannot-run`, so it is NOT a theme.status descriptor. Public `assertion-strip/status-glyph` name preserved as an alias (the pinning test stays green).
4. **sidebar-signals** — `status-order` + `status-labels` derived from the shared `theme.status` vocabulary (single-sourced, no re-encoding).

## VESTIGIAL
- Dropped test-only-dead `config/get-egress-profile`; the 16 test sites now deref `config/session-egress-profile`.
- Dropped the no-arg `([])` arity of `config/include-sensitive?` (every production caller already passes a frame-id); the 5 no-arg test sites now pass `nil`. Stale shim docstring + comment updated.
- `args/get-effective-args` intentionally **NOT** removed (deferred to the facade audit, per the bead).

No public Story surface changed (`gen-variant-snippet` et al. keep their signatures + byte output; `status-glyph` keeps its name/value; `include-sensitive?` keeps the documented frame-id seam), so no `tools/story/spec/*` update was needed.

## Gates
```
cd implementation && npm run test:cljs
# → Ran 7860 tests containing 32552 assertions. 0 failures, 0 errors.

cd tools/story && clojure -M:test
# → Ran 1705 tests containing 6311 assertions. 0 failures, 0 errors.
```