### PR TITLE
fix(mcp-conformance,spec/009): elision-marker :reason -> :frame/:marks (EP-0015 §8) + live-emission gate (rf2-hvn83u)

### DIFF
--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -2437,7 +2437,7 @@ The walker substitutes large values with a single normative marker shape:
    :bytes  5242880                             ;; pr-str byte count, exact when known
    :type   :string                             ;; one of :map :vector :set :scalar :string
    :digest "sha256:abc123..."                  ;; hex digest, optional (gated on :include-digests?)
-   :reason :schema
+   :reason :frame                              ;; declaration provenance — :frame (frame-declared :large) or :marks (imperative add-marks/set-marks)
    :hint   "Upload preview blob"               ;; copied verbatim from the declaration's :hint slot
    :handle [:rf.elision/at [:user :uploaded-pdf]]}}  ;; EDN form passable to get-path
 ```
@@ -2447,7 +2447,7 @@ The shape is captured normatively at [Spec-Schemas §`:rf/elision-marker`](Spec-
 - **`:path`** — REQUIRED. The **absolute** path inside the snapshot slice (NOT relative to the elision site). An agent that asked for `:path [:user]` and got a marker back at the `:uploaded-pdf` slot sees `:path [:user :uploaded-pdf]`. The handle is copy-pasteable without rebasing.
 - **`:bytes`** — REQUIRED. The `pr-str` byte count of the elided value. Lets an agent decide "fetch anyway" (small enough for this turn) vs "skip" (over the per-turn budget).
 - **`:type`** — REQUIRED. One of `:map`, `:vector`, `:set`, `:scalar`, `:string`. Tells the agent which access pattern to use — a `:vector` is paginatable via `get-path` with an index range; a `:string` of 5MB is not.
-- **`:reason`** — REQUIRED. Always `:schema`; schema metadata is the canonical size-elision declaration source.
+- **`:reason`** — REQUIRED. The declaration **provenance**, one of the closed enum `[:frame :marks]` (normative at [Spec-Schemas §`:rf/elision-marker`](Spec-Schemas.md#rfelision-marker)). Per EP-0015 §8 (*Schemas Describe Shape, Not Public Egress Policy*) the durable size-elision declaration is **frame-owned** — `(rf/reg-frame :app {:large {:app-db [[…]]}})` installs it under `:source :frame` (`re-frame.frame-classification`), so a frame-declared slot emits `:reason :frame`. An imperatively-declared slot (`re-frame.marks` `add-marks` / `set-marks`) emits `:reason :marks`. The pre-EP-0015 `:schema` value is retired: a `reg-app-schema` `{:large? true}` slot prop is no longer a route into the elision registry.
 - **`:hint`** — REQUIRED (may be `nil`). A free-form short string copied verbatim from the Malli slot's `{:hint "..."}` metadata.
 - **`:handle`** — REQUIRED. An EDN vector of shape `[:rf.elision/at <path>]` (or `[:rf.elision/at <path> :as-of-epoch <epoch-id>]` when the marker rides inside a past-epoch payload — see §Composition below). The handle is **a normal EDN vector**, not a tagged literal — agents pattern-match on the leading `:rf.elision/at` keyword without needing a reader hook. The path inside the handle is the same as the marker's `:path` field. Passing the handle to the existing re-frame2-pair-mcp `get-path` tool fetches the literal elided value, subject to that tool's own cap check (a `:rf.mcp/overflow` is the failure mode if the literal is over-cap).
 - **`:digest`** — OPTIONAL. A `sha256:<hex>` content digest, computed only when `:rf.size/include-digests?` is true on the call. Default off because the digest forces a full walk of the elided value, which negates the elision's cost-saving. When enabled (debug builds, integrity-check workflows), callers compare digests across turns to detect change-without-fetch.

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -97,5 +97,21 @@
                        ;; transitive story/implementation tree it pulls is
                        ;; the cost of validating the real builder.
                        day8/re-frame2-story-mcp
-                       {:local/root "../../story-mcp"}}
+                       {:local/root "../../story-mcp"}
+                       ;; rf2-hvn83u — the canonical wire-elision walker
+                       ;; (`re-frame.elision/elide-wire-value`) so the
+                       ;; `:rf.size/large-elided` gate can drive the REAL
+                       ;; emitter LIVE over a frame-declared `:large` slot
+                       ;; and validate the emitted marker against the
+                       ;; `ElisionMarker` schema. Without this gate the
+                       ;; marker was FIXTURE+grep only — exactly why the
+                       ;; pre-EP-0015 `:reason :schema` pin sat stale and
+                       ;; VACUOUS (the canonical schema validated only the
+                       ;; impossible `:schema` shape while the runtime
+                       ;; emitted `:frame`/`:marks`). `:local/root` to core
+                       ;; (not the transitive story-mcp pull) makes the
+                       ;; classpath dependency intentional, mirroring the
+                       ;; diff-encode + de-dupe live-emission gates.
+                       day8/re-frame2
+                       {:local/root "../../../implementation/core"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/cascade_bundle_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/cascade_bundle_test.clj
@@ -195,23 +195,18 @@
     (is (m/validate CascadeBundle
                     (assoc re-frame2-pair-cascade-bundle-fixture
                            :dispatch-id :cart/checkout))
-        "a keyword cascade id (not :ungrouped) is application-shaped and accepted"))
-  (testing "cascade-bundle topics ship under :cascades; frameless under :events"
-    ;; Cascade-bundle topics: the progress payload's slot is :cascades.
-    (let [cascade-tick {:sub-id "sub-1"
-                        :cascades [re-frame2-pair-cascade-bundle-fixture]
-                        :dropped-events 0 :dropped-bytes 0}]
-      (is (vector? (:cascades cascade-tick))
-          ":cascades slot rides as a vector on cascade-bundle topics"))
-    ;; Frameless topic: the progress payload's slot is :events with
-    ;; single trace events (no cascade structure).
-    (let [frameless-tick {:sub-id "sub-2"
-                          :events [{:operation :rf.registry/registered
-                                    :op-type :rf.registry
-                                    :tags {}}]
-                          :dropped-events 0 :dropped-bytes 0}]
-      (is (vector? (:events frameless-tick))
-          ":events slot rides on the :frameless topic — flat trace events")
-      (is (not (contains? (first (:events frameless-tick))
-                          :rf.trace/dispatch-id))
-          "frameless events carry NO :rf.trace/dispatch-id tag"))))
+        "a keyword cascade id (not :ungrouped) is application-shaped and accepted")))
+
+;; rf2-hvn83u (LOW): the former "cascade-bundle topics ship under
+;; :cascades; frameless under :events" testing block was DROPPED — it
+;; asserted `vector?` / `not contains?` over locally hand-built literal
+;; maps (`cascade-tick` / `frameless-tick`), which is tautological: the
+;; values were constructed as vectors / without the key the assertion
+;; checked for, so the block could never fail and observed no real
+;; emitter. The genuine cascade-vs-frameless distinction is pinned by the
+;; two schema-rejection `testing` blocks above (`:ungrouped` rejected on a
+;; CascadeBundle and inside a CascadeBundleVector via the `not-ungrouped?`
+;; predicate). Tying the dropped tautology to a real progress-notification
+;; subscribe-emit projection would require the heavyweight live emitter
+;; and is out of scope for the fixture-drift fix; the schema gates carry
+;; the contract.

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -281,7 +281,7 @@
    [:path    [:vector :any]]
    [:bytes   :int]
    [:type    [:enum :map :vector :set :scalar :string]]
-   [:reason  [:enum :schema]]
+   [:reason  [:enum :frame :marks]]
    [:hint    [:maybe :string]]
    [:handle  [:tuple [:= :rf.elision/at] [:vector :any]]]
    [:digest  {:optional true} :string]])
@@ -593,29 +593,41 @@
 
    {:key      :rf.size/large-elided
     :schema   ElisionMarker
-    ;; Reserved by Conventions / spec; re-frame2-pair-mcp emits today. Two
-    ;; fixtures below represent two distinct emission shapes —
-    ;; schema/string vs schema/map-with-digest (the schema-driven
-    ;; nomination path is the only nomination path post Path-D /
-    ;; rf2-w3n5u).
+    ;; Reserved by Conventions / spec; re-frame2-pair-mcp emits today. The
+    ;; `:reason` slot carries the declaration provenance per EP-0015 §8
+    ;; (rf2-d2r3um): the large declaration is now FRAME-OWNED (`:source
+    ;; :frame` — `re-frame.frame-classification/install!`), so `:reason`
+    ;; is `:frame` for a frame-declared slot, or `:marks` for an
+    ;; imperative `add-marks`/`set-marks` declaration (`re-frame.marks`).
+    ;; The pre-EP-0015 `:schema` nomination path is gone. Three fixtures
+    ;; below cover both `:reason` variants × two body shapes
+    ;; (string-with-hint / map-with-digest / set-via-marks).
     :servers  #{:re-frame2-pair-mcp}
-    :fixtures {:re-frame2-pair-mcp-schema-string
+    :fixtures {:re-frame2-pair-mcp-frame-string
                {:rf.size/large-elided
                 {:path   [:user :uploaded-pdf]
                  :bytes  102400
                  :type   :string
-                 :reason :schema
+                 :reason :frame
                  :hint   "User-uploaded PDF; fetch via get-path."
                  :handle [:rf.elision/at [:user :uploaded-pdf]]}}
-               :re-frame2-pair-mcp-schema-with-digest
+               :re-frame2-pair-mcp-frame-with-digest
                {:rf.size/large-elided
                 {:path   [:cofx :db]
                  :bytes  524288
                  :type   :map
-                 :reason :schema
+                 :reason :frame
                  :hint   nil
                  :handle [:rf.elision/at [:cofx :db]]
-                 :digest "sha256:deadbeefcafef00d"}}}}
+                 :digest "sha256:deadbeefcafef00d"}}
+               :re-frame2-pair-mcp-marks-set
+               {:rf.size/large-elided
+                {:path   [:scratch :payload]
+                 :bytes  262144
+                 :type   :set
+                 :reason :marks
+                 :hint   "Imperatively marked via set-marks; fetch via get-path."
+                 :handle [:rf.elision/at [:scratch :payload]]}}}}
 
    {:key      :rf.mcp/cache-hit
     :schema   CacheHit

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -93,6 +93,15 @@
             [de-dupe.core    :as dd]
             [malli.core      :as m]
             [malli.error     :as me]
+            ;; rf2-hvn83u — the canonical framework wire-elision walker +
+            ;; the frame-owned classification install path (EP-0015 §8),
+            ;; so the `:rf.size/large-elided` gate drives the REAL emitter
+            ;; LIVE over a frame-declared `:large` slot (not a fixture).
+            [re-frame.core   :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame  :as frame]
+            [re-frame.frame-classification :as frame-class]
+            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.overflow :as mcp-overflow]
             [re-frame.mcp-conformance.fixtures :as fx]
@@ -344,7 +353,7 @@
   (testing "ElisionMarker rejects an extra sibling top-level key"
     (is (not (m/validate ElisionMarker
                          {:rf.size/large-elided {:path [:a] :bytes 1 :type :map
-                                                 :reason :schema :hint nil
+                                                 :reason :frame :hint nil
                                                  :handle [:rf.elision/at [:a]]}
                           :sneaky :key}))))
   (testing "CacheHit rejects an extra sibling top-level key"
@@ -565,10 +574,23 @@
 ;;                           (`mcp-base/overflow.cljc/overflow-payload`)
 ;;                           is additionally exercised live below since
 ;;                           it too is JVM-reachable.
+;;   - :rf.size/large-elided — LIVE here (rf2-hvn83u). Emitter is the
+;;                           framework wire-elision walker
+;;                           (`re-frame.elision/elide-wire-value`, `.cljc`,
+;;                           on the JVM classpath via the `:test` alias's
+;;                           core `:local/root`). Driven below over a
+;;                           frame-declared `:large` slot; the emitted
+;;                           marker is validated against the canonical
+;;                           `ElisionMarker` schema. This gate is exactly
+;;                           what was MISSING when the pre-EP-0015
+;;                           `:reason :schema` pin sat stale — the fixture
+;;                           +grep layers never observed the real emitter,
+;;                           so a `:frame`-emitting runtime validating
+;;                           against a `:schema`-only schema went unseen.
 ;;   - :rf.mcp/summary     — FIXTURE+grep only. Emitter is re-frame2-pair-mcp
 ;;     :rf.mcp/dedup-table   CLJS (`tools/*.cljs`) with no JVM-reachable
 ;;     :rf.mcp/cache-hit     counterpart; a pure-JVM live probe is
-;;     :rf.size/large-elided impossible. Their bodies are pure data
+;;                           impossible. Their bodies are pure data
 ;;                           transforms already unit-tested in mcp-base /
 ;;                           re-frame2-pair-mcp; a live SDK probe for each
 ;;                           is tracked as future work (it requires the
@@ -629,6 +651,91 @@
     (is (m/validate Overflow marker)
         (str "Live-built overflow marker failed Overflow validation:\n"
              (me/humanize (m/explain Overflow marker))))))
+
+;; ---------------------------------------------------------------------------
+;; :rf.size/large-elided — live-emission gate (rf2-hvn83u).
+;;
+;; The load-bearing gate that catches the exact drift this bead fixed: the
+;; canonical schema had `:reason [:enum :schema]` while the runtime emits
+;; `:frame`/`:marks` (EP-0015 §8 — the large declaration is FRAME-OWNED,
+;; not schema-owned). With only a fixture (authored to match the stale
+;; schema) and a source-text grep (literal key only), the schema validated
+;; an IMPOSSIBLE shape and a real `:frame` marker would have FAILED — yet
+;; every gate stayed green. This gate drives the REAL walker
+;; (`re-frame.elision/elide-wire-value`) over a frame-declared `:large`
+;; slot and validates the emitted marker against the canonical
+;; `ElisionMarker` schema, so a `:reason`-enum (or any body-shape) drift
+;; between runtime and schema now turns this gate red.
+;;
+;; Self-contained runtime setup: this artefact's other tests are pure
+;; data and carry no `use-fixtures`, so the gate stands up + tears down
+;; its own minimal frame runtime (mirroring
+;; `implementation/core/test/re_frame/elision_test.clj`'s `reset-runtime`
+;; + `install-class!`).
+
+(defn- elision-live-marker
+  "Drive `re-frame.elision/elide-wire-value` LIVE over a frame-declared
+  `:large` `app-db` slot and return the emitted `:rf.size/large-elided`
+  marker map. `large` is a vector of `:rf/path` vectors installed through
+  the frame-owned classification path (EP-0015 §8). `v` is the wire value
+  walked under the `:rf/default` frame scope."
+  [large v]
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.elision :reload)
+  (elision/clear-warning-cache!)
+  (elision/configure! {:rf.size/threshold-bytes 16384})
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (frame-class/install!
+      :rf/default
+      (frame-class/validate+extract :rf/default {:large {:app-db (vec large)}}))
+    (elision/elide-wire-value v)))
+
+(deftest elision-marker-emitted-live-by-canonical-walker
+  ;; Drive the REAL walker over a frame-declared `:large` slot and assert
+  ;; the emitted marker (a) is the canonical single-key wrapper and (b)
+  ;; validates against the `ElisionMarker` schema — the gate that would
+  ;; have caught the `:reason :schema` → `:frame` drift.
+  (let [out    (elision-live-marker
+                 [[:user :uploaded-pdf]]
+                 {:user {:name "Ada" :uploaded-pdf "<<5MB-blob>>"}})
+        marker (get-in out [:user :uploaded-pdf])]
+    (testing "the walker substitutes a :rf.size/large-elided marker at the declared slot"
+      (is (elision/marker? marker)
+          (str "elide-wire-value MUST substitute a :rf.size/large-elided "
+               "marker at a frame-declared :large slot. Got: " (pr-str marker))))
+    (testing "the live-emitted marker validates against the canonical ElisionMarker schema"
+      (is (m/validate ElisionMarker marker)
+          (str "Live-emitted elision marker failed ElisionMarker validation "
+               "— the canonical schema has drifted from the runtime emitter "
+               "(this is exactly the rf2-hvn83u :reason :schema vs :frame "
+               "drift the fixture+grep layers missed):\n"
+               (me/humanize (m/explain ElisionMarker marker)))))
+    (testing "the live :reason is the frame-owned provenance (EP-0015 §8), NOT the retired :schema"
+      (is (= :frame (get-in marker [:rf.size/large-elided :reason]))
+          (str "A frame-declared :large slot MUST emit :reason :frame "
+               "(EP-0015 §8). Got: "
+               (pr-str (get-in marker [:rf.size/large-elided :reason])))))
+    (testing "the marker carries the absolute declared path"
+      (is (= [:user :uploaded-pdf]
+             (get-in marker [:rf.size/large-elided :path]))))))
+
+(deftest elision-marker-schema-rejects-retired-schema-reason
+  ;; Contrapositive: the corrected `ElisionMarker` schema MUST REJECT the
+  ;; pre-EP-0015 `:reason :schema` shape. This pins that the fix is not
+  ;; merely additive — the impossible runtime shape the old gate uniquely
+  ;; validated is now explicitly out of contract, so a regression that
+  ;; widened `:reason` back to `:schema` turns this gate red.
+  (is (not (m/validate ElisionMarker
+                       {:rf.size/large-elided
+                        {:path   [:user :uploaded-pdf]
+                         :bytes  102400
+                         :type   :string
+                         :reason :schema
+                         :hint   nil
+                         :handle [:rf.elision/at [:user :uploaded-pdf]]}}))
+      ":reason :schema is the retired pre-EP-0015 shape and MUST NOT validate"))
 
 ;; ---------------------------------------------------------------------------
 ;; Source-text vocabulary pin. The literal marker key MUST appear in
@@ -1063,20 +1170,21 @@
                  {:path [:user :pdf]
                   :bytes 102400
                   :type :string
-                  :reason :schema
+                  :reason :frame
                   :hint "User PDF; fetch via get-path."
                   :handle [:rf.elision/at [:user :pdf]]}}
                 :elided-large 1}
                ;; story-mcp emission (rf2-koq5m): `run-variant` /
-               ;; `preview-variant` elide schema-`:large?` / over-threshold
-               ;; `:app-db` leaves and count the `:rf.size/large-elided`
-               ;; markers via `egress/count-elided` (→ mcp-base
-               ;; `count-elided-markers`).
+               ;; `preview-variant` elide frame-declared `:large` /
+               ;; over-threshold `:app-db` leaves (the declaration is
+               ;; frame-owned post EP-0015 §8 — `:reason :frame`) and
+               ;; count the `:rf.size/large-elided` markers via
+               ;; `egress/count-elided` (→ mcp-base `count-elided-markers`).
                :story-mcp-run-variant
                {:status :pass :frame :story.button/primary
                 :app-db {:blob {:rf.size/large-elided
                                 {:path [:blob] :bytes 102400 :type :string
-                                 :reason :schema :hint nil
+                                 :reason :frame :hint nil
                                  :handle [:rf.elision/at [:blob]]}}}
                 :elided-large 1}}}])
 


### PR DESCRIPTION
## What

The runtime is **correct** — `re-frame.elision/->marker` emits `:reason (or reason :frame)` / `:marks` per EP-0015 §8 (the large declaration is frame-owned, `:source :frame`; schema is no longer a route into the elision registry). The mcp-conformance corpus + spec/009 prose tracked the **retired pre-EP-0015 `:schema`** model, making the elision-marker gate **VACUOUS**: `ElisionMarkerBody` pinned `:reason [:enum :schema]`, so it validated only an *impossible* shape while a real `:frame` marker would have **FAILED** — and the fixture+grep layers never observed the real emitter, so the drift was invisible.

## Changes (rf2-hvn83u — all 4 authoritative steps + the LOW item)

1. **`schemas.clj`** — `ElisionMarkerBody` `:reason [:enum :schema]` -> `[:enum :frame :marks]`.
2. **Fixtures** — 5 stale `:reason :schema` -> `:frame` (schemas.clj ×2, wire_vocab_test.clj ×3) + a new `:reason :marks` variant fixture (set body).
3. **spec/009 §Wire marker (HOT-ZONE — surgical)** — the example (`:reason :frame`) and the prose (`"Always :schema..."` -> the closed `[:frame :marks]` provenance enum, cross-linked to `Spec-Schemas §:rf/elision-marker`). Per-marker live-vs-fixture policy note updated to move `:rf.size/large-elided` into the LIVE category.
4. **NEW live-emission gate** — drives the **REAL** walker `re-frame.elision/elide-wire-value` over a frame-declared `:large` slot and validates the emitted marker against `ElisionMarker` (verified: emits `:reason :frame`, validates true; corrected schema rejects `:reason :schema`). Plus a contrapositive deftest. Adds `day8/re-frame2` core as an explicit `:local/root` so the classpath dependency is intentional, mirroring the diff-encode + de-dupe gates. **This is the layer whose absence let the fixture-only drift recur.**
5. **LOW (`cascade_bundle_test.clj`)** — dropped the tautological "cascade-bundle topics ship under :cascades" testing block (asserted `vector?` / `not-contains?` over locally hand-built literal maps); the real cascade-vs-frameless contract is pinned by the `:ungrouped` schema-rejection blocks above.

## Follow-up filed

**rf2-9wvwpa** (P2, discovered-from this bead): `re-frame.schemas/validate.cljc:177-192` emits a SECOND `:rf.size/large-elided` marker with `:reason :schema` (and `:path []`, no `:hint`) for the schema-validation-failure size-safety arm — a third reason value outside `[:frame :marks]` that also omits the required `:hint`. spec/010-Schemas.md:295-307 still documents the retired `:source :schema` route. Out of scope here (this bead is scoped to mcp-conformance + spec/009 + `elide-wire-value`); needs a ruling on whether that's a legit third variant or should align.

## Gates (all green)

\`\`\`
cd implementation && npm run test:cljs
  -> Ran 7865 tests containing 32590 assertions. 0 failures, 0 errors.

tools/mcp-conformance/wire-vocab $ clojure -M:test
  -> Ran 95 tests containing 925 assertions. 0 failures, 0 errors.
     (new live-emission gate green; every-fixture-conforms-to-its-canonical-schema still passes)

rm -rf docs/spec && cp -r spec docs/spec && python -m mkdocs build --strict
  -> Documentation built in ~20s (clean; spec/009 touched)
\`\`\`