### PR TITLE
refactor(machines-viz): extract shared grammar/id-codec ns; de-triplicate emitters (rf2-b2ygd2)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -83,31 +83,22 @@
 
   Per `tools/machines-viz/spec/000-Vision.md` §Decision trace
   §Interactive renderer (revised 2026-05-21)."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            ;; rf2-b2ygd2 — the SHARED grammar walker + injective id codec
+            ;; the three emitters (chart / mermaid / scxml) route through, so
+            ;; they address every node identically (one escape codec, one
+            ;; source of truth — no desync landmine).
+            [day8.re-frame2-machines-viz.grammar :as g]))
 
 ;; ---- definition walker --------------------------------------------------
 
-(defn- target-path?
-  "True when `v` is a grammar vector-path target (Spec 005)."
-  [v]
-  (and (vector? v)
-       (seq v)
-       (every? keyword? v)))
+;; rf2-b2ygd2 — grammar primitives now live in the shared `grammar` ns. The
+;; public-API names this ns has always exported (`name-of`, `history-node?`)
+;; are kept as thin re-exports so existing requirers (`chart.projection`,
+;; `scxml`, tests) are unchanged.
+(def ^{:doc "rf2-b2ygd2 — re-export of `grammar/history-node?`.
 
-(defn- transition-candidates
-  "Normalise a transition spec to candidate maps. Mirrors the
-  equivalent fn in the mermaid emitter; kept local so this ns has no
-  cross-dependency on machines-viz."
-  [spec]
-  (cond
-    (keyword? spec)     [{:target spec}]
-    (target-path? spec) [{:target spec}]
-    (map? spec)         [spec]
-    (vector? spec)      (mapcat transition-candidates spec)
-    :else               []))
-
-(defn history-node?
-  "rf2-m285a — true when a node under a compound's `:states` is a
+  rf2-m285a — true when a node under a compound's `:states` is a
   `:type :history` PSEUDO-STATE (Spec 005 §History states), not an
   ordinary occupiable substate. A history pseudo-state is NEVER active:
   a transition *to* it resolves to the compound's recorded / default
@@ -115,18 +106,13 @@
   The projector must paint it as a small `history-marker` glyph inside
   its owning compound — keeping incoming edges but treating it as
   neither initial nor final nor compound (it declares only `:type` /
-  `:deep?` / `:default-target`)."
-  [state-node]
-  (and (map? state-node)
-       (= :history (:type state-node))))
+  `:deep?` / `:default-target`)."}
+  history-node? g/history-node?)
 
-(defn- parent-path [path]
-  (if (seq path)
-    (pop path)
-    []))
+(def ^{:arglists '([v])
+       :doc "rf2-b2ygd2 — re-export of `grammar/name-of`.
 
-(defn name-of
-  "Render a guard / action / entry / exit symbol-like value as a short
+  Render a guard / action / entry / exit symbol-like value as a short
   string WITHOUT throwing on fn values. Keywords use `ns/name` when
   namespaced, plain `name` otherwise; non-keywords fall through to
   `str`. Inlined fn guards / actions surface their `:name` meta (named
@@ -135,15 +121,8 @@
 
   Public + namespace-preserving — `chart.projection` reuses this (it
   previously carried a near-duplicate `safe-name` that dropped the
-  namespace; rf2-ee38b.21 collapses the two)."
-  [v]
-  (cond
-    (nil? v)     nil
-    (keyword? v) (if-let [n (namespace v)]
-                   (str n "/" (name v))
-                   (name v))
-    (fn? v)      (or (some-> v meta :name str) "fn")
-    :else        (str v)))
+  namespace; rf2-ee38b.21 collapses the two)."}
+  name-of g/name-of)
 
 ;; ---- consumer-attachment requirements (rf2-skhlw2.1) --------------------
 ;;
@@ -301,13 +280,15 @@
     edge itself (flagging `:internal? true`), so this fn never sees it."
   [source-path target]
   (cond
-    (= :same-state target) (vec source-path)
-    (keyword? target)      (conj (parent-path source-path) target)
-    (target-path? target)  (vec target)
-    :else                  nil))
+    (= :same-state target)  (vec source-path)
+    (keyword? target)       (conj (g/parent-path source-path) target)
+    (g/target-path? target) (vec target)
+    :else                   nil))
 
