### PR TITLE
refactor(mcp): lift dedup to mcp-base + route coerce-int through coerce-finite-long; doc/test-export tidy (rf2-ttspi7)

### DIFF
--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -37,6 +37,13 @@
 ;;   - `section_grouping.cljc` — patch-list → path-headed cluster
 ;;                          sections (rf2-qeous); consumed by
 ;;                          diff-encode.
+;;   - `dedup.cljc`     — structural-dedup encode step at the wire
+;;                        boundary (`empty-payload?` / `dedup-value`,
+;;                        rf2-ttspi7). The byte-identical forward
+;;                        direction both servers shared; the inverse
+;;                        (`dedup-expand`) is test-only and stays local
+;;                        to each consumer (see the ns docstring for the
+;;                        placement RULE).
 ;;   - `overflow.cljc`  — overflow-marker payload builder (rf2-rvyzy).
 ;;   - `cap.cljc`       — two-stage wire-boundary token-budget cap
 ;;                        pipeline + `ResultIO` protocol (rf2-eyelu /
@@ -73,6 +80,13 @@
 ;; predicate, the diff algorithm). Consumers add the impl-side dep
 ;; themselves.
 ;;
+;; The lone external runtime dep is `day8/de-dupe` (rf2-ttspi7) — the
+;; structural-dedup library `dedup.cljc` calls. It is framework-
+;; agnostic (a pure persistent-data-structure walker, `.cljc` both
+;; arms) so it sits cleanly inside the zero-impl-dep rule. Both
+;; consumers already pinned the SAME git tag (`v0.3.0`); the pin moves
+;; here so the two servers can't drift on a dedup-algorithm change.
+;;
 ;; ## CLJC
 ;;
 ;; Sources are `.cljc` so they load identically into the JVM
@@ -88,7 +102,26 @@
 ;; `:local/root` → `:mvn/version` before invoking clein, mirroring
 ;; the adapter jars).
 {:paths ["src"]
- :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
+ :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
+
+         ;; day8/de-dupe — structural dedup of persistent data structures
+         ;; (rf2-ttspi7 lifts the wire-boundary encode step here from both
+         ;; consumers). The library substitutes repeated subtrees with
+         ;; namespaced-symbol references (`de-dupe.cache/cache-N`); the
+         ;; flat cache map round-trips back through `expand` on the agent
+         ;; host. `.cljc` both arms, so it loads into story-mcp's JVM
+         ;; classpath and re-frame2-pair-mcp's shadow-cljs build alike.
+         ;;
+         ;; Pinned to git-tag `v0.3.0` — the same tag both consumers
+         ;; previously pinned (rf2-obpa9 / rf2-90eft / rf2-nw6sj), so the
+         ;; base + both servers lockstep and can't drift on a dedup-
+         ;; algorithm change. The tag resolves to the peeled commit
+         ;; `367de784faf13c710a895bed867f36a36e594a2a` (tools.deps resolves
+         ;; `:git/tag` against the peeled commit, not the annotated tag
+         ;; object `e5d2465a855b9efbc27f71d508259e8d50da1168`).
+         day8/de-dupe        {:git/url "https://github.com/day8/de-dupe.git"
+                              :git/tag "v0.3.0"
+                              :git/sha "367de784faf13c710a895bed867f36a36e594a2a"}}
 
  :aliases
  ;; metosin/malli is TEST-ONLY (rf2-rgg7d). mcp-base's runtime sources

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -37,7 +37,7 @@ that ride on those framework surfaces.
 
 ## Index
 
-Twelve namespaces under `re-frame.mcp-base.*`. Each ships its own
+Thirteen namespaces under `re-frame.mcp-base.*`. Each ships its own
 per-namespace contract doc; the table below indexes them:
 
 | ns | Surface | Per-namespace spec |
@@ -49,6 +49,7 @@ per-namespace contract doc; the table below indexes them:
 | `args` | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
 | `diff-encode` | Path-keyed structural diff for epoch `:db-after` slots projected into path-headed cluster sections (rf2-1wdzp / rf2-qeous) + encoder/decoder Malli gate. | [`diff-encode.md`](diff-encode.md) |
 | `section-grouping` | Patch-list → path-headed cluster sections (`group-patches-into-sections` / `sections->patches`, rf2-qeous); consumed by `diff-encode`. | [`section-grouping.md`](section-grouping.md) |
