### PR TITLE
fix(core): no-id reload registry-stale (P1) + recordable Instant + registrar collision gating + fx-override fail-open (rf2-3az1vn)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -613,11 +613,44 @@
                              :recovery       :replaced-with-default})
             original-fx-id))
 
+        ;; `nil` / `false` — the documented noop-style placeholder
+        ;; (spec/002 §`:fx-overrides`): "no override", silently fall
+        ;; through to the original fx. KEPT silent on purpose.
+        (or (nil? override-target) (false? override-target))
+        original-fx-id
+
         :else
-        ;; Neither fn nor keyword — treat as "no override" and fall
-        ;; through to the original fx. Includes `nil` (documented in
-        ;; spec/002 §`:fx-overrides` as a noop-style placeholder).
-        original-fx-id))
+        ;; Any OTHER value (a number / string / map / vector / …) is a
+        ;; malformed `:fx-overrides` entry — an `:fx-overrides` value must
+        ;; be an fx-id keyword (id-redirect), a fn (override body), or
+        ;; nil/false (noop). Fail LOUD, matching the sibling
+        ;; unregistered-keyword branch (rf2-3az1vn P2 + spec/002 §`:fx-overrides`
+        ;; :else throw): emit `:rf.error/override-fallthrough` through BOTH
+        ;; error substrates so a silently-swallowed bad override surfaces in
+        ;; dev AND production observability, then fall through to the original
+        ;; fx (recovery `:replaced-with-default`).
+        (do
+          (emit-fx-error! :rf.error/override-fallthrough
+                          origin-event
+                          origin-event-id
+                          frame-id
+                          nil
+                          {:failing-id    original-fx-id
+                           :overrides-map overrides
+                           :override      override-target
+                           :frame         frame-id
+                           :reason        (str "Override for `"
+                                               original-fx-id
+                                               "` is `"
+                                               (pr-str override-target)
+                                               "`, which is not a valid `:fx-overrides` "
+                                               "value — it must be an fx-id keyword "
+                                               "(id-redirect), a function (override body), "
+                                               "or nil/false (noop). Using the registered `"
+                                               original-fx-id
+                                               "` instead.")
+                           :recovery      :replaced-with-default})
+          original-fx-id)))
     original-fx-id))
 
 (defn- resolved-fx-meta

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -678,22 +678,31 @@
 
 (defn- swap-frame-generation!
   "Swap `new-generation` onto `frame-object`, returning the RELOADED frame
-  object. For an `:id`-bearing frame the live-frame registry slot is updated IN
-  PLACE (the same id keeps naming the same live context, now running the new
-  generation) — but ONLY when the registry currently holds THIS object (so a
-  reload of a stale object handle does not clobber a frame re-registered under
-  the id since). A direct (no-id) frame object's reloaded copy is simply
-  returned for the caller to hold. Returns the reloaded frame object."
+  object. The live-frame registry slot is updated IN PLACE under the frame's
+  `:rf.frame/runnable-id` ADDRESS — the SAME key `make-frame` registered the
+  object under (the public `:rf.frame/id` for an id-bearing frame, a private
+  gensym `:rf.frame/<gensym>` for a no-id direct object). Keying by the
+  runnable-id is what keeps generation routing coherent for a NO-ID frame too:
+  dispatch / subscribe collapse a frame object to its runnable-id and then
+  re-resolve the generation from this registry, so the slot MUST point at the
+  reloaded object or a reloaded no-id frame would resolve the stale OLD image
+  (and a child dispatch carrying the runnable-id likewise). The update is
+  guarded by an `identical?` stale-handle check — applied ONLY when the registry
+  currently holds THIS object — so a reload of a stale object handle does not
+  clobber a frame re-registered under the id since. Returns the reloaded frame
+  object (the caller also holds it directly)."
   [frame-object new-generation]
-  (let [reloaded (swap-generation frame-object new-generation)
-        id       (:rf.frame/id frame-object)]
-    (when (some? id)
+  (let [reloaded    (swap-generation frame-object new-generation)
+        runnable-id (get frame-object frame/runnable-id-key)]
+    (when (some? runnable-id)
       ;; Update the registry slot in place, but only if it still holds THIS
-      ;; object — guards against clobbering a frame re-registered under the id.
+      ;; object — guards against clobbering a frame re-registered under the
+      ;; runnable-id. Applies to id-bearing AND no-id frames: the no-id frame's
+      ;; gensym runnable-id slot is what dispatch/subscribe re-resolve through.
       (swap! live-frames
              (fn [m]
-               (if (identical? frame-object (get m id))
-                 (assoc m id reloaded)
+               (if (identical? frame-object (get m runnable-id))
+                 (assoc m runnable-id reloaded)
                  m))))
     reloaded))
 

--- a/implementation/core/src/re_frame/recordable.cljc
+++ b/implementation/core/src/re_frame/recordable.cljc
@@ -39,8 +39,7 @@
 
   Pure namespace — no runtime state, no trace, no host I/O. `.cljc` so the
   JVM test sweep exercises the walker cross-host."
-  #?(:clj (:import [java.util UUID Date]
-                   [java.time Instant])))
+  #?(:clj (:import [java.util UUID Date])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -52,13 +51,24 @@
      :cljs (uuid? x)))
 
 (defn- inst-leaf?
-  "A `#inst` value: a `java.util.Date` or `java.time.Instant` on the JVM, a
-  `js/Date` on CLJS. `#inst` is a tagged EDN literal, so an instant IS
-  recordable data even though it is a host object — the EDN reader round-trips
-  it. (Contrast a bare host `Date` used as a non-`#inst` opaque handle: there
-  is no such thing — every Date prints / reads as `#inst`.)"
+  "A `#inst` value that ROUND-TRIPS through `pr-str` / `read-string`: a
+  `java.util.Date` on the JVM, a `js/Date` on CLJS. `#inst` is a tagged EDN
+  literal, so such an instant IS recordable data even though it is a host
+  object — the EDN reader's default `#inst` reader returns it unchanged in
+  meaning.
+
+  `java.time.Instant` is DELIBERATELY excluded on the JVM. Although Clojure's
+  `pr-str` prints an `Instant` with the `#inst` tag, the EDN reader's default
+  `#inst` reader produces a `java.util.Date`, NOT an `Instant` — and with no
+  data-reader bound for the tag a bare `read-string` of the printed form throws
+  `No reader function for tag inst`. So an `Instant` does NOT round-trip; treat
+  it as a non-recordable host handle so the failure surfaces AT THE SOURCE
+  coeffect (via `explain-non-recordable`) rather than far away at replay /
+  Xray / SSR / epoch-export time. Authors who genuinely need to record an
+  instant convert to `java.util.Date` (`Date/from`) at the boundary
+  (rf2-3az1vn P2)."
   [x]
-  #?(:clj  (or (instance? Date x) (instance? Instant x))
+  #?(:clj  (instance? Date x)
      :cljs (instance? js/Date x)))
 
 (defn- recordable-leaf?

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -604,21 +604,27 @@
         ;; Per Spec 009 §Hot-reload dedup — re-emits suppressed by shape
         ;; (B4 ruling, rf2-g1b2m): consult the dedup table. Identical
         ;; shape on re-register (a hot-reload that didn't actually
-        ;; change the handler) emits ZERO trace events; a real edit
-        ;; emits exactly one `:rf.registry/handler-replaced`. The
-        ;; sibling collision-warning is gated on the same allow signal
-        ;; — a suppressed hot-reload re-emit must not surface the
-        ;; collision warning either.
+        ;; change the handler) emits ZERO `:rf.registry/handler-replaced`
+        ;; trace events; a real edit emits exactly one.
         (when interop/debug-enabled?
           (when (dedup-allow? :rf.registry/handler-replaced kind id metadata)
             (emit! :rf.registry/handler-replaced
-                   {:kind kind :id id :different-fn? different?})
-            ;; Per Spec 001 §Re-registration of a different function —
-            ;; collision warning (rf2-45kaz). Fires alongside
-            ;; handler-replaced when the fn-identity actually changed,
-            ;; with the same per-(kind, id) suppression discipline so
-            ;; the dev stream stays readable across hot-reload churn.
-            (maybe-emit-collision! kind id previous metadata))))
+                   {:kind kind :id id :different-fn? different?}))
+          ;; Per Spec 001 §Re-registration of a different function —
+          ;; collision warning (rf2-45kaz). Decoupled from the
+          ;; handler-replaced dedup gate (rf2-3az1vn P2): the collision
+          ;; warning detects a CROSS-SOURCE id clash by PROVENANCE
+          ;; (different `(ns, file, line)`), not by handler-fn shape, and
+          ;; carries its OWN per-(kind, id) suppression (`collision-warned`).
+          ;; Nesting it inside the `dedup-allow?` (handler-replaced) gate
+          ;; meant a kind with no rotating `:handler-fn` — `:frame`,
+          ;; `:route`, `:head` — could be deduped-away by shape and so a
+          ;; GENUINE cross-source clash for those kinds never warned. Call
+          ;; it independently (still under `interop/debug-enabled?` for
+          ;; production elision); `collision?` keeps a same-source hot-reload
+          ;; re-eval silent, and the warn-once cache keeps the dev stream
+          ;; readable across reload churn.
+          (maybe-emit-collision! kind id previous metadata)))
       ;; First-time registration — emit handler-registered per Spec 009
       ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
       ;; this to track when fresh ids appear in the registry. The B4

