### PR TITLE
chore: trivial doc/require tidy — unused require + stale docstrings + six→seven source counts (rf2-fth89h)

### DIFF
--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -106,8 +106,10 @@
                                       registrations + late-bind hook
                                       publication for the stub family
                                       (rf2-lwmgw).
-   - `re-frame.util-json`           — pure-Clojure JSON reader extracted
-                                      per rf2-p7da; shared by the decode
+   - `re-frame.util-json`           — JSON reader extracted per rf2-p7da
+                                      (Cheshire on the JVM, native
+                                      `JSON.parse` on CLJS); shared by
+                                      the decode
                                       pipeline. (Currently shipped in
                                       the http artefact; lift to core
                                       if a second consumer appears.)

--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -58,7 +58,6 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.privacy :as privacy]
-            [re-frame.projection :as projection]
             [re-frame.reply :as reply]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))

--- a/implementation/schemas/test/re_frame/schemas_walker_large_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_large_test.clj
@@ -9,10 +9,11 @@
   every operator family by `schemas_walker_operators_test`, but the
   `:large?` public entry point — `extract-large-paths-from-schema`,
   re-exported from `re-frame.schemas` and published as the
-  `:schemas/extract-large-paths-from-schema` late-bind hook that
-  `re-frame.elision` consumes — had no direct slice-local unit
-  coverage. It was exercised ONLY indirectly via one `reg-app-schema`
-  elision-population integration test (`schemas_reg_side_effects_test`).
+  `:schemas/extract-large-paths-from-schema` late-bind hook that the
+  machines / resources / http artefacts consume (EP-0015 §8 removed the
+  former `re-frame.elision` registry-population feed; durable egress
+  classification is now frame-owned) — had no direct slice-local unit
+  coverage.
 
   A regression in the `:large?` wiring (a wrong flag-key threaded
   through the shared walker, or a structural-recognition break that the

--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -29,7 +29,7 @@
 ;; `rf/project-error`, dispatches `:rf/hydrate`, or relies on the
 ;; `:rf.server/*` fxs / the per-request response accumulator (read via
 ;; `re-frame.ssr/get-response`) — loading the namespace registers the
-;; six `:rf.server/*` fxs, the `:rf/hydrate` handler, and publishes the
+;; seven `:rf.server/*` fxs, the `:rf/hydrate` handler, and publishes the
 ;; late-bind hooks (`:ssr/render-tree-hash`) and the plain-atom adapter's
 ;; `:render-to-string` slot.
 ;;

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -22,7 +22,7 @@
     - `:rf/hydrate` event with `:replace-frame-state` semantics; the server-
       supplied payload's `:rf/app-db` replaces the client frame-state
       (app-db + serializable runtime-db).
-    - The six `:rf.server/*` response-shape fxs gated by `:platforms
+    - The seven `:rf.server/*` response-shape fxs gated by `:platforms
       #{:server}`; the accumulator at `[:rf/response]` is consumed by
       the host adapter after drain. Per §HTTP response contract.
     - `reg-error-projector` + default `:rf.ssr/default-error-projector`,
@@ -67,7 +67,7 @@
             ;; rf2-kjf3m.2 — the standard `:rf.fx.server/*-args` /
             ;; `:rf.server/cookie` Malli args schemas Spec 011 §Standard fx
             ;; (line 438) + [Spec-Schemas §Standard fx args schemas] name as
-            ;; registered. Attached as the `:schema` key on the six
+            ;; registered. Attached as the `:schema` key on the seven
             ;; `:rf.server/*` reg-fx calls below so the Spec 010 §step-5
             ;; fx-args `:schema` boundary check actually fires on the server
             ;; fx args (it previously did not — the calls carried only :doc
@@ -293,7 +293,7 @@ the client's registered app-schema digest. A mismatch emits a structured
    :platforms #{:client}}
   hydrate/check-schema-digest-fx)
 
-;; ---- the six :rf.server/* response-shape fxs ------------------------------
+;; ---- the seven :rf.server/* response-shape fxs ----------------------------
 ;;
 ;; Per Spec 011 §HTTP response contract.
 


### PR DESCRIPTION
Implements **rf2-fth89h** — four disjoint low-risk tidies pooled from CLEAN vestigial reviews. All trivial, no behaviour change.

1. **reply-conformance** — drop unused `[re-frame.projection]` require (`reply_egress_projection_conformance_cljs_test.cljc`). Alias was unused; the ns is still transitively loaded and only `elision/` is referenced.
2. **http_managed** — fix `util-json` docstring. It is not a "pure-Clojure JSON reader"; verified `util_json.cljc` uses Cheshire on the JVM and native `js/JSON.parse` on CLJS. Docstring now says so.
3. **schemas_walker_large_test** — fix docstring. The `:schemas/extract-large-paths-from-schema` late-bind hook is consumed by the **machines / resources / http** artefacts (verified via `git grep` on the late-bind directory + consumers), **not** `re-frame.elision`. EP-0015 §8 (rf2-d2r3um) removed the elision registry-population feed; durable egress classification is now frame-owned. Dropped the stale "elision-population integration test" framing.
4. **SSR six→seven** — the `:rf.server/*` response-shape fxs number **seven** since `:rf.server/safe-redirect` (rf2-zfm8v) — confirmed by counting `reg-fx :rf.server/*` calls in `ssr.cljc` (set-status, set-header, append-header, set-cookie, delete-cookie, redirect, safe-redirect). Updated the stale "six" current-set counts in SOURCE only:
   - `ssr/src/re_frame/ssr.cljc` — namespace doc (l.25), the rf2-kjf3m.2 require comment (l.70), the section header (l.296).
   - `ssr/deps.edn` (l.32).
   - **Not** touched: `spec/011` (separate deferred hot-zone item, per bead). `server_fx_schemas.cljc` "six" references are historically-scoped ("Pre-rf2-kjf3m.2 the six…") or safe-redirect's-six-siblings — correct, kept.

## Quality gates (all green)
\`\`\`
cd implementation && npm run test:cljs   # 7865 tests, 32596 assertions — 0 failures, 0 errors
implementation/reply-conformance$ clojure -M:test  # 28 tests, 397 assertions — 0/0
implementation/http$            clojure -M:test  # 449 tests, 2066 assertions — 0/0
implementation/schemas$         clojure -M:test  # 311 tests, 18808 assertions — 0/0
implementation/ssr$             clojure -M:test  # 366 tests, 1465 assertions — 0/0
\`\`\`
No `docs/` touched (mkdocs N/A).