### PR TITLE
fix(xray): correct vector diff replay for mixed insert+delete edit scripts (rf2-3eplfk)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -262,29 +262,54 @@ there.
 
 A vector/list `:-` removal flows through the off-path
 `:vector-removals` channel (a removed before-index has no stable
-after-side path — the survivors shift up). **Multiple `:-` edits at one
-sequential are recovered by replaying the edit-indices against the
-progressively-shrinking before-sequence**, because Editscript applies
-`:-` edits *sequentially*: each `:-` at edit-index `i` removes the
-element *currently* at index `i` after all prior `:-` at this parent.
-A contiguous tail deletion therefore repeats the same edit-index (`[1 2
-3] → [1]` ⇒ `[[1] :-] [[1] :-]`) and a scattered deletion uses
-post-shift indices (`[:a :b :c :d] → [:a :c]` ⇒ `[[1] :-] [[2] :-]`).
-Resolving each `:-` against the *original* before-vector independently
-(the pre-fix approach) read the wrong element for every edit after the
-first — reporting one before-value repeatedly and dropping the rest.
-The replay recovers the true before-index + before-value for every
-removed element regardless of contiguity or multiplicity.
+after-side path — the survivors shift up). The removals channel **and**
+the `:same-shifted` shift channel both derive from **one unified replay
+of the `:+` and `:-` edits in edit-script order** against a single
+evolving slot vector (`replay-vector-edits`, rf2-3eplfk), because
+Editscript applies `:+`/`:-` edits *sequentially* against an evolving
+sequence: each `:-` at edit-index `i` removes the element *currently* at
+index `i` *after* every prior `:+` insert **and** `:-` delete at this
+parent has shifted the sequence. A `:-`'s edit-index is therefore a
+position relative to the sequence as it stands at that edit — **not** a
+pristine before-index.
 
