### PR TITLE
fix(pair-mcp): carry :pred in watch-epochs continuation cursor + count elided markers pre-dedup (rf2-mb17rj)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -1560,7 +1560,12 @@ The cursor's payload (base64-encoded EDN; subject to change behind the
 opaque boundary) carries the last-emitted epoch-id plus sticky window
 fields (`:ms`, `:until-ms`, `:frame`) so subsequent pages see the same
 window the first call did — fresh epochs landing during pagination
-don't sneak in mid-iteration.
+don't sneak in mid-iteration. `watch-epochs` additionally stickies its
+`:pred` filter in the cursor (rf2-mb17rj): a continuation that passes
+back only `:cursor` keeps filtering by the first call's predicate.
+Without this the second page would silently degrade to match-all and
+return every epoch after the watermark unfiltered, with an envelope
+indistinguishable from a correctly-filtered page.
 
 ### Cursor staleness
 
@@ -1682,8 +1687,10 @@ loop should call us repeatedly with the same `since-id`.
 
 **Args**: `since-id` (string, optional — omit to start fresh; supplanted
 by `cursor` when both are supplied), `pred` (object, optional predicate
-filter, keys from: `:event-id`, `:event-id-prefix`, `:effects`,
-`:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`,
+filter — sticky across cursor pagination, encoded in the cursor on the
+first call (rf2-mb17rj), so a continuation passing back only `:cursor`
+keeps the same filter; keys from: `:event-id`, `:event-id-prefix`,
+`:effects`, `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`,
 `:timing-ms`), `frame` (string — frame-id, colon-tolerant:
 `"rf/default"` and `":rf/default"` resolve identically, rf2-lbm21),
 `limit` (int, default 50 — see §Cursor pagination above), `cursor`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -70,7 +70,7 @@
         mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         dedup?    (args/parse-bool-arg raw-args :dedup)
         limit     (cursor/parse-limit-arg (wire/arg raw-args :limit))
-        pred-map  (when-let [p (wire/arg raw-args :pred)] (js->clj p :keywordize-keys true))
+        pred-arg  (when-let [p (wire/arg raw-args :pred)] (js->clj p :keywordize-keys true))
         cursor-in (cursor/decode-cursor (wire/arg raw-args :cursor))]
     (if (= cursor-in ::cursor/malformed)
       (js/Promise.resolve
@@ -80,12 +80,23 @@
             ;; so the agent's continuation flow stays consistent.
             effective-after (or (:after-id cursor-in) since-id)
             sticky-frame    (or (:frame cursor-in) frame)
+            ;; rf2-mb17rj — sticky `:pred`, mirroring the
+            ;; `:frame`/`:after-id` pattern above and trace-window's
+            ;; sticky `:ms`/`:until-ms`. The cursor encodes the
+            ;; first-call predicate; a continuation that passes back
+            ;; ONLY `:cursor` (the documented opaque-cursor flow)
+            ;; restores it here. Without this, page 2+ fell back to
+            ;; `(or pred-map {})` = `{}` = MATCH-ALL — every epoch
+            ;; after the watermark returned unfiltered, with an
+            ;; envelope identical to a correctly-filtered page so the
+            ;; agent couldn't detect the drop.
+            sticky-pred     (or (:pred cursor-in) pred-arg)
             epochs-since-call (if sticky-frame
                                 (ef/rt-call 'epochs-since effective-after sticky-frame)
                                 (ef/rt-call 'epochs-since effective-after))
             matches-form (str "(filterv #"
                               (ef/emit (ef/rt-call 'epoch-matches?
-                                                   (or pred-map {})
+                                                   (or sticky-pred {})
                                                    (ef/rt-raw "%")))
                               " (:epochs r))")
             history-call (if sticky-frame
@@ -145,7 +156,13 @@
                                          :after-id next-id
                                          :ms       nil
                                          :until-ms nil
-                                         :frame    sticky-frame}))
+                                         :frame    sticky-frame
+                                         ;; rf2-mb17rj — carry the sticky
+                                         ;; predicate so page 2+ keeps
+                                         ;; filtering. nil when no pred was
+                                         ;; supplied (round-trips losslessly
+                                         ;; through the base64-of-EDN codec).
+                                         :pred     sticky-pred}))
                       remaining     (or (:remaining v) 0)
                       history-count (or (:history-count v) 0)
                       since-count   (or (:since-count v) 0)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -181,7 +181,18 @@
         ;; :elided-large counts upstream-pre-elided markers per
         ;; Spec 009 §Indicator field (rf2-8cntr) — shared by
         ;; `trace-window` and `watch-epochs`.
