### PR TITLE
fix(machines): correlate guard-suppressed :after timer work-id (rf2-ze13fg LOW); MEDIUM history fix STOPPED for ruling

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -927,6 +927,15 @@
               {:guard-suppressed? true
                :actor-id          actor-id
                :state             (last prefix)
+               ;; rf2-ze13fg — carry the declaring path so `after-fired-reply`
+               ;; (via `timer-work-id`) yields the canonical
+               ;; `[:rf.work/timer [<actor> <decl-path>] epoch]` work-id. The
+               ;; live (`resolve-hit`) and stale branches both set `:decl-path`;
+               ;; without it here the guard-suppressed `:rf.machine.timer/fired`
+               ;; `:fired? false` reply degrades to `[:rf.work/timer <actor>
+               ;; epoch]` and fails to correlate with the scheduled/cancelled/
+               ;; stale rows for the SAME timer (spec/005:3568/3585).
+               :decl-path         prefix
                :delay             delay-key
                :epoch             carried-epoch})))]
     (cond
@@ -2120,6 +2129,14 @@
               {:guard-suppressed? true
                :actor-id          actor-id
                :state             :rf/parallel-root
+               ;; rf2-ze13fg — the parallel-ROOT timer's declaring path is the
+               ;; empty path `[]` (the root `:after` lives on the machine map,
+               ;; decl-path `[]`). Carry it so `after-fired-reply` builds the
+               ;; canonical work-id `[:rf.work/timer [<actor>] epoch]` and the
+               ;; guard-suppressed root reply correlates with its scheduled/
+               ;; cancelled/stale counterparts (the stale branch below already
+               ;; sets `:decl-path []`). Per spec/005:3568/3585.
+               :decl-path         []
                :delay             delay-key
                :epoch             carried-epoch}))
 


### PR DESCRIPTION
## rf2-ze13fg — machines correctness

The bead carried two items. The **LOW** item is fixed; the **MEDIUM** item is **STOPPED for a ruling** per the bead's CRITICAL re-verify-or-STOP gate (the proposed change is mis-scoped and breaks the history feature). Details below.

---

### LOW — guard-suppressed `:after` timer work-id (FIXED)

`transition.cljc:927` (`pick-after-transition`, per-node) and `:2120` (`root-after-match`, parallel-root) build the guard-suppressed (`:fired? false`) result map but omitted `:decl-path`. The live (`resolve-hit`, sets `:decl-path prefix`) and stale (sets `:decl-path decl-path` / `[]`) branches both set it.

Downstream, `after-fired-reply` reads `(:decl-path match)` → `timer-work-id actor-id decl-path epoch`. With `decl-path` nil and an `actor-id` present, `timer-work-id`'s `logical-id` falls to the `:else actor-id` arm, producing `[:rf.work/timer <actor> epoch]` instead of the canonical `[:rf.work/timer [<actor> <decl-path>] epoch]` — so a guard-suppressed timer's `:rf.machine.timer/fired` reply fails to correlate (by `:work/id`) with the scheduled / cancelled / stale rows for the SAME timer. Per spec/005:3568/3585 (Managed-Effects §Work-id correlation).

Fix: add `:decl-path prefix` to the per-node guard-suppressed map and `:decl-path []` to the parallel-root one (the root `:after` declares at the empty path). Additive — no existing assertion changes.

---

### MEDIUM — history over-record on the surviving LCCA: STOPPED, ruling needed

The bead asked to change `record-exit-history`'s gate (transition.cljc:1633) from `(<= lca-len depth)` to `(< lca-len depth)`, and to "re-derive the now-wrong expectations in call (2)" of `history-deep-restores-leaf-path.edn` (plus the two history tests), asserting the `:away` / lca-len-0 case is preserved.

**Re-verification of the LCCA-not-exited rule CONFIRMS it** (the code-level direction is right):
- spec/005:1379 — "Stop at the LCCA exclusive (the LCCA itself does not exit; we are not leaving it)."
- spec/005:3124 — "Every time the exit cascade **leaves a compound state** that owns a history pseudo-state, the runtime records that compound's last-active configuration."
- spec/005:3149 — the recording write is for the *source* compound "if it owns history and **is being exited**."
- SCXML W3C: history is recorded "before taking any transition **that exits the parent**." SCION/SCXML Appendix-D algorithm records history only `for state in statesExited` (the exit set). XState v5 docs: history is restored "when **exiting and reentering a parent state**" — a transition "from **outside** the parent."

So a compound that is the LCCA (survives) should **not** record. The direction `<`-not-`<=` aligns to XState v5/SCXML.

**BUT the bead's scope/claim is wrong, and applying the change as described breaks the feature.** The media-player charts used by the deep + shallow conformance fixtures, `machine_history_smoke_test.clj`, and `machine_history_unit_cljs_test.cljc` all record `:player`'s history on a transition **within** `:player` (`:stop`: `[:player :playing :mid-track]` → `[:player :stopped]`, or `:play` to `[:player :hist]`). These never exit `:player` — `:player` is the LCCA, `lca-len = 1`, and `:player` sits at `depth 1`, so `(< 1 1)` is **false** → records nothing → restores fall back to `:default` instead of `:recorded`.

This is **not** "re-derive call 2": it is wrong for call (1) too, and the empirical result of applying the `<`-only change is **40 failing assertions** across the history smoke + unit suites (recorded-config goes nil; restores degrade `:recorded`→`:default`; cascade `:source` flips; parallel per-region recordings vanish). The `:away`/lca-len-0 case (`deep-nesting-records-each-compound-independently`) is preserved (genuine exit, lca-len 0) — but it's the only one, contradicting the bead's "preserves every legitimate exit recording."

**The real question is a design ruling, not a mechanical gate flip:** does deep/shallow history record when the compound's *active child subtree* is torn down even though the compound itself survives as LCCA (current `<=`, **explicitly documented** at transition.cljc:1605-1613) — or **only** when the compound itself is exited to an outside sibling (strict SCXML/XState v5)? The latter requires re-modelling the history fixtures/charts so the history-owning compound is actually left (e.g. add a top-level sibling the player exits to), which is a much larger change than the bead authorizes and overturns the documented design. Per the bead's CRITICAL instruction — "if your re-verification does NOT confirm the LCA-not-exited rule (i.e. the old fixture value was right), STOP and report" — the inverse also holds here: my re-verification confirms the *rule* but reveals the *blast radius* contradicts the bead, so I'm not unilaterally overturning normative fixtures. **No fixture/test was changed.**

The two deferred suspected items (spawn-all reserved keys; parallel root-target cross-region ctx) were left untouched.

---

### Quality gates (LOW-only diff — all green)

```
cd implementation && npm run test:cljs
  → Ran 7865 tests containing 32590 assertions. 0 failures, 0 errors.
    (includes scxml_conformance_cljs_test + machines_conformance_test (.edn fixtures)
     + machine_history_unit_cljs_test)

cd implementation/machines && clojure -M:test   (machines JVM; includes machines_conformance_test + scxml_conformance)
  → Ran 774 tests containing 2548 assertions. 0 failures, 0 errors.
```

(For the record: with the `<=`→`<` MEDIUM change applied, machines JVM = 40 failures, 0 errors — the empirical basis for the STOP.)