-The `:same-shifted` **shift-suffix projection uses the same replay**
-(rf2-1njv97): the `(was N)` before-index of a surviving element is the
-original index left in the survivor list once the `:-` edits have been
-replayed (and the `:+` insert-markers spliced in), *not* an arithmetic
-`after-index − inserts + deletes` count. Treating the post-shift `:-`
+The slot vector starts as `(range before-len)`. Each `:+` splices an
+insert-marker at its (current) index; each `:-` records and removes
+whatever slot currently sits at its index. The final slots align 1:1
+with the after-vector (a survivor's original before-index or an
+insert-marker); the recorded removals carry the true before-index for
+every dropped element. `:r` (replace) edits stay *out* of the replay —
+a replace is length- and order-preserving, so it never shifts a
+subsequent index or adds/removes a slot — and their after-indices are
+skipped from the shift output (they classify as `:modified`).
+
+> **Why the unified `:+`/`:-` replay (rf2-3eplfk).** An earlier
+> implementation replayed **only** the `:-` edits against pristine
+> `(range before-len)`, ignoring interleaved `:+` inserts. That is
+> correct for delete-only (no inserts shift the indices) and insert-only
+> (no deletes) scripts — which is why those cases passed — but **wrong**
+> for a *mixed* insert+delete script: the `:-` index had already been
+> shifted by a prior `:+`, so deleting against pristine indices read the
+> wrong slot. Symptoms: mis-attributed removal (`[:a :b :c] → [:X :a :c]`
+> ⇒ `[[0] :+ :X] [[2] :-]` reported `:c` removed when `:b` was, and
+> marked the surviving `:c` `:same-shifted`); a surviving element struck
+> (`[:a :b :c :d] → [:X :a :d]` struck the surviving `:d`); a **dropped**
+> removal (an out-of-range `:-` whose true index sat past `before-len`
+> because a prior `:+` grew the sequence was silently skipped —
+> `[:a :b :c :d] → [:a :X :b :c]` ⇒ `[[1] :+ :X] [[4] :-]` lost `:d`'s
+> removal and emitted a phantom shift). Same wrong-before/after class as
+> the scar history rf2-1njv97 / rf2-yucxn / rf2-vu42n, with the
+> mixed-edit case uncovered. The unified walk removes the actual slot at
+> each `:-`'s post-shift index and derives the `(was N)` shift suffix
+> from the *same* slots, so the two channels can never disagree.
+
+The `:same-shifted` `(was N)` before-index of a surviving element is the
+original index left in that slot once the unified replay finishes — *not*
+a deletes-then-splice-inserts reconstruction and *not* an arithmetic
+`after-index − inserts + deletes` count. (Treating the post-shift `:-`
 edit-indices as before-indices over-counted deletes for scattered /
-multi-element removals (`[:a :b :c :d] → [:a :c]` reported the surviving
-`:c` as `(was 3)` instead of `(was 2)`); the single-delete case lined up
-only by coincidence.
+multi-element removals — `[:a :b :c :d] → [:a :c]` reported the surviving
+`:c` as `(was 3)` instead of `(was 2)` — rf2-1njv97.)
 
 > **Renderer note (rf2-vu42n, fixed).** The inline vector / list / seq
 > body renderer **consumes** this `:vector-removals` channel (plus the

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -393,135 +393,123 @@
 ;;
 ;; This is a per-vector linear walk, O(N + edits-per-vector). Pure.
 
-(defn- replay-vector-deletes
-  "Replay Editscript's `:-` edits against a live `survivors` list of
-  ORIGINAL before-indices and return `{:removed :survivors}`.
+(defn- replay-vector-edits
+  "rf2-3eplfk — UNIFIED replay of an Editscript edit script at ONE
+  vector/list parent. Replays the `:+` (insert) and `:-` (delete) edits in
+  EDIT-SCRIPT ORDER against a single evolving slot vector and returns
+  `{:removed :slots}` — the one source of truth for BOTH the removals
+  channel (`resolve-vector-removals`) and the shift channel
+  (`shift-suffixes-for-vector`).
 
-  Editscript applies `:-` edits SEQUENTIALLY against a progressively-
-  shrinking sequence: each `:-` at edit-index `i` removes the element
-  CURRENTLY occupying index `i`, AFTER all prior `:-` at this parent have
-  already been applied. A contiguous tail deletion therefore repeats the
-  SAME edit-index (`[1 2 3] → [1]` ⇒ `[[1] :-] [[1] :-]`), and a scattered
-  deletion uses post-shift indices (`[:a :b :c :d] → [:a :c]` ⇒ `[[1] :-]
-  [[2] :-]`). These are NOT stable before-indices.
+  ## Why a unified `:+`/`:-` replay (the bug this fixes)
 
-  `survivors` starts as `(range before-len)`. For each delete edit-index
-  `i` in Editscript order we record `survivors[i]` into `:removed` (in
-  removal order) then splice it out, so what remains in `:survivors` are
-  the before-indices of all surviving elements in after-order. An out-of-
-  range edit-index (should not happen for well-formed Editscript output)
-  is skipped rather than crashing the projection. Pure.
+  Editscript applies `:+`/`:-` edits SEQUENTIALLY against an EVOLVING
+  sequence: a `:-` at edit-index `i` removes whatever element CURRENTLY
+  occupies index `i`, AFTER every prior `:+` insert AND `:-` delete at this
+  parent has already shifted the sequence. So a `:-`'s edit-index is a
+  position relative to the sequence AS IT STANDS at that edit — NOT a
+  pristine before-index.
 
-  Used by both `shift-suffixes-for-vector` (`:survivors`) and
-  `resolve-vector-removals` (`:removed`)."
-  [before-len delete-idxs]
-  (loop [survivors  (vec (range before-len))
-         [i & more] delete-idxs
-         removed    []]
-    (if (nil? i)
-      {:removed removed :survivors survivors}
-      (if (and (>= i 0) (< i (count survivors)))
-        (recur (into (subvec survivors 0 i)
-                     (subvec survivors (inc i)))
-               more
-               (conj removed (nth survivors i)))
-        ;; Defensive: a malformed out-of-range edit-index is skipped
-        ;; rather than crashing the projection.
-        (recur survivors more removed)))))
+  The pre-fix code (rf2-lkehao's `replay-vector-deletes`) replayed ONLY the
+  `:-` edits against `(range before-len)`, IGNORING the interleaved `:+`
+  inserts. For a delete-only script that is correct (no inserts shift the
+  indices). But for a MIXED insert+delete script it reads the WRONG slot —
+  every symptom in rf2-3eplfk (mis-attributed removal, surviving element
+  struck, DROPPED out-of-range removal, phantom shift) traces to deleting
+  against pristine indices when prior inserts had already shifted them.
+  Example `[:a :b :c :d] → [:a :X :b :c]` ⇒ `[[1] :+ :X] [[4] :-]`: against
+  `(range 4)` the `[4] :-` is out-of-range and silently dropped; against the
+  evolving sequence (length 5 after the insert) index 4 correctly removes
+  before-index 3 (`:d`).
+
+  ## The walk
+
+  `slots` starts as `(range before-len)` — every before-index in order.
+  For each edit in script order:
+    - `:+` at index `i` splices an `::insert` marker at the CURRENT index
+      `i` (clamped to the current length). The marker carries no
+      before-index — it is the `:added` element occupying that after-slot.
+    - `:-` at index `i` removes whatever slot currently sits at `i`; if that
+      slot is a real before-index it is recorded into `:removed` (in removal
+      order). An `::insert` removed before it is finalised (Editscript would
+      not normally emit this) is dropped without recording.
+  `:r` edits are NOT passed here: a replace is length- and order-preserving,
+  so it never shifts a subsequent `:+`/`:-` index and never removes/adds a
+  slot — it stays out of the replay and is handled at classification time
+  (`:modified`).
+
+  The final `:slots` aligns 1:1 with the AFTER-vector by index: each entry
+  is either an original before-index (a survivor) or `::insert` (a `:+`
+  slot). `:removed` is the before-indices removed, in removal order. Out-of-
+  range edit-indices (should not happen for well-formed Editscript output)
+  are skipped defensively rather than crashing the projection. Pure."
+  [before-len ordered-edits]
+  (loop [slots         (vec (range before-len))
+         [edit & more] ordered-edits
+         removed       []]
+    (if (nil? edit)
+      {:removed removed :slots slots}
+      (let [op (second edit)
+            i  (peek (first edit))]
+        (case op
+          :+ (let [i (min (max i 0) (count slots))]
+               (recur (into (conj (subvec slots 0 i) ::insert)
+                            (subvec slots i))
+                      more
+                      removed))
+          :- (if (and (>= i 0) (< i (count slots)))
+               (let [slot (nth slots i)
+                     removed' (if (= ::insert slot)
+                                ;; defensive: an inserted marker removed
+                                ;; before finalisation contributes no
+                                ;; before-index. Not expected from
+                                ;; well-formed Editscript output.
+                                removed
+                                (conj removed slot))]
+                 (recur (into (subvec slots 0 i)
+                              (subvec slots (inc i)))
+                        more
+                        removed'))
+               ;; Defensive: a malformed out-of-range edit-index is skipped
+               ;; rather than crashing the projection.
+               (recur slots more removed))
+          ;; Any other op (shouldn't reach — only :+/:- are passed) is a
+          ;; no-op for the replay.
+          (recur slots more removed))))))
 
 (defn- shift-suffixes-for-vector
-  "Given an after-vector's length + the per-position edits Editscript
-  emitted at this vector's path, return a map
-  `{after-index was-before-index}` for every after-element whose
-  identity moved positionally (op `:same-shifted`).
+  "Given a vector parent's before-length, its unified replay `slots`
+  (from `replay-vector-edits` — `:+`/`:-` replayed in edit-script order),
+  and the `:r` after-indices at this parent, return a map
+  `{after-index was-before-index}` for every after-element whose identity
+  moved positionally (op `:same-shifted`).
 
-  The logic REPLAYS the edit script against a live `survivors` list of
-  ORIGINAL before-indices — the same technique `resolve-vector-removals`
-  (rf2-yucxn) uses for the removals channel. This is mandatory because
-  Editscript emits `:-` edits at POST-shift indices applied SEQUENTIALLY
-  against a shrinking vector — they are NOT stable before-indices. The
-  pre-fix `delete-idxs ≤ cursor` fixed-point (rf2-1njv97) mis-read those
-  post-shift indices as before-indices and over-counted deletes for any
-  scattered/multi-element removal (`[:a :b :c :d] → [:a :c]` reported the
-  surviving `:c` as `(was 3)` instead of `(was 2)`; the single-delete case
-  worked only by coincidence).
+  The `slots` vector aligns 1:1 with the after-vector: each entry is either
+  an original before-index (a survivor) or `::insert` (a `:+` slot). This is
+  the SAME unified walk that feeds the removals channel (rf2-3eplfk) — the
+  shift was-index is derived from it, NOT from a deletes-then-splice-inserts
+  reconstruction (the pre-fix two-step replayed deletes against pristine
+  `(range before-len)` then spliced inserts afterward, which mis-read every
+  `:-` whose edit-index a prior `:+` had shifted: e.g.
+  `[:a :b :c :d] → [:X :a :d]` struck the surviving `:d` and reported `:c`
+  removed; the unified walk removes the actual `:b`/`:c` and reports `:d`
+  `(was 3)` correctly).
 
-  Replay procedure:
-    1. `survivors` starts as `(range before-len)` — every before-index.
-    2. Apply each `:-` in Editscript order: edit-index `i` removes the
-       element CURRENTLY at `survivors[i]` (post-shift), shrinking the list.
-       What remains are the before-indices of all surviving elements, in
-       after-order.
-    3. Splice each `:+` (keyed by AFTER-index, ascending) into the survivor
-       list as a `nil` insert-marker, so the list aligns 1:1 with the
-       after-vector by index.
-  The resulting `slots` vector maps `after-index → original before-index`
-  (or `nil` for an inserted slot). Positions with edits (`:+` / `:r`) are
-  skipped from the output because they classify under :added / :modified,
-  not :same-shifted; an after-index whose before-index equals it (no move)
-  is likewise omitted."
-  [before-len edits-at-this-vector]
-  (let [;; `:+` edits are keyed by their AFTER-index; `:-` edits carry
-        ;; POST-shift edit-indices in Editscript order (NOT before-indices);
-        ;; `:r` edits sit at a shared, surviving index.
-        delete-edit-idxs (->> edits-at-this-vector
-                              (filter (fn [edit] (= :- (second edit))))
-                              (mapv (fn [edit] (peek (first edit)))))
-        insert-idxs      (->> edits-at-this-vector
-                              (filter (fn [edit] (= :+ (second edit))))
-                              (map (fn [edit] (peek (first edit))))
-                              (sort)
-                              vec)
-        replace-idxs     (->> edits-at-this-vector
-                              (filter (fn [edit] (= :r (second edit))))
-                              (map (fn [edit] (peek (first edit))))
-                              (into #{}))
-        ;; Step 1+2 — replay the `:-` deletes against the survivor list of
-        ;; original before-indices, removing the post-shift slot each time.
-        survivors-after-deletes
-        (:survivors (replay-vector-deletes before-len delete-edit-idxs))
-        ;; Step 3 — splice insert-markers (nil) at each `:+` after-index so
-        ;; the slot vector aligns position-for-position with the after-vector.
-        slots
-        (reduce (fn [acc after-idx]
-                  (let [after-idx (min after-idx (count acc))]
-                    (into (conj (subvec acc 0 after-idx) nil)
-                          (subvec acc after-idx))))
-                survivors-after-deletes
-                insert-idxs)
-        insert-set (set insert-idxs)]
-    ;; Emit `{after-index before-index}` only for surviving (non-edit) slots
-    ;; whose position actually moved.
-    (reduce-kv
-      (fn [acc after-idx before-idx]
-        (if (or (nil? before-idx)                  ; inserted slot → :added
-                (contains? insert-set after-idx)
-                (contains? replace-idxs after-idx) ; replaced slot → :modified
-                (= after-idx before-idx))          ; unmoved → no suffix
-          acc
-          (assoc acc after-idx before-idx)))
-      {}
-      (vec slots))))
-
-(defn- group-edits-by-vector-parent
-  "Group all edits by their parent path WHEN the parent is a vector.
-  Returns `{[parent-path] [edits...]}`. Map-key edits are filtered out
-  (their parents are maps; R6 doesn't apply)."
-  [edits after]
-  (reduce
-    (fn [acc [path _op _val :as edit]]
-      (if (empty? path)
+  An after-index whose slot is an `::insert` classifies under `:added`
+  (skipped here); an after-index in `replace-set` classifies under
+  `:modified` (skipped); a survivor whose before-index equals its after-
+  index has not moved (skipped). Everything else is a positional move →
+  `:same-shifted` with the survivor's before-index as `:was-index`."
+  [slots replace-set]
+  (reduce-kv
+    (fn [acc after-idx slot]
+      (if (or (= ::insert slot)                  ; inserted slot → :added
+              (contains? replace-set after-idx)  ; replaced slot → :modified
+              (= after-idx slot))                ; unmoved survivor → no suffix
         acc
-        (let [parent-path (vec (butlast path))
-              parent-val  (value-at after parent-path)
-              leaf-key    (peek path)]
-          (if (and (or (vector? parent-val)
-                       (sequential? parent-val))
-                   (integer? leaf-key))
-            (update acc parent-path (fnil conj []) edit)
-            acc))))
+        (assoc acc after-idx slot)))
     {}
-    edits))
+    (vec slots)))
 
 ;; =========================================================================
 ;; main projection
@@ -856,35 +844,34 @@
        vec))
 
 (defn- resolve-vector-removals
-  "rf2-yucxn — recover the true `{:before-index :before-value}` for every
-  `:-` edit Editscript emits at a single vector/list parent.
+  "rf2-yucxn / rf2-3eplfk — recover the true `{:before-index :before-value}`
+  for every element removed at a single vector/list parent.
 
-  Editscript applies `:-` edits SEQUENTIALLY against a progressively-
-  shrinking sequence: each `:-` at edit-index `i` removes the element
-  CURRENTLY occupying index `i`, AFTER all prior `:-` at this parent have
-  already been applied. A contiguous tail deletion therefore repeats the
-  SAME edit-index (`[1 2 3] → [1]` ⇒ `[[1] :-] [[1] :-]`), and a scattered
-  deletion uses post-shift indices (`[:a :b :c :d] → [:a :c]` ⇒ `[[1] :-]
-  [[2] :-]`). Resolving `(value-at before [parent i])` independently per
-  edit (the pre-fix approach) read the WRONG element for every edit after
-  the first — reporting one before-value repeatedly and dropping the
-  genuinely-removed tail elements.
+  `removed` is the vector of ORIGINAL before-indices removed at this parent,
+  as recorded by the UNIFIED `replay-vector-edits` walk (which replays
+  `:+`/`:-` in edit-script order — see that fn's docstring). `bvec` is the
+  parent's before-side sequence as a vector.
 
-  We replay the edits against a live mutable index map: `survivors` is the
-  vector of ORIGINAL before-indices still present; each `:-` at edit-index
-  `i` removes (and records) `survivors[i]`, then drops it from `survivors`.
-  The recorded original index resolves the before-value via `(nth bvec _)`.
+  ## Why the unified replay (rf2-3eplfk)
 
-  `edits` are the raw `:-` edits at THIS parent in Editscript order; `bvec`
-  is the parent's before-side sequence as a vector. Returns a vector of
-  `{:before-index :before-value}` in before-index order. Pure."
-  [edits bvec]
-  (let [edit-idxs (mapv (fn [e] (peek (first e))) edits)
-        recovered (:removed (replay-vector-deletes (count bvec) edit-idxs))]
-    (->> recovered
-         sort
-         (mapv (fn [orig] {:before-index orig
-                           :before-value (nth bvec orig)})))))
+  Editscript applies `:+`/`:-` edits SEQUENTIALLY against an EVOLVING
+  sequence: a `:-`'s edit-index is a position AFTER prior `:+` inserts have
+  shifted it. The pre-fix path (rf2-yucxn / rf2-lkehao) replayed ONLY the
+  `:-` edits against `(range before-len)`, IGNORING interleaved inserts —
+  correct for delete-only scripts but WRONG for mixed insert+delete (it
+  read the wrong slot, and silently DROPPED an out-of-range `:-` whose true
+  index sat past `before-len` because a prior `:+` had grown the sequence).
+  Recording before-indices from the one unified walk fixes both. (The even
+  earlier per-edit `(value-at before [parent i])` resolution read one
+  before-value repeatedly and dropped the rest.)
+
+  Returns a vector of `{:before-index :before-value}` in before-index
+  order. Pure."
+  [removed bvec]
+  (->> removed
+       sort
+       (mapv (fn [orig] {:before-index orig
+                         :before-value (nth bvec orig)}))))
 
 (defn project
   "Compute the diff projection for `(before, after)`. Returns a map per
@@ -905,34 +892,88 @@
           ;; occupying that slot. We therefore route vector deletions
           ;; into a separate `:vector-removals` channel and leave the
           ;; after-path leaf classifications to the shift walker.
+          ;;
+          ;; A vector PARENT is recognised from EITHER side (rf2-3eplfk):
+          ;; a `:-`'s parent is a sequential in `before`, a `:+`'s parent
+          ;; is a sequential in `after`. For an in-place edit (no parent
+          ;; type-change) both agree; we accept either so a single grouping
+          ;; captures the whole edit script per vector parent.
+          seq-coll?
+          (fn [v]
+            (or (vector? v)
+                (and (sequential? v) (not (map? v)) (not (set? v)))))
           vector-parent?
           (fn [path]
             (when (seq path)
-              (let [parent (value-at before (vec (butlast path)))]
-                (or (vector? parent)
-                    (and (sequential? parent) (not (map? parent)) (not (set? parent)))))))
-          ;; Split raw edits into vector-`:-` deletions (per parent) and
-          ;; everything else. The deletions are grouped by parent path IN
-          ;; EDIT ORDER so `resolve-vector-removals` can replay them against
-          ;; the live before-sequence (rf2-yucxn — a single post-shift
-          ;; before-index resolution per edit was wrong for multi-element
-          ;; / scattered deletions).
-          [vec-del-edits other-edits]
+              (let [pp (vec (butlast path))]
+                (or (seq-coll? (value-at before pp))
+                    (seq-coll? (value-at after pp))))))
+          ;; rf2-3eplfk — UNIFIED grouping. Collect, per vector parent, the
+          ;; ordered `:+`/`:-` edits (in edit-script order) for the single
+          ;; `replay-vector-edits` walk, plus the set of `:r` after-indices
+          ;; (replaces are length-/order-preserving so they sit OUT of the
+          ;; replay, but their after-indices are skipped from the shift
+          ;; output). Vector `:-` deletions are also peeled OUT of the
+          ;; per-leaf classification stream into `other-edits` (their after-
+          ;; path identity is unstable — see the channel rationale above);
+          ;; `:+`/`:r` stay in `other-edits` for their `:added`/`:modified`
+          ;; leaf ops.
+          {:keys [vec-groups other-edits]}
           (reduce
-            (fn [[dels oth] [path op _value :as edit]]
-              (if (and (= op :-) (vector-parent? path))
-                [(update dels (vec (butlast path)) (fnil conj []) edit) oth]
-                [dels (conj oth edit)]))
-            [{} []]
+            (fn [acc [path op _value :as edit]]
+              (let [parent-path (vec (butlast path))
+                    leaf-key    (peek path)
+                    vparent?    (and (integer? leaf-key)
+                                     (vector-parent? path))]
+                (cond
+                  ;; vector `:-` — feeds the unified replay; NOT a per-leaf op.
+                  (and vparent? (= op :-))
+                  (-> acc
+                      (update-in [:vec-groups parent-path :ordered] (fnil conj []) edit))
+
+                  ;; vector `:+` — feeds the unified replay AND stays in
+                  ;; other-edits for its `:added` leaf expansion.
+                  (and vparent? (= op :+))
+                  (-> acc
+                      (update-in [:vec-groups parent-path :ordered] (fnil conj []) edit)
+                      (update :other-edits conj edit))
+
+                  ;; vector `:r` — record its after-index for the shift
+                  ;; skip-set; stays in other-edits for its `:modified` op.
+                  (and vparent? (= op :r))
+                  (-> acc
+                      (update-in [:vec-groups parent-path :replace-idxs] (fnil conj #{}) leaf-key)
+                      (update :other-edits conj edit))
+
+                  :else
+                  (update acc :other-edits conj edit))))
+            {:vec-groups {} :other-edits []}
             raw)
+          ;; rf2-3eplfk — ONE `replay-vector-edits` walk per vector parent
+          ;; produces BOTH the removals (`:removed`) and the shift slots
+          ;; (`:slots`). Both downstream channels derive from this single
+          ;; evolving-survivor walk so they can never disagree about which
+          ;; slot a `:-` removed (the scar history rf2-1njv97/yucxn/vu42n
+          ;; was two replays that diverged on mixed insert+delete scripts).
+          vec-replays
+          (reduce-kv
+            (fn [acc parent-path {:keys [ordered]}]
+              (let [before-val (value-at before parent-path)
+                    before-len (if (seq-coll? before-val) (count before-val) 0)]
+                (assoc acc parent-path
+                       (replay-vector-edits before-len (or ordered [])))))
+            {}
+            vec-groups)
           vector-removals
           (reduce-kv
-            (fn [acc parent-path edits]
-              (let [bvec (vec (value-at before parent-path))]
-                (assoc acc parent-path
-                       (resolve-vector-removals edits bvec))))
+            (fn [acc parent-path {:keys [removed]}]
+              (if (seq removed)
+                (let [bvec (vec (value-at before parent-path))]
+                  (assoc acc parent-path
+                         (resolve-vector-removals removed bvec)))
+                acc))
             {}
-            vec-del-edits)
+            vec-replays)
           ;; Step 1 — expand each non-vector-deletion raw edit into
           ;; per-leaf ops at every path the operator can navigate to in
           ;; the AFTER tree.
@@ -976,31 +1017,24 @@
                 acc))
             {}
             per-leaf)
-          ;; Step 3 — R6 vector shift suffixes. For each vector-typed
-          ;; parent that received +/- edits, compute the (after-index →
-          ;; before-index) map and emit `:same-shifted` ops for any
-          ;; after-index whose identity moved.
-          edits-by-vec-parent
-          (group-edits-by-vector-parent raw after)
+          ;; Step 3 — R6 vector shift suffixes. Derived from the SAME unified
+          ;; `replay-vector-edits` slots that fed the removals channel
+          ;; (rf2-3eplfk) — `:same-shifted` for any surviving after-index
+          ;; whose before-index moved. The `:r` after-indices (collected in
+          ;; the unified grouping) are skipped because they classify as
+          ;; `:modified`, not `:same-shifted`.
           shift-suffix
-          (reduce
-            (fn [acc [parent-path edits]]
-              (let [;; The shift replay reconstructs survivor before-indices
-                    ;; from the BEFORE-side length (rf2-1njv97); the after
-                    ;; length is recoverable from the slot vector itself.
-                    before-val (value-at before parent-path)
-                    before-len (cond
-                                 (vector? before-val)     (count before-val)
-                                 (sequential? before-val) (count before-val)
-                                 :else 0)
-                    shifts (shift-suffixes-for-vector before-len edits)]
+          (reduce-kv
+            (fn [acc parent-path {:keys [slots]}]
+              (let [replace-set (get-in vec-groups [parent-path :replace-idxs] #{})
+                    shifts      (shift-suffixes-for-vector slots replace-set)]
                 (reduce-kv
                   (fn [acc' after-idx before-idx]
                     (assoc acc' (conj (vec parent-path) after-idx) before-idx))
                   acc
                   shifts)))
             {}
-            edits-by-vec-parent)
+            vec-replays)
           ;; Inject :same-shifted ops where applicable. We DO NOT clobber
           ;; an existing :added/:modified op — only annotate idle (so far
           ;; absent from path-ops, meaning identical-value) slots whose

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -1079,3 +1079,129 @@
       (is (= :children (engine/op-at p [:a :b :c])))
       (is (= #{} (:wholly-changed-roots p))))))
 
+;; ---- rf2-3eplfk — MIXED insert+delete edit scripts ---------------------
+;;
+;; P1 correctness defect: Editscript applies `:+`/`:-` SEQUENTIALLY against
+;; an EVOLVING sequence, so a `:-`'s edit-index is a position AFTER prior
+;; `:+` inserts shifted it. The pre-fix engine replayed ONLY the `:-` edits
+;; against pristine `(range before-len)`, IGNORING interleaved inserts —
+;; correct for delete-only / insert-only (why those tests passed) but WRONG
+;; for mixed scripts. The fix replays BOTH `:+` and `:-` in edit-script
+;; order against ONE evolving survivor vector; the removals channel AND the
+;; shift channel both derive from that single walk.
+;;
+;; Each repro below was verified on the JVM against Editscript 0.6.5; the
+;; edit script each produces is noted, with the WRONG pre-fix output and the
+;; CORRECT post-fix output. Same wrong-before/after class as the scar
+;; history rf2-1njv97 / rf2-yucxn / rf2-vu42n, mixed-edit case uncovered.
+
+(deftest eplfk-insert-before-delete-mis-attributed-removal
+  (testing "rf2-3eplfk repro 1 — `[:a :b :c] → [:X :a :c]` ⇒
+            `[[0] :+ :X] [[2] :-]`. The `:-` at edit-index 2 hits the
+            EVOLVING sequence `[X a b c]`, removing `:b` (before-idx 1).
+            Pre-fix replayed `[2]` against `(range 3)` → removed `:c`
+            (before-idx 2) AND marked the surviving `:c` `:same-shifted`.
+            Correct: `:b` removed; `:X` added at 0; `:a` shifted (was 0);
+            `:c` UNMOVED (after-idx 2 = before-idx 2, no suffix)."
+    (let [p (engine/project [:a :b :c] [:X :a :c])]
+      ;; removal is :b (before-idx 1), NOT :c
+      (is (= [{:before-index 1 :before-value :b}]
+             (get-in p [:vector-removals []]))
+          "must report :b removed, not :c")
+      ;; after-index 0 = :X added
+      (is (= :added (engine/op-at p [0])))
+      (is (= :X (:after (engine/entry-at p [0]))))
+      ;; after-index 1 = :a, shifted from before-idx 0
+      (is (= :same-shifted (engine/op-at p [1])))
+      (is (= 0 (engine/shifted-was-index p [1])))
+      ;; after-index 2 = :c, UNMOVED (before-idx 2) — no :same-shifted, no
+      ;; phantom suffix. Pre-fix wrongly tagged this slot.
+      (is (= :same (engine/op-at p [2]))
+          "surviving :c is unmoved — must NOT be struck or shifted")
+      (is (nil? (engine/shifted-was-index p [2]))))))
+
+(deftest eplfk-insert-before-double-delete-survivor-struck
+  (testing "rf2-3eplfk repro 2 — `[:a :b :c :d] → [:X :a :d]` ⇒
+            `[[0] :+ :X] [[2] :-] [[2] :-]`. Against the evolving sequence
+            the two `:-` at edit-index 2 remove `:b` then `:c`. Pre-fix
+            replayed `[2] [2]` against `(range 4)` → removed `:c` then `:d`,
+            STRIKING the surviving `:d`. Correct: `:b` + `:c` removed; `:d`
+            survives at after-idx 2, shifted from before-idx 3."
+    (let [p (engine/project [:a :b :c :d] [:X :a :d])]
+      (is (= [{:before-index 1 :before-value :b}
+              {:before-index 2 :before-value :c}]
+             (get-in p [:vector-removals []]))
+          "must report :b and :c removed, not :c and :d")
+      (is (= :added (engine/op-at p [0])))
+      (is (= :X (:after (engine/entry-at p [0]))))
+      (is (= :same-shifted (engine/op-at p [1])))
+      (is (= 0 (engine/shifted-was-index p [1])))
+      ;; :d survives — it is NOT in the removals, and carries (was 3)
+      (is (= :same-shifted (engine/op-at p [2]))
+          "surviving :d must not be struck")
+      (is (= 3 (engine/shifted-was-index p [2]))))))
+
+(deftest eplfk-insert-then-tail-delete-dropped-removal
+  (testing "rf2-3eplfk repro 3 — `[:a :b :c :d] → [:a :X :b :c]` ⇒
+            `[[1] :+ :X] [[4] :-]`. The `:-` at edit-index 4 hits the
+            evolving sequence `[a X b c d]` (length 5), removing `:d`
+            (before-idx 3). Pre-fix replayed `[4]` against `(range 4)` →
+            index 4 OUT OF RANGE → removal SILENTLY DROPPED, and the
+            phantom shift walk mis-aligned the survivors. Correct: `:d`
+            removed; `:X` added at 1; `:b`/`:c` shifted."
+    (let [p (engine/project [:a :b :c :d] [:a :X :b :c])]
+      ;; the removal must NOT be dropped
+      (is (= [{:before-index 3 :before-value :d}]
+             (get-in p [:vector-removals []]))
+          ":d's removal must not be dropped (was out-of-range pre-fix)")
+      ;; after-index 0 = :a unmoved
+      (is (= :same (engine/op-at p [0])))
+      (is (nil? (engine/shifted-was-index p [0])))
+      ;; after-index 1 = :X added
+      (is (= :added (engine/op-at p [1])))
+      (is (= :X (:after (engine/entry-at p [1]))))
+      ;; after-index 2 = :b, shifted from before-idx 1
+      (is (= :same-shifted (engine/op-at p [2])))
+      (is (= 1 (engine/shifted-was-index p [2])))
+      ;; after-index 3 = :c, shifted from before-idx 2
+      (is (= :same-shifted (engine/op-at p [3])))
+      (is (= 2 (engine/shifted-was-index p [3])))
+      ;; no phantom shift entry beyond the after-vector length
+      (is (nil? (engine/shifted-was-index p [4]))))))
+
+(deftest eplfk-double-insert-then-mid-delete-dropped-removal
+  (testing "rf2-3eplfk repro 4 — `[:a :b :c :d] → [:X :Y :a :b :d]` ⇒
+            `[[0] :+ :X] [[1] :+ :Y] [[4] :-]`. After both inserts the
+            evolving sequence is `[X Y a b c d]`; the `:-` at edit-index 4
+            removes `:c` (before-idx 2). Pre-fix replayed `[4]` against
+            `(range 4)` → index 4 OUT OF RANGE → `:c`'s removal DROPPED.
+            Correct: `:c` removed; `:X`/`:Y` added; `:a`/`:b`/`:d` shifted."
+    (let [p (engine/project [:a :b :c :d] [:X :Y :a :b :d])]
+      (is (= [{:before-index 2 :before-value :c}]
+             (get-in p [:vector-removals []]))
+          ":c's removal must not be dropped")
+      (is (= :added (engine/op-at p [0])))
+      (is (= :X (:after (engine/entry-at p [0]))))
+      (is (= :added (engine/op-at p [1])))
+      (is (= :Y (:after (engine/entry-at p [1]))))
+      ;; after-index 2 = :a (was 0), 3 = :b (was 1), 4 = :d (was 3)
+      (is (= :same-shifted (engine/op-at p [2])))
+      (is (= 0 (engine/shifted-was-index p [2])))
+      (is (= :same-shifted (engine/op-at p [3])))
+      (is (= 1 (engine/shifted-was-index p [3])))
+      (is (= :same-shifted (engine/op-at p [4])))
+      (is (= 3 (engine/shifted-was-index p [4]))))))
+
+(deftest eplfk-mixed-edit-in-nested-vector-parent
+  (testing "rf2-3eplfk — the mixed insert+delete fix holds at a NESTED
+            vector parent (keyed by parent path, not just root). `{:xs
+            [:a :b :c]} → {:xs [:X :a :c]}` mirrors repro 1 under `[:xs]`."
+    (let [p (engine/project {:xs [:a :b :c]} {:xs [:X :a :c]})]
+      (is (= [{:before-index 1 :before-value :b}]
+             (get-in p [:vector-removals [:xs]])))
+      (is (= :added (engine/op-at p [:xs 0])))
+      (is (= :same-shifted (engine/op-at p [:xs 1])))
+      (is (= 0 (engine/shifted-was-index p [:xs 1])))
+      (is (= :same (engine/op-at p [:xs 2])))
+      (is (nil? (engine/shifted-was-index p [:xs 2]))))))
+

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1535,6 +1535,78 @@
     (is (not (contains? struck "50")) "50 survives (shifted 4→2) — not struck")
     (is (not (contains? struck "10")) "10 survives in place — not struck")))
 
+;; =========================================================================
+;; rf2-3eplfk — MIXED insert+delete edit scripts render the genuinely-
+;; removed member struck and the survivors un-morphed. Mirrors
+;; `diff-removed-vector-element-no-sentinel-leak` (the delete-only render
+;; guard) for the mixed-edit case the engine bug uncovered.
+;; =========================================================================
+;;
+;; These exercise the SAME render path as the rf2-vu42n scattered-removal
+;; tests above (`render-vec-diff` threads the real `engine/project`), so a
+;; regression in the unified-replay engine fix surfaces here as the WRONG
+;; member struck (or a survivor morphed). Each case is a repro from the
+;; rf2-3eplfk bead.
+
+(deftest diff-vector-insert-before-delete-strikes-removed-not-survivor
+  ;; rf2-3eplfk repro 1: `[:a :b :c] -> [:X :a :c]` ⇒ `[[0] :+ :X] [[2] :-]`.
+  ;; :b (before-idx 1) is removed; :X added; :a/:c survive. Pre-fix struck
+  ;; :c (a SURVIVOR) and never surfaced :b.
+  (let [before [:a :b :c]
+        after  [:X :a :c]
+        h      (render-vec-diff before after)
+        all    (collect-text h)
+        struck (struck-members h)]
+    (testing "the genuinely-removed member :b is struck"
+      (is (contains? struck ":b") ":b (removed@1) is struck"))
+    (testing "the surviving members are NOT struck (not morphed)"
+      (is (not (contains? struck ":c"))
+          ":c SURVIVES (unmoved at after-idx 2) — must not be struck")
+      (is (not (contains? struck ":a"))
+          ":a SURVIVES (shifted 0→1) — must not be struck")
+      (is (not (contains? struck ":X"))
+          ":X is the inserted element — added, not struck"))
+    (testing "every member still visible somewhere in the tree"
+      (is (re-find #":a" all))
+      (is (re-find #":b" all))
+      (is (re-find #":c" all))
+      (is (re-find #":X" all)))))
+
+(deftest diff-vector-insert-before-double-delete-survivor-not-struck
+  ;; rf2-3eplfk repro 2: `[:a :b :c :d] -> [:X :a :d]` ⇒
+  ;; `[[0] :+ :X] [[2] :-] [[2] :-]`. :b + :c removed; :d SURVIVES.
+  ;; Pre-fix struck :d (a survivor) and dropped :c.
+  (let [before [:a :b :c :d]
+        after  [:X :a :d]
+        h      (render-vec-diff before after)
+        struck (struck-members h)]
+    (testing "the two genuinely-removed members are struck"
+      (is (contains? struck ":b") ":b (removed) is struck")
+      (is (contains? struck ":c") ":c (removed) is struck"))
+    (testing "the surviving :d is NOT struck"
+      (is (not (contains? struck ":d"))
+          ":d SURVIVES at after-idx 2 — must not be struck"))))
+
+(deftest diff-vector-insert-then-tail-delete-shows-dropped-removal
+  ;; rf2-3eplfk repro 3: `[:a :b :c :d] -> [:a :X :b :c]` ⇒
+  ;; `[[1] :+ :X] [[4] :-]`. :d (before-idx 3) removed. Pre-fix DROPPED the
+  ;; removal entirely (edit-index 4 out-of-range vs pristine `(range 4)`),
+  ;; so :d never rendered struck. The fix must surface it.
+  (let [before [:a :b :c :d]
+        after  [:a :X :b :c]
+        h      (render-vec-diff before after)
+        all    (collect-text h)
+        struck (struck-members h)]
+    (testing "the removed :d is struck (not silently dropped)"
+      (is (contains? struck ":d") ":d (removed@3) is struck"))
+    (testing "the survivors are not struck"
+      (is (not (contains? struck ":a")) ":a survives in place — not struck")
+      (is (not (contains? struck ":b")) ":b survives (shifted) — not struck")
+      (is (not (contains? struck ":c")) ":c survives (shifted) — not struck")
+      (is (not (contains? struck ":X")) ":X is inserted — added, not struck"))
+    (testing ":d still visible in the tree"
+      (is (re-find #":d" all) "the dropped element :d appears struck-through"))))
+
 (deftest sequential-diff-children-scattered-removal-shape
   ;; The pure projection-aware child walk directly: for `[:a :b :c :d] ->
   ;; [:a :c]` it emits before-ordered triples with the removed members at


### PR DESCRIPTION
## rf2-3eplfk — P1 xray diff-engine correctness

`tools/xray/src/day8/re_frame2_xray/diff/engine.cljc`. Editscript applies `:+`/`:-` edits **sequentially against an evolving sequence**, so a `:-`'s edit-index is a position *after* prior `:+` inserts shifted it. The prior engine (`replay-vector-deletes`, from rf2-lkehao) replayed **only** the `:-` edits against pristine `(range before-len)`, ignoring interleaved inserts. Correct for delete-only / insert-only scripts (why those tests passed) — **wrong** for mixed insert+delete: it read the wrong slot, struck surviving elements, and silently **dropped** out-of-range removals whose true index sat past `before-len` because a prior `:+` had grown the sequence.

## The unified-replay rework

Replaced `replay-vector-deletes` with a single **`replay-vector-edits`** walk that replays **both `:+` and `:-` in edit-script order** against one evolving slot vector (`(range before-len)` of survivor before-indices + `::insert` markers). It returns `{:removed :slots}`:

- **`resolve-vector-removals`** now takes the recorded `:removed` before-indices directly.
- **`shift-suffixes-for-vector`** now derives the `(was N)` suffix from the same `:slots` (a survivor's before-index or `::insert`), **not** a deletes-then-splice-inserts reconstruction.

Both channels derive from the *one* evolving-survivor walk, so they can never disagree about which slot a `:-` removed (the scar history rf2-1njv97 / yucxn / vu42n was two replays diverging on mixed scripts). `:r` edits stay out of the replay (length-/order-preserving) and are skipped from shift output (classify `:modified`). `project` builds one per-vector-parent grouping; the now-dead `group-edits-by-vector-parent` is removed.

## The 4 mixed-edit regression cases (verified on JVM, Editscript 0.6.5)

| Repro | Edit script | Pre-fix (WRONG) | Post-fix (CORRECT) |
|---|---|---|---|
| `[:a :b :c] → [:X :a :c]` | `[[0] :+ :X] [[2] :-]` | removed `:c`; struck surviving `:c` (`:same-shifted`) | removed **`:b`**; `:X` added@0; `:a` `(was 0)`; `:c` `:same` (unmoved) |
| `[:a :b :c :d] → [:X :a :d]` | `[[0] :+ :X] [[2] :-] [[2] :-]` | removed `:c`+`:d`; **struck surviving `:d`** | removed **`:b`+`:c`**; `:d` survives `(was 3)` |
| `[:a :b :c :d] → [:a :X :b :c]` | `[[1] :+ :X] [[4] :-]` | **DROPPED `:d`'s removal** (idx 4 out-of-range vs `(range 4)`) + phantom shift | removed **`:d`**; `:X` added@1; `:b` `(was 1)`; `:c` `(was 2)` |
| `[:a :b :c :d] → [:X :Y :a :b :d]` | `[[0] :+ :X] [[1] :+ :Y] [[4] :-]` | **DROPPED `:c`'s removal** | removed **`:c`**; `:X`/`:Y` added; `:a`/`:b`/`:d` shifted |

Added as engine `.cljc` tests (`engine_cljs_test.cljc`): the 4 above + a nested-vector-parent (`{:xs …}`) case. Each pins exact `:vector-removals`, per-after-index `op-at`, and `shifted-was-index`, and asserts **no phantom shift** / **no dropped removal**.

## Render test (edn_inspector)

3 `.cljs` render tests mirroring `diff-vector-scattered-removal-strikes-removed-not-survivors` / `diff-removed-vector-element-no-sentinel-leak`, driving the real projection through `render-vec-diff` and asserting via `struck-members` that the **struck element is the genuinely-removed one** and **survivors are not morphed** (incl. the dropped-removal repro: `:d` now renders struck instead of vanishing).

## Spec

Updated `tools/xray/spec/004-App-DB-Diff.md` §Changed-paths to describe the unified `:+`/`:-` replay (superseding the delete-only-then-splice-inserts prose) with the rf2-3eplfk mixed-edit rationale.

## Quality gates (all green)

```
cd implementation && npm run test:cljs
  → Ran 7873 tests containing 32648 assertions. 0 failures, 0 errors.
    (incl. engine_cljs_test + diff_engine_consistency + edn_inspector + the new mixed-edit + render cases)

cd tools/xray && clojure -M:test   # engine is .cljc
  → Ran 1234 tests containing 5621 assertions. 0 failures, 0 errors.
    (+5 new engine tests / +41 assertions over the 1229 baseline; all prior delete-only / insert-only / R5-R8 engine tests stay green)
```