+| `dedup` | Structural-dedup encode step at the wire boundary (`empty-payload?` / `dedup-value`, over `day8/de-dupe`'s equality walk; rf2-ttspi7). Forward direction only — the test-only inverse stays consumer-side. | [`dedup.md`](dedup.md) |
 | `overflow` | Overflow-marker payload SHAPE builder (`overflow-payload`) + `token-estimate` + fallback hint (rf2-rvyzy). | [`overflow.md`](overflow.md) |
 | `cap` | Wire-boundary two-stage token-budget cap pipeline + `max-tokens` resolver + `ResultIO` protocol (rf2-eyelu / rf2-ih7g4). | [`cap.md`](cap.md) |
 | `cursor` | Shared cursor-pagination machinery — base64 codec, opaque encode/decode with `::malformed` recovery, `:limit` clamp, `cursor-stale-result` envelope (rf2-ee38b.19). | [`cursor.md`](cursor.md) |
@@ -57,8 +58,10 @@ per-namespace contract doc; the table below indexes them:
 
 All `.cljc`, so consumers compile them under their own platform —
 re-frame2-pair-mcp's shadow-cljs node build, story-mcp's JVM
-classpath. The library's `deps.edn` carries only
-`org.clojure/clojure`; no consumer-side runtime deps.
+classpath. The library's `deps.edn` carries `org.clojure/clojure` plus
+the one framework-agnostic external dep `dedup` needs —
+`day8/de-dupe`, a pure persistent-data-structure walker (rf2-ttspi7);
+no consumer-side transport runtime deps.
 
 ## Handler-arity divergence
 
@@ -125,12 +128,15 @@ Two rules:
    surfaces. New primitives land in a consumer first; if a second
    consumer needs the same code, lift it then.
 
-2. **It must be pure CLJC with no consumer-side deps.** The base's
-   `deps.edn` carries only `org.clojure/clojure`. If your primitive
-   needs cheshire / re-frame.trace / shadow-cljs / js-interop, it
-   belongs in its consumer, not here. (story-mcp's `sensitive.cljc`
-   ns keeps a thin local alias over `re-frame.privacy/sensitive?`
-   for code-review locality — the predicate itself lives here.)
+2. **It must be framework-runtime-free, with no consumer-side
+   transport deps.** The base's `deps.edn` carries `org.clojure/clojure`
+   plus the framework-agnostic `day8/de-dupe` walker (rf2-ttspi7). If
+   your primitive needs cheshire / re-frame.trace / shadow-cljs /
+   js-interop, it belongs in its consumer, not here. (re-frame2-pair-mcp
+   keeps a thin local alias ns — `tools/sensitive.cljs` — that
+   delegates to `re-frame.mcp-base.sensitive` for code-review locality;
+   story-mcp requires `re-frame.mcp-base.sensitive` directly. The
+   predicate itself lives here.)
 
 **What this rules OUT** — concrete rejection cases so a contributor
 sees the trap before falling in:

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the ALGORITHM that drives the overflow marker into a result. Until rf2-eyelu this pipeline was duplicated near-identically in re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped results). The only structural difference between the two implementations was the SHAPE of the result map and the platform-appropriate accessor used to read its `:text` slots — algorithm identical.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the cross-MCP cursor codec, the EDN-with-no-tagged-literals reader, the size cap, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope. The cursor PAYLOAD shape is consumer-side (story carries `{:offset :total :sig}`; pair carries `{:after-id :ms :until-ms :frame}`).
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/dedup.md
+++ b/tools/mcp-base/spec/dedup.md
@@ -1,0 +1,85 @@
+# `dedup` — structural-dedup encode step at the wire boundary (rf2-ttspi7)
+
+> **Type:** Reference (`tools/mcp-base/spec/`)
+> Owns the cross-MCP FORWARD (encode) half of wire-boundary structural dedup — `empty-payload?` and `dedup-value` over `day8/de-dupe`'s equality walk. The INVERSE (`dedup-expand`) is test-only and deliberately stays consumer-side. Diff-encode (the epoch `:db-after` transform that runs just before dedup) lives in [`diff-encode.md`](diff-encode.md); the wire-cap that runs just after lives in [`cap.md`](cap.md).
+
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+
+## The problem it solves
+
+Persistent data structures share subtrees in memory; `pr-str` flattens the sharing, so a payload with N references to the same subtree serialises that subtree N times. `day8/de-dupe` walks a persistent data structure, hash-identifies repeated subtrees, and rewrites the structure as a flat cache map keyed by `de-dupe.cache/cache-N` namespaced symbols; the companion `expand` reconstructs it exactly on the agent host.
+
+Both shipped servers emit the same kinds of duplicate-rich payloads:
+
+- **re-frame2-pair-mcp** — the `:epochs` slice (`:db-before` + a path-keyed `:db-after` diff against it) and the per-tick subscribe `:events` vector.
+- **story-mcp** — `run-variant` results (`:app-db` + `:snapshot` + `:rendered-hiccup`, the same sensitive values reappearing across three derived trees), assertion vectors, recorder replay tuples.
+
+The encode step (`empty-payload?` + `dedup-value`) was byte-identical across both servers. rf2-ttspi7 lifted it here so the two servers cannot drift on a dedup-algorithm change; each consumer's `dedup` ns now delegates.
+
+## Scope
+
+`dedup` owns:
+
+- `empty-payload?` — the no-win short-circuit predicate.
+- `dedup-value` — the equality-based encode + cross-MCP wrap.
+
+`dedup` does NOT own:
+
+- **The inverse (`dedup-expand`).** Neither MCP server inverts the transform at runtime — the wire contract is that the agent host calls `de-dupe.core/expand` directly on the wire payload. The inverse is therefore test-only, and its placement is a *consumer* decision (see [§The inverse stays consumer-side](#the-inverse-stays-consumer-side)).
+- **The `:rf.mcp/dedup-table` marker key** — pinned in [`vocab.md`](vocab.md) (`dedup-table-key`).
+- **The diff-encode step that precedes it** — [`diff-encode.md`](diff-encode.md).
+- **The wire-cap that follows it** — [`cap.md`](cap.md). Ordering matters: dedup shrinks first so the cap-honest size is post-dedup.
+
+## Surface
+
+### `empty-payload? v` → boolean
+
+```clojure
+(defn empty-payload? [v]
+  (or (nil? v)
+      (and (coll? v) (empty? v))
+      (not (coll? v))))
+```
+
+True for values where dedup yields no win — `nil`, empty collections, scalars. A payload with no repeated subtrees deduplicates to a one-entry cache whose wire shape is *very slightly larger* than the input; the predicate lets `dedup-value` skip the wrap for those degenerate cases so empty / single-record responses don't grow.
+
+### `dedup-value v enabled?` → value
+
+```clojure
+(defn dedup-value [v enabled?]
+  (if (or (not enabled?) (empty-payload? v))
+    v
+    {vocab/dedup-table-key (de-dupe.core/de-dupe-eq v)}))
+```
+
+Applies structural dedup to `v` and wraps the result in the cross-MCP marker `{:rf.mcp/dedup-table <cache-map>}`. Returns `v` unchanged when `enabled?` is false or when `empty-payload?` short-circuits.
+
+#### Why `de-dupe-eq` (equality), not `de-dupe` (identity)
+
+Values reaching the wire boundary are equality-shared, not identity-shared: re-frame2-pair-mcp reconstructs CLJS values from EDN over bencode (no identity sharing survives the transport), and story-mcp synthesises assertion records and rendered hiccup fresh per call. Equality is what makes the cross-record share-pooling actually fire on the wire boundary.
+
+## The inverse stays consumer-side
+
+`dedup-expand` (the inverse of `dedup-value`) is NOT lifted. It is never called by either MCP server at runtime, so it is test-only, and each consumer keeps it where its own test-corpus topology wants it:
+
+- **re-frame2-pair-mcp** keeps it in `re-frame2-pair-mcp.test-utils` — its CLJS test corpus already has a `test-utils` ns, so "test-only" is signalled by location.
+- **story-mcp** keeps it in its production `tools/dedup.cljc` — its JVM test corpus has no `test-utils` ns, and a sibling ns for one helper is more ceremony than the helper costs. The fn is harmlessly available at runtime and never invoked by the server.
+
+Lifting only the forward direction keeps each inverse-placement decision local and intact. This is the deliberate RULE recorded under rf2-ttspi7, not an oversight.
+
+## Wire shape
+
+A deduped payload is wrapped in a top-level marker `{:rf.mcp/dedup-table <cache-map>}`, sourced from `vocab/dedup-table-key` so the slot is byte-identical across servers — an agent that learned the slot on one server recognises it on the other. Agents reconstruct by calling `de-dupe.core/expand` on the cache-map value.
+
+## The `day8/de-dupe` dep
+
+`dedup.cljc` is the one base namespace with an external runtime dep: `day8/de-dupe`, pinned to git-tag `v0.3.0` (the same tag both consumers previously pinned, rf2-obpa9 / rf2-90eft / rf2-nw6sj). It is framework-agnostic — a pure persistent-data-structure walker, `.cljc` both arms — so it sits cleanly inside the base's zero-impl-dep / no-consumer-transport-dep rule. Pinning it here keeps the base + both servers in lockstep.
+
+## See also
+
+- [`README.md`](README.md) — the per-namespace index this doc is part of.
+- [`diff-encode.md`](diff-encode.md) — the epoch `:db-after` transform that runs immediately before dedup in re-frame2-pair-mcp's pipeline.
+- [`cap.md`](cap.md) — the wire-cap that runs immediately after dedup (dedup shrinks first).
+- [`vocab.md`](vocab.md) — the `:rf.mcp/dedup-table` marker key.
+- rf2-obpa9 / rf2-90eft — the beads that landed dedup in re-frame2-pair-mcp and story-mcp respectively.
+- rf2-ttspi7 — the bead that lifted the byte-identical encode step here.

--- a/tools/mcp-base/spec/descriptor-manifest.md
+++ b/tools/mcp-base/spec/descriptor-manifest.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The shared, platform-agnostic serialiser + drift-check that lets BOTH MCP servers (`re-frame2-pair-mcp`, `story-mcp`) GENERATE / VALIDATE a committed `tool-descriptors.edn` manifest from their tool registry — so adding / removing / renaming an MCP tool goes RED in CI until the manifest is regenerated. Models the project's API-governance keystone (`rf2-3nbl5.2`, `spec/api-manifest.edn`) on the MCP descriptor surface (`rf2-sofwv`).
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md).
 
 ## The problem it solves
 

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Each `:rf/epoch-record` carries `:db-before` and `:db-after` — near-identical full app-db snapshots. `pr-str` doesn't preserve structural sharing, so on the wire the pair is roughly 2× app-db per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db. This ns replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before` so the wire payload approaches the structural-sharing cost rather than the deep-copy cost. The patch list is grouped into path-breadcrumb sections via [`section-grouping.md`](section-grouping.md).
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/egress.md
+++ b/tools/mcp-base/spec/egress.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The cross-MCP, framework-runtime-free mirror of the closed six-member `:rf.egress/*` profile enum and its `:rf.size/*` floor (EP-0015 §10). A pure-data table + `profile-size-opts` resolver an MCP server uses to express its egress boundary as a NAMED profile — *which boundary is this?* — without pulling the framework runtime graph into its bundle.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## The problem it solves
 

--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Per [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md), the framework's `rf/elide-wire-value` walker substitutes over-threshold leaves with a `{:rf.size/large-elided {…}}` marker before the payload leaves the runtime. Every MCP tool that returns a tree-typed payload surfaces a scalar count of those substitutions on its response envelope (the `:elided-large` slot — see [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)). This namespace owns the **counter**, not the walker.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the indicator-field splice (`with-indicators`) enforcing the MUST-level "omit when zero" rule, plus the wire-bounded `:rf.mcp/*` marker detection used by the cache + cap boundary steps. The indicator KEYS themselves live in [`vocab.md`](vocab.md); this ns owns the splice + detection logic.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/overflow.md
+++ b/tools/mcp-base/spec/overflow.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the overflow marker (the `{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens … :tool … :hint …}}` map). The cap-enforcement glue (counting tokens, replacing the payload) lives in [`cap.md`](cap.md).
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/section-grouping.md
+++ b/tools/mcp-base/spec/section-grouping.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Projects a flat diff patch-list into path-headed cluster **sections** — the same sections-per-cluster decomposition Xray's panel renderer ships (rf2-gfxmk Phase 1 of rf2-abts7), but computed from the patch list rather than the annotated tree. [`diff-encode.md`](diff-encode.md) consumes this to shape the `:db-after` marker's `:sections` slot.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP (xray-mcp was dropped in rf2-bu21t; xray now ships as a Clojars-only library, not an MCP server) — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 
@@ -80,7 +80,7 @@ The default-OFF posture aligns with the framework's privacy-by-default stance (p
 
 re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its classpath); story-mcp is JVM-side and DOES have the framework primitive available. The predicate here matches the spirit of `re-frame.privacy/sensitive?` but adds the fail-closed posture (rf2-ih7g4): the runtime always stamps the literal boolean, but if a transport bug delivers any other truthy value, the filter drops the event AND logs so the contract drift surfaces in operator output rather than leaking the event.
 