-        elided         (base-elision/count-elided-markers deduped)]
+        ;;
+        ;; rf2-mb17rj — count the markers over the PRE-dedup payload
+        ;; (`encoded`), not `deduped`. `dedup-value` pools N identical
+        ;; `:rf.size/large-elided` maps into ONE structural-sharing
+        ;; cache entry, so walking `deduped` undercounts (1 instead of
+        ;; N). The marker SET is identical pre/post dedup — dedup only
+        ;; re-shapes structural references; it never drops a marker —
+        ;; so counting pre-dedup is exact and the markers still ride the
+        ;; wire intact. Mirrors the `:snapshot-map` arm, which already
+        ;; sidesteps this by using the server `:server-elided` count
+        ;; taken before dedup.
+        elided         (base-elision/count-elided-markers encoded)]
     {:value      deduped
      :indicators {:dropped dropped
                   :elided  elided

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cursor_pagination_test.cljs
@@ -15,8 +15,11 @@
   output. The live runtime call sits behind the nREPL eval boundary
   and is covered by the stdio-roundtrip harness; this layer pins the
   cursor contract."
-  (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame2-pair-mcp.tools.cursor :as cursor]))
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.cursor :as cursor]
+            [re-frame2-pair-mcp.tools.watch-epochs :as we]))
 
 (def default-limit cursor/default-limit)
 
@@ -401,3 +404,125 @@
     (is (not (contains? all-ids "epoch-104")))
     (is (= 50 (count all-ids))
         "Page 1 + page 2 = original 50 records, no admission of fresh ones")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-mb17rj — watch-epochs carries the sticky :pred in the continuation
