### PR TITLE
feat(resources): EP-0021 wave 3 — :rf.resource/load-more event + refetch reset (rf2-6474lx)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -406,6 +406,14 @@
 (events/reg-event :rf.resource/refetch
                      generation-meta
                      resource-events/refetch-handler)
+;; EP-0021 R2 — `:rf.resource/load-more` extends an infinite feed by one page.
+;; It mints a generation (the same host-side monotone allocator, for stale
+;; suppression — the work-id derives from it) and records the work-ledger
+;; `:started-at` from the causal `:rf/time-ms`, so it declares the recordable
+;; generation-allocation cofx + the time cofx exactly like ensure / refetch.
+(events/reg-event :rf.resource/load-more
+                     generation-meta
+                     resource-events/load-more-handler)
 ;; EP-0017 (rf2-601ife): `invalidate-tags` writes the durable `:invalidated-at`
 ;; fact from the event's causal `:rf/time-ms`, so it declares the time cofx.
 (events/reg-event :rf.resource/invalidate-tags
@@ -456,6 +464,19 @@
 (events/reg-event :rf.resource.internal/failed
                      time-meta
                      resource-events/failed-handler)
+;; EP-0021 R1/R2 — the infinite-feed PAGE reply handlers. DISTINCT from the
+;; scalar succeeded / failed replies: a page success APPENDS / replaces-in-place
+;; one page (`entry-replace-page`); a page failure is the THIRD error channel
+;; (`entry-page-failed` keeps the feed + records `:page-error`). They reuse the
+;; same `live-entry-for-reply` verification + stale suppression and consume the
+;; reply token's causal `:rf/time-ms` (→ `:loaded-at` / `:completed-at`), so
+;; each declares the time cofx. User code MUST NOT dispatch them.
+(events/reg-event :rf.resource.internal/page-succeeded
+                     time-meta
+                     resource-events/page-succeeded-handler)
+(events/reg-event :rf.resource.internal/page-failed
+                     time-meta
+                     resource-events/page-failed-handler)
 (events/reg-event :rf.resource.internal/aborted
                      time-meta
                      resource-events/aborted-handler)

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -97,6 +97,86 @@
 ;; byte-for-byte with the mutation-success path so a patched / populated entry
 ;; ages exactly as a fetched one (rf2-366u0g).
 
+;; ---- infinite-feed page context + reply addressing (EP-0021 R8) -----------
+;;
+;; An infinite resource reuses the WHOLE load-causing path (`ensure-load`):
+;; identity, scope, generation, work-ledger row, dedupe, stale suppression,
+;; transport lowering. It differs in exactly two places (R1/R2/R8 — no new
+;; entry kind, no 6th FSM state):
+;;
+;;   1. the entry it seeds on a first load is `empty-infinite-entry` (the
+;;      `:data` page vector + page-param facts), not the scalar `empty-entry`;
+;;   2. the transport request carries the RESERVED page ctx
+;;      `{:rf.resource/page-param p :rf.resource/page-index i}` (R8 — the
+;;      already-reserved `ctx` slot, NOT a new 3-arity), and the reply is
+;;      addressed at the PAGE reply handlers (`:rf.resource.internal/page-*`)
+;;      so a page success APPENDS (`entry-append-page`) rather than overwriting
+;;      the whole value (`entry-succeeded`). The page-param + page-index ride
+;;      the reply `:reply-payload` so the append knows which param to record.
+;;
+;; Page-0 (a first `ensure`, or a `refetch`'s replacement page-0) uses
+;; `page-param-for-spec` (the framework default `nil`, overridable via
+;; `:initial-page-param`) at index 0; a `load-more` uses `next-param-for` over
+;; the accumulated pages at index `page-count`. The single home so the page-0
+;; fetch and the load-more fetch lower identically.
+
+(def page-reserved-ctx-param-key
+  "The RESERVED `:request` ctx key carrying the resolved page-param for an
+  infinite feed's THIS page (R8). The `:request` fn reads it via
+  `{:rf.resource/keys [page-param page-index]}`. Per Spec 016 §Registration —
+  :infinite (the reserved ctx is the page extension point)."
+  :rf.resource/page-param)
+
+(def page-reserved-ctx-index-key
+  "The RESERVED `:request` ctx key carrying the 0-based page index for an
+  infinite feed's THIS page (R8). Per Spec 016 §Registration — :infinite."
+  :rf.resource/page-index)
+
+(defn page-request-ctx
+  "Build the RESERVED `:request` ctx for an infinite feed page fetch (R8):
+  `{:rf.resource/page-param p :rf.resource/page-index i}`. The `:request` fn
+  reads `p` / `i` from this map's reserved keys; a non-infinite resource never
+  reaches here (it lowers with a nil ctx, unchanged). Per Spec 016
+  §Registration — :infinite / §Causal event — load-more."
+  [page-param page-index]
+  {page-reserved-ctx-param-key page-param
+   page-reserved-ctx-index-key page-index})
+
+(def page-succeeded-reply
+  "The framework-internal infinite-feed page-success reply event id
+  (`:rf.resource.internal/page-succeeded`). DISTINCT from
+  `:rf.resource.internal/succeeded` (the scalar whole-value settle): a page
+  success APPENDS the decoded page to the feed's page vector
+  (`entry-append-page`) rather than overwriting `:data`. User code MUST NOT
+  dispatch it. Per Spec 016 §Causal event — load-more."
+  :rf.resource.internal/page-succeeded)
+
+(def page-failed-reply
+  "The framework-internal infinite-feed page-failure reply event id
+  (`:rf.resource.internal/page-failed`). DISTINCT from
+  `:rf.resource.internal/failed`: a page (N>0 load-more) failure is the THIRD
+  error channel (`entry-page-failed` keeps the feed + records `:page-error`),
+  not a first-load `:error` / whole-feed `:refresh-error`. User code MUST NOT
+  dispatch it. Per Spec 016 §Causal event — load-more (the third error
+  channel)."
+  :rf.resource.internal/page-failed)
+
+(defn- infinite-page-reply-payload
+  "The verification payload for an infinite-feed page fetch — the SAME
+  stale-suppression identity the scalar reply carries (`:work/id` /
+  `:resource/key` / `:scope` / `:generation`; the `:rf.frame/id` is merged by
+  `build-managed-args`) PLUS the resolved `:rf.resource/page-param` and
+  `:rf.resource/page-index` so the page-success reply records the right param
+  in `:page-params` (the param is reply state, never re-derived at settle).
+  Per Spec 016 §Causal event — load-more."
+  [scoped-key scope generation work-id page-param page-index]
+  {:work/id                  work-id
+   :resource/key             scoped-key
+   :scope                    scope
+   :generation               generation
+   page-reserved-ctx-param-key page-param
+   page-reserved-ctx-index-key page-index})
+
 ;; ---- ensure / refetch — the load-causing events ---------------------------
 
 (defn- ensure-load
@@ -150,8 +230,15 @@
         ;; rf2-rplgkw: scope (resolve-scope-for-event → canonicalize-scope) +
         ;; cparams (validate+canonicalize-params) are ALREADY canonical.
         scoped-key (state/scoped-resource-key* scope resource cparams)
+        ;; EP-0021 R1: an infinite feed is the SAME durable entry whose `:data`
+        ;; is the ordered page vector — seed `empty-infinite-entry` (the page
+        ;; facts) on a first load, NOT the scalar `empty-entry`. A registered
+        ;; non-infinite resource seeds the scalar entry unchanged.
+        infinite?  (registry/infinite-resource? spec)
         entry      (or (get-in runtime-db (state/entry-path scoped-key))
-                       (state/empty-entry resource scoped-key))
+                       (if infinite?
+                         (state/empty-infinite-entry resource scoped-key)
+                         (state/empty-entry resource scoped-key)))
         prior-work (:current-work entry)
         in-flight? (some? prior-work)
         ;; JOINABLE work (rf2-v4ygg5): an `ensure` may DEDUPE onto the prior
@@ -321,12 +408,46 @@
             ;; mints the same `:started-at` / `:deadline-at`.
             started-at time-ms
             deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
+            ;; EP-0021 R6 — a forced REFETCH of an infinite feed resets the
+            ;; accumulation per the resource's `:refetch` policy BEFORE the
+            ;; replacement page-0 starts. The ruled DEFAULT is window-preserving
+            ;; (keep the visible pages until the replacement page-0 succeeds —
+            ;; a focus/reconnect/invalidation refetch never collapses a loaded
+            ;; feed to page 0); the opt-ins `:refetch-all-pages?` /
+            ;; `:refetch-window` are R6 day-one knobs handled at the reply layer
+            ;; (the replacement page-0 success determines what is kept). On an
+            ;; ENSURE (not force-new) the entry is left as-is — a fresh ensure of
+            ;; an infinite feed first-loads page 0 (empty `:data`), and an ensure
+            ;; of an already-loaded feed never reaches the `:else` fresh-load
+            ;; branch (fresh-skip / dedupe handle it). Window-preserving is a
+            ;; pure no-op on `entry'` here (the page vector simply stays), so the
+            ;; reset is recorded on the entry only when an opt-in discards.
+            refetch-policy (when infinite? (:refetch spec))
             entry'     (cond-> (state/entry-start-load
                                  entry {:generation generation :work-id work-id
                                         :request-id request-id :owner owner})
                          ;; `:keep-previous?` projection pointer (a pointer
                          ;; only — never this key's data / tags).
-                         prev-key (assoc :previous-key prev-key))
+                         prev-key (assoc :previous-key prev-key)
+                         ;; EP-0021 R6 — a forced REFETCH of an infinite feed
+                         ;; resets the accumulation to the kept window per the
+                         ;; `:refetch` policy (window-preserving default = a
+                         ;; pure no-op; `:refetch-all-pages?` / `:refetch-window`
+                         ;; truncate the tail). An ensure (not force-new) leaves
+                         ;; the feed untouched (page-0 first load).
+                         (and infinite? force-new?)
+                         (state/entry-refetch-reset
+                           {:next-page-param-fn (:next-page-param spec)
+                            :prev-page-param-fn (:prev-page-param spec)
+                            :refetch-policy     refetch-policy}))
+            ;; EP-0021 R8 — the page context for THIS fetch. A first ensure /
+            ;; a refetch's replacement fetch a page-0 (`page-param-for-spec` —
+            ;; the framework `nil` default, overridable via `:initial-page-param`
+            ;; — at index 0). A non-infinite resource passes a nil ctx (R8 — the
+            ;; reserved ctx is empty for a non-infinite request, unchanged).
+            page-param (when infinite? (state/page-param-for-spec spec))
+            page-index 0
+            req-ctx    (when infinite? (page-request-ctx page-param page-index))
             ;; a forced refetch over an in-flight prior attempt SUPERSEDES it:
             ;; mark the old work record :superseded (terminal) and emit a
             ;; best-effort abort (opportunistic; stale suppression already
@@ -359,8 +480,24 @@
             ;; stamp the qualified :rf.frame/id + :work/id + :resource/key +
             ;; :scope + :generation so the reply handlers verify before
             ;; writing (stale suppression is the correctness boundary).
+            ;; EP-0021 R8 — the `:request` fn keeps its settled `(params ctx)`
+            ;; shape; an infinite feed's reserved `ctx` carries the resolved
+            ;; page context for THIS page, a non-infinite resource's ctx is
+            ;; nil (unchanged). NO new arity.
             http-args  (let [req-fn (:request spec)]
-                         (req-fn cparams nil))
+                         (req-fn cparams req-ctx))
+            ;; EP-0021 R1/R2 — an infinite page fetch is addressed at the PAGE
+            ;; reply handlers (`:rf.resource.internal/page-*`) so a page success
+            ;; APPENDS / REPLACES-IN-PLACE rather than overwriting the whole
+            ;; value; the reply payload carries the resolved `:page-param` /
+            ;; `:page-index` so the settle records the right param. A
+            ;; non-infinite resource keeps the scalar reply addressing.
+            reply-overrides (when infinite?
+                              {:on-success-id page-succeeded-reply
+                               :on-failure-id page-failed-reply
+                               :reply-payload (infinite-page-reply-payload
+                                                scoped-key scope generation
+                                                work-id page-param page-index)})
             ;; rf2-rrcfwk — guard the declared transport (registration-time
             ;; misconfig throw), then lower directly into the only
             ;; initial-scope transport. The one-arm dispatch indirection
