### PR TITLE
refactor(security-tests): lift contains-sentinel?/redacted?/large-marker? to security.gen (rf2-n5bkm7)

### DIFF
--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -61,7 +61,6 @@
   egress is out of scope and not gold-plated."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [clojure.walk :as walk]
             [re-frame.core :as rf]
             ;; Publishes the Malli late-bind validate/explain/sensitive hooks;
             ;; without it `route-url` soft-passes (no validation throw) and the
@@ -100,17 +99,11 @@
 
 (defn- contains-sentinel?
   "Deep-walk `x`; true when the sentinel string appears anywhere (as a
-  value, inside a collection, or inside a stringified form)."
+  value - matched as a SUBSTRING - inside a collection, or inside a
+  stringified form). Thin wrapper over the shared `gen/contains-string?`
+  (rf2-n5bkm7); the sentinel is matched as a substring (`exact? false`)."
   [x]
-  (let [hit (volatile! false)]
-    (walk/postwalk
-      (fn [node]
-        (when (and (string? node) (re-find (re-pattern sentinel) node))
-          (vreset! hit true))
-        node)
-      x)
-    (or @hit
-        (boolean (re-find (re-pattern sentinel) (pr-str x))))))
+  (gen/contains-string? x sentinel false))
 
 ;; ===========================================================================
 ;; SITE 1 — :rf.error/machine-action-exception :exception-data

--- a/implementation/security/test/re_frame/security/gen.cljc
+++ b/implementation/security/test/re_frame/security/gen.cljc
@@ -25,7 +25,8 @@
   space, swept reproducibly. For security boundaries that is the right
   shape - we want broad casing/shape coverage, and a hostile-input corpus
   (in each surface's test ns) pins the named regression cases exactly."
-  (:refer-clojure :exclude [rand-nth]))
+  (:refer-clojure :exclude [rand-nth])
+  (:require [clojure.walk :as walk]))
 
 ;; ---------------------------------------------------------------------------
 ;; Seeded PRNG - a 32-bit LCG (numerical-recipes constants). Deterministic
@@ -167,3 +168,52 @@
            (cond-> {:fail v :index i :seed seed}
              threw (assoc :threw threw))))
        nil))))
+
+;; ---------------------------------------------------------------------------
+;; Shared egress-scan helpers - lifted from the per-surface security test
+;; namespaces, which each hand-copied a structurally identical deep
+;; `contains-sentinel?` plus the `redacted?` / `large-marker?` one-liners
+;; (rf2-n5bkm7). Consolidating them here removes the maintenance-only risk of
+;; one copy gaining a leak-class fix the siblings silently miss.
+;;
+;; Each surface keeps its OWN per-file sentinel string local and calls
+;; `(contains-string? x sentinel exact?)`, passing `exact?` to preserve that
+;; surface's per-node matching: some surfaces match the sentinel as an EXACT
+;; string equality on each walked leaf (`exact? true`), others as a SUBSTRING
+;; (`exact? false`, the `re-find` form - catches a sentinel embedded inside a
+;; larger leaf). Either way the `pr-str` fallback always uses a SUBSTRING scan,
+;; so a sentinel surviving inside a non-string leaf (a keyword/symbol form
+;; built from it, or a stringified collection) is still caught.
+;; ---------------------------------------------------------------------------
+
+(defn contains-string?
+  "Deep-walk `x`; true when `needle` appears anywhere - as a value, inside a
+  collection, or inside a stringified form. When `exact?` is truthy, a walked
+  STRING leaf matches only on exact `=` equality with `needle`; otherwise a
+  leaf matches when `needle` is a SUBSTRING of it (`re-find`). The `pr-str`
+  fallback always uses a substring scan, so `needle` surviving inside a
+  non-string leaf (e.g. a keyword/symbol form built from it) is also caught."
+  [x needle exact?]
+  (let [hit (volatile! false)]
+    (walk/postwalk
+      (fn [node]
+        (when (and (string? node)
+                   (if exact?
+                     (= needle node)
+                     (re-find (re-pattern needle) node)))
+          (vreset! hit true))
+        node)
+      x)
+    (or @hit
+        (boolean (re-find (re-pattern needle) (pr-str x))))))
+
+(defn redacted?
+  "True when `v` is the redaction sentinel keyword `:rf/redacted`."
+  [v]
+  (= :rf/redacted v))
+
+(defn large-marker?
+  "True when `v` is a structural large-elision marker (a map carrying
+  `:rf.size/large-elided`)."
+  [v]
+  (and (map? v) (contains? v :rf.size/large-elided)))

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -47,7 +47,6 @@
   (see PR Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
-            [clojure.walk :as walk]
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.security.gen :as gen]))
 