-Consumers that want to bind to the framework primitive (story-mcp does, for code-review locality) alias the surface in their own ns and delegate through here.
+Consumers reach the predicate two ways: re-frame2-pair-mcp keeps a thin local alias ns (`tools/sensitive.cljs`) that delegates here, for code-review locality; story-mcp requires `re-frame.mcp-base.sensitive` directly (no local alias ns). Either way the fail-closed predicate itself lives here.
 
 ## Conformance posture
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The single source of truth for the marker keys an agent learns once and recognises across every MCP server in the re-frame2 pair — `re-frame2-pair-mcp` and `story-mcp`. A rename here is a wire-protocol break; the cross-MCP conformance gate under `tools/mcp-conformance/wire-vocab/` fails loud when that happens.
 
-This doc is one of twelve per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
+This doc is one of thirteen per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`egress.md`](egress.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`dedup.md`](dedup.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -1,0 +1,86 @@
+(ns re-frame.mcp-base.dedup
+  "Structural dedup at the wire boundary — the cross-MCP forward
+  (encode) direction (rf2-obpa9 / rf2-90eft, lifted to the base by
+  rf2-ttspi7).
+
+  ## Why dedup at the wire boundary
+
+  Persistent data structures share subtrees in memory; `pr-str` flattens
+  the sharing. `day8/de-dupe` walks a persistent data structure,
+  hash-identifies repeated subtrees, and rewrites the structure as a
+  flat cache map keyed by `de-dupe.cache/cache-N` namespaced symbols.
+  The library guarantees round-trip exactness via the companion `expand`
+  function; the agent host can decode locally.
+
+  Both MCP servers ship the same kinds of duplicate-rich payloads:
+  re-frame2-pair-mcp's `:epochs` slice (`:db-before` + path-keyed
+  `:db-after` diff), subscribe progress `:events`; story-mcp's
+  `run-variant` results (`:app-db` + `:snapshot` + `:rendered-hiccup`),
+  assertion vectors, recorder replay tuples. The encode step is
+  byte-identical across both servers, so it lives here once.
+
+  ## Why `de-dupe-eq` (equality), not `de-dupe` (identity)
+
+  Values reaching the wire boundary are equality-shared, not identity-
+  shared: re-frame2-pair-mcp reconstructs CLJS values from EDN over
+  bencode (no identity sharing survives the transport); story-mcp
+  synthesises assertion records and rendered hiccup fresh per call.
+  Equality is what makes the cross-record share-pooling actually fire on
+  the wire boundary.
+
+  ## Wire shape
+
+  A deduped payload is wrapped in a top-level marker:
+  `{:rf.mcp/dedup-table <cache-map>}` (`vocab/dedup-table-key`). Agents
+  reconstruct by calling `de-dupe.core/expand` on the cache-map value —
+  a cross-MCP key by construction, so an agent that learned the slot on
+  one server sees the byte-identical slot on the other.
+
+  ## Idempotence on no-dedup-opportunity
+
+  A payload with no repeated subtrees deduplicates to a one-entry cache
+  (the wire shape is very slightly larger than the input). The encoder
+  skips wrapping in that case via the `empty-payload?` short-circuit, so
+  empty / single-record responses don't grow.
+
+  ## What does NOT live here — the inverse (`dedup-expand`)
+
+  The forward direction is byte-identical, so it is lifted. The INVERSE
+  (`dedup-expand`) is NOT — neither MCP server calls it at runtime (the
+  wire contract is that the agent host calls `de-dupe.core/expand`
+  directly), so it is test-only, and each consumer's placement reflects
+  its own test-corpus topology rather than a shared shape:
+
+  - re-frame2-pair-mcp keeps it in `re-frame2-pair-mcp.test-utils`
+    (its CLJS test corpus already has a test-utils ns; \"test-only\" is
+    signalled by location).
+  - story-mcp keeps it in its production `dedup.cljc` (its JVM test
+    corpus has no test-utils ns; a sibling ns for one helper is more
+    ceremony than the helper costs — it is harmlessly available at
+    runtime and never invoked by the server).
+
+  Lifting only the forward direction keeps each inverse's placement
+  decision local and intact (rf2-ttspi7)."
+  (:require [de-dupe.core :as dd]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+(defn empty-payload?
+  "True for values where dedup yields no win — nil, empty collections,
+  scalars. Skipping the wrap avoids the trivial cache-of-one shape
+  bloating the wire for empty / single-record responses."
+  [v]
+  (or (nil? v)
+      (and (coll? v) (empty? v))
+      (not (coll? v))))
+
+(defn dedup-value
+  "Apply structural dedup to `v` and wrap the result in the cross-MCP
+  marker (`vocab/dedup-table-key`). Returns `v` unchanged when
+  `enabled?` is false or when `v` is empty / scalar (no dedup
+  opportunity). Uses `de-dupe.core/de-dupe-eq` (equality-based) — see
+  the namespace docstring for the identity-vs-equality rationale."
+  [v enabled?]
+  (if (or (not enabled?) (empty-payload? v))
+    v
+    (let [cache (dd/de-dupe-eq v)]
+      {vocab/dedup-table-key cache})))

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.clj
@@ -1,0 +1,73 @@
+(ns re-frame.mcp-base.dedup-test
+  "Tests for the lifted wire-boundary dedup encode step (rf2-ttspi7).
+
+  Pins the byte-identical forward direction both MCP servers now
+  delegate to: the `empty-payload?` short-circuit, the cross-MCP wrap
+  shape, the opt-out, and round-trip exactness via `de-dupe.core/expand`
+  (the inverse the agent host calls — NOT a base surface)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [de-dupe.core :as dd]
+            [re-frame.mcp-base.dedup :as dedup]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+(deftest empty-payload?-true-for-no-win-values
+  (testing "nil, empty colls, and scalars yield no dedup win"
+    (is (true? (boolean (dedup/empty-payload? nil))))
+    (is (true? (boolean (dedup/empty-payload? []))))
+    (is (true? (boolean (dedup/empty-payload? {}))))
+    (is (true? (boolean (dedup/empty-payload? #{}))))
+    (is (true? (boolean (dedup/empty-payload? ""))))
+    (is (true? (boolean (dedup/empty-payload? 42))))
+    (is (true? (boolean (dedup/empty-payload? :a-keyword))))))
+
+(deftest empty-payload?-false-for-non-empty-colls
+  (is (false? (boolean (dedup/empty-payload? [1 2 3]))))
+  (is (false? (boolean (dedup/empty-payload? {:a 1}))))
+  (is (false? (boolean (dedup/empty-payload? #{:x})))))
+
+(deftest dedup-value-disabled-returns-input-verbatim
+  (let [v [{:a 1} {:a 1}]]
+    (is (identical? v (dedup/dedup-value v false))
+        "enabled? false is a verbatim passthrough")))
+
+(deftest dedup-value-empty-payload-returns-input-verbatim
+  ;; No dedup opportunity ⇒ skip the wrap (the one-entry cache would be
+  ;; slightly LARGER than the input).
+  (is (= [] (dedup/dedup-value [] true)))
+  (is (= {} (dedup/dedup-value {} true)))
+  (is (nil? (dedup/dedup-value nil true)))
+  (is (= 42 (dedup/dedup-value 42 true))))
+
+(deftest dedup-value-wraps-in-cross-mcp-marker
+  (let [shared {:repeated [:big :subtree :here]}
+        v      {:a shared :b shared :c shared}
+        out    (dedup/dedup-value v true)]
+    (testing "the wire shape is the cross-MCP dedup-table marker"
+      (is (map? out))
+      (is (contains? out vocab/dedup-table-key))
+      (is (= #{vocab/dedup-table-key} (set (keys out)))
+          "exactly one top-level slot, the dedup-table marker"))))
+
+(deftest dedup-value-round-trips-exactly
+  ;; The agent host reconstructs by calling de-dupe.core/expand on the
+  ;; cache-map value — pin that the wrap is losslessly reversible.
+  (let [shared {:repeated (vec (range 50))}
+        v      {:a shared :b shared :c shared :scalars [1 2 3]}
+        out    (dedup/dedup-value v true)
+        cache  (get out vocab/dedup-table-key)]
+    (is (= v (dd/expand cache))
+        "expand on the cache-map reconstructs the original structure")))
+
+(deftest dedup-value-uses-equality-not-identity
+  ;; Values reconstructed from EDN (re-frame2-pair-mcp) or synthesised
+  ;; fresh per call (story-mcp) are equality-shared, not identity-shared.
+  ;; `de-dupe-eq` must pool them; build two EQUAL-but-not-IDENTICAL
+  ;; subtrees and assert the round-trip still holds (the share fires).
+  (let [a   {:k (vec (range 30))}
+        b   {:k (vec (range 30))}            ; equal to a, distinct object
+        _   (is (not (identical? a b)))
+        v   {:left a :right b}
+        out (dedup/dedup-value v true)]
+    (is (contains? out vocab/dedup-table-key))
+    (is (= v (dd/expand (get out vocab/dedup-table-key)))
+        "equality-shared subtrees round-trip through the wrap")))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -442,13 +442,40 @@
 (defn- coerce-int
   "Coerce an MCP numeric arg to an integer, or `::bad` if it isn't a
   whole number. Accepts a JS/CLJS number (must be integral) or a numeric
-  string. Fractional numbers and non-numeric junk are `::bad`."
+  string. Fractional numbers and non-numeric junk are `::bad`.
+
+  Cross-runtime safe-integer guard (rf2-ykv9a0, routed here by
+  rf2-ttspi7): the numeric core goes through
+  `base-args/coerce-finite-long`, which returns `nil` for `##NaN` /
+  `##Inf` / `##-Inf` and for any finite magnitude outside the JS
+  safe-integer window `[-(2^53−1), 2^53−1]`. Previously a JS
+  `Number.isInteger` value above that ceiling (e.g. `9007199254740993`,
+  representable as a JS integral double but NOT round-trippable through
+  a CLJS `long` / a JVM long without loss) passed straight through to
+  `(long raw)` here while `mcp-base` rejected the same value — the
+  divergence this routing closes. The tagged `[:ok]`/`[:err]` wrappers
+  (`parse-positive-int-arg` etc.) stay local; only the numeric core is
+  shared.
+
+  A whole numeric below the safe-integer ceiling but outside the window
+  on the string arm is caught by routing the parsed string back through
+  the SAME guard. Fractional numbers are still `::bad` (the integer
+  knobs reject non-whole values; we do NOT adopt mcp-base's benign-floor
+  posture here)."
   [raw]
   (cond
-    (and (number? raw) (js/Number.isInteger raw)) (long raw)
-    (number? raw)                                 ::bad
-    (string? raw)                                 (or (parse-long (str/trim raw)) ::bad)
-    :else                                         ::bad))
+    (and (number? raw) (js/Number.isInteger raw))
+    (if-let [n (base-args/coerce-finite-long raw)] n ::bad)
+
+    (number? raw)
+    ::bad
+
+    (string? raw)
+    (let [parsed (parse-long (str/trim raw))]
+      (if (and parsed (base-args/coerce-finite-long parsed)) parsed ::bad))
+
+    :else
+    ::bad))
 
 (defn- err-int
   "Build the `[:err {…}]` envelope for an invalid numeric arg. `arg-name`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
@@ -51,16 +51,14 @@
             [re-frame.mcp-base.overflow :as base-overflow]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
-;; `default-max-tokens` and `token-estimate` come from
-;; `re-frame.mcp-base.overflow` (rf2-vw4sq) — the cap value and the
-;; character→token approximation are cross-MCP conventions, pinned once
-;; in the base.
+;; `default-max-tokens` and the character→token approximation
+;; (`base-overflow/token-estimate`) come from `re-frame.mcp-base.overflow`
+;; (rf2-vw4sq) — both are cross-MCP conventions pinned once in the base.
+;; `default-max-tokens` is re-exported here because production call sites
+;; reference `cap/default-max-tokens`; the test-only `token-estimate`
+;; re-export moved to `test-utils` (rf2-ttspi7) — production code calls
+;; `base-overflow/token-estimate` directly.
 (def default-max-tokens base-overflow/default-max-tokens)
-
-(defn token-estimate
-  "Delegates to `base-overflow/token-estimate`."
-  [s]
-  (base-overflow/token-estimate s))
 
 (defn max-tokens-arg
   "Resolve the per-call cap from MCP args. Returns the integer cap in
@@ -98,9 +96,11 @@
    "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})
 
 ;; The fallback string lives in `re-frame.mcp-base.overflow` so the
-;; cross-MCP marker presents identically. Re-exported here to avoid
-;; touching the every-call-site `get overflow-hints` usage.
-(def overflow-hint-fallback base-overflow/overflow-hint-fallback)
+;; cross-MCP marker presents identically. Production reads it via
+;; `base-overflow/overflow-hint-fallback` (or, more usually, lets
+;; `base-cap/apply-cap` apply the fallback when a tool has no specific
+;; hint). The test-only `overflow-hint-fallback` re-export moved to
+;; `test-utils` (rf2-ttspi7).
 
 (def ^:private result-io
   "ResultIO reify over re-frame2-pair-mcp's `#js {:content #js [...]}` shape

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dedup.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dedup.cljs
@@ -53,20 +53,20 @@
 
   A payload with no repeated subtrees deduplicates to a one-entry cache
   (the wire shape is very slightly larger than the input). The encoder
-  skips wrapping in that case via an `empty-payload?` short-circuit."
-  (:require [de-dupe.core :as dedup]
-            [re-frame.mcp-base.args :as base-args]
-            [re-frame.mcp-base.diff-encode :as base-diff]
-            [re-frame.mcp-base.vocab :as base-vocab]))
+  skips wrapping in that case via an `empty-payload?` short-circuit.
+
+  ### Where the dedup encode step lives (rf2-ttspi7)
+
+  `empty-payload?` and `dedup-value` were byte-identical to story-mcp's,
+  so they are lifted to `re-frame.mcp-base.dedup` and delegated here.
+  The diff-encode delegations are unchanged."
+  (:require [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.dedup :as base-dedup]
+            [re-frame.mcp-base.diff-encode :as base-diff]))
 
 ;; ---------------------------------------------------------------------------
 ;; Diff-encoded epoch slice.
 ;; ---------------------------------------------------------------------------
-
-(defn diff-encode-db-after
-  "Delegates to `re-frame.mcp-base.diff-encode/diff-encode-db-after`."
-  [epoch]
-  (base-diff/diff-encode-db-after epoch))
 
 (defn diff-encode-epochs
   "Delegates to `re-frame.mcp-base.diff-encode/diff-encode-epochs`."
@@ -84,25 +84,16 @@
 ;; ---------------------------------------------------------------------------
 
 (defn empty-payload?
-  "True for values where dedup yields no win — nil, empty collections,
-  scalars. Skipping the wrap avoids the trivial cache-of-one shape
-  bloating the wire for empty / single-record responses."
+  "Delegates to `re-frame.mcp-base.dedup/empty-payload?` (rf2-ttspi7)."
   [v]
-  (or (nil? v)
-      (and (coll? v) (empty? v))
-      (not (coll? v))))
+  (base-dedup/empty-payload? v))
 
 (defn dedup-value
-  "Apply structural dedup to `v` and wrap the result in the cross-MCP
-  marker (`base-vocab/dedup-table-key` — rf2-vw4sq). Returns `v`
-  unchanged when `enabled?` is false or when `v` is empty / scalar
-  (no dedup opportunity). Uses `de-dupe-eq` (equality-based) — see
-  the section header for the identity-vs-equality rationale."
+  "Delegates to `re-frame.mcp-base.dedup/dedup-value` (rf2-ttspi7). Uses
+  `de-dupe-eq` (equality-based) — see the section header for the
+  identity-vs-equality rationale."
   [v enabled?]
-  (if (or (not enabled?) (empty-payload? v))
-    v
-    (let [cache (dedup/de-dupe-eq v)]
-      {base-vocab/dedup-table-key cache})))
+  (base-dedup/dedup-value v enabled?))
 
 ;; `dedup-expand` (the inverse of `dedup-value`) has moved to
 ;; `re-frame2-pair-mcp.test-utils/dedup-expand` (rf2-ambfv). It's

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/result_envelope.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/result_envelope.cljs
@@ -95,10 +95,13 @@
   namespaces); single-sourced from `re-frame.mcp-base.vocab/result-key`."
   base-vocab/result-key)
 
-(def ^:private preview-cap
+(def preview-cap
   "Max chars of an unserializable value's `pr-str` text to carry on the
   wire as `:preview`. Long enough to identify the shape, short enough to
-  stay well under the token cap on its own."
+  stay well under the token cap on its own.
+
+  Public (rf2-ttspi7) so the test-only `test-utils/truncate-preview`
+  pins against the SAME single-sourced cap the runtime wrap embeds."
   240)
 
 ;; ---------------------------------------------------------------------------
@@ -315,16 +318,8 @@
   [result-map]
   (boolean (some-> result-map meta ::codec-error)))
 
-;; ---------------------------------------------------------------------------
-;; Preview helper (server-side; used by tests + diagnostics).
-;; ---------------------------------------------------------------------------
-
-(defn truncate-preview
-  "Truncate `text` to `preview-cap` chars with a char-count suffix —
-  the same shape the runtime wrap emits. Exposed for the server-side
-  tests so the preview contract is pinned in one place."
-  [text]
-  (let [n (count text)]
-    (if (> n preview-cap)
-      (str (subs text 0 preview-cap) " …(" n " chars)")
-      text)))
+;; `truncate-preview` (the test-only preview-shape helper) moved to
+;; `re-frame2-pair-mcp.test-utils/truncate-preview` (rf2-ttspi7) — the
+;; MCP server never calls it; only tests assert the preview contract.
+;; It pins against the same `preview-cap` constant below (now public so
+;; the single source of truth stays here).

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/lazy_summary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/lazy_summary_test.cljs
@@ -18,8 +18,8 @@
   Wire-byte / token-budget assertions appear at the end — the
   discovery-snapshot scenario MUST fit the 5,000-token cap."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.args :as args]
-            [re-frame2-pair-mcp.tools.cap :as cap]
             [re-frame2-pair-mcp.tools.snapshot-pipeline :as pipeline]
             [re-frame2-pair-mcp.tools.summary :as summary]))
 
@@ -271,7 +271,7 @@
         {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              with-app-db-summary {} :summary)
         wire (pr-str snapshot)
-        tokens (cap/token-estimate wire)]
+        tokens (tu/token-estimate wire)]
     (is (< tokens 5000)
         (str "Discovery snapshot under :summary mode MUST fit the 5k-token cap. "
              "Got " tokens " tokens, " (count wire) " chars."))))
@@ -285,7 +285,7 @@
         {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              with-app-db-full {} :full)
         wire (pr-str snapshot)
-        tokens (cap/token-estimate wire)]
+        tokens (tu/token-estimate wire)]
     (is (> tokens 50000)
         (str "Full-mode discovery snapshot ships the raw payload — "
              "should be many multiples of the cap. Got " tokens " tokens."))))
