### PR TITLE
refactor(conformance): share near-miss-variants + reply fixture constants (rf2-b2a3a2)

### DIFF
--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -71,6 +71,7 @@
             [re-frame.event-emit :as event-emit]
             [re-frame.late-bind :as late-bind]
             [re-frame.observability :as observability]
+            [re-frame.privacy :as privacy]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -1426,7 +1427,7 @@
 ;;     and the off-box sink omitting/redacting raw event args).
 ;; ===========================================================================
 
-(defn- redacted? [v] (= :rf/redacted v))
+(defn- redacted? [v] (= privacy/redacted-sentinel v))
 
 (deftest ep0015-off-box-handled-event-sink-receives-projected-record-event-args-omitted
   (testing "EP-0015 §9 / Spec 015: the NORMAL production off-box observation

--- a/implementation/reply-conformance/test/re_frame/reply_conformance_fixtures.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_conformance_fixtures.cljc
@@ -1,0 +1,78 @@
+(ns re-frame.reply-conformance-fixtures
+  "Shared reply-conformance fixture constants + builders (rf2-b2a3a2 —
+  extracted from the reply-conformance tier's three suites:
+  `reply-vocab-conformance`, `reply-functor-law`,
+  `reply-egress-projection`).
+
+  Two facts were duplicated verbatim across the tier and are owned here:
+
+    - `completion-time-ms` — the durable EP-0017 causal completion time
+      (the value the LIVE reply dispatch carries as the flat `:rf.cofx`
+      `:rf/time-ms` fact). Three suites each declared the SAME magic
+      `1781078400456` (twice as a literal inside the vocab suite's
+      resource/mutation success builders). One source of truth here keeps
+      the durable-completion-fact value aligned across the tier.
+
+    - `canonical-ok-reply` — the canonical `:ok` reply SHAPE the functor
+      (`route-reply`) and egress (`ok-reply`) suites each spelled inline:
+      `:status :ok`, a `:value`, a `[:rf.work/* …]` `:work/id` tuple, a
+      `:work/kind`, an `:rf.frame/id`, and the durable `:completed-at`
+      causal completion fact. The varying slots (value / work-id /
+      work-kind / frame-id / optional work-status) are parameters; the
+      shape — and its `:completed-at` default — is owned here so a drift
+      in the canonical `:ok` envelope shape is made once.
+
+  KEPT WITHIN reply-conformance (NOT cross-corpus-shared into
+  event-conformance — separate `deps.edn`, higher friction). This ns is
+  NOT a test (no `-cljs-test$` suffix), so the `npm run test:cljs`
+  node-test gate compiles it as a required namespace but never runs it as
+  a deftest; the JVM `clojure -M:test` runner likewise only scans the
+  `*-test` namespaces.")
+
+;; ---------------------------------------------------------------------------
+;; EP-0017 — the durable causal completion time the reply-conformance tier
+;; threads onto a reply as `:completed-at` (the same value the LIVE reply
+;; dispatch carries as the flat `:rf.cofx` `:rf/time-ms` fact — the single
+;; framework-provided recordable coeffect, stamped at the causal boundary;
+;; see `re-frame.router` §`:rf.cofx`).
+;; ---------------------------------------------------------------------------
+
+(def completion-time-ms
+  "The durable EP-0017 causal completion-time fixture value (ms since
+  epoch). Shared by every reply-conformance suite that seeds a
+  `:completed-at`."
+  1781078400456)
+
+;; ---------------------------------------------------------------------------
+;; The canonical `:ok` reply SHAPE. The varying slots are parameters; the
+;; envelope shape + the durable `:completed-at` default are owned here.
+;; ---------------------------------------------------------------------------
+
+(defn canonical-ok-reply
+  "Build the canonical `:ok` reply map (Managed-Effects §The uniform reply
+  envelope): `:status :ok` + a `:value` + a `[:rf.work/* …]` `:work/id`
+  tuple + a `:work/kind` + an `:rf.frame/id` + the durable `:completed-at`
+  causal completion fact (defaulting to `completion-time-ms`).
+
+  Opts:
+    :value        — the decoded result (required).
+    :work/id      — the `[:rf.work/* …]` attempt-identity tuple (required).
+    :work/kind    — the family work-kind keyword (required).
+    :rf.frame/id  — the owning frame (required).
+    :work/status  — OPTIONAL; included only when supplied (the egress suite
+                    pins `:completed`; the functor suite omits it).
+    :completed-at — OPTIONAL; defaults to `completion-time-ms`."
+  [{value        :value
+    work-id      :work/id
+    work-kind    :work/kind
+    frame-id     :rf.frame/id
+    work-status  :work/status
+    completed-at :completed-at
+    :or          {completed-at completion-time-ms}}]
+  (cond-> {:status       :ok
+           :value        value
+           :work/id      work-id
+           :work/kind    work-kind
+           :rf.frame/id  frame-id
+           :completed-at completed-at}
+    (some? work-status) (assoc :work/status work-status)))