@@ -83,8 +82,8 @@
 (defn- contains-sentinel?
   "Deep-walk `x`; true when the sentinel string appears ANYWHERE — as a
   value, inside a collection, in a secondary slot (`:tags :received`), or
-  inside a stringified form. Mirrors the deep-scan helper the sibling
-  security namespaces (error-slot / http-body egress) use.
+  inside a stringified form. Thin wrapper over the shared
+  `gen/contains-string?` (rf2-n5bkm7).
 
   Why a deep scan and not just `:tags :value` + `sensitive-event?`
   (rf2-h2yvs finding 1): the gate-OFF contract is \"the sentinel never
@@ -93,17 +92,11 @@
   `:tags :received`; a survivor with its `:sensitive?` stamp stripped (so it
   no longer classifies sensitive) and the sentinel only in `:received` would
   slip past the narrow checks while this property stayed green. A deep scan
-  catches that secondary-slot leak class."
+  catches that secondary-slot leak class. The sentinel is matched as an EXACT
+  string leaf (`exact? true`); the shared `pr-str` fallback still substring-
+  scans the stringified form."
   [x]
-  (let [hit (volatile! false)]
-    (walk/postwalk
-      (fn [node]
-        (when (and (string? node) (= sentinel node))
-          (vreset! hit true))
-        node)
-      x)
-    (or @hit
-        (boolean (re-find (re-pattern sentinel) (pr-str x))))))
+  (gen/contains-string? x sentinel true))
 
 ;; ---------------------------------------------------------------------------
 ;; Event generators.

--- a/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
@@ -55,7 +55,6 @@
   local revert + restore (see PR Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [clojure.walk :as walk]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.marks :as marks]
@@ -78,19 +77,11 @@
 
 (defn- contains-sentinel?
   "Deep-walk `x`; true when the sentinel appears ANYWHERE (value, nested,
-  stringified). The contract is \"the sentinel never survives the boundary.\""
+  stringified). The contract is \"the sentinel never survives the boundary.\"
+  Thin wrapper over the shared `gen/contains-string?` (rf2-n5bkm7); the
+  sentinel is matched as an EXACT string leaf (`exact? true`)."
   [x]
-  (let [hit (volatile! false)]
-    (walk/postwalk
-      (fn [node]
-        (when (and (string? node) (= sentinel node)) (vreset! hit true))
-        node)
-      x)
-    (or @hit (boolean (re-find (re-pattern sentinel) (pr-str x))))))
-
-(defn- redacted? [v] (= :rf/redacted v))
-(defn- large-marker? [v]
-  (and (map? v) (contains? v :rf.size/large-elided)))
+  (gen/contains-string? x sentinel true))
 
 (def ^:private big-string (apply str (repeat 40000 \x)))
 
