### PR TITLE
fix(story): multiset schema-violation agreement floor (close false-green) (rf2-5mrnwx)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1545,13 +1545,22 @@ an opt-in (rf2-5x1wt.21). It rests on three pieces, all pure data → data:
 - **`run-result` wires the verdict.** A declared expectation that matched a
   violation mints a `:pass` record; an **unmatched** expectation mints a
   `:fail` record — a *missing* expected violation fails the run. The
-  exactly-consumed selectors are passed to the agreement floor
-  (`evidence/tape-shows-failure?`'s `consumed-selectors`), so an
-  exactly-expected violation does **not** trip the floor, while any
-  **unconsumed** violation keeps its selector OUT of that set and the floor
-  fails the run on it. A *different* violation than expected therefore fails
-  twice over (a `:fail` record for the missing expected violation AND the
-  floor on the emitted-but-unexpected one).
+  matcher's **multiset `:unconsumed` vector** — the violations left after the
+  exact pairing, NOT a set-subtraction over the consumed selectors — is the
+  agreement floor's schema signal (`evidence/evidence-shows-failure?`'s
+  `:unconsumed` arity). This is load-bearing: a set of consumed *selectors*
+  collapses duplicates, so when M&lt;N expectations match a selector with N
+  violations the set would falsely excuse **all** N and report `:pass` (the
+  rf2-5mrnwx false-green). Threading the matcher's already-correct multiset
+  `:unconsumed` keeps the (N−M) genuinely-unconsumed violations as a floor
+  signal, so an exactly-expected violation does **not** trip the floor while a
+  partially- or un-consumed one does. A *different* violation than expected
+  therefore fails twice over (a `:fail` record for the missing expected
+  violation AND the floor on the emitted-but-unexpected one). The public
+  `story/tape-shows-failure?` keeps its set-keyed `consumed-selectors`
+  convenience arity (the caller-supplied escape hatch, correct when at most
+  one violation exists per selector); `run-result` also subtracts that
+  caller-supplied set from the multiset `:unconsumed` before the floor.
 
 **Rollback does not hide a violation.** The floor reads the retained epoch
 *tape*, not the final app-db. A handler whose schema validation failed but

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -773,17 +773,39 @@
   raw-tape convenience that projects then delegates here.
 
   `epoch-tape` is still needed for the `:outcome` check (a per-epoch slot,
-  not one of the projected vectors); `violations` / `effects` are the
-  projected `schema-violations` / `effects` outputs; `consumed-selectors`
-  is the set of violation selectors the run's `:rf.assert/schema-error`
-  expectations exactly consumed (subtracted from the violation signal so an
-  EXPECTED schema failure does not trip the floor)."
-  [epoch-tape violations effects consumed-selectors]
-  (let [unconsumed (remove #(contains? consumed-selectors (:selector %)) violations)]
-    (boolean
-      (or (seq unconsumed)
-          (some failed-outcome? epoch-tape)
-          (some error-effect? effects)))))
+  not one of the projected vectors); `effects` are the projected `effects`
+  output.
+
+  TWO schema-consumption modes (spec/017 §Schema rule step 4 requires EXACT
+  MULTISET consumption — any violation left UNCONSUMED fails the run):
+
+  - 4-arity `[epoch-tape violations effects consumed-selectors]` — the
+    convenience SET path. `violations` is the full projected
+    `schema-violations` vector; `consumed-selectors` is a SET of selectors to
+    excuse. This collapses duplicate selectors (a selector in the set excuses
+    EVERY same-selector violation), so it is only correct when at most one
+    violation exists per selector OR every same-selector violation is
+    expected. `tape-shows-failure?` delegates here for the public set-keyed
+    API.
+
+  - 5-arity `[epoch-tape unconsumed-violations effects _ :unconsumed]` — the
+    MULTISET path. The caller passes the matcher's already-computed
+    `:unconsumed` violation vector (`result/match-schema-expectations`, an
+    EXACT multiset pairing: N expectations of a selector consume exactly N of
+    that selector's violations). The floor's schema signal is simply
+    `(seq unconsumed-violations)` — no set-subtraction, so N>1 same-selector
+    violations partially consumed by M<N expectations correctly leave (N−M)
+    unconsumed and trip the floor. The `run-result` assembly uses this path
+    so a partially-consumed schema violation is NOT falsely excused
+    (rf2-5mrnwx)."
+  ([epoch-tape violations effects consumed-selectors]
+   (let [unconsumed (remove #(contains? consumed-selectors (:selector %)) violations)]
+     (evidence-shows-failure? epoch-tape unconsumed effects nil :unconsumed)))
+  ([epoch-tape unconsumed-violations effects _ _unconsumed-marker]
+   (boolean
+     (or (seq unconsumed-violations)
+         (some failed-outcome? epoch-tape)
+         (some error-effect? effects)))))
 
 (defn tape-shows-failure?
   "True iff the retained `epoch-tape` carries evidence that the run did NOT

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -738,8 +738,28 @@
         ;; + effects `project-evidence` already derived, not a re-walk of the
         ;; raw tape (the tape is still needed for the per-epoch `:outcome`
         ;; signal). One tape, one projection.
+        ;;
+        ;; The schema-violation floor signal is the matcher's MULTISET
+        ;; `:unconsumed` (the EXACT pairing: N expectations of a selector
+        ;; consume exactly N same-selector violations) — NOT a set-subtraction
+        ;; over `consumed-selectors`. A set collapses duplicate selectors, so
+        ;; M<N expectations of a selector with N violations would falsely
+        ;; excuse ALL N — a partially-consumed schema violation reading green
+        ;; (rf2-5mrnwx false-green). Threading the matcher's already-correct
+        ;; `:unconsumed` (pinned by result_test, pair-expectations) reuses the
+        ;; verified pairing rather than re-deriving, so the floor trips on the
+        ;; (N−M) genuinely-unconsumed violations.
+        ;;
+        ;; The caller-supplied `consumed-selectors` escape hatch still excuses
+        ;; its selectors from the floor: those are pre-computed excuses that
+        ;; never went through the matcher, so they are subtracted (set-keyed,
+        ;; as documented) from the matcher's multiset `:unconsumed`. The UNION
+        ;; surfaced as the result's `:consumed-selectors` is unchanged.
+        unconsumed     (cond->> (:unconsumed schema-match)
+                         (seq consumed-selectors)
+                         (remove #(contains? consumed-selectors (:selector %))))
         tape-red?      (evidence/evidence-shows-failure?
-                         tape violations (:effects evidence-slots) consumed)
+                         tape unconsumed (:effects evidence-slots) nil :unconsumed)
         ;; The agreement floor escalates ONLY a would-be pass — a real
         ;; :fail / :error / :cannot-run already outranks it (the floor never
         ;; downgrades a higher verdict).

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -420,16 +420,24 @@
   (spec/021 §1 — \"schema violations, including consumed expected
   violations\"). Pure data → data.
 
-  A violation is `:consumed?` true iff its `:selector` appears among the
-  selectors a declared `:rf.assert/schema-error` expectation exactly
-  consumed. That set is the run-result's `:consumed-selectors` slot (the
-  agreement-floor set `re-frame.story.result/run-result` surfaces) — the
-  single source of truth, READ here rather than re-derived. A legacy /
-  partial result that predates the slot is tolerated via a fallback that
-  recovers the set from the run's `:rf.assert/schema-error` assertion
-  records (a `:pass` schema-error record consumed the violation whose
-  selector matches its `:actual`, per
-  `re-frame.story.result/schema-error-record`).
+  A violation is `:consumed?` true iff a declared `:rf.assert/schema-error`
+  expectation exactly consumed THAT violation. Consumption is an EXACT
+  MULTISET pairing (spec/017 §Schema rule step 4): N expectations of a
+  selector consume exactly N of that selector's violations, so when M<N
+  expectations match a selector with N violations, only M of the N read
+  `:consumed?` (the remaining N−M are the agreement-floor failure cause).
+  Marking by mere selector-SET membership would falsely mark ALL N consumed
+  and so DISAGREE with the floor (rf2-5mrnwx) — the multiset count comes
+  from the run's `:rf.assert/schema-error :pass` records, one per
+  matched expectation, each carrying the consumed violation's selector as
+  `:actual` (`re-frame.story.result/schema-error-record`).
+
+  The caller-supplied `:consumed-selectors` escape hatch (selectors
+  pre-excused outside the matcher, with NO `:pass` record) still excuses
+  EVERY same-selector violation — set-keyed, matching the floor's treatment
+  of that input. A legacy / partial result that predates the
+  `:consumed-selectors` slot falls back to the same `:pass`-record
+  derivation (multiset).
 
       [{:selector   <selector>
         :where      <surface>
@@ -443,26 +451,46 @@
   the tape carried no schema violations. Pure data → data; JVM-testable."
   [result]
   (let [violations (or (:schema-violations result) [])
-        ;; Read the canonical consumed-selector set the run-result surfaces
-        ;; (single source of truth). Only when the key is ABSENT — a legacy /
-        ;; partial result that predates the slot — fall back to re-deriving it
-        ;; from the `:rf.assert/schema-error :pass` records' `:actual`.
-        consumed   (if (contains? result :consumed-selectors)
-                     (or (:consumed-selectors result) #{})
-                     (into #{}
-                           (comp (filter #(= :rf.assert/schema-error (:assertion %)))
-                                 (filter #(= :pass (or (:status %)
-                                                       (when (:passed? %) :pass))))
-                                 (keep :actual))
-                           (or (:assertions result) [])))]
-    (mapv (fn [{:keys [selector where failing-id reason epoch-id]}]
-            {:selector   selector
-             :where      where
-             :failing-id failing-id
-             :consumed?  (contains? consumed selector)
-             :reason     reason
-             :epoch-id   epoch-id})
-          violations)))
+        ;; The multiset of selectors expectations EXACTLY consumed — one
+        ;; `:rf.assert/schema-error :pass` record per matched expectation,
+        ;; `:actual` = the consumed violation's selector
+        ;; (`result/schema-error-record`). `frequencies` gives the per-selector
+        ;; consumed COUNT so M<N consumption marks exactly M of N same-selector
+        ;; violations (the agreement-floor multiset, not a set).
+        consumed-freqs (frequencies
+                         (into []
+                               (comp (filter #(= :rf.assert/schema-error (:assertion %)))
+                                     (filter #(= :pass (or (:status %)
+                                                           (when (:passed? %) :pass))))
+                                     (keep :actual))
+                               (or (:assertions result) [])))
+        ;; The caller-supplied escape-hatch selectors: in `:consumed-selectors`
+        ;; but with NO matching `:pass` record (pre-excused outside the
+        ;; matcher). These excuse EVERY same-selector violation (set-keyed,
+        ;; mirroring the floor). When the slot is absent (legacy result) there
+        ;; is no escape hatch — the `:pass`-record multiset is authoritative.
+        escape-hatch   (into #{}
+                             (remove consumed-freqs)
+                             (when (contains? result :consumed-selectors)
+                               (or (:consumed-selectors result) #{})))
+        ;; Sequential multiset consumption: walk violations in tape order,
+        ;; decrementing each selector's remaining consumed budget so exactly
+        ;; the first N occurrences of a selector read `:consumed?`.
+        step       (fn [{:keys [budget acc]} {:keys [selector] :as v}]
+                     (let [remaining (get budget selector 0)
+                           consumed? (or (pos? remaining)
+                                         (contains? escape-hatch selector))]
+                       {:budget (if (pos? remaining)
+                                  (update budget selector dec)
+                                  budget)
+                        :acc    (conj acc
+                                      {:selector   selector
+                                       :where      (:where v)
+                                       :failing-id (:failing-id v)
+                                       :consumed?  consumed?
+                                       :reason     (:reason v)
+                                       :epoch-id   (:epoch-id v)})}))]
+    (:acc (reduce step {:budget consumed-freqs :acc []} violations))))
 
 (defn cannot-run-rows
   "Project the run-result's `:cannot-run` slot (the per-requirement refusal

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -310,6 +310,36 @@
                [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]})]
       (is (= :fail (:status r)))))
 