-(defn reenter?
-  "rf2-9dj21r — true when a transition candidate opts in to the EXTERNAL
+(def ^{:arglists '([candidate])
+       :doc "rf2-b2ygd2 — re-export of `grammar/reenter?`.
+
+  rf2-9dj21r — true when a transition candidate opts in to the EXTERNAL
   restart axis (`:reenter? true`). Spec 005 §Self-transitions + XState v5:
   a TARGETED transition is INTERNAL by default — its own `:exit`/`:entry`
   do not re-run — and only `:reenter? true` makes a self / proper-ancestor
@@ -318,10 +299,8 @@
   a bare keyword / vector-path target never does. Carried onto the edge so
   the chart / Mermaid / SCXML emitters render a `:reenter? true` transition
   distinct from its internal default (otherwise two runtime-distinct
-  machines chart + export IDENTICALLY)."
-  [candidate]
-  (and (map? candidate)
-       (true? (:reenter? candidate))))
+  machines chart + export IDENTICALLY)."}
+  reenter? g/reenter?)
 
 (defn on-done-edges
   "rf2-41goo — emit the completion edge(s) for a node's `:on-done`
@@ -369,7 +348,7 @@
                 ;; rf2-9dj21r — carry the external-restart axis (a
                 ;; target-bearing `:on-done` may opt in to `:reenter?`).
                 (reenter? candidate) (assoc :reenter? true)))))
-        (transition-candidates on-done-spec)))
+        (g/transition-candidates on-done-spec)))
 
 (defn- collect-state-edges
   "Walk a state node and return edge-maps for every statically-
@@ -412,7 +391,7 @@
                                  internal? (assoc :internal? true)
                                  ;; rf2-9dj21r — the external-restart opt-in.
                                  (reenter? candidate) (assoc :reenter? true)))))
-                         (transition-candidates spec)))
+                         (g/transition-candidates spec)))
                  (:on state-node))
          (mapcat (fn [[delay spec]]
                    (keep (fn [candidate]
@@ -443,7 +422,7 @@
                                  internal? (assoc :internal? true)
                                  ;; rf2-9dj21r — the external-restart opt-in.
                                  (reenter? candidate) (assoc :reenter? true)))))
-                         (transition-candidates spec)))
+                         (g/transition-candidates spec)))
                  (:after state-node))
          (mapcat (fn [candidate]
                    ;; rf2-mnp93.4 — an internal (action-only) `:always`
@@ -473,7 +452,7 @@
                           ;; keys, and a cross/ancestor `:always` target may
                           ;; legitimately carry it).
                           (reenter? candidate) (assoc :reenter? true))])))
-                 (transition-candidates (:always state-node)))
+                 (g/transition-candidates (:always state-node)))
          ;; rf2-41goo — the compound / region-compound `:on-done`
          ;; completion edge (XState `onDone`). The done node is THIS node
          ;; (its path is the `done.state.<id>` the engine raises).
@@ -554,30 +533,12 @@
 
 ;; ---- public ids ---------------------------------------------------------
 
-(defn- escape-id-segment
-  "Sanitise one path segment into an xyflow-id-safe string
-  INJECTIVELY — distinct inputs always yield distinct outputs.
-
-  The naive `str/replace #\"[^a-zA-Z0-9_]\" \"_\"` collapses `:a/b`,
-  `:a-b`, `:a_b` all to `\"a_b\"` (rf2-ee38b.21 P2): a React key
-  collision drops one node + makes every edge addressing either
-  ambiguous. Hyphens are pervasive in re-frame keywords
-  (`:logged-in`, `:rate-limited`), so the collision is reachable.
-
-  Scheme: every char outside `[a-zA-Z0-9]` becomes `_<hex>` (the
-  underscore itself included), so the mapping is reversible and no two
-  distinct chars share an encoding. The path separator `__` (double
-  underscore) can never appear inside a segment because a literal `_`
-  encodes to `_5f`."
-  [s]
-  (str/join
-    (map (fn [ch]
-           (if (re-matches #"[a-zA-Z0-9]" (str ch))
-             (str ch)
-             (str "_" #?(:clj  (format "%02x" (int ch))
-                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
-                                 (if (= 1 (count h)) (str "0" h) h))))))
-         s)))
+;; rf2-b2ygd2 — the xyflow-id-safe injective escape is the SHARED
+;; `grammar/escape-id-segment` (the correctness-critical codec the mermaid +
+;; scxml id emitters mint the SAME way, so all three address every node
+;; identically). Aliased locally so `node-id` / `region-node-id` below read
+;; unchanged.
+(def ^:private escape-id-segment g/escape-id-segment)
 
 (defn node-id
   "Stable string id for a node, suitable for xyflow ids and SCXML
@@ -890,32 +851,16 @@
                       internal?            (assoc :internal? true)
                       ;; rf2-9dj21r — carry the external-restart axis.
                       (reenter? candidate) (assoc :reenter? true)))))
-              (transition-candidates spec)))
+              (g/transition-candidates spec)))
       machine-on)))
 