--- a/implementation/core/test/re_frame/cofx_envelope_test.clj
+++ b/implementation/core/test/re_frame/cofx_envelope_test.clj
@@ -272,6 +272,44 @@
     (is (nil? (recordable/safe-preview (atom 1)))
         "no preview for a non-recordable value (never the raw host object)")))
 
+(deftest jvm-instant-is-not-recordable-only-date-is
+  ;; rf2-3az1vn P2: a `java.util.Date` round-trips through pr-str / read-string
+  ;; (the EDN reader's default `#inst` reader returns a Date), so it stays
+  ;; recordable. A `java.time.Instant` does NOT round-trip — Clojure prints it
+  ;; with the `#inst` tag but `read-string` of that form throws
+  ;; `No reader function for tag inst` (no data-reader bound), and even with the
+  ;; default reader it would come back a Date, not an Instant. So an Instant is
+  ;; rejected as a host handle at the SOURCE coeffect (explain-non-recordable),
+  ;; not far away at replay / Xray / SSR time — and safe-preview never leaks it.
+  (testing "a java.util.Date (#inst literal) IS recordable and round-trips"
+    (let [d (java.util.Date. 1781078400123)]
+      (is (recordable/recordable-edn-value? d)
+          "a java.util.Date is recordable EDN data")
+      (is (nil? (recordable/explain-non-recordable d))
+          "no failing descriptor for a Date")
+      (is (= d (read-string (pr-str d)))
+          "a Date round-trips through pr-str / read-string unchanged")))
+  (testing "a java.time.Instant is NOT recordable — rejected at the source"
+    (let [inst (java.time.Instant/ofEpochMilli 1781078400123)]
+      (is (not (recordable/recordable-edn-value? inst))
+          "a java.time.Instant is NOT recordable EDN data")
+      (let [bad (recordable/explain-non-recordable inst)]
+        (is (some? bad) "explain-non-recordable returns a descriptor for an Instant")
+        (is (= [] (:path bad)) "the failing path is the root (the value itself)")
+        (is (re-find #"(?i)instant" (:bad-type bad))
+            "the bad-type names the Instant host class"))
+      (is (nil? (recordable/safe-preview inst))
+          "safe-preview refuses an Instant — no non-round-tripping preview leak")
+      (testing "the round-trip the predicate protects against actually fails"
+        (is (thrown? RuntimeException
+              (read-string (pr-str inst)))
+            "read-string of a printed Instant throws (No reader function for tag inst)"))))
+  (testing "an Instant BURIED in a collection is rejected (deep walk)"
+    (let [bad (recordable/explain-non-recordable
+                {:ok 1 :when {:at (java.time.Instant/ofEpochMilli 0)}})]
+      (is (some? bad) "the buried Instant is found")
+      (is (= [:when :at] (:path bad)) "the path locates the buried Instant"))))
+
 (deftest supplied-non-edn-cofx-value-is-cofx-value-invalid
   ;; THE adversarial acceptance leg: a non-EDN supplied cofx value throws
   ;; :rf.error/cofx-value-invalid; an EDN one passes.

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -1164,6 +1164,54 @@
         (is (= 1 (count fallthrough))
             "exactly one :rf.error/override-fallthrough trace surfaced the un-registered redirect target")))))
 