@@ -309,6 +309,6 @@
     (is (> ratio 50)
         (str "Lazy-summary MUST shrink the discovery snapshot by at "
              "least 50x. Got " (int ratio) "x (summary=" (count summary-wire)
-             " chars (~" (cap/token-estimate summary-wire) " tokens) "
+             " chars (~" (tu/token-estimate summary-wire) " tokens) "
              "vs full=" (count full-wire) " chars (~"
-             (cap/token-estimate full-wire) " tokens))."))))
+             (tu/token-estimate full-wire) " tokens))."))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/path_slicing_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/path_slicing_test.cljs
@@ -14,15 +14,15 @@
   `tools.args/parse-path-arg`, `tools.summary/tree-summary`,
   `tools.summary/deepest-valid-prefix`,
   `tools.snapshot-pipeline/slice-app-db-in-snapshot`,
-  `tools.cap/token-estimate`. A rename or signature change surfaces
+  `test-utils/token-estimate`. A rename or signature change surfaces
   as a failing test rather than a silent contract drift.
 
   Live end-to-end coverage of `get-path-tool` and the snapshot
   `:path` arg lives in `test/stdio-roundtrip.js` (degraded-mode
   dispatch) and the manual live-nREPL integration test."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.args :as args]
-            [re-frame2-pair-mcp.tools.cap :as cap]
             [re-frame2-pair-mcp.tools.snapshot-pipeline :as pipeline]
             [re-frame2-pair-mcp.tools.summary :as summary]))
 
