### PR TITLE
feat(resources): EP-0021 wave 4 — infinite subscription family (items/pages/infinite-state/fetching-next?) (rf2-72a9ia)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -463,7 +463,16 @@
                           :owner        owner
                           :cause        cause
                           :started-at   started-at
-                          :deadline-at  deadline})
+                          :deadline-at  deadline
+                          ;; EP-0021 R2 — an ensure / refetch of an infinite
+                          ;; feed always fetches PAGE 0 (`page-index` 0 above —
+                          ;; a first load or a window-preserving refetch's
+                          ;; replacement page). Recording 0 (not nil) marks this
+                          ;; in-flight work as NOT a load-more, so a whole-feed
+                          ;; `:fetching?` refresh derives `:fetching-next?`
+                          ;; FALSE. A non-infinite resource records no page-index
+                          ;; (nil). Per Spec 016 §Subscription contract (R2).
+                          :page-index   (when infinite? page-index)})
             rdb'       (-> runtime-db
                            (assoc-in (state/entry-path scoped-key) entry')
                            (cond->
@@ -686,7 +695,15 @@
                           :owner        owner
                           :cause        cause
                           :started-at   started-at
-                          :deadline-at  deadline})
+                          :deadline-at  deadline
+                          ;; EP-0021 R2 — a load-more is an APPEND at the
+                          ;; positive page index (`page-count` ≥ 1, the tail);
+                          ;; recording it on the durable row is what lets the
+                          ;; `:fetching-next?` sub tell a load-more in flight
+                          ;; apart from a whole-feed `:fetching?` refresh (which
+                          ;; fetches page-0). Per Spec 016 §Causal event —
+                          ;; load-more / §Subscription contract (R2).
+                          :page-index   page-index})
             owner-newly-attached? (and (some? owner)
                                        (not (contains? (:active-owners entry) owner)))
             rdb'       (-> runtime-db

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -1245,6 +1245,55 @@
     (fn? page->items)      page->items
     :else                  nil))
 
+(defn merge-pages->items
+  "PURE infinite-feed MERGE projection (EP-0021 R3): flatten the accumulated
+  page vector `pages` into the single merged item list — the headline
+  `:rf.resource/items` read. The flatten rule is LOUD, not magic:
+
+    - a page that is ALREADY A VECTOR flattens by identity (its elements ARE
+      the items — no accessor needed);
+    - a page that is non-vector / enveloped (e.g. `{:items […] :page-info …}`)
+      flattens via the resource's REQUIRED `:page->items` accessor;
+    - a non-vector page with NO `:page->items` accessor is a loud
+      `:rf.error/infinite-missing-page-accessor` error — the runtime-detected
+      counterpart the wave-2 registry validation deferred to this merge site
+      (the registry cannot inspect a page shape at registration time; only the
+      merge sees a concrete page). The framework NEVER guesses `:items` /
+      `:data`.
+
+  `resolved-accessor` is the already-resolved `:page->items` fn (via
+  `resolve-page->items`) or nil. `resource-id` / `where` name the offending
+  feed + the public sub surface for the error diagnostic. Returns a VECTOR of
+  the concatenated items (`(into [] (mapcat …) pages)`); an empty / nil page
+  vector yields `[]`. Per Spec 016 §Subscription contract — the merged list
+  and page metadata (R3)."
+  [pages resolved-accessor resource-id where]
+  (into []
+        (mapcat
+          (fn [page]
+            (cond
+              ;; an already-vector page IS its items (identity flatten)
+              (vector? page)         page
+              ;; a declared accessor lifts a non-vector / enveloped page
+              (some? resolved-accessor) (resolved-accessor page)
+              ;; loud over guessing (R3): a non-vector page + no accessor
+              :else
+              (error/throw-error!
+                :rf.error/infinite-missing-page-accessor
+                where
+                (str "infinite resource " resource-id " accumulated a non-vector "
+                     "page but declares no :page->items accessor — the merged "
+                     ":rf.resource/items list cannot flatten it. Declare "
+                     ":page->items (a keyword key or a (fn [page] → items)) on the "
+                     "reg-resource; the framework does NOT guess :items / :data. "
+                     "Per Spec 016 §Subscription contract (R3).")
+                {:recovery :fix-registration
+                 :extra    {:resource-id resource-id
+                            :page-shape  (cond (map? page) :map
+                                               (seq? page) :seq
+                                               :else       (type page))}}))))
+        (or pages [])))
+
 ;; ---- reverse-index recompute (Spec 016 §Restore and replay part 5) --------
 ;;
 ;; `:tag-index` and `:owner-index` are DERIVED projections of the entries'

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -50,6 +50,7 @@
             [re-frame.interop :as interop]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.state :as state]
+            [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.subs :as subs]
             [re-frame.trace :as trace]))
 
@@ -406,6 +407,224 @@
     (when (and (:previous-key e) (nil? (:data e)))
       (:data (get-in rt (state/entry-path (:previous-key e)))))))
 