+(deftest malformed-fx-override-value-fails-loud
+  (testing "a non-fn / non-keyword / non-nil :fx-overrides value (number / string
+            / map) emits :rf.error/override-fallthrough and runs the original fx —
+            no longer silently swallowed (rf2-3az1vn P2)"
+    (doseq [bad-value [42 "not-an-override" {:also :bad} [:vec :tor]]]
+      (let [original-fired (atom 0)
+            traces         (collect-traces! ::malformed-override)]
+        (rf/reg-fx :fx-test.3az1vn/target
+                   {:platforms #{:client :server}}
+                   (fn [_ _] (swap! original-fired inc)))
+        (rf/reg-event :fx-test.3az1vn/issue
+          (fn [_ _] {:fx [[:fx-test.3az1vn/target {}]]}))
+        (rf/dispatch-sync
+          [:fx-test.3az1vn/issue]
+          {:fx-overrides {:fx-test.3az1vn/target bad-value}})
+        (rf/unregister-listener! ::malformed-override)
+        (is (= 1 @original-fired)
+            (str "the original fx ran (recovery :replaced-with-default) for "
+                 (pr-str bad-value)))
+        (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
+          (is (= 1 (count fallthrough))
+              (str "exactly one :rf.error/override-fallthrough surfaced the malformed "
+                   "override value " (pr-str bad-value))))))))
+
+(deftest nil-and-false-fx-override-values-stay-silent
+  (testing "nil and false :fx-overrides values are the documented noop placeholder
+            (spec/002 §`:fx-overrides`): silent fall-through to the original fx,
+            NO :rf.error/override-fallthrough trace (rf2-3az1vn P2 — the silent
+            no-op is intentionally KEPT)"
+    (doseq [noop-value [nil false]]
+      (let [original-fired (atom 0)
+            traces         (collect-traces! ::noop-override)]
+        (rf/reg-fx :fx-test.3az1vn/noop-target
+                   {:platforms #{:client :server}}
+                   (fn [_ _] (swap! original-fired inc)))
+        (rf/reg-event :fx-test.3az1vn/noop-issue
+          (fn [_ _] {:fx [[:fx-test.3az1vn/noop-target {}]]}))
+        (rf/dispatch-sync
+          [:fx-test.3az1vn/noop-issue]
+          {:fx-overrides {:fx-test.3az1vn/noop-target noop-value}})
+        (rf/unregister-listener! ::noop-override)
+        (is (= 1 @original-fired)
+            (str "the original fx ran for the noop placeholder " (pr-str noop-value)))
+        (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
+          (is (empty? fallthrough)
+              (str "no override-fallthrough trace for the documented noop value "
+                   (pr-str noop-value))))))))
+
 ;; ---- 7c. reserved-fx OVERRIDE TIER (rf2-snsup5) ---------------------------
 ;;
 ;; Mike-ruled 2026-06-10 (option A, STATE-INSTALLATION criterion): a reserved

--- a/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
@@ -40,6 +40,7 @@
             [re-frame.core           :as rf]
             [re-frame.events         :as events]
             [re-frame.image          :as image]
+            [re-frame.image-assembly :as asm]
             [re-frame.registrar      :as registrar]
             [re-frame.live-frame     :as lf]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -513,3 +514,107 @@
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
                     (:rf.error/id (ex-data e)))))
           "an unknown frame id fails loud through the facade export"))))