--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -59,6 +59,7 @@
             [re-frame.elision :as elision]
             [re-frame.privacy :as privacy]
             [re-frame.reply :as reply]
+            [re-frame.reply-conformance-fixtures :as fixtures]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -102,16 +103,21 @@
 (def ^:private work-id
   [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1])
 
-(def ^:private completed-at-ms 1781078400456)
+;; Shared across the reply-conformance tier — owned by
+;; `re-frame.reply-conformance-fixtures` (rf2-b2a3a2).
+(def ^:private completed-at-ms fixtures/completion-time-ms)
 
 (defn- ok-reply []
-  {:status       :ok
-   :value        (reply-body)
-   :work/id      work-id
-   :work/kind    :resource
-   :work/status  :completed
-   :rf.frame/id  frame-id
-   :completed-at completed-at-ms})
+  ;; The canonical :ok reply SHAPE built via the shared
+  ;; `re-frame.reply-conformance-fixtures/canonical-ok-reply` (rf2-b2a3a2).
+  ;; This suite's row additionally pins `:work/status :completed`.
+  (fixtures/canonical-ok-reply
+    {:value        (reply-body)
+     :work/id      work-id
+     :work/kind    :resource
+     :work/status  :completed
+     :rf.frame/id  frame-id
+     :completed-at completed-at-ms}))
 
 (defn- error-reply []
   ;; The failure payload's wire-bearing leaves sit at the declared coordinates

--- a/implementation/reply-conformance/test/re_frame/reply_functor_law_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_functor_law_cljs_test.cljc
@@ -87,6 +87,7 @@
   functor law."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.reply :as reply]
+            [re-frame.reply-conformance-fixtures :as fixtures]
             [re-frame.routing.reply :as route-reply]
             [re-frame.machines.reply :as m-reply]))
 
@@ -106,18 +107,20 @@
 ;; dropped or mutated the completion fact (mis-threading causal completion
 ;; time, the bead's rf2-ear61v concern) would surface in the identity-
 ;; preservation test.
-(def ^:private completion-time-ms 1781078400456)
+;; Shared across the reply-conformance tier — owned by
+;; `re-frame.reply-conformance-fixtures` (rf2-b2a3a2).
+(def ^:private completion-time-ms fixtures/completion-time-ms)
 
 (def ^:private route-reply
   "A canonical route-loader :ok reply (the loader's decoded payload). The
   route work-id rides; the value is the loaded resource; `:completed-at` is
-  the durable causal completion time (EP-0017)."
-  {:status       :ok
-   :value        {:article {:id 42 :title "Welcome"}}
-   :work/id      (route-reply/work-id {:route-id :route/article :nav-token "nav-1" :loader-id :article/loaded})
-   :work/kind    :route
-   :rf.frame/id  :app/main
-   :completed-at completion-time-ms})
+  the durable causal completion time (EP-0017). Built via the shared
+  `re-frame.reply-conformance-fixtures/canonical-ok-reply` (rf2-b2a3a2)."
+  (fixtures/canonical-ok-reply
+    {:value       {:article {:id 42 :title "Welcome"}}
+     :work/id     (route-reply/work-id {:route-id :route/article :nav-token "nav-1" :loader-id :article/loaded})
+     :work/kind   :route
+     :rf.frame/id :app/main}))
 
 (def ^:private spawn-reply
   "A canonical machine spawned-actor :ok reply (the child's :output-key

--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -66,6 +66,7 @@
             ;; though `clojure -M:test` is green. See rf2-u99i9j.
             #?(:cljs [cljs.reader])
             [re-frame.reply :as reply]
+            [re-frame.reply-conformance-fixtures :as fixtures]
             [re-frame.http-reply :as http-reply]
             [re-frame.resources.reply :as rreply]
             [re-frame.machines.reply :as m-reply]
@@ -98,7 +99,9 @@
 ;; live-dispatch `:rf.cofx` half is owned by the router / per-family lowering
 ;; suites. The HTTP / resource / mutation success fixtures seed this value;
 ;; the machine fixture seeds its own (distinct) value.
-(def ^:private completion-time-ms 1781078400456)
+;; Shared across the reply-conformance tier — owned by
+;; `re-frame.reply-conformance-fixtures` (rf2-b2a3a2).
+(def ^:private completion-time-ms fixtures/completion-time-ms)
 
 (def ^:private http-ctx
   {:request-id   :article/by-id
@@ -213,7 +216,7 @@
     :work-head :rf.work/resource
     :success   #(rreply/success-reply resource-vp {:title "Welcome"}
                                       {:work-kind rreply/work-kind-resource
-                                       :completed-at 1781078400456})
+                                       :completed-at completion-time-ms})
     :error     #(rreply/failure-reply resource-vp a-failure
                                       {:work-kind rreply/work-kind-resource})
     :cancel    #(rreply/failure-reply resource-vp an-abort