@@ -153,7 +153,7 @@
     (is (= 5000 (:count marker)))
     (is (= summary/summary-keys-cap (count (:keys marker))))
     (is (true? (:keys-truncated? marker)))
-    (is (< (cap/token-estimate (pr-str marker)) 5000)
+    (is (< (tu/token-estimate (pr-str marker)) 5000)
         "Marker for a 5k-entry map MUST still fit the wire cap")))
 
 (deftest tree-summary-scalar-returns-value-unchanged
@@ -316,6 +316,6 @@
         [out _] (pipeline/slice-app-db-in-snapshot snap nil :summary)
         wire    (pr-str (-> out :rf/default :app-db))]
     (is (contains? (-> out :rf/default :app-db) :rf.mcp/summary))
-    (is (< (cap/token-estimate wire) 5000)
+    (is (< (tu/token-estimate wire) 5000)
         (str "Summary marker MUST be under the 5k cap. Got "
-             (cap/token-estimate wire) " tokens for serialised marker"))))
+             (tu/token-estimate wire) " tokens for serialised marker"))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/result_envelope_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/result_envelope_test.cljs
@@ -17,6 +17,7 @@
        unchanged (additive codec)."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.result-envelope :as renv]))
 
 ;; ---------------------------------------------------------------------------
@@ -192,8 +193,8 @@
 
 (deftest truncate-preview-caps-long-text
   (let [long-text (apply str (repeat 500 "x"))
-        out       (renv/truncate-preview long-text)]
+        out       (tu/truncate-preview long-text)]
     (is (str/includes? out "chars)") "a long preview carries the char-count suffix")
     (is (< (count out) 500) "the preview is truncated under the source length"))