-(defn- normalise-root-targets
-  "rf2-3v3gv1 — normalise a PARALLEL-ROOT `:on` candidate's `:target` into a
-  vector of region-qualified absolute targets `[[<region> & <in-region-path>]
-  …]`, mirroring the runtime resolver (`re-frame.machines.parallel/
-  normalise-root-targets`) so the projected edges address the SAME regions the
-  engine moves. Per the grammar (Spec 005 §Root parallel `:on`):
-
-    - nil / absent → `[]` (TARGETLESS / action-only — runs `:action` / `:fx`,
-      moves no region);
-    - a vector of KEYWORDS (`[:a :two]`) → ONE region-qualified target (head =
-      region name, rest = the in-region path); wrapped to `[[:a :two]]`;
-    - a vector of VECTORS (`[[:a :x] [:b :y]]`) → MULTIPLE region-qualified
-      targets, returned as-is.
-
-  An empty vector return means action-only — the caller self-anchors a
-  terminal/internal root chip rather than emitting a moved-region edge."
-  [target]
-  (cond
-    (nil? target)                        []
-    (and (vector? target)
-         (every? vector? target))        (vec target)
-    (vector? target)                     [target]
-    :else                                []))
+;; rf2-b2ygd2 — the parallel-root `:target` normaliser is the SHARED
+;; `grammar/normalise-root-targets` (also used by the SCXML emitter as
+;; `root-region-qualified-targets`), mirroring the runtime resolver
+;; (`re-frame.machines.parallel/normalise-root-targets`). Aliased locally so
+;; `collect-parallel-root-edges` / `collect-parallel-root-after-edges` below
+;; read unchanged.
+(def ^:private normalise-root-targets g/normalise-root-targets)
 
 (defn- collect-parallel-root-edges
   "rf2-3v3gv1 — emit edges for a `:type :parallel` machine's OWN top-level
@@ -972,7 +917,7 @@
                 ;; node as an internal chip (moves no region).
                 [(cond-> (assoc base :to [] :internal? true)
                    (reenter? candidate) (assoc :reenter? true))])))
-          (transition-candidates spec)))
+          (g/transition-candidates spec)))
       root-on)))
 
 (defn- collect-parallel-root-after-edges
@@ -1016,7 +961,7 @@
                      targets)
                 [(cond-> (assoc base :to [] :internal? true)
                    (reenter? candidate) (assoc :reenter? true))])))
-          (transition-candidates spec)))
+          (g/transition-candidates spec)))
       root-after)))
 
 ;; ---- public projection --------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -1,0 +1,200 @@