+  (testing "rf2-5mrnwx — TWO same-selector violations PARTIALLY consumed by ONE
+            expectation FAILS the run (the floor reads the matcher's MULTISET
+            :unconsumed, not a set-subtraction that would falsely excuse both)"
+    ;; The exact false-green repro from the bead: 2× :event :x schema
+    ;; violations + 1× [:rf.assert/schema-error {:where :event :event :x}]
+    ;; expectation. The set-keyed floor dropped BOTH violations (selector held
+    ;; once) and reported :pass; the multiset floor leaves the 2nd unconsumed.
+    (let [r (result/run-result
+              {:epoch-tape [(schema-epoch :event :x) (schema-epoch :event :x)]
+               :schema-expectations
+               [[:rf.assert/schema-error {:where :event :event :x}]]})]
+      (is (= :fail (:status r))
+          "one of two same-selector violations is UNCONSUMED → the floor fails the run")
+      (is (= 2 (count (:schema-violations r))) "both violations stay projected")
+      ;; the single expectation still PASSES its own assertion (it consumed one
+      ;; violation); it is the floor — not the assertion — that fails the run.
+      (is (= :pass (:status (first (filter #(= :rf.assert/schema-error (:assertion %))
+                                           (:assertions r)))))
+          "the matched expectation's record is :pass; the floor escalates the run")))
+
+  (testing "rf2-5mrnwx — TWO same-selector violations FULLY consumed by TWO
+            expectations PASSES (multiset balance: N expectations, N violations)"
+    (let [r (result/run-result
+              {:epoch-tape [(schema-epoch :event :x) (schema-epoch :event :x)]
+               :schema-expectations
+               [[:rf.assert/schema-error {:where :event :event :x}]
+                [:rf.assert/schema-error {:where :event :event :x}]]})]
+      (is (= :pass (:status r))
+          "both violations exactly consumed → the floor does not trip")))
+
   (testing "final app-db ROLLBACK does not hide the violation — the tape retains
             it even when the epoch outcome is :ok and app-db is clean"
     (let [tape [(epoch {:db-after {:clean true}        ; rolled-back, acceptable db

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -1033,50 +1033,52 @@
       (is (true?  (:consumed? (first rows)))  "exactly-consumed expected violation")
       (is (false? (:consumed? (second rows))) "unconsumed → agreement-floor failure")
       (is (= "invalid role" (:reason (second rows))))))
-  (testing "rf2-uyebc — schema-rows READS the result's `:consumed-selectors`
-            slot (single source of truth) rather than re-deriving it"
+  (testing "rf2-5mrnwx — schema-rows uses the EXACT MULTISET consumption from
+            the `:pass` schema-error records, so a partially-consumed selector
+            marks exactly M of N (not all) and AGREES with the agreement floor"
+    ;; TWO same-selector violations, ONE matching expectation → exactly one
+    ;; consumed, one unconsumed. A set-keyed mark would falsely show BOTH
+    ;; consumed and disagree with the (now multiset) floor.
+    (let [result {:schema-violations
+                  [{:selector [:event :x] :where :event :failing-id :x :epoch-id 1}
+                   {:selector [:event :x] :where :event :failing-id :x :epoch-id 2}]
+                  :consumed-selectors #{[:event :x]}
+                  :assertions
+                  [{:assertion :rf.assert/schema-error :status :pass
+                    :actual [:event :x]}]}
+          rows   (test-mode/schema-rows result)]
+      (is (= 2 (count rows)))
+      (is (true?  (:consumed? (first rows)))
+          "first of the two same-selector violations is the consumed one")
+      (is (false? (:consumed? (second rows)))
+          "second same-selector violation left UNCONSUMED → floor failure cause")))
+  (testing "rf2-uyebc — a consumed-selector with NO matching `:pass` record is
+            a caller-supplied escape hatch and excuses every same-selector
+            violation (set-keyed, mirroring the floor)"
     (let [result {:schema-violations
                   [{:selector [:event :auth/login] :where :event
                     :failing-id :auth/login :epoch-id 3}
                    {:selector [:app-db [:user] [:role]] :where :app-db
                     :failing-id nil :epoch-id 4 :reason "invalid role"}]
+                  ;; escape-hatch excuses the first selector (no :pass record)
                   :consumed-selectors #{[:event :auth/login]}
                   :assertions []}
           rows   (test-mode/schema-rows result)]
-      (is (true?  (:consumed? (first rows)))  "selector in :consumed-selectors")
+      (is (true?  (:consumed? (first rows)))  "escape-hatch selector excused")
       (is (false? (:consumed? (second rows)))
-          "selector absent from :consumed-selectors")))
-  (testing "rf2-uyebc — when `:consumed-selectors` and the `:actual` of a
-            `:pass` schema-error record DIVERGE, schema-rows trusts the
-            canonical slot (proving it no longer re-derives from `:actual`)"
-    (let [result {:schema-violations
-                  [{:selector [:event :auth/login] :where :event}
-                   {:selector [:app-db [:user] [:role]] :where :app-db}]
-                  ;; canonical set consumes the SECOND selector …
-                  :consumed-selectors #{[:app-db [:user] [:role]]}
-                  ;; … but a stale `:pass` record's `:actual` names the FIRST.
-                  ;; If schema-rows re-derived from `:actual` the first row
-                  ;; would read :consumed?; reading the slot, the SECOND does.
-                  :assertions
-                  [{:assertion :rf.assert/schema-error :status :pass
-                    :actual [:event :auth/login]}]}
-          rows   (test-mode/schema-rows result)]
-      (is (false? (:consumed? (first rows)))
-          "first selector NOT in :consumed-selectors despite matching :actual")
-      (is (true?  (:consumed? (second rows)))
-          "second selector IS in :consumed-selectors — slot is authoritative")))
-  (testing "rf2-uyebc — empty `:consumed-selectors` present ⇒ nothing consumed
-            (the slot is honoured even when empty; no fallback re-derivation)"
+          "selector absent from :consumed-selectors → unconsumed")))
+  (testing "rf2-uyebc — empty `:consumed-selectors`: a `:pass` record still
+            carries the multiset consumption (one matched expectation = one
+            consumed violation), so the matched violation reads consumed"
     (let [result {:schema-violations
                   [{:selector [:event :auth/login] :where :event}]
                   :consumed-selectors #{}
-                  ;; a :pass record exists, but the empty slot wins
                   :assertions
                   [{:assertion :rf.assert/schema-error :status :pass
                     :actual [:event :auth/login]}]}
           rows   (test-mode/schema-rows result)]
-      (is (false? (:consumed? (first rows)))
-          "empty :consumed-selectors ⇒ no re-derivation, nothing consumed")))
+      (is (true? (:consumed? (first rows)))
+          "the `:pass` record's consumed violation reads consumed (multiset source)")))
   (testing "no violations → empty"
     (is (= [] (test-mode/schema-rows {})))))
 


