### PR TITLE
docs(resources): de-wave EP-0021 comments + note :infinite/:next-page-param in reg-resource docstring (rf2-8tujm2, rf2-5synkw)

### DIFF
--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -135,7 +135,8 @@
 ;; (`{:rf.resource/page-param p :rf.resource/page-index i}`); a non-infinite
 ;; `:request` still receives a nil/empty ctx (NO new 3-arity). The
 ;; `:rf.error/infinite-missing-page-accessor` error is RUNTIME-detected at the
-;; first non-vector page in the merge layer (wave 4), not here — at registration
+;; first non-vector page in the subs merge site (state/merge-pages->items), not
+;; here — at registration
 ;; we have no page to inspect; here we shape-validate `:page->items` (a keyword
 ;; or fn) when present.
 
@@ -157,8 +158,8 @@
     - the optional `:prev-page-param` (R7 mirror) MUST be a fn when present;
     - the optional `:page->items` (R3 accessor) MUST be a keyword or fn when
       present (a non-vector page with NO `:page->items` is the RUNTIME-detected
-      `:rf.error/infinite-missing-page-accessor`, raised at the merge site in
-      wave 4 — not here);
+      `:rf.error/infinite-missing-page-accessor`, raised at the subs merge site
+      — not here);
     - the optional `:refetch` policy (R6) MUST be a map with a boolean
       `:refetch-all-pages?` and/or an integer `:refetch-window` when present.
 
@@ -340,6 +341,10 @@
   Validates the spec (the REQUIRED, fail-closed `:scope` policy first;
   then `:params-schema` and `:request`) and writes a `:resource`-kind
   registrar entry carrying the spec plus any captured source coords.
+
+  An `:infinite true` resource additionally REQUIRES `:next-page-param` (and
+  may declare `:prev-page-param` / `:page->items` / `:refetch` /
+  `:initial-page-param`) — see Spec 016 §Infinite resources and load-more feeds.
 
   Returns `resource-id` per the `reg-*` return-value convention
   ([Conventions §reg-* return-value convention])."

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -967,8 +967,8 @@
 ;;
 ;; `:data` / `:page-params` / `:next-page-param` are the durable facts; the
 ;; merged list, `:has-next-page?`, `:fetching-next?`, `:page-count`, etc. are
-;; DERIVED in the subs layer (wave 4), never stored. The load-more EVENT
-;; (wave 3) drives `entry-append-page` / `entry-page-failed` from the work
+;; DERIVED in the subs layer, never stored. The `:rf.resource/load-more` event
+;; drives `entry-append-page` / `entry-page-failed` from the work
 ;; ledger reply path; these are the pure transitions it calls.
 
 (defn infinite-entry?
@@ -990,7 +990,7 @@
 (defn page-param-for-spec
   "The page-0 param for an infinite resource `spec`: the resource's optional
   `:initial-page-param`, or the framework default (`nil`) when none is
-  declared. The single home so the load-more event (wave 3) and the first-load
+  declared. The single home so the load-more event and the first-load
   page-0 fetch agree. Per Spec 016 §Causal event — load-more."
   [spec]
   (get spec :initial-page-param initial-page-param))
@@ -1233,10 +1233,10 @@
   "PURE: resolve a feed's `:page->items` accessor (a keyword key or a
   `(fn [page] → seq-of-items)`) into a fn `(page → seq-of-items)`. A keyword is
   lifted to its `get` accessor. When `page->items` is nil, returns nil — the
-  caller (the merge site, wave 4) then applies the IDENTITY-flatten rule for a
+  caller (the merge site) then applies the IDENTITY-flatten rule for a
   vector page and raises `:rf.error/infinite-missing-page-accessor` for a
   non-vector page (R3, loud over guessing). The single home so the registry
-  shape-validation and the wave-4 merge agree on what shapes are accepted. Per
+  shape-validation and the subs merge agree on what shapes are accepted. Per
   Spec 016 §Subscription contract (R3)."
   [page->items]
   (cond
@@ -1256,7 +1256,7 @@
       flattens via the resource's REQUIRED `:page->items` accessor;
     - a non-vector page with NO `:page->items` accessor is a loud
       `:rf.error/infinite-missing-page-accessor` error — the runtime-detected
-      counterpart the wave-2 registry validation deferred to this merge site
+      counterpart the registry validation deferred to this merge site
       (the registry cannot inspect a page shape at registration time; only the
       merge sees a concrete page). The framework NEVER guesses `:items` /
       `:data`.


### PR DESCRIPTION
Comment/docstring-only cleanup of the EP-0021 infinite-resources source. No behaviour change. Both beads touch `implementation/resources/src/re_frame/resources/registry.cljc`, so they were done in one pass and sequenced.

## rf2-8tujm2 (P3) — de-wave stale build-sequencing references
The 7-wave EP-0021 build left 8 references to build WAVES ("wave 2"/"wave 3"/"wave 4") describing build SEQUENCING, not the finished code's structure. Now that all waves are merged, those mean nothing to a reader of finished code. Re-worded each to name the LAYER/namespace/role instead (technical meaning preserved):

- `registry.cljc` L138: "merge layer (wave 4)" -> "subs merge site (state/merge-pages->items)"
- `registry.cljc` L161 (validate-infinite-spec! docstring): "raised at the merge site in wave 4" -> "raised at the subs merge site"
- `state.cljc` L970: "DERIVED in the subs layer (wave 4)" -> dropped "(wave 4)"
- `state.cljc` L971: "The load-more EVENT (wave 3)" -> "The `:rf.resource/load-more` event"
- `state.cljc` L993 (page-param-for-spec docstring): "the load-more event (wave 3)" -> "the load-more event"
- `state.cljc` L1236 (resolve-page->items docstring): "the caller (the merge site, wave 4)" -> "the caller (the merge site)"
- `state.cljc` L1239 (same docstring): "the wave-4 merge agree" -> "the subs merge agree"
- `state.cljc` L1259 (merge-pages->items docstring): "the wave-2 registry validation deferred" -> "the registry validation deferred"

`events.cljc` / `subs.cljc` / `work_ledger.cljc` / `trace_egress.cljc` carry no wave-N residue (their cross-references already name layers) — left untouched. The remaining "EP-0016 wave" hits in `classification.cljc` / `scope_registry.cljc` / `ssr.cljc` are a different epic's work-wave naming, not EP-0021 build sequencing — out of scope.

## rf2-5synkw (P4) — surface :infinite slice in public reg-resource docstring
Added one sentence to the public `reg-resource` docstring (the var a load-more author lands on first), noting that `:infinite true` additionally REQUIRES `:next-page-param` (and may declare `:prev-page-param` / `:page->items` / `:refetch` / `:initial-page-param`), with a Spec 016 pointer. Previously only the private `validate-infinite-spec!` and the infinite subs documented this.

## Quality gates
```
cd implementation && npm run test:cljs   # green
# Ran 7949 tests containing 33079 assertions.
# 0 failures, 0 errors.
```