+(ns day8.re-frame2-machines-viz.grammar
+  "Shared, PURE grammar walker + injective id codec for the three
+  machines-viz emitters (chart / mermaid / SCXML) — rf2-b2ygd2.
+
+  ## Why this ns exists
+
+  The three emitters each project a re-frame2 machine definition (Spec
+  005 §Transition table grammar) into a different surface — the chart's
+  xyflow node/edge graph, a Mermaid `stateDiagram-v2` string, and a W3C
+  SCXML document. To stay faithful to one another (001-Topology-Parity.md
+  §3.1 G9 — 'faithful across all three emitters'), they MUST address every
+  node by the SAME injective id and walk the transition grammar the SAME
+  way. Pre-rf2-b2ygd2 the walker + codec were HAND-COPIED into all three
+  emitters: `target-path?`, `parent-path`, `transition-candidates`,
+  `history-node?`, `reenter?`, `escape-id-segment` (the
+  correctness-critical injective scheme), the fn-tolerant name renderer,
+  and `normalise-root-targets` each appeared three times. Three copies =
+  three chances to drift; a drift in the escape codec silently re-wires
+  every edge in ONE emitter relative to the others.
+
+  This ns is the SINGLE SOURCE OF TRUTH. The three emitters route through
+  it so the codec + walker can never desync.
+
+  ## What stays SEPARATE (genuinely-distinct SCXML variants)
+
+  Two SCXML walkers are NOT collapsed in here — they implement a
+  deliberately different grammar and must stay in `scxml.cljc`:
+
+  - `scxml/root-transition-candidates` — root-grammar-aware: a
+    vector-of-VECTORS (`[[:a :x] [:b :y]]`) is a SINGLE multi-region
+    target, NOT a candidate fork (the generic `transition-candidates`
+    below would mis-split it).
+  - the SCXML decode side (`unescape-id-segment`, `decode-target`, …) —
+    the INVERSE codec, used only on import.
+
+  Per `tools/machines-viz/spec/*`: the cross-emitter agreement +
+  injective id codec contracts are described there; this ns is the pure
+  internal implementation those contracts already assume."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Grammar walker — transition-spec normalisation
+;; ---------------------------------------------------------------------------
+
+(defn target-path?
+  "True when `v` is a grammar VECTOR-PATH target (Spec 005): a non-empty
+  vector of keywords."
+  [v]
+  (and (vector? v)
+       (seq v)
+       (every? keyword? v)))
+
+(defn transition-candidates
+  "Normalise a transition spec to candidate maps (Spec 005 §Transition
+  table grammar). A transition spec may be:
+
+  - a keyword — the target state;
+  - a vector path of keywords — an absolute target path;
+  - a map — `{:target ... :action ... :guard ...}` (no `:target` =
+    internal / action-only);
+  - a vector of specs — multiple candidates (first-match wins at runtime;
+    every target-bearing branch surfaces);
+  - anything else (e.g. an inline fn) — dropped (cannot statically
+    resolve).
+
+  The SINGLE shared walker the chart + mermaid + the per-state SCXML
+  emitters all use. NOTE the root-parallel SCXML emitter uses its OWN
+  `scxml/root-transition-candidates` instead — a vector-of-vectors there
+  is one multi-region target, not a candidate fork."
+  [spec]
+  (cond
+    (keyword? spec)     [{:target spec}]
+    (target-path? spec) [{:target spec}]
+    (map? spec)         [spec]
+    (vector? spec)      (mapcat transition-candidates spec)
+    :else               []))
+
+(defn parent-path
+  "The parent path of `path` (its `pop`); `[]` for an empty/top-level
+  path."
+  [path]
+  (if (seq path)
+    (pop path)
+    []))
+
+(defn history-node?
+  "rf2-m285a — true when a node under a compound's `:states` is a
+  `:type :history` PSEUDO-STATE (Spec 005 §History states), not an
+  ordinary occupiable substate. A history pseudo-state is NEVER active: a
+  transition *to* it resolves to the compound's recorded / default leaf
+  configuration. Every emitter paints it as a history marker (chart
+  `history-marker` glyph, mermaid `H`/`H*` alias, SCXML `<history>`),
+  never an ordinary state."
+  [state-node]
+  (and (map? state-node)
+       (= :history (:type state-node))))
+
+(defn reenter?
+  "rf2-9dj21r — true when a transition candidate opts in to the EXTERNAL
+  restart axis (`:reenter? true`). Spec 005 §Self-transitions + XState v5:
+  a TARGETED transition is INTERNAL by default — its own `:exit`/`:entry`
+  do not re-run — and only `:reenter? true` makes a self / proper-ancestor
+  / compound-declared-descendant target EXTERNAL (re-run `:exit`+`:entry`,
+  restart the target's `:after` timers + tear-down-and-respawn its
+  `:spawn` children). Matches the engine's `(true? (:reenter?
+  transition))` read (`re-frame.machines.transition`). Only a map
+  candidate can carry it; a bare keyword / vector-path target never does.
+  Carried onto every emitter's edge so a `:reenter? true` transition
+  renders DISTINCTLY from its internal default (otherwise two
+  runtime-distinct machines project IDENTICALLY)."
+  [candidate]
+  (and (map? candidate)
+       (true? (:reenter? candidate))))
+
+(defn normalise-root-targets
+  "rf2-3v3gv1 / rf2-656ivk / rf2-m3otj2 — normalise a PARALLEL-ROOT `:on` /
+  `:after` candidate's `:target` into a vector of region-qualified absolute
+  targets `[[<region> & <in-region-path>] …]`, mirroring the runtime resolver
+  (`re-frame.machines.parallel/normalise-root-targets`) so the projected /
+  exported edges address the SAME regions the engine moves. Per the grammar
+  (Spec 005 §Root parallel `:on` / §Root-level `:after`):
+
+    - nil / absent → `[]` (TARGETLESS / action-only — runs `:action` / `:fx`,
+      moves no region);
+    - a vector of KEYWORDS (`[:a :two]`) → ONE region-qualified target (head =
+      region name, rest = the in-region path); wrapped to `[[:a :two]]`;
+    - a vector of VECTORS (`[[:a :x] [:b :y]]`) → MULTIPLE region-qualified
+      targets, returned as-is.
+
+  An empty vector return means action-only — the caller self-anchors a
+  terminal/internal root chip rather than emitting a moved-region edge.
+
+  Shared by the chart projector (`chart.layout`) and the SCXML emitter
+  (`scxml`, as `root-region-qualified-targets`); the mermaid emitter
+  consumes the per-candidate exploder form (`root-region-qualified-
+  candidates`) which is built on the same vector-of-vectors test."
+  [target]
+  (cond
+    (nil? target)                        []
+    (and (vector? target)
+         (every? vector? target))        (vec target)
+    (vector? target)                     [target]
+    :else                                []))
+
+;; ---------------------------------------------------------------------------
+;; Name rendering — fn-tolerant guard / action / event labels
+;; ---------------------------------------------------------------------------
+
+(defn name-of
+  "Render a guard / action / entry / exit symbol-like value as a short
+  string WITHOUT throwing on fn values. Keywords use `ns/name` when
+  namespaced, plain `name` otherwise; non-keywords fall through to `str`.
+  Inlined fn guards / actions surface their `:name` meta (named
+  `(fn name [...] ...)` / `(defn ...)`) or `\"fn\"` when anonymous — so the
+  label reads cleanly instead of `#object[Function]`.
+
+  The shared fn-tolerant renderer (chart `name-of`, mermaid
+  `keyword-label`/`label-value`, SCXML `ref->label` all collapse here). A
+  `nil` ref renders `nil`."
+  [v]
+  (cond
+    (nil? v)     nil
+    (keyword? v) (if-let [n (namespace v)]
+                   (str n "/" (name v))
+                   (name v))
+    (fn? v)      (or (some-> v meta :name str) "fn")
+    :else        (str v)))
+
+;; ---------------------------------------------------------------------------
+;; Injective id codec — the correctness-critical scheme
+;; ---------------------------------------------------------------------------
+
+(defn escape-id-segment
+  "Sanitise one path segment into an id-safe string INJECTIVELY — distinct
+  inputs always yield distinct outputs.
+
+  The naive `str/replace #\"[^a-zA-Z0-9_]\" \"_\"` collapses `:a/b`,
+  `:a-b`, `:a_b` all to `\"a_b\"` (rf2-ee38b.21 P2 / rf2-mnp93.1/.6): a
+  collision drops one node + makes every edge addressing either ambiguous.
+  Hyphens are pervasive in re-frame keywords (`:logged-in`,
+  `:rate-limited`), so the collision is reachable.
+
+  Scheme: every char outside `[A-Za-z0-9]` becomes `_<2-hex>` (the
+  underscore itself included → `_5f`), so the mapping is reversible and no
+  two distinct chars share an encoding. Because the result contains no two
+  consecutive underscores, the reserved markers the consumers layer on top
+  — `_2f` (the hex of `/`) for a keyword's ns/name boundary, `__` between
+  path segments (xyflow `node-id` / mermaid `sanitise-id`), `__`/`___`
+  (SCXML ns-name / path separators) — can never arise from segment
+  content. This is the SINGLE injective scheme all three emitters' id
+  codecs build on, so they address every node identically."
+  [s]
+  (str/join
+    (map (fn [ch]
+           (if (re-matches #"[A-Za-z0-9]" (str ch))
+             (str ch)
+             (str "_" #?(:clj  (format "%02x" (int ch))
+                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
+                                 (if (= 1 (count h)) (str "0" h) h))))))
+         s)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -95,7 +95,11 @@
   a PR description, Notion, or any other Mermaid-aware markdown
   renderer."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]))
+            [re-frame.error :as error]
+            ;; rf2-b2ygd2 — the SHARED grammar walker + injective id codec
+            ;; the three emitters route through, so they address every node
+            ;; identically (one escape codec, one source of truth).
+            [day8.re-frame2-machines-viz.grammar :as g]))
 
 (def ^:private header-comment
   ;; Inserted at the top of every emitted block so a reader who pastes
@@ -110,12 +114,13 @@
 (def ^:private root-fallback-segment :rf.machines-viz.mermaid/root-fallback)
 (def ^:private parallel-root-path [:rf.machines-viz.mermaid/parallel-root])
 
-(defn- keyword-label
-  "Return a human-readable keyword label without the leading colon."
-  [id]
-  (if-let [ns (namespace id)]
-    (str ns "/" (name id))
-    (name id)))
+;; rf2-b2ygd2 — `keyword-label` is the SHARED fn-tolerant `grammar/name-of`
+;; (identical for keywords: `ns/name` or `name`, no leading colon). `label-
+;; value` keeps its Mermaid-edge dispatch (string verbatim, else `pr-str`).
+(def ^{:arglists '([id])
+       :doc "rf2-b2ygd2 — re-export of `grammar/name-of`: a human-readable
+  keyword label without the leading colon."}
+  keyword-label g/name-of)
 
 (defn- label-value
   "Return a label string for values that appear on Mermaid edges."
@@ -125,47 +130,13 @@
     (string? v)  v
     :else        (pr-str v)))
 
-(defn- target-path?
-  "True when `v` is a grammar vector-path target."
-  [v]
-  (and (vector? v)
-       (seq v)
-       (every? keyword? v)))
-
-(defn- history-node?
-  "rf2-m285a — true when a node under a compound's `:states` is a
-  `:type :history` PSEUDO-STATE (Spec 005 §History states), not an
-  ordinary occupiable substate. A history pseudo-state is never active:
-  a transition *to* it resolves to the compound's recorded / default
-  leaf. Pre-fix the Mermaid emitter rendered it as a bare leaf id in
-  incoming edges with no declaration, so it read as an ordinary state."
-  [state-node]
-  (and (map? state-node)
-       (= :history (:type state-node))))
-
-(defn- escape-id-segment
-  "Escape one keyword ns/name part INJECTIVELY into a Mermaid-id-safe
-  string: every char outside `[A-Za-z0-9]` becomes `_<2-hex>` (the
-  underscore itself → `_5f`). Distinct inputs always yield distinct
-  outputs, and the result contains no two consecutive underscores, so
-  the `_2f` ns/name marker and the `__` path separator can never arise
-  from segment content.
-
-  rf2-mnp93.6 — mirrors `chart/layout/escape-id-segment` (the SAME
-  injective scheme the SCXML codec + the chart's xyflow `node-id` use),
-  so the three emitters address every node identically. The naive
-  `str/replace #\"[^a-zA-Z0-9_]\" \"_\"` collapsed `:a/b`, `:a-b`, `:a_b`
-  all to `\"a_b\"` — two distinct states became ONE Mermaid node, silently
-  mis-wiring every edge to/from either."
-  [s]
-  (str/join
-    (map (fn [ch]
-           (if (re-matches #"[A-Za-z0-9]" (str ch))
-             (str ch)
-             (str "_" #?(:clj  (format "%02x" (int ch))
-                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
-                                 (if (= 1 (count h)) (str "0" h) h))))))
-         s)))
+;; rf2-b2ygd2 — grammar walker + injective id codec aliased from the SHARED
+;; `grammar` ns (the same `escape-id-segment` the chart `node-id` + the SCXML
+;; codec mint, so all three emitters address every node identically —
+;; rf2-mnp93.6).
+(def ^:private target-path? g/target-path?)
+(def ^:private history-node? g/history-node?)
+(def ^:private escape-id-segment g/escape-id-segment)
 
 (defn- id-segment
   "Render one path segment as an INJECTIVE Mermaid-id-safe string.
@@ -233,34 +204,15 @@
       (str/replace #"[\r\n]+" " ")
       (str/replace "\"" "'")))
 
-(defn- transition-candidates
-  "Normalise a transition spec to candidate maps.
+;; rf2-b2ygd2 — the transition-spec walker is the SHARED
+;; `grammar/transition-candidates` (chart + per-state SCXML emitters share
+;; it). NOTE the parallel-ROOT mermaid path uses its own region-aware
+;; exploder (`root-region-qualified-candidates`), mirroring the SCXML
+;; `root-transition-candidates` divergence (a vector-of-vectors is one
+;; multi-region target, not a candidate fork).
+(def ^:private transition-candidates g/transition-candidates)
 
-  Per Spec 005 §Transition table grammar, a transition spec may be:
-
-  - A keyword — the target state.
-  - A vector path of keywords — an absolute target path from the
-    current root (top-level machine root, or parallel-region root).
-  - A vector of transition specs — multiple candidates, first-match
-    wins at runtime; Mermaid renders every target-bearing branch.
-  - A map — `{:target ... :action ... :guard ...}`; `:target` is the
-    target state. Without `:target` the transition is internal (no
-    edge).
-  - A function — implementation-defined; we cannot statically render
-    a fn-shaped transition without running it, so we drop the edge."
-  [spec]
-  (cond
-    (keyword? spec)     [{:target spec}]
-    (target-path? spec) [{:target spec}]
-    (map? spec)         [spec]
-    (vector? spec)      (mapcat transition-candidates spec)
-    :else               []))
-
-(defn- parent-path
-  [path]
-  (if (seq path)
-    (pop path)
-    []))
+(def ^:private parent-path g/parent-path)
 
 (defn- resolve-target-path
   "Resolve a transition target against `source-path`.
@@ -281,17 +233,12 @@
   (when-let [guard (:guard candidate)]
     (str " [" (sanitise-label guard) "]")))
 
-(defn- reenter?
-  "rf2-9dj21r — true when a transition candidate opts in to the EXTERNAL
-  restart axis (`:reenter? true`, Spec 005 §Self-transitions / XState v5).
-  A TARGETED transition is INTERNAL by default; only `:reenter? true` makes
-  a self / ancestor / compound-declared-descendant target external (re-run
-  `:exit`+`:entry`, restart the target's `:after` timers + `:spawn`
-  children). Without this distinction a `{:target :same-state}` transition
-  charts IDENTICALLY whether or not `:reenter? true` is set."
-  [candidate]
-  (and (map? candidate)
-       (true? (:reenter? candidate))))
+;; rf2-b2ygd2 — the external-restart predicate is the SHARED
+;; `grammar/reenter?` (Spec 005 §Self-transitions / XState v5: a TARGETED
+;; transition is INTERNAL by default; only `:reenter? true` makes it
+;; external). Without this distinction a `{:target :same-state}` transition
+;; charts IDENTICALLY whether or not `:reenter? true` is set.
+(def ^:private reenter? g/reenter?)
 
 (defn- reenter-suffix
   "rf2-9dj21r — a trailing `↻` marker on the Mermaid edge label for a

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -140,6 +140,13 @@
   Per [`API.md`](../../spec/API.md) §SCXML import/export."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
+            ;; rf2-b2ygd2 — the SHARED grammar walker + injective id codec
+            ;; the three emitters route through, so they address every node
+            ;; identically (one escape codec, one source of truth). The SCXML
+            ;; DECODE side (unescape / decode-target) + the root-grammar-aware
+            ;; `root-transition-candidates` stay LOCAL — they are genuinely
+            ;; distinct from the shared emit-side walker.
+            [day8.re-frame2-machines-viz.grammar :as g]
             ;; rf2-bs3us — share the canonical parallel-root done-state id
             ;; with the chart projector so the two emitters agree on the
             ;; `done.state.<id>` label (single source of truth).
@@ -228,23 +235,14 @@
   rf2-mnp93.7)."
   "___")
 