-  (is (= "short" (renv/truncate-preview "short"))
+  (is (= "short" (tu/truncate-preview "short"))
       "a short preview is returned verbatim"))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -125,6 +125,40 @@
   (let [[tag _] (args/parse-positive-int-arg "max-events" "soon")]
     (is (= :err tag) "non-numeric junk is rejected")))
 
+;; rf2-ykv9a0 cross-runtime safe-integer guard, routed through
+;; `base-args/coerce-finite-long` by rf2-ttspi7. A whole numeric (or
+;; numeric string) ABOVE the JS safe-integer ceiling (2^53 − 1 =
+;; 9 007 199 254 740 991) is NOT losslessly representable across both
+;; hosts; before the routing it slipped past `coerce-int`'s
+;; `Number.isInteger` check (a double like 9007199254740993 is "integral"
+;; in JS) and reached the runtime budget, while mcp-base's `max-tokens`
+;; rejected the same value — the divergence this closes.
+
+(deftest positive-int-arg-rejects-over-safe-integer
+  ;; 2^53 + 1 — past the safe-integer window. `Number.isInteger` is true
+  ;; for it (it's a whole double), so it would have passed the OLD
+  ;; coerce-int; the finite/range guard now rejects it as a bad numeric.
+  (let [over (+ 9007199254740992 1)
+        [tag env] (args/parse-positive-int-arg "max-buffered-events" over)]
+    (is (= :err tag) "an over-safe-integer numeric is rejected, not forwarded")
+    (is (= :invalid-numeric-arg (:reason env)))
+    (is (= "max-buffered-events" (:arg env))))
+  ;; The string arm routes the parsed value through the SAME guard.
+  (let [[tag _] (args/parse-positive-int-arg "poll-ms" "9007199254740993")]
+    (is (= :err tag) "an over-safe-integer numeric STRING is rejected too"))
+  ;; The boundary value (exactly 2^53 − 1) is in-domain and accepted.
+  (is (= [:ok 9007199254740991]
+         (args/parse-positive-int-arg "max-buffered-bytes" 9007199254740991))
+      "the safe-integer ceiling itself is in-domain"))
+
+(deftest non-negative-int-arg-rejects-over-safe-integer
+  (let [[tag env] (args/parse-non-negative-int-arg "max-events" (+ 9007199254740992 1))]
+    (is (= :err tag) "an over-safe-integer numeric is rejected on the non-negative arm too")
+    (is (= :invalid-numeric-arg (:reason env))))
+  (is (= [:ok 9007199254740991]
+         (args/parse-non-negative-int-arg "max-ms" 9007199254740991))
+      "the safe-integer ceiling itself is in-domain"))
+
 (deftest non-negative-int-arg-accepts-zero-sentinel
   ;; 0 = unbounded — the documented sentinel for max-ms / max-events.
   (is (= [:ok 0] (args/parse-non-negative-int-arg "max-ms" 0)))
@@ -953,7 +987,7 @@
       (is (= "subscribe" (:tool marker)))
       (is (= 500 (:cap-tokens marker)))
       (is (> (:token-count marker) 500)))
-    (is (<= (cap/token-estimate msg) 500)
+    (is (<= (tu/token-estimate msg) 500)
         "the overflow-marker message itself stays under the cap")))
 
 (deftest emit-progress-tick-nil-cap-disables-gate

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/test_utils.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/test_utils.cljs
@@ -35,12 +35,25 @@
   exactness against an MCP-shaped wire payload without growing the
   production surface. The agent host reconstructs locally via
   `de-dupe.core/expand`; the MCP server never calls the inverse, so the
-  helper lives here, signalling \"test-only\" by location."
+  helper lives here, signalling \"test-only\" by location.
+
+  ## Test-only base re-exports (rf2-ttspi7)
+
+  `token-estimate`, `overflow-hint-fallback`, and `truncate-preview`
+  used to be re-exported from the production `tools.cap` /
+  `tools.result-envelope` namespaces SOLELY so the test corpus could
+  reach them — production code calls `base-overflow` / `base-cap`
+  directly and never used the local aliases. Hosting them here (the
+  test-only home) keeps the production surface lean while still pinning
+  the cross-MCP token rule + overflow-fallback contract + preview cap in
+  one shared test-side place."
   (:require [applied-science.js-interop :as j]
             [cljs.reader :as edn]
             [de-dupe.core :as dedup]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.freshness :as freshness]
+            [re-frame2-pair-mcp.tools.result-envelope :as renv]
+            [re-frame.mcp-base.overflow :as base-overflow]
             [re-frame.mcp-base.vocab :as base-vocab]))
 
 ;; ---------------------------------------------------------------------------
