### PR TITLE
refactor(scripts): merge dup epoch artefact, share sleep/countMatches/sentinel-scan/policy-test utils (rf2-j552l2)

### DIFF
--- a/implementation/scripts/_mcp-conformance-install-policy.test.cjs
+++ b/implementation/scripts/_mcp-conformance-install-policy.test.cjs
@@ -37,61 +37,19 @@ const assert = require('assert/strict');
 const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
+// Shared stripComments (EXECUTABLE-source-only matching) + framework-free
+// test harness (rf2-j552l2). perTestPass:true preserves this suite's
+// per-test `PASS  <name>` line.
+const { stripComments, createPolicyTestSuite } = require('./_policy-test-util.cjs');
 
 const SCRIPTS_DIR = __dirname;
 const RUNNER_PATH = path.join(SCRIPTS_DIR, 'test-mcp-conformance.cjs');
 const REPO_ROOT = path.resolve(SCRIPTS_DIR, '..', '..');
 const TOOLS = path.join(REPO_ROOT, 'tools');
 
-const tests = [];
-function test(name, fn) {
-  tests.push({ name, fn });
-}
+const { test, run } = createPolicyTestSuite('mcp-conformance-install-policy', { perTestPass: true });
 
 const RUNNER_SRC = fs.readFileSync(RUNNER_PATH, 'utf8');
-
-// Strip line- and block-comments so policy assertions match EXECUTABLE
-// source only — the doc-comment necessarily quotes `npm install`. Reuse
-// the same simple stripper shape as _script-spawn-policy.test.cjs.
-function stripComments(src) {
-  let out = '';
-  let i = 0;
-  const n = src.length;
-  let inLine = false;
-  let inBlock = false;
-  let inStr = false;
-  let strQuote = '';
-  while (i < n) {
-    const c = src[i];
-    const c2 = src[i + 1];
-    if (inLine) {
-      if (c === '\n') { inLine = false; out += c; }
-      i += 1;
-      continue;
-    }
-    if (inBlock) {
-      if (c === '*' && c2 === '/') { inBlock = false; i += 2; continue; }
-      i += 1;
-      continue;
-    }
-    if (inStr) {
-      out += c;
-      if (c === '\\') { out += c2 == null ? '' : c2; i += 2; continue; }
-      if (c === strQuote) { inStr = false; strQuote = ''; }
-      i += 1;
-      continue;
-    }
-    if (c === '/' && c2 === '/') { inLine = true; i += 2; continue; }
-    if (c === '/' && c2 === '*') { inBlock = true; i += 2; continue; }
-    if (c === '"' || c === "'" || c === '`') {
-      inStr = true; strQuote = c; out += c; i += 1; continue;
-    }
-    out += c;
-    i += 1;
-  }
-  return out;
-}
-
 const RUNNER_CODE = stripComments(RUNNER_SRC);
 
 // 1. Install steps are declared via `install: true` + resolved through
@@ -279,21 +237,4 @@ test('LIVE: lockfile-backed tool packages the runner installs have a present, dr
   );
 });
 
-let failed = 0;
-for (const { name, fn } of tests) {
-  try {
-    fn();
-    console.log(`PASS  ${name}`);
-  } catch (err) {
-    failed += 1;
-    console.error(`FAIL  ${name}`);
-    console.error(err && err.stack ? err.stack : err);
-  }
-}
-
-if (failed > 0) {
-  console.error(`mcp-conformance-install-policy tests: ${failed} failed.`);
-  process.exit(1);
-}
-
-console.log(`mcp-conformance-install-policy tests: ${tests.length} passed.`);
+run();

--- a/implementation/scripts/_orchestrator-teardown-policy.test.cjs
+++ b/implementation/scripts/_orchestrator-teardown-policy.test.cjs
@@ -52,6 +52,9 @@
 const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
+// Shared stripComments (EXECUTABLE-source-only matching) + framework-free
+// test harness (rf2-j552l2).
+const { stripComments, createPolicyTestSuite } = require('./_policy-test-util.cjs');
 
 const IMPL_SCRIPTS_DIR = __dirname;
 const EXAMPLES_SCRIPTS_DIR = path.resolve(
@@ -62,10 +65,7 @@ const EXAMPLES_SCRIPTS_DIR = path.resolve(
   'scripts',
 );
 
-const tests = [];
-function test(name, fn) {
-  tests.push({ name, fn });
-}
+const { test, run } = createPolicyTestSuite('orchestrator-teardown-policy');
 
 // The full inventory of `serve-and-run-*.cjs` orchestrators across the two
 // scripts dirs. Every one is launched by an `npm run test:*` entry-point
@@ -90,50 +90,6 @@ function orchestratorFiles() {
     ...serveAndRunFilesIn(IMPL_SCRIPTS_DIR),
     ...serveAndRunFilesIn(EXAMPLES_SCRIPTS_DIR),
   ];
-}
-
-// Strip line- and block-comments so the policy assertions match only
-// EXECUTABLE source, not the explanatory comments that necessarily name
-// the very symbols we require/forbid. String literals are left intact.
-// Mirrors the stripComments in _script-spawn-policy.test.cjs (deliberately
-// simple — a residue gate over our own first-party scripts, not a parser).
-function stripComments(src) {
-  let out = '';
-  let i = 0;
-  const n = src.length;
-  let inLine = false;
-  let inBlock = false;
-  let inStr = false;
-  let strQuote = '';
-  while (i < n) {
-    const c = src[i];
-    const c2 = src[i + 1];
-    if (inLine) {
-      if (c === '\n') { inLine = false; out += c; }
-      i += 1;
-      continue;
-    }
-    if (inBlock) {
-      if (c === '*' && c2 === '/') { inBlock = false; i += 2; continue; }
-      i += 1;
-      continue;
-    }
-    if (inStr) {
-      out += c;
-      if (c === '\\') { out += c2 == null ? '' : c2; i += 2; continue; }
-      if (c === strQuote) { inStr = false; strQuote = ''; }
-      i += 1;
-      continue;
-    }
-    if (c === '/' && c2 === '/') { inLine = true; i += 2; continue; }
-    if (c === '/' && c2 === '*') { inBlock = true; i += 2; continue; }
-    if (c === '"' || c === "'" || c === '`') {
-      inStr = true; strQuote = c; out += c; i += 1; continue;
-    }
-    out += c;
-    i += 1;
-  }
-  return out;
 }
 
 const CREATE_CLEANUP_RE = /\bcreateHarnessCleanup\b/;
