### PR TITLE
feat(resources): EP-0021 wave 2 — :infinite registration validation + durable page-vector entry/transitions (rf2-kuh9l2)

### DIFF
--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -124,6 +124,138 @@
     {:recovery :fix-registration
      :extra    extra}))
 
+;; ---- :infinite registration validation (Spec 016 §Infinite resources) -----
+;;
+;; The `:infinite`-only additive slice of the `reg-resource` args-map
+;; (`:rf/infinite-resource-args`, Spec-Schemas; EP-0021 R1–R8). `:infinite
+;; true` selects the slice and makes `:next-page-param` REQUIRED — a fail-closed
+;; gate symmetric with the `:scope` / `:params-schema` / `:request` gates above.
+;; The per-page cursor is NEVER a registration key (R8): it is the
+;; runtime-threaded page-param the `:request` fn reads from its RESERVED ctx
+;; (`{:rf.resource/page-param p :rf.resource/page-index i}`); a non-infinite
+;; `:request` still receives a nil/empty ctx (NO new 3-arity). The
+;; `:rf.error/infinite-missing-page-accessor` error is RUNTIME-detected at the
+;; first non-vector page in the merge layer (wave 4), not here — at registration
+;; we have no page to inspect; here we shape-validate `:page->items` (a keyword
+;; or fn) when present.
+
+(defn infinite-resource?
+  "True iff `spec` declares an infinite feed (`:infinite true`). The single
+  predicate the registry validation and the runtime read so the `:infinite`
+  slice is gated by the SAME marker. Per Spec 016 §Registration — :infinite."
+  [spec]
+  (true? (:infinite spec)))
+
+(defn- validate-infinite-spec!
+  "Validate the `:infinite`-only slice of a `reg-resource` spec (Spec 016
+  §Infinite resources and load-more feeds, EP-0021). A no-op when the resource
+  is NOT infinite (`:infinite` absent / not `true`). When `:infinite true`:
+
+    - `:next-page-param` is REQUIRED and MUST be a fn — a missing / non-fn
+      value raises `:rf.error/infinite-missing-next-page-param` (R8 gate,
+      symmetric with `:scope` / `:params-schema` / `:request`);
+    - the optional `:prev-page-param` (R7 mirror) MUST be a fn when present;
+    - the optional `:page->items` (R3 accessor) MUST be a keyword or fn when
+      present (a non-vector page with NO `:page->items` is the RUNTIME-detected
+      `:rf.error/infinite-missing-page-accessor`, raised at the merge site in
+      wave 4 — not here);
+    - the optional `:refetch` policy (R6) MUST be a map with a boolean
+      `:refetch-all-pages?` and/or an integer `:refetch-window` when present.
+
+  Also rejects an `:infinite` value that is present but not literally `true`
+  (`:infinite false` is meaningless — a resource is infinite or it is an
+  ordinary resource; the flag is `[:= true]` per `:rf/infinite-resource-args`).
+  Fails in dev AND prod (a caller bug)."
+  [resource-id spec]
+  (when (contains? spec :infinite)
+    ;; `:infinite` is the `[:= true]` selector — present-but-not-true is a typo.
+    (when-not (true? (:infinite spec))
+      (throw (registration-error
+               :rf.error/invalid-resource-spec
+               'rf/reg-resource
+               (str "resource " resource-id " declares :infinite "
+                    (pr-str (:infinite spec)) " — the :infinite flag is the "
+                    "literal `true` selector for the load-more feed kind. Omit "
+                    "it for an ordinary resource. Per Spec 016 §Infinite "
+                    "resources and load-more feeds.")
+               {:resource-id resource-id :infinite (:infinite spec)})))
+    (when (infinite-resource? spec)
+      ;; `:next-page-param` is REQUIRED + MUST be a fn (the R8 gate).
+      (when-not (fn? (:next-page-param spec))
+        (throw (registration-error
+                 :rf.error/infinite-missing-next-page-param
+                 'rf/reg-resource
+                 (str "infinite resource " resource-id " declares no valid "
+                      ":next-page-param. :infinite true makes :next-page-param "
+                      "REQUIRED — a pure fn (last-page all-pages) → next-param | "
+                      "nil (nil = the single terminal, no more pages). Per Spec "
+                      "016 §Registration — :infinite (R8).")
+                 {:resource-id resource-id :next-page-param (:next-page-param spec)})))
+      ;; `:prev-page-param` (R7 mirror) MUST be a fn when present.
+      (when (and (contains? spec :prev-page-param)
+                 (not (fn? (:prev-page-param spec))))
+        (throw (registration-error
+                 :rf.error/invalid-resource-spec
+                 'rf/reg-resource
+                 (str "infinite resource " resource-id " declares a "
+                      ":prev-page-param that is not a fn (got "
+                      (pr-str (:prev-page-param spec)) "). :prev-page-param is "
+                      "the optional R7 bidirectional mirror — a pure fn "
+                      "(first-page all-pages) → prev-param | nil. Per Spec 016 "
+                      "§Causal event — load-more (R7).")
+                 {:resource-id resource-id :prev-page-param (:prev-page-param spec)})))
+      ;; `:page->items` (R3 accessor) MUST be a keyword or fn when present.
+      (when (and (contains? spec :page->items)
+                 (not (or (keyword? (:page->items spec))
+                          (fn? (:page->items spec)))))
+        (throw (registration-error
+                 :rf.error/invalid-resource-spec
+                 'rf/reg-resource
+                 (str "infinite resource " resource-id " declares a :page->items "
+                      "that is neither a keyword nor a fn (got "
+                      (pr-str (:page->items spec)) "). :page->items is the R3 "
+                      "merge accessor for a non-vector / enveloped page — a "
+                      "keyword key (e.g. :items) or (fn [page] → seq-of-items). "
+                      "Per Spec 016 §Subscription contract (R3).")
+                 {:resource-id resource-id :page->items (:page->items spec)})))
+      ;; `:refetch` (R6 policy) MUST be a well-formed map when present.
+      (when (contains? spec :refetch)
+        (let [refetch (:refetch spec)
+              {:keys [refetch-all-pages? refetch-window]} refetch]
+          (when-not (map? refetch)
+            (throw (registration-error
+                     :rf.error/invalid-resource-spec
+                     'rf/reg-resource
+                     (str "infinite resource " resource-id " declares a :refetch "
+                          "that is not a map (got " (pr-str refetch) "). :refetch "
+                          "is the R6 policy map {:refetch-all-pages? bool "
+                          ":refetch-window int}; omitted ⇒ the window-preserving "
+                          "default. Per Spec 016 §Refetch and invalidation of an "
+                          "infinite feed (R6).")
+                     {:resource-id resource-id :refetch refetch})))
+          (when (and (contains? refetch :refetch-all-pages?)
+                     (not (boolean? refetch-all-pages?)))
+            (throw (registration-error
+                     :rf.error/invalid-resource-spec
+                     'rf/reg-resource
+                     (str "infinite resource " resource-id "'s :refetch "
+                          ":refetch-all-pages? is not a boolean (got "
+                          (pr-str refetch-all-pages?) "). Per Spec 016 §Refetch "
+                          "and invalidation of an infinite feed (R6).")
+                     {:resource-id resource-id :refetch refetch})))
+          (when (and (contains? refetch :refetch-window)
+                     (not (integer? refetch-window)))
+            (throw (registration-error
+                     :rf.error/invalid-resource-spec
+                     'rf/reg-resource
+                     (str "infinite resource " resource-id "'s :refetch "
+                          ":refetch-window is not an integer (got "
+                          (pr-str refetch-window) "). It bounds how much of the "
+                          "accumulation is refreshed. Per Spec 016 §Refetch and "
+                          "invalidation of an infinite feed (R6).")
+                     {:resource-id resource-id :refetch refetch}))))))
+  nil))
+
 (defn- validate-resource-spec!
   "Fail loudly at the authoring boundary when a resource spec omits the
   REQUIRED keys (Spec 016 §Resource registration spec). The fail-closed
@@ -190,6 +322,13 @@
                   "N ms); a non-positive or absent value means no polling. Per "
                   "Spec 016 §Polling.")
              {:resource-id resource-id :poll-interval-ms (:poll-interval-ms spec)})))