@@ -369,14 +506,16 @@
             ;; lands (the guard becomes the dispatch).
             lower-fx   (do (transport/assert-managed-transport! transport-id where)
                            (transport-http/lower
-                             {:http-args    http-args
-                              :request-id   request-id
-                              :work-id      work-id
-                              :resource/key scoped-key
-                              :scope        scope
-                              :frame-id     frame-id
-                              :generation   generation
-                              :where        where}))]
+                             (merge
+                               {:http-args    http-args
+                                :request-id   request-id
+                                :work-id      work-id
+                                :resource/key scoped-key
+                                :scope        scope
+                                :frame-id     frame-id
+                                :generation   generation
+                                :where        where}
+                               reply-overrides)))]
         (trace/emit! :rf.event :rf.resource/work-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
@@ -427,6 +566,203 @@
   Payload: `{:resource :scope :params :cause}`."
   [cofx [_event-id payload]]
   (ensure-load cofx payload {:force-new? true :where 'rf.resource/refetch}))
+
+;; ---- load-more — the infinite-feed page-extension event (EP-0021 R2) ------
+;;
+;; A causal event that extends an infinite feed by ONE page. It reuses the
+;; WHOLE load-causing substrate — generation, work-ledger row, dedupe, stale
+;; suppression, transport lowering — and differs from `ensure`/`refetch` only
+;; in WHICH page it fetches: the NEXT page param derived from the accumulated
+;; tail (`next-param-for`), at index `page-count` (an APPEND), addressed at the
+;; PAGE reply handlers so the success appends rather than overwrites (R1/R2/R8).
+;;
+;; FSM (R2 — no 6th state): a `load-more` on a `:loaded` feed transitions to
+;; `:fetching` (the existing refresh-class transition — the feed has data, so
+;; `entry-start-load` chooses `:fetching` and the accumulated pages stay
+;; visible). The two SKIP paths fire no request:
+;;   - TERMINAL (`next-param-for` is nil — no more pages): a no-op that emits
+;;     `:rf.resource/load-more-skipped` `:reason :no-next-page`;
+;;   - IN-FLIGHT (a page fetch is already running): dedupe against the live
+;;     work, emit `:rf.resource/load-more-skipped` `:reason :in-flight`.
+;; A `load-more` on a feed that does not exist / is not yet loaded is also a
+;; no-op (`:reason :no-feed` — there is no tail to derive the next param from;
+;; the first page is `ensure`'s page-0, not a load-more).
+
+(defn- load-more-loaded
+  "Core of `:rf.resource/load-more` (EP-0021 R2). Resolves the feed's scoped
+  key (the FEED identity — the per-page param is NOT in the key, R1), reads the
+  live entry, and either SKIPS (terminal / in-flight / no-feed — no request) or
+  issues the NEXT page fetch (derived param at index `page-count`) through the
+  resource's `:request` with the reserved page ctx, recording a work-ledger row
+  and transitioning the feed to `:fetching` (pages stay visible). Reuses the
+  recorded generation allocation (replay-stable) and the page reply addressing
+  so the success appends via `entry-append-page` and a failure records
+  `:page-error` (`entry-page-failed`). Returns the reg-event effects map."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id
+    gen-allocation :rf.resource/generation-allocation
+    time-ms :rf/time-ms, app-db :db}
+   {:keys [resource owner cause] :as payload} {:keys [where]}]
+  (let [runtime-db (or rt {})
+        spec       (registry/require-resource-spec! resource where)
+        scope      (registry/resolve-scope-for-event
+                     resource spec {:payload-scope (:scope payload) :db app-db} where)
+        cparams    (registry/validate+canonicalize-params
+                     resource spec (state/params-present? payload) where)
+        scoped-key (state/scoped-resource-key* scope resource cparams)
+        entry      (get-in runtime-db (state/entry-path scoped-key))
+        prior-work (:current-work entry)
+        prior-record (when prior-work (work-ledger/get-record runtime-db prior-work))
+        prior-status (:status prior-record)
+        ;; a page fetch (or any fetch) is genuinely in flight when the linked
+        ;; work record is LIVE (`:queued` / `:running`) — the same `joinable?`
+        ;; liveness the `ensure` dedupe uses (rf2-v4ygg5). A doomed
+        ;; (`:abort-requested`) / terminal pointer is NOT in flight.
+        in-flight? (and (some? prior-record)
+                        (not (work-ledger/terminal? prior-status))
+                        (not= :abort-requested prior-status))
+        pages      (:data entry)
+        next-param (state/next-param-for (:next-page-param spec) pages)
+        terminal?  (state/terminal? next-param)
+        page-index (state/page-count entry)]
+    (cond
+      ;; ----- no feed: load-more before page 0 exists — no-op --------------
+      ;; The first page is `ensure`'s page-0, not a load-more; a load-more with
+      ;; no accumulated tail has no param to derive (`next-param-for` returns
+      ;; nil on an empty/absent page vector, so this also covers a not-yet-
+      ;; loaded feed). Fail-quiet (a trace), never a spurious request.
+      (or (nil? entry) (not (state/infinite-entry? entry)) (empty? pages))
+      (do
+        (trace/emit! :rf.event :rf.resource/load-more-skipped
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :reason :no-feed :owner owner :cause cause})
+        {:rf.db/runtime runtime-db})
+
+      ;; ----- terminal: no more pages — no-op (R2) -------------------------
+      terminal?
+      (do
+        (trace/emit! :rf.event :rf.resource/load-more-skipped
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :reason :no-next-page :page-count page-index
+                      :owner owner :cause cause})
+        {:rf.db/runtime runtime-db})
+
+      ;; ----- dedupe: a page fetch is already in flight — no-op (R2) -------
+      ;; A second load-more while one is running JOINS (no new generation, no
+      ;; second request), exactly as a duplicate `ensure` does. The owner /
+      ;; cause are folded onto the live work record so the in-flight page is
+      ;; attributed to the new caller too.
+      in-flight?
+      (let [rdb' (work-ledger/update-record
+                   runtime-db prior-work work-ledger/join-owner+cause owner cause)]
+        (trace/emit! :rf.event :rf.resource/load-more-skipped
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :reason :in-flight :work/id prior-work
+                      :page-count page-index :owner owner :cause cause})
+        {:rf.db/runtime rdb'})
+
+      ;; ----- issue the next page fetch (fresh generation, APPEND) ---------
+      :else
+      (let [generation (:generation gen-allocation)
+            work-id    (work-ledger/resource-work-id scoped-key generation)
+            request-id (work-ledger/managed-request-id frame-id work-id)
+            started-at time-ms
+            deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
+            transport-id (or (:transport spec) transport/default-transport)
+            ;; transition the FEED to its in-flight status. The feed has data,
+            ;; so `entry-start-load` chooses `:fetching` (the refresh-class
+            ;; transition — pages stay visible, no skeleton); it bumps the
+            ;; generation/attempt, records `:current-work` + `:request-id`, and
+            ;; attaches the owner. The page vector is UNTOUCHED (a load-more
+            ;; never collapses the feed). Per Spec 016 §Causal event — load-more.
+            entry'     (state/entry-start-load
+                         entry {:generation generation :work-id work-id
+                                :request-id request-id :owner owner})
+            record     (work-ledger/work-record
+                         {:work-id      work-id
+                          :frame-id     frame-id
+                          :resource/key scoped-key
+                          :generation   generation
+                          :transport    transport-id
+                          :owner        owner
+                          :cause        cause
+                          :started-at   started-at
+                          :deadline-at  deadline})
+            owner-newly-attached? (and (some? owner)
+                                       (not (contains? (:active-owners entry) owner)))
+            rdb'       (-> runtime-db
+                           (assoc-in (state/entry-path scoped-key) entry')
+                           (work-ledger/put-record work-id record)
+                           (cond->
+                             owner (update-in (state/owner-index-path)
+                                              update owner (fnil conj #{}) (state/key-id scoped-key))))
+            ;; R8 — the reserved page ctx for THIS (next) page: the derived
+            ;; param at index `page-count` (an append).
+            req-ctx    (page-request-ctx next-param page-index)
+            http-args  (let [req-fn (:request spec)]
+                         (req-fn cparams req-ctx))
+            lower-fx   (do (transport/assert-managed-transport! transport-id where)
+                           (transport-http/lower
+                             {:http-args    http-args
+                              :request-id   request-id
+                              :work-id      work-id
+                              :resource/key scoped-key
+                              :scope        scope
+                              :frame-id     frame-id
+                              :generation   generation
+                              :where        where
+                              ;; page reply addressing — a page success APPENDS
+                              ;; at this index; the payload carries the resolved
+                              ;; param so the settle records it in :page-params.
+                              :on-success-id page-succeeded-reply
+                              :on-failure-id page-failed-reply
+                              :reply-payload (infinite-page-reply-payload
+                                               scoped-key scope generation
+                                               work-id next-param page-index)}))]
+        (trace/emit! :rf.event :rf.resource/load-more
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :generation generation :work/id work-id
+                      :page-param next-param :page-index page-index
+                      :page-count page-index :owner owner :cause cause})
+        (trace/emit! :rf.event :rf.resource/work-started
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :generation generation :work/id work-id
+                      :status :running :owner owner :cause cause})
+        (trace/emit! :rf.event :rf.resource/fetch-started
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :generation generation :work/id work-id
+                      :status (:status entry') :owner owner :cause cause})
+        (when owner-newly-attached?
+          (trace/emit! :rf.event :rf.resource/owner-attached
+                       {:rf.frame/id frame-id :resource/key scoped-key
+                        :generation generation :owner owner :cause cause
+                        :work/id work-id :joined-in-flight? false}))
+        {:rf.db/runtime rdb'
+         :fx [[:rf.resource/commit-generation {:value generation}]
+              [:rf.resource/record-work-handle
+               {:frame-id frame-id :work-id work-id
+                :transport transport-id :request-id request-id}]
+              lower-fx]}))))
+
+(defn load-more-handler
+  "`:rf.resource/load-more` — extend an infinite feed by one page (EP-0021
+  R2). Computes the next page param from the feed's accumulated tail (via the
+  resource's `:next-page-param`), issues the managed request for that page with
+  the reserved page ctx `{:rf.resource/page-param p :rf.resource/page-index i}`,
+  records a work-ledger row, and transitions the feed to `:fetching` (the
+  existing refresh-class transition — the accumulated pages stay visible).
+
+  A TERMINAL feed (`:next-page-param` nil) is a no-op (`:reason :no-next-page`);
+  a load-more while a page fetch is already in flight DEDUPES against the live
+  work (`:reason :in-flight`); a load-more before page 0 exists is a no-op
+  (`:reason :no-feed`). On success the page is APPENDED (`entry-append-page`)
+  via the `:rf.resource.internal/page-succeeded` reply; a failure records
+  `:page-error` (`entry-page-failed`) via `:rf.resource.internal/page-failed` —
+  the third error channel (the feed keeps its pages). Generation + work-id
+  stale suppression protect a late page reply exactly as for any fetch. Per
+  Spec 016 §Causal event — load-more. Payload:
+  `{:resource :scope :params :owner :cause}`."
+  [cofx [_event-id payload]]
+  (load-more-loaded cofx payload {:where 'rf.resource/load-more}))
 
 ;; ---- focus / reconnect revalidation (rf2-vtblcq) --------------------------
 ;;
@@ -1802,6 +2138,192 @@
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
+        {:rf.db/runtime rdb'}))))
+
+;; ---- infinite-feed page reply handlers (EP-0021 R1/R2) --------------------
+;;
+;; A page fetch (a first ensure's page-0, a refetch's replacement page-0, or a
+;; load-more's next page) settles through these reply handlers — DISTINCT from
+;; the scalar `succeeded-handler` / `failed-handler` because a page success
+;; APPENDS / REPLACES-IN-PLACE a single page (`entry-replace-page`, which
+;; delegates to `entry-append-page` when the index is at the tail) rather than
+;; overwriting the whole `:data`, and a page failure is the THIRD error channel
+;; (`entry-page-failed` keeps the feed + records `:page-error`). They reuse the
+;; SAME verification + stale-suppression substrate (`live-entry-for-reply` /
+;; `stale-suppress-reply`) so a superseded / cross-frame / restored-dangling
+;; page reply can NEVER append to a newer (or another frame's) feed — the
+;; monotonic generation allocator guarantees a pre-supersession page reply's
+;; generation never matches the live feed.
+
+(defn page-succeeded-handler
+  "`:rf.resource.internal/page-succeeded` — an infinite-feed page fetch
+  succeeded (EP-0021 R1/R2). Re-lifts the transport's PUBLIC reply into the
+  canonical reply map, verifies frame + `:work/id` + generation against the
+  live feed entry, and on match APPENDS / REPLACES-IN-PLACE the decoded page at
+  the reply's `:rf.resource/page-index` (`entry-replace-page` — an append when
+  the index is at the tail, the load-more / page-0 case; an in-place replace for
+  a window-preserving refetch's page-0), recording the resolved
+  `:rf.resource/page-param` in `:page-params`, recomputing `:next-page-param` /
+  `:prev-page-param`, clearing `:page-error`, and returning the feed to
+  `:loaded` (structural sharing preserves every unchanged page). A stale /
+  superseded / cross-frame page reply is SUPPRESSED — it MUST NEVER mutate a
+  newer feed. Per Spec 016 §Causal event — load-more.
+
+  Event shape: `[_ <verification-payload> <http-result>]` — the managed-HTTP
+  transport appends `{:kind :success :value <decoded-page>}` as the last arg;
+  the decoded page is read from there (with the `:data` durable-layer fallback
+  for direct-dispatch tests) and appended."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
+   [_event-id {work-id :work/id resource-key :resource/key
+               :keys [generation]
+               page-param :rf.resource/page-param
+               page-index :rf.resource/page-index :as payload} http-result]]
+  (let [runtime-db   (or rt {})
+        page         (rreply/transport-success-value payload http-result :data)
+        completed-at time-ms
+        reply        (rreply/success-reply payload page
+                                           {:work-kind rreply/work-kind-resource
+                                            :completed-at completed-at})
+        entry        (live-entry-for-reply runtime-db frame-id payload)]
+    (if (nil? entry)
+      ;; STALE SUPPRESSION (mandatory) — a superseded / vanished / cross-frame
+      ;; page reply never appends to a newer feed. Recorded `:status :stale` /
+      ;; `:work/status :suppressed` through the shared reply substrate, exactly
+      ;; as the scalar success path does.
+      (let [stale (stale-suppress-reply runtime-db resource-key payload
+                                        {:outcome :page-success})]
+        (emit-resource-stale-suppressed!
+          frame-id resource-key work-id generation :page-success stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed {:reason :stale-reply :outcome :page-success})})
+      (let [spec      (registry/resource-meta (:resource/id entry))
+            decoded   (:value reply)
+            loaded-at (:completed-at reply)
+            stale-at  (state/stale-at-for spec loaded-at)
+            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))
+            entry'    (state/entry-replace-page
+                        entry {:page decoded :page-param page-param
+                               :page-index page-index
+                               :next-page-param-fn (:next-page-param spec)
+                               :prev-page-param-fn (:prev-page-param spec)
+                               :loaded-at loaded-at :stale-at stale-at})
+            poll-delay-ms (when (seq (:active-owners entry'))
+                            (state/positive-or-nil (:poll-interval-ms spec)))
+            rdb'      (-> runtime-db
+                          (assoc-in (state/entry-path resource-key) entry')
+                          (work-ledger/update-record
+                            work-id work-ledger/mark-terminal
+                            :completed {:loaded-at loaded-at :page-index page-index})
+                          (work-ledger/prune-terminal-for-key resource-key)
+                          ;; route blocking: a route-owned blocking infinite feed
+                          ;; blocks on page 0 — drain the slot when page 0 lands.
+                          (route/drain-blocking resource-key entry' :success))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-completed
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation :status :completed})
+        (trace/emit! :rf.event :rf.resource/page-appended
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation
+                      :page-index page-index :page-count (state/page-count entry')
+                      :next-page-param (:next-page-param entry')
+                      :terminal? (state/terminal? (:next-page-param entry'))})
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms poll-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource/key   resource-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :poll-delay-ms  poll-delay-ms
+                        :server?        (state/server-frame? frame-id)}]]))))))
+
+(defn page-failed-handler
+  "`:rf.resource.internal/page-failed` — an infinite-feed page fetch failed
+  (EP-0021 R2 — the THIRD error channel). Verifies frame + work-id +
+  generation; on match the feed returns to `:loaded`, KEEPS ALL accumulated
+  pages, and records `:page-error` (`entry-page-failed`) — distinct from a
+  first-load `:error` and a whole-feed `:refresh-error`, so a view shows
+  \"couldn't load more — retry\" without losing the feed. A stale / superseded /
+  cross-frame reply is SUPPRESSED. An ABORT (`:rf.http/aborted`) is a
+  cancellation, not a page error: the feed settles to `:loaded` (data kept)
+  with NO `:page-error` written, and the work row settles `:cancelled`.
+
+  Event shape: `[_ <verification-payload> <http-result>]` — the transport
+  appends `{:kind :failure :failure <:rf.http/* envelope>}` as the last arg."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
+   [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload} http-result]]
+  (let [runtime-db   (or rt {})
+        error        (rreply/transport-failure-envelope payload http-result)
+        completed-at time-ms
+        reply        (rreply/failure-reply payload error
+                                           {:work-kind rreply/work-kind-resource
+                                            :completed-at completed-at})
+        aborted?     (= :cancelled (:status reply))
+        entry        (live-entry-for-reply runtime-db frame-id payload)]
+    (cond
+      ;; STALE SUPPRESSION (mandatory) — stale wins over the natural status
+      ;; (a stale abort settles :suppressed, never an accepted :cancelled).
+      (nil? entry)
+      (let [stale (stale-suppress-reply runtime-db resource-key payload
+                                        {:outcome (if aborted? :aborted :page-failure)})]
+        (emit-resource-stale-suppressed!
+          frame-id resource-key work-id generation
+          (if aborted? :aborted :page-failure) stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed {:reason :stale-reply
+                                       :outcome (if aborted? :aborted :page-failure)
+                                       :completed-at completed-at})})
+
+      ;; ABORT — an intentional cancellation of the page fetch. The feed keeps
+      ;; its pages and returns to :loaded WITHOUT a :page-error (a cancellation
+      ;; is not a load-more failure). The work row settles terminal :cancelled.
+      aborted?
+      (let [entry' (assoc entry :status :loaded :current-work nil)
+            rdb'   (-> runtime-db
+                       (assoc-in (state/entry-path resource-key) entry')
+                       (work-ledger/update-record
+                         work-id work-ledger/mark-terminal
+                         :cancelled {:reason :aborted :completed-at completed-at})
+                       (route/drain-blocking resource-key entry' :success))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation
+                      :status-before (:status entry) :status-after (:status entry')})
+        {:rf.db/runtime rdb'})
+
+      ;; PAGE FAILURE — the third error channel: keep the feed, record
+      ;; :page-error, return to :loaded. (`route/drain-blocking … :failure`
+      ;; only flips a blocking FIRST-load — a feed that already has pages keeps
+      ;; :loaded, so the slot drains like a success; a blocking page-0 failure
+      ;; with no prior pages surfaces the route error via entry-page-failed
+      ;; keeping :status :loaded — but a blocking infinite route blocks on page
+      ;; 0, which on first failure has no data, so drain-blocking keys on the
+      ;; entry's :status. entry-page-failed always returns :loaded, so a route
+      ;; never errors on a load-more page failure — exactly the intent.)
+      :else
+      (let [entry' (state/entry-page-failed entry {:error error})
+            rdb'   (-> runtime-db
+                       (assoc-in (state/entry-path resource-key) entry')
+                       (work-ledger/update-record
+                         work-id work-ledger/mark-terminal
+                         :failed {:error error :completed-at completed-at})
+                       (route/drain-blocking resource-key entry' :success))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-completed
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation :status :failed})
+        (trace/emit! :rf.event :rf.resource/page-failed
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation
+                      :status-before (:status entry) :status-after (:status entry')
+                      :page-error error})
         {:rf.db/runtime rdb'}))))
 
 (defn stale-fired-handler

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -689,13 +689,29 @@
     ;; unknown signal — no transition (defensive; callers pass the closed set)
     status))
 
+;; `infinite-entry?` (the `:infinite?` feed predicate) is defined below in the
+;; infinite-feed refinement section, but `has-data?` reads it — forward-declare
+;; so the canonical predicate stays in one home (the infinite section) while the
+;; shared status derivation can consult it (EP-0021 R1).
+(declare infinite-entry?)
+
 (defn has-data?
   "True iff the entry currently has usable last-known-good `:data`. The
   fact `:loading?` / `:fetching?` / `:has-data?` derive from. Spec 016
   §Status semantics — durable entries store facts, derived booleans are
-  computed (here + in subs), never stored."
+  computed (here + in subs), never stored.
+
+  EP-0021 R1: an INFINITE feed's `:data` is the ordered PAGE VECTOR, seeded
+  EMPTY (`[]`) before page 0 loads. An empty page vector is NO usable data —
+  the feed first-loads page 0 (`:loading`), not a refresh (`:fetching`). So a
+  feed is `has-data?` iff it has at least one accumulated page; only an empty
+  vector (not a non-empty one, and not a scalar nil) reads as no-data. A scalar
+  entry is `has-data?` iff its `:data` is non-nil (unchanged)."
   [entry]
-  (some? (:data entry)))
+  (let [data (:data entry)]
+    (if (infinite-entry? entry)
+      (boolean (seq data))
+      (some? data))))
 
 (defn entry-stale?
   "Derived freshness fact: true iff `entry` is stale against `clock-ms` —
@@ -1103,6 +1119,114 @@
            :status       :loaded
            :page-error   error
            :current-work nil)
+    entry))
+
+(defn entry-replace-page
+  "PURE infinite-feed page REPLACE-IN-PLACE transition (R6 window-preserving
+  refetch): replace the page at `page-index` of the feed `entry` with a
+  freshly-fetched, decoded `page` (and its resolved `page-param`), WITHOUT
+  growing the feed — the accumulated tail is preserved and stays visible. This
+  is the settle a window-preserving `refetch`'s replacement page-0 performs
+  (the ruled R6 default): the feed never collapses to page 0; page 0 is
+  refreshed in place and the rest of the window is kept.
+
+  Like `entry-append-page` it recomputes `:next-page-param` / `:prev-page-param`
+  from the resulting page vector, clears `:page-error` / `:refresh-error`,
+  re-stamps `:loaded-at` / `:stale-at`, returns to `:loaded`, clears
+  `:current-work`, and bumps `:revision` UNCONDITIONALLY (an authoritative
+  durable write — EP-0019 / byl7bk). Structural sharing keeps every OTHER page
+  identical (only the replaced index is new).
+
+  When `page-index` is at or beyond the current page count this DELEGATES to
+  `entry-append-page` (a replacement past the tail is an append — e.g. a
+  window-preserving refetch of a feed that was emptied), so one settle covers
+  both the in-place refresh and the append. A nil entry is returned unchanged.
+  Per Spec 016 §Refetch and invalidation of an infinite feed (R6)."
+  [entry {:keys [page next-page-param-fn prev-page-param-fn page-param page-index
+                 loaded-at stale-at] :as opts}]
+  (if entry
+    (let [pages (or (:data entry) [])]
+      (if (>= page-index (count pages))
+        (entry-append-page entry opts)
+        (let [prev-page (nth pages page-index)
+              ;; structural sharing: keep the OLD page value when the decoded
+              ;; page is `=` (a refetch that returned identical page-0 stays
+              ;; quiet downstream); only the replaced index is ever new.
+              shared    (if (and (some? prev-page) (= prev-page page)) prev-page page)
+              pages'    (assoc pages page-index shared)
+              params'   (assoc (or (:page-params entry) []) page-index page-param)]
+          (-> entry
+              (assoc :status          :loaded
+                     :data            pages'
+                     :page-params     params'
+                     :next-page-param (next-param-for next-page-param-fn pages')
+                     :prev-page-param (prev-param-for prev-page-param-fn pages')
+                     :page-error      nil
+                     :refresh-error   nil
+                     :loaded-at       loaded-at
+                     :stale-at        stale-at
+                     :invalidated-at  nil
+                     :current-work    nil)
+              bump-revision))))
+    entry))
+
+(defn refetch-keep-count
+  "PURE: how many leading pages a `refetch` of an infinite feed KEEPS, given
+  the resource's optional `:refetch` policy (R6) and the feed's current
+  `page-count`. The ruled DEFAULT is window-preserving — keep EVERY
+  accumulated page (`page-count`), so a focus/reconnect/invalidation refetch
+  never collapses a loaded feed to page 0. The day-one opt-ins:
+
+    - `:refetch-all-pages? true` — do NOT preserve the window: keep ONLY page 0
+      (the replacement page-0 re-accumulates the feed from scratch, the
+      TanStack-parity \"refresh the whole thing\" intent; v1 re-fetches page 0
+      and the user re-loads forward rather than a synchronous N-page sweep);
+    - `:refetch-window n` — bound the kept window to the first `n` pages
+      (clamped to `[1, page-count]` — a refetch always keeps at least page 0,
+      and never invents pages beyond what is loaded).
+
+  Returns the keep-count (always ≥ 1 for a non-empty feed; 0 for an empty
+  feed). Per Spec 016 §Refetch and invalidation of an infinite feed (R6)."
+  [refetch-policy page-count]
+  (let [{:keys [refetch-all-pages? refetch-window]} refetch-policy]
+    (cond
+      (zero? page-count)          0
+      refetch-all-pages?          1
+      (integer? refetch-window)   (max 1 (min refetch-window page-count))
+      :else                       page-count)))
+
+(defn entry-refetch-reset
+  "PURE infinite-feed REFETCH reset transition (R6), applied at refetch-ISSUE
+  (before the replacement page-0 fetch starts): truncate the feed's
+  accumulation to the first `keep-count` pages per `refetch-keep-count`, so the
+  in-flight refetch refreshes exactly the intended window. The ruled DEFAULT
+  (window-preserving) keeps EVERY page — a pure no-op here — so the accumulated
+  pages stay visible during the refetch (the feed is `:fetching`, not collapsed
+  to page 0). The opt-ins (`:refetch-all-pages?` / `:refetch-window`) truncate
+  the tail.
+
+  The `:next-page-param` is RECOMPUTED from the (possibly truncated) tail so a
+  windowed refetch resumes load-more from the kept window's edge; `:page-params`
+  is truncated in step. `:data` / `:page-params` keep their leading pages by
+  identity (structural sharing — only the dropped tail changes). Does NOT touch
+  `:status` / `:current-work` / `:revision` (the caller's `entry-start-load`
+  already transitioned the entry to `:fetching` and recorded the work). A nil /
+  non-infinite / empty entry is returned unchanged. Per Spec 016 §Refetch and
+  invalidation of an infinite feed (R6)."
+  [entry {:keys [next-page-param-fn prev-page-param-fn refetch-policy]}]
+  (if (and entry (infinite-entry? entry) (seq (:data entry)))
+    (let [pages      (:data entry)
+          keep-count (refetch-keep-count refetch-policy (count pages))]
+      (if (>= keep-count (count pages))
+        entry                                   ;; window-preserving — keep all
+        (let [pages'  (subvec pages 0 keep-count)
+              params' (subvec (or (:page-params entry) []) 0
+                              (min keep-count (count (:page-params entry))))]
+          (assoc entry
+                 :data            pages'
+                 :page-params     params'
+                 :next-page-param (next-param-for next-page-param-fn pages')
+                 :prev-page-param (prev-param-for prev-page-param-fn pages')))))
     entry))
 
 (defn resolve-page->items

--- a/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
@@ -1,0 +1,402 @@
+(ns re-frame.resources-infinite-load-more-cljs-test
+  "Runtime behaviour for the infinite-feed `:rf.resource/load-more` event +
+  page reply handlers + the R6 refetch reset (EP-0021 wave 3, Spec 016
+  §Infinite resources and load-more feeds).
+
+  Wave 2 landed the PURE entry transitions (`empty-infinite-entry` /
+  `next-param-for` / `entry-append-page` / `entry-page-failed` / …); this
+  slice wires them to the EVENT layer:
+
+    1. `:rf.resource/ensure` on an infinite resource fetches PAGE 0 only
+       (page ctx `{:rf.resource/page-param nil :rf.resource/page-index 0}`),
+       seeds an `empty-infinite-entry`, and addresses the PAGE reply handlers;
+    2. `:rf.resource/load-more` derives the next page param from the tail,
+       issues the next page (index = page-count), and APPENDS on success +
+       advances the cursor;
+    3. a TERMINAL feed (`:next-page-param` nil) load-more is a no-op;
+    4. a load-more while a page fetch is in flight DEDUPES (no second request);
+    5. a stale / superseded page reply is SUPPRESSED (never appends to a newer
+       feed);
+    6. a page-fetch failure is the THIRD error channel — the feed keeps its
+       pages + records `:page-error` (NOT `:error` / `:refresh-error`);
+    7. `:rf.resource/refetch` preserves the visible window by default (R6); the
+       `:refetch-all-pages?` / `:refetch-window` opt-ins truncate the tail.
+
+  The capturing transport REPLAYS the real reply-append shape (Spec 014 §Reply
+  addressing — the live transport conj's its result as the LAST arg of the
+  internal reply event), so the page reply handlers run against the genuine
+  3-element event. The subscription family is wave 4 (out of scope)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.test-support]
+   ;; production HTTP fx surface (so the transport feature probe resolves);
+   ;; the fetch itself is overridden by the capturing reply stub below.
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport that REPLAYS the real reply-append shape ----------
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- capturing-transport-fixture
+  [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-transport-fixture)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- runtime-db
+  ([] (runtime-db :rf/default))
+  ([frame-id] (rf/runtime-db-value frame-id)))
+
+(defn- entry
+  ([scoped-key] (entry :rf/default scoped-key))
+  ([frame-id scoped-key]
+   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+
+(defn- reply-success!
+  "Dispatch the captured `:on-success` reply with the transport's success
+  result appended as the LAST arg — the live managed-HTTP transport shape."
+  ([data] (reply-success! @last-managed-args data))
+  ([args data]
+   (rf/dispatch-sync (conj (:on-success args) {:kind :success :value data}))))
+
+(defn- reply-failure!
+  ([failure] (reply-failure! @last-managed-args failure))
+  ([args failure]
+   (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure}))))
+
+(def ^:private next-cursor
+  "Read the next cursor off a page's `:page-info` envelope; nil ⇒ terminal."
+  (fn [last-page _all-pages] (get-in last-page [:page-info :next-cursor])))
+
+(def ^:private prev-cursor
+  (fn [first-page _all-pages] (get-in first-page [:page-info :prev-cursor])))
+
+(defn- page
+  "An enveloped page: items + a page-info cursor envelope."
+  ([items next-c] (page items next-c nil))
+  ([items next-c prev-c]
+   {:items items :page-info {:next-cursor next-c :prev-cursor prev-c}}))
+
+(defn- feed-spec
+  "A minimal valid infinite-feed resource spec (global scope, a :filter param,
+  cursor pagination via :page-info)."
+  ([] (feed-spec {}))
+  ([overrides]
+   (merge {:scope            :rf.scope/global
+           :infinite         true
+           :params-schema    [:map [:filter :keyword]]
+           :request          (fn [{:keys [filter]} {:rf.resource/keys [page-param page-index]}]
+                               {:request {:method :get :url "/api/feed"
+                                          :params (cond-> {:filter filter :page-index page-index}
+                                                    page-param (assoc :cursor page-param))}})
+           :next-page-param  next-cursor
+           :prev-page-param  prev-cursor
+           :page->items      :items
+           :tags             (fn [{:keys [filter]} _data] #{[:feed filter]})}
+          overrides)))
+
+(defn- feed-key [resource]
+  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+
+(defn- ensure! [resource]
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource resource :scope :rf.scope/global
+                      :params {:filter :recent} :owner [:test :w]}]))
+
+(defn- load-more! [resource]
+  (rf/dispatch-sync [:rf.resource/load-more
+                     {:resource resource :scope :rf.scope/global
+                      :params {:filter :recent} :owner [:test :w]
+                      :cause [:user :feed/load-more]}]))
+
+(defn- load-page-0!
+  "Ensure (page-0) a feed and settle it with `pg`. Returns the scoped key."
+  [resource pg]
+  (rf/reg-resource resource (feed-spec))
+  (ensure! resource)
+  (reply-success! pg)
+  (feed-key resource))
+
+;; ===========================================================================
+;; 1. ensure on an infinite resource fetches page 0 only (seed + page ctx)
+;; ===========================================================================
+
+(deftest ensure-infinite-seeds-feed-and-page-0-ctx
+  (testing "ensure of an infinite resource seeds an empty infinite entry +
+            fetches page 0 with the reserved page ctx (R8)"
+    (rf/reg-resource :inf1/feed (feed-spec))
+    (ensure! :inf1/feed)
+    (let [e (entry (feed-key :inf1/feed))]
+      (is (state/infinite-entry? e) "seeded an infinite entry (R1)")
+      (is (= :loading (:status e)) "first load (no data) is :loading")
+      (is (= [] (:data e)) "page vector still empty (page-0 in flight)"))
+    (testing "the request received the page-0 ctx {:page-param nil :page-index 0}"
+      (let [req-params (get-in @last-managed-args [:request :params])]
+        (is (= 0 (:page-index req-params)) "page-index 0")
+        (is (not (contains? req-params :cursor)) "page-0 cursor is nil")))
+    (testing "the reply is addressed at the PAGE reply handler (not the scalar)"
+      (is (= :rf.resource.internal/page-succeeded (first (:on-success @last-managed-args))))
+      (is (= :rf.resource.internal/page-failed (first (:on-failure @last-managed-args)))))))
+
+(deftest ensure-page-0-success-appends
+  (testing "a page-0 success appends to :data + advances the cursor + :loaded"
+    (let [k (load-page-0! :inf2/feed (page [:a :b] "c1"))
+          e (entry k)]
+      (is (= :loaded (:status e)))
+      (is (= [(page [:a :b] "c1")] (:data e)) "page-0 accumulated")
+      (is (= [nil] (:page-params e)) "page-0 param is nil")
+      (is (= "c1" (:next-page-param e)) "cursor advanced from the page")
+      (is (= 1 (state/page-count e))))))
+
+;; ===========================================================================
+;; 2. load-more appends + advances the cursor (the headline behaviour)
+;; ===========================================================================
+
+(deftest load-more-appends-and-advances-cursor
+  (testing "load-more on a loaded feed fetches the NEXT page (derived param) +
+            transitions to :fetching, then appends on success (R2)"
+    (let [k (load-page-0! :lm/feed (page [:a] "c1"))]
+      (load-more! :lm/feed)
+      (let [e (entry k)]
+        (is (= :fetching (:status e)) "feed has data → refresh-class :fetching")
+        (is (= 1 (state/page-count e)) "page vector unchanged while in flight (pages stay visible)"))
+      (testing "the load-more request carried the derived next param + index 1"
+        (let [req-params (get-in @last-managed-args [:request :params])]
+          (is (= 1 (:page-index req-params)))
+          (is (= "c1" (:cursor req-params)) "the cursor is the page-0-derived next param")))
+      (reply-success! (page [:b] "c2"))
+      (let [e (entry k)]
+        (is (= :loaded (:status e)))
+        (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e)) "appended in order")
+        (is (= [nil "c1"] (:page-params e)) "param per page, page-0 = nil")
+        (is (= "c2" (:next-page-param e)) "cursor advanced to page-1's next")
+        (is (= 2 (state/page-count e)))))))
+
+(deftest load-more-multiple-pages-accumulate
+  (testing "successive load-more accumulate the feed in order"
+    (let [k (load-page-0! :lm3/feed (page [:a] "c1"))]
+      (load-more! :lm3/feed) (reply-success! (page [:b] "c2"))
+      (load-more! :lm3/feed) (reply-success! (page [:c] "c3"))
+      (let [e (entry k)]
+        (is (= 3 (state/page-count e)))
+        (is (= [(page [:a] "c1") (page [:b] "c2") (page [:c] "c3")] (:data e)))
+        (is (= [nil "c1" "c2"] (:page-params e)))
+        (is (= "c3" (:next-page-param e)))))))
+
+(deftest load-more-recomputes-prev-mirror
+  (testing "append re-derives :prev-page-param from the head (R7 mirror)"
+    (let [k (load-page-0! :lmp/feed (page [:a] "c1" "p-head"))]
+      (load-more! :lmp/feed)
+      (reply-success! (page [:b] "c2" "p-tail"))
+      (is (= "p-head" (:prev-page-param (entry k))) "prev comes from the FIRST page"))))
+
+;; ===========================================================================
+;; 3. terminal-nil load-more is a no-op (R2)
+;; ===========================================================================
+
+(deftest load-more-terminal-is-noop
+  (testing "load-more on a feed whose next-param is nil fires NO request (R2)"
+    ;; page-0 has a nil next-cursor → terminal
+    (let [k (load-page-0! :term/feed (page [:a] nil))]
+      (is (nil? (:next-page-param (entry k))) "feed is terminal")
+      (reset! last-managed-args nil)
+      (load-more! :term/feed)
+      (is (nil? @last-managed-args) "no request issued on a terminal load-more")
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "feed unchanged (still :loaded)")
+        (is (= 1 (state/page-count e)) "no page appended")
+        (is (nil? (:current-work e)) "no work record created")))))
+
+(deftest load-more-no-feed-is-noop
+  (testing "load-more before page-0 exists is a no-op (the first page is ensure's)"
+    (rf/reg-resource :nf/feed (feed-spec))
+    (reset! last-managed-args nil)
+    (load-more! :nf/feed)
+    (is (nil? @last-managed-args) "no request when there is no accumulated feed")
+    (is (nil? (entry (feed-key :nf/feed))) "no entry conjured by a load-more")))
+
+;; ===========================================================================
+;; 4. concurrent load-more dedupes against the in-flight page (R2)
+;; ===========================================================================
+
+(deftest concurrent-load-more-dedupes
+  (testing "a second load-more while one is in flight JOINS — no second request,
+            no new generation (R2 dedupe)"
+    (let [k (load-page-0! :dd/feed (page [:a] "c1"))]
+      (load-more! :dd/feed)
+      (let [e1   (entry k)
+            wid1 (:current-work e1)
+            gen1 (:generation e1)
+            args1 @last-managed-args]
+        (is (= :fetching (:status e1)))
+        (reset! last-managed-args nil)
+        ;; a second load-more while the first is still in flight
+        (load-more! :dd/feed)
+        (let [e2 (entry k)]
+          (is (nil? @last-managed-args) "no second request fired (deduped)")
+          (is (= gen1 (:generation e2)) "no new generation on dedupe")
+          (is (= wid1 (:current-work e2)) "same in-flight work record"))
+        ;; the single in-flight page settles ONCE → exactly one append
+        (reply-success! args1 (page [:b] "c2"))
+        (let [e3 (entry k)]
+          (is (= 2 (state/page-count e3)) "exactly one page appended despite two load-mores")
+          (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e3))))))))
+
+;; ===========================================================================
+;; 5. stale / superseded page reply is suppressed (mandatory boundary)
+;; ===========================================================================
+
+(deftest stale-page-reply-suppressed
+  (testing "a late page reply carrying a superseded work-id / generation NEVER
+            appends to the newer feed (Spec 016 §stale suppression)"
+    (let [k (load-page-0! :st/feed (page [:a] "c1"))]
+      ;; first load-more (generation N) — capture its in-flight args, do NOT reply
+      (load-more! :st/feed)
+      (let [args1 @last-managed-args
+            wid1  (:current-work (entry k))
+            gen1  (:generation (entry k))]
+        ;; a refetch supersedes the in-flight load-more (forces a new generation)
+        (rf/dispatch-sync [:rf.resource/refetch
+                           {:resource :st/feed :scope :rf.scope/global
+                            :params {:filter :recent} :cause [:test :supersede]}])
+        (let [gen2 (:generation (entry k))]
+          (is (not= gen1 gen2) "refetch forced a new generation")
+          ;; the OLD load-more page reply lands late — it must be suppressed
+          (reply-success! args1 (page [:STALE] "cX"))
+          (let [e (entry k)]
+            (is (not (some #(= % (page [:STALE] "cX")) (:data e)))
+                "the stale page was NOT appended")
+            (is (= gen2 (:generation e)) "entry generation unchanged by the stale reply"))
+          (testing "the suppressed work row settles terminal :suppressed"
+            (let [rec (work-ledger/get-record (runtime-db) wid1)]
+              (is (= :suppressed (:status rec))))))))))
+
+;; ===========================================================================
+;; 6. page-fetch failure is the THIRD error channel (keep feed + :page-error)
+;; ===========================================================================
+
+(deftest page-failure-keeps-feed-records-page-error
+  (testing "a load-more failure keeps ALL pages + records :page-error — NOT the
+            first-load :error / whole-feed :refresh-error channel (R2)"
+    (let [k        (load-page-0! :pf/feed (page [:a] "c1"))
+          envelope {:kind :rf.http/server :status 503}]
+      (load-more! :pf/feed)
+      (reply-failure! envelope)
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "feed returns to :loaded (NOT :error)")
+        (is (= 1 (state/page-count e)) "accumulated pages kept")
+        (is (= [(page [:a] "c1")] (:data e)) "page vector untouched")
+        (is (= "c1" (:next-page-param e)) "cursor untouched — retry is possible")
+        (is (= envelope (:page-error e)) ":page-error recorded (third channel)")
+        (is (nil? (:error e)) "NOT the first-load :error channel")
+        (is (nil? (:refresh-error e)) "NOT the refresh :refresh-error channel")
+        (is (nil? (:current-work e)) ":current-work cleared")))))
+
+(deftest page-failure-recovers-on-next-success
+  (testing "a successful load-more after a page failure clears :page-error"
+    (let [k (load-page-0! :pfr/feed (page [:a] "c1"))]
+      (load-more! :pfr/feed)
+      (reply-failure! {:kind :rf.http/server :status 503})
+      (is (some? (:page-error (entry k))) "failure recorded")
+      ;; retry the load-more — it succeeds this time
+      (load-more! :pfr/feed)
+      (reply-success! (page [:b] "c2"))
+      (let [e (entry k)]
+        (is (nil? (:page-error e)) "the next success cleared the page-error")
+        (is (= 2 (state/page-count e)) "the retried page appended")))))
+
+;; ===========================================================================
+;; 7. refetch reset — R6 window-preserving default + opt-ins
+;; ===========================================================================
+
+(defn- accumulate-3! [resource spec-overrides]
+  "Register + load page 0 + two load-mores → a 3-page feed. Returns key."
+  (rf/reg-resource resource (feed-spec spec-overrides))
+  (ensure! resource) (reply-success! (page [:a] "c1"))
+  (load-more! resource) (reply-success! (page [:b] "c2"))
+  (load-more! resource) (reply-success! (page [:c] "c3"))
+  (feed-key resource))
+
+(deftest refetch-preserves-window-by-default
+  (testing "the ruled R6 DEFAULT preserves the visible window — a refetch keeps
+            the accumulated pages visible (does NOT collapse to page 0) and
+            replaces page-0 in place on success"
+    (let [k (accumulate-3! :rw/feed {})]
+      (is (= 3 (state/page-count (entry k))) "3 pages accumulated")
+      (rf/dispatch-sync [:rf.resource/refetch
+                         {:resource :rw/feed :scope :rf.scope/global
+                          :params {:filter :recent} :cause [:test :refresh]}])
+      (let [e (entry k)]
+        (is (= :fetching (:status e)) "refetch is refresh-class (data kept)")
+        (is (= 3 (state/page-count e)) "WINDOW PRESERVED — feed NOT collapsed to page 0"))
+      (testing "the replacement fetches page-0 (index 0, nil cursor)"
+        (let [req-params (get-in @last-managed-args [:request :params])]
+          (is (= 0 (:page-index req-params)))
+          (is (not (contains? req-params :cursor)))))
+      (reply-success! (page [:a*] "c1"))
+      (let [e (entry k)]
+        (is (= :loaded (:status e)))
+        (is (= 3 (state/page-count e)) "still 3 pages after the replacement succeeds")
+        (is (= (page [:a*] "c1") (nth (:data e) 0)) "page-0 replaced in place")
+        (is (= (page [:b] "c2") (nth (:data e) 1)) "tail preserved")
+        (is (= (page [:c] "c3") (nth (:data e) 2)) "tail preserved")))))
+
+(deftest refetch-all-pages-opt-in-collapses-to-page-0
+  (testing ":refetch-all-pages? opts OUT of window-preserving — the tail is
+            dropped at refetch and the feed re-accumulates from page 0 (R6)"
+    (let [k (accumulate-3! :ra/feed {:refetch {:refetch-all-pages? true}})]
+      (rf/dispatch-sync [:rf.resource/refetch
+                         {:resource :ra/feed :scope :rf.scope/global
+                          :params {:filter :recent} :cause [:test :refresh-all]}])
+      (let [e (entry k)]
+        (is (= 1 (state/page-count e)) "truncated to page 0 at refetch"))
+      (reply-success! (page [:a*] "c1"))
+      (let [e (entry k)]
+        (is (= 1 (state/page-count e)) "feed re-accumulates from page 0")
+        (is (= (page [:a*] "c1") (nth (:data e) 0)))))))
+
+(deftest refetch-window-opt-in-bounds-the-kept-window
+  (testing ":refetch-window n keeps the first n pages, drops beyond (R6)"
+    (let [k (accumulate-3! :rwn/feed {:refetch {:refetch-window 2}})]
+      (rf/dispatch-sync [:rf.resource/refetch
+                         {:resource :rwn/feed :scope :rf.scope/global
+                          :params {:filter :recent} :cause [:test :window]}])
+      (let [e (entry k)]
+        (is (= 2 (state/page-count e)) "kept the first 2 pages, dropped the 3rd")
+        (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e))))
+      (reply-success! (page [:a*] "c1"))
+      (let [e (entry k)]
+        (is (= 2 (state/page-count e)) "window held after the replacement")
+        (is (= (page [:a*] "c1") (nth (:data e) 0)) "page-0 replaced in place")))))
+
+;; ===========================================================================
+;; 8. ensure dedupe / fresh-skip still applies to an infinite feed's page-0
+;; ===========================================================================
+
+(deftest ensure-infinite-fresh-skip-serves-cache
+  (testing "a second ensure of a fresh loaded infinite feed serves cache (no
+            new page-0 fetch) — the scalar fresh-skip applies unchanged"
+    (let [k (load-page-0! :fs/feed (page [:a] "c1"))
+          gen0 (:generation (entry k))]
+      (reset! last-managed-args nil)
+      (ensure! :fs/feed)
+      (is (nil? @last-managed-args) "fresh loaded feed served from cache, no refetch")
+      (is (= gen0 (:generation (entry k))) "no new generation")
+      (is (= 1 (state/page-count (entry k))) "feed untouched"))))


### PR DESCRIPTION
EP-0021 build, **wave 3 of 7** (docs/EP/EP-0021 §Bead Plan step 3, rf2-6474lx). Waves 1 (spec) + 2 (registry + pure state transitions) are merged; this wave wires those transitions to the **event layer**.

## What landed

Per Spec 016 §Infinite resources and load-more feeds (EP-0021 R1/R2/R6/R8):

- **`:rf.resource/load-more`** (`events/load-more-handler`) — derives the next page param from the accumulated tail (wave-2 `next-param-for`), issues the page fetch through the resource's `:request` with the reserved page ctx `{:rf.resource/page-param p :rf.resource/page-index i}` (R8 — no new arity), records a work-ledger row, and transitions the feed to `:fetching` (the existing refresh-class transition — accumulated pages stay visible). Skip paths fire no request: **terminal** (`next-param-for` nil → `:reason :no-next-page`), **in-flight dedupe** (a second load-more joins the live work → `:reason :in-flight`), **no-feed** (load-more before page 0 exists → `:reason :no-feed`).
- **`:rf.resource/ensure` on an infinite resource** seeds `empty-infinite-entry` and fetches **page 0 only** (`page-param-for-spec` at index 0), addressing the page reply handlers.
- **Page reply handlers** (`:rf.resource.internal/page-succeeded` / `page-failed`) — distinct from the scalar `succeeded`/`failed`: a page success **appends / replaces-in-place** one page (`entry-replace-page`, delegating to wave-2 `entry-append-page` at the tail); a page failure is the **third error channel** (`entry-page-failed` keeps the feed + records `:page-error`). Both reuse the existing `live-entry-for-reply` verification + `stale-suppress-reply` — a superseded / cross-frame / restored-dangling page reply can never append to a newer feed.
- **R6 refetch reset** — **window-preserving DEFAULT** (keep the visible window; the replacement page-0 replaces index 0 in place, never collapsing a loaded feed to page 0); the **`:refetch-all-pages?`** / **`:refetch-window`** opt-ins truncate the tail at refetch-issue (`state/entry-refetch-reset` + `refetch-keep-count`).
- `state/has-data?` now treats an **empty infinite page vector as no-data**, so a page-0 first load is `:loading` (not `:fetching`).

Reuses the managed-fetch / work-ledger / generation-allocation machinery **wholesale** — the load-more lowering rides `transport.http/build-managed-args`' existing `:on-success-id` / `:on-failure-id` / `:reply-payload` reply-addressing overrides; **no new transport or stale-suppression substrate** was added. The four new trace ops (`:rf.resource/load-more` / `page-appended` / `load-more-skipped` / `page-failed`) are emitted inline (reserved in spec; the 009 catalogue + Xray panel are wave 6). **Scope:** the subscription family is wave 4 (not added here); no `tools/xray/` source touched.

## Quality gates (both green)

```
cd implementation && npm run test:cljs
# → Ran 7920 tests containing 32835 assertions. 0 failures, 0 errors.

cd implementation/resources && clojure -M:test
# → Ran 534 tests containing 2254 assertions. 0 failures, 0 errors.
#   (+15 new wave-3 tests: load-more append/advance, terminal no-op,
#    concurrent dedupe, stale-page-reply suppressed, page-failure keeps
#    feed + :page-error, refetch window-preserve + :refetch-all-pages? +
#    :refetch-window)
```

On merge, the mayor dispatches **wave 4** (infinite subscription family).