### PR TITLE
refactor(resources): consolidate helpers into state/reply; use core wall-clock (rf2-366u0g)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -88,34 +88,14 @@
 ;; private host-clock helper here: a handler reading the live host clock for a
 ;; freshness DECISION would be non-replayable (a replay under a later clock
 ;; could take a different branch). Passive view / SSR re-derivation reads
-;; (`subs.cljc`, `ssr.cljc`) keep their own ambient `now-ms` — those are reads,
+;; (`subs.cljc`, `ssr.cljc`) keep their own ambient clock — those are reads,
 ;; not handler decisions (EP §Restore endorses lazy on-read freshness for the
 ;; VIEW layer).
-
-(defn- stale-at-for
-  "Compute `:stale-at` from `loaded-at` + the resource's `:stale-after-ms`
-  policy, or nil when the resource declares no staleness policy (it never
-  goes stale on a timer). Per Spec 016 §Stale and GC scheduling."
-  [spec loaded-at]
-  (when-let [ms (:stale-after-ms spec)]
-    (+ loaded-at ms)))
-
-(defn- positive-or-nil
-  "Return `ms` when it is a positive number, else nil (a non-positive /
-  absent policy never arms a timer). Guards a timer delay derived from an
-  absolute timestamp comparison so a clock-skewed or already-elapsed deadline
-  yields nil rather than a negative wall-clock delay."
-  [ms]
-  (when (and (number? ms) (pos? ms)) ms))
-
-(defn- server-frame?
-  "True iff `frame-id` is an SSR / server frame (its `:config :platform` is
-  `:server`, set by the `:ssr-server` preset). Reads ONLY the FRAME's
-  platform — NOT the host-wide `active-platform` default (which is `:server`
-  on the JVM, so a JVM client-mode unit test must still arm timers). Per Spec
-  016 §Stale and GC scheduling (no wall-clock background timers under SSR)."
-  [frame-id]
-  (= :server (:platform (frame/frame-meta frame-id))))
+;;
+;; The pure stale / timer helpers this ns reads (`stale-at-for` /
+;; `positive-or-nil` / `server-frame?`) live in `state.cljc` — shared
+;; byte-for-byte with the mutation-success path so a patched / populated entry
+;; ages exactly as a fetched one (rf2-366u0g).
 
 ;; ---- ensure / refetch — the load-causing events ---------------------------
 
@@ -700,7 +680,7 @@
         owned?     (seq (:active-owners entry))
         in-flight? (and entry (entry-revalidation-in-flight? runtime-db entry))
         ;; the resource's declared interval — the re-arm delay (cancel-then-arm)
-        interval   (positive-or-nil
+        interval   (state/positive-or-nil
                      (:poll-interval-ms (registry/resource-meta (:resource/id entry))))
         decision   (cond
                      (nil? entry)     :no-entry
@@ -736,7 +716,7 @@
                   :stale-delay-ms nil
                   :gc-delay-ms    nil
                   :poll-delay-ms  interval
-                  :server?        (server-frame? frame-id)}]))))))
+                  :server?        (state/server-frame? frame-id)}]))))))
 
 ;; ---- invalidate-tags — exact tag invalidation -----------------------------
 
@@ -1407,27 +1387,11 @@
 ;; shape so the runtime-slice tests keep exercising the entry semantics
 ;; deterministically.
 
-(defn- reply-success-data
-  "Extract the decoded success data from a managed-HTTP success reply. The
-  transport appends `{:kind :success :value <decoded-data>}` as `http-result`
-  (arg 3); read its `:value`. Falls back to an inline `:data` on the
-  verification payload (the direct-dispatch test shape)."
-  [verification-payload http-result]
-  (if (contains? http-result :value)
-    (:value http-result)
-    (:data verification-payload)))
-
-(defn- reply-failure-error
-  "Extract the failure envelope from a managed-HTTP failure reply. The
-  transport appends `{:kind :failure :failure <:rf.http/* envelope>}` as
-  `http-result` (arg 3); read its `:failure` (the closed `:rf.http/*`
-  failure shape, the same envelope `:error` / `:refresh-error` carry — Spec
-  016 §Status semantics). Falls back to an inline `:error` on the
-  verification payload (the direct-dispatch test shape)."
-  [verification-payload http-result]
-  (if (contains? http-result :failure)
-    (:failure http-result)
-    (:error verification-payload)))
+;; The transport-payload extractors a reply handler lifts from arg 3 live in
+;; `re-frame.resources.reply` (`transport-success-value` /
+;; `transport-failure-envelope`) — shared with the mutation write path, which
+;; differs only by the inline durable-layer fallback key (`:data` here for a
+;; resource entry, `:result` for a mutation instance — rf2-366u0g).
 
 (def ^:private http-aborted-kind
   "The managed-HTTP failure `:kind` for an intentional abort/cancellation
@@ -1468,11 +1432,12 @@
   Event shape: `[_ <verification-payload> <http-result>]` — the managed-HTTP
   transport appends `{:kind :success :value <decoded-data>}` as the last arg
   (Spec 014 §Reply addressing); the decoded data is read from there
-  (`reply-success-data`) and re-lifted into the canonical `:value`."
+  (`rreply/transport-success-value` with the `:data` durable-layer fallback)
+  and re-lifted into the canonical `:value`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
    [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
-        value      (reply-success-data payload http-result)
+        value      (rreply/transport-success-value payload http-result :data)
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps + EP-0017 declared-only delivery
         ;; (rf2-601ife): the reply is a CAUSAL TOKEN. The host completion time
@@ -1524,7 +1489,7 @@
             ;; `:stale-at` is computed from it + the resource's
             ;; `:stale-after-ms` policy — never an ambient clock read here.
             loaded-at (:completed-at reply)
-            stale-at  (stale-at-for spec loaded-at)
+            stale-at  (state/stale-at-for spec loaded-at)
             ;; arm the advisory stale / GC timers from the resource's policy
             ;; (Spec 016 §Stale and GC scheduling). The DELAYS are relative
             ;; from now (the durable absolute :stale-at / :loaded-at remain the
@@ -1532,8 +1497,8 @@
             ;; an advisory nudge). A resource declaring no :stale-after-ms /
             ;; :gc-after-ms arms neither. nil when this resource arms no timers
             ;; (no schedule-timers fx emitted).
-            stale-delay-ms (positive-or-nil (:stale-after-ms spec))
-            gc-delay-ms    (positive-or-nil (:gc-after-ms spec))
+            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))
             tags-fn   (:tags spec)
             ;; tags are produced from the params + decoded data; the canonical
             ;; params are the third element of the scoped key
