### PR TITLE
fix(routing): demote bare catch-all below concrete routes so / wins over /* (rf2-1ugs5u)

### DIFF
--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -288,7 +288,7 @@
            counts      {:static 0 :named 0 :splat 0 :optional 0 :total 0}]
       (if-not (< i n)
         (let [{:keys [static total splat optional named]} counts
-              ;; Spec 012 §Route ranking algorithm rule 4: the catch-all
+              ;; Spec 012 §Route ranking algorithm rule 2: the catch-all
               ;; is EXACTLY the bare `/*` pattern — a single unnamed splat
               ;; with no other segments. A NAMED splat (`/*rest`) is a rest
               ;; param and out-ranks the catch-all, so it MUST NOT be
@@ -307,10 +307,22 @@
            ;; `:close-end` to skip past it when eliding.
            :groups  inner
            :pattern pattern
+           ;; Spec 012 §Route ranking algorithm. The catch-all
+           ;; discriminator (rule 2) is lifted AHEAD of total-length
+           ;; (rule 3): the bare `/*` also matches the root URL `/` (the
+           ;; splat captures the literal "/"), and a home route
+           ;; `{:path "/"}` parses to total-length 0 while `/*` is
+           ;; length 1 — so if total-length compared first, `/*` would
+           ;; out-length the root and shadow it (rf2-1ugs5u). Putting the
+           ;; catch-all bit before length demotes `/*` below `/` (and
+           ;; every other concrete route). For any two NON-catch-all
+           ;; patterns the catch-all bit ties (both 1), so the comparison
+           ;; falls through to total-length exactly as before — only
+           ;; rankings involving the bare `/*` change.
            :rank    [static
+                     (if catch-all? 0 1)
                      total
                      (- splat)
-                     (if catch-all? 0 1)
                      (- optional)]})
         (let [ch (.charAt ^String pattern i)]
           (cond

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -1927,37 +1927,41 @@
 
 ;; ---- rf2-yjali: named splat out-ranks the bare catch-all ----------------
 ;;
-;; Spec 012 §Route ranking algorithm rule 4: "Rest params beat
-;; catch-all/not-found." The catch-all is EXACTLY the bare `/*` pattern
-;; (`is-catch-all? (= pattern "/*")` in the spec pseudocode). A NAMED
-;; splat (`/*rest`) is a rest param, so it must out-rank `/*`. Before the
-;; fix `parse-pattern`'s classifier flagged ANY single-splat-only pattern
-;; as catch-all, so `/*rest` tied with `/*` at rank element 4 instead of
-;; beating it.
+;; Spec 012 §Route ranking algorithm rule 2: "The bare catch-all `/*` is
+;; demoted below every other matching route." The catch-all is EXACTLY
+;; the bare `/*` pattern (`is-catch-all? (= pattern "/*")` in the spec
+;; pseudocode). A NAMED splat (`/*rest`) is a rest param, so it must
+;; out-rank `/*`. Before the rf2-yjali fix `parse-pattern`'s classifier
+;; flagged ANY single-splat-only pattern as catch-all, so `/*rest` tied
+;; with `/*` at the catch-all rank element instead of beating it.
+;; (rf2-1ugs5u lifted that catch-all element from index 3 to index 1 —
+;; ahead of total-length — so the bare `/*` loses to the root `/` too.)
 
 (deftest parse-pattern-named-splat-outranks-bare-catch-all
   (testing "rf2-yjali — only the bare `/*` is catch-all; a named splat
-            `/*rest` ranks above it at rank element 4 (Spec 012 rule 4)"
+            `/*rest` ranks above it at the catch-all rank element
+            (Spec 012 rule 2)"
     (let [catch-all (:rank (routing.match/parse-pattern "/*"))
           rest-splat (:rank (routing.match/parse-pattern "/*rest"))]
-      ;; Rank element 3 (0-indexed) is the rule-4 catch-all discriminator:
+      ;; Rank element 1 (0-indexed) is the catch-all discriminator
+      ;; (Spec 012 rule 2, lifted ahead of total-length by rf2-1ugs5u):
       ;; 0 = catch-all (less specific), 1 = not catch-all (more specific).
-      (is (= 0 (nth catch-all 3))
-          "bare `/*` is classified as the catch-all (rank elem 4 = 0)")
-      (is (= 1 (nth rest-splat 3))
-          "named `/*rest` is NOT the catch-all (rank elem 4 = 1)")
+      (is (= 0 (nth catch-all 1))
+          "bare `/*` is classified as the catch-all (rank elem 1 = 0)")
+      (is (= 1 (nth rest-splat 1))
+          "named `/*rest` is NOT the catch-all (rank elem 1 = 1)")
       ;; The two patterns are identical on every other rank element
       ;; (statics, length, splat, optional) — the catch-all discriminator
       ;; is the ONLY difference, and it must make `/*rest` win.
-      (is (= (assoc catch-all 3 :x) (assoc rest-splat 3 :x))
-          "the two ranks differ ONLY at the rule-4 catch-all element")
+      (is (= (assoc catch-all 1 :x) (assoc rest-splat 1 :x))
+          "the two ranks differ ONLY at the catch-all element")
       (is (pos? (compare rest-splat catch-all))
-          "lexicographic compare: `/*rest` out-ranks `/*` (rule 4)"))))
+          "lexicographic compare: `/*rest` out-ranks `/*` (rule 2)"))))
 
 (deftest match-url-named-splat-wins-over-bare-catch-all
   (testing "rf2-yjali — when both `/*rest` and `/*` are registered, a
             multi-segment URL resolves to the named-splat route, not the
-            catch-all (Spec 012 §Route ranking rule 4)"
+            catch-all (Spec 012 §Route ranking rule 2)"
     (rf/reg-route :route/catch-all {:path "/*"})
     (rf/reg-route :route/rest      {:path "/*rest"})
     (let [m (routing/match-url "/some/deep/path")]
@@ -1965,6 +1969,69 @@
           "named-splat route wins the rule-4 tiebreak against bare catch-all")
       (is (= {:rest "some/deep/path"} (:params m))
           "the named splat captures the whole tail under :rest"))))
+
+;; ---- rf2-1ugs5u: root `/` wins over the bare catch-all `/*` for URL "/" --
+;;
+;; Spec 012 §Route ranking algorithm rule 2: the bare catch-all `/*` is
+;; demoted below every other matching route. The bug: `/*` ALSO matches
+;; the root URL "/" (the unnamed splat captures the literal "/"), and a
+;; home route `{:path "/"}` parses to total-length 0 while `/*` is
+;; length 1. With total-length (rule 3) compared BEFORE the catch-all
+;; demotion, `/*` out-lengthed the root and won for "/" — shadowing the
+;; home route registration-order-independently. The fix lifts the
+;; catch-all discriminator (rank elem 1) ahead of total-length (rank
+;; elem 2) so the root (and every concrete route) wins over `/*`.
+
+(deftest parse-pattern-root-outranks-bare-catch-all-rf2-1ugs5u
+  (testing "rf2-1ugs5u — the root `/` out-ranks the bare catch-all `/*`
+            even though `/*` is the longer pattern; the catch-all
+            discriminator (rank elem 1) is consulted before total-length
+            (rank elem 2)"
+    (let [root      (:rank (routing.match/parse-pattern "/"))
+          catch-all (:rank (routing.match/parse-pattern "/*"))]
+      ;; rank elem 1 (0-indexed) is the catch-all discriminator:
+      ;; root = 1 (not catch-all), `/*` = 0 (is catch-all).
+      (is (= 1 (nth root 1))
+          "root `/` is NOT the catch-all (rank elem 1 = 1)")
+      (is (= 0 (nth catch-all 1))
+          "bare `/*` IS the catch-all (rank elem 1 = 0)")
+      ;; `/*` is the LONGER pattern (total-length 1 vs the root's 0) yet
+      ;; STILL loses — proving the catch-all demotion precedes length.
+      (is (= 0 (nth root 2))
+          "root `/` has total-length 0 (parse loop never runs for `/`)")
+      (is (= 1 (nth catch-all 2))
+          "bare `/*` has total-length 1 (the lone splat segment)")
+      (is (pos? (compare root catch-all))
+          "lexicographic compare: root `/` out-ranks the catch-all `/*`
+           DESPITE being shorter — the catch-all demotion wins first"))))
+
+(deftest match-url-root-wins-over-catch-all-rf2-1ugs5u
+  (testing "rf2-1ugs5u — match-url \"/\" returns the ROOT route, not the
+            catch-all, when both `/` and `/*` are registered
+            (registration-order-independent)"
+    ;; catch-all registered FIRST so the bug (if present) can't hide
+    ;; behind registration order — the rank cascade, not order, must win.
+    (rf/reg-route :route/catch-all {:path "/*"})
+    (rf/reg-route :route/home      {:path "/"})
+    (let [m (routing/match-url "/")]
+      (is (= :route/home (:route-id m))
+          "the root route wins match-url \"/\" over the catch-all")
+      (is (= {} (:params m))
+          "the root match carries an empty params map (no splat capture)")))
+
+  (testing "rf2-1ugs5u — the result is order-independent: home registered
+            first ALSO resolves \"/\" to the home route"
+    (rf/reg-route :route/home      {:path "/"})
+    (rf/reg-route :route/catch-all {:path "/*"})
+    (is (= :route/home (:route-id (routing/match-url "/")))
+        "home wins regardless of registration order"))
+
+  (testing "rf2-1ugs5u — the catch-all still wins a NON-root URL that the
+            home route cannot match (the demotion only loses the root)"
+    (rf/reg-route :route/home      {:path "/"})
+    (rf/reg-route :route/catch-all {:path "/*"})
+    (is (= :route/catch-all (:route-id (routing/match-url "/anything/deep")))
+        "catch-all still catches URLs no concrete route matches")))
 
 (deftest match-against-root-pattern-matches-root-path
   (testing "rf2-aleg9 — the special `/` pattern matches the root URL

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -171,9 +171,9 @@ When more than one registered route can match the same URL, `match-url` MUST res
 Ranking rules, evaluated in order. The first rule that distinguishes the candidates wins; later rules are only consulted on ties.
 
 1. **More static segments beat fewer.** Count the literal (non-param, non-splat) segments in each candidate's `:path`. Higher count wins. `/users/me` (2 statics) beats `/users/:id` (1 static) for `/users/me`.
-2. **Among equally-static-counted matches, longer paths beat shorter.** Total segment count breaks the tie on equal static-count. `/users/:id/edit` beats `/users/:id` for `/users/abc/edit`.
-3. **Named params beat rest params.** A `:name` segment is more specific than a `*name` splat. `/files/:name` beats `/files/*rest` for `/files/x`.
-4. **Rest params beat catch-all/not-found.** A `*rest` segment is more specific than a top-level catch-all `/*` (or a registered `:rf.route/not-found`). `/files/*rest` beats `/*` for `/files/x/y`.
+2. **The bare catch-all `/*` is demoted below every other matching route.** The bare top-level catch-all (`/*`, an unnamed splat with no other segments) is the universal least-specific fallback — above only `:rf.route/not-found`. Any other route that matches the same URL wins. This demotion is consulted **before** total-length (rule 3), because the catch-all also matches the root URL `/` (the splat captures the literal `/`), and a registered home route `{:path "/"}` has segment-length 0 while `/*` has length 1 — without the early demotion the catch-all would out-length the root and shadow it. The discriminator is therefore lifted ahead of total-length so `/` (and every other concrete route) wins over `/*`. `/` beats `/*` for `/`; `/files/*rest` (a *named* rest param, not the bare catch-all) beats `/*` for `/files/x/y`. A registered `:rf.route/not-found` is the only route below the bare catch-all.
+3. **Among equally-static-counted, non-catch-all matches, longer paths beat shorter.** Total segment count breaks the tie on equal static-count. `/users/:id/edit` beats `/users/:id` for `/users/abc/edit`.
+4. **Named params beat rest params.** A `:name` segment is more specific than a `*name` splat. `/files/:name` beats `/files/*rest` for `/files/x`.
 5. **Exact routes beat optional-group routes.** A pattern with no `{...}?` group is more specific than a pattern that matches the same URL only by virtue of an optional group. `/about` beats `/{:base}?/about` for `/about`.
 6. **Registration order is the final tiebreak only if every structural score is equal.** When two routes are *structurally indistinguishable* (same statics, same length, same params/splats, same optional groups), the route registered first wins. This case is **discouraged** — implementations MUST emit a `:rf.warning/route-shadowed-by-equal-score` warning at registration time when a new route is added and an existing route has an equal structural score on the same URL family. Tooling and AI scaffolds use the warning to flag potential conflicts.
 
@@ -189,10 +189,16 @@ The cascade is **structural** — the score is computable from each pattern's pa
         has-optional?  (some optional-group? segments)
         is-catch-all?  (= pattern "/*")]
     ;; Higher score = more specific. Tuple compares lexicographically.
+    ;; The catch-all demotion (rule 2) is lifted ahead of total-length
+    ;; (rule 3): the bare `/*` also matches the root URL `/`, and a home
+    ;; route `{:path "/"}` has total-length 0 while `/*` has length 1, so
+    ;; if total-length came first the catch-all would out-length the root
+    ;; and shadow it. Putting the catch-all discriminator before length
+    ;; makes `/` (and every concrete route) win over `/*`.
     [static-count                 ;; rule 1
-     total-length                 ;; rule 2
-     (if has-splat? 0 1)          ;; rule 3 — named params beat splats
-     (if is-catch-all? 0 1)       ;; rule 4 — rest beats catch-all
+     (if is-catch-all? 0 1)       ;; rule 2 — bare catch-all demoted below all
+     total-length                 ;; rule 3 — among non-catch-all, longer wins
+     (if has-splat? 0 1)          ;; rule 4 — named params beat splats
      (if has-optional? 0 1)       ;; rule 5 — exact beats optional-group
      ;; rule 6 — registration order — applied externally as a stable sort
      ]))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3085,9 +3085,9 @@ The structural-rank tuple `match-url` computes for each registered route, per [0
   ;; A vector of integers, lexicographically comparable. Higher = more specific.
   ;; The registrar's stable-sort by registration time provides rule 6.
   [:tuple :int                                                            ;; rule 1 — static-segment count
-          :int                                                            ;; rule 2 — total segment count
-          [:enum 0 1]                                                     ;; rule 3 — splat? 0 = has splat; 1 = no splat (named params win)
-          [:enum 0 1]                                                     ;; rule 4 — catch-all? 0 = is "/*"; 1 = otherwise
+          [:enum 0 1]                                                     ;; rule 2 — catch-all? 0 = is bare "/*" (demoted below all); 1 = otherwise
+          :int                                                            ;; rule 3 — total segment count (among non-catch-all routes)
+          [:enum 0 1]                                                     ;; rule 4 — splat? 0 = has splat; 1 = no splat (named params win)
           [:enum 0 1]])                                                   ;; rule 5 — has optional group? 0 = yes; 1 = no
 ```
 

--- a/spec/conformance/fixtures/route-ranking-precedence.edn
+++ b/spec/conformance/fixtures/route-ranking-precedence.edn
@@ -25,7 +25,11 @@
    :route/files.named     {:path "/files/:name" :params [:map [:name :string]]}
    :route/files.splat     {:path "/files/*rest" :params [:map [:rest :string]]}
 
-   ;; Rule 4 — rest params beat catch-all
+   ;; Rule 2 — the bare catch-all is demoted below every concrete route.
+   ;; The catch-all also matches the root URL "/", and the home route has
+   ;; total-length 0 vs the catch-all's 1, so the catch-all discriminator
+   ;; MUST precede total-length or `/*` shadows `/` for "/" (rf2-1ugs5u).
+   :route/home            {:path "/"}
    :route/catch-all       {:path "/*"}
    :route/files.rest      {:path "/files/*rest" :params [:map [:rest :string]]}
 
@@ -50,9 +54,16 @@
   {:call :match-url :url "/files/x.txt"
    :expect {:route-id :route/files.named :params {:name "x.txt"} :query {} :fragment nil :validation-failed? false}}
 
-  ;; Rule 4: /files/a/b/c — :route/files.rest wins over :route/catch-all
+  ;; Rule 2: /files/a/b/c — :route/files.rest (named splat) wins over the
+  ;; bare catch-all :route/catch-all
   {:call :match-url :url "/files/a/b/c"
    :expect {:route-id :route/files.rest :params {:rest "a/b/c"} :query {} :fragment nil :validation-failed? false}}
+
+  ;; Rule 2 (root vs catch-all, rf2-1ugs5u): "/" — :route/home wins over
+  ;; :route/catch-all even though `/*` is the longer pattern. The catch-all
+  ;; demotion is consulted before total-length, so the shorter root wins.
+  {:call :match-url :url "/"
+   :expect {:route-id :route/home :params {} :query {} :fragment nil :validation-failed? false}}
 
   ;; Rule 5: /about — :route/about (exact) wins over :route/optional-about
   {:call :match-url :url "/about"

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
@@ -33,9 +33,11 @@
 
 (defn- rank-cell
   "Render a single rank tuple as compact mono text. The 6-tuple is
-  `[static total -splat catch-all? -optional -reg-index]` per
-  `parse-pattern`; surface it verbatim — the lens is about exposing
-  the cascade, not interpreting it."
+  `[static catch-all? total -splat -optional -reg-index]` per
+  `parse-pattern` (the catch-all discriminator precedes total-length
+  so the bare `/*` is demoted below all concrete routes — rf2-1ugs5u);
+  surface it verbatim — the lens is about exposing the cascade, not
+  interpreting it."
   [rank]
   [:span {:style {:font-family mono-stack
                   :font-size   "11px"


### PR DESCRIPTION
## What & why (rf2-1ugs5u, P1 routing correctness)

Registering a home route `{:path "/"}` plus a catch-all fallback `{:path "/*"}` made `match-url "/"` return the **catch-all**, not the root — registration-order-independently. HIGH user-facing defect.

**Root cause.** The bare catch-all `/*` also matches the root URL `/` (its unnamed splat captures the literal `/`). A home route `{:path "/"}` parses to total-length **0** (the `parse-pattern` loop never runs for `/`), while `/*` is total-length **1**. The rank tuple compared **rule 2 (total-length) BEFORE the catch-all demotion** (rule 4 at tuple position 3), so `/*` out-lengthed the root at tuple position 1 and won before the catch-all discriminator was ever consulted. (`match.cljc` rank tuple + `registry.cljc` descending sort.) The spec encoded the SAME wrong order in spec/012 §Route ranking algorithm.

## Fix (spec-first)

**Spec edit (`spec/012-Routing.md` §Route ranking algorithm — HOT-ZONE, sole toucher):** lifted the bare-catch-all demotion ahead of total-length in both the numbered cascade and the pseudocode tuple. New structural tuple:

```
[static-count               ;; rule 1
 (if is-catch-all? 0 1)     ;; rule 2 — bare catch-all demoted below all   <-- lifted
 total-length               ;; rule 3 — among non-catch-all, longer wins
 (if has-splat? 0 1)        ;; rule 4 — named params beat splats
 (if has-optional? 0 1)]    ;; rule 5 — exact beats optional-group
```

Also updated `spec/Spec-Schemas.md` `:rf/route-rank` element-order doc to match.

**Impl edit (`implementation/routing/src/re_frame/routing/match.cljc`):** reordered the `:rank` tuple emitted by `parse-pattern` to `[static (if catch-all? 0 1) total (- splat) (- optional)]`, with a comment explaining the lift. `registry.cljc` is positionally agnostic (it sorts the whole tuple via `compare` and compares the 5-element structural prefix for equal-score ties), so no further impl change.

**Why the GUARD holds — no other ranking case regresses.** `catch-all?` is `0` only for the single bare `/*` and `1` for every other pattern. For any two NON-catch-all patterns the bit ties (both `1`), so the comparison falls through to total-length **exactly as before** — only rankings *involving the bare `/*`* change, and those correctly demote it below all concrete routes (above only `:rf.route/not-found`).

## Before / after — full ranking-suite proof

Live patched tuples `[static catch-all? total -splat -optional]` and cascade winners (every case verified against `routing_registry_test` + `route-ranking-precedence.edn`):

```
  /                  vs /*                 => / WINS          (FIXED — was /* WINS)
  /*rest             vs /*                 => /*rest WINS      (rule 2 preserved)
  /files/*rest       vs /*                 => /files/*rest WINS
  /users/me          vs /users/:id         => /users/me WINS   (rule 1)
  /users/:id/edit    vs /users/:id         => /users/:id/edit WINS (rule 3)
  /files/:name       vs /files/*rest       => /files/:name WINS (rule 4)
  /about             vs /{:base}?/about     => /about WINS      (rule 5)
```

`compare(/*, /)` was `1` (catch-all out-ranked root) before; now root out-ranks the catch-all despite being the shorter pattern.

## New regression coverage

- `match-url-root-wins-over-catch-all-rf2-1ugs5u` (test): `match-url "/"` → root, both registration orders; `/*` still catches non-root URLs no concrete route matches.
- `parse-pattern-root-outranks-bare-catch-all-rf2-1ugs5u` (test): root out-ranks `/*` despite being shorter; pins the catch-all element at index 1 and total-length at index 2.
- `route-ranking-precedence.edn` conformance fixture: added `:route/home {:path "/"}` and a `match-url "/" → :route/home` call.
- Subsumes the LOW empty-keyword-param finding from nppld9.

Updated the rf2-yjali named-splat test's rank-element indices (catch-all discriminator moved index 3 → 1) and the Xray `simulate-url` rank-cell docstring (tuple-layout note). Did NOT touch the `:can-leave` no-op-self-nav item (separate ruling).

## Quality gates — all green

```
cd implementation && npm run test:cljs        # 7865 tests, 32590 assertions, 0 failures, 0 errors
implementation/routing  clojure -M:test        # 299 tests, 1436 assertions, 0 failures, 0 errors
implementation/core     clojure -M:test        # 1804 tests, 7852 assertions, 0 failures, 0 errors (conformance runner incl. route-ranking-precedence.edn)
rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict   # Documentation built in 15.39s, no warnings (spec/012 touched)
```