### PR TITLE
test(scripts): harden gate holes — CRLF job-scope + shell-opt/trusted-exemption regex (rf2-8ng3e1)

### DIFF
--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -575,9 +575,13 @@ function storyXrayJobBlock(workflow) {
   const start = workflow.indexOf('\n  story-xray-browser:');
   assert.notEqual(start, -1, 'story-xray-browser job not found in test.yml');
   // The next top-level job starts at the next `\n  <name>:` at 2-space
-  // indent. Find it from just after the job header.
+  // indent. Find it from just after the job header. The workflow file is
+  // CRLF, so the line break after the next job header is `\r\n` — match
+  // `\r?\n` (mirroring jobBlock) or the search never matches and this
+  // returns the whole rest-of-file, letting a later job's step satisfy a
+  // story-xray-browser assertion (rf2-8ng3e1).
   const rest = workflow.slice(start + 1);
-  const nextJob = rest.search(/\n {2}[A-Za-z0-9_-]+:\n/);
+  const nextJob = rest.search(/\n {2}[A-Za-z0-9_-]+:\r?\n/);
   return nextJob === -1 ? rest : rest.slice(0, nextJob);
 }
 

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -94,7 +94,15 @@ function gateScriptFiles() {
   return [...cjsFilesIn(SCRIPTS_DIR), ...cjsFilesIn(EXAMPLES_SCRIPTS_DIR)];
 }
 
-const SHELL_OPT_RE = /\bshell\s*:\s*(true|isWin)\b/;
+// Any `shell:` option whose RHS is NOT the literal `false` is a
+// violation. The earlier `(true|isWin)` enumeration only caught the two
+// forms the audit happened to see, so a future `shell: process.platform
+// === 'win32'` / `shell: useShell` / `shell: 1` + a bare-name exe would
+// slip the rf2-33vvc command-hijack class. Forbid every truthy/dynamic
+// RHS; only `shell: false` (and absence of the option) is allowed
+// (rf2-8ng3e1). The `(?!false\b)` negative lookahead lets `false` pass
+// while rejecting any other non-whitespace RHS token.
+const SHELL_OPT_RE = /\bshell\s*:\s*(?!false\b)\S/;
 // A `.cmd`-suffixed npx literal — `'npx.cmd'` / `"npx.cmd"`. Always a
 // violation: the Windows `.cmd` shim only ever needs naming when you
 // spawn it directly under a shell, which every hardened form avoids.