-(defn- escape-id-segment
-  "Escape one keyword ns/name part INJECTIVELY into an xsd:ID-safe
-  string: every char outside `[A-Za-z0-9]` becomes `_<2-hex>` (the
-  underscore itself → `_5f`). Distinct inputs always yield distinct
-  outputs and the result contains no two consecutive underscores, so the
-  `__` / `___` reserved markers can never arise from segment content.
-  Mirrors `chart/layout/escape-id-segment` (single injective scheme
-  across all machines-viz id emitters)."
-  [s]
-  (str/join
-    (map (fn [ch]
-           (if (re-matches #"[A-Za-z0-9]" (str ch))
-             (str ch)
-             (str "_" #?(:clj  (format "%02x" (int ch))
-                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
-                                 (if (= 1 (count h)) (str "0" h) h))))))
-         s)))
+;; rf2-b2ygd2 — the xsd:ID-safe injective escape is the SHARED
+;; `grammar/escape-id-segment` (every char outside `[A-Za-z0-9]` → `_<2-hex>`,
+;; the underscore itself → `_5f`; no two consecutive underscores, so the
+;; `__` / `___` reserved markers can never arise from segment content). The
+;; SINGLE injective scheme across all machines-viz id emitters, so the SCXML
+;; codec mints byte-identical segment escapes to the chart `node-id` + mermaid
+;; `sanitise-id`.
+(def ^:private escape-id-segment g/escape-id-segment)
 
 (defn- unescape-id-segment
   "Inverse of `escape-id-segment`: replace every `_<2-hex>` triple with
@@ -335,17 +333,13 @@
   [depth]
   (apply str (repeat depth "  ")))
 