+;; ---- the infinite-feed projection family (EP-0021 R3) ---------------------
+;;
+;; The merged list + page metadata for an `:infinite` feed. All passive, all
+;; DERIVED (never stored — derived values are not durable facts), and — for
+;; the merge — FRAMEWORK-OWNED MEMOISED rather than an ordinary app sub over
+;; `:pages` (R3, the deliberate divergence from the `:select` precedent: the
+;; merge is the headline read of every feed, so the framework owns the
+;; memoised projection once). The page-vector lives in the entry's `:data`
+;; (R1); these subs read it from the SAME frame-state signal the scalar family
+;; reads, resolving the feed identity via `entry-for`.
+;;
+;; `:fetching-next?` is the one projection that is NOT a pure function of the
+;; entry alone (R2): a load-more and a whole-feed refresh BOTH leave the feed
+;; at `:fetching` (no 6th FSM state). The distinguishing durable fact is the
+;; in-flight work record's `:page-index` — a load-more APPENDS at a positive
+;; index (the tail), a page-0 fetch / refetch fetches index 0 — so the sub
+;; joins the entry's `:current-work` to its work-ledger row and reads the
+;; recorded page index (the "page-fetch work evidence" R1 names).
+
+(defn- feed-entry-for
+  "Read the infinite-feed entry for a sub `payload` (resolving + validating its
+  scoped key against `runtime-db` / `app-db`), or nil when no entry / a
+  non-infinite entry. The infinite projections are no-ops on an ordinary
+  (non-feed) resource — they project the documented empty-feed shape rather
+  than throwing, so a view that subscribes the wrong family degrades to empty
+  rather than crashing (the loud failure is reserved for a genuine
+  missing-accessor merge, below)."
+  [runtime-db app-db payload]
+  (let [e (entry-for runtime-db app-db payload)]
+    (when (state/infinite-entry? e) e)))
+
+;; Framework-owned merge memo (R3). A bounded per-feed cache keyed on the
+;; feed's byte `key-id` → `{:pages <page-vector> :items <merged-vector>}`. The
+;; sub re-runs its body on EVERY frame-state change (an unrelated runtime-db /
+;; app-db commit), but the page vector only moves when a page is actually
+;; appended / replaced, so the expensive `(into [] (mapcat …) pages)` flatten
+;; is skipped (an `identical?` hit) on every re-run that did not touch THIS
+;; feed's pages. The subscription layer's own output `=` memoisation then keeps
+;; the sub quiet downstream; this memo additionally keeps the COMPUTATION quiet
+;; (the framework owns the merge, not the app — R3). Host-side transient state
+;; (NOT runtime-db); cleared per-test by the resources reset hook.
+(defonce ^:private
+  ^{:doc "Framework-owned `:rf.resource/items` merge memo: `{<feed-key-id>
+   {:pages <page-vector> :items <merged-items-vector>}}`. ONE slot per feed
+   key, OVERWRITTEN in place on each recompute — it grows with the number of
+   DISTINCT feed keys ever merged (the same growth profile as the runtime-db
+   `:entries` map), not per-append; each slot is a tiny pair of pointers
+   (structurally shared with the entry's `:data`). The merge recomputes ONLY
+   when the cached `:pages` is not `identical?` to the live page vector (a real
+   append / replace), so a sub re-running on an unrelated frame-state change
+   re-uses the prior merged list. A stale slot for a GC'd feed is harmless (it
+   is just re-keyed the next time that key reloads, or never read again) and is
+   dropped wholesale on the per-test reset; a host-side derivation cache is not
+   correctness-bearing, so it carries no eviction-on-GC machinery. Host-side
+   transient (NOT runtime-db); reset per-test by `reset-merge-memo!`."}
+  items-merge-memo
+  (atom {}))
+
+(defn reset-merge-memo!
+  "Drop the framework-owned `:rf.resource/items` merge memo (test isolation).
+  Published as a reset hook so the shared CLJS reset-runtime fixture clears it
+  per test — it is host-side transient dev state (a derivation cache), not
+  runtime-db. Returns nil."
+  []
+  (reset! items-merge-memo {})
+  nil)
+
+(defn merged-items
+  "The framework-owned, MEMOISED merged item list for an infinite-feed
+  `entry` (R3) — the headline `:rf.resource/items` read. Resolves the
+  resource's `:page->items` accessor and flattens the entry's `:data` page
+  vector via `state/merge-pages->items` (vector pages flatten by identity; a
+  non-vector page REQUIRES the accessor or raises
+  `:rf.error/infinite-missing-page-accessor`). Memoised on the page-vector
+  IDENTITY keyed by the feed's `key-id`: a re-run whose page vector is
+  `identical?` to the last merged one returns the cached merged list without
+  re-flattening. Returns `[]` for a nil / empty feed. Pure modulo the memo."
+  [entry where]
+  (let [pages (:data entry)]
+    (if (empty? pages)
+      []
+      (let [k-id   (state/key-id (:resource/key entry))
+            cached (get @items-merge-memo k-id)]
+        (if (and cached (identical? (:pages cached) pages))
+          (:items cached)
+          (let [spec     (registry/resource-meta (:resource/id entry))
+                accessor (state/resolve-page->items (:page->items spec))
+                merged   (state/merge-pages->items
+                           pages accessor (:resource/id entry) where)]
+            (swap! items-merge-memo assoc k-id {:pages pages :items merged})
+            merged))))))
+
+(defn items-sub-fn
+  "Project `:rf.resource/items` — the merged / flattened item list of an
+  infinite feed (the HEADLINE read). Framework-owned + memoised (R3). `[]`
+  when no feed / empty feed. Raises `:rf.error/infinite-missing-page-accessor`
+  when a non-vector page has no `:page->items`. Per Spec 016 §Subscription
+  contract."
+  [frame-state [_id payload]]
+  (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
+    (if e (merged-items e 'rf.resource/items) [])))
+
+(defn pages-sub-fn
+  "Project `:rf.resource/pages` — the raw ordered page vector (the TanStack
+  `pages` analogue), for views that need page boundaries. `[]` when no feed.
+  Per Spec 016 §Subscription contract."
+  [frame-state [_id payload]]
+  (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
+    (vec (:data e))))
+
+(defn page-count-sub-fn
+  "Project `:rf.resource/page-count` — the number of accumulated pages (0 when
+  no feed). Per Spec 016 §Subscription contract."
+  [frame-state [_id payload]]
+  (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
+    (state/page-count e)))
+
+(defn has-next-page?-sub-fn
+  "Project `:rf.resource/has-next-page?` — `(some? :next-page-param)`, the
+  observable terminal (a view never re-derives nil). false when no feed. Per
+  Spec 016 §Subscription contract."
+  [frame-state [_id payload]]
+  (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
+    (and (some? e) (not (state/terminal? (:next-page-param e))))))
+
+(defn has-prev-page?-sub-fn
+  "Project `:rf.resource/has-prev-page?` — `(some? :prev-page-param)`, the
+  bidirectional mirror (observable; the prepend event is deferred, R7). false
+  when no feed. Per Spec 016 §Subscription contract."
+  [frame-state [_id payload]]
+  (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
+    (and (some? e) (not (state/terminal? (:prev-page-param e))))))
+
+(defn page-error-sub-fn
+  "Project `:rf.resource/page-error` — the last load-more failure envelope
+  (the THIRD error channel; distinct from `:error` / `:refresh-error`), or
+  nil. Per Spec 016 §Subscription contract / §Causal event — load-more."
+  [frame-state [_id payload]]
+  (:page-error (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)))
+
+(defn- fetching-next?*
+  "DERIVED `:fetching-next?` (R2): true iff a LOAD-MORE is in flight on the
+  feed `entry`, read from `runtime-db`. A load-more and a whole-feed refresh
+  both leave the feed at `:fetching` (no 6th FSM state), so the entry status
+  alone cannot tell them apart; the distinguishing durable fact is the
+  in-flight work record's `:page-index` — a load-more APPENDS at a POSITIVE
+  index (the tail), a page-0 fetch / refetch fetches index 0. The sub joins
+  the entry's `:current-work` pointer to its live work-ledger row and reads the
+  recorded page index. false when the feed is not fetching, has no live work,
+  or the live work is a page-0 fetch / whole-feed refresh. Per Spec 016
+  §Causal event — load-more (R2) / §Subscription contract."
+  [runtime-db entry]
+  (boolean
+    (when (and (some? entry) (= :fetching (:status entry)))
+      (let [work-id (:current-work entry)
+            record  (when work-id (work-ledger/get-record runtime-db work-id))
+            status  (:status record)]
+        (and (some? record)
+             ;; the work is genuinely LIVE (not terminal / doomed) …
+             (not (work-ledger/terminal? status))
+             (not= :abort-requested status)
+             ;; … and it is a load-more APPEND (a positive page index), not a
+             ;; page-0 fetch / whole-feed refresh (index 0 / absent).
+             (let [pi (:page-index record)]
+               (and (integer? pi) (pos? pi))))))))
+
+(defn fetching-next?-sub-fn
+  "Project `:rf.resource/fetching-next?` — a load-more in flight (R2),
+  distinct from `:fetching?` (a whole-feed refresh). Per Spec 016
+  §Subscription contract / §Causal event — load-more."
+  [frame-state [_id payload]]
+  (let [rt (runtime-of frame-state)
+        e  (feed-entry-for rt (app-of frame-state) payload)]
+    (fetching-next?* rt e)))
+
+(defn infinite-state-sub-fn
+  "Project `:rf.resource/infinite-state` — the combined infinite view-model
+  (the feed analogue of `:rf.resource/state`): the merged `:items`, the raw
+  `:pages`, `:page-count`, `:has-next-page?` / `:has-prev-page?`, the DERIVED
+  `:loading?` / `:fetching?` / `:fetching-next?` / `:stale?` / `:has-data?`,
+  and the three error channels (`:error` first-load / `:refresh-error`
+  whole-feed / `:page-error` load-more). Framework-owned + memoised merge (R3).
+  Empty-feed shape when no infinite entry. Per Spec 016 §Subscription
+  contract."
+  [frame-state [_id payload]]
+  (let [rt (runtime-of frame-state)
+        e  (feed-entry-for rt (app-of frame-state) payload)]
+    (if (nil? e)
+      ;; documented empty-feed projection (idle, nothing accumulated)
+      {:status :idle :items [] :pages [] :page-count 0
+       :has-next-page? false :has-prev-page? false
+       :loading? false :fetching? false :fetching-next? false
+       :stale? false :has-data? false
+       :error nil :refresh-error nil :page-error nil}
+      (let [next? (fetching-next?* rt e)]
+        {:status         (:status e)
+         :items          (merged-items e 'rf.resource/infinite-state)
+         :pages          (vec (:data e))
+         :page-count     (state/page-count e)
+         :has-next-page? (not (state/terminal? (:next-page-param e)))
+         :has-prev-page? (not (state/terminal? (:prev-page-param e)))
+         :loading?       (= :loading (:status e))
+         ;; `:fetching?` is a WHOLE-FEED refresh; `:fetching-next?` is a
+         ;; load-more — both ride `:fetching` (no 6th FSM state, R2), so split
+         ;; them here so the view-model fields are disjoint.
+         :fetching?      (and (= :fetching (:status e)) (not next?))
+         :fetching-next? next?
+         :stale?         (stale? e)
+         ;; an infinite feed's `:data` is the page VECTOR (`[]` when empty), so
+         ;; `:has-data?` is "≥ 1 accumulated page" — delegated to the shared
+         ;; `state/has-data?` (which knows the infinite-feed shape: `(seq data)`,
+         ;; never the scalar `(some? data)` that an empty `[]` would satisfy), so
+         ;; the sub and the restore/FSM readers never drift.
+         :has-data?      (state/has-data? e)
+         :error          (:error e)
+         :refresh-error  (:refresh-error e)
+         :page-error     (:page-error e)}))))
+
 ;; ---- registration helper -------------------------------------------------
 
 (defn register-subs!
@@ -451,4 +670,32 @@
   (subs/reg-frame-state-sub :rf.resource/previous-data
     {:doc "Passive read of the prior key's data, projected while a new page/filter resource first-loads under :keep-previous? (not inserted into the new entry). Per Spec 016 §Paginated and previous data."}
     previous-data-sub-fn)
+  ;; ---- the infinite-feed projection family (EP-0021 R3) -----------------
+  ;; `:rf.resource/items` / `:pages` / `:infinite-state` are the framework-
+  ;; owned MEMOISED merge subs (R3 — NOT ordinary app subs over :pages); the
+  ;; page-metadata subs round out the load-more UI state.
+  (subs/reg-frame-state-sub :rf.resource/items
+    {:doc "Passive read of an infinite feed's MERGED / flattened item list (the headline read) — DERIVED + framework-owned-memoised by concatenating each accumulated page's items (R3). A vector page flattens by identity; a non-vector / enveloped page REQUIRES a :page->items accessor (else :rf.error/infinite-missing-page-accessor). [] for a non-feed / empty feed. Per Spec 016 §Subscription contract (R3)."}
+    items-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/pages
+    {:doc "Passive read of an infinite feed's raw ordered page vector (the TanStack `pages` analogue) — for views that need page boundaries. [] for a non-feed. Per Spec 016 §Subscription contract (R3)."}
+    pages-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/page-count
+    {:doc "Passive read of an infinite feed's accumulated page count (0 when no feed). Per Spec 016 §Subscription contract."}
+    page-count-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/has-next-page?
+    {:doc "Passive read: true iff an infinite feed has a next page ((some? :next-page-param) — nil is the single terminal). false for a non-feed / terminal feed. Per Spec 016 §Subscription contract."}
+    has-next-page?-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/has-prev-page?
+    {:doc "Passive read: true iff an infinite feed has a prev page ((some? :prev-page-param) — the bidirectional mirror; the prepend event is deferred, R7). false for a non-feed. Per Spec 016 §Subscription contract."}
+    has-prev-page?-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/fetching-next?
+    {:doc "Passive read: true iff a LOAD-MORE is in flight on an infinite feed (R2) — distinct from :fetching? (a whole-feed refresh). Derived from the in-flight work record's page index (a load-more appends at a positive index). Per Spec 016 §Subscription contract / §Causal event — load-more."}
+    fetching-next?-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/page-error
+    {:doc "Passive read of an infinite feed's last LOAD-MORE failure envelope (the third error channel; distinct from :error first-load and :refresh-error whole-feed), or nil. Per Spec 016 §Subscription contract / §Causal event — load-more."}
+    page-error-sub-fn)
+  (subs/reg-frame-state-sub :rf.resource/infinite-state
+    {:doc "Passive read of an infinite feed's combined view-model `{:status :items :pages :page-count :has-next-page? :has-prev-page? :loading? :fetching? :fetching-next? :stale? :has-data? :error :refresh-error :page-error}` — the feed analogue of :rf.resource/state, with the framework-owned-memoised merged :items (R3). Empty-feed shape when no infinite entry. Per Spec 016 §Subscription contract (R3)."}
+    infinite-state-sub-fn)
   nil)

--- a/implementation/resources/src/re_frame/resources/test_support.cljc
+++ b/implementation/resources/src/re_frame/resources/test_support.cljc
@@ -74,6 +74,11 @@
   ;; host-side transient dev state; clearing it lets each test observe the
   ;; one-shot warning freshly without a prior test's emission masking it.
   (subs/reset-scope-mismatch-warnings!)
+  ;; and the framework-owned `:rf.resource/items` merge memo (EP-0021 R3) —
+  ;; host-side transient derivation cache (the infinite-feed merged-list
+  ;; projection), not runtime-db; cleared so a prior test's feed merge cannot
+  ;; be served for a later test's `=`-equal page vector.
+  (subs/reset-merge-memo!)
   ;; and the host-side WRITE-side scope-mismatch dev-warning dedupe set
   ;; (rf2-byl7bk.4) — the mutation-settlement complement of the sub-side
   ;; warning; likewise host-side transient dev state, cleared so each test

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -217,22 +217,39 @@
   - `:cause`       — the initiating cause (nil-safe; folded into `:causes`)
   - `:cancellable?`— best-effort cancel hint (default true)
   - `:started-at`  — epoch-ms
-  - `:deadline-at` — epoch-ms or nil"
+  - `:deadline-at` — epoch-ms or nil
+  - `:page-index`  — EP-0021 R1/R2: the 0-based PAGE the attempt is fetching for
+                     an INFINITE feed (the durable \"page-fetch work evidence\"
+                     R1 names). A page-0 fetch (a first ensure / a
+                     window-preserving refetch's replacement page) is `0`; a
+                     `:rf.resource/load-more` APPEND is the positive index past
+                     the accumulated tail. Absent (nil) for an ordinary
+                     (non-infinite) resource / mutation attempt. The
+                     `:rf.resource/fetching-next?` sub reads it to distinguish a
+                     load-more in flight (positive index) from a whole-feed
+                     `:fetching?` refresh (page-0). Plain EDN — it rides SSR /
+                     restore with the rest of the row."
   [{:keys [work-id frame-id generation transport
-           owner cause cancellable? started-at deadline-at]
+           owner cause cancellable? started-at deadline-at page-index]
     resource-key :resource/key}]
-  {:work/id      work-id
-   :work/kind    work-kind-resource
-   :work/frame   frame-id
-   :resource/key resource-key
-   :generation   generation
-   :transport    transport
-   :status       :running
-   :owners       (if owner #{owner} #{})
-   :causes       (if cause [cause] [])
-   :cancellable? (if (some? cancellable?) cancellable? true)
-   :started-at   started-at
-   :deadline-at  deadline-at})
+  (cond-> {:work/id      work-id
+           :work/kind    work-kind-resource
+           :work/frame   frame-id
+           :resource/key resource-key
+           :generation   generation
+           :transport    transport
+           :status       :running
+           :owners       (if owner #{owner} #{})
+           :causes       (if cause [cause] [])
+           :cancellable? (if (some? cancellable?) cancellable? true)
+           :started-at   started-at
+           :deadline-at  deadline-at}
+    ;; EP-0021 — record the page index for an infinite-feed page fetch so
+    ;; `:fetching-next?` is derivable from the durable row (a load-more =
+    ;; a positive index; a page-0 fetch / refetch = 0). Omitted entirely for
+    ;; a non-infinite attempt (page-index nil) — the row shape is unchanged
+    ;; for every ordinary resource / mutation.
+    (some? page-index) (assoc :page-index page-index)))
 
 ;; ---- durable reply-target (rf2-6kdcs9) ------------------------------------
 ;;

--- a/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
@@ -1,0 +1,349 @@
+(ns re-frame.resources-infinite-subs-cljs-test
+  "The infinite-feed subscription family (EP-0021 wave 4, Spec 016
+  §Subscription contract — the merged list and page metadata (R3)).
+
+  Waves 1-3 landed the durable feed entry (`:data` = the ordered page vector),
+  the `:rf.resource/load-more` event, and the page reply handlers. This slice
+  is the READ side — the framework-owned, MEMOISED projection family:
+
+    - `:rf.resource/items` — the merged / flattened list (the HEADLINE read);
+    - `:rf.resource/pages` — the raw ordered page vector;
+    - `:rf.resource/infinite-state` — the combined view-model;
+    - `:rf.resource/page-count` / `:has-next-page?` / `:has-prev-page?` /
+      `:page-error` — page metadata;
+    - `:rf.resource/fetching-next?` — a LOAD-MORE in flight (R2), DISTINCT from
+      `:fetching?` (a whole-feed refresh), derived from the in-flight work
+      record's page index;
+    - the R3 LOUD merge: a non-vector page with no `:page->items` raises
+      `:rf.error/infinite-missing-page-accessor` at the merge site.
+
+  The subs are PASSIVE — they never cause a fetch (the load-more EVENT does).
+  Driven through the live event + capturing-transport path so the projections
+  read genuine accumulated feed entries."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.subs]
+   [re-frame.resources.test-support]
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport (replays the real reply-append shape) ------------
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- capturing-transport-fixture [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-transport-fixture)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- runtime-db [] (rf/runtime-db-value :rf/default))
+(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+
+(defn- reply-success!
+  ([data] (reply-success! @last-managed-args data))
+  ([args data]
+   (rf/dispatch-sync (conj (:on-success args) {:kind :success :value data}))))
+
+(defn- reply-failure!
+  ([failure] (reply-failure! @last-managed-args failure))
+  ([args failure]
+   (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure}))))
+
+(def ^:private next-cursor
+  (fn [last-page _all-pages] (get-in last-page [:page-info :next-cursor])))
+(def ^:private prev-cursor
+  (fn [first-page _all-pages] (get-in first-page [:page-info :prev-cursor])))
+
+(defn- page
+  "An enveloped (non-vector) page: items + a page-info cursor envelope."
+  ([items next-c] (page items next-c nil))
+  ([items next-c prev-c]
+   {:items items :page-info {:next-cursor next-c :prev-cursor prev-c}}))
+
+(defn- feed-spec
+  "A minimal valid infinite-feed resource spec — enveloped pages with a
+  :page->items accessor (the common non-vector case)."
+  ([] (feed-spec {}))
+  ([overrides]
+   (merge {:scope            :rf.scope/global
+           :infinite         true
+           :params-schema    [:map [:filter :keyword]]
+           :request          (fn [{:keys [filter]} {:rf.resource/keys [page-param page-index]}]
+                               {:request {:method :get :url "/api/feed"
+                                          :params (cond-> {:filter filter :page-index page-index}
+                                                    page-param (assoc :cursor page-param))}})
+           :next-page-param  next-cursor
+           :prev-page-param  prev-cursor
+           :page->items      :items
+           :tags             (fn [{:keys [filter]} _data] #{[:feed filter]})}
+          overrides)))
+
+(defn- feed-key [resource]
+  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+
+(defn- q [resource]
+  {:resource resource :scope :rf.scope/global :params {:filter :recent}})
+
+(defn- ensure! [resource]
+  (rf/dispatch-sync [:rf.resource/ensure
+                     (assoc (q resource) :owner [:test :w])]))
+
+(defn- load-more! [resource]
+  (rf/dispatch-sync [:rf.resource/load-more
+                     (assoc (q resource) :owner [:test :w]
+                            :cause [:user :feed/load-more])]))
+
+(defn- load-page-0!
+  "Register + ensure a feed and settle page-0 with `pg`. Returns the resource."
+  [resource pg]
+  (rf/reg-resource resource (feed-spec))
+  (ensure! resource)
+  (reply-success! pg)
+  resource)
+
+;; ===========================================================================
+;; 1. empty-feed projections (a passive sub NEVER fetches)
+;; ===========================================================================
+
+(deftest empty-feed-projections
+  (rf/reg-resource :is1/feed (feed-spec))
+  (testing "before any load the infinite projections are the empty-feed shape"
+    (is (= [] @(rf/subscribe [:rf.resource/items (q :is1/feed)])))
+    (is (= [] @(rf/subscribe [:rf.resource/pages (q :is1/feed)])))
+    (is (= 0 @(rf/subscribe [:rf.resource/page-count (q :is1/feed)])))
+    (is (false? @(rf/subscribe [:rf.resource/has-next-page? (q :is1/feed)])))
+    (is (false? @(rf/subscribe [:rf.resource/has-prev-page? (q :is1/feed)])))
+    (is (false? @(rf/subscribe [:rf.resource/fetching-next? (q :is1/feed)])))
+    (is (nil? @(rf/subscribe [:rf.resource/page-error (q :is1/feed)]))))
+  (testing "infinite-state empty-feed view-model"
+    (is (= {:status :idle :items [] :pages [] :page-count 0
+            :has-next-page? false :has-prev-page? false
+            :loading? false :fetching? false :fetching-next? false
+            :stale? false :has-data? false
+            :error nil :refresh-error nil :page-error nil}
+           @(rf/subscribe [:rf.resource/infinite-state (q :is1/feed)]))))
+  (testing "no entry was conjured by subscribing (subs are passive)"
+    (is (nil? (entry (feed-key :is1/feed))))))
+
+;; ===========================================================================
+;; 2. :rf.resource/items merges pages in order (the headline read)
+;; ===========================================================================
+
+(deftest items-merges-pages-in-order
+  (load-page-0! :is2/feed (page [:a :b] "c1"))
+  (testing "after page-0 :items is the flat merged list of page-0 items"
+    (is (= [:a :b] @(rf/subscribe [:rf.resource/items (q :is2/feed)]))))
+  (load-more! :is2/feed) (reply-success! (page [:c :d] "c2"))
+  (load-more! :is2/feed) (reply-success! (page [:e] nil))   ;; terminal page
+  (testing "successive load-mores accumulate the merged list IN ORDER"
+    (is (= [:a :b :c :d :e] @(rf/subscribe [:rf.resource/items (q :is2/feed)]))
+        "items concatenated across pages in load order"))
+  (testing ":pages returns the raw ordered page vector (boundaries preserved)"
+    (is (= [(page [:a :b] "c1") (page [:c :d] "c2") (page [:e] nil)]
+           @(rf/subscribe [:rf.resource/pages (q :is2/feed)])))))
+
+(deftest items-vector-pages-flatten-by-identity
+  (testing "a feed whose pages are ALREADY vectors flattens with NO accessor (R3)"
+    ;; pages are bare vectors of items; next-cursor lives in a parallel scheme —
+    ;; here we use a fixed-count terminal (return nil after 2 pages). NO
+    ;; :page->items key at all (vector pages need none).
+    (rf/reg-resource :isv/feed
+      (dissoc (feed-spec {:next-page-param (fn [_last-page all-pages]
+                                             (when (< (count all-pages) 2)
+                                               (str "p" (count all-pages))))})
+              :page->items))
+    (ensure! :isv/feed) (reply-success! [:a :b])
+    (is (= [:a :b] @(rf/subscribe [:rf.resource/items (q :isv/feed)]))
+        "a vector page IS its items — no :page->items needed")
+    (load-more! :isv/feed) (reply-success! [:c :d])
+    (is (= [:a :b :c :d] @(rf/subscribe [:rf.resource/items (q :isv/feed)]))
+        "vector pages concatenate by identity")))
+
+(deftest items-fn-accessor
+  (testing "a (fn [page] …) :page->items accessor is honoured"
+    (rf/reg-resource :isf/feed
+      (feed-spec {:page->items (fn [p] (:rows p))
+                  :next-page-param (fn [_ _] nil)
+                  :request (fn [_ _] {:request {:method :get :url "/f"}})}))
+    (ensure! :isf/feed) (reply-success! {:rows [:x :y]})
+    (is (= [:x :y] @(rf/subscribe [:rf.resource/items (q :isf/feed)])))))
+
+;; ===========================================================================
+;; 3. page metadata (page-count / has-next? / has-prev? / page-error)
+;; ===========================================================================
+
+(deftest page-metadata-projections
+  (load-page-0! :is3/feed (page [:a] "c1" "p0"))
+  (testing "after one (non-terminal) page: count 1, has-next? true, has-prev? true"
+    (is (= 1 @(rf/subscribe [:rf.resource/page-count (q :is3/feed)])))
+    (is (true? @(rf/subscribe [:rf.resource/has-next-page? (q :is3/feed)]))
+        "next cursor present ⇒ has-next?")
+    (is (true? @(rf/subscribe [:rf.resource/has-prev-page? (q :is3/feed)]))
+        "prev cursor present ⇒ has-prev? (mirror observable, R7)"))
+  (load-more! :is3/feed) (reply-success! (page [:b] nil))   ;; terminal next
+  (testing "after the terminal page: count 2, has-next? FALSE (nil terminal)"
+    (is (= 2 @(rf/subscribe [:rf.resource/page-count (q :is3/feed)])))
+    (is (false? @(rf/subscribe [:rf.resource/has-next-page? (q :is3/feed)]))
+        "nil next-param is the single terminal ⇒ has-next? false")))
+
+(deftest has-prev-false-when-no-mirror
+  (testing "has-prev? is false when the feed declares no :prev-page-param"
+    (rf/reg-resource :isnp/feed (dissoc (feed-spec) :prev-page-param))
+    (ensure! :isnp/feed) (reply-success! (page [:a] "c1"))
+    (is (false? @(rf/subscribe [:rf.resource/has-prev-page? (q :isnp/feed)])))))
+
+;; ===========================================================================
+;; 4. :fetching-next? — a load-more in flight, DISTINCT from :fetching? (R2)
+;; ===========================================================================
+
+(deftest fetching-next?-true-during-load-more
+  (load-page-0! :is4/feed (page [:a] "c1"))
+  (testing "a settled feed (no work in flight) is NOT fetching-next?"
+    (is (false? @(rf/subscribe [:rf.resource/fetching-next? (q :is4/feed)])))
+    (is (= :loaded (:status (entry (feed-key :is4/feed))))))
+  ;; issue a load-more but do NOT reply — the page fetch is now in flight
+  (load-more! :is4/feed)
+  (testing "while the load-more page is in flight the feed is :fetching"
+    (is (= :fetching (:status (entry (feed-key :is4/feed))))
+        "load-more is a refresh-class transition (no 6th FSM state, R2)"))
+  (testing ":fetching-next? is TRUE during a load-more (R2)"
+    (is (true? @(rf/subscribe [:rf.resource/fetching-next? (q :is4/feed)]))))
+  (testing "the combined view-model splits the two: fetching-next? true,
+            fetching? FALSE (a load-more is NOT a whole-feed refresh)"
+    (let [vm @(rf/subscribe [:rf.resource/infinite-state (q :is4/feed)])]
+      (is (true?  (:fetching-next? vm)))
+      (is (false? (:fetching? vm)) "whole-feed :fetching? distinct from load-more")
+      (is (= [:a] (:items vm)) "the accumulated page stays visible (no skeleton)")))
+  ;; settle the load-more — back to :loaded, fetching-next? clears
+  (reply-success! (page [:b] "c2"))
+  (testing "after the page lands :fetching-next? clears"
+    (is (false? @(rf/subscribe [:rf.resource/fetching-next? (q :is4/feed)])))
+    (is (= [:a :b] @(rf/subscribe [:rf.resource/items (q :is4/feed)])))))
+
+(deftest fetching?-true-fetching-next?-false-on-whole-feed-refresh
+  (load-page-0! :is4b/feed (page [:a] "c1"))
+  (load-more! :is4b/feed) (reply-success! (page [:b] "c2"))
+  (testing "a whole-feed REFETCH (page-0 in flight) is :fetching? but NOT
+            :fetching-next? — the two are disjoint (R2)"
+    ;; force a refetch; do NOT reply — page-0 replacement is now in flight
+    (rf/dispatch-sync [:rf.resource/refetch (assoc (q :is4b/feed) :owner [:test :w])])
+    (is (= :fetching (:status (entry (feed-key :is4b/feed))))
+        "a refetch over a loaded feed is :fetching (data kept)")
+    (let [vm @(rf/subscribe [:rf.resource/infinite-state (q :is4b/feed)])]
+      (is (false? (:fetching-next? vm)) "a whole-feed refresh is NOT a load-more")
+      (is (true?  (:fetching? vm)) "it IS a whole-feed :fetching? refresh"))
+    (is (false? @(rf/subscribe [:rf.resource/fetching-next? (q :is4b/feed)])))))
+
+;; ===========================================================================
+;; 5. page-error — the THIRD error channel surfaced as a sub
+;; ===========================================================================
+
+(deftest page-error-projection
+  (load-page-0! :is5/feed (page [:a] "c1"))
+  (load-more! :is5/feed)
+  (reply-failure! {:kind :rf.http/server :status 503})
+  (testing "a load-more failure surfaces via :rf.resource/page-error,
+            keeps the feed, and is NOT the :error / :refresh-error channel"
+    (is (= {:kind :rf.http/server :status 503}
+           @(rf/subscribe [:rf.resource/page-error (q :is5/feed)])))
+    (let [vm @(rf/subscribe [:rf.resource/infinite-state (q :is5/feed)])]
+      (is (= {:kind :rf.http/server :status 503} (:page-error vm)))
+      (is (nil? (:error vm)) "NOT the first-load error channel")
+      (is (nil? (:refresh-error vm)) "NOT the whole-feed refresh channel")
+      (is (= [:a] (:items vm)) "the feed is kept (couldn't-load-more, retry)")
+      (is (= :loaded (:status vm))))))
+
+;; ===========================================================================
+;; 6. the combined :infinite-state view-model
+;; ===========================================================================
+
+(deftest infinite-state-view-model
+  (load-page-0! :is6/feed (page [:a :b] "c1"))
+  (load-more! :is6/feed) (reply-success! (page [:c] nil))    ;; terminal
+  (testing "the combined view-model assembles every projection"
+    (is (= {:status :loaded
+            :items [:a :b :c]
+            :pages [(page [:a :b] "c1") (page [:c] nil)]
+            :page-count 2
+            :has-next-page? false
+            :has-prev-page? false
+            :loading? false :fetching? false :fetching-next? false
+            :stale? false :has-data? true
+            :error nil :refresh-error nil :page-error nil}
+           @(rf/subscribe [:rf.resource/infinite-state (q :is6/feed)])))))
+
+;; ===========================================================================
+;; 7. the LOUD merge — :rf.error/infinite-missing-page-accessor (R3)
+;; ===========================================================================
+
+(deftest missing-page-accessor-raises-at-merge
+  (testing "a non-vector page with NO :page->items raises at the merge site
+            (R3, loud over guessing — the runtime-detected error wave-2
+            deferred to the merge layer). Asserted at the MERGE layer
+            (`state/merge-pages->items` / the framework-owned `merged-items`
+            projection) — a sub-body throw is otherwise routed to the runtime
+            error path, the same level the sub-unresolved-scope test asserts at."
+    ;; valid registration (no :page->items declared); the page is enveloped, so
+    ;; the MERGE is where the missing accessor is detected.
+    (rf/reg-resource :iserr/feed
+      (dissoc (feed-spec) :page->items))        ;; non-vector pages, no accessor
+    (ensure! :iserr/feed)
+    (reply-success! (page [:a :b] "c1"))         ;; an enveloped (map) page
+    (let [e (entry (feed-key :iserr/feed))]
+      (testing "the entry accumulated the enveloped page fine (merge is read-side)"
+        (is (= 1 (state/page-count e))))
+      (testing "the pure merge raises :rf.error/infinite-missing-page-accessor"
+        (is (thrown-with-msg?
+              #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+              #"infinite-missing-page-accessor"
+              (state/merge-pages->items
+                (:data e) (state/resolve-page->items nil)
+                :iserr/feed 'rf.resource/items))))
+      (testing "the framework-owned merged-items projection raises too"
+        (is (thrown-with-msg?
+              #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+              #"infinite-missing-page-accessor"
+              (#'re-frame.resources.subs/merged-items e 'rf.resource/items))))
+      (testing "the error carries the canonical :rf.error/id discriminator"
+        (is (= :rf.error/infinite-missing-page-accessor
+               (try (state/merge-pages->items
+                      (:data e) (state/resolve-page->items nil)
+                      :iserr/feed 'rf.resource/items)
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) ex
+                      (:rf.error/id (ex-data ex))))))))))
+
+;; ===========================================================================
+;; 8. the merge is framework-owned + MEMOISED (R3)
+;; ===========================================================================
+
+(deftest items-merge-is-memoised
+  (testing "the merged-items computation is memoised on the page-vector identity
+            (a re-run with an identical page vector returns the cached merge)"
+    (load-page-0! :is8/feed (page [:a :b] "c1"))
+    (let [e      (entry (feed-key :is8/feed))
+          first  (state/merge-pages->items
+                   (:data e) (state/resolve-page->items :items)
+                   :is8/feed 'rf.resource/items)
+          ;; via the memoised entry path
+          m1     (#'re-frame.resources.subs/merged-items e 'rf.resource/items)
+          m2     (#'re-frame.resources.subs/merged-items e 'rf.resource/items)]
+      (is (= [:a :b] first))
+      (is (= [:a :b] m1))
+      (is (identical? m1 m2)
+          "a second merge of the IDENTICAL page vector returns the same (cached) value"))))


### PR DESCRIPTION
EP-0021 build, **wave 4 of 7** (rf2-72a9ia). Waves 1-3 MERGED (spec/016 model + registry/state + load-more event). This slice implements the framework-owned MEMOISED infinite subscription family per Spec 016 §Subscription contract — the merged list and page metadata (R3).

## What landed

`implementation/resources/src/re_frame/resources/subs.cljc` — the `:rf.resource/*` infinite projection family, all passive, all derived (never stored):

- **`:rf.resource/items`** — the merged / flattened list (the HEADLINE read), **framework-owned + memoised** on the page-vector identity (the deliberate R3 divergence from the `:select` precedent — not an ordinary app sub over `:pages`). A vector page flattens by identity; a non-vector / enveloped page REQUIRES a `:page->items` accessor.
- **`:rf.resource/pages`** — the raw ordered page vector.
- **`:rf.resource/infinite-state`** — the combined view-model (the feed analogue of `:rf.resource/state`).
- **`:rf.resource/page-count` / `:has-next-page?` / `:has-prev-page?` / `:page-error`** — page metadata.
- **`:rf.resource/fetching-next?`** — a load-more in flight (R2), **distinct from `:fetching?`** (a whole-feed refresh).

### The `:fetching-next?` split (R2)

A load-more and a whole-feed refresh BOTH leave the feed at `:fetching` (no 6th FSM state). The distinguishing **durable** fact is the in-flight work-ledger row's **page index** — a `load-more` APPENDS at a positive index (the tail); a page-0 fetch / refetch records 0. `work-record` now carries an optional `:page-index` (the "page-fetch work evidence" R1 names), omitted entirely for non-infinite / mutation work (byte-identical to before). The sub joins the entry's `:current-work` to its live row and reads the recorded index.

### The loud merge (R3)

`state/merge-pages->items` flattens the page vector; a non-vector page with no `:page->items` raises **`:rf.error/infinite-missing-page-accessor`** at the merge layer (the runtime-detected error wave-2 deferred here; the id is already reserved in spec/016 §Error roster). **No spec/009 catalogue row added — that is wave 6.** No SSR/tooling/guide touched (waves 5-7).

The merge memo is host-side transient (one slot per feed key, overwritten in place; reset per-test).

## Quality gates

```
$ cd implementation && npm run test:cljs
Ran 7932 tests containing 32931 assertions.
0 failures, 0 errors.

$ cd implementation/resources && clojure -M:test
Ran 546 tests containing 2302 assertions.
0 failures, 0 errors.
```

New tests (`resources_infinite_subs_cljs_test.cljc`, runs in BOTH runtimes): items merges pages in order; vector pages flatten by identity + fn accessor; pages returns the vector; page metadata (count / has-next? / has-prev?); `:fetching-next?` true during load-more / false on whole-feed refresh; page-error projection; the combined view-model; missing-page-accessor raises at merge; the merge is memoised on page-vector identity.

On merge the mayor dispatches waves 5-7 (SSR/restore confirm, Xray tooling + spec/009 catalogue, guide+example).