@@ -130,3 +143,36 @@
   (if (and (map? v) (contains? v base-vocab/dedup-table-key))
     (dedup/expand (get v base-vocab/dedup-table-key))
     v))
+
+;; ---------------------------------------------------------------------------
+;; Test-only base re-exports (rf2-ttspi7).
+;;
+;; Production code calls `base-overflow` / `base-cap` directly; these
+;; aliases existed only so the test corpus could reach the cross-MCP
+;; token rule, the overflow-fallback hint, and the preview cap. Hosting
+;; them here keeps the production namespaces lean.
+;; ---------------------------------------------------------------------------
+
+(defn token-estimate
+  "Delegates to `re-frame.mcp-base.overflow/token-estimate` — the
+  cross-MCP `(quot (count s) 4)` token approximation. Test-only home for
+  what `tools.cap` used to re-export (rf2-ttspi7)."
+  [s]
+  (base-overflow/token-estimate s))
+
+(def overflow-hint-fallback
+  "The cross-MCP overflow-marker fallback hint string, sourced from
+  `re-frame.mcp-base.overflow/overflow-hint-fallback`. Test-only home for
+  what `tools.cap` used to re-export (rf2-ttspi7)."
+  base-overflow/overflow-hint-fallback)
+
+(defn truncate-preview
+  "Truncate `text` to `result-envelope/preview-cap` chars with a
+  char-count suffix — the same shape the runtime wrap emits. Test-only
+  home for what `tools.result-envelope` used to re-export (rf2-ttspi7);
+  pins the preview contract against the single-sourced production cap."
+  [text]
+  (let [n (count text)]
+    (if (> n renv/preview-cap)
+      (str (subs text 0 renv/preview-cap) " …(" n " chars)")
+      text)))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
@@ -8,10 +8,12 @@
   is replaced with a structured `{:rf.mcp/overflow ...}` marker.
 
   Tests pin the public helpers directly from
-  `re-frame2-pair-mcp.tools.cap`: `token-estimate`, `max-tokens-arg`,
-  `overflow-payload`, `sum-text-tokens`, `apply-cap`,
-  `overflow-hints`, `overflow-hint-fallback`, `default-max-tokens`.
-  A rename or signature change surfaces as a failing test rather
+  `re-frame2-pair-mcp.tools.cap`: `max-tokens-arg`, `overflow-payload`,
+  `sum-text-tokens`, `apply-cap`, `overflow-hints`, `default-max-tokens`.
+  The two cross-MCP re-exports that production never used —
+  `token-estimate` and `overflow-hint-fallback` — moved to
+  `re-frame2-pair-mcp.test-utils` (rf2-ttspi7) and are pinned via `tu/`
+  here. A rename or signature change surfaces as a failing test rather
   than a silent contract drift.
 
   Live end-to-end coverage of `invoke` lives in
@@ -20,6 +22,7 @@
   (:require [cljs.test :refer-macros [deftest is]]
             [cljs.reader]
             [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.cap :as cap]))
 
 ;; ---------------------------------------------------------------------------
@@ -45,11 +48,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest token-estimate-is-chars-div-4
-  (is (zero? (cap/token-estimate "")))
-  (is (zero? (cap/token-estimate "abc")))
-  (is (= 1 (cap/token-estimate "abcd")))
-  (is (= 250 (cap/token-estimate (big-string 1000))))
-  (is (= 5000 (cap/token-estimate (big-string 20000)))))
+  (is (zero? (tu/token-estimate "")))
+  (is (zero? (tu/token-estimate "abc")))
+  (is (= 1 (tu/token-estimate "abcd")))
+  (is (= 250 (tu/token-estimate (big-string 1000))))
+  (is (= 5000 (tu/token-estimate (big-string 20000)))))
 
 ;; ---------------------------------------------------------------------------
 ;; max-tokens-arg — per-call override resolution.
@@ -98,7 +101,7 @@
 (deftest sum-text-tokens-single-slot
   (let [r (ok-text-result {:hello "world"})]
     (is (pos? (cap/sum-text-tokens r)))
-    (is (= (cap/token-estimate (read-text r)) (cap/sum-text-tokens r)))))
+    (is (= (tu/token-estimate (read-text r)) (cap/sum-text-tokens r)))))
 
 (deftest sum-text-tokens-empty-content-is-zero
   (is (zero? (cap/sum-text-tokens #js {:content #js []}))))
@@ -156,7 +159,7 @@
         edn (read-edn out)
         marker (:rf.mcp/overflow edn)]
     (is (= "no-such-tool" (:tool marker)))
-    (is (= cap/overflow-hint-fallback (:hint marker)))))
+    (is (= tu/overflow-hint-fallback (:hint marker)))))
 
 (deftest apply-cap-unknown-strategy-degrades-safely
   ;; Unknown strategy must NOT throw and must NOT ship the over-budget
@@ -203,7 +206,7 @@
   ;; Small text slot, large structuredContent. The token sum must reflect
   ;; the structured JSON bytes, not just the text slot.
   (let [r          (dual-coded-result {:ok? true} {:big-payload (big-string 30000)})
-        text-only  (cap/token-estimate (read-text r))
+        text-only  (tu/token-estimate (read-text r))
         total      (cap/sum-text-tokens r)]
     (is (> total (+ text-only 5000))
         "structuredContent JSON bytes MUST be summed alongside the text slot")))
@@ -386,7 +389,7 @@
       (is (string? (:hint marker)))
       (is (re-find #"(?i)filter|max-events|max-buffered" (:hint marker))
           "the marker carries the subscribe per-tool next-step hint"))
