### PR TITLE
refactor(core): consolidate elision/marks helpers + trace cascade-bucketing + default-interceptor (rf2-ih437c)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -228,12 +228,19 @@
   (reset! warned-unschema'd #{})
   nil)
 
-(defn- pr-str-bytes
+(defn ^:no-doc pr-str-bytes
+  "Return a byte-count for a value's printed representation. Used by the
+  `:rf.size/large-elided` marker payload. `^:no-doc` public so
+  `re-frame.marks` reuses it rather than re-inlining the same `pr-str`
+  byte-count a second time (rf2-ih437c)."
   [v]
   #?(:clj  (count (.getBytes ^String (pr-str v) "UTF-8"))
      :cljs (count (pr-str v))))
 
-(defn- value-type
+(defn ^:no-doc value-type
+  "Coarse value-type tag for the `:rf.size/large-elided` marker payload.
+  `^:no-doc` public so `re-frame.marks` reuses it rather than re-inlining
+  the same closed `cond` a second time (rf2-ih437c)."
   [v]
   (cond
     (map? v)    :map
@@ -259,7 +266,11 @@
     [:rf.elision/at path :as-of-epoch as-of-epoch]
     [:rf.elision/at path]))
 
-(defn- ->marker
+(defn ^:no-doc ->marker
+  "Build the `:rf.size/large-elided` marker map for value `v` at `path`.
+  `^:no-doc` public so `re-frame.marks/large-marker` builds the marker
+  here (with `{:reason :marks}`) rather than re-inlining the shape a
+  second time (rf2-ih437c)."
   [v path {:keys [hint as-of-epoch include-digests? reason]}]
   (let [body (cond-> {:path   (vec path)
                       :bytes  (pr-str-bytes v)

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -229,21 +229,32 @@
                       ctx-delta-segments)]
     (when (seq slots) slots)))
 
-(defn- framework-default-interceptor?
-  "True iff `interceptor` is a framework-installed scaffolding interceptor
-  whose ctx-delta should NOT be captured for the Xray AFTER INTERCEPTORS
-  surface — they are not user-meaningful interceptors. Mirrors the
-  filter the Xray panel applies on the registration-time list (`:rf/
-  default? true`, the substrate-side marker).
+(defn ^:no-doc framework-default-interceptor?
+  "True iff `x` is a framework-installed scaffolding interceptor VALUE —
+  the framework's own appended handler-wrapper, stamped `:rf/default?
+  true` (see `re-frame.events/register-event!`). Two callers share this
+  one predicate (rf2-ih437c):
+
+    - `invoke-after` (this ns) skips its ctx-delta capture for these —
+      they are framework machinery, not user-meaningful interceptors on
+      the Xray AFTER INTERCEPTORS surface.
+    - `re-frame.interceptor-registry/resolve-chain` lets this ONE inline
+      value pass through a chain untouched (the reference-only flip,
+      rf2-0adhqs.9, rejects every other inline value). `interceptor-
+      registry` already `:require`s this ns, so it calls here rather than
+      keeping a second copy.
 
   EP-0017 removed `inject-cofx`; no interceptor carries `:rf/cofx-id`
   anymore (coeffect delivery moved to context assembly), so the old
   `:rf/cofx-id` skip-clause was permanently dead and has been removed
-  (rf2-oky3gt) — the predicate is now the `:rf/default?` check alone.
+  (rf2-oky3gt) — the predicate is the `:rf/default?` check alone.
 
-  Pure predicate; no allocation when the interceptor carries no flag."
-  [interceptor]
-  (true? (:rf/default? interceptor)))
+  The `(map? x)` guard makes the predicate total over a chain entry of
+  ANY shape (the registry calls it on raw chain entries that may be
+  references, not only resolved maps); pure, no allocation when `x`
+  carries no flag."
+  [x]
+  (and (map? x) (true? (:rf/default? x))))
 
 (defn- invoke-after [context interceptor]
   (if-let [f (:after interceptor)]

--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -188,15 +188,15 @@
            (contains? x :after)
            (contains? x :id))))
 
-(defn framework-default-interceptor?
-  "True when `x` is the framework's own appended handler-wrapping interceptor
-  value (stamped `:rf/default? true` — see `re-frame.events`). This is the ONE
-  inline interceptor value `resolve-chain` lets pass through a chain untouched:
-  it is framework machinery (the terminal `:before` that invokes the user
-  handler), not an application-authored chain entry, so the reference-only flip
-  (rf2-0adhqs.9) does not reject it."
-  [x]
-  (and (map? x) (true? (:rf/default? x))))
+;; `framework-default-interceptor?` (the `(map? x)`-guarded `:rf/default?`
+;; predicate) is the ONE inline interceptor value `resolve-chain` lets pass
+;; through a chain untouched: it is framework machinery (the terminal
+;; `:before` that invokes the user handler), not an application-authored
+;; chain entry, so the reference-only flip (rf2-0adhqs.9) does not reject
+;; it. The predicate lives in `re-frame.interceptor` (already required here)
+;; and is shared with that ns's `invoke-after` ctx-delta-capture gate —
+;; one copy, not two (rf2-ih437c). Call it as
+;; `interceptor/framework-default-interceptor?`.
 
 (defn interceptor-ref?
   "True when `x` is an interceptor REFERENCE (Spec 002 §Interceptor
@@ -437,7 +437,7 @@
   framework default) is `:rf.error/invalid-interceptor-ref`.
 
   The ONE inline value that passes through untouched is the framework's own
-  appended handler-wrapper (`:rf/default? true` — `framework-default-interceptor?`):
+  appended handler-wrapper (`:rf/default? true` — `interceptor/framework-default-interceptor?`):
   it is framework machinery, not an application-authored chain entry.
 
   `chain` is a sequential of refs (+ the framework default tail); returns a
@@ -464,7 +464,7 @@
               ;; The framework's own appended handler-wrapper (`:rf/default?
               ;; true`) — framework machinery, not an authored chain entry;
               ;; passes through untouched (the reference-only carve-out).
-              (framework-default-interceptor? entry) entry
+              (interceptor/framework-default-interceptor? entry) entry
               ;; A stale INLINE interceptor value — reference-only flip rejects
               ;; it LOUD (EP-0022, rf2-0adhqs.9): register it + reference by id.
               (interceptor-value? entry) (throw-inline-interceptor-removed! entry)
@@ -483,7 +483,7 @@
   resolve the ref, or to reject the inline value loudly)."
   [chain]
   (boolean (some (fn [entry]
-                   (and (not (framework-default-interceptor? entry))
+                   (and (not (interceptor/framework-default-interceptor? entry))
                         (or (interceptor-ref? entry)
                             (interceptor-value? entry))))
                  chain)))

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -788,28 +788,14 @@
 ;;      under `:value`/`:input-signals`, ...) — the projection is per-
 ;;      tag-shape.
 
-(defn- ->bytes
-  "Return a byte-count for a value's printed representation. Used by
-  the `:rf.size/large-elided` marker payload."
-  [v]
-  #?(:clj  (count (.getBytes ^String (pr-str v) "UTF-8"))
-     :cljs (count (pr-str v))))
-
-(defn- value-type
-  [v]
-  (cond
-    (map? v)    :map
-    (vector? v) :vector
-    (set? v)    :set
-    (string? v) :string
-    :else       :scalar))
-
 (defn large-marker
   "Build the `:rf.size/large-elided` marker for value `v` at `path`.
-  Mirror of `re-frame.elision/->marker`'s shape — inlined so this ns
-  carries no dependency on elision's privates. Carries `:reason
-  :marks` so consumers can discriminate per-registration marks
-  from schema-driven marks.
+  Delegates to `re-frame.elision/->marker` with `{:reason :marks}` so
+  the marker shape is built in ONE place — this ns already requires
+  `re-frame.elision`, so there is no extra dependency (the stale
+  \"carries no dependency on elision's privates\" rationale is gone,
+  rf2-ih437c). The `:reason :marks` tag lets consumers discriminate
+  per-registration marks from schema-driven marks.
 
   Public because the off-box epoch egress projector
   (`re-frame.epoch.tool-pair/projected-record`, rf2-at60h) reuses it to
@@ -818,13 +804,7 @@
   `:reason :marks` provenance the whole-output propagation table sets,
   built in ONE place rather than re-inlined a third time."
   [v path]
-  (let [p (vec path)]
-    {:rf.size/large-elided
-     {:path   p
-      :bytes  (->bytes v)
-      :type   (value-type v)
-      :reason :marks
-      :handle [:rf.elision/at p]}}))
+  (elision/->marker v path {:reason :marks}))
 
 (defn- walk-with-marks
   "Walk `v` and substitute sentinels at the declared paths. Paths in

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -106,9 +106,16 @@
 
 ;; ---- cascade record -------------------------------------------------------
 
-(def ^:private empty-cascade
+(def ^:no-doc empty-cascade
   "Slot template for a cascade record. Per-cascade reduction starts here;
   every key the consumer can rely on lives in the template.
+
+  `^:no-doc` public so `re-frame.trace.tooling/cascade-bundle` folds the
+  per-frame ring's events with `absorb` over this same template rather
+  than re-inlining the slot set + the bucketing cond a second time
+  (rf2-ih437c). Both nss are dev-side and bundle-isolated from production
+  CLJS; this ns carries no requires, so the new tooling→projection edge
+  introduces no cycle and no production-bundle leak.
 
   `:event` is the dispatched event VECTOR (the convenient
   slim form most consumers need). `:dispatched` is the full
@@ -190,13 +197,20 @@
       [nil :ungrouped]
       [(cascade-frame frame-index ev) id])))
 
-(defn- absorb
+(defn ^:no-doc absorb
   "Fold one trace event into the per-cascade accumulator.
 
   The `:event` bucket lands the event VECTOR on `:event` (slim,
   consumers' common case) AND the full trace event on `:dispatched`
   (preserves top-level hoisted slots like `:rf.trace/call-site` per
-  rf2-twt7m Change 1)."
+  rf2-twt7m Change 1).
+
+  `^:no-doc` public so `re-frame.trace.tooling/cascade-bundle` reuses
+  this same fold (over `empty-cascade`) rather than re-inlining the
+  six-domino classification cond a third time (rf2-ih437c). Any extra
+  keys the caller seeds the accumulator with (e.g. tooling's
+  `:trace-events`) are preserved untouched — `absorb` only writes the
+  domino slots."
   [acc ev]
   (case (domino-bucket ev)
     :event   (assoc acc :event              (get-in ev [:tags :rf.event/v])

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -61,7 +61,15 @@
 
   Per Spec 009 §Per-frame trace rings."
   (:require [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.late-bind :as late-bind]
+            ;; rf2-ih437c: `cascade-bundle` reuses the six-domino fold
+            ;; (`absorb` over `empty-cascade`) from the projection ns
+            ;; rather than re-inlining the classification cond. Both nss
+            ;; are dev-side and bundle-isolated from production CLJS (the
+            ;; `trace-tooling` bundle-isolation entry pins tooling's
+            ;; absence from the counter bundle); projection carries no
+            ;; requires of its own, so this edge introduces no cycle.
+            [re-frame.trace.projection :as projection]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -381,64 +389,24 @@
 ;; Per Spec 009 §`trace-buffer` API — per-frame, cascade bundles by
 ;; default. `:flat true` opt returns raw trace events.
 
-(defn- effects-bucket?
-  [{:keys [op-type operation]}]
-  (and (= op-type :rf.fx) (not= operation :rf.fx/do-fx)))
-
-(defn- subs-bucket?
-  [{:keys [op-type]}]
-  (= op-type :rf.sub))
-
-(defn- renders-bucket?
-  [{:keys [op-type operation]}]
-  (and (= op-type :rf.view) (= operation :rf.view/render)))
-
-(defn- handler-marker?
-  [{:keys [op-type operation]}]
-  (and (= op-type :rf.event)
-       (or (= operation :rf.event/run-start)
-           (= operation :rf.event/run-end))))
-
-(defn- dispatched-marker?
-  [{:keys [op-type operation]}]
-  (and (= op-type :rf.event) (= operation :rf.event/dispatched)))
-
-(defn- fx-marker?
-  [{:keys [operation]}]
-  (= operation :rf.fx/do-fx))
-
 (defn- cascade-bundle
   "Project the events for one cascade into a Spec 009 cascade-bundle
-  (the `group-cascades` shape, per-cascade)."
-  [frame-id dispatch-id events]
-  (let [base {:dispatch-id  dispatch-id
-              :frame        frame-id
-              :trace-events events
-              :event        nil
-              :dispatched   nil
-              :handler      nil
-              :fx           nil
-              :effects      []
-              :subs         []
-              :renders      []
-              :other        []
-              :parent-dispatch-id nil}]
-    (reduce (fn [acc ev]
-              (cond
-                (dispatched-marker? ev)
-                (assoc acc
-                       :event              (get-in ev [:tags :rf.event/v])
-                       :dispatched         ev
-                       :parent-dispatch-id (get-in ev [:tags :rf.trace/parent-dispatch-id]))
+  (the `group-cascades` shape, per-cascade).
 
-                (handler-marker? ev) (assoc acc :handler ev)
-                (fx-marker? ev)      (assoc acc :fx ev)
-                (effects-bucket? ev) (update acc :effects conj ev)
-                (subs-bucket? ev)    (update acc :subs conj ev)
-                (renders-bucket? ev) (update acc :renders conj ev)
-                :else                (update acc :other conj ev)))
-            base
-            events)))
+  rf2-ih437c: folds with `re-frame.trace.projection/absorb` over
+  `projection/empty-cascade` — the canonical six-domino classification
+  + slot set — rather than re-inlining the bucketing cond + the six
+  `*-bucket?`/`*-marker?` predicates a second time. The seed map carries
+  the extra `:trace-events` slot the cascade-bundle wire shape needs;
+  `absorb` only writes the domino slots, so `:trace-events` (and the
+  pre-seeded `:dispatch-id` / `:frame`) survive the fold untouched."
+  [frame-id dispatch-id events]
+  (reduce projection/absorb
+          (assoc projection/empty-cascade
+                 :dispatch-id  dispatch-id
+                 :frame        frame-id
+                 :trace-events events)
+          events))
 
 (defn- match-cascade?
   "Filter a cascade bundle against the cascade-level filter keys."


### PR DESCRIPTION
DELICATE kernel dedup (rf2-ih437c) — high-confidence consolidations only. The 4 uncertain items noted on 8mwuo1 are deliberately untouched. Each removed copy delegates to a canonical owner; the require was verified present before each (or, for trace tooling, a new dev-side edge into a require-free ns — no cycle).

## Consolidations

### 1. `marks/value-type` + `marks/->bytes` → `elision/value-type` + `elision/pr-str-bytes`
Promoted both elision helpers to `^:no-doc` public; deleted the marks copies.

### 2. `marks/large-marker` → `elision/->marker v path {:reason :marks}`
`elision/->marker` promoted `^:no-doc` public. **Marker-shape diff:** the ONLY delta is an added `:hint nil` key (`elision/->marker` always writes `:hint`; the old marks copy omitted it). Verified tolerated:
- marks/epoch/security tests use `get-in` / a `marker?` predicate, never exact-`=` on the body.
- The wire-vocab `ElisionMarkerBody` schema is open (not `{:closed true}`) and `:hint` is `[:maybe :string]`, so `nil` validates. (The marks path already emits `:reason :marks`, which is outside that schema's `[:enum :schema]` — it was never validated against it, so no regression.)
- `marks` already `:require`s `re-frame.elision` (the stale "carries no dependency on elision's privates" docstring is corrected).

### 3. `trace.tooling/cascade-bundle` → `projection/absorb` over `projection/empty-cascade`
Both promoted `^:no-doc` public. `cascade-bundle`'s inlined six-domino reduce-cond was a verbatim copy of `absorb`; the 6 `*-bucket?`/`*-marker?` predicates (`effects-bucket?`, `subs-bucket?`, `renders-bucket?`, `handler-marker?`, `dispatched-marker?`, `fx-marker?`) only fed that cond and are deleted. The seed map keeps the extra `:trace-events` slot; `absorb` only writes the domino slots so it survives untouched.
- **Bundle isolation preserved:** `tooling → projection` is a new dev-side edge. `projection.cljc` carries **zero requires** (no cycle), and both nss are bundle-isolated from production CLJS. The gate confirms `trace-tooling` + `trace-cascade` sentinels stay absent from the counter bundle.

### 4. `framework-default-interceptor?` defined twice → one copy in `interceptor.cljc`
Kept the `(map? x)`-guarded version in `interceptor.cljc` (promoted `^:no-doc` public, so `invoke-after` and the registry share it). Deleted the `interceptor-registry.cljc` copy; its two call sites (`resolve-chain`, `chain-needs-resolution?`) now call `interceptor/framework-default-interceptor?`. `interceptor-registry` already `:require`s `interceptor`. The `(map? x)` guard is a strict superset for `invoke-after` (its arg is always a resolved map), so behaviour is unchanged.

## Grep-proof: required copy was already present (no new cycle)
```
marks.cljc:40       (:require [re-frame.elision :as elision]      # consolidations 1+2
interceptor_registry.cljc:65  [re-frame.interceptor :as interceptor]   # consolidation 4
projection.cljc     (no :require line)                            # zero requires -> tooling->projection edge has no cycle
tooling.cljc:72     [re-frame.trace.projection :as projection]    # the new dev-side edge (consolidation 3)
```

## Deferred (premise failed the brief's "verify before each" gate)
The bead's **third part of item 4** — `cascade.cljc:105-216` `aggregate-cascade` → `domino-bucket` — is **NOT done**. `domino-bucket` collapses `:rf.sub/run` and `:rf.sub/skip` both into `:sub`, and maps both flow ops to `:other`. `aggregate-cascade` must split `:subs-recomputed`/`:subs-skipped` and `:flows-computed`/`:flows-skipped` (pinned by `trace_cascade_captured_test/aggregate-cascade-shape-pin`). Using `domino-bucket` would silently break the Reactive panel's run/skip + flow distinction. The required `cascade → projection` require was also absent. Surfaced as a finding rather than executed.

## Quality gates — all green
```
core JVM   clojure -M:test : Ran 1804 tests / 7852 assertions — 0 failures, 0 errors
epoch JVM  clojure -M:test : Ran  358 tests / 1419 assertions — 0 failures, 0 errors
npm run test:cljs          : Ran 7865 tests / 32596 assertions — 0 failures, 0 errors
npm run test:elision       : PASS — production 41/41 absent; control 41/41 present
npm run test:bundle-isolation : PASS — 22 artefacts; 40 internal sentinels absent (incl trace-cascade + trace-tooling)
npm run test:xray-feature-gate : 15 scenarios, 0 failures, 13 matrix rows — exit 0
```