-(defn- transition-candidates
-  "Normalise a transition spec to candidate maps. Same grammar
-  walker as `mermaid.cljc/transition-candidates`."
-  [spec]
-  (cond
-    (keyword? spec) [{:target spec}]
-    (vector? spec)  (if (every? keyword? spec)
-                      [{:target spec}]
-                      (mapcat transition-candidates spec))
-    (map? spec)     [spec]
-    :else           []))
+;; rf2-b2ygd2 — the generic per-state transition-spec walker is the SHARED
+;; `grammar/transition-candidates` (chart + mermaid share it). NOTE the
+;; parallel-ROOT SCXML emitter uses its OWN `root-transition-candidates`
+;; (below) instead — there a vector-of-VECTORS is a SINGLE multi-region
+;; target, NOT a candidate fork, so it must NOT route through the generic
+;; walker. That divergence is PRESERVED.
+(def ^:private transition-candidates g/transition-candidates)
 
 ;; --- path qualification (rf2-mnp93.7) ------------------------------------
 ;;
@@ -361,22 +355,14 @@
 ;; (a sibling keyword when it shares the source's parent, else the
 ;; absolute vector path) so the round-trip is exact.
 
-(defn- target-path?
-  "True when `v` is a grammar VECTOR-PATH target (a vector of keywords)."
-  [v]
-  (and (vector? v) (seq v) (every? keyword? v)))
-
-(defn- history-node?
-  "rf2-m285a — true when a node under a compound's `:states` is a
-  `:type :history` PSEUDO-STATE (Spec 005 §History states). W3C SCXML has
-  a first-class `<history>` element; pre-fix `emit-state` emitted a
-  `<state>` / `<final>` for it (losing the history semantics on export
-  AND making round-trip produce a DIFFERENT machine)."
-  [state-node]
-  (and (map? state-node)
-       (= :history (:type state-node))))
-
-(defn- parent-path [path] (if (seq path) (pop path) []))
+;; rf2-b2ygd2 — grammar primitives aliased from the SHARED `grammar` ns. W3C
+;; SCXML emits a first-class `<history>` element for a `:type :history`
+;; pseudo-state (Spec 005 §History states); pre-fix `emit-state` emitted a
+;; `<state>` / `<final>`, losing the history semantics + making round-trip
+;; produce a DIFFERENT machine.
+(def ^:private target-path? g/target-path?)
+(def ^:private history-node? g/history-node?)
+(def ^:private parent-path g/parent-path)
 
 (defn- resolve-target-path
   "Resolve a transition target to its ABSOLUTE path from the machine
@@ -690,25 +676,15 @@
                       [{:target spec}])            ; :vec-target — ONE target
     :else           []))
 
