### PR TITLE
fix(http): cross-host Set-Cookie response-header shape parity (rf2-wmdmou)

### DIFF
--- a/implementation/http/src/re_frame/http_transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http_transport_cljs.cljc
@@ -29,11 +29,49 @@
 ;; ---- platform transport: CLJS Fetch ---------------------------------------
 
 #?(:cljs
-   (defn- fetch-headers->map [^js fetch-headers]
+   (defn- fetch-headers->map
+     "Flatten a Fetch `Headers` object into a plain Clojure map, matching
+     the JVM transport's `jvm-headers->map` response-headers SHAPE
+     contract (rf2-0xvm1 / Spec 014 §Request envelope: `string → string`,
+     or `string → vector of strings` for a multi-valued header).
+
+     rf2-wmdmou — cross-host `Set-Cookie` parity. `Headers.forEach`
+     iterates ONE pair per (case-folded) name with multi-valued headers
+     COMMA-FOLDED into a single string — and for `Set-Cookie` specifically
+     the Fetch spec keeps it OUT of the combined view (`forEach` yields
+     only the LAST `Set-Cookie` line; the earlier lines are dropped). That
+     diverged from the JVM, where `jvm-headers->map` rides every wire line
+     of a multi-valued header as a vector element — so a two-cookie
+     response decoded to a 2-element `[\"session=…\" \"csrf=…\"]` vector on
+     the JVM but a single (last-cookie-only) string on CLJS, silently
+     LOSING the first `Set-Cookie` and comma-folding any other repeated
+     header. Comma-folding `Set-Cookie` is itself an RFC 6265 §3 violation
+     (cookie attribute values legally embed commas — `Expires=Wed, 21 Oct
+     …`), the exact hazard rf2-0xvm1 fixed on the JVM.
+
+     The Fetch API exposes `Headers.getSetCookie()` precisely to recover
+     the unfolded `Set-Cookie` lines (browser + Node 18.7+ / undici). We
+     use it to restore the per-line vector shape so a multi-valued
+     `Set-Cookie` decodes IDENTICALLY on both hosts; a single `Set-Cookie`
+     stays a plain string (matching the JVM's single-valued fast path).
+     Other repeated headers remain comma-folded by `forEach` — Fetch
+     offers no unfold for them and that residual is a documented Fetch
+     limitation, not a data-loss bug (only `Set-Cookie` both loses lines
+     AND is RFC-illegal to fold)."
+     [^js fetch-headers]
      (let [out #js {}]
        (.forEach fetch-headers
                  (fn [v k] (aset out k v)))
-       (js->clj out))))
+       (let [m (js->clj out)
+             ;; rf2-wmdmou — recover the unfolded `Set-Cookie` lines so the
+             ;; shape matches the JVM (single → string, multi → vector of
+             ;; the verbatim wire lines, every line preserved).
+             set-cookies (when (fn? (.-getSetCookie fetch-headers))
+                           (vec (.getSetCookie fetch-headers)))]
+         (case (count set-cookies)
+           0 m
+           1 (assoc m "set-cookie" (first set-cookies))
+           (assoc m "set-cookie" set-cookies))))))
 
 #?(:cljs
    (defn cljs-fetch

--- a/implementation/http/test/re_frame/http_set_cookie_parity_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_set_cookie_parity_cljs_test.cljc
@@ -1,0 +1,115 @@
+(ns re-frame.http-set-cookie-parity-cljs-test
+  "rf2-wmdmou — cross-host response-headers SHAPE parity for `Set-Cookie`
+  (Spec 014 §Request envelope: `string → string`, or `string → vector of
+  strings` for a multi-valued header).
+
+  Named `*-cljs-test.cljc` so BOTH cognitect.test-runner (JVM
+  `clojure -M:test`) and shadow-cljs (`npm run test:cljs`, `cljs-test$`
+  ns-regexp) discover it — the contract under test is host-symmetric BY
+  DESIGN, so a single source asserted on both runtimes is the right shape.
+
+  The defect (a CONFIRMED MEDIUM from the tap2r6 http correctness review):
+  the JVM transport's `jvm-headers->map` (rf2-0xvm1) rides every wire line
+  of a multi-valued response header as a vector element — so two
+  `Set-Cookie` lines decode to a 2-element vector, each cookie preserved
+  verbatim. The CLJS transport's `fetch-headers->map` used a bare
+  `Headers.forEach` + `js->clj`, and `forEach` keeps `Set-Cookie` OUT of
+  its combined view: it yields ONLY THE LAST `Set-Cookie` line, silently
+  DROPPING the earlier one(s). A two-cookie 2xx/4xx response therefore
+  decoded to a 2-element vector on the JVM but a single (last-only) string
+  on CLJS — an undocumented, untraced cross-host divergence that LOSES a
+  cookie and contradicts the JVM's RFC-6265-§3-correct shape.
+
+  rf2-wmdmou recovers the unfolded lines on CLJS via
+  `Headers.getSetCookie()` so a multi-valued `Set-Cookie` decodes
+  IDENTICALLY on both hosts (single → string; multi → a vector of the
+  verbatim wire lines, every line preserved)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])
+   #?(:clj  [re-frame.http-transport-jvm :as transport-jvm]
+      :cljs [re-frame.http-transport-cljs :as transport-cljs]))
+  #?(:clj (:import [java.net.http HttpHeaders]
+                   [java.util Map]
+                   [java.util.function BiPredicate])))
+
+;; ---------------------------------------------------------------------------
+;; Per-host adapter: build the host's native response-headers object from a
+;; Clojure `{header-name [wire-line ...]}` map, then run the host's
+;; flatten-to-Clojure-map helper. The ASSERTIONS below are identical across
+;; hosts — that symmetry is the contract.
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (def ^:private flatten-headers @#'transport-jvm/jvm-headers->map))
+
+#?(:cljs
+   (def ^:private flatten-headers @#'transport-cljs/fetch-headers->map))
+
+#?(:clj
+   (defn- decode-headers
+     "Build a real `java.net.http.HttpHeaders` from `{name [v ...]}` and
+     flatten it through the JVM transport's `jvm-headers->map`."
+     [m]
+     (let [java-map (reduce-kv
+                      (fn [^java.util.HashMap acc k vs]
+                        (.put acc k (java.util.ArrayList. ^java.util.Collection vs))
+                        acc)
+                      (java.util.HashMap.)
+                      m)
+           accept-all (reify BiPredicate (test [_ _ _] true))]
+       (flatten-headers (HttpHeaders/of ^Map java-map ^BiPredicate accept-all)))))
+
+#?(:cljs
+   (defn- decode-headers
+     "Build a real Fetch `Headers` from `{name [v ...]}` (`.append` per wire
+     line, mirroring how a response is parsed) and flatten it through the
+     CLJS transport's `fetch-headers->map`."
+     [m]
+     (let [h (js/Headers.)]
+       (doseq [[k vs] m
+               v vs]
+         (.append h k v))
+       (flatten-headers h))))
+
+;; ---------------------------------------------------------------------------
+;; The parity assertions (identical on both hosts)
+;; ---------------------------------------------------------------------------
+
+(deftest single-set-cookie-is-string-cross-host
+  (testing "rf2-wmdmou — a single Set-Cookie line decodes to a plain STRING
+            on both hosts (the single-valued fast path; no spurious
+            1-element vector)"
+    (let [out (decode-headers {"Set-Cookie" ["only=1; Path=/"]})]
+      (is (= "only=1; Path=/" (get out "set-cookie"))
+          "single cookie preserved as a string")
+      (is (string? (get out "set-cookie"))
+          "shape is string, not a 1-element vector"))))
+
+(deftest multi-set-cookie-is-vector-of-verbatim-lines-cross-host
+  (testing "rf2-wmdmou — TWO Set-Cookie lines decode to a 2-element vector of
+            the verbatim wire lines on BOTH hosts. Pre-fix the CLJS host
+            dropped the FIRST cookie and returned only the last as a string;
+            the JVM already rode both as a vector. This is the headline
+            cross-host parity regression."
+    (let [cookies ["session=abc; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT"
+                   "csrf=xyz; Path=/; Expires=Thu, 22 Oct 2026 07:28:00 GMT"]
+          out     (decode-headers {"Set-Cookie" cookies})
+          v       (get out "set-cookie")]
+      (is (vector? v)
+          "multi-valued Set-Cookie MUST be a vector on both hosts — comma-
+           folding violates RFC 6265 §3 (cookie values embed commas) and
+           forEach-folding loses all but the last line")
+      (is (= 2 (count v)) "BOTH cookie lines survive (no dropped first cookie)")
+      (is (= cookies v)
+          "each line preserved verbatim — the comma inside Expires is intact,
+           not interpreted as a separator, and the first line is not lost"))))
+
+(deftest no-set-cookie-leaves-map-untouched-cross-host
+  (testing "rf2-wmdmou — a response with no Set-Cookie decodes its other
+            headers unchanged (the recovery is surgical to Set-Cookie); a
+            single non-cookie header stays a string on both hosts"
+    (let [out (decode-headers {"Content-Type" ["application/json"]})]
+      (is (= "application/json" (get out "content-type")))
+      (is (not (contains? out "set-cookie"))
+          "no spurious set-cookie key is synthesised"))))


### PR DESCRIPTION
## What

Re-located + fixed the CONFIRMED MEDIUM from the tap2r6 http correctness review (the consolidated report summarised away its exact file:line). The defect is a cross-host **response-headers SHAPE parity divergence** for `Set-Cookie`.

## The defect

- **JVM** (`jvm-headers->map`, rf2-0xvm1): rides every wire line of a multi-valued response header as a vector element. Two `Set-Cookie` lines → a 2-element vector, each cookie verbatim (RFC 6265 §3 correct — cookie values legally embed commas).
- **CLJS** (`fetch-headers->map`, pre-fix): bare `Headers.forEach` + `js->clj`. `forEach` keeps `Set-Cookie` OUT of its combined view — it yields **only the LAST** `Set-Cookie` line and **silently DROPS** the earlier one(s).

So a two-cookie response decoded to `["session=…" "csrf=…"]` (vector) on the JVM but `"csrf=…"` (single, last-only string) on CLJS — an undocumented, untraced divergence that **loses a cookie**. These headers flow into the `:rf.http/http-4xx`/`-5xx` failure-reply `:headers` slot (Spec 014 §Failure categories, line 490) and the decode sniff.

Confirmed by repro: Node `Headers.forEach` over two `Set-Cookie` lines yields only the last; `getSetCookie()` returns both.

## The fix

`fetch-headers->map` now recovers the unfolded lines via `Headers.getSetCookie()` (browser + Node 18.7+/undici), producing the **same shape as the JVM**: single → string, multi → a vector of verbatim wire lines (every line preserved). Other repeated headers stay comma-folded by `forEach` — Fetch offers no unfold for them and that residual is a documented Fetch limitation, not data loss (only `Set-Cookie` both loses lines AND is RFC-illegal to fold).

**Spec unchanged**: the `string → (string | vector-of-strings)` multi-valued shape is already normative at spec/014 §Request envelope (line 157); this aligns the CLJS reference's response-header decode to it.

## Regression

`http_set_cookie_parity_cljs_test.cljc` — a host-symmetric `.cljc` asserted on **both** the JVM (`clojure -M:test`) and CLJS (`npm run test:cljs`) runners, pinning single→string, multi→verbatim-line-vector, and no-cookie passthrough identically. Fails against pre-fix CLJS (which dropped the first cookie and returned a string).

## Quality gates

```
cd implementation && npm run test:cljs
# Ran 7876 tests containing 32655 assertions. 0 failures, 0 errors.

cd implementation/http && clojure -M:test
# Ran 452 tests containing 2073 assertions. 0 failures, 0 errors.
```