@@ -1550,7 +1515,7 @@
             ;; tick. A resource declaring no `:poll-interval-ms` (or one whose
             ;; entry is owner-free at settle) arms no poll timer.
             poll-delay-ms (when (seq (:active-owners entry'))
-                            (positive-or-nil (:poll-interval-ms spec)))
+                            (state/positive-or-nil (:poll-interval-ms spec)))
             ;; on a successful load the tag index for this key is REPLACED
             ;; with the new tags (old tags removed); recompute is the simple,
             ;; correct way to keep both indexes consistent. The work row
@@ -1595,7 +1560,7 @@
                         :stale-delay-ms stale-delay-ms
                         :gc-delay-ms    gc-delay-ms
                         :poll-delay-ms  poll-delay-ms
-                        :server?        (server-frame? frame-id)}]]))))))
+                        :server?        (state/server-frame? frame-id)}]]))))))
 
 (defn- entry-abort-settled
   "Settle a LIVE entry whose current attempt was ABORTED (a cancellation, NOT
@@ -1640,15 +1605,15 @@
   Event shape: `[_ <verification-payload> <http-result>]` — the managed-HTTP
   transport appends `{:kind :failure :failure <:rf.http/* envelope>}` as the
   last arg (Spec 014 §Reply addressing); the failure envelope is read from
-  there (`reply-failure-error`) and re-lifted into the canonical reply map
-  (`rreply/failure-reply` — `:status :error` with the envelope under
+  there (`rreply/transport-failure-envelope`) and re-lifted into the canonical
+  reply map (`rreply/failure-reply` — `:status :error` with the envelope under
   `:error`, or `:status :cancelled` for an `:rf.http/aborted` envelope; per
   Managed-Effects §Status taxonomy / EP-0011 §Resource Reply And Work
   Ledger)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
    [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
-        error      (reply-failure-error payload http-result)
+        error      (rreply/transport-failure-envelope payload http-result)
         ;; EP-0017 declared-only delivery + EP-0010 §Managed Effects And Reply
         ;; Tokens (rf2-rl27r2): a FAILED / CANCELLED completion is still a
         ;; managed-async completion with a reply token, so its causal completion
@@ -1947,7 +1912,7 @@
             ;; resource's own :gc-after-ms (positive-guarded — a resource with
             ;; no GC policy never armed one, so it never reaches this branch).
             gc-delay (when (not= :no-entry reason)
-                       (positive-or-nil (:gc-after-ms (registry/resource-meta (:resource/id entry)))))]
+                       (state/positive-or-nil (:gc-after-ms (registry/resource-meta (:resource/id entry)))))]
         (trace/emit! :rf.event :rf.resource/gc-skipped
                      {:rf.frame/id frame-id :resource/key resource-key
                       :reason reason
@@ -1961,7 +1926,7 @@
                         ;; nil disarms that kind in schedule-timers-handler)
                         :stale-delay-ms nil
                         :gc-delay-ms    gc-delay
-                        :server?        (server-frame? frame-id)}]]))))))
+                        :server?        (state/server-frame? frame-id)}]]))))))
 
 (defn stale-suppressed-handler
   "`:rf.resource.internal/stale-suppressed` — a late reply carrying a

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -89,41 +89,21 @@
 ;; clock is read at a durable write site, so this ns no longer defines a
 ;; `now-ms` helper (the remaining timer DELAYS are advisory host transients
 ;; computed from the durable absolute timestamps).
-
-(defn- stale-at-for
-  "Compute `:stale-at` for a patched / populated resource entry from
-  `loaded-at` + the resource's `:stale-after-ms` policy, or nil. Mirrors the
-  resource read path so a patched entry ages exactly as a fetched one."
-  [resource-spec loaded-at]
-  (when-let [ms (:stale-after-ms resource-spec)]
-    (+ loaded-at ms)))
-
-(defn- positive-or-nil
-  "Return `ms` when it is a positive number, else nil (a non-positive /
-  absent policy never arms a timer). Mirrors `events/positive-or-nil` so a
-  patched / populated entry arms exactly the timers a fetched one would."
-  [ms]
-  (when (and (number? ms) (pos? ms)) ms))
-
-(defn- server-frame?
-  "True iff `frame-id` is an SSR / server frame (its `:config :platform` is
-  `:server`). Reads ONLY the FRAME's platform — NOT the host-wide
-  `active-platform` default (which is `:server` on the JVM, so a JVM
-  client-mode unit test must still arm timers). Mirrors
-  `events/server-frame?`. Per Spec 016 §Stale and GC scheduling (no
-  wall-clock background timers under SSR)."
-  [frame-id]
-  (= :server (:platform (frame/frame-meta frame-id))))
+;;
+;; The pure stale / timer helpers a patched / populated entry reads
+;; (`stale-at-for` / `positive-or-nil` / `server-frame?`) live in `state.cljc`
+;; — shared byte-for-byte with the read path so a patched entry ages exactly as
+;; a fetched one and arms exactly the timers a fetched one would (rf2-366u0g).
 
 (defn- timer-delays
   "The advisory stale / GC timer delays for a patched / populated entry from
   the resource spec's `:stale-after-ms` / `:gc-after-ms` policy, or nil when
   the resource declares neither (so no `:rf.resource/schedule-timers` fx is
   emitted for that key). Mirrors the read path's
-  `positive-or-nil`-guarded delay derivation."
+  `state/positive-or-nil`-guarded delay derivation."
   [resource-spec]
-  (let [stale-delay-ms (positive-or-nil (:stale-after-ms resource-spec))
-        gc-delay-ms    (positive-or-nil (:gc-after-ms resource-spec))]
+  (let [stale-delay-ms (state/positive-or-nil (:stale-after-ms resource-spec))
+        gc-delay-ms    (state/positive-or-nil (:gc-after-ms resource-spec))]
     (when (or stale-delay-ms gc-delay-ms)
       {:stale-delay-ms stale-delay-ms :gc-delay-ms gc-delay-ms})))
 
@@ -213,7 +193,7 @@
           (let [entry (get-in db' (state/entry-path scoped-key))]
             (if (and entry (state/has-data? entry))
               (let [rspec    (registry/resource-meta (:resource/id entry))
-                    stale-at (stale-at-for rspec clock-ms)
+                    stale-at (state/stale-at-for rspec clock-ms)
                     entry'   (mstate/patch-entry entry patch-fn result
                                                  {:clock-ms clock-ms :stale-at stale-at})
                     delays   (timer-delays rspec)]
@@ -253,7 +233,7 @@
         (fn [[db' ks policies nils sk] scoped-key value]
           (let [[_scope resource-id rparams] scoped-key
                 rspec    (registry/resource-meta resource-id)
-                stale-at (stale-at-for rspec clock-ms)
+                stale-at (state/stale-at-for rspec clock-ms)
                 tags-fn  (:tags rspec)
                 tags     (when tags-fn (set (tags-fn rparams value)))
                 entry    (get-in db' (state/entry-path scoped-key))
@@ -532,7 +512,7 @@
                      (update-in db' (state/entries-path) dissoc (state/key-id scoped-key))
                      (let [[_scope resource-id _p] scoped-key
                            rspec    (registry/resource-meta resource-id)
-                           stale-at (stale-at-for rspec clock-ms)
+                           stale-at (state/stale-at-for rspec clock-ms)
                            tags-fn  (:tags rspec)
                            ;; a freshly-seeded entry needs its resource's tags
                            ;; (so a later invalidation can reach it). An existing
@@ -1602,24 +1582,11 @@
 ;; of the same decoded result — the reply-map spelling is `:value`, kh9jz6 /
 ;; EP-0007). A direct-dispatch test may inline :result / :error on arg 2.
 
-(defn- reply-success-result
-  "Extract the decoded mutation result from a managed-HTTP success reply
-  (`{:kind :success :value <data>}` appended as arg 3). Falls back to an
-  inline `:result` on the verification payload (the direct-dispatch test
-  shape)."
-  [verification-payload http-result]
-  (if (contains? http-result :value)
-    (:value http-result)
-    (:result verification-payload)))
-
-(defn- reply-failure-error
-  "Extract the failure envelope from a managed-HTTP failure reply
-  (`{:kind :failure :failure <envelope>}` appended as arg 3). Falls back to
-  an inline `:error` on the verification payload."
-  [verification-payload http-result]
-  (if (contains? http-result :failure)
-    (:failure http-result)
-    (:error verification-payload)))
+;; The transport-payload extractors a reply handler lifts from arg 3 live in
+;; `re-frame.resources.reply` (`transport-success-value` /
+;; `transport-failure-envelope`) — shared with the resource read path, which
+;; differs only by the inline durable-layer fallback key (`:result` here for a
+;; mutation instance, `:data` for a resource entry — rf2-366u0g).
 
 (defn succeeded-handler
   "`:rf.mutation.internal/succeeded` — a mutation write succeeded. Verifies
@@ -1661,7 +1628,7 @@
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. The internal mutation reply
         ;; target receives it directly; the decoded result is `:value`.
-        reply      (rreply/success-reply payload (reply-success-result payload http-result)
+        reply      (rreply/success-reply payload (rreply/transport-success-value payload http-result :result)
                                          {:work-kind rreply/work-kind-mutation
                                           :completed-at completed-at})
         result     (:value reply)
@@ -1831,7 +1798,7 @@
             ;; populated ownerless entry would carry a durable :stale-at /
             ;; :gc-after-ms policy but NO armed reaper. Per Spec 016 §Stale
             ;; and GC scheduling.
-            server?     (server-frame? frame-id)
+            server?     (state/server-frame? frame-id)
             timer-fx    (mapv (fn [[scoped-key {:keys [stale-delay-ms gc-delay-ms]}]]
                                 [:rf.resource/schedule-timers
                                  {:frame-id       frame-id
@@ -1968,7 +1935,7 @@
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. `:error` carries the closed
         ;; `:rf.http/*` envelope the instance `:error` also stores.
-        reply      (rreply/failure-reply payload (reply-failure-error payload http-result)
+        reply      (rreply/failure-reply payload (rreply/transport-failure-envelope payload http-result)
                                          {:work-kind rreply/work-kind-mutation
                                           :completed-at completed-at})
         error      (:error reply)

--- a/implementation/resources/src/re_frame/resources/reply.cljc
+++ b/implementation/resources/src/re_frame/resources/reply.cljc
@@ -137,6 +137,46 @@
   (= http-aborted-kind (:kind error)))
 
 ;; ---------------------------------------------------------------------------
+;; Transport-payload extractors (Spec 014 §Reply addressing). The managed-HTTP
+;; transport APPENDS its PUBLIC reply payload as the LAST arg of the
+;; framework-internal reply event:
+;;   [:rf.*.internal/succeeded <verification-payload> {:kind :success :value <data>}]
+;;   [:rf.*.internal/failed    <verification-payload> {:kind :failure :failure <envelope>}]
+;; Both the resource read path (`events.cljc`) and the mutation write path
+;; (`mutation_events.cljc`) lift arg 3 identically — they differ ONLY by the
+;; inline DURABLE-LAYER spelling the direct-dispatch test shape falls back to
+;; (`:data` for a resource entry, `:result` for a mutation instance). One
+;; shared failure extractor + one fallback-key-parameterized success extractor
+;; (rf2-366u0g) so the two surfaces never drift.
+;; ---------------------------------------------------------------------------
+
+(defn transport-success-value
+  "Extract the decoded success value from a managed-HTTP success reply. The
+  transport appends `{:kind :success :value <decoded>}` as `http-result`
+  (arg 3); read its `:value`. Falls back to an inline value on the
+  verification payload under `fallback-key` (the direct-dispatch test shape,
+  no transport in the loop) — `:data` for a resource entry, `:result` for a
+  mutation instance (kh9jz6 / EP-0007: `:value` is the reply-map spelling;
+  `:data` / `:result` are the durable-layer spellings)."
+  [verification-payload http-result fallback-key]
+  (if (contains? http-result :value)
+    (:value http-result)
+    (get verification-payload fallback-key)))
+
+(defn transport-failure-envelope
+  "Extract the failure envelope from a managed-HTTP failure reply. The
+  transport appends `{:kind :failure :failure <:rf.http/* envelope>}` as
+  `http-result` (arg 3); read its `:failure` (the closed `:rf.http/*` failure
+  shape, the same envelope the durable entry `:error` / `:refresh-error`
+  carries — Spec 016 §Status semantics). Falls back to an inline `:error` on
+  the verification payload (the direct-dispatch test shape). Identical for the
+  resource and mutation surfaces (rf2-366u0g)."
+  [verification-payload http-result]
+  (if (contains? http-result :failure)
+    (:failure http-result)
+    (:error verification-payload)))
+
+;; ---------------------------------------------------------------------------
 ;; Canonical reply-map builders (Managed-Effects §The reply map / §Status
 ;; taxonomy). The verification payload the resource / mutation lowering
 ;; stamped supplies the identity / correlation facts; the transport's

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -59,6 +59,7 @@
   snapshot — Spec 016 §Restore and replay part 5) and need not ride. Per
   Spec 016 §Runtime-subsystem graduation clause 4."
   (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
             [re-frame.resources.classification :as classification]
@@ -82,21 +83,24 @@
 (declare settle-entry-to-last-stable)
 
 ;; ---- shared clock ---------------------------------------------------------
-
-(defn now-ms
-  "Current epoch-ms — the server clock stamped on `loaded-at` / `stale-at`
-  and the live clock the client compares restored absolute timestamps
-  against to surface skew. Host-platform clock (JVM under SSR; the browser
-  on the client). Per Spec 016 §SSR and hydration (absolute timestamps).
-
-  Public (rf2-wshzsp) so the restore-reconcile suite can `with-redefs` it to a
-  sentinel and ADVERSARIALLY pin that restore reads it ONLY for the clock-skew
-  DIAGNOSTIC — never to freshen a DURABLE restored entry/instance timestamp
-  (EP-0010 §Restore/Replay: \"restored resource entries do not re-read the live
-  clock during install\")."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.now js/Date)))
+;;
+;; The WALL-clock epoch-ms read this slice uses — the server clock stamped on
+;; `loaded-at` / `stale-at`, and the live clock the client compares restored
+;; absolute timestamps against to surface skew — is the core
+;; `re-frame.interop/epoch-now-ms` (rf2-366u0g). It is byte-identical to the
+;; private `now-ms` this ns used to define (`System/currentTimeMillis` on the
+;; JVM, `js/Date.now` on CLJS) and is the canonical EP-0010 §Time wall-clock
+;; surface — NOT the perf clock `interop/now-ms` (`performance.now()` on CLJS,
+;; origin-relative, ~1e4), which is incomparable with `js/Date`-based freshness
+;; checks. These resources are durable freshness / skew readers, so the wall
+;; clock is correct.
+;;
+;; `interop/epoch-now-ms` is PUBLIC (rf2-wshzsp test seam preserved): the
+;; restore-reconcile suite `with-redefs`-stubs it to a sentinel and ADVERSARIALLY
+;; pins that restore reads it ONLY for the clock-skew DIAGNOSTIC — never to
+;; freshen a DURABLE restored entry / instance timestamp (EP-0010
+;; §Restore/Replay: "restored resource entries do not re-read the live clock
+;; during install").
 
 ;; ---- freshness classification (Spec 016 §Status semantics) ----------------
 ;;
@@ -244,6 +248,41 @@
     (let [[scope resource-id params] scoped-key]
       [(redact-key-component scope) resource-id (redact-key-component params)])))
 
+(defn disposition+project-key
+  "Resolve a scoped key's resource OWNER spec, compute its frame-aware
+  whole-entry disposition, and project the key accordingly — the shared
+  disposition+project-key pipeline (rf2-366u0g). Returns
+  `[projected-key disposition spec]`:
+
+    1. `spec`        ← `registry/resource-meta` of `scoped-key`'s resource-id;
+    2. `disposition` ← `classification/whole-entry-disposition-for spec frame-id`
+       (the coarse owner `:sensitive?` / `:large?` claim PLUS the named-scope-
+       resolver derived-sensitivity inheritance against the frame);
+    3. projected key ← `project-scoped-key scoped-key disposition spec`
+       (`:redact` / `:omit` replace scope + params with opaque content-addressed
+       `{:rf/redacted <digest>}` tokens; `:serialize` projects per-slot
+       `:params-schema` marks — the resource-id always survives).
+
+  The single home for the pipeline the SSR durable-egress projection
+  (`project-entry`), the TOOL-egress algebra view (`tooling/project-key-for-
+  egress`), and the off-box TRACE-egress projector
+  (`trace_egress/project-trace-scoped-key`, in its REGISTERED-owner branch —
+  it keeps its own nil-spec fail-closed-to-`:redact` + idempotent-token guards
+  as the OUTER wrapper) all reuse, so the owner classification + key projection
+  never drift between egress boundaries. Pure.
+
+  It lives HERE (not in `classification`) because the pipeline needs both
+  `project-scoped-key` (this ns) AND `registry/resource-meta` — and
+  `re-frame.resources.registry` already requires `classification`, so hosting
+  it in `classification` would introduce a require cycle. `ssr` already
+  requires both `classification` and `registry`, and the trace / tool egress
+  callers already require `ssr`."
+  [scoped-key frame-id]
+  (let [resource-id (second scoped-key)
+        spec        (registry/resource-meta resource-id)
+        disposition (classification/whole-entry-disposition-for spec frame-id)]
+    [(project-scoped-key scoped-key disposition spec) disposition spec]))
+
 (defn- project-entry
   "Project a single durable cache `entry` (under `scoped-key`) to its wire
   shape per its classification, against the SSR `frame-id` (so the shared
@@ -280,17 +319,23 @@
   [frame-id clock-ms entry]
   (let [scoped-key  (:resource/key entry)
         resource-id (second scoped-key)
-        ;; resolve the owner spec once: it carries BOTH the coarse root-prop
-        ;; disposition (`whole-entry-disposition`) and the per-slot
-        ;; `:data-schema` marks (`project-data` layer (a)) — EP-0015 §6.
-        spec        (registry/resource-meta resource-id)
-        ;; frame-aware disposition: the OWNER's coarse `:sensitive?` / `:large?`
-        ;; claim, PLUS the named-scope-resolver derived-sensitivity inheritance
-        ;; arm — a `{:from-db <id>}` scope resolver reading a frame-sensitive
-        ;; `:db` input upgrades the entry to `:redact` even when the owner did
-        ;; not declare `:sensitive?` (EP-0016 wave rf2-fi6tda.1; Spec 015
-        ;; §Derived sensitivity).
-        disposition (classification/whole-entry-disposition-for spec frame-id)
+        ;; The shared disposition+project-key pipeline (rf2-366u0g) resolves the
+        ;; owner spec ONCE, computes the frame-aware whole-entry disposition, and
+        ;; projects the scoped key in one call:
+        ;;   - the spec carries BOTH the coarse root-prop disposition AND the
+        ;;     per-slot `:data-schema` marks (`project-data` layer (a) — EP-0015
+        ;;     §6), needed below for the `:serialize` data projection;
+        ;;   - the disposition is the OWNER's coarse `:sensitive?` / `:large?`
+        ;;     claim PLUS the named-scope-resolver derived-sensitivity inheritance
+        ;;     arm (a `{:from-db <id>}` resolver reading a frame-sensitive `:db`
+        ;;     input upgrades to `:redact` even when the owner did not declare
+        ;;     `:sensitive?` — EP-0016 wave rf2-fi6tda.1; Spec 015 §Derived
+        ;;     sensitivity);
+        ;;   - `projected-key` is the in-entry `:resource/key` copy projected the
+        ;;     SAME way as the wire MAP key (rf2-9e0tyq) — a `:redact` / `:omit`
+        ;;     resource redacts its scope + params to opaque content-addressed
+        ;;     tokens, so the raw identity never rides in EITHER carrier.
+        [projected-key disposition spec] (disposition+project-key scoped-key frame-id)
         stale?      (entry-stale? entry clock-ms)
         ;; metadata-only entries refetch on the client if a live route owner
         ;; needs them; serialized stale entries also refetch (background);
@@ -337,14 +382,13 @@
         ;; survive the round-trip (Spec 016 §Restore and replay part 2 — a
         ;; non-terminal attempt is dangling on install).
         wire-entry  (dissoc wire-entry :current-work)
-        ;; rf2-9e0tyq — the in-entry `:resource/key` copy is PROJECTED the same
-        ;; way as the wire MAP key (`project-scoped-key`): a `:redact` / `:omit`
-        ;; resource redacts its scope + params to opaque content-addressed
-        ;; tokens here too, so the raw identity never rides in EITHER carrier.
-        ;; The client's `recompute-indexes` keys index members on the byte
-        ;; `key-id` of this projected `:resource/key`, matching the wire map key.
-        wire-entry  (assoc wire-entry :resource/key
-                           (project-scoped-key scoped-key disposition spec))
+        ;; rf2-9e0tyq — the in-entry `:resource/key` copy is the SAME projected
+        ;; key computed above (`disposition+project-key`), matching the wire MAP
+        ;; key: a `:redact` / `:omit` resource redacts its scope + params to
+        ;; opaque content-addressed tokens here too, so the raw identity never
+        ;; rides in EITHER carrier. The client's `recompute-indexes` keys index
+        ;; members on the byte `key-id` of this projected `:resource/key`.
+        wire-entry  (assoc wire-entry :resource/key projected-key)
         meta'       (assoc base
                            :disposition (case disposition
                                           :serialize :serialized
@@ -394,7 +438,7 @@
         entries   (:entries resources)]
     (if (seq entries)
       (let [frame-id (frame/resolve-current-frame)
-            clock-ms (now-ms)
+            clock-ms (interop/epoch-now-ms)
             ;; rf2-9e0tyq — the projected wire entries are RE-KEYED on the byte
             ;; `key-id` of each entry's PROJECTED `:resource/key` (the wire
             ;; entry's own `:resource/key`, set by `project-entry`), so the
@@ -642,7 +686,7 @@
   record). The drain reads the LIVE frame each tick (`frame-runtime-db-value`)
   so a reply that lands mid-pump is observed."
   [frame-id {:keys [pump! deadline-ms clock-fn tick-ms]}]
-  (let [clock-fn (or clock-fn now-ms)
+  (let [clock-fn (or clock-fn interop/epoch-now-ms)
         rdb0     (frame/frame-runtime-db-value frame-id)
         blocking (current-blocking-keys rdb0)]
     (if (empty? blocking)
@@ -867,7 +911,7 @@
          entries   (:entries resources)]
      (if-not (seq entries)
        runtime-db
-       (let [clock-ms (now-ms)
+       (let [clock-ms (interop/epoch-now-ms)
              ;; reconcile each entry: orphan SSR owners + clear current-work +
              ;; settle a non-terminal entry to last-stable (rf2-bg6qah).
              ;; Hydration passes nil live-nav-token — there is no client
@@ -1260,7 +1304,7 @@
     epoch's `:committed-at` (the committing token's `:rf.cofx`
     `:rf/time-ms`, replay-stable per EP-0010 §Time). It is the source of the
     DURABLE `:settled-at` stamped on a PENDING mutation instance dangled on
-    restore — NOT the live install clock (`now-ms`). Per EP-0010 §Restore/Replay
+    restore — NOT the live install clock (`interop/epoch-now-ms`). Per EP-0010 §Restore/Replay
     a durable frame-state field MUST come from a causal input, never an ambient
     world read at install. nil on the pure-unit 1-/2-arity (no token / no real
     restore epoch), where it falls back to the live clock — those paths install
@@ -1285,7 +1329,7 @@
          live-nav-token (get-in runtime-db routing-current-nav-token-path)]
      (if-not (or (seq entries) (seq ledger) (seq mutations))
        runtime-db
-       (let [clock-ms (now-ms)
+       (let [clock-ms (interop/epoch-now-ms)
              ;; reconcile each entry: orphan SSR owners + STALE-NAV route
              ;; owners (part 4) + clear current-work (part 2) + settle a
              ;; mid-flight status to last-stable (restore-specific — the wire
@@ -1321,7 +1365,7 @@
              ;; come from the restore's CAUSAL time (`restore-time-ms` — the
              ;; restored epoch's `:committed-at`, itself the committing token's
              ;; `:rf.cofx` `:rf/time-ms`), NOT the ambient `clock-ms`
-             ;; (`now-ms`) read above. Sourcing it from the live install clock
+             ;; (`interop/epoch-now-ms`) read above. Sourcing it from the live install clock
              ;; would make the durable stamp non-replayable (the exact shape the
              ;; EP's restore clause warns against: a durable write fed by an
              ;; ambient read at install). `clock-ms` legitimately feeds ONLY the
@@ -1530,7 +1574,7 @@
 
   `frame-id` (3-arity) is the explicit hydration target the trace rows are
   tagged with; the 1-/2-arity overloads omit it (a frame-agnostic decision)."
-  ([runtime-db] (hydrate-refetch-plan runtime-db (now-ms) nil))
+  ([runtime-db] (hydrate-refetch-plan runtime-db (interop/epoch-now-ms) nil))
   ([runtime-db clock-ms] (hydrate-refetch-plan runtime-db clock-ms nil))
   ([runtime-db clock-ms frame-id]
    (let [entries (get-in runtime-db [state/resources-key :entries])
@@ -1628,4 +1672,4 @@
   the server projected under their own scoped keys)."
   [frame-id]
   (let [rdb (frame/swap-runtime-db! frame-id hydrate-runtime-db frame-id)]
-    (hydrate-refetch-plan (or rdb {}) (now-ms) frame-id)))
+    (hydrate-refetch-plan (or rdb {}) (interop/epoch-now-ms) frame-id)))

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -713,6 +713,48 @@
          (or (some? (:invalidated-at entry))
              (when-let [sa (:stale-at entry)] (>= clock-ms sa))))))
 
+;; ---- shared stale / timer helpers (Spec 016 §Stale and GC scheduling) ------
+;;
+;; The cache-entry `:stale-at` derivation, the timer-delay positivity guard, and
+;; the SSR/server-frame test are read identically by the READ path
+;; (`events.cljc` — first load / refresh / poll) and the MUTATION-success path
+;; (`mutation_events.cljc` — a patched / populated entry must age exactly as a
+;; fetched one). They are pinned here so a patched entry's staleness, the timer
+;; delay guard, and the no-wall-clock-background-timers-under-SSR rule never
+;; drift between the two writers (rf2-366u0g).
+
+(defn stale-at-for
+  "Compute an entry's `:stale-at` from `loaded-at` + the resource's
+  `:stale-after-ms` policy, or nil when the resource declares no staleness
+  policy (it never goes stale on a timer). The single home both the read path
+  (first load / refresh) and the mutation-success path (patch / populate) read
+  so a patched entry ages exactly as a fetched one. Per Spec 016 §Stale and GC
+  scheduling."
+  [spec loaded-at]
+  (when-let [ms (:stale-after-ms spec)]
+    (+ loaded-at ms)))
+
+(defn positive-or-nil
+  "Return `ms` when it is a positive number, else nil (a non-positive / absent
+  policy never arms a timer). Guards a timer delay derived from an absolute
+  timestamp comparison so a clock-skewed or already-elapsed deadline yields nil
+  rather than a negative wall-clock delay. The single guard both the read path
+  and the mutation-success path arm their stale / GC / poll timers through. Per
+  Spec 016 §Stale and GC scheduling."
+  [ms]
+  (when (and (number? ms) (pos? ms)) ms))
+
+(defn server-frame?
+  "True iff `frame-id` is an SSR / server frame (its `:config :platform` is
+  `:server`, set by the `:ssr-server` preset). Reads ONLY the FRAME's platform
+  — NOT the host-wide `active-platform` default (which is `:server` on the JVM,
+  so a JVM client-mode unit test must still arm timers). The single home both
+  the read path and the mutation-success path consult before arming a
+  wall-clock background timer. Per Spec 016 §Stale and GC scheduling (no
+  wall-clock background timers under SSR)."
+  [frame-id]
+  (= :server (:platform (frame/frame-meta frame-id))))
+
 ;; ---- per-entry revision (EP-0019 §Decision 2 / byl7bk Open Issue 5) --------
 ;;
 ;; `:revision` is the per-entry WRITE identity the optimistic-rollback settle

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -269,14 +269,15 @@
     e))
 
 ;; ---- derived freshness (Spec 016 §Status semantics) -----------------------
-
-(defn- now-ms
-  "Current epoch-ms — the live clock the `:stale?` derivation compares
-  `:stale-at` against. Freshness is computed from durable timestamps, not
-  from trusting a timer fired on time (Spec 016 §Stale and GC scheduling)."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.now js/Date)))
+;;
+;; The live clock the `:stale?` derivation compares `:stale-at` against is the
+;; core WALL-clock `re-frame.interop/epoch-now-ms` (rf2-366u0g) — byte-identical
+;; to the private `now-ms` this ns used to define (`System/currentTimeMillis`
+;; on the JVM, `js/Date.now` on CLJS), and the canonical EP-0010 §Time
+;; wall-clock surface. NOT the perf clock `interop/now-ms` (`performance.now()`
+;; on CLJS, origin-relative), which is incomparable with the `js/Date`-based
+;; `:stale-at` timestamps. Freshness is computed from durable timestamps, not
+;; from trusting a timer fired on time (Spec 016 §Stale and GC scheduling).
 
 (defn- stale?
   "Derived: an entry is stale iff it has been explicitly invalidated
@@ -286,9 +287,10 @@
   refreshing stale data. Per Spec 016 §Status semantics. A computed value,
   never a stored fact. Delegates to the single shared `state/entry-stale?`
   derivation (the same one the SSR projection + the stale-timer re-check
-  use) so freshness never drifts between readers."
+  use) so freshness never drifts between readers; the live clock is the
+  canonical wall-clock `interop/epoch-now-ms`."
   [entry]
-  (state/entry-stale? entry (now-ms)))
+  (state/entry-stale? entry (interop/epoch-now-ms)))
 
 ;; ---- the projections (public derived sub values) -------------------------
 

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -38,7 +38,6 @@
   shapes in [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
   (:require [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.resources.classification :as classification]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.scope-registry :as scope-registry]
             [re-frame.resources.ssr :as ssr]
@@ -381,18 +380,19 @@
 ;; `:inputs` / `:work-ledger`, which a generic value-path walk cannot reach).
 ;;
 ;; The projection reuses the SAME resource OWNER classification the SSR /
-;; durable-egress path uses — never a tooling-private elider:
-;;   - `classification/whole-entry-disposition-for` resolves the coarse
-;;     `:sensitive?` / `:large?` root-prop claim PLUS the named-scope-resolver
-;;     derived-sensitivity inheritance against the frame (so a `{:from-db}`
-;;     scope reading a frame-sensitive `:db` input redacts even when the owner
-;;     did not declare `:sensitive?`);
-;;   - `ssr/project-scoped-key` then projects the scoped key per that
-;;     disposition — `:redact` / `:omit` replace scope + params with opaque
-;;     content-addressed `{:rf/redacted <digest>}` tokens (distinct values
-;;     stay distinct, so graph connectivity by projected key is preserved),
-;;     while `:serialize` applies the per-slot `:params-schema` marks and
-;;     otherwise rides verbatim (non-sensitive identity is preserved).
+;; durable-egress path uses — never a tooling-private elider — through the
+;; shared `ssr/disposition+project-key` pipeline (rf2-366u0g):
+;;   - `classification/whole-entry-disposition-for` (inside the shared helper)
+;;     resolves the coarse `:sensitive?` / `:large?` root-prop claim PLUS the
+;;     named-scope-resolver derived-sensitivity inheritance against the frame
+;;     (so a `{:from-db}` scope reading a frame-sensitive `:db` input redacts
+;;     even when the owner did not declare `:sensitive?`);
+;;   - `ssr/project-scoped-key` (inside the shared helper) then projects the
+;;     scoped key per that disposition — `:redact` / `:omit` replace scope +
+;;     params with opaque content-addressed `{:rf/redacted <digest>}` tokens
+;;     (distinct values stay distinct, so graph connectivity by projected key
+;;     is preserved), while `:serialize` applies the per-slot `:params-schema`
+;;     marks and otherwise rides verbatim (non-sensitive identity is preserved).
 ;; The resource-id (position 1 of the 3-tuple) always survives, so a tool still
 ;; sees WHICH resource each node names and edges still join nodes by the same
 ;; projected key.
@@ -402,12 +402,13 @@
   the `frame-id` classification (rf2-0t0l3w). Returns `[projected-key
   disposition]`. `:redact` / `:omit` replace scope + params with opaque
   tokens; `:serialize` projects per-slot `:params-schema` marks (a no-op when
-  none) — the resource-id always survives. Pure."
+  none) — the resource-id always survives. Pure. Delegates to the shared
+  `ssr/disposition+project-key` pipeline (rf2-366u0g — the SAME owner
+  classification + key projection the SSR durable-egress + off-box trace-egress
+  paths use), dropping the spec it does not need."
   [scoped-key frame-id]
-  (let [resource-id (second scoped-key)
-        spec        (registry/resource-meta resource-id)
-        disposition (classification/whole-entry-disposition-for spec frame-id)]
-    [(ssr/project-scoped-key scoped-key disposition spec) disposition]))
+  (let [[projected-key disposition _spec] (ssr/disposition+project-key scoped-key frame-id)]
+    [projected-key disposition]))
 
 (defn- project-work-id
   "Project the scoped key embedded in a resource work-id

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -67,8 +67,7 @@
   The redaction is the off-box DEFAULT; the trusted-local `:include-sensitive?`
   opt-in lifts it at the epoch consumer (the `local-raw` boundary — the same
   switch the app-db / HTTP-body / scope-resolved redactions honour)."
-  (:require [re-frame.resources.classification :as classification]
-            [re-frame.resources.registry :as registry]
+  (:require [re-frame.resources.registry :as registry]
             [re-frame.resources.ssr :as ssr]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -97,15 +96,22 @@
     (and (redacted-token? (nth scoped-key 0)) (redacted-token? (nth scoped-key 2)))
     [scoped-key true]
 
+    ;; fail closed — owner unreadable, redact scope + params, keep the id. This
+    ;; nil-spec fail-closed-to-`:redact` (and the idempotent-token guard above)
+    ;; is the OUTER wrapper the trace-egress family keeps around the shared
+    ;; disposition+project-key pipeline (rf2-366u0g): tooling / SSR egress treat
+    ;; an unregistered owner as `:serialize` (the algebra read), but a TRACE row
+    ;; whose owner we cannot read is not provably safe.
+    (nil? (registry/resource-meta (second scoped-key)))
+    [(ssr/project-scoped-key scoped-key :redact nil) true]
+
+    ;; REGISTERED owner — the shared pipeline computes the disposition + projects
+    ;; the key exactly as the SSR durable-egress + tool-egress paths do. `:redact`
+    ;; / `:omit` redacts the scope+params; `:serialize` rides verbatim — so the
+    ;; sensitivity flag is `(not= :serialize disposition)`.
     :else
-    (let [resource-id (second scoped-key)
-          spec        (registry/resource-meta resource-id)]
-      (if (nil? spec)
-        ;; fail closed — owner unreadable, redact scope + params, keep the id
-        [(ssr/project-scoped-key scoped-key :redact nil) true]
-        (let [disposition (classification/whole-entry-disposition-for spec frame-id)]
-          [(ssr/project-scoped-key scoped-key disposition spec)
-           (not= :serialize disposition)])))))
+    (let [[projected-key disposition _spec] (ssr/disposition+project-key scoped-key frame-id)]
+      [projected-key (not= :serialize disposition)])))
 
 (def ^:private scoped-key-slot
   "Tag slots on a resource / mutation trace row that carry a SINGLE scoped-key

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -82,8 +82,7 @@
   trace). The two continuations are kept distinct: the ledger owns the
   framework-internal reified continuation; the call-site target is the app's
   transport-payload continuation."
-  (:require [re-frame.identity :as identity]
-            [re-frame.late-bind :as late-bind]
+  (:require [re-frame.late-bind :as late-bind]
             [re-frame.reply :as reply]
             [re-frame.resources.state :as state]))
 
@@ -125,7 +124,7 @@
   [scoped-key generation]
   [:rf.work/resource scoped-key generation])
 
-(defn work-id-id
+(def work-id-id
   "The CEDN-1 BYTE-IDENTITY map-key for a `work-id`
   (`[:rf.work/resource <scoped-key> <generation>]`) — its `canonical-bytes`
   string (rf2-9e0tyq). The work-ledger runtime-db map is keyed on THIS string,
@@ -137,9 +136,14 @@
   map-key comparison exactly the CEDN-1 identity. The work-id VECTOR remains
   the kind-preserving `:work/id` carried in the record, the entry's
   `:current-work`, and on the wire. Total on a work-id over a canonical
-  scoped-key. Per Spec 016 §Frame work ledger."
-  [work-id]
-  (identity/canonical-bytes work-id))
+  scoped-key. Per Spec 016 §Frame work ledger.
+
+  This IS `state/key-id` (both are `canonical-bytes` of an
+  already-canonical EDN identity — rf2-366u0g): the work-id-as-map-key
+  byte-identity rule is the SAME rule the scoped-key-as-map-key follows, so
+  the ledger surface re-binds the one canonical wrapper under its own name
+  rather than re-typing the `canonical-bytes` call."
+  state/key-id)
 
 (defn managed-request-id
   "Build the frame-QUALIFIED managed-HTTP transport correlation token
@@ -177,10 +181,11 @@
   "The terminal work statuses an attempt may reach with an outcome
   summary. Terminal rows are pruned on the linked entry's next successful
   transition; a bounded per-resource-key tail is retained for Xray. Per
-  Spec 016 §Ledger row retention and identity. (Mirrors
-  `re-frame.resources.state/terminal-work-statuses`; re-exported here as
-  the ledger surface's own name so a ledger consumer reads one home.)"
-  #{:completed :failed :timed-out :suppressed :cancelled})
+  Spec 016 §Ledger row retention and identity. The canonical set lives in
+  `re-frame.resources.state/terminal-work-statuses` (rf2-366u0g — no longer
+  re-typed here); re-bound under the ledger surface's own name so a ledger
+  consumer reads one home."
+  state/terminal-work-statuses)
 
 (defn terminal?
   "True iff `status` is a terminal work-ledger status (the attempt has

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -42,6 +42,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
+   [re-frame.interop :as interop]
    [re-frame.late-bind :as late-bind]
    ;; load-bearing side-effecting require: the façade publishes the restore
    ;; reconcile hook + registers the resource registrar kind.
@@ -184,12 +185,12 @@
   ;; not re-read the live clock during install." The structural restore tests
   ;; prove the durable timestamps SURVIVE (they are passed through, not
   ;; recomputed); this one PROVES it adversarially — it stubs the ONLY live-clock
-  ;; read in the reconcile (`ssr/now-ms`) to a sentinel NOTHING durable should
-  ;; ever stamp, then asserts every restored entry's :loaded-at / :stale-at /
-  ;; :invalidated-at is the SNAPSHOT's value, untouched by the sentinel. A
-  ;; regression that freshened any durable timestamp from the live install clock
-  ;; would stamp the sentinel and fail loudly here.
-  (testing "the live install clock (now-ms) does NOT freshen any durable restored
+  ;; read in the reconcile (`interop/epoch-now-ms`) to a sentinel NOTHING durable
+  ;; should ever stamp, then asserts every restored entry's :loaded-at /
+  ;; :stale-at / :invalidated-at is the SNAPSHOT's value, untouched by the
+  ;; sentinel. A regression that freshened any durable timestamp from the live
+  ;; install clock would stamp the sentinel and fail loudly here.
+  (testing "the live install clock (interop/epoch-now-ms) does NOT freshen any durable restored
             entry timestamp — they ride through equal to the snapshot's"
     (let [sentinel    9999999999999  ; the install-clock value nothing durable may stamp
           ;; one of each freshness shape: a loaded entry with a future stale-at,
@@ -201,7 +202,7 @@
                               :loaded-at 1000 :stale-at 8000 :invalidated-at 1500})
           ka (state/scoped-resource-key :rf.scope/global :a {})
           kb (state/scoped-resource-key :rf.scope/global :b {})]
-      (with-redefs [ssr/now-ms (constantly sentinel)]
+      (with-redefs [interop/epoch-now-ms (constantly sentinel)]
         (let [out (ssr/reconcile-on-restore (runtime-db-with {ka loaded kb invalidated}) :app/main)
               es  (get-in out [state/resources-key :entries])
               ;; rf2-9e0tyq — entries are keyed on the byte key-id.
@@ -363,7 +364,7 @@
           pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
           rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}]
-      (with-redefs [ssr/now-ms (constantly live-sentinel)]
+      (with-redefs [interop/epoch-now-ms (constantly live-sentinel)]
         (let [out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms restore-time})
               inst (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1)])]
           (is (= :error (:status inst)) "the pending instance is terminally dangled")
@@ -377,7 +378,7 @@
           pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
           rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}]
-      (with-redefs [ssr/now-ms (constantly live-sentinel)]
+      (with-redefs [interop/epoch-now-ms (constantly live-sentinel)]
         (let [out (ssr/reconcile-on-restore rdb :app/main)]
           (is (= live-sentinel (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :settled-at]))
               "no causal time supplied → the unit path falls back to the live clock"))))))


### PR DESCRIPTION
## What

Implements **rf2-366u0g** — the 5 high-confidence in-artefact consolidations + 1 cross-artefact clock fix from the nka88r resources dedup review. The 3 uncertain items (stale-suppression reply quartet, host-side-table teardown trio, intra-file skeletons) are deliberately NOT touched.

### (1) Stale / timer helpers → `state.cljc`
`stale-at-for`, `positive-or-nil`, `server-frame?` were byte-identical between `events.cljc` and `mutation_events.cljc` (the mutation copies' docstrings even said "Mirrors events/"). Moved all three to `state.cljc` (already required by both); call sites now read `state/*`. A patched/populated entry ages exactly as a fetched one from one home.

### (2) Reply extractors → `reply.cljc`
`reply-failure-error` was an exact dup across both event namespaces; the success extractor differed ONLY by the inline durable-layer fallback key (`:data` for a resource entry vs `:result` for a mutation instance). Lifted into shared `reply/transport-failure-envelope` + fallback-key-parameterized `reply/transport-success-value`.

### (3) `terminal-statuses` → re-bind
`work_ledger/terminal-statuses` re-typed `state/terminal-work-statuses`'s `#{:completed :failed :timed-out :suppressed :cancelled}`. Now `(def terminal-statuses state/terminal-work-statuses)`.

### (4) `work-id-id` → re-bind
`work_ledger/work-id-id` was a one-line `canonical-bytes` wrapper identical to `state/key-id` (both `canonical-bytes` of an already-canonical EDN identity). Now `(def work-id-id state/key-id)`.

### (5) disposition+project-key pipeline → `ssr/disposition+project-key`
`tooling/project-key-for-egress`, `trace_egress/project-trace-scoped-key`, and `ssr/project-entry` each re-resolved spec → `whole-entry-disposition-for` → `project-scoped-key`. Factored into one shared `ssr/disposition+project-key` (lives in `ssr`, not `classification`, because the pipeline needs `registry/resource-meta` and `registry` already requires `classification` — hosting it in `classification` would be a require cycle). `trace_egress` keeps its **nil-spec fail-closed-to-`:redact` + idempotent-token guards as the OUTER wrapper** (tooling/SSR intentionally treat a nil spec as `:serialize`).

### (6) Cross-artefact: delete resources `now-ms` → `interop/epoch-now-ms`
The private `now-ms` in `ssr.cljc` + `subs.cljc` was byte-identical to core `interop/epoch-now-ms` (the EP-0010 §Time **wall clock** — `System/currentTimeMillis` / `js/Date.now`), **NOT** the perf clock `interop/now-ms` (`performance.now()`). These resources are durable freshness/skew readers, so the wall clock is correct. The restore-reconcile `with-redefs` test seam moves to the public `interop/epoch-now-ms` (still redefinable).

Also removed two now-unused requires (`identity` from `work_ledger`; `classification` from `tooling` + `trace_egress`).

## Gates (all green)

- `resources JVM clojure -M:test` — **504 tests / 2118 assertions, 0 failures** (post-rebase re-run green)
- `npm run test:cljs` — **7865 tests / 32596 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **15 scenarios, 0 failures, 0 build warnings**
- restore-reconcile suite (`re-frame.resources-restore-cljs-test`) — **35 tests / 119 assertions, 0 failures** (exercises the relocated test seam)