-(defn- root-region-qualified-targets
-  "rf2-656ivk / rf2-m3otj2 — normalise a parallel-ROOT `:on` / `:after`
-  transition's `:target` into a vector of region-qualified absolute targets
-  `[[<region> & <in-region-path>] …]`, mirroring the runtime resolver
-  (`re-frame.machines.parallel/normalise-root-targets`) and the chart
-  projector (`chart.layout/normalise-root-targets`). Per the grammar
-  (Spec 005 §Root parallel `:on` / §Root-level `:after`):
-
-    - nil / absent  → `[]` (TARGETLESS / action-only);
-    - a vector of KEYWORDS (`[:a :two]`) → ONE region-qualified target
-      (head = region, rest = in-region path); wrapped to `[[:a :two]]`;
-    - a vector of VECTORS (`[[:a :x] [:b :y]]`) → MULTIPLE, returned as-is."
-  [target]
-  (cond
-    (nil? target)                  []
-    (and (vector? target)
-         (every? vector? target))  (vec target)
-    (vector? target)               [target]
-    :else                          []))
+;; rf2-b2ygd2 — the parallel-root `:target` normaliser is the SHARED
+;; `grammar/normalise-root-targets` (also the chart projector's
+;; `normalise-root-targets`), mirroring the runtime resolver
+;; (`re-frame.machines.parallel/normalise-root-targets`):
+;;   - nil / absent  → `[]` (TARGETLESS / action-only);
+;;   - vector of KEYWORDS (`[:a :two]`) → ONE region-qualified target;
+;;   - vector of VECTORS (`[[:a :x] [:b :y]]`) → MULTIPLE, returned as-is.
+;; This is the inverse-symmetric partner of `decode-root-parallel-target`.
+(def ^:private root-region-qualified-targets g/normalise-root-targets)
 
 (defn- emit-root-parallel-transition
   "rf2-656ivk / rf2-m3otj2 — emit ONE root-parallel `<transition>` (an `:on`


### PR DESCRIPTION
## What

Extract a pure `cljc` namespace **`day8.re-frame2-machines-viz.grammar`** holding the grammar walker + injective id codec that were **hand-copied across the three emitters** (`chart/layout.cljc`, `mermaid.cljc`, `scxml.cljc`), and route all three through it. One escape codec, one walker, one source of truth — eliminating the desync landmine (a drift in one copy of the escape codec would silently re-wire every edge in that emitter relative to the others).

## The extracted ns (`grammar.cljc`)

- `target-path?`, `transition-candidates`, `parent-path`
- `history-node?`, `reenter?`, `normalise-root-targets`
- `name-of` — the fn-tolerant guard/action/event name renderer
- `escape-id-segment` — **the correctness-critical injective scheme** (`[A-Za-z0-9]` passes through, every other char → `_<2-hex>`, `_` → `_5f`; no two consecutive underscores, so the `_2f` / `__` / `___` reserved markers can never arise from segment content)

## The 3 emitters routed through it

- **`chart/layout.cljc`** — `node-id`/`region-node-id` mint via `g/escape-id-segment`; `resolve-target-path` uses `g/parent-path`/`g/target-path?`; `collect-*` walkers use `g/transition-candidates`; `normalise-root-targets` aliased. Public API names (`name-of`, `history-node?`, `reenter?`) kept as thin re-exports so `chart.projection`, `scxml`, and tests are unchanged.
- **`mermaid.cljc`** — `keyword-label` → `g/name-of`; `target-path?`/`history-node?`/`escape-id-segment`/`transition-candidates`/`parent-path`/`reenter?` aliased to `g/`.
- **`scxml.cljc`** — `escape-id-segment`/`target-path?`/`history-node?`/`parent-path`/`transition-candidates` aliased; `root-region-qualified-targets` → `g/normalise-root-targets`.

## Preserved distinct variants (NOT collapsed into the shared walker)

- **`scxml/root-transition-candidates`** — root-grammar-aware: a vector-of-VECTORS (`[[:a :x] [:b :y]]`) is a SINGLE multi-region target (`:vec-target`), NOT a candidate fork. Stays local.
- **`scxml`'s 2-arity `resolve-target-path`** + the SCXML decode side (`unescape-id-segment`, `decode-target`, …). Stay local — the inverse codec, import-only.
- **`mermaid`'s 3-arity `resolve-target-path`** (prepends `root-path` for vector targets) + its per-candidate **`root-region-qualified-candidates`** exploder. Stay local.
- **`scxml/ref->label`** untouched — its keyword branch goes through the SCXML id codec (`cond=`), genuinely different from the plain `name-of` rendering.

## Cross-emitter agreement — green BEFORE and AFTER

The `cross_emitter_agreement_cljs_test` (byte-identical ids, 001-Topology-Parity G9) is the safety net. Ran green before the refactor (baseline) and after:

```
# machines-viz: clojure -M:test
Ran 550 tests containing 1927 assertions.   0 failures, 0 errors.
#   (incl. cross-emitter-agreement: Ran 13 tests containing 91 assertions. 0 failures, 0 errors.)

# implementation: npm run test:cljs
Ran 7865 tests containing 32596 assertions.  0 failures, 0 errors.
```

## Spec

Spec unchanged because the extraction is a **pure internal refactor with identical output**: the `tools/machines-viz/spec/*` docs describe the cross-emitter agreement (G9) and the injective xsd:ID/`node-id` codec as **behavioural contracts**, not internal code structure — both remain exactly true (proven by the byte-identical-ids test passing before+after).