@@ -120,9 +111,9 @@
                      :rf.egress/local-redacted]]
       (let [out (rf/project-egress (app-db-value)
                   {:frame :pub/offbox :rf.egress/profile profile})]
-        (is (redacted? (get-in out [:auth :token]))
+        (is (gen/redacted? (get-in out [:auth :token]))
             (str profile ": frame-owned sensitive app-db leaf redacted"))
-        (is (large-marker? (get-in out [:docs :blob]))
+        (is (gen/large-marker? (get-in out [:docs :blob]))
             (str profile ": frame-owned large app-db leaf elided to a marker"))
         (is (= 3 (get-in out [:public :count]))
             (str profile ": unmarked sibling passes through"))
@@ -151,7 +142,7 @@
     (binding [frame/*current-frame* nil]
       (let [out (rf/project-egress (app-db-value)
                   {:rf.egress/profile :rf.egress/off-box-tool})]
-        (is (redacted? out) "frameless egress fails closed to :rf/redacted")
+        (is (gen/redacted? out) "frameless egress fails closed to :rf/redacted")
         (is (not (contains-sentinel? out))))
       ;; The deliberate opt-out: include-sensitive? true gets an identity walk
       ;; against the no-frame policy (the single control point).
@@ -169,7 +160,7 @@
       (let [out (rf/project-egress (app-db-value)
                   {:frame :pub/never-registered
                    :rf.egress/profile :rf.egress/off-box-tool})]
-        (is (redacted? out)
+        (is (gen/redacted? out)
             "an unknown / destroyed frame fails closed, identically to frameless")
         (is (not (contains-sentinel? out)))))))
 
@@ -185,7 +176,7 @@
     (rf/reg-frame :pub/large {:large {:app-db [[:upload]]}})
     (let [out (rf/project-egress {:upload big-string :public "ok"}
                 {:frame :pub/large :rf.egress/profile :rf.egress/off-box-tool})]
-      (is (large-marker? (:upload out)) "the large leaf is a structural marker")
+      (is (gen/large-marker? (:upload out)) "the large leaf is a structural marker")
       (is (not= big-string (:upload out)) "the raw large value is NOT shipped")
       (is (= "ok" (:public out))))))
 
@@ -198,8 +189,8 @@
     (let [out (rf/project-egress {:secret big-string}
                 {:frame :pub/both
                  :rf.egress/profile :rf.egress/off-box-observability})]
-      (is (redacted? (:secret out)) "the both-marked path is :rf/redacted")
-      (is (not (large-marker? (:secret out)))
+      (is (gen/redacted? (:secret out)) "the both-marked path is :rf/redacted")
+      (is (not (gen/large-marker? (:secret out)))
           "NO large marker — no path/size/digest can leak for a sensitive path"))))
 
 ;; ---------------------------------------------------------------------------
@@ -227,7 +218,7 @@
                        (let [out (rf/project-egress value
                                    {:frame fid
                                     :rf.egress/profile :rf.egress/off-box-tool})]
-                         (and (redacted? (get-in out path))
+                         (and (gen/redacted? (get-in out path))
                               (not (contains-sentinel? out)))))))]
       (is (nil? result)
           (str "a declared-sensitive path leaked the sentinel: "
@@ -263,9 +254,9 @@
       (let [projected (rf/project-egress raw-app-db
                         {:frame :pub/snap
                          :rf.egress/profile :rf.egress/off-box-tool})]
-        (is (redacted? (get-in projected [:auth :token]))
+        (is (gen/redacted? (get-in projected [:auth :token]))
             "PUBLIC: project-egress of the snapshot :app-db redacts the sensitive leaf")
-        (is (large-marker? (get-in projected [:docs :blob]))
+        (is (gen/large-marker? (get-in projected [:docs :blob]))
             "PUBLIC: project-egress elides the large leaf")
         (is (not (contains-sentinel? projected))
             "PUBLIC: no sentinel crosses the projected boundary")))))

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -55,7 +55,6 @@
   Confirmed by temporary local revert + restore (see PR Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [clojure.walk :as walk]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
@@ -76,22 +75,12 @@
 (defn- contains-sentinel?
   "Deep-walk `x`; true when the sentinel string appears ANYWHERE — as a
   value, inside a collection, nested in a secondary slot, or inside a
-  stringified form. Mirrors the deep-scan helper the sibling security
-  namespaces (mcp-egress / error-slot / http-body egress) use: the contract
-  is \"the sentinel never survives,\" not merely \"the primary slot reads
-  clean.\""
+  stringified form. The contract is \"the sentinel never survives,\" not
+  merely \"the primary slot reads clean.\" Thin wrapper over the shared
+  `gen/contains-string?` (rf2-n5bkm7); the sentinel is matched as an EXACT
+  string leaf (`exact? true`)."
   [x]
-  (let [hit (volatile! false)]
-    (walk/postwalk
-      (fn [node]
-        (when (and (string? node) (= sentinel node))
-          (vreset! hit true))
-        node)
-      x)
-    (or @hit
-        (boolean (re-find (re-pattern sentinel) (pr-str x))))))
-
-(defn- redacted? [v] (= :rf/redacted v))
+  (gen/contains-string? x sentinel true))
 
 ;; ---------------------------------------------------------------------------
 ;; A frame classifying the reply-VALUE-relative paths the wire slots carry.
@@ -119,9 +108,6 @@
   (rf/reg-frame frame-id
     {:sensitive {:app-db [[:token] [:partner-key] [:detail :token]]}
      :large     {:app-db [[:doc]]}}))
-
-(defn- large-marker? [v]
-  (and (map? v) (contains? v :rf.size/large-elided)))
 
 ;; ---------------------------------------------------------------------------
 ;; PROPERTY 1 — framed trace egress: every wire-bearing slot routes through
@@ -151,13 +137,13 @@
                  :rf.size/include-large?     false})]
       ;; Wire-bearing slots: the declared-sensitive token leaf redacts,
       ;; everywhere it surfaces (value / error / correlation / meta).
-      (is (redacted? (get-in out [:value :token])) ":value sensitive leaf redacted")
-      (is (large-marker? (get-in out [:value :doc])) ":value large leaf elided")
+      (is (gen/redacted? (get-in out [:value :token])) ":value sensitive leaf redacted")
+      (is (gen/large-marker? (get-in out [:value :doc])) ":value large leaf elided")
       (is (= 7 (get-in out [:value :public])) "unmarked sibling rides through")
-      (is (redacted? (get-in out [:error :detail :token])) ":error sensitive leaf redacted")
-      (is (redacted? (get-in out [:correlation :partner-key])) ":correlation sensitive leaf redacted")
+      (is (gen/redacted? (get-in out [:error :detail :token])) ":error sensitive leaf redacted")
+      (is (gen/redacted? (get-in out [:correlation :partner-key])) ":correlation sensitive leaf redacted")
       (is (= "t-1" (get-in out [:correlation :trace-id])) "non-sensitive correlation fact rides")
-      (is (redacted? (get-in out [:meta :token])) ":meta sensitive leaf redacted")
+      (is (gen/redacted? (get-in out [:meta :token])) ":meta sensitive leaf redacted")
       ;; No sentinel survives ANY wire slot.
       (is (not (contains-sentinel? (:value out))))
       (is (not (contains-sentinel? (:error out))))
@@ -206,9 +192,9 @@
                        :work/status :failed}
             out (reply/trace-summary reply-map nil)]
         ;; Every wire slot fails closed to the whole-value sentinel.
-        (is (redacted? (:error out)) ":error fails closed (whole slot redacted)")
-        (is (redacted? (:correlation out)) ":correlation fails closed")
-        (is (redacted? (:meta out)) ":meta fails closed")
+        (is (gen/redacted? (:error out)) ":error fails closed (whole slot redacted)")
+        (is (gen/redacted? (:correlation out)) ":correlation fails closed")
+        (is (gen/redacted? (:meta out)) ":meta fails closed")
         (is (not (contains-sentinel? out)) "no sentinel survives frameless egress")
         ;; Identity facts still ride (framework data is not walked).
         (is (= :error (:status out)))
@@ -380,12 +366,12 @@
           out (rf/project-egress value
                 {:frame :reply/proj
                  :rf.egress/profile :rf.egress/off-box-tool})]
-      (is (redacted? (:token out)) "off-box-tool redacts the sensitive reply leaf")
-      (is (large-marker? (:doc out)) "off-box-tool elides the large reply leaf")
+      (is (gen/redacted? (:token out)) "off-box-tool redacts the sensitive reply leaf")
+      (is (gen/large-marker? (:doc out)) "off-box-tool elides the large reply leaf")
       (is (= 7 (:public out)))
       (is (not (contains-sentinel? out))))
     ;; Frameless project-egress fails closed (no :rf/default synthesis).
     (binding [frame/*current-frame* nil]
       (let [out (rf/project-egress {:token sentinel}
                   {:rf.egress/profile :rf.egress/off-box-observability})]
-        (is (redacted? out) "frameless reply-value egress fails closed")))))
+        (is (gen/redacted? out) "frameless reply-value egress fails closed")))))

--- a/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
@@ -34,7 +34,6 @@
   revert + restore (see PR Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [clojure.walk :as walk]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             ;; Publishes the Malli late-bind validate/explain hooks; without
@@ -80,19 +79,12 @@
 
 (defn- contains-sentinel?
   "Deep-walk `x`; true when the sentinel string appears anywhere (as a
-  value, inside a collection, or inside a stringified form)."
+  value - matched as a SUBSTRING - inside a collection, or inside a
+  stringified form, e.g. a keyword or symbol form built from it). Thin
+  wrapper over the shared `gen/contains-string?` (rf2-n5bkm7); the sentinel
+  is matched as a substring (`exact? false`)."
   [x]
-  (let [hit (volatile! false)]
-    (walk/postwalk
-      (fn [node]
-        (when (and (string? node) (re-find (re-pattern sentinel) node))
-          (vreset! hit true))
-        node)
-      x)
-    ;; Also catch the sentinel surviving inside a non-string leaf via pr-str
-    ;; (e.g. a keyword or symbol form built from it).
-    (or @hit
-        (re-find (re-pattern sentinel) (pr-str x)))))
+  (gen/contains-string? x sentinel false))
 
 ;; ---------------------------------------------------------------------------
 ;; Recursive generator - build [schema db] where a :sensitive? scalar slot

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -55,7 +55,6 @@
   restore (see PR Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [clojure.walk :as walk]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             ;; Publishes the Malli late-bind validate/explain hooks; without
@@ -104,17 +103,11 @@
 
 (defn- contains-sentinel?
   "Deep-walk `x`; true when the sentinel string appears anywhere (as a
-  value, inside a collection, or inside a stringified form)."
+  value - matched as a SUBSTRING - inside a collection, or inside a
+  stringified form). Thin wrapper over the shared `gen/contains-string?`
+  (rf2-n5bkm7); the sentinel is matched as a substring (`exact? false`)."
   [x]
-  (let [hit (volatile! false)]
-    (walk/postwalk
-      (fn [node]
-        (when (and (string? node) (re-find (re-pattern sentinel) node))
-          (vreset! hit true))
-        node)
-      x)
-    (or @hit
-        (re-find (re-pattern sentinel) (pr-str x)))))
+  (gen/contains-string? x sentinel false))
 
 ;; ---------------------------------------------------------------------------
 ;; Trace capture — register a listener, run `f`, return the single


### PR DESCRIPTION
## What

DEDUP test-helper consolidation (rf2-n5bkm7). The deep sentinel-scan helper `contains-sentinel?` was independently hand-copied across **six** security test namespaces — structurally identical deep `postwalk` scans differing only in `=` vs `re-find` matching of a per-file sentinel. The `redacted?` (`= :rf/redacted v`) and `large-marker?` one-liners were additionally copied in two of them (reply-envelope-egress + public-profile-projection).

This lifts them to the shared `re-frame.security.gen` substrate.

## How

- **`gen/contains-string?` `[x needle exact?]`** — the consolidated deep scan, parameterized by an `exact?` flag governing the per-node string comparison: `exact? true` → exact-leaf `=`; `exact? false` → `re-find` substring. The `pr-str` fallback **always** substring-scans (catches a sentinel surviving inside a stringified/keyword form), matching every original copy.
- **`gen/redacted?`** and **`gen/large-marker?`** — the two predicate one-liners.
- Each of the 6 surfaces keeps its **own per-file sentinel string local** and now delegates through a thin one-line `contains-sentinel?` wrapper that pins its original matching semantics:
  - substring (`exact? false`): error-slot-egress, schema-redaction, validation-redaction-invariant
  - exact-leaf (`exact? true`): mcp-egress, public-profile-projection, reply-envelope-egress
- `redacted?`/`large-marker?` call sites rewritten to `gen/redacted?` / `gen/large-marker?`; the local defs removed.
- The now-unused `[clojure.walk :as walk]` require dropped from all 6 files; `gen.cljc` gains it (where the walk now lives).

Behaviour preserved: every original returned a truthy/nil from `contains-sentinel?` (two omitted the `boolean` wrapper); the shared helper returns `boolean`, which is truthiness-identical under all call sites (`not` / `some` / `not-any?`).

## Quality gates (both green)

```
cd implementation && npm run test:cljs && npm run test:security
```

- `npm run test:cljs` — Ran 7873 tests containing 32648 assertions. **0 failures, 0 errors.**
- `npm run test:security` — Ran 86 tests containing 607 assertions. **0 failures, 0 errors.** (security build: 0 warnings — no unused-require fallout from the dropped `clojure.walk`.)

Closes rf2-n5bkm7.