@@ -268,20 +224,4 @@ test('stripComments removes comment text but preserves code (rf2-c3hffe)', () =>
   );
 });
 
-let failed = 0;
-for (const { name, fn } of tests) {
-  try {
-    fn();
-  } catch (err) {
-    failed += 1;
-    console.error(`FAIL ${name}`);
-    console.error(err && err.stack ? err.stack : err);
-  }
-}
-
-if (failed > 0) {
-  console.error(`orchestrator-teardown-policy tests: ${failed} failed.`);
-  process.exit(1);
-}
-
-console.log(`orchestrator-teardown-policy tests: ${tests.length} passed.`);
+run();

--- a/implementation/scripts/_policy-test-util.cjs
+++ b/implementation/scripts/_policy-test-util.cjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * Shared utilities for the source-policy gate suites (rf2-j552l2).
+ *
+ * The `_*-policy.test.cjs` gates are static source scanners: they read a
+ * first-party script's text and assert on it. Three pieces had drifted into
+ * verbatim copies across them (rf2-u4vtlh / rf2-b4d7o1 review):
+ *
+ *   - `stripComments` — a deliberately simple (NOT a JS parser) stripper of
+ *     line- and block-comments that LEAVES string literals intact, so a
+ *     policy assertion matches EXECUTABLE source only and a doc-comment that
+ *     necessarily quotes the very token the gate forbids/requires is not a
+ *     false positive (or, for a forbidden token, a false negative). Three
+ *     byte-identical copies lived in _mcp-conformance-install-policy /
+ *     _orchestrator-teardown-policy / _script-spawn-policy.
+ *
+ *   - the standalone test harness (`const tests=[]; function test(){...}` +
+ *     the run loop + the `<label> tests: N passed/failed.` footer) the
+ *     framework-free `_*.test.cjs` convention repeats.
+ *
+ *   - `loopbackBindRe` — the http-server `-a 127.0.0.1` loopback-bind
+ *     matcher. Two callers ( _script-spawn-policy + _story-script-runners-
+ *     policy) shared the identical tail `,[\s\S]{0,80}?'-a','127.0.0.1'`
+ *     but differ in the bin-token alternation they anchor it to; the factory
+ *     keeps each caller's exact token set so neither gate's strictness
+ *     changes.
+ *
+ * This is a plain helper module (NOT a `.test.cjs`), so the `test:script-*`
+ * runners don't execute it as a suite; the policy suites `require` it.
+ */
+
+// Strip line- and block-comments so policy assertions match EXECUTABLE
+// source only — the doc-comments necessarily quote the very symbols the
+// gates require/forbid. String literals are left intact (so a real
+// `shell: true` hidden in a literal would still trip its gate).
+// Deliberately simple: a residue stripper over our own first-party
+// scripts, not a general-purpose JS parser.
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  let inLine = false;
+  let inBlock = false;
+  let inStr = false;
+  let strQuote = '';
+  while (i < n) {
+    const c = src[i];
+    const c2 = src[i + 1];
+    if (inLine) {
+      if (c === '\n') { inLine = false; out += c; }
+      i += 1;
+      continue;
+    }
+    if (inBlock) {
+      if (c === '*' && c2 === '/') { inBlock = false; i += 2; continue; }
+      i += 1;
+      continue;
+    }
+    if (inStr) {
+      out += c;
+      if (c === '\\') { out += c2 == null ? '' : c2; i += 2; continue; }
+      if (c === strQuote) { inStr = false; strQuote = ''; }
+      i += 1;
+      continue;
+    }
+    if (c === '/' && c2 === '/') { inLine = true; i += 2; continue; }
+    if (c === '/' && c2 === '*') { inBlock = true; i += 2; continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      inStr = true; strQuote = c; out += c; i += 1; continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+// Build the http-server loopback-bind matcher. `binTokenPattern` is the
+// RegExp-source alternation for the bin token a launcher names before its
+// `'-a', '127.0.0.1'` argument pair (e.g. `'HTTP_SERVER_BIN'` for the
+// constant form, or `'(?:httpServerBin\\(\\)|HTTP_SERVER_BIN)'` to also
+// accept the lazy-resolver form). The shared tail tolerates a short window
+// of intervening args/whitespace between the bin token and the loopback
+// pair. NB `[\s\S]{0,80}?` (not `[^]`): the JS-regex `[^]`-any-char gotcha.
+function loopbackBindRe(binTokenPattern) {
+  return new RegExp(
+    `${binTokenPattern},[\\s\\S]{0,80}?['"]-a['"]\\s*,\\s*['"]127\\.0\\.0\\.1['"]`,
+  );
+}
+
+// Create a standalone, framework-free test harness matching the
+// `_*.test.cjs` convention. `label` names the suite in the footer.
+//   opts.perTestPass : true ⇒ print `PASS  <name>` per passing test and
+//                      `FAIL  <name>` (two-space) on failure (the
+//                      _mcp-conformance-install-policy posture); false
+//                      (default) ⇒ no per-test PASS line, `FAIL <name>`
+//                      (one-space) on failure (the other policy suites).
+// Returns { test, run }: `test(name, fn)` registers; `run()` executes all
+// registered tests, prints the footer, and `process.exit(1)` on any
+// failure (otherwise returns normally).
+function createPolicyTestSuite(label, opts = {}) {
+  const { perTestPass = false } = opts;
+  const tests = [];
+  function test(name, fn) {
+    tests.push({ name, fn });
+  }
+  function run() {
+    let failed = 0;
+    for (const { name, fn } of tests) {
+      try {
+        fn();
+        if (perTestPass) console.log(`PASS  ${name}`);
+      } catch (err) {
+        failed += 1;
+        console.error(`${perTestPass ? 'FAIL ' : 'FAIL'} ${name}`);
+        console.error(err && err.stack ? err.stack : err);
+      }
+    }
+    if (failed > 0) {
+      console.error(`${label} tests: ${failed} failed.`);
+      process.exit(1);
+    }
+    console.log(`${label} tests: ${tests.length} passed.`);
+  }
+  return { test, run };
+}
+
+module.exports = {
+  stripComments,
+  loopbackBindRe,
+  createPolicyTestSuite,
+};

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -49,6 +49,13 @@
 const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
+// Shared stripComments (EXECUTABLE-source-only matching) + loopbackBindRe
+// factory + framework-free test harness (rf2-j552l2).
+const {
+  stripComments,
+  loopbackBindRe,
+  createPolicyTestSuite,
+} = require('./_policy-test-util.cjs');
 
 const SCRIPTS_DIR = __dirname;
 // rf2-y9o5e3 — the executable browser-gate launchers under
@@ -66,55 +73,7 @@ const EXAMPLES_SCRIPTS_DIR = path.resolve(
   'scripts',
 );
 
-const tests = [];
-function test(name, fn) {
-  tests.push({ name, fn });
-}
-
-// Strip line- and block-comments so the policy assertions match only
-// EXECUTABLE source, not the explanatory comments that necessarily
-// quote the very strings we forbid (`shell: true`, `npx.cmd`, ...).
-// Deliberately simple: this is a residue gate over our own first-party
-// scripts, not a general-purpose JS parser. String literals are left
-// intact so a real `shell: true` hidden in a literal would still trip.
-function stripComments(src) {
-  let out = '';
-  let i = 0;
-  const n = src.length;
-  let inLine = false;
-  let inBlock = false;
-  let inStr = false;
-  let strQuote = '';
-  while (i < n) {
-    const c = src[i];
-    const c2 = src[i + 1];
-    if (inLine) {
-      if (c === '\n') { inLine = false; out += c; }
-      i += 1;
-      continue;
-    }
-    if (inBlock) {
-      if (c === '*' && c2 === '/') { inBlock = false; i += 2; continue; }
-      i += 1;
-      continue;
-    }
-    if (inStr) {
-      out += c;
-      if (c === '\\') { out += c2 == null ? '' : c2; i += 2; continue; }
-      if (c === strQuote) { inStr = false; strQuote = ''; }
-      i += 1;
-      continue;
-    }
-    if (c === '/' && c2 === '/') { inLine = true; i += 2; continue; }
-    if (c === '/' && c2 === '*') { inBlock = true; i += 2; continue; }
-    if (c === '"' || c === "'" || c === '`') {
-      inStr = true; strQuote = c; out += c; i += 1; continue;
-    }
-    out += c;
-    i += 1;
-  }
-  return out;
-}
+const { test, run } = createPolicyTestSuite('script-spawn-policy');
 
 // Every `.cjs` launcher in a scanned scripts dir (excludes the test
 // suites and the lib/ helpers — the harness lib carries its own
@@ -252,8 +211,7 @@ for (const base of EXAMPLES_LAUNCHERS) {
 // regex matches the http-server bin token followed (within a short
 // window) by the `'-a', '127.0.0.1'` pair. NB `[\s\S]{0,80}?` not `[^]`
 // (the JS-regex `[^]`-any-char gotcha).
-const LOOPBACK_BIND_RE =
-  /HTTP_SERVER_BIN,[\s\S]{0,80}?['"]-a['"]\s*,\s*['"]127\.0\.0\.1['"]/;
+const LOOPBACK_BIND_RE = loopbackBindRe('HTTP_SERVER_BIN');
 const IMPL_LOOPBACK_LAUNCHERS = [
   'serve-and-run-browser-tests.cjs',
   'check-story-static.cjs',
@@ -339,20 +297,4 @@ test('stripComments removes comment text but preserves code', () => {
   assert.equal(stripComments('const s = "keep // me";'), 'const s = "keep // me";');
 });
 
-let failed = 0;
-for (const { name, fn } of tests) {
-  try {
-    fn();
-  } catch (err) {
-    failed += 1;
-    console.error(`FAIL ${name}`);
-    console.error(err && err.stack ? err.stack : err);
-  }
-}
-
-if (failed > 0) {
-  console.error(`script-spawn-policy tests: ${failed} failed.`);
-  process.exit(1);
-}
-
-console.log(`script-spawn-policy tests: ${tests.length} passed.`);
+run();

--- a/implementation/scripts/_story-script-runners-policy.test.cjs
+++ b/implementation/scripts/_story-script-runners-policy.test.cjs
@@ -38,6 +38,8 @@
 const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
+// Shared loopbackBindRe factory + framework-free test harness (rf2-j552l2).
+const { loopbackBindRe, createPolicyTestSuite } = require('./_policy-test-util.cjs');
 
 const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'examples', 'scripts');
 const PLAY_SCRIPTS_RUNNER = path.join(
@@ -58,10 +60,7 @@ const {
   MIN_PLAY_ROWS,
 } = require(PLAY_SCRIPTS_RUNNER);
 
-const tests = [];
-function test(name, fn) {
-  tests.push({ name, fn });
-}
+const { test, run } = createPolicyTestSuite('story-script-runners-policy');
 
 // ---- Finding 1: pageerror is fatal, even with all play rows matched ----
 
@@ -127,8 +126,7 @@ test('play-scripts runner verdict is computed from BOTH failures and pageErrors 
 // feature-load runner uses the HTTP_SERVER_BIN constant — accept both).
 // NB `[\s\S]{0,80}?` (not `[^]]`): the latter is the JS-regex gotcha
 // `[^]` (any char) followed by a literal `]`, which would NOT match here.
-const LOOPBACK_BIND_RE =
-  /(?:httpServerBin\(\)|HTTP_SERVER_BIN),[\s\S]{0,80}?['"]-a['"]\s*,\s*['"]127\.0\.0\.1['"]/;
+const LOOPBACK_BIND_RE = loopbackBindRe('(?:httpServerBin\\(\\)|HTTP_SERVER_BIN)');
 
 for (const runner of [PLAY_SCRIPTS_RUNNER, FEATURE_LOAD_RUNNER]) {
   const base = path.basename(runner);
@@ -274,20 +272,4 @@ test('play-scripts runner gates discovery on checkRowsNonVacuous (rf2-54xbp / rf
   );
 });
 
-let failed = 0;
-for (const { name, fn } of tests) {
-  try {
-    fn();
-  } catch (err) {
-    failed += 1;
-    console.error(`FAIL ${name}`);
-    console.error(err && err.stack ? err.stack : err);
-  }
-}
-
-if (failed > 0) {
-  console.error(`story-script-runners-policy tests: ${failed} failed.`);
-  process.exit(1);
-}
-
-console.log(`story-script-runners-policy tests: ${tests.length} passed.`);
+run();

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -1,16 +1,27 @@
 #!/usr/bin/env node
 /*
- * Per-feature artefact bundle-isolation verifier (bead rf2-51x5,
- * discovered-from rf2-o423 test-coverage audit).
+ * Bundle-isolation verifier (bead rf2-51x5, discovered-from rf2-o423
+ * test-coverage audit; scope since broadened to tools/ + dev-only deps).
  *
  * The counter example is the canonical no-feature app: it imports zero
- * per-feature artefacts. Every per-feature split (schemas / machines /
- * routing / flows / http / ssr) was verified at PR-time with a one-shot
- * grep against this same bundle; this script makes the same assertion
- * permanent so a future change that accidentally re-imports a split-out
- * namespace into core (e.g. `(:require [re-frame.flows])` slipping into
- * `re-frame.core`) is caught by CI rather than by a downstream consumer
- * paying for the regression.
+ * per-feature artefacts AND nothing under tools/. Three families of
+ * leak are pinned absent from its production bundle:
+ *   - per-feature splits (schemas / machines / routing / flows / http /
+ *     ssr / epoch) — each ships as its own Maven jar; core MUST NOT
+ *     `:require` any of them (the re-export wrappers late-bind at call
+ *     time);
+ *   - the tooling siblings + dev-only composers (trace.tooling,
+ *     subs.tooling, the EP-0014 algebra-view siblings, derivation.graph,
+ *     trace.cascade, Story) — dev/inspection surfaces gated behind the
+ *     Xray preload;
+ *   - dev-only npm/Maven dependencies machines-viz + the Xray EDN widget
+ *     pull in (xyflow / elkjs / cljs-devtools / zprint / editscript).
+ * Every one of these was verified at PR-time with a one-shot grep against
+ * this same bundle; this script makes the assertion permanent so a future
+ * change that accidentally re-imports a split-out namespace into core
+ * (e.g. `(:require [re-frame.flows])` slipping into `re-frame.core`) — or
+ * drags a tools/ ns / dev dep into a production-reachable path — is caught
+ * by CI rather than by a downstream consumer paying for the regression.
  *
  * Strategy: grep, not parse — the same shape as scripts/check-elision.cjs
  * and scripts/check-perf-bundle.cjs. The closure compiler may rename
@@ -173,69 +184,35 @@ const ARTEFACTS = [
     expectedAllowListHits: 2,
   },
 
-  // Epoch artefact (rf2-69ad2 split — re-frame.epoch lives at
-  // implementation/epoch/). Xray's preload.cljs `:requires`
-  // re-frame.epoch to anchor it onto the dev classpath so every
-  // Xray-enabled build has working time-travel; the preload is
-  // dev-only (gated by shadow-cljs `:devtools/preloads`) so the
-  // anchor must NOT pull epoch into a production bundle. This entry
-  // pins that contract — if a host or a refactor accidentally
-  // `:requires` re-frame.epoch from production-classpath code, the
-  // sentinel below will appear in the counter bundle and this check
-  // fails (per audit rf2-i0veg §5c).
+  // Epoch artefact (rf2-69ad2 / rf2-lt4e split — re-frame.epoch lives
+  // at implementation/epoch/; Tool-Pair §Time-travel surface, the
+  // seventh per-feature split per rf2-5vjj Strategy B). Counter imports
+  // zero epoch symbols — the `day8/re-frame2-epoch` artefact must DCE
+  // entirely when the consuming app doesn't `:require` re-frame.epoch.
+  // Xray's preload.cljs `:requires` re-frame.epoch to anchor it onto the
+  // dev classpath so every Xray-enabled build has working time-travel;
+  // the preload is dev-only (gated by shadow-cljs `:devtools/preloads`)
+  // so the anchor must NOT pull epoch into a production bundle. Core's
+  // public re-exports (`rf/epoch-history`, `rf/restore-epoch!`, …) look
+  // the producing fns up through the late-bind hook table at call time;
+  // a non-zero internal-sentinel hit means the epoch namespace got
+  // dragged in (most likely a stray `:require` in a core/* ns — per
+  // audit rf2-i0veg §5c). The trace-op keywords below are emitted from
+  // epoch.cljc's function bodies as keyword data and survive `:advanced`
+  // (string literals are not renamed) regardless of whether
+  // `interop/debug-enabled?` gates the emission callsite.
   {
     name: 'epoch',
     internalSentinels: [
       // epoch.cljc — restore-schema-mismatch trace op-name (a string
       // literal inside `enabled-ops` and emitted from the restore
-      // path). Unique to epoch.cljc; survives :advanced (string
-      // literals are not renamed).
+      // path). Unique to epoch.cljc.
       { source: 're-frame.epoch (rf.epoch/restore-schema-mismatch)',
         sentinel: 'rf.epoch/restore-schema-mismatch' },
-      // epoch.cljc — restore-during-drain trace op-name. Same
-      // contract; second sentinel guards against a future rename
-      // of one but not the other.
+      // epoch.cljc — restore-during-drain trace op-name. Second
+      // sentinel guards against a future rename of one but not the other.
       { source: 're-frame.epoch (rf.epoch/restore-during-drain)',
         sentinel: 'rf.epoch/restore-during-drain' },
-    ],
-    consumerAllowList: null,
-    expectedAllowListHits: 0,
-  },
-
-  {
-    name: 'ssr',
-    internalSentinels: [
-      // ssr.cljc — namespace-prefix on every server-only fx and trace
-      // op (`:rf.server/respond`, `:rf.server/redirect`, ...). The
-      // prefix appears in the bundle only when ssr.cljc's body is
-      // compiled in.
-      { source: 're-frame.ssr server-only fx prefix (rf.server/)',
-        sentinel: 'rf.server/' },
-      // ssr.cljc — :rf/hydrate event-id (the CLJS hydration entry
-      // point registered by ssr.cljc).
-      { source: 're-frame.ssr hydrate event (rf/hydrate)',
-        sentinel: 'rf/hydrate' },
-    ],
-    consumerAllowList: null,
-    expectedAllowListHits: 0,
-  },
-
-  // Epoch (rf2-lt4e — Tool-Pair §Time-travel surface, the seventh
-  // per-feature split per rf2-5vjj Strategy B). Counter imports
-  // zero epoch symbols — the `day8/re-frame2-epoch` artefact must
-  // DCE entirely when the consuming app doesn't `:require`
-  // `re-frame.epoch`. Core's public re-exports (`rf/epoch-history`,
-  // `rf/restore-epoch!`, …) look the producing fns up through the
-  // late-bind hook table at call time; a non-zero internal-sentinel
-  // hit here means the epoch namespace got dragged in (most likely
-  // a stray `:require` in a core/* ns). The trace-op keywords below
-  // are emitted from epoch.cljc's function bodies as keyword data
-  // and survive `:advanced` regardless of whether `interop/debug-
-  // enabled?` gates the emission callsite (the keyword name is
-  // referenced at the gate test, not only inside the gated body).
-  {
-    name: 'epoch',
-    internalSentinels: [
       // epoch.cljc — on-frame-destroyed! emits this per silenced cb.
       { source: 're-frame.epoch on-frame-destroyed! (rf.epoch.cb/silenced-on-frame-destroy)',
         sentinel: 'rf.epoch.cb/silenced-on-frame-destroy' },
@@ -259,6 +236,24 @@ const ARTEFACTS = [
     // the example's entry points.
     consumerAllowList: /epoch\/settle!/g,
     expectedAllowListHits: 1,
+  },
+
+  {
+    name: 'ssr',
+    internalSentinels: [
+      // ssr.cljc — namespace-prefix on every server-only fx and trace
+      // op (`:rf.server/respond`, `:rf.server/redirect`, ...). The
+      // prefix appears in the bundle only when ssr.cljc's body is
+      // compiled in.
+      { source: 're-frame.ssr server-only fx prefix (rf.server/)',
+        sentinel: 'rf.server/' },
+      // ssr.cljc — :rf/hydrate event-id (the CLJS hydration entry
+      // point registered by ssr.cljc).
+      { source: 're-frame.ssr hydrate event (rf/hydrate)',
+        sentinel: 'rf/hydrate' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
   },
 
   // re-frame.trace.tooling (rf2-qwm0a — dev-tooling buffer + listener

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -36,6 +36,7 @@ const fs   = require('fs');
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
 const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
+const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -603,21 +604,19 @@ function checkBundle(label, bundlePath, mustContain) {
 // true ⇒ every sentinel must be PRESENT; false ⇒ every sentinel must be
 // ABSENT. Returns { ok, passed, checked }. Shared by the dev-only ABSENT
 // check and the EP-0023 PROD-SURVIVING (present) / PROD-ABSENT-WHEN-UNUSED
-// (absent) checks (rf2-32siq3.40).
+// (absent) checks (rf2-32siq3.40). The loop + tally are the shared
+// `assertSentinelSet` (lib/sentinel-scan.cjs, rf2-j552l2); this wrapper
+// supplies the elision gate's exact diagnostic line format.
 function assertSentinels(blob, sentinels, mustContain) {
-  let ok = true;
-  let passed = 0;
-  for (const { source, sentinel } of sentinels) {
-    const present  = blob.includes(sentinel);
-    const expected = mustContain ? 'PRESENT' : 'ABSENT';
-    const actual   = present     ? 'PRESENT' : 'ABSENT';
-    const ok1      = present === mustContain;
-    const tag      = ok1 ? 'OK' : 'FAIL';
-    report.detail(`          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
-    if (ok1) passed += 1;
-    else ok = false;
-  }
-  return { ok, passed, checked: sentinels.length };
+  return assertSentinelSet(blob, sentinels, {
+    mustContain,
+    emit: (line) => report.detail(line),
+    formatLine: ({ source, sentinel, present, tag }) => {
+      const expected = mustContain ? 'PRESENT' : 'ABSENT';
+      const actual   = present     ? 'PRESENT' : 'ABSENT';
+      return `          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`;
+    },
+  });
 }
 
 // ----- main ------------------------------------------------------------------

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -32,7 +32,8 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
+const { classifyReleaseBundle, countMatches } = require('./lib/read-release-bundle.cjs');
+const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -85,22 +86,19 @@ function checkBundle(label, bundlePath, mustContain) {
   report.detail(`[perf-bundle] ${label}: ${bundlePath}`);
   report.detail(`              bundle size: ${blob.length} chars`);
 
-  let ok = true;
-  let passedCount = 0;
-  for (const { source, sentinel } of PERF_SENTINELS) {
-    const present = blob.includes(sentinel);
-    const expected = mustContain ? 'PRESENT' : 'ABSENT';
-    const actual   = present     ? 'PRESENT' : 'ABSENT';
-    const passed   = present === mustContain;
-    const tag      = passed ? 'OK' : 'FAIL';
-    report.detail(`              [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
-    if (passed) passedCount += 1;
-    if (!passed) ok = false;
-  }
+  const { ok, passed } = assertSentinelSet(blob, PERF_SENTINELS, {
+    mustContain,
+    emit: (line) => report.detail(line),
+    formatLine: ({ source, sentinel, present, tag }) => {
+      const expected = mustContain ? 'PRESENT' : 'ABSENT';
+      const actual   = present     ? 'PRESENT' : 'ABSENT';
+      return `              [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`;
+    },
+  });
   return {
     ok,
     checked: PERF_SENTINELS.length,
-    passed: passedCount,
+    passed,
     bytes: blob.length,
     bundlePath,
     missing: false,
@@ -109,12 +107,15 @@ function checkBundle(label, bundlePath, mustContain) {
 
 // Count `performance.mark|performance.measure|re-frame.performance` for
 // the report. The PR body wants the raw count number for both bundles,
-// per the bead's bundle-grep contract.
+// per the bead's bundle-grep contract. The actual global-match count is
+// delegated to the shared `countMatches` (lib/read-release-bundle.cjs —
+// it resets the /g RegExp's lastIndex defensively); this wrapper keeps
+// the patterns-array → alternation construction and the null-blob → null
+// distinction the report's missing-bundle diagnostic relies on (the
+// shared primitive maps null → 0).
 function countOccurrences(blob, patterns) {
   if (blob == null) return null;
-  const re = new RegExp(patterns.join('|'), 'g');
-  const m  = blob.match(re);
-  return m ? m.length : 0;
+  return countMatches(blob, new RegExp(patterns.join('|'), 'g'));
 }
 
 // ----- main ------------------------------------------------------------------

--- a/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
+++ b/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
@@ -51,7 +51,7 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { classifyReleaseBundle, countSubstring } = require('./lib/read-release-bundle.cjs');
+const { assertSentinelSet, classifyOrFail } = require('./lib/sentinel-scan.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -174,32 +174,31 @@ const SLIM_SSR_PRESENCE_SENTINELS = [
 
 // ----- helpers ---------------------------------------------------------------
 //
-// Bundle reading + the countSubstring grep primitive are shared with the
-// sibling check-* scripts via scripts/lib/read-release-bundle.cjs
-// (rf2-jkake.15). `readReleaseBlob` reads only top-level *.js — the
-// release artefact — so a stale dev-build `cljs-runtime/` subdir from a
-// prior `shadow-cljs compile` doesn't get grep-ed alongside (rf2-z9a06):
-// that trap, first documented inline here, was the reason the reader was
-// factored out (rf2-qlk4w) and is now the shared default for the whole
-// check-*-bundle family.
+// Bundle reading is shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-jkake.15): `readReleaseBlob`
+// reads only top-level *.js — the release artefact — so a stale dev-build
+// `cljs-runtime/` subdir from a prior `shadow-cljs compile` doesn't get
+// grep-ed alongside (rf2-z9a06); that trap, first documented inline here,
+// was the reason the reader was factored out (rf2-qlk4w) and is now the
+// shared default for the whole check-*-bundle family. The per-sentinel
+// scan loop + tally is the shared assertSentinelSet (scripts/lib/
+// sentinel-scan.cjs, rf2-j552l2); checkAbsent / checkPresent below supply
+// this gate's exact diagnostic line format.
 
 // ----- the four contract checks ---------------------------------------------
 
 function checkAbsent(blob, sentinels, blobLabel) {
   // Assert each sentinel's hit-count is 0. Used for the slim build's
   // "no stock-Reagent / no react-dom/server" assertion.
-  let ok = true;
-  let passedCount = 0;
-  for (const { source, sentinel } of sentinels) {
-    const hits = countSubstring(blob, sentinel);
-    const passed = hits === 0;
-    const tag = passed ? 'OK' : 'FAIL';
-    report.detail(`    [${tag}] ${source}: ` +
-                  `${JSON.stringify(sentinel)} expected 0 in ${blobLabel}, was ${hits}`);
-    if (passed) passedCount += 1;
-    if (!passed) ok = false;
-  }
-  return { ok, checked: sentinels.length, passed: passedCount };
+  const { ok, passed } = assertSentinelSet(blob, sentinels, {
+    mustContain: false,
+    count: true,
+    emit: (line) => report.detail(line),
+    formatLine: ({ source, sentinel, hits, tag }) =>
+      `    [${tag}] ${source}: ` +
+      `${JSON.stringify(sentinel)} expected 0 in ${blobLabel}, was ${hits}`,
+  });
+  return { ok, checked: sentinels.length, passed };
 }
 
 function checkPresent(blob, sentinels, blobLabel) {
@@ -208,18 +207,15 @@ function checkPresent(blob, sentinels, blobLabel) {
   // bundle, proving the grep has signal. If a sentinel goes to 0 in the
   // stock build too (e.g. a future Reagent rev DCEs it), we re-derive
   // the sentinel set; this script then prevents silent vacuous passes.
-  let ok = true;
-  let passedCount = 0;
-  for (const { source, sentinel } of sentinels) {
-    const hits = countSubstring(blob, sentinel);
-    const passed = hits >= 1;
-    const tag = passed ? 'OK' : 'FAIL';
-    report.detail(`    [${tag}] ${source}: ` +
-                  `${JSON.stringify(sentinel)} expected >=1 in ${blobLabel}, was ${hits}`);
-    if (passed) passedCount += 1;
-    if (!passed) ok = false;
-  }
-  return { ok, checked: sentinels.length, passed: passedCount };
+  const { ok, passed } = assertSentinelSet(blob, sentinels, {
+    mustContain: true,
+    count: true,
+    emit: (line) => report.detail(line),
+    formatLine: ({ source, sentinel, hits, tag }) =>
+      `    [${tag}] ${source}: ` +
+      `${JSON.stringify(sentinel)} expected >=1 in ${blobLabel}, was ${hits}`,
+  });
+  return { ok, checked: sentinels.length, passed };
 }
 
 // ----- main ------------------------------------------------------------------
@@ -230,43 +226,49 @@ function main() {
 
   const slimDir  = path.join(ROOT, 'out', 'examples', 'counter-slim-and-fast');
   const stockDir = path.join(ROOT, 'out', 'examples', 'counter');
-  const slimCls  = classifyReleaseBundle(slimDir);
-  const stockCls = classifyReleaseBundle(stockDir);
-  const slim  = slimCls.blob;
-  const stock = stockCls.blob;
-
-  if (slimCls.status !== 'ok') {
-    report.flushDetails();
-    if (slimCls.status === 'empty') {
+  // classifyOrFail (scripts/lib/sentinel-scan.cjs, rf2-j552l2) shares the
+  // missing/empty two-arm guard (rf2-utvst non-vacuous floor); each reject
+  // callback owns this gate's actionable stderr + the exit.
+  const slimCls = classifyOrFail(slimDir, {
+    onMissing: (dir) => {
+      report.flushDetails();
+      console.error(`[reagent-slim-bundle-isolation] slim bundle missing — ${dir}`);
+      console.error('                    Did you run "shadow-cljs release examples/counter-slim-and-fast"?');
+      process.exit(1);
+    },
+    onEmpty: (dir) => {
+      report.flushDetails();
       // Non-vacuous floor (rf2-utvst): the slim bundle is checked
       // negative-only (Contracts 2+3); a present-but-empty slim dir
       // satisfies both absence checks and would false-GREEN.
-      console.error(`[reagent-slim-bundle-isolation] slim bundle present but empty (zero top-level JS) — ${slimDir}`);
+      console.error(`[reagent-slim-bundle-isolation] slim bundle present but empty (zero top-level JS) — ${dir}`);
       console.error('                    The release emitted no bundle; the stock-Reagent and');
       console.error('                    react-dom/server absence checks would pass vacuously.');
       console.error('                    Rebuild "shadow-cljs release examples/counter-slim-and-fast".');
-    } else {
-      console.error(`[reagent-slim-bundle-isolation] slim bundle missing — ${slimDir}`);
-      console.error('                    Did you run "shadow-cljs release examples/counter-slim-and-fast"?');
-    }
-    process.exit(1);
-  }
-  if (stockCls.status !== 'ok') {
-    report.flushDetails();
-    if (stockCls.status === 'empty') {
-      console.error(`[reagent-slim-bundle-isolation] stock bundle present but empty (zero top-level JS) — ${stockDir}`);
-      console.error('                    The methodology control emitted no bundle; the stock-');
-      console.error('                    Reagent present-check would have no signal.');
-      console.error('                    Rebuild "shadow-cljs release examples/counter".');
-    } else {
-      console.error(`[reagent-slim-bundle-isolation] stock bundle missing — ${stockDir}`);
+      process.exit(1);
+    },
+  });
+  const stockCls = classifyOrFail(stockDir, {
+    onMissing: (dir) => {
+      report.flushDetails();
+      console.error(`[reagent-slim-bundle-isolation] stock bundle missing — ${dir}`);
       console.error('                    Did you run "shadow-cljs release examples/counter"?');
       console.error('                    The stock bundle is required as the methodology control:');
       console.error('                    its presence of the stock-Reagent sentinels proves the');
       console.error('                    grep has signal.');
-    }
-    process.exit(1);
-  }
+      process.exit(1);
+    },
+    onEmpty: (dir) => {
+      report.flushDetails();
+      console.error(`[reagent-slim-bundle-isolation] stock bundle present but empty (zero top-level JS) — ${dir}`);
+      console.error('                    The methodology control emitted no bundle; the stock-');
+      console.error('                    Reagent present-check would have no signal.');
+      console.error('                    Rebuild "shadow-cljs release examples/counter".');
+      process.exit(1);
+    },
+  });
+  const slim  = slimCls.blob;
+  const stock = stockCls.blob;
 
   report.detail(`slim  bundle: ${slimDir}  (${slim.length} chars)`);
   report.detail(`stock bundle: ${stockDir} (${stock.length} chars)`);

--- a/implementation/scripts/check-uix-helix-reagent-free.cjs
+++ b/implementation/scripts/check-uix-helix-reagent-free.cjs
@@ -36,7 +36,8 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { classifyReleaseBundle, countSubstring } = require('./lib/read-release-bundle.cjs');
+const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
+const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -67,9 +68,10 @@ const REAGENT_SENTINELS = [
 
 // ----- helpers ---------------------------------------------------------------
 //
-// Bundle reading + the countSubstring grep primitive are shared with the
-// sibling check-* scripts via scripts/lib/read-release-bundle.cjs
-// (rf2-jkake.15).
+// Bundle reading is shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-jkake.15); the per-sentinel
+// present/absent scan loop + tally is the shared assertSentinelSet
+// (scripts/lib/sentinel-scan.cjs, rf2-j552l2).
 
 function checkBundle(label, bundlePath, mustContain) {
   const { status, blob } = classifyReleaseBundle(bundlePath);
@@ -91,23 +93,20 @@ function checkBundle(label, bundlePath, mustContain) {
   report.detail(`  ${label}: ${bundlePath}`);
   report.detail(`    bundle size: ${blob.length} chars`);
 
-  let ok = true;
-  let passedCount = 0;
-  for (const { source, sentinel } of REAGENT_SENTINELS) {
-    const hits     = countSubstring(blob, sentinel);
-    const present  = hits > 0;
-    const expected = mustContain ? 'PRESENT (>=1)' : 'ABSENT (0)';
-    const actual   = present     ? `PRESENT (${hits})` : 'ABSENT (0)';
-    const passed   = present === mustContain;
-    const tag      = passed ? 'OK' : 'FAIL';
-    report.detail(`    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
-    if (passed) passedCount += 1;
-    if (!passed) ok = false;
-  }
+  const { ok, passed } = assertSentinelSet(blob, REAGENT_SENTINELS, {
+    mustContain,
+    count: true,
+    emit: (line) => report.detail(line),
+    formatLine: ({ source, sentinel, present, hits, tag }) => {
+      const expected = mustContain ? 'PRESENT (>=1)' : 'ABSENT (0)';
+      const actual   = present     ? `PRESENT (${hits})` : 'ABSENT (0)';
+      return `    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`;
+    },
+  });
   return {
     ok,
     checked: REAGENT_SENTINELS.length,
-    passed: passedCount,
+    passed,
     bytes: blob.length,
     bundlePath,
     missing: false,

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -28,9 +28,9 @@ function isValidExplicitPort(port) {
 // free" WITHOUT touching net.listen — port 0 would otherwise bind an
 // ephemeral port (a false "free" for an unusable advertised port), and
 // negative / overflow values would throw ERR_SOCKET_BAD_PORT instead of
-// the controlled fall-through. (rf2-84gzw / rf2-0u8kz — shared with
-// serve-and-run-browser-tests and check-story-static, which carry their
-// own copies for now.)
+// the controlled fall-through. (rf2-84gzw / rf2-0u8kz — the shared
+// resolveServePort below routes serve-and-run-browser-tests and
+// check-story-static through this single implementation.)
 function isPortFree(port) {
   if (!isValidExplicitPort(port)) return Promise.resolve(false);
   return new Promise((resolve) => {

--- a/implementation/scripts/lib/sentinel-scan.cjs
+++ b/implementation/scripts/lib/sentinel-scan.cjs
@@ -1,0 +1,91 @@
+// Shared sentinel-scan helpers for the bundle check-* gates (rf2-j552l2).
+//
+// The bundle-isolation / elision / perf / reagent-slim gates all share the
+// same two micro-shapes, which had drifted into four near-identical inline
+// copies (rf2-u4vtlh / rf2-b4d7o1 review):
+//
+//   1. A present/absent assertion over a SET of sentinels against an
+//      already-read bundle blob. The loop, the per-sentinel pass test, the
+//      `{ ok, passed, checked }` tally, and the choice between substring-
+//      count detection (countSubstring) and `blob.includes` boolean
+//      detection are identical across the four gates. ONLY the per-sentinel
+//      diagnostic line differs (indent width, whether it says "sentinel",
+//      whether it names a blob label, whether it shows the raw hit-count or
+//      a PRESENT/ABSENT word). So `assertSentinelSet` owns the loop + tally
+//      and delegates the exact line text to a caller-supplied `formatLine`,
+//      keeping every gate's diagnostic output byte-identical while sharing
+//      the load-bearing logic.
+//
+//   2. The classify-or-fail guard each gate runs before scanning: a
+//      `classifyReleaseBundle` whose status is anything but 'ok' must reject
+//      the run (a 'missing' dir AND a present-but-empty 'empty' dir both
+//      false-GREEN an absence-only check — the rf2-utvst non-vacuous floor).
+//      `classifyOrFail` centralises that two-arm branch; the actionable
+//      stderr text stays caller-supplied (each gate names its own rebuild
+//      command).
+//
+// Neither helper prints anything itself except through the sinks the caller
+// passes (`emit` for detail lines, the onMissing/onEmpty callbacks for the
+// reject path), so the gate reporters keep full control of buffering /
+// flush ordering.
+
+'use strict';
+
+const { classifyReleaseBundle, countSubstring } = require('./read-release-bundle.cjs');
+
+// Assert a set of `{ source, sentinel }` entries against an already-read
+// bundle `blob`. Shared by the four bundle check-* gates (rf2-j552l2).
+//
+//   opts.mustContain : true  ⇒ each sentinel must be PRESENT to pass;
+//                      false ⇒ each sentinel must be ABSENT to pass.
+//   opts.count       : true  ⇒ detect via countSubstring (exposes the raw
+//                              hit-count to the formatter); false ⇒ detect
+//                              via blob.includes (boolean present only).
+//   opts.emit(line)  : sink for each per-sentinel diagnostic line (e.g. a
+//                      gate reporter's `report.detail`). Omit to stay silent.
+//   opts.formatLine({ source, sentinel, present, hits, passed, tag })
+//                    : returns the EXACT diagnostic string for one sentinel.
+//                      `hits` is null in boolean (count:false) mode. `tag`
+//                      is 'OK' | 'FAIL'. Omit to emit no per-line text.
+//
+// Returns `{ ok, passed, checked }` — `ok` is true iff every sentinel
+// passed; `passed` is the count that passed; `checked` is sentinels.length.
+function assertSentinelSet(blob, sentinels, opts = {}) {
+  const { mustContain = false, count = false, emit, formatLine } = opts;
+  let ok = true;
+  let passed = 0;
+  for (const { source, sentinel } of sentinels) {
+    const hits = count ? countSubstring(blob, sentinel) : null;
+    const present = count ? hits > 0 : blob.includes(sentinel);
+    const passed1 = present === mustContain;
+    const tag = passed1 ? 'OK' : 'FAIL';
+    if (emit && formatLine) {
+      emit(formatLine({ source, sentinel, present, hits, passed: passed1, tag }));
+    }
+    if (passed1) passed += 1;
+    else ok = false;
+  }
+  return { ok, passed, checked: sentinels.length };
+}
+
+// Classify a release output dir and branch on the non-'ok' states
+// (rf2-utvst non-vacuous floor). On 'missing' calls `onMissing(dir)`; on
+// 'empty' calls `onEmpty(dir)` (falling back to onMissing if onEmpty is
+// omitted). Returns the classification `{ status, files, blob }` so an 'ok'
+// caller can use the already-read blob without re-reading. The reject-path
+// callbacks own the actionable stderr text + the exit/return decision.
+function classifyOrFail(dir, { onMissing, onEmpty } = {}) {
+  const cls = classifyReleaseBundle(dir);
+  if (cls.status === 'missing') {
+    if (onMissing) onMissing(dir);
+  } else if (cls.status === 'empty') {
+    if (onEmpty) onEmpty(dir);
+    else if (onMissing) onMissing(dir);
+  }
+  return cls;
+}
+
+module.exports = {
+  assertSentinelSet,
+  classifyOrFail,
+};

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -29,15 +29,15 @@ const {
   parseFailureCounts,
   summaryPartsFromText,
 } = require('./lib/browser-test-report.cjs');
+// `sleep` is the shared poll primitive — verbatim the same
+// `setTimeout`-backed Promise this runner used to define inline
+// (rf2-j552l2 dedup; exported from lib/local-browser-harness.cjs).
+const { sleep } = require('./lib/local-browser-harness.cjs');
 
 const URL = process.env.BROWSER_TEST_URL || 'http://localhost:8021';
 const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || '120000', 10);
 const POLL_MS = 200;
 const VERBOSE_TESTS = isVerboseTests();
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 // rf2-mwx08: capture the `ran` + `failErr` lines as an ATOMIC pair from
 // a single source. summaryPartsFromText now only ever yields a non-null


### PR DESCRIPTION
Implements bead **rf2-j552l2** — implementation/scripts dedup + vestigial cleanup (from the u4vtlh / b4d7o1 reviews). The 7 in-scope items only; the deferred api-manifest / `*_check.clj`-skeleton / `lib/shadow-spawn.cjs` items (hot-zone) are NOT touched.

## What changed (net −199 lines; 11 modified, 2 new)

**Vestigial**
1. `check-bundle-isolation.cjs` — merged the two `name:'epoch'` ARTEFACT entries (they double-counted `epoch` in the PASS summary; the second header's "newly introduced / seventh split" prose contradicted the first). One entry now: union of all **6** epoch sentinels + the `epoch/settle!` allow-list (`expectedAllowListHits:1`). `ARTEFACTS` is 21 entries (was 22) — the gate now reports `21 artefact entries`.
2. `lib/local-browser-harness.cjs` — dropped the stale `isPortFree` docstring clause "shared with serve-and-run-browser-tests and check-story-static, which carry their own copies for now"; both consumers route through the shared `resolveServePort` and keep no local copy.
3. `check-bundle-isolation.cjs` banner — reworded the stale "counter example per-feature" framing to name the three leak families the gate now pins (per-feature splits, tooling siblings/composers, dev-only npm/Maven deps).

**Dedup**
4. `run-browser-tests.cjs` — dropped the verbatim local `sleep`; imports the shared one from `lib/local-browser-harness.cjs`.
5. `check-perf-bundle.cjs` — `countOccurrences` now delegates the global-match count to the shared `countMatches` (`lib/read-release-bundle.cjs`, which resets the `/g` `lastIndex`), keeping the patterns-array → null-blob wrapper the diagnostic relies on.
6. **new `lib/sentinel-scan.cjs`** (`assertSentinelSet` + `classifyOrFail`) — the shared present/absent sentinel-scan loop + tally and the missing/empty classify-or-fail guard, consumed by `check-uix-helix-reagent-free` / `check-perf-bundle` / `check-elision` / `check-reagent-slim-bundle-isolation`. Each caller keeps its exact diagnostic line format via a `formatLine` callback — verified **byte-identical** to the prior inline loops (7 present/absent × formatter scenarios).
7. **new `_policy-test-util.cjs`** (`stripComments` + `loopbackBindRe` factory + `createPolicyTestSuite` harness) — de-duped the 3 verbatim ~38-line `stripComments` copies, the shared `-a 127.0.0.1` loopback-bind matcher tail (each caller keeps its own bin-token alternation, so no gate's strictness changes), and the framework-free test harness across the four `_*-policy.test.cjs` gates.

Removal-tombstone comments kept (accurate traceability).

## Quality gates — all green locally (the dedup'd scripts ARE these gates)
```
test:bundle-isolation  → PASS bundle-isolation: 21 artefact entries; 40 internal sentinels absent; 3 allow-list budgets ok
                         PASS uix-helix-reagent-free: 3 bundles; 6 sentinel checks
test:perf-bundle       → PASS perf-bundle: off-count=0; on-count=12
test:elision           → PASS elision: production 41/41 absent; EP-0023 1/1 + 1/1; control 41/41 present
test:reagent-slim:bundle-isolation → PASS: 4 contracts; 21 sentinel checks
test:browser           → Ran 220 tests containing 693 assertions. 0 failures, 0 errors.
test:script-policy     → exit 0 (script-spawn 119 / orchestrator 40 / mcp 5 / story-runners 17 + the rest)
test:script-helpers    → exit 0 (read-release-bundle 25, local-browser-harness 24, + the rest)
```