+;; cursor.
+;;
+;; THE BUG: `watch-epochs`'s first-call `:next-cursor` encoded :after-id /
+;; :frame but NOT the predicate, and the host derived the filter ONLY from
+;; the `:pred` arg. An agent paginating via the documented opaque-cursor
+;; flow (pass back JUST `:cursor`, no `:pred`) kept the sticky frame but
+;; LOST the predicate → page 2+ ran `epoch-matches?` with `{}` = MATCH-ALL,
+;; returning every epoch after the watermark unfiltered, with an envelope
+;; identical to a correctly-filtered page so the agent couldn't detect it.
+;;
+;; These pins exercise BOTH ends of the round-trip:
+;;   1. The first-call `:next-cursor` actually carries the predicate.
+;;   2. A page-2 call with ONLY `:cursor` (no `:pred` arg) still emits a
+;;      filtering `epoch-matches?` form — the sticky pred from the cursor,
+;;      NOT the match-all `{}`.
+;; ---------------------------------------------------------------------------
+
+(defn- with-form-capture!
+  "Install a `nrepl/cljs-eval-value` stub that answers the runtime
+  preload-probe with `true` and the real epoch form with `canned`,
+  capturing the NON-probe (epoch) form-strings into `forms-atom`.
+  Restores the original in `.finally`. Mirrors the substr-matching
+  installer in `watch_epochs_test`; here we additionally need the form
+  string, not just the value. The probe form is identified by the
+  `__re_frame2_pair_runtime` marker so it is neither captured nor
+  answered with the matches map (which `runtime-preloaded?` would read
+  as a failed probe)."
+  [forms-atom canned body-fn]
+  (let [orig  nrepl/cljs-eval-value
+        probe? (fn [form-str]
+                 (and (string? form-str)
+                      (re-find #"__re_frame2_pair_runtime" form-str)))
+        answer (fn [form-str]
+                 (if (probe? form-str)
+                   true
+                   (do (swap! forms-atom conj form-str)
+                       canned)))
+        stub  (fn
+                ([_conn _build-id form-str]
+                 (js/Promise.resolve (answer form-str)))
+                ([_conn _build-id form-str _opts]
+                 (js/Promise.resolve (answer form-str))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(deftest watch-epochs-next-cursor-carries-pred
+  (testing "first-call :next-cursor round-trips the :pred so page 2 can resume filtered"
+    (async done
+      (let [forms (atom [])
+            ;; Runtime form output: a page with a :next-id so a
+            ;; continuation cursor is minted.
+            canned {:matches       [{:epoch-id :e1}]
+                    :id-aged-out?  false
+                    :requested-id  nil
+                    :head-id       :e2
+                    :next-id       :e1
+                    :history-count 5
+                    :since-count   5
+                    :remaining     4}]
+        (-> (with-form-capture! forms canned
+              (fn []
+                (-> (we/watch-epochs-tool
+                      nil
+                      (tu/args->js {:pred #js {:event-id ":ev/login"} :limit 1}))
+                    (.then (fn [result]
+                             (let [edn         (tu/extract-edn result)
+                                   next-cursor (:next-cursor edn)
+                                   decoded     (cursor/decode-cursor next-cursor)]
+                               (is (some? next-cursor) "a continuation cursor was minted")
+                               ;; `js->clj :keywordize-keys true` keywordizes
+                               ;; the KEYS only — the pred VALUE rides as the
+                               ;; JSON string it arrived as (the runtime side
+                               ;; coerces). The cursor round-trips it verbatim.
+                               (is (= {:event-id ":ev/login"} (:pred decoded))
+                                   "the cursor carries the first-call predicate verbatim")
+                               (is (= :e1 (:after-id decoded)))
+                               (done))))))))))))
+
+(deftest watch-epochs-page-2-with-only-cursor-still-filters
+  (testing "page-2 call with ONLY :cursor (no :pred arg) emits a filtering epoch-matches? form, NOT match-all"
+    (async done
+      (let [forms (atom [])
+            ;; A cursor as it would have been minted on page 1, carrying
+            ;; the sticky predicate (and frame/after-id). This is exactly
+            ;; what the agent passes back verbatim.
+            page-1-cursor (cursor/encode-cursor
+                            {:v 1 :after-id :e1 :ms nil :until-ms nil
+                             :frame :rf/default
+                             :pred {:event-id :ev/login}})
+            canned {:matches       []
+                    :id-aged-out?  false
+                    :requested-id  :e1
+                    :head-id       :e9
+                    :next-id       nil
+                    :history-count 9
+                    :since-count   4
+                    :remaining     0}]
+        (-> (with-form-capture! forms canned
+              (fn []
+                ;; The continuation call passes ONLY :cursor — no :pred,
+                ;; no :frame, no :since-id. The documented opaque-cursor
+                ;; flow.
+                (-> (we/watch-epochs-tool nil (tu/args->js {:cursor page-1-cursor}))
+                    (.then (fn [_result]
+                             (let [form-str (first @forms)]
+                               (is (some? form-str) "a runtime form was emitted")
+                               ;; THE REGRESSION ASSERTION: the emitted
+                               ;; epoch-matches? call carries the sticky
+                               ;; predicate from the cursor.
+                               (is (re-find #"epoch-matches\? \{:event-id :ev/login\}"
+                                            form-str)
+                                   "page-2 form filters by the sticky pred from the cursor")
+                               ;; And NOT the match-all empty map — the
+                               ;; pre-fix behaviour.
+                               (is (not (re-find #"epoch-matches\? \{\}" form-str))
+                                   "page-2 form must NOT degrade to match-all {}")
+                               (done))))))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_test.cljs
@@ -1,0 +1,106 @@
+(ns re-frame2-pair-mcp.wire-pipeline-test
+  "Correctness unit tests for `wire-pipeline/run-wire-pipeline`
+  indicator counting on the `:epoch-vector` arm (rf2-mb17rj).
+
+  The `:epoch-vector` arm (trace-window / watch-epochs) walks the
+  payload locally for the `:elided-large` indicator — the count is NOT
+  pre-shipped from the runtime (unlike `:snapshot-map` / `:scalar-value`,
+  which carry `:server-elided`).
+
+  THE BUG (rf2-mb17rj, LOW): the arm counted markers over the
+  POST-dedup payload. `day8/de-dupe` pools N identical
+  `:rf.size/large-elided` maps into ONE structural-sharing cache entry,
+  so a payload with N identical markers reported `:elided-large == 1`
+  instead of N. The markers themselves rode the wire intact (no
+  data-loss / leak) — only the scalar indicator undercounted.
+
+  THE FIX: count over the PRE-dedup (`encoded`) payload. The marker
+  SET is identical pre/post dedup (dedup only re-shapes structural
+  references; it never drops a marker), so the pre-dedup count is
+  exact.
+
+  These pin `run-wire-pipeline` directly — the pure transform — rather
+  than through the live nREPL eval boundary (covered by the
+  stdio-roundtrip harness)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.mcp-base.elision :as base-elision]
+            [re-frame2-pair-mcp.tools.dedup :as dedup]
+            [re-frame2-pair-mcp.tools.wire-pipeline :as wp]))
+
+(defn- large-marker
+  "A `:rf.size/large-elided` marker as `rf/elide-wire-value` emits it
+  (Spec 009 §Size elision in traces). `path` distinguishes the handle;
+  pass the SAME path to all records to make the marker maps EQUAL so
+  dedup pools them — the exact pre-fix undercount trigger."
+  [path]
+  {:rf.size/large-elided
+   {:path path :bytes 102400 :type :string
+    :handle [:rf.elision/at path]}})
+
+(defn- epoch-with-marker
+  "An epoch record carrying an IDENTICAL large-elided marker in its
+  `:db-before` (which diff-encode preserves verbatim). `:db-after`
+  equals `:db-before`, so the intra-record diff is empty and the
+  marker survives only on `:db-before`. Three such records share one
+  marker map by equality."
+  [n marker]
+  {:epoch-id  n
+   :event-id  (keyword (str "ev" n))
+   :db-before {:slot marker}
+   :db-after  {:slot marker}})
+
+;; ---------------------------------------------------------------------------
+;; rf2-mb17rj — :elided-large counts EVERY marker, not the deduped count.
+;; ---------------------------------------------------------------------------
+
+(deftest epoch-vector-counts-all-elided-markers-pre-dedup
+  (testing "3 records each carrying an identical large-elided marker → :elided-large == 3 (dedup on)"
+    (let [marker (large-marker [:slot])
+          epochs (vec (for [n (range 3)] (epoch-with-marker n marker)))
+          {:keys [indicators]}
+          (wp/run-wire-pipeline epochs {:kind   :epoch-vector
+                                        :incl?  false
+                                        :mode   :diff
+                                        :dedup? true})]
+      (is (= 3 (:elided indicators))
+          "every one of the 3 identical markers is counted, NOT pooled to 1 by dedup")
+      ;; Guard against a regression that re-walks the deduped payload:
+      ;; that path collapses the 3 equal markers to a single cache
+      ;; entry, so the walker would see 1.
+      (is (= 3 (count epochs)) "fixture sanity: 3 records"))))
+
+(deftest epoch-vector-dedup-of-equal-markers-would-undercount-without-fix
+  (testing "the deduped payload genuinely pools the 3 equal markers — proving the fix is load-bearing"
+    (let [marker  (large-marker [:slot])
+          epochs  (vec (for [n (range 3)] (epoch-with-marker n marker)))
+          encoded (dedup/diff-encode-epochs epochs :diff)
+          deduped (dedup/dedup-value encoded true)]
+      ;; The pre-fix code walked `deduped` and would have returned 1
+      ;; here; the fix walks `encoded` and returns 3.
+      (is (= 1 (base-elision/count-elided-markers deduped))
+          "dedup pools the 3 equal markers → walking the deduped payload undercounts to 1 (the bug)")
+      (is (= 3 (base-elision/count-elided-markers encoded))
+          "walking the pre-dedup payload counts all 3 (the fix)"))))
+
+(deftest epoch-vector-elided-count-stable-with-dedup-off
+  (testing "dedup off → no pooling → :elided-large == 3 either way"
+    (let [marker (large-marker [:slot])
+          epochs (vec (for [n (range 3)] (epoch-with-marker n marker)))
+          {:keys [indicators]}
+          (wp/run-wire-pipeline epochs {:kind   :epoch-vector
+                                        :incl?  false
+                                        :mode   :diff
+                                        :dedup? false})]
+      (is (= 3 (:elided indicators))
+          "with dedup off the count is unchanged — the fix is dedup-invariant"))))
+
+(deftest epoch-vector-no-markers-counts-zero
+  (testing "marker-free payload → :elided-large == 0 (the common path)"
+    (let [epochs [{:epoch-id 1 :event-id :ev1 :db-before {:a 1} :db-after {:a 2}}
+                  {:epoch-id 2 :event-id :ev2 :db-before {:a 2} :db-after {:a 3}}]
+          {:keys [indicators]}
+          (wp/run-wire-pipeline epochs {:kind   :epoch-vector
+                                        :incl?  false
+                                        :mode   :diff
+                                        :dedup? true})]
+      (is (= 0 (:elided indicators))))))


### PR DESCRIPTION
Implements **rf2-mb17rj** — two confirmed correctness defects in `tools/re-frame2-pair-mcp`.

## The cursor fix (MEDIUM — pagination correctness)

`watch-epochs`'s first-call `:next-cursor` encoded `:after-id`/`:frame` but **not** the predicate, and the host derived the filter only from the `:pred` arg. An agent paginating via the documented opaque-cursor flow (pass back just `:cursor`) kept the sticky frame but **lost the predicate** — page 2+ ran `epoch-matches?` with `{}` = **match-all**, returning every epoch after the watermark unfiltered. The envelope was identical to a correctly-filtered page, so the agent could not detect the drop.

Fix: encode `:pred` into `next-cursor` and restore it on decode via `(or (:pred cursor-in) pred-arg)`, mirroring the existing `:frame`/`:after-id` sticky pattern and trace-window's sticky `:ms`/`:until-ms` (the cursor is opaque — passed back verbatim).

## The indicator fix (LOW — `:elided-large` undercount)

`run-epoch-vector` counted `:rf.size/large-elided` markers over the **post-dedup** payload. `day8/de-dupe` pools N identical marker maps into one structural-sharing cache entry, so the scalar `:elided-large` indicator reported `1` not `N`. **Not a leak / data-loss** — the markers ride the wire intact; only the scalar indicator undercounted.

Fix: count over the **pre-dedup** (`encoded`) payload. The marker set is identical pre/post dedup (dedup only re-shapes structural references; it never drops a marker), so the pre-dedup count is exact. Mirrors the `:snapshot-map` arm, which already sidesteps this via the server `:server-elided` count taken before dedup.

## Tests

- **2-page pred-continuation regression** (`cursor_pagination_test.cljs`): the first-call cursor round-trips the predicate, and a page-2 call with **only** `:cursor` (no `:pred` arg) emits a filtering `epoch-matches? {…}` form, **not** match-all `{}`.
- **3-record elided-large test** (`wire_pipeline_test.cljs`, new): 3 records sharing one identical large-elided marker yield `:elided-large == 3` with dedup on; a companion pin proves the deduped payload genuinely pools to `1` (the fix is load-bearing) and that the count is dedup-invariant.

## Spec

`003-Tool-Catalogue.md` §Cursor pagination + the `watch-epochs` `:pred` arg note now document the sticky-predicate contract (standing pair-mcp spec rule). The `:elided-large` pre/post-dedup counting is an internal impl detail not specified in the spec — no spec change there.

The 5 suspected-LOW items deferred on 4abndd were **not** actioned.

## Quality gates (all green)

```
cd implementation && npm run test:cljs
  Ran 7865 tests containing 32590 assertions. 0 failures, 0 errors.

tools/re-frame2-pair-mcp — npm test
  Ran 1097 tests containing 3628 assertions. 0 failures, 0 errors.

tools/mcp-conformance — npm test
  ALL CONFORMANCE TESTS GREEN
  (incl. pair-mcp end-to-end, callTool coverage ratchet 29/29,
   wire-vocab JVM: 93 tests / 922 assertions, 0 failures)
```