### PR TITLE
refactor(ssr): single-source emit-always-on-error! within the ssr artefact (rf2-50e82k)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -13,7 +13,6 @@
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
             [re-frame.ssr.error-projector :as error-projector]
             [re-frame.ssr.response :as response]
             [re-frame.trace :as trace]))
@@ -35,18 +34,11 @@
 ;; the recoverable-degradation members — same `non-projection-eligible-error?`
 ;; gate that governs the wire (promotion changes what SHIPPERS see, never
 ;; what the WIRE does).
-
-(defn emit-always-on-error!
-  "Fan a PRE-BUILT always-on SSR error record out through the corpus-wide
-  error-emit registry (surface #4), via the `:error-emit/dispatch-error-
-  record` late-bind hook. `record` is the union shape `{:error <kw> :frame
-  <id-or-nil> :time <ms> + flat category keys}`. A no-op when the
-  `error-emit` producer hasn't loaded (the hook is nil) — the dev
-  `trace/emit-error!` companion still fires. Returns nil."
-  [record]
-  (when-let [dispatch-error-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
-    (dispatch-error-record! record))
-  nil)
+;;
+;; The `emit-always-on-error!` helper itself is SINGLE-SOURCED in
+;; `re-frame.ssr.error-projector` (rf2-50e82k — this ns already :requires
+;; it for the projector); call sites here go through
+;; `error-projector/emit-always-on-error!`.
 
 (defn- candidate-frame-for-error
   "Select the frame to project against for a trace-event: the frame named
@@ -310,7 +302,7 @@
       ;; drops BOTH buffered duplicates, so the wire status is driven solely
       ;; by the DIRECT `apply-error-projection!` call (no double-stamp, no
       ;; re-project on a later flush). Union record shape.
-      (emit-always-on-error!
+      (error-projector/emit-always-on-error!
         {:error :rf.error/ssr-render-failed
          :frame frame-id
          :time  (interop/now-ms)

--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -56,10 +56,20 @@
 ;; exclusive). So the always-on record cannot drive a second projection of
 ;; the same frame. NON-PROJECTING by design.
 
-(defn- emit-always-on-error!
+(defn emit-always-on-error!
   "Fan a PRE-BUILT always-on SSR error record out through the corpus-wide
-  error-emit registry via the `:error-emit/dispatch-error-record` late-bind
-  hook. No-op when the producer hasn't loaded. Returns nil."
+  error-emit registry (surface #4), via the `:error-emit/dispatch-error-
+  record` late-bind hook. `record` is the union shape `{:error <kw> :frame
+  <id-or-nil> :time <ms> + flat category keys}`. A no-op when the
+  `error-emit` producer hasn't loaded (the hook is nil) — the dev
+  `trace/emit-error!` companion still fires. Returns nil.
+
+  SINGLE SOURCE within the ssr artefact (rf2-50e82k): both the projector
+  (`project-error`) and the listener (`re-frame.ssr.error-listener`, which
+  already :requires this ns) call this one definition, closing the drift
+  risk on the `:error-emit/dispatch-error-record` hook keyword + the
+  nil-return contract. (The ssr-ring artefact keeps its own local wrapper
+  in `re-frame.ssr.ring.lifecycle` — a deliberate artefact boundary.)"
   [record]
   (when-let [dispatch-error-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record! record))


### PR DESCRIPTION
## What

`emit-always-on-error!` was defined **twice** in the ssr artefact with identical bodies — a private copy in `error_projector.cljc` and a public copy in `error_listener.cljc`. `error_listener` already `:require`s `error_projector` (no cycle / bundle barrier), so they are consolidated to one definition.

- Make `error_projector`'s the single **public** home (drop `defn-` → `defn`), folding the richer listener docstring into it.
- `error_listener` calls `error-projector/emit-always-on-error!` at its one call site.
- Drop the now-unused `re-frame.late-bind` require from `error_listener`.

Closes the drift risk on the `:error-emit/dispatch-error-record` hook keyword + the nil-return contract.

### Untouched (per the bead's DO-NOT-TOUCH list)
- The 3rd copy in `ssr-ring/lifecycle.clj:62` — a deliberate ssr→ssr-ring artefact boundary (ssr-ring owns its local wrapper).
- The 2 record-builder call sites in `error_projector/project-error` (mutually-exclusive catch vs non-conforming arms, kept for clarity).

## Quality gates

```
cd implementation && npm run test:cljs
# Ran 7865 tests containing 32596 assertions. 0 failures, 0 errors.

cd implementation/ssr && clojure -M:test   # ssr JVM, ssr_error_* tests green
# Ran 366 tests containing 1465 assertions. 0 failures, 0 errors.
```

Closes rf2-50e82k.