### PR DESCRIPTION
## What

Closes the P1 false-green at the Story evidence boundary (rf2-5mrnwx). A run that emitted an **unconsumed** schema-validation-failure could report `:status :pass`.

### Root cause
`run-result` (result.cljc) discarded the matcher's exact multiset `:unconsumed` and passed only a **set** of consumed selectors to the agreement floor. `evidence/evidence-shows-failure?` then did `(remove #(contains? consumed-selectors (:selector %)) violations)`. When N>1 violations share ONE selector but only M<N expectations consume it, the set holds the selector once, so the `remove` dropped **all N** — including the (N−M) genuinely-unconsumed ones — and the floor never tripped. spec/004 §schema-error + spec/017 §Schema rule step 4 require EXACT MULTISET consumption (any violation left unconsumed fails the run).

### The floor fix
Thread the matcher's already-correct multiset `:unconsumed` (`result/match-schema-expectations`, pinned by `result_test`) straight into the floor via a new `:unconsumed` arity on `evidence-shows-failure?` — the schema signal is simply `(seq unconsumed-violations)`, **no set-subtraction**. The caller-supplied `consumed-selectors` escape hatch is still honoured (set-keyed, subtracted from the multiset `:unconsumed` before the floor). The public `story/tape-shows-failure?` keeps its set-keyed convenience arity unchanged.