@@ -106,12 +114,28 @@ const NPX_CMD_LITERAL_RE = /(['"])npx\.cmd\1/;
 const NPX_BARE_LITERAL_RE = /(['"])npx\1/;
 const TRUSTED_EXE_RE = /resolveTrustedExe/;
 const CROSS_SPAWN_RE = /cross-spawn|crossSpawn/;
+// The bare-'npx' exemption is name-whitelisted to the single blessed
+// launcher. The exemption was previously earned file-WIDE by any file
+// merely MENTIONING resolveTrustedExe + cross-spawn, so a file routing
+// ONE spawn through the blessed posture won a blanket bare-'npx' pass for
+// a SEPARATE, unrouted spawn elsewhere in the same file. Pinning the
+// exemption to the audited file (test-mcp-conformance.cjs, which routes
+// every spawn through resolveTrustedExe + crossSpawn.sync) closes that
+// cross-file slip: any other launcher that grows a bare 'npx' is now a
+// violation regardless of which helpers it imports (rf2-8ng3e1).
+const TRUSTED_RESOLUTION_FILES = new Set(['test-mcp-conformance.cjs']);
 
 for (const file of gateScriptFiles()) {
   const base = path.basename(file);
   const code = stripComments(fs.readFileSync(file, 'utf8'));
+  // The exemption is gated on the file NAME (the audited, whole-file-
+  // routed launcher) AND on it still carrying the trusted-resolution
+  // posture — so even the blessed file loses the pass if it ever drops
+  // resolveTrustedExe / cross-spawn (rf2-8ng3e1).
   const usesTrustedResolution =
-    TRUSTED_EXE_RE.test(code) && CROSS_SPAWN_RE.test(code);
+    TRUSTED_RESOLUTION_FILES.has(base) &&
+    TRUSTED_EXE_RE.test(code) &&
+    CROSS_SPAWN_RE.test(code);
 
   test(`${base}: no shell:true / shell:isWin spawn (rf2-wn4o1 / rf2-33vvc)`, () => {
     assert.doesNotMatch(


### PR DESCRIPTION
Closes **rf2-8ng3e1**. Three regression-window gate holes — all GREEN today; these fixes prevent FUTURE false-greens. Each verified by constructing the would-slip input and proving the hardened gate now rejects it.

## 1. CRLF scope-bleed (MEDIUM) — `_changed-surfaces.test.cjs` `storyXrayJobBlock`
The next-job search `/\n {2}[A-Za-z0-9_-]+:\n/` lacked the `\r?` that the sibling `jobBlock` helper already carries. `test.yml` is CRLF, so the search never matched → the helper returned the whole rest-of-file (15 job headers), and the PR-job-content assertions scanned a bled tail (moving `test:xray-feature-gate:smoke` or `test:story-play-scripts` out of the PR job into a later job would still pass).

**Fix:** `/\n {2}[A-Za-z0-9_-]+:\r?\n/`.

**Verified against the real CRLF `test.yml`:** the fixed block returns ONLY the story-xray-browser job (7253 chars, **0** sibling job headers; ends at its own `retention-days` step) vs. the buggy block's 69034 chars / 15 headers. A mutated workflow relocating the smoke step into a later sibling job is now REJECTED (buggy regex would have false-greened it).

## 2. shell-opt enumeration (LOW) — `_script-spawn-policy.test.cjs` `SHELL_OPT_RE`
Matched only `true|isWin`, so a future `shell: <other-truthy>` (`process.platform === ...`, `useShell`, `1`) + a bare-name exe would slip the rf2-33vvc command-hijack class.

**Fix:** `/\bshell\s*:\s*(?!false\b)\S/` — forbids every non-`false` RHS.

**Verified:** `shell: false` / `shell:false` pass; `shell: true`, `shell: isWin`, `shell: process.platform === "win32"`, `shell: useShell`, `shell: 1`, `shell:opts.shell` all now rejected.

## 3. trusted-resolution exemption (LOW) — `_script-spawn-policy.test.cjs`
`usesTrustedResolution` was computed file-WIDE (any file merely *mentioning* `resolveTrustedExe` + `cross-spawn`) and early-returned, so a file routing ONE spawn through the blessed posture earned a blanket bare-`'npx'` pass for a SEPARATE, unrouted spawn.

**Fix:** name-whitelisted the exemption to the audited `test-mcp-conformance.cjs` (still gated on it carrying the posture), closing the cross-file slip. Confirmed `test-mcp-conformance.cjs` is the only file with both the posture and a bare-`npx` literal today.

**Verified:** blessed file stays exempt; an impostor launcher that imports the posture for one spawn but holds a separate bare-`npx` is now REJECTED; the blessed file loses the exemption if it ever drops the posture.

The 3 SUSPECTED deferred items noted in the bead are NOT actioned here.

## Quality gates (all green)
```
cd implementation && npm run test:script-policy && npm run test:script-helpers
```
- `npm run test:script-policy` → EXIT 0 (changed-surfaces: 110 passed, script-spawn-policy: 119 passed)
- `npm run test:script-helpers` → EXIT 0
- `node scripts/_changed-surfaces.test.cjs` (direct) → EXIT 0, 110 passed — confirms the CRLF job-scope now isolates the story-xray job
- `node scripts/_script-spawn-policy.test.cjs` (direct) → EXIT 0, 119 passed