### PR TITLE
docs(tools): refresh §Shipped mcp-base namespace count 11->13 (rf2-qsfuvy part A)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -151,7 +151,7 @@ wired into the build, and consumers can use it today.
   [`tools/testbed-support/README.md`](./testbed-support/README.md).
 
 - **`tools/mcp-base/`** — `day8/re-frame2-mcp-base`. Shared primitives
-  for the MCP servers (`re-frame2-pair-mcp`, `story-mcp`): eleven
+  for the MCP servers (`re-frame2-pair-mcp`, `story-mcp`): thirteen
   namespaces — `vocab` (wire-vocabulary constants `:rf.mcp/*`,
   `:rf.size/*`, JSON-RPC error codes), `sensitive` (spec/009 §Privacy
   default-suppress filter), `elision` (`:rf.size/large-elided`
@@ -161,9 +161,11 @@ wired into the build, and consumers can use it today.
   rf2-qeous), `overflow` (overflow-marker payload shape, rf2-rvyzy),
   `cap` (wire-boundary token-budget cap pipeline, rf2-eyelu), `cursor`
   (shared cursor-pagination machinery, rf2-ee38b.19), `envelope`
-  (indicator-field `with-indicators` splice, rf2-ee38b.19), and
+  (indicator-field `with-indicators` splice, rf2-ee38b.19),
   `descriptor-manifest` (tool-descriptor manifest generator +
-  drift-check, rf2-sofwv). Pure `.cljc` with zero runtime deps beyond
+  drift-check, rf2-sofwv), `egress` (EP-0015 profile-adoption egress
+  filter, rf2-qus09h), and `dedup` (cross-MCP dedup-envelope, lifted
+  rf2-ttspi7). Pure `.cljc` with zero runtime deps beyond
   `org.clojure/clojure`. Per rf2-vw4sq. See
   [`tools/mcp-base/spec/README.md`](./mcp-base/spec/README.md).
 


### PR DESCRIPTION
## What

`tools/README.md` §Shipped — the `tools/mcp-base/` entry said "eleven namespaces" and enumerated 11. The directory now holds 13 `.cljc` namespaces. This PR:

- Updates the count "eleven" -> "thirteen".
- Adds the two missing enumeration entries:
  - `egress` (EP-0015 profile-adoption egress filter, rf2-qus09h)
  - `dedup` (cross-MCP dedup-envelope, lifted rf2-ttspi7)

Doc-only: one prose word + two list entries.

## Verified namespace count on disk

```
$ ls tools/mcp-base/src/re_frame/mcp_base/*.cljc
args  cap  cursor  dedup  descriptor_manifest  diff_encode  egress
elision  envelope  overflow  section_grouping  sensitive  vocab
```

13 files -> "thirteen". Enumeration now matches one-to-one.

## Scope note

This is **part (A) only** of rf2-qsfuvy. **Part (B)** — `:machines-viz-viewer` build automation in the hot-zone `shadow-cljs.edn` — **remains deferred** (a small design decision; not auto-actioned per the bead). Not touched here.

## Quality gates

`tools/README.md` is **not** in the docs tree: `mkdocs.yml` has `docs_dir: docs` and the nav contains no reference to `tools/README.md`. The standing `rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict` gate copies `spec/` only and does not include `tools/README.md`, so this file is not part of the mkdocs build. No build gate applies to this doc-only change.