### The test_mode fix
`ui/test_mode/pure.cljc` `schema-rows` marked `:consumed?` by selector-SET membership, so both same-selector violations rendered consumed — disagreeing with the (now multiset) floor. It now reads the EXACT MULTISET from the run's `:rf.assert/schema-error :pass` records (one per matched expectation, `:actual` = consumed selector) via sequential per-selector consumption, so exactly M of N read consumed. A slot selector with no matching `:pass` record is the caller escape hatch and excuses all same-selector violations.

### Spec
`spec/017-Testing-Story.md` §schema-violation-invariant updated to document the multiset floor wiring (the prior set-subtraction text described the false-green). spec/004 already said "multiset-consumption match" and defers to 017.

### Regression (proves `:fail`)
- `result_test`: the exact bead repro — 2× `:event :x` violations + 1 `[:rf.assert/schema-error {:where :event :event :x}]` expectation — now returns `:fail`, with both violations still projected and the single expectation's record still `:pass` (it is the **floor**, not the assertion, that escalates the run). Plus the fully-consumed (2 violations + 2 expectations) case stays `:pass`.
- `story_ui_test`: pins the multiset `schema-rows` marking (1 of 2 same-selector violations consumed; escape-hatch and `:pass`-record-as-multiset cases).

## Quality gates (all green)

```
cd implementation && npm run test:cljs
# Ran 7865 tests containing 32590 assertions. 0 failures, 0 errors.

cd tools/story && clojure -M:test
# Ran 1705 tests containing 6316 assertions. 0 failures, 0 errors.
```

REPL-verified the bead repro returns `:status :fail` / 2 violations projected.