### PR TITLE
fix(examples): realworld EditorSlice schema + realworld_resources page-1 cache-key (rf2-01jbr9)

### DIFF
--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -208,8 +208,11 @@
    [:submit-error [:maybe :string]]])
 
 (def EditorSlice
+  ;; NOTE: the state vocabulary (`:mode` = :create/:edit, lifecycle `:status`)
+  ;; lives in the :ui/article-editor machine snapshot (runtime-db), NOT this
+  ;; app-db slice — see `editor-slice` in article_editor.cljs (:54-67), whose
+  ;; map never carries `:mode`/`:status`. The slice carries only the data.
   [:map
-   [:mode [:enum :create :edit]]
    [:slug [:maybe :string]]
    [:draft [:map
             [:title :string]
@@ -222,7 +225,6 @@
                [:body :string]
                [:tagList :string]]]
    [:submitted [:maybe :any]]
-   [:status :keyword]
    [:errors :map]
    [:touched [:set :keyword]]
    [:submit-attempted? {:optional true} :boolean]

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -171,7 +171,10 @@
          A fresh `:loaded` entry the route already ensured is a cache-hit; a
          logged-out resolution fail-closes."}
   (fn [{rt :rf.db/runtime} _]
-    (let [page (get-in rt [:rf.runtime/routing :current :query :page])]
+    ;; Default to page 1 so the ensure hits the SAME `{:page 1}` key the home
+    ;; route + feed subscription use on the canonical no-`?page=` URL — a raw
+    ;; nil would ensure an orphan `{:page nil}` entry (rf2-01jbr9).
+    (let [page (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)]
       {:fx [[:dispatch [:rf.resource/ensure
                         {:resource :realworld/feed
                          :params   {:page page}

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -62,7 +62,13 @@
     ;; into identity. Every server-visible list option participates in the
     ;; cache key (Spec 016 §Paginated and previous data).
     :params    (fn [route] {:tag  (tag-fn route)
-                            :page (get-in route [:query :page])})
+                            ;; Default to page 1 so the canonical no-`?page=`
+                            ;; URL owns the SAME `{:page 1}` key the views
+                            ;; subscribe through (`(or (:page q) 1)`); a raw
+                            ;; nil would mint a `{:page nil}` entry no view
+                            ;; reads, leaving first-page lists permanently
+                            ;; empty (rf2-01jbr9).
+                            :page (or (get-in route [:query :page]) 1)})
     :blocking? true
     :keep-previous? true}
    {:resource  :realworld/tags
@@ -78,7 +84,9 @@
    ;; into params here like every other paginated list.
    {:resource  :realworld/feed
     :scope     {:from-db :realworld/session}
-    :params    (fn [route] {:page (get-in route [:query :page])})
+    ;; Default to page 1 — the feed subscription reads `(or (:page q) 1)`
+    ;; too, so the route must own `{:page 1}` on the bare URL (rf2-01jbr9).
+    :params    (fn [route] {:page (or (get-in route [:query :page]) 1)})
     :blocking? false
     :keep-previous? true}])
 
@@ -168,8 +176,9 @@
      :params    (fn [route] {:username (get-in route [:params :username])})
      :blocking? true}
     {:resource  :realworld/author-articles
+     ;; Default to page 1 to match the view's `(or (:page q) 1)` key (rf2-01jbr9).
      :params    (fn [route] {:username (get-in route [:params :username])
-                             :page     (get-in route [:query :page])})
+                             :page     (or (get-in route [:query :page]) 1)})
      :blocking? false
      :keep-previous? true}]})
 
@@ -189,8 +198,9 @@
      :params    (fn [route] {:username (get-in route [:params :username])})
      :blocking? true}
     {:resource  :realworld/favorited-articles
+     ;; Default to page 1 to match the view's `(or (:page q) 1)` key (rf2-01jbr9).
      :params    (fn [route] {:username (get-in route [:params :username])
-                             :page     (get-in route [:query :page])})
+                             :page     (or (get-in route [:query :page]) 1)})
      :blocking? false
      :keep-previous? true}]})
 

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -361,7 +361,10 @@
       ;; ensure the session feed under the principal-switch lease the app uses
       (rf/dispatch-sync [:auth/ensure-session-feed] {:frame f})
       (reply-success! @last-managed-args {:articles [{:slug "x"}] :articlesCount 1} f)