-    (is (<= (cap/token-estimate out) 500)
+    (is (<= (tu/token-estimate out) 500)
         "the overflow-marker message itself stays under the cap")))
 
 (deftest cap-message-respects-custom-cap-override

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dedup.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dedup.cljc
@@ -59,40 +59,30 @@
   A payload with no repeated subtrees deduplicates to a one-entry
   cache (the wire shape is very slightly larger than the input). The
   encoder skips wrapping in that case via an `empty-payload?` short-
-  circuit — matching pair-mcp's behaviour byte-for-byte."
+  circuit — matching pair-mcp's behaviour byte-for-byte.
+
+  ## Where the dedup encode step lives (rf2-ttspi7)
+
+  `empty-payload?` and `dedup-value` were byte-identical to pair-mcp's,
+  so they are lifted to `re-frame.mcp-base.dedup` and delegated here.
+  Only the INVERSE (`dedup-expand`) stays local — see its docstring for
+  why story-mcp keeps its inverse in production while pair-mcp keeps
+  its inverse in test-utils."
   (:require [de-dupe.core :as dd]
+            [re-frame.mcp-base.dedup :as base-dedup]
             [re-frame.mcp-base.vocab :as base-vocab]))
 
 (defn empty-payload?
-  "True for values where dedup yields no win — nil, empty collections,
-  scalars. Skipping the wrap avoids the trivial cache-of-one shape
-  bloating the wire for empty / single-record responses.
-
-  Mirrors `re-frame2-pair-mcp.tools.dedup/empty-payload?` byte-for-byte
-  so cross-MCP behaviour is uniform."
+  "Delegates to `re-frame.mcp-base.dedup/empty-payload?` (rf2-ttspi7)."
   [v]
-  (or (nil? v)
-      (and (coll? v) (empty? v))
-      (not (coll? v))))
+  (base-dedup/empty-payload? v))
 
 (defn dedup-value
-  "Apply structural dedup to `v` and wrap the result in the cross-MCP
-  marker (`base-vocab/dedup-table-key`). Returns `v` unchanged when
-  `enabled?` is false or when `v` is empty / scalar (no dedup
-  opportunity).
-
-  Uses `de-dupe.core/de-dupe-eq` (equality-based) — see the namespace
-  docstring for the identity-vs-equality rationale.
-
-  Mirrors `re-frame2-pair-mcp.tools.dedup/dedup-value` byte-for-byte;
-  the only difference is the underlying `de-dupe` library entry
-  resolves to the JVM-side `.cljc` arm rather than the CLJS arm.
-  Algorithm + wire shape are identical by `.cljc` design."
+  "Delegates to `re-frame.mcp-base.dedup/dedup-value` (rf2-ttspi7). Uses
+  `de-dupe.core/de-dupe-eq` (equality-based) — see the namespace
+  docstring for the identity-vs-equality rationale."
   [v enabled?]
-  (if (or (not enabled?) (empty-payload? v))
-    v
-    (let [cache (dd/de-dupe-eq v)]
-      {base-vocab/dedup-table-key cache})))
+  (base-dedup/dedup-value v enabled?))
 
 (defn dedup-expand
   "Reverse `dedup-value`. Given a value possibly wrapped in the


### PR DESCRIPTION
Implements **rf2-ttspi7** — MCP tool-stack dedup + vestigial cleanup. One cohesive PR across mcp-base + story-mcp + re-frame2-pair-mcp (the A1 lift touches all three).

## A1 — lift the byte-identical dedup encode step to mcp-base
- New `re-frame.mcp-base.dedup` owns `empty-payload?` + `dedup-value` (the forward/encode direction both servers shared byte-for-byte, over `day8/de-dupe`'s equality walk).
- Both consumers' `dedup` namespaces now delegate.
- mcp-base gains the framework-agnostic `day8/de-dupe` dep, pinned to `v0.3.0` — the same git tag both consumers already pinned, so base + both servers lockstep.

### RULE — where `dedup-expand` (the inverse) lands
Only the **forward** direction lifts. The inverse is never called by either MCP server at runtime (the agent host calls `de-dupe.core/expand` directly), so it is test-only and each consumer keeps it where its own test-corpus topology wants it:
- **re-frame2-pair-mcp** keeps it in `test-utils.cljs` (its CLJS corpus already has a test-utils ns).
- **story-mcp** keeps it in production `tools/dedup.cljc` (no JVM test-utils ns; a sibling ns for one helper is more ceremony than it costs).

This keeps each inverse-placement decision local and intact. Recorded in the new `spec/dedup.md`.

## A2 — route pair-mcp `coerce-int` through `base-args/coerce-finite-long` (correctness fix)
`coerce-int` (args.cljs) accepted any `Number.isInteger` value, so a JS integral double **above the safe-integer ceiling** (e.g. `9007199254740993`) slipped through to the runtime budget on `subscribe` / `eval_cljs` / `dispatch` / `tail_build` / `watch_until`, while mcp-base's `max-tokens` rejected the same value (the rf2-ykv9a0 divergence). The numeric core now routes through the shared `coerce-finite-long` guard; the string arm re-routes the parsed value through the same guard. The tagged `[:ok]`/`[:err]` wrappers stay local. Added over-safe-integer tests on both the positive and non-negative arms (incl. the exactly-`2^53−1` boundary, which stays in-domain).

## B1 — fix stale doc claim
`spec/README.md` and `spec/sensitive.md` claimed story-mcp keeps a thin local `sensitive.cljc` alias ns. It doesn't — story-mcp requires `re-frame.mcp-base.sensitive` directly; **re-frame2-pair-mcp** is the one with a thin local alias (`tools/sensitive.cljs`). Corrected both.

## B2 — move 4 pair-mcp test-only re-exports off the production surface
Production code never used these aliases (it calls `base-overflow` / `base-cap` directly):
- `dedup/diff-encode-db-after` — dropped outright (no caller; tests use the `base-diff` alias).
- `cap/token-estimate`, `cap/overflow-hint-fallback`, `result-envelope/truncate-preview` — relocated to `test-utils`; test call sites + requires updated. `preview-cap` de-privatised so the relocated helper pins the single-sourced cap.

Also adds `spec/dedup.md` (new per-namespace contract) and threads it into the 12 sibling `See also` footers + the README index table (twelve → thirteen namespaces).

## Quality gates (all green)
\`\`\`
# mcp-base
clojure -M:test                              # 247 tests, 825 assertions, 0 fail (incl. new dedup_test)
npx shadow-cljs compile cljs-test            # 15 tests, 95 assertions, 0 fail
# story-mcp
clojure -M:test                              # 284 tests, 1396 assertions, 0 fail
clojure -M:gen --check                       # tool-descriptors.edn in sync (20 tools)
# re-frame2-pair-mcp
npm test                                     # 1091 tests, 3616 assertions, 0 fail
npm run check:descriptors                    # tool-descriptors.edn in sync (29 tools)
# implementation
npm run test:cljs                            # 7860 tests, 32552 assertions, 0 fail
npm run test:bundle-isolation                # PASS (22 entries; 40 sentinels absent; reagent-free ok)
# mcp-conformance
wire-vocab: clojure -M:test                  # 93 tests, 922 assertions, 0 fail
npm run test:dedup-envelope                  # 6/6 pass
\`\`\`