+  ;; `:infinite` is OPTIONAL (Spec 016 §Infinite resources and load-more feeds,
+  ;; EP-0021). When declared it gates the `:infinite`-only slice
+  ;; (`:rf/infinite-resource-args`): `:infinite true` makes `:next-page-param`
+  ;; REQUIRED, and shape-validates the other infinite-only keys. Reject a
+  ;; malformed `:infinite` shape loudly at the authoring boundary (R1–R8 are
+  ;; the binding rulings).
+  (validate-infinite-spec! resource-id spec)
   nil)
 
 ;; ---- reg-resource / clear-resource ---------------------------------------

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -930,6 +930,197 @@
              :data          nil
              :current-work  nil))))
 
+;; ---- infinite-feed entry refinement + transitions -------------------------
+;; ---- (Spec 016 §Infinite resources and load-more feeds, EP-0021 R1/R2/R8) -
+;;
+;; An infinite feed is NOT a new entry KIND (R1) — it is the SAME durable
+;; `:rf/resource-entry` whose `:data` is refined to be the ORDERED PAGE
+;; VECTOR (one element per accumulated page, in load order). There is no
+;; sixth FSM state (R2): a load-more reuses the existing `:fetching`
+;; refresh-class transition (`entry-start-load` / `next-status`), and a
+;; load-more reply settles through these pure transitions instead of the
+;; whole-value `entry-succeeded`. The infinite-only facts the entry carries
+;; ALONGSIDE the page vector:
+;;
+;;   :infinite?       true                    — the feed marker (R1)
+;;   :data            [<page-0> <page-1> …]    — the ordered page sequence
+;;   :page-params     [nil <param-1> …]        — one per page (page-0 = nil)
+;;   :next-page-param <param-or-nil>           — recomputed each load; nil = terminal
+;;   :prev-page-param <param-or-nil>           — bidirectional mirror (R7; load-prev deferred)
+;;   :page-error      <envelope-or-nil>        — the THIRD error channel (load-more failure)
+;;
+;; `:data` / `:page-params` / `:next-page-param` are the durable facts; the
+;; merged list, `:has-next-page?`, `:fetching-next?`, `:page-count`, etc. are
+;; DERIVED in the subs layer (wave 4), never stored. The load-more EVENT
+;; (wave 3) drives `entry-append-page` / `entry-page-failed` from the work
+;; ledger reply path; these are the pure transitions it calls.
+
+(defn infinite-entry?
+  "True iff `entry` is an infinite-feed entry (`:infinite?` set). The single
+  predicate the runtime / subs read so an infinite feed is distinguished from
+  an ordinary single-value entry without re-inspecting `:data`'s shape. Per
+  Spec 016 §Durable cache shape (R1)."
+  [entry]
+  (true? (:infinite? entry)))
+
+(def initial-page-param
+  "The framework default page-param for the FIRST page (page-0) of an infinite
+  feed — `nil` (the TanStack `initialPageParam` analogue). A resource may
+  override it with an optional `:initial-page-param` registration key. Per
+  Spec 016 §Causal event — load-more (the first page is fetched with
+  `:page-param nil`)."
+  nil)
+
+(defn page-param-for-spec
+  "The page-0 param for an infinite resource `spec`: the resource's optional
+  `:initial-page-param`, or the framework default (`nil`) when none is
+  declared. The single home so the load-more event (wave 3) and the first-load
+  page-0 fetch agree. Per Spec 016 §Causal event — load-more."
+  [spec]
+  (get spec :initial-page-param initial-page-param))
+
+(defn empty-infinite-entry
+  "Construct an empty `:idle` infinite-feed entry for `resource-id` (and the
+  scoped key). Refines `empty-entry` with the infinite facts: the `:infinite?`
+  marker, the page vector / page-params seeded EMPTY (no pages yet — page-0 is
+  the first load), and the `:next-page-param` / `:prev-page-param` /
+  `:page-error` channels nil. The page vector starts `[]` (an empty,
+  not-yet-loaded feed) rather than nil so `next-param-for` / `page-count`
+  reason about a vector from the first transition. Per Spec 016 §Durable cache
+  shape (R1)."
+  ([resource-id] (empty-infinite-entry resource-id nil))
+  ([resource-id scoped-key]
+   (assoc (empty-entry resource-id scoped-key)
+          :infinite?       true
+          :data            []
+          :page-params     []
+          :next-page-param nil
+          :prev-page-param nil
+          :page-error      nil)))
+
+(defn next-param-for
+  "PURE next-page-param derivation (R8): given the resource's `:next-page-param`
+  fn `(fn [last-page all-pages] → next-param | nil)` and the accumulated
+  `pages` vector, return the NEXT page param — or `nil`, the SINGLE canonical
+  terminal (\"no more pages\"). An empty `pages` (no page loaded yet) yields
+  `nil` (there is no last page to derive from — the page-0 param comes from
+  `page-param-for-spec`, not this fn). `next-page-param-fn` is invoked with the
+  LAST loaded page and ALL pages so far (TanStack `getNextPageParam(lastPage,
+  allPages)`). The derived `:has-next-page?` is `(some? next-param)`. Per Spec
+  016 §Registration — :infinite / §Causal event — load-more."
+  [next-page-param-fn pages]
+  (when (and next-page-param-fn (seq pages))
+    (next-page-param-fn (peek pages) pages)))
+
+(defn prev-param-for
+  "PURE prev-page-param derivation (R7 bidirectional MIRROR): given the
+  resource's optional `:prev-page-param` fn `(fn [first-page all-pages] →
+  prev-param | nil)` and the accumulated `pages`, return the PREV page param
+  (computed from the FIRST page) — or `nil`. The mirror is defined NOW (it is
+  free — the same machinery as `next-param-for`); the prepend EVENT
+  (`:rf.resource/load-prev`) is DEFERRED, so v1 never advances backward, but
+  `:has-prev-page?` is observable. Returns nil when no `:prev-page-param` fn is
+  declared or no page is loaded. Per Spec 016 §Causal event — load-more (R7)."
+  [prev-page-param-fn pages]
+  (when (and prev-page-param-fn (seq pages))
+    (prev-page-param-fn (first pages) pages)))
+
+(defn terminal?
+  "PURE: true iff a feed whose derived `next-param` is the single canonical
+  terminal `nil` has reached the end (no more pages). The complement of the
+  derived `:has-next-page?` (`(some? next-param)`). The single home so the
+  load-more event's no-op-on-terminal check and the subs `:has-next-page?`
+  projection agree on the terminal rule. Per Spec 016 §Registration — :infinite
+  (nil is the SINGLE terminal)."
+  [next-param]
+  (nil? next-param))
+
+(defn page-count
+  "PURE: the number of accumulated pages in an infinite feed `entry` (the
+  derived `:page-count`). Reads the `:data` page vector length; total over an
+  ordinary (nil `:data`) entry (0). Per Spec 016 §Subscription contract."
+  [entry]
+  (count (:data entry)))
+
+(defn entry-append-page
+  "PURE infinite-feed APPEND transition (R1/R2): append a freshly-fetched,
+  decoded `page` (with its resolved `page-param`) to the feed `entry`, advance
+  the cursor, and return the feed to `:loaded`. The single durable mutation a
+  successful load-more performs:
+
+    - APPEND `page` to the `:data` page vector (structural sharing keeps every
+      PRIOR page identical — only the appended page is new, Spec 016 §Durable
+      cache shape);
+    - APPEND `page-param` to `:page-params` (one per page; page-0's param is
+      whatever the page-0 fetch used — `page-param-for-spec`);
+    - RECOMPUTE `:next-page-param` from the new tail via `next-page-param-fn`
+      (`nil` = the terminal — `:has-next-page?` then derives false) and
+      `:prev-page-param` from the head via `prev-page-param-fn`;
+    - CLEAR `:page-error` (a successful load-more clears the prior load-more
+      failure, Spec 016 §Causal event — load-more);
+    - re-stamp `:loaded-at` / `:stale-at` and return to `:loaded` (the feed was
+      `:fetching` during the load-more — the accumulated pages stayed visible),
+      clear `:current-work`, and bump the per-entry `:revision` UNCONDITIONALLY
+      (this is an authoritative durable write — EP-0019 / byl7bk).
+
+  `opts`: `{:page …  :next-page-param-fn …  :prev-page-param-fn …  :page-param …
+            :loaded-at …  :stale-at …}` — `:page` is the decoded page to append.
+  A nil `entry` is returned unchanged (there is nothing to append to — a
+  missing feed entry). Per Spec 016 §Causal event — load-more (R2) / §Durable
+  cache shape (R1)."
+  [entry {:keys [page next-page-param-fn prev-page-param-fn page-param loaded-at stale-at]}]
+  (if entry
+    (let [pages' (conj (or (:data entry) []) page)]
+      (-> entry
+          (assoc :status          :loaded
+                 :data            pages'
+                 :page-params     (conj (or (:page-params entry) []) page-param)
+                 :next-page-param (next-param-for next-page-param-fn pages')
+                 :prev-page-param (prev-param-for prev-page-param-fn pages')
+                 :page-error      nil
+                 :refresh-error   nil
+                 :loaded-at       loaded-at
+                 :stale-at        stale-at
+                 :invalidated-at  nil
+                 :current-work    nil)
+          bump-revision))
+    entry))
+
+(defn entry-page-failed
+  "PURE infinite-feed LOAD-MORE FAILURE transition: a load-more page fetch
+  (page N>0) failed. UNLIKE a first-load failure (`entry-failed` → `:error`,
+  no data) and a whole-feed refresh failure (`entry-failed` → `:loaded`,
+  `:refresh-error`), a load-more failure is the THIRD error channel: the feed
+  returns to `:loaded`, KEEPS ALL accumulated pages (the page vector + cursor
+  are untouched), and records `:page-error` — so a view shows \"couldn't load
+  more — retry\" without losing the feed. `:page-error` is cleared by the next
+  successful load-more or whole-feed load. Clears `:current-work`. A nil entry
+  is returned unchanged. Per Spec 016 §Causal event — load-more (the third
+  error channel)."
+  [entry {:keys [error]}]
+  (if entry
+    (assoc entry
+           :status       :loaded
+           :page-error   error
+           :current-work nil)
+    entry))
+
+(defn resolve-page->items
+  "PURE: resolve a feed's `:page->items` accessor (a keyword key or a
+  `(fn [page] → seq-of-items)`) into a fn `(page → seq-of-items)`. A keyword is
+  lifted to its `get` accessor. When `page->items` is nil, returns nil — the
+  caller (the merge site, wave 4) then applies the IDENTITY-flatten rule for a
+  vector page and raises `:rf.error/infinite-missing-page-accessor` for a
+  non-vector page (R3, loud over guessing). The single home so the registry
+  shape-validation and the wave-4 merge agree on what shapes are accepted. Per
+  Spec 016 §Subscription contract (R3)."
+  [page->items]
+  (cond
+    (nil? page->items)     nil
+    (keyword? page->items) #(get % page->items)
+    (fn? page->items)      page->items
+    :else                  nil))
+
 ;; ---- reverse-index recompute (Spec 016 §Restore and replay part 5) --------
 ;;
 ;; `:tag-index` and `:owner-index` are DERIVED projections of the entries'

--- a/implementation/resources/test/re_frame/resources_infinite_registration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_registration_cljs_test.cljc
@@ -1,0 +1,158 @@
+(ns re-frame.resources-infinite-registration-cljs-test
+  "Registry validation for the `:infinite` resource registration kind
+  (EP-0021 wave 2, Spec 016 §Infinite resources and load-more feeds, the
+  `:rf/infinite-resource-args` slice).
+
+  These tests lock the AUTHORING-boundary gate: `:infinite true` selects the
+  infinite slice and makes `:next-page-param` REQUIRED (the R8 gate,
+  `:rf.error/infinite-missing-next-page-param`); the optional infinite-only
+  keys (`:prev-page-param` / `:page->items` / `:refetch`) are shape-validated;
+  a non-infinite resource is untouched; a malformed `:infinite` value is
+  rejected loud. The page-cursor is NEVER a registration key (R8) — it rides
+  the runtime-threaded reserved `:request` ctx, not the spec.
+
+  RUNTIME page state-transitions live in the sibling
+  `resources_infinite_state_cljs_test`; the load-more EVENT (wave 3) and the
+  merged-list SUBS (wave 4) are out of scope here."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.registrar :as registrar]
+            [re-frame.resources.registry :as registry]))
+
+(defn- base-infinite-spec
+  "A minimal VALID `:infinite` resource spec — the three ordinary REQUIRED
+  keys plus the `:infinite` flag + the REQUIRED `:next-page-param` (R8)."
+  []
+  {:doc             "test infinite feed"
+   :scope           :rf.scope/global
+   :params-schema   [:map [:filter :keyword]]
+   :infinite        true
+   :request         (fn [_feed-params {:rf.resource/keys [page-param]}]
+                      {:request {:method :get :url "/api/feed"
+                                 :params (cond-> {} page-param (assoc :cursor page-param))}})
+   :next-page-param (fn [last-page _all-pages]
+                      (get-in last-page [:page-info :next-cursor]))})
+
+(use-fixtures :each
+  {:before (fn [] (registrar/clear-kind! :resource))
+   :after  (fn [] (registrar/clear-kind! :resource))})
+
+(deftest valid-infinite-spec-registers
+  (testing "a well-formed :infinite spec registers + reads back"
+    (is (= :feed/timeline (registry/reg-resource :feed/timeline (base-infinite-spec))))
+    (let [meta (registry/resource-meta :feed/timeline)]
+      (is (true? (:infinite meta)))
+      (is (fn? (:next-page-param meta))))))
+
+(deftest valid-infinite-spec-with-all-optionals-registers
+  (testing "the full optional infinite slice (R3/R6/R7) registers"
+    (is (= :feed/full
+           (registry/reg-resource
+             :feed/full
+             (assoc (base-infinite-spec)
+                    :prev-page-param   (fn [first-page _all] (get-in first-page [:page-info :prev-cursor]))
+                    :page->items       :items
+                    :initial-page-param "p0"
+                    :page-data-schema  :app/timeline-page
+                    :refetch           {:refetch-all-pages? false :refetch-window 3}))))))
+
+(deftest infinite-without-next-page-param-rejected
+  (testing ":infinite true with NO :next-page-param => infinite-missing-next-page-param (R8 gate)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"infinite-missing-next-page-param"
+          (registry/reg-resource :feed/no-next
+                                 (dissoc (base-infinite-spec) :next-page-param)))))
+  (testing ":next-page-param present but NOT a fn => same gate"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"infinite-missing-next-page-param"
+          (registry/reg-resource :feed/bad-next
+                                 (assoc (base-infinite-spec) :next-page-param :not-a-fn))))))
+
+(deftest non-infinite-resource-untouched
+  (testing "an ordinary (non-:infinite) resource needs no :next-page-param"
+    (is (= :res/plain
+           (registry/reg-resource
+             :res/plain
+             {:scope :rf.scope/global
+              :params-schema [:map [:slug :string]]
+              :request (fn [_ _] {:request {:method :get :url "/x"}})}))))
+  (testing "a non-infinite resource may carry a :next-page-param key harmlessly (ignored — not gated)"
+    ;; The :infinite slice is GATED on :infinite true; a stray :next-page-param
+    ;; on a non-infinite resource is not validated as the infinite slice.
+    (is (= :res/plain2
+           (registry/reg-resource
+             :res/plain2
+             {:scope :rf.scope/global
+              :params-schema [:map]
+              :request (fn [_ _] {:request {:method :get :url "/y"}})
+              :next-page-param 42})))))
+
+(deftest infinite-flag-must-be-literal-true
+  (testing ":infinite false is a meaningless typo => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/false-flag
+                                 (assoc (base-infinite-spec) :infinite false)))))
+  (testing ":infinite \"true\" (string) is not the literal selector => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/string-flag
+                                 (assoc (base-infinite-spec) :infinite "true"))))))
+
+(deftest prev-page-param-shape-validated
+  (testing "a non-fn :prev-page-param => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/bad-prev
+                                 (assoc (base-infinite-spec) :prev-page-param :not-a-fn)))))
+  (testing "a fn :prev-page-param is accepted"
+    (is (= :feed/good-prev
+           (registry/reg-resource :feed/good-prev
+                                  (assoc (base-infinite-spec)
+                                         :prev-page-param (fn [_first _all] nil)))))))
+
+(deftest page-accessor-shape-validated
+  (testing "a keyword :page->items is accepted"
+    (is (= :feed/kw-acc
+           (registry/reg-resource :feed/kw-acc
+                                  (assoc (base-infinite-spec) :page->items :items)))))
+  (testing "a fn :page->items is accepted"
+    (is (= :feed/fn-acc
+           (registry/reg-resource :feed/fn-acc
+                                  (assoc (base-infinite-spec) :page->items (fn [p] (:items p)))))))
+  (testing "a :page->items that is neither keyword nor fn => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/bad-acc
+                                 (assoc (base-infinite-spec) :page->items 99))))))
+
+(deftest refetch-policy-shape-validated
+  (testing "a well-formed :refetch policy registers"
+    (is (= :feed/rf-ok
+           (registry/reg-resource :feed/rf-ok
+                                  (assoc (base-infinite-spec)
+                                         :refetch {:refetch-all-pages? true :refetch-window 5}))))
+    (is (= :feed/rf-empty
+           (registry/reg-resource :feed/rf-empty
+                                  (assoc (base-infinite-spec) :refetch {})))))
+  (testing "a non-map :refetch => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/rf-nonmap
+                                 (assoc (base-infinite-spec) :refetch true)))))
+  (testing "a non-boolean :refetch-all-pages? => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/rf-badbool
+                                 (assoc (base-infinite-spec) :refetch {:refetch-all-pages? :yes})))))
+  (testing "a non-integer :refetch-window => invalid-resource-spec"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-resource-spec"
+          (registry/reg-resource :feed/rf-badwin
+                                 (assoc (base-infinite-spec) :refetch {:refetch-window 1.5}))))))
+
+(deftest infinite-resource-predicate
+  (testing "infinite-resource? recognises the :infinite true marker"
+    (is (true? (registry/infinite-resource? (base-infinite-spec))))
+    (is (false? (registry/infinite-resource? {:infinite false})))
+    (is (false? (registry/infinite-resource? {})))))

--- a/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
@@ -1,0 +1,223 @@
+(ns re-frame.resources-infinite-state-cljs-test
+  "Pure state-transition unit tests for the durable infinite-feed entry
+  refinement (EP-0021 wave 2, Spec 016 §Durable cache shape (R1) / §Causal
+  event — load-more (R2)).
+
+  An infinite feed is the SAME `:rf/resource-entry` whose `:data` is the
+  ordered page vector (R1 — no new entry kind). These tests lock the PURE
+  transition fns the wave-3 load-more event will drive from the work-ledger
+  reply path:
+
+    - `empty-infinite-entry` seeds the feed facts (page vector / params /
+      cursor / page-error);
+    - `next-param-for` / `prev-param-for` derive the cursor from the
+      accumulated pages (nil = the SINGLE terminal);
+    - `entry-append-page` appends a fetched page + advances the cursor +
+      returns to :loaded;
+    - `entry-page-failed` is the THIRD error channel (keeps the feed,
+      records :page-error);
+    - `resolve-page->items` lifts the R3 accessor.
+
+  The load-more EVENT (wave 3) + subs (wave 4) are out of scope."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.resources.state :as state]))
+
+(def ^:private next-cursor
+  "A :next-page-param fn: read the next cursor off the last page's envelope;
+  nil ⇒ terminal."
+  (fn [last-page _all-pages] (get-in last-page [:page-info :next-cursor])))
+
+(def ^:private prev-cursor
+  (fn [first-page _all-pages] (get-in first-page [:page-info :prev-cursor])))
+
+(defn- page
+  "A non-vector / enveloped page: items + a page-info cursor envelope."
+  [items next-c]
+  {:items items :page-info {:next-cursor next-c}})
+
+;; ---- empty-infinite-entry --------------------------------------------------
+
+(deftest empty-infinite-entry-shape
+  (testing "an empty infinite entry carries the infinite facts (R1)"
+    (let [e (state/empty-infinite-entry :feed/timeline [:rf.scope/global :feed/timeline {:filter :recent}])]
+      (is (true? (:infinite? e)))
+      (is (state/infinite-entry? e))
+      (is (= [] (:data e))            "page vector seeded empty (not nil)")
+      (is (= [] (:page-params e)))
+      (is (nil? (:next-page-param e)))
+      (is (nil? (:prev-page-param e)))
+      (is (nil? (:page-error e)))
+      (is (= :idle (:status e)))
+      (is (= 0 (state/page-count e)))
+      (testing "it is still an ordinary resource entry (R1 — no new kind)"
+        (is (= :feed/timeline (:resource/id e)))
+        (is (= [:rf.scope/global :feed/timeline {:filter :recent}] (:resource/key e)))
+        (is (contains? e :revision))
+        (is (contains? e :active-owners))))))
+
+(deftest ordinary-entry-not-infinite
+  (testing "an ordinary entry is not an infinite feed"
+    (is (false? (state/infinite-entry? (state/empty-entry :res/plain))))))
+
+;; ---- next-param-for / prev-param-for / terminal ----------------------------
+
+(deftest next-param-derivation
+  (testing "next-param-for derives the next cursor from the last page"
+    (is (= "c1" (state/next-param-for next-cursor [(page [:a] "c1")])))
+    (is (= "c2" (state/next-param-for next-cursor [(page [:a] "c1") (page [:b] "c2")]))
+        "derives from the LAST page, not the first"))
+  (testing "nil last-page next-cursor is the SINGLE terminal"
+    (is (nil? (state/next-param-for next-cursor [(page [:a] nil)]))))
+  (testing "an empty page vector yields nil (no last page to derive from)"
+    (is (nil? (state/next-param-for next-cursor []))))
+  (testing "no :next-page-param fn yields nil"
+    (is (nil? (state/next-param-for nil [(page [:a] "c1")])))))
+
+(deftest prev-param-derivation-mirror
+  (testing "prev-param-for derives from the FIRST page (R7 mirror)"
+    (let [pages [{:items [:a] :page-info {:prev-cursor "p0"}}
+                 {:items [:b] :page-info {:prev-cursor "p1"}}]]
+      (is (= "p0" (state/prev-param-for prev-cursor pages))
+          "the prev cursor comes from the head, not the tail")))
+  (testing "no :prev-page-param fn yields nil (mirror not declared)"
+    (is (nil? (state/prev-param-for nil [(page [:a] "c1")])))))
+
+(deftest terminal-rule
+  (testing "terminal? is the nil-next-param rule (R8 single terminal)"
+    (is (true? (state/terminal? nil)))
+    (is (false? (state/terminal? "c1")))
+    (is (false? (state/terminal? 0)) "0 is a legit cursor, not terminal")))
+
+;; ---- entry-append-page -----------------------------------------------------
+
+(deftest append-first-page
+  (testing "appending page-0 to an empty feed accumulates + advances the cursor"
+    (let [e0 (state/empty-infinite-entry :feed/timeline)
+          e1 (state/entry-append-page
+               e0 {:page (page [:a :b] "c1")
+                   :page-param nil           ;; page-0 param is nil (initial)
+                   :next-page-param-fn next-cursor
+                   :loaded-at 1000 :stale-at 61000})]
+      (is (= [(page [:a :b] "c1")] (:data e1)))
+      (is (= [nil] (:page-params e1)))
+      (is (= "c1" (:next-page-param e1)) "cursor advanced to next")
+      (is (= :loaded (:status e1)))
+      (is (= 1000 (:loaded-at e1)))
+      (is (= 61000 (:stale-at e1)))
+      (is (= 1 (state/page-count e1)))
+      (is (> (:revision e1) (:revision e0)) "authoritative write bumps revision (EP-0019)"))))
+
+(deftest append-multiple-pages-accumulates
+  (testing "successive appends grow the feed in order + re-derive the cursor"
+    (let [e (-> (state/empty-infinite-entry :feed/timeline)
+                (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+                                          :next-page-param-fn next-cursor
+                                          :loaded-at 1000 :stale-at 2000})
+                (state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
+                                          :next-page-param-fn next-cursor
+                                          :loaded-at 1100 :stale-at 2100})
+                (state/entry-append-page {:page (page [:c] "c3") :page-param "c2"
+                                          :next-page-param-fn next-cursor
+                                          :loaded-at 1200 :stale-at 2200}))]
+      (is (= [(page [:a] "c1") (page [:b] "c2") (page [:c] "c3")] (:data e)))
+      (is (= [nil "c1" "c2"] (:page-params e)) "one param per page, page-0 = nil")
+      (is (= "c3" (:next-page-param e)))
+      (is (= 3 (state/page-count e)))
+      (is (= 1200 (:loaded-at e)) "loaded-at re-stamped each append"))))
+
+(deftest append-terminal-page
+  (testing "a page whose next-cursor is nil sets :next-page-param nil (terminal)"
+    (let [e (-> (state/empty-infinite-entry :feed/timeline)
+                (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+                                          :next-page-param-fn next-cursor
+                                          :loaded-at 1 :stale-at 2})
+                (state/entry-append-page {:page (page [:b] nil) :page-param "c1"
+                                          :next-page-param-fn next-cursor
+                                          :loaded-at 3 :stale-at 4}))]
+      (is (nil? (:next-page-param e)) "terminal — no more pages")
+      (is (state/terminal? (:next-page-param e)))
+      (is (= 2 (state/page-count e)) "the terminal page IS accumulated"))))
+
+(deftest append-recomputes-prev-mirror
+  (testing "append re-derives :prev-page-param from the head when a fn is supplied"
+    (let [e (state/entry-append-page
+              (state/empty-infinite-entry :feed/timeline)
+              {:page {:items [:a] :page-info {:prev-cursor "p0"}}
+               :page-param nil
+               :next-page-param-fn (fn [_ _] nil)
+               :prev-page-param-fn prev-cursor
+               :loaded-at 1 :stale-at 2})]
+      (is (= "p0" (:prev-page-param e))))))
+
+(deftest append-clears-page-error
+  (testing "a successful append clears a prior :page-error (load-more recovery)"
+    (let [failed (-> (state/empty-infinite-entry :feed/timeline)
+                     (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+                                               :next-page-param-fn next-cursor
+                                               :loaded-at 1 :stale-at 2})
+                     (state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
+          recovered (state/entry-append-page failed
+                                              {:page (page [:b] "c2") :page-param "c1"
+                                               :next-page-param-fn next-cursor
+                                               :loaded-at 3 :stale-at 4})]
+      (is (some? (:page-error failed)) "the failure recorded a page-error")
+      (is (nil? (:page-error recovered)) "the next success cleared it")
+      (is (= 2 (state/page-count recovered))))))
+
+(deftest append-nil-entry-noop
+  (testing "appending to a nil entry returns nil unchanged (no feed to append to)"
+    (is (nil? (state/entry-append-page nil {:page (page [:a] "c1")
+                                            :next-page-param-fn next-cursor
+                                            :loaded-at 1 :stale-at 2})))))
+
+;; ---- entry-page-failed (the THIRD error channel) ---------------------------
+
+(deftest page-failure-keeps-feed
+  (testing "a load-more failure keeps ALL pages + records :page-error (third channel)"
+    (let [loaded (-> (state/empty-infinite-entry :feed/timeline)
+                     (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+                                               :next-page-param-fn next-cursor
+                                               :loaded-at 1 :stale-at 2})
+                     (state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
+                                               :next-page-param-fn next-cursor
+                                               :loaded-at 3 :stale-at 4}))
+          envelope {:kind :rf.http/server :status 503}
+          failed (state/entry-page-failed loaded {:error envelope})]
+      (is (= :loaded (:status failed)) "feed returns to :loaded, NOT :error")
+      (is (= 2 (state/page-count failed)) "all accumulated pages kept")
+      (is (= (:data loaded) (:data failed)) "page vector untouched")
+      (is (= "c2" (:next-page-param failed)) "cursor untouched")
+      (is (= envelope (:page-error failed)) ":page-error recorded")
+      (is (nil? (:error failed)) "NOT the first-load :error channel")
+      (is (nil? (:refresh-error failed)) "NOT the refresh :refresh-error channel")
+      (is (nil? (:current-work failed)) ":current-work cleared"))))
+
+(deftest page-failed-nil-entry-noop
+  (testing "page-failed on a nil entry returns nil unchanged"
+    (is (nil? (state/entry-page-failed nil {:error {:kind :rf.http/server}})))))
+
+;; ---- resolve-page->items (R3 accessor) -------------------------------------
+
+(deftest page-accessor-resolution
+  (testing "a keyword accessor lifts to its get fn"
+    (let [acc (state/resolve-page->items :items)]
+      (is (fn? acc))
+      (is (= [:a :b] (acc {:items [:a :b]})))))
+  (testing "a fn accessor passes through"
+    (let [f (fn [p] (:rows p))
+          acc (state/resolve-page->items f)]
+      (is (= [:x] (acc {:rows [:x]})))))
+  (testing "nil accessor resolves to nil (caller applies vector-identity / raises at merge)"
+    (is (nil? (state/resolve-page->items nil))))
+  (testing "a non-keyword / non-fn accessor resolves to nil"
+    (is (nil? (state/resolve-page->items 99)))))
+
+;; ---- page-param-for-spec (page-0 cursor) -----------------------------------
+
+(deftest page-0-param-default
+  (testing "page-0 param defaults to nil (TanStack initialPageParam analogue)"
+    (is (nil? (state/page-param-for-spec {})))
+    (is (nil? (state/page-param-for-spec {:initial-page-param nil}))))
+  (testing "an :initial-page-param override is honoured"
+    (is (= "p0" (state/page-param-for-spec {:initial-page-param "p0"})))))


### PR DESCRIPTION
EP-0021 build **wave 2 of 7** (rf2-kuh9l2). RUNTIME only, resources artefact — registry validation + the durable page-vector entry shape/transitions. Implements to the MERGED wave-1 spec (`spec/016-Resources.md` §Infinite resources and load-more feeds + §Resolved decisions R1–R8; `spec/Spec-Schemas.md` `:rf/infinite-resource-args`) exactly. NO load-more event (wave 3), NO subs (wave 4).

## Registry validation — `registry.cljc` `validate-infinite-spec!`
`:infinite true` selects the additive `:rf/infinite-resource-args` slice and is gated fail-closed at registration:
- **`:next-page-param` REQUIRED** — a missing / non-fn value is the R8 gate `:rf.error/infinite-missing-next-page-param` (symmetric with the `:scope` / `:params-schema` / `:request` gates).
- `:infinite` present-but-not-literally-`true` is rejected (`[:= true]` selector; `:infinite false` is meaningless) → `:rf.error/invalid-resource-spec`.
- Optional infinite-only keys shape-validated when present: `:prev-page-param` (R7 mirror) must be a fn; `:page->items` (R3 accessor) must be a keyword or fn; `:refetch` (R6 policy) must be a map with a boolean `:refetch-all-pages?` and/or an integer `:refetch-window`.
- The per-page cursor is **never** a registration key (R8) — it rides the runtime-threaded reserved `:request` ctx.
- `:rf.error/infinite-missing-page-accessor` stays **runtime-detected** at the first non-vector page in the merge layer (wave 4) — at registration there is no page to inspect; here only `:page->items`'s shape is validated.

## State shape + transitions — `state.cljc` (R1: NO new entry kind)
The feed is the same `:rf/resource-entry` whose `:data` is refined to the **ordered page vector** — mapped to the spec:
- **`empty-infinite-entry`** — seeds the feed facts: `:infinite?`, `:data []`, `:page-params []`, `:next-page-param` / `:prev-page-param` / `:page-error` nil (R1 §Durable cache shape).
- **`next-param-for` / `prev-param-for`** — pure cursor derivation from accumulated pages; `nil` = the single canonical terminal (`terminal?`, R8). Next derives from the last page, prev from the first (R7 mirror; load-prev event deferred).
- **`entry-append-page`** — the pure APPEND transition (R1/R2): append the decoded page + its param to `:data` / `:page-params`, recompute `:next-page-param` from the new tail, clear `:page-error`, re-stamp `:loaded-at`/`:stale-at`, return to `:loaded`, bump `:revision` unconditionally (EP-0019). **No 6th FSM state** — reuses the existing refresh-class `:fetching`/`:loaded`.
- **`entry-page-failed`** — the **third error channel**: keeps all accumulated pages + cursor, records `:page-error` (distinct from first-load `:error` and whole-feed `:refresh-error`); cleared by the next successful append.
- **`resolve-page->items`** lifts the R3 accessor (keyword|fn → fn); **`page-param-for-spec`** resolves the page-0 cursor (default `nil`, `:initial-page-param` override).

## Tests (new)
- `resources_infinite_registration_cljs_test.cljc` — good/bad `:infinite` shapes: valid (+ all optionals) registers; missing/non-fn `:next-page-param` rejected; non-infinite untouched; `:infinite` non-true rejected; `:prev-page-param`/`:page->items`/`:refetch` shape gates.
- `resources_infinite_state_cljs_test.cljc` — empty-entry shape; next/prev derivation + terminal-nil; first/multi/terminal page append + accumulation + cursor advance; page-error third-channel keeps the feed; accessor + page-0-param resolution.

## Quality gates
\`\`\`
cd implementation && npm run test:cljs
# => Ran 7900 tests containing 32740 assertions. 0 failures, 0 errors.
# resources JVM:
cd implementation/resources && clojure -M:test
# => Ran 519 tests containing 2180 assertions. 0 failures, 0 errors.
\`\`\`

On merge the mayor dispatches **wave 3** (the `:rf.resource/load-more` event handler).