-      (let [fk (feed-key "alice" nil)]
+      ;; :auth/ensure-session-feed defaults `:page` to 1 (rf2-01jbr9) so it hits
+      ;; the SAME canonical `{:page 1}` key the home route + feed subscription
+      ;; use on the no-`?page=` URL — assert against that key, not `{:page nil}`.
+      (let [fk (feed-key "alice" 1)]
         (is (some? (entry f fk)) "the session feed entry exists for alice")
         ;; also seed a PUBLIC global read so we can prove logout leaves it alone
         (rf/dispatch-sync [:rf.resource/ensure


### PR DESCRIPTION
Fixes two confirmed demo-breaking bugs in the reagent RealWorld examples (rf2-01jbr9). Examples are test-free so CI missed both; both are one-line fixes.

## [1] examples/reagent/realworld — EditorSlice schema rejects every `[:editor]` write
`EditorSlice` (schema.cljs) required non-optional `[:mode [:enum :create :edit]]` + `[:status :keyword]`, but `editor-slice` (article_editor.cljs:54-67) never produces `:mode`/`:status` — the state vocabulary migrated into the `:ui/article-editor` machine snapshot (runtime-db), per the slice docstring. `:mode` is read back from the machine snapshot at `:editor/submit` (article_editor.cljs:284), never from app-db. So every `[:editor]` write (`:editor/initialise`, `:load-article`, `:loaded`, `:submit-success`, `:delete-success`) failed the path-based app-db schema (Spec 010) and rolled back the `:db` effect under the dev build (`goog.DEBUG` default) — the editor never populated a loaded article and never persisted.

**Fix:** dropped `:mode`/`:status` from `EditorSlice` (they are fully machine-owned now — verified `editor-slice` and the machine before relaxing) rather than `{:optional true}`, per bead guidance.

## [2] examples/reagent/realworld_resources — page-1 resource cache-key mismatch
The route resource `:params` fns owned the cache key with a raw `(get-in route [:query :page])` = `nil` on the canonical no-`?page=` URL, but every view subscribes through a defaulted `(or (:page q) 1)` and reads the `{:page 1}` key. `{:page nil}` ≠ `{:page 1}` (the params-schema `[:page {:optional true} [:maybe :int]]` makes present-nil valid and uncoerced; canonicalization preserves value semantics). So the route owned an orphan `{:page nil}` entry no view ever read — first-page home global list + Your Feed + both profile tabs rendered permanently empty/skeleton; page 2+ worked; back-to-page-1 re-broke.

**Fix:** defaulted `:page` to 1 at all 5 cited param-fn sites — `routing.cljs:65/81/172/193` (home/feed/author-articles/favorited-articles) + `auth.cljs:174` (`:auth/ensure-session-feed`) — so the owned key matches the subscribed `{:page 1}`.

## Test follow-on
The `logout-clears-the-session-scoped-feed` unit test asserted against the old buggy `{:page nil}` feed key minted by `:auth/ensure-session-feed`; updated it to `{:page 1}` to match the corrected event. (The `favorite-populates-...` test keeps `{:page nil}` — it hand-ensures that key directly in the test via `:rf.resource/ensure {:params {:page nil}}`, not via the app event, so it is unaffected.)

## Verification (examples are test-free — reasoned + unit-test-backed)
- Fix [1]: the `editor-flow-gates-submit-and-reply-to-navigates` CLJS test drives `:editor/initialise` → `:edit-field` → `:submit` and reads back through subs — exercises the `[:editor]` writes under the dev schema validation. Green.
- Fix [2]: the `logout`/`:auth/ensure-session-feed` CLJS test now proves the feed entry lands on the `{:page 1}` key (no orphan `{:page nil}`). Green.

## Gates
\`\`\`
cd implementation && npm run test:examples && npm run test:cljs
\`\`\`
- `npm run test:examples` → 3 adapter specs, 0 failures (204 files compiled, 0 warnings); EXIT=0
- `npm run test:cljs` → Ran 7865 tests containing 32590 assertions. 0 failures, 0 errors.