### PR TITLE
fix(reagent-slim): SSR escape-text 5-char parity + vendor-prop typo (rf2-4dlxga)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -823,10 +823,12 @@ Per Stage 1 DECISION-6 + Stage 2 §2.5 + S3-005: pure-CLJS recursive walker; ~15
   (-> s
       (str/replace "&"  "&amp;")
       (str/replace "<"  "&lt;")
-      (str/replace ">"  "&gt;")))
+      (str/replace ">"  "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'"  "&#39;")))
 ```
 
-Lift the existing implementation from `re-frame.ssr/escape-html` (`ssr.cljc:50-57`) — the SSR seam already has battle-tested escaping. Reuse, don't re-implement. (This is the same shape `react-dom/server` uses; parity test in §12 confirms.)
+Lift the existing implementation from `re-frame.ssr.html-helpers/escape-html` — the SSR seam already has battle-tested escaping. Reuse, don't re-implement. Text content escapes the full 5-char set (`& < > " '`), byte-equal to `escape-html`; the apostrophe entity is the **decimal** `&#39;` (React 19's `escapeTextForBrowser` emits the equivalent **hex** `&#x27;`, so the apostrophe byte is pinned against the in-repo helper, not the React reference — see `parity-escaped-text-quotes-apostrophe` in §12). The `& < > "` bytes match `react-dom/server` exactly.
 
 ### §8.3 Attribute serialisation
 
@@ -856,7 +858,7 @@ The same narrowed `convert-prop-value` rules apply (per S3-005): the static-mark
 
 **Inline-style value serialisation (`emit-style-attr` / `style-string`)** must match `react-dom/server.renderToStaticMarkup`'s `pushStyleAttribute` (rf2-9nyg6):
 
-- A *numeric* value gets a `px` suffix unless the value is `0` or the property is in React's `unitlessNumber` set (`flex`, `flex-grow`, `z-index`, `opacity`, `line-height`, `font-weight`, `order`, the vendor-prefixed entries, …). `{:width 10}` → `width:10px`; `{:flex-grow 1}` → `flex-grow:1`. The `unitless-style-props` set in `reagent2.dom.server` mirrors React 19.2.0's set verbatim — keyed on the *camelCase* property name (the same form the React-element path hands React via `cached-prop-name`), so the hiccup key is camelCased before the lookup, then converted to the kebab CSS name with React's own rule (`([A-Z]) → -$1`, lower-case, `^ms- → -ms-`).
+- A *numeric* value gets a `px` suffix unless the value is `0` or the property is in React's `unitlessNumber` set (`flex`, `flex-grow`, `z-index`, `opacity`, `line-height`, `font-weight`, `order`, the vendor-prefixed entries, …). `{:width 10}` → `width:10px`; `{:flex-grow 1}` → `flex-grow:1`. The `unitless-style-props` set in `reagent2.dom.server` mirrors React 19.2.0's set verbatim — keyed on the *camelCase* property name (the same form the React-element path hands React via `cached-prop-name`), so the hiccup key is camelCased before the lookup, then converted to the kebab CSS name with React's own rule (`([A-Z]) → -$1`, lower-case, `^ms- → -ms-`). "Verbatim" includes React's own capital-K typo `WebKitBoxFlexGroup`: the camelCase token both React and this serializer compute is the lowercase-k `WebkitBoxFlexGroup`, so the lookup misses in **both** and `{:WebkitBoxFlexGroup 2}` renders `-webkit-box-flex-group:2px` (not the unitless `:2`). Mirroring the typo is what preserves byte-parity — "correcting" the k would diverge from React (pinned by `parity-style-webkit-box-flex-group`).
 - An entry whose value is `nil`, a boolean, or `""` is **omitted entirely** (no empty `prop:` declaration).
 - CSS custom properties (`--foo`) are emitted name-and-value verbatim with no `px` logic. The React-element path agrees: `dash-to-prop-name` short-circuits `--`-prefixed names so a style key like `:--gap` is preserved (not camelCased to `Gap`), matching React's style handling and this serializer (rf2-ygknv finding 2 — previously the live path camelCased `--gap` → `Gap`, silently dropping the variable and breaking SSR/client parity).
 

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -85,19 +85,23 @@
 ;; ---------------------------------------------------------------------------
 ;; HTML escaping
 ;;
-;; Lifted from re-frame.ssr/escape-html (ssr.cljc:51-57). The text-content
-;; path doesn't escape `'` or `"`; the attribute path does. React's
+;; Lifted from re-frame.ssr.html-helpers/escape-html. The text-content
+;; path escapes the full 5-char set (`& < > " '`); the attribute path
+;; escapes only `&` and `"` (double-quoted values). React's
 ;; renderToStaticMarkup uses the same split. Per §8.2.
 ;; ---------------------------------------------------------------------------
 
 (defn- escape-text
-  "Escape text content per HTML5: `&`, `<`, `>`. Quotes are not
-  escaped in text-content positions. Matches react-dom/server."
+  "Full text-node HTML escape: `&`, `<`, `>`, `\"`, `'`. Byte-equal to
+  re-frame.ssr.html-helpers/escape-html and React 19's
+  escapeTextForBrowser (the 5-char text-content set)."
   [s]
   (-> (str s)
       (str/replace "&" "&amp;")
       (str/replace "<" "&lt;")
-      (str/replace ">" "&gt;")))
+      (str/replace ">" "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'" "&#39;")))
 
 (defn- escape-attr
   "Escape attribute content per HTML5 with double-quoted values:
@@ -439,6 +443,15 @@
     "msZoom" "msFlexGrow" "msFlexNegative" "msFlexOrder" "msFlexPositive"
     "msFlexShrink" "msGridColumn" "msGridColumnSpan" "msGridRow"
     "msGridRowSpan" "WebkitAnimationIterationCount" "WebkitBoxFlex"
+    ;; NOTE: `WebKitBoxFlexGroup` keeps React 19.2.0's capital-K typo
+    ;; VERBATIM (rf2-4dlxga). React's `unitlessNumber` Set really does
+    ;; spell it with a capital K, while the camelCase prop token this
+    ;; serializer (and React itself) computes is `WebkitBoxFlexGroup`
+    ;; (lowercase k). So the lookup MISSES in React too — React emits
+    ;; `-webkit-box-flex-group:2px`, and mirroring the typo is what
+    ;; preserves byte-parity. Lowercasing the k here would make us emit
+    ;; the unitless `:2`, diverging from React. Confirmed empirically
+    ;; against react-dom/server 19.2.0; see parity-style-webkit-box-flex-group.
     "WebKitBoxFlexGroup" "WebkitBoxOrdinalGroup" "WebkitColumnCount"
     "WebkitColumns" "WebkitFlex" "WebkitFlexGrow" "WebkitFlexPositive"
     "WebkitFlexShrink" "WebkitLineClamp"})

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -124,6 +124,22 @@
     (let [[a b] (=parity [:div "1 < 2 && 3 > 0"])]
       (is (= a b)))))
 