+
+;; ===========================================================================
+;; 10. NO-ID FRAME RELOAD IS REGISTRY-COHERENT (rf2-3az1vn P1) — reloading a
+;;     DIRECT (no public :id) frame object must patch the live-frame registry
+;;     slot keyed by the object's PRIVATE runnable-id. Dispatch / subscribe
+;;     collapse a frame object to its runnable-id keyword and then RE-RESOLVE the
+;;     generation from the registry (router/frame-resolution-target reads
+;;     (live-frame runnable-id)) — so if the slot still pointed at the OLD object
+;;     after a reload, a dispatch / subscribe / child dispatch through the
+;;     reloaded object would silently resolve the STALE v1 image. The old
+;;     swap-frame-generation! `(when (some? id) …)` guard skipped no-id frames
+;;     (their public id is nil), leaving the gensym slot stale; the fix keys the
+;;     in-place update by the runnable-id (present on every object) under the same
+;;     identical? stale-handle guard.
+;; ===========================================================================
+
+(deftest no-id-reload-patches-the-runnable-id-registry-slot
+  (testing "(a) (live-frame (:rf.frame/runnable-id reloaded)) carries v2 after a
+            no-id reload — the registry slot dispatch/subscribe re-resolve through
+            points at the reloaded object, not the stale v1 one (rf2-3az1vn P1)"
+    (let [pool-v1 [(event-desc "ex.counter.v1" :counter/inc
+                               (fn [{:keys [db]} _] {:db (update db :n (fnil + 0) 1)}))
+                   (sub-desc   "ex.counter.v1" :counter/value (fn [db _] (:n db)))]
+          pool-v2 [(event-desc "ex.counter.v2" :counter/inc
+                               (fn [{:keys [db]} _] {:db (update db :n (fnil + 0) 10)}))
+                   (sub-desc   "ex.counter.v2" :counter/value (fn [db _] (:n db)))]
+          img-v1  (image/image {:include-ns ["ex.counter.v1"]})
+          img-v2  (image/image {:include-ns ["ex.counter.v2"]})
+          ;; NO :id — a direct object keyed in the registry under a gensym
+          ;; runnable-id only.
+          frame   (lf/make-frame {:images [img-v1] :initial-db {:n 0}} pool-v1)
+          runnable (:rf.frame/runnable-id frame)
+          reloaded (:rf.frame/frame (rf/reload-images! frame {:images [img-v2]} pool-v2))]
+      (is (some? runnable) "a no-id object carries a private runnable-id")
+      (is (empty? (lf/live-frame-ids)) "but contributes no PUBLIC id")
+      (is (identical? reloaded (lf/live-frame runnable))
+          "(a) the runnable-id registry slot now holds the RELOADED v2 object")
+      (is (= :counter/inc (:id (asm/resolve-descriptor
+                                 (lf/frame-generation (lf/live-frame runnable))
+                                 :event :counter/inc)))
+          "and (live-frame runnable-id) resolves the v2 generation's descriptor"))))
+
+(deftest no-id-reload-dispatch-and-subscribe-resolve-v2 ;; (b)
+  (testing "(b) a REAL dispatch + subscribe through the reloaded no-id object
+            resolve the v2-only registration — they collapse the object to its
+            runnable-id and re-resolve from the (now-patched) registry slot
+            (rf2-3az1vn P1)"
+    (let [;; v1 has NO :counter/bump; v2 adds it. So resolving the v2-only id at
+          ;; all proves the reloaded generation (not the stale v1) is in force.
+          pool-v1 [(event-desc "ex.c.v1" :counter/inc
+                               (fn [{:keys [db]} _] {:db (assoc db :gen :v1)}))
+                   (sub-desc   "ex.c.v1" :counter/which (fn [db _] (:gen db)))]
+          pool-v2 [(event-desc "ex.c.v2" :counter/inc
+                               (fn [{:keys [db]} _] {:db (assoc db :gen :v2)}))
+                   (event-desc "ex.c.v2" :counter/bump ;; v2-ONLY event
+                               (fn [{:keys [db]} _] {:db (assoc db :bumped true)}))
+                   (sub-desc   "ex.c.v2" :counter/which (fn [db _] (:gen db)))]
+          img-v1  (image/image {:include-ns ["ex.c.v1"]})
+          img-v2  (image/image {:include-ns ["ex.c.v2"]})
+          frame   (lf/make-frame {:images [img-v1] :initial-db {}} pool-v1)
+          reloaded (:rf.frame/frame (rf/reload-images! frame {:images [img-v2]} pool-v2))]
+      ;; Dispatch the SHARED id through the reloaded object: it must run v2's impl.
+      (rf/dispatch-sync reloaded [:counter/inc])
+      (is (= :v2 (:gen (rf/app-db-value reloaded)))
+          "dispatch through the reloaded object ran the v2 :counter/inc handler")
+      ;; Dispatch the V2-ONLY id: it resolves only if the registry slot is v2.
+      (rf/dispatch-sync reloaded [:counter/bump])
+      (is (true? (:bumped (rf/app-db-value reloaded)))
+          "the v2-only :counter/bump resolved + ran — the runnable-id slot is v2")
+      ;; Subscribe through the reloaded object: the v2 sub computes over v2 app-db.
+      (is (= :v2 @(rf/subscribe reloaded [:counter/which]))
+          "subscribe through the reloaded object resolved the v2 sub")
+      (testing "dispatching through the OLD pre-reload object handle ALSO resolves
+                v2 — both handles collapse to the same runnable-id, whose slot is
+                now the reloaded generation (no stale-handle divergence)"
+        (rf/dispatch-sync frame [:counter/bump])
+        (is (true? (:bumped (rf/app-db-value frame)))
+            "the v2-only id resolved through the original handle too")))))
+
+(deftest no-id-reload-child-dispatch-resolves-v2 ;; (c)
+  (testing "(c) a CHILD :dispatch emitted from the reloaded no-id frame's handler
+            re-enters process-event! for the SAME runnable-id, re-derives the
+            generation from the (patched) registry slot, and resolves the v2-only
+            child — proving the whole cascade stays on the reloaded image
+            (rf2-3az1vn P1)"
+    (let [;; v1 parent has no child wiring. v2 parent emits a v2-only child via :fx.
+          pool-v1 [(event-desc "ex.cd.v1" :counter/inc
+                               (fn [{:keys [db]} _] {:db (assoc db :parent :v1)}))]
+          pool-v2 [(event-desc "ex.cd.v2" :counter/inc
+                               (fn [{:keys [db]} _]
+                                 {:db (assoc db :parent :v2)
+                                  :fx [[:dispatch [:counter/child]]]}))
+                   (event-desc "ex.cd.v2" :counter/child ;; v2-ONLY child
+                               (fn [{:keys [db]} _] {:db (assoc db :child :v2)}))]
+          img-v1  (image/image {:include-ns ["ex.cd.v1"]})
+          img-v2  (image/image {:include-ns ["ex.cd.v2"]})
+          frame   (lf/make-frame {:images [img-v1] :initial-db {}} pool-v1)
+          reloaded (:rf.frame/frame (rf/reload-images! frame {:images [img-v2]} pool-v2))]
+      (rf/dispatch-sync reloaded [:counter/inc])
+      (let [db (rf/app-db-value reloaded)]
+        (is (= :v2 (:parent db)) "the parent resolved the v2 :counter/inc handler")
+        (is (= :v2 (:child db))
+            "the CHILD :dispatch re-derived the generation from the patched
+             runnable-id slot and resolved the v2-only :counter/child handler")))))

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -219,11 +219,28 @@
 
 (deftest reload-a-direct-frame-object
   (testing "reload-images! accepts a direct frame OBJECT as the target; the
-            registry is untouched (a no-id frame never entered it) and the
-            reloaded copy is returned for the caller to hold"
+            reloaded copy is returned for the caller to hold AND the live-frame
+            registry slot keyed by the object's PRIVATE runnable-id is patched in
+            place to the reloaded object. A no-id frame contributes no PUBLIC id
+            (live-frame-ids stays empty), but it IS registered under a gensym
+            runnable-id — and dispatch/subscribe re-resolve the generation FROM
+            that slot, so it must carry the reloaded (v2) object, not the stale v1
+            one (rf2-3az1vn P1: the old (when (some? id) …) guard skipped this)"
     (let [frame    (lf/make-frame {:images [img]} pool-v1)
+          runnable (:rf.frame/runnable-id frame)
           reloaded (:rf.frame/frame (lf/reload-images! frame {:images [img]} pool-v2))]
-      (is (empty? (lf/live-frame-ids)) "registry stays empty for a no-id reload")
+      (is (empty? (lf/live-frame-ids))
+          "a no-id frame contributes no PUBLIC id — live-frame-ids stays empty")
+      (testing "the registry slot keyed by the gensym runnable-id now holds the
+                RELOADED object (the v2 image), not the stale v1 object"
+        (is (some? runnable) "a no-id object still carries a private runnable-id")
+        (is (identical? reloaded (lf/live-frame runnable))
+            "the runnable-id slot points at the reloaded object")
+        (is (= ::inc-v2 (:handler-fn (asm/resolve-descriptor
+                                       (lf/frame-generation (lf/live-frame runnable))
+                                       :event :counter/inc)))
+            "(live-frame runnable-id) resolves the v2 image — the registry slot
+             is no longer stale"))
       (is (= ::inc-v2 (:handler-fn (asm/resolve-descriptor
                                      (lf/frame-generation reloaded) :event :counter/inc))))
       (testing "the original object is unchanged (immutable value; caller swaps

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -347,3 +347,66 @@
         (is (= 1 (count collisions))
             "collision warning fires once and is then suppressed")))))
 
+;; =============================================================================
+;; F3 — collision warning is DECOUPLED from the handler-replaced dedup gate
+;;      (rf2-3az1vn P2)
+;;
+;; A kind with NO `:handler-fn` — `:frame` / `:route` / `:head` — replaces its
+;; slot WITHOUT rotating a handler fn. The B4 hot-reload dedup-by-shape table
+;; (`trace.tooling/dedup-allow?`) strips source-coords (`:ns`/`:file`/`:line`/
+;; `:column`) from the shape, so two cross-source registrations of such a kind
+;; with otherwise-identical metadata hash to the IDENTICAL shape →
+;; `dedup-allow? :rf.registry/handler-replaced` returns FALSE (an idempotent
+;; hot-reload re-emit). The prior code NESTED `maybe-emit-collision!` inside
+;; that `dedup-allow?` gate, so a GENUINE cross-source clash for these kinds
+;; never warned. The fix calls the collision check independently. The collision
+;; warning keys on PROVENANCE (not shape), so it must still fire.
+;; =============================================================================
+
+(defn- reg-no-handler-fn!
+  "Register a `kind` id carrying NO `:handler-fn` (a `:frame` / `:route` /
+  `:head`-shaped slot) with an explicit source-coord `provenance` envelope. The
+  residual metadata is identical across calls except for provenance, so the B4
+  shape table sees the SAME shape on re-register — exactly the case the old
+  nested-collision code dedup-suppressed."
+  [kind id provenance]
+  (registrar/register! kind id (merge (or provenance {}) {:doc "slot"})))
+
+(deftest collision-fires-for-no-handler-fn-kind-despite-shape-dedup
+  (testing "a :frame-kind cross-source reassignment WARNS even though its shape
+            is dedup-identical (no rotating :handler-fn) — collision is decoupled
+            from the handler-replaced dedup gate (rf2-3az1vn P2)"
+    (let [recorded (record-traces! ::no-fn-collision)]
+      ;; Two DIFFERENT authoring sites register the SAME :frame id. No handler-fn
+      ;; on either, identical residual metadata → identical dedup shape.
+      (reg-no-handler-fn! :frame :surface/main
+                          {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1})
+      (reg-no-handler-fn! :frame :surface/main
+                          {:ns 'feature.b :file "feature/b.cljc" :line 20 :column 1})
+      (let [replaced (filterv (fn [ev]
+                                (and (= :rf.registry (:op-type ev))
+                                     (= :rf.registry/handler-replaced (:operation ev))))
+                              @recorded)
+            collisions (warnings-of recorded :rf.warning/registration-collision)]
+        (is (empty? replaced)
+            "handler-replaced is dedup-SUPPRESSED — the shape is identical (no
+             handler-fn rotation); this is the gate that used to hide the collision")
+        (is (= 1 (count collisions))
+            "the collision warning STILL fires — it is decoupled from the dedup gate")
+        (let [t (:tags (first collisions))]
+          (is (= :frame (:kind t)))
+          (is (= :surface/main (:id t)))
+          (is (= 'feature.b (:ns (:source-coords t))))
+          (is (= 'feature.a (:ns (:previous-coords t)))))))))
+
+(deftest collision-still-silent-on-same-source-for-no-handler-fn-kind
+  (testing "a same-source re-eval of a no-handler-fn kind stays SILENT — the
+            decoupled collision check still keys on provenance, not shape"
+    (let [recorded (record-traces! ::no-fn-same-source)
+          coords   {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1}]
+      (reg-no-handler-fn! :frame :surface/hot coords)
+      (reg-no-handler-fn! :frame :surface/hot coords)
+      (is (empty? (warnings-of recorded :rf.warning/registration-collision))
+          "same (ns,file,line) re-eval is a hot reload — no collision even though
+           the collision check now runs unconditionally"))))
+


### PR DESCRIPTION
Implements **rf2-3az1vn** — 4 confirmed core-correctness defects (h7iwgj review). Files disjoint from in-flight core work; branched off current origin/main. The 3 suspected P3 items are NOT touched (deferred, need confirmation).

## [P1] live_frame no-id reload registry-stale
`swap-frame-generation!` updated the live-frame registry slot keyed by the public `:rf.frame/id`, guarded by `(when (some? id) ...)`. But the registry is keyed by `:rf.frame/runnable-id` — for an id-bearing frame `runnable-id == id`, but a NO-ID direct frame's runnable-id is a private gensym, so the guard skipped it. Dispatch/subscribe collapse a frame object to its runnable-id (`build-envelope` → `frame-target->id`) and then RE-RESOLVE the generation from the registry (`router/frame-resolution-target` → `(live-frame runnable-id)`), so a reloaded no-id frame's slot kept pointing at the OLD object → dispatch/subscribe/child-dispatch silently resolved the stale v1 image.

**Fix:** key the in-place update by `:rf.frame/runnable-id` (present on every object), under the same `identical?` stale-handle guard. Subsumes the id-bearing case, fixes the no-id case.

**Regressions** (in `live_cascade_frame_resolution_cljs_test` — real dispatch/subscribe machinery):
- (a) `(live-frame (:rf.frame/runnable-id reloaded))` carries v2
- (b) a real dispatch + subscribe through the reloaded object resolve a v2-only registration
- (c) a child `:dispatch` from the reloaded frame's handler resolves v2

Also fixed the wrong "registry is untouched (a no-id frame never entered it)" comment + assertion in `live_frame_reload_cljs_test`.

## [P2] recordable inst-leaf? — drop Instant
A `java.util.Date` round-trips through `pr-str`/`read-string` (the EDN `#inst` reader returns a Date), so it stays recordable. A `java.time.Instant` does NOT — `read-string` of its printed form throws `No reader function for tag inst`. Dropped `(instance? Instant x)` from the JVM branch so an Instant routes to `explain-non-recordable` (fails at the source coeffect, not at replay/Xray/SSR), and `safe-preview` no longer leaks a non-round-tripping preview. Removed the now-unused `Instant` import.

## [P2] registrar — decouple collision warning from handler-replaced dedup
`maybe-emit-collision!` (provenance-keyed, own per-(kind,id) warn-once) was nested inside the `(when (dedup-allow? :rf.registry/handler-replaced ...))` shape-dedup gate. For a kind with no rotating `:handler-fn` (`:frame`/`:route`/`:head`), `dedup-allow?` strips source-coords from the shape → two cross-source registrations hash identical → `false` → the collision NEVER warned. Now called independently under `interop/debug-enabled?`. Same-source re-eval stays silent (collision keys on provenance).

## [P2] fx resolve-override :else — fail open on malformed values
A non-fn / non-keyword / non-nil `:fx-overrides` value (number/string/map/vector) was silently swallowed. Now emits `:rf.error/override-fallthrough` through both error substrates and falls through to the original fx (recovery `:replaced-with-default`), matching the sibling unregistered-keyword branch. `nil`/`false` stay the documented silent noop placeholder.

## Quality gates — all green
```
npm run test:cljs            → Ran 7876 tests, 32661 assertions. 0 failures, 0 errors.
core JVM clojure -M:test     → Ran 1812 tests, 7895 assertions. 0 failures, 0 errors.
scripts/test-jvm-implementation.sh → PASS implementation JVM artefacts (all)
npm run test:elision         → PASS elision: production 41/41 absent; EP-0023 provenance-survives + assembly-DCE
npm run test:bundle-isolation → PASS bundle-isolation + uix-helix-reagent-free
```