@@ -224,7 +227,7 @@
     :work-head :rf.work/resource ;; mutation reuses the resource head with a [:rf.mutation …] key
     :success   #(rreply/success-reply mutation-vp {:slug "w" :title "Welcome"}
                                       {:work-kind rreply/work-kind-mutation
-                                       :completed-at 1781078400456})
+                                       :completed-at completion-time-ms})
     :error     #(rreply/failure-reply mutation-vp a-failure
                                       {:work-kind rreply/work-kind-mutation})
     :cancel    #(rreply/failure-reply mutation-vp an-abort

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
@@ -69,7 +69,8 @@
             [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [malli.error :as me]
-            [re-frame.mcp-conformance.fixtures :as fx]))
+            [re-frame.mcp-conformance.fixtures :as fx]
+            [re-frame.mcp-conformance.wire-vocab.source-pins :as pins]))
 
 ;; ---------------------------------------------------------------------------
 ;; The closed reply vocabularies — mirrored from re-frame.reply as literal
@@ -213,21 +214,6 @@
    "implementation/machines/src/re_frame/machines/transition.cljc"
    "implementation/routing/src/re_frame/routing/nav_token.cljc"])
 
-(defn- near-miss-variants
-  "Near-miss spellings of a `:rf.reply/*` key a rename MUST NOT slip through:
-  snake_case name, ns-dots→underscores, pluralised, predicate form."
-  [k]
-  (let [s   (pr-str k)
-        ns* (namespace k)
-        nm  (name k)]
-    (cond-> []
-      (str/includes? nm "-")
-      (conj (str ":" ns* "/" (str/replace nm #"-" "_")))
-      (str/includes? ns* ".")
-      (conj (str ":" (str/replace ns* #"\." "_") "/" nm))
-      true
-      (into [(str s "s") (str s "?")]))))
-
 ;; ===========================================================================
 ;; (1) Schema conformance — every production-shaped fixture validates.
 ;; ===========================================================================
@@ -344,7 +330,7 @@
             production emit site — a rename to a near-miss form must FAIL"
     (let [sources (into {} (map (juxt identity fx/read-source)) emit-source-files)]
       (doseq [k reply-envelope-keys
-              variant (near-miss-variants k)
+              variant (pins/near-miss-variants k)
               [file text] sources]
         (is (not (re-find (fx/variant-regex variant) text))
             (str "near-miss spelling " variant " of " (pr-str k)


### PR DESCRIPTION
Implements **rf2-b2a3a2** — three disjoint conformance dedup fixes.

## (A) wire-vocab `reply_envelope_test.clj`
Deleted the private `near-miss-variants` (a verbatim copy of the shared one), added `[re-frame.mcp-conformance.wire-vocab.source-pins :as pins]` to the `:require`, and call `pins/near-miss-variants` at the anti-pin site. The `:rf.reply/*` keys are ordinary namespaced kws the shared generator already covers; `str` stays required (still used by the source-pin asserts).

## (B) reply-conformance fixture constants
New support ns `test/re_frame/reply_conformance_fixtures.cljc` owns:
- `completion-time-ms` (`1781078400456`) — the durable EP-0017 causal completion fact, previously declared three times (plus two inline literals in the vocab suite's resource/mutation success builders).
- `canonical-ok-reply` — the canonical `:ok` reply shape builder (`:status :ok` + `:value` + `[:rf.work/* …]` `:work/id` + `:work/kind` + `:rf.frame/id` + `:completed-at` default; optional `:work/status`).

Wired into the three suites:
- `reply_vocab_conformance_cljs_test.cljc` — `completion-time-ms` + the two inline literals.
- `reply_functor_law_cljs_test.cljc` — `completion-time-ms` + the inline `route-reply` `:ok` map → `canonical-ok-reply`.
- `reply_egress_projection_conformance_cljs_test.cljc` — `completed-at-ms` + the inline `ok-reply` builder → `canonical-ok-reply` (pins `:work/status :completed`).

Kept WITHIN reply-conformance — not cross-corpus-shared into event-conformance. The fixtures ns has no `*-cljs-test` suffix, so the node gate compiles it as a required ns but never runs it as a deftest.

## (C) event-conformance minor correctness
`event_model_conformance_cljs_test.cljc` `redacted?` now references `re-frame.privacy/redacted-sentinel` (added the `:require`) instead of the literal `:rf/redacted`.

## Gates
```
cd implementation && npm run test:cljs        # 7865 tests / 32596 assertions, 0 failures
# JVM clojure -M:test:
#   tools/mcp-conformance/wire-vocab           93 tests / 922 assertions, 0 failures
#   implementation/reply-conformance           28 tests / 397 assertions, 0 failures
#   implementation/event-conformance           59 tests / 206 assertions, 0 failures
```
All anti-pin / reply deftests stay green. Gates re-run post-rebase onto current `origin/main`.