+(deftest parity-escaped-text-quotes-apostrophe
+  (testing "rf2-4dlxga: text content escapes the full 5-char set
+            (& < > \" '). The serializer must be byte-equal to
+            re-frame.ssr.html-helpers/escape-html — which emits the
+            DECIMAL apostrophe entity &#39; (React 19 emits the
+            equivalent hex &#x27;, so the apostrophe byte is pinned
+            against the in-repo helper, not the React reference)."
+    ;; & < > and " agree byte-for-byte with react-dom/server, so a
+    ;; =parity assertion catches the previous missing-quote-escape bug.
+    (let [[a b] (=parity [:div "a < b > c & d \"e\""])]
+      (is (= a b)))
+    ;; Apostrophe diverges from React's hex form, so pin the full
+    ;; 5-char output against the in-repo escape-html target directly.
+    (is (= "<div>say &quot;hi&quot; &amp; &#39;bye&#39;</div>"
+           (via-rewrite [:div "say \"hi\" & 'bye'"])))))
+
 ;; ---------------------------------------------------------------------------
 ;; Attributes
 ;; ---------------------------------------------------------------------------
@@ -310,6 +326,24 @@
       (is (= a b)))
     (is (= "<div style=\"width:10em;color:red\"></div>"
            (via-rewrite [:div {:style {:width "10em" :color "red"}}])))))
+
+(deftest parity-style-webkit-box-flex-group
+  (testing "rf2-4dlxga: `WebkitBoxFlexGroup` gets px (NOT unitless) —
+            React 19.2.0's unitlessNumber Set spells the entry with a
+            capital K (`WebKitBoxFlexGroup`), but the camelCase prop
+            token is lowercase-k `WebkitBoxFlexGroup`, so React's own
+            lookup misses and it emits px. Byte-parity requires the
+            serializer to mirror the typo and emit px too."
+    (let [[a b] (=parity [:div {:style {:WebkitBoxFlexGroup 2}}])]
+      (is (= a b)))
+    (is (= "<div style=\"-webkit-box-flex-group:2px\"></div>"
+           (via-rewrite [:div {:style {:WebkitBoxFlexGroup 2}}])))
+    ;; Sibling vendor entries whose camelCase token DOES match the Set
+    ;; stay unitless (regression guard that the typo is scoped to one key).
+    (let [[a b] (=parity [:div {:style {:WebkitBoxFlex 3}}])]
+      (is (= a b)))
+    (is (= "<div style=\"-webkit-box-flex:3\"></div>"
+           (via-rewrite [:div {:style {:WebkitBoxFlex 3}}])))))
 
 (deftest style-custom-property-verbatim
   (testing "CSS custom property (--foo) passes through verbatim, no px"

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
@@ -36,10 +36,16 @@
     (is (= "<div>1 &lt; 2 &amp;&amp; 3 &gt; 0</div>"
            (server/render-to-static-markup [:div "1 < 2 && 3 > 0"])))))
 
-(deftest text-content-quotes-not-escaped
-  (testing "quotes are NOT escaped in text content (matches react-dom/server)"
-    (is (= "<div>say \"hi\"</div>"
-           (server/render-to-static-markup [:div "say \"hi\""])))))
+(deftest text-content-quotes-and-apostrophe-escaped
+  (testing "rf2-4dlxga: quotes (\" -> &quot;) and apostrophes (' -> &#39;)
+            ARE escaped in text content — byte-equal to
+            re-frame.ssr.html-helpers/escape-html's full 5-char set"
+    (is (= "<div>say &quot;hi&quot;</div>"
+           (server/render-to-static-markup [:div "say \"hi\""])))
+    (is (= "<div>it&#39;s</div>"
+           (server/render-to-static-markup [:div "it's"])))
+    (is (= "<div>say &quot;hi&quot; &amp; &#39;bye&#39;</div>"
+           (server/render-to-static-markup [:div "say \"hi\" & 'bye'"])))))
 
 (deftest text-content-numbers-and-keywords
   (testing "numeric children stringify"


### PR DESCRIPTION
## Summary

Fixes **rf2-4dlxga**. `reagent2.dom.server/escape-text` escaped only `&` `<` `>`, making the text-content path diverge from `re-frame.ssr.html-helpers/escape-html` (IMPL-SPEC §8.2) and React 19's `escapeTextForBrowser` — both escape the full 5-char set. Output stayed valid HTML, so this was a byte-parity break (not a correctness/security issue).

### Changes
- **`escape-text`**: add `"` → `&quot;` and `'` → `&#39;` so it is **byte-equal** to `escape-html`. The apostrophe entity is the **decimal** `&#39;` (matching the in-repo helper); React 19 emits the semantically-equivalent **hex** `&#x27;`, so the apostrophe byte is pinned against the helper, not the React reference.
- Corrected the now-accurate `escape-text` docstring + the leading comment block + the IMPL-SPEC §8.2 code snippet (which still showed the buggy 3-char form and falsely claimed it lifted `escape-html`).
- **New parity case** `parity-escaped-text-quotes-apostrophe` in `parity_cljs_test.cljs`: a `=parity` assertion for the `& < > "` subset (byte-identical to `react-dom/server`, catches the missing-quote-escape) plus an explicit-string assertion pinning the full 5-char output incl. `&#39;`.
- Updated the stale `server_cljs_test` case (was named `text-content-quotes-not-escaped` and **encoded the bug**) → now `text-content-quotes-and-apostrophe-escaped`, asserting the corrected output.

### WebKitBoxFlexGroup (the LOW item) — investigated, NOT changed
The bead asked to lowercase the `K` in `WebKitBoxFlexGroup` (server.cljs:446), on the premise the lookup misses and emits `2px` where React emits `2`. **The premise is inverted.** React 19.2.0's `unitlessNumber` Set genuinely spells the entry with a **capital K** (`WebKitBoxFlexGroup` — a long-standing typo in React's own source), while the camelCase prop token both React and this serializer compute is the lowercase-k `WebkitBoxFlexGroup`. So the lookup **misses in React too**, and React emits `-webkit-box-flex-group:2px`. Lowercasing the k would make the serializer emit the unitless `:2` and **diverge** from React — the opposite of byte-parity.

Verified empirically against `react-dom/server` 19.2.0:
```
WebkitBoxFlex:      <div style="-webkit-box-flex:3"></div>      (unitless, lookup hits)
WebkitBoxFlexGroup: <div style="-webkit-box-flex-group:2px"></div>  (px, lookup misses)
```
Kept the verbatim typo, documented it inline + in IMPL-SPEC §8.x, and pinned it with `parity-style-webkit-box-flex-group`.

## Test plan

The new parity case fails pre-fix and passes post-fix (proven by reverting the `escape-text` change — `parity-escaped-text-quotes-apostrophe` + the updated server-test case fail, 5 failures total; restored → 0).

```
cd implementation && npm run test:cljs && npm run test:reagent-slim:bundle-isolation
```
- `test:cljs`: Ran 7875 tests containing 32656 assertions. **0 failures, 0 errors.**
- `test:reagent-slim:bundle-isolation`: **PASS** — 4 contracts passed; 21 sentinel checks.

Closes rf2-4dlxga.