### PR TITLE
test(resources): EP-0021 pure-fn (replace/refetch-reset) + :initial-page-param runtime coverage (rf2-zttcem, rf2-sqro7j)

### DIFF
--- a/implementation/resources/test/re_frame/resources_infinite_initial_page_param_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_initial_page_param_cljs_test.cljc
@@ -1,0 +1,130 @@
+(ns re-frame.resources-infinite-initial-page-param-cljs-test
+  "EVENT/runtime coverage for the infinite-feed `:initial-page-param` override
+  (EP-0021 R8, Spec 016 §Causal event — load-more — the page-0 cursor, the
+  TanStack `initialPageParam` analogue).
+
+  The pure boundary (`state/page-param-for-spec`) is already pinned in
+  `resources_infinite_state_cljs_test` (`page-0-param-default`). This slice
+  closes the RUNTIME gap: that a non-nil `:initial-page-param` actually RIDES
+  into the page-0 request and is recorded as page-0's `:page-params` entry. A
+  regression that ignored the override on the page-0 fetch (e.g. hardcoding
+  nil) would pass every default-param test — every existing event/example test
+  uses the framework `nil` default.
+
+  In `ensure-load` (events.cljc) the page-0 param is
+  `(state/page-param-for-spec spec)` and the reserved request ctx is
+  `(page-request-ctx page-param 0)`, which the resource's `:request` fn reads
+  via `{:rf.resource/keys [page-param page-index]}`. The capturing transport
+  below REPLAYS the live managed-HTTP reply shape (Spec 014 §Reply addressing)
+  so the page reply handler runs against the genuine 3-element event."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.test-support]
+   ;; production HTTP fx surface (so the transport feature probe resolves);
+   ;; the fetch itself is overridden by the capturing reply stub below.
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport that REPLAYS the real reply-append shape ----------
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- capturing-transport-fixture
+  [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-transport-fixture)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- runtime-db [] (rf/runtime-db-value :rf/default))
+
+(defn- entry [scoped-key]
+  (get-in (runtime-db) (state/entry-path scoped-key)))
+
+(defn- reply-success!
+  "Dispatch the captured `:on-success` reply with the transport's success
+  result appended as the LAST arg — the live managed-HTTP transport shape."
+  [data]
+  (rf/dispatch-sync (conj (:on-success @last-managed-args) {:kind :success :value data})))
+
+(def ^:private next-cursor
+  (fn [last-page _all-pages] (get-in last-page [:page-info :next-cursor])))
+
+(defn- page [items next-c] {:items items :page-info {:next-cursor next-c}})
+
+(defn- feed-spec
+  "A minimal valid infinite-feed spec. The `:request` fn surfaces the
+  runtime-threaded page-param as the request's `:cursor` so a test can observe
+  exactly which page-0 param rode into the fetch."
+  [overrides]
+  (merge {:scope            :rf.scope/global
+          :infinite         true
+          :params-schema    [:map [:filter :keyword]]
+          :request          (fn [{:keys [filter]} {:rf.resource/keys [page-param page-index]}]
+                              {:request {:method :get :url "/api/feed"
+                                         :params (cond-> {:filter filter :page-index page-index}
+                                                   page-param (assoc :cursor page-param))}})
+          :next-page-param  next-cursor
+          :page->items      :items
+          :tags             (fn [{:keys [filter]} _data] #{[:feed filter]})}
+         overrides))
+
+(defn- feed-key [resource]
+  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+
+(defn- ensure! [resource]
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource resource :scope :rf.scope/global
+                      :params {:filter :recent} :owner [:test :w]}]))
+
+;; ===========================================================================
+;; :initial-page-param override RIDES into the page-0 request + page-params
+;; ===========================================================================
+
+(deftest initial-page-param-rides-into-page-0-request
+  (testing "a non-nil :initial-page-param is threaded into the page-0 FETCH —
+            the request carries it as the derived page-0 cursor (R8)"
+    (rf/reg-resource :ipp/feed (feed-spec {:initial-page-param "p0"}))
+    (ensure! :ipp/feed)
+    (let [req-params (get-in @last-managed-args [:request :params])]
+      (is (= 0 (:page-index req-params)) "still the page-0 fetch (index 0)")
+      (is (= "p0" (:cursor req-params))
+          "the :initial-page-param override rode into the page-0 request's cursor"))))
+
+(deftest initial-page-param-recorded-as-page-0-param
+  (testing "after the page-0 reply settles, :page-params records the OVERRIDE
+            (not nil) for page 0 — the durable cursor fact (R8)"
+    (rf/reg-resource :ipp2/feed (feed-spec {:initial-page-param "p0"}))
+    (ensure! :ipp2/feed)
+    (reply-success! (page [:a :b] "c1"))
+    (let [e (entry (feed-key :ipp2/feed))]
+      (is (= :loaded (:status e)))
+      (is (= [(page [:a :b] "c1")] (:data e)) "page-0 accumulated")
+      (is (= ["p0"] (:page-params e))
+          "page-0's recorded param is the override 'p0', NOT the framework nil default")
+      (is (= "c1" (:next-page-param e)) "cursor then advances from the page envelope"))))
+
+(deftest default-initial-page-param-is-nil-baseline
+  (testing "BASELINE — with no override the page-0 request carries no cursor +
+            records nil (so the override assertions above are meaningful)"
+    (rf/reg-resource :ippd/feed (feed-spec {}))
+    (ensure! :ippd/feed)
+    (is (not (contains? (get-in @last-managed-args [:request :params]) :cursor))
+        "no override → page-0 request carries no cursor")
+    (reply-success! (page [:a] "c1"))
+    (is (= [nil] (:page-params (entry (feed-key :ippd/feed))))
+        "page-0 param recorded nil by default")))

--- a/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
@@ -16,6 +16,14 @@
       returns to :loaded;
     - `entry-page-failed` is the THIRD error channel (keeps the feed,
       records :page-error);
+    - `entry-replace-page` refreshes a page IN PLACE (R6 window-preserving
+      refetch settle) — incl. the structural-sharing identical-value branch
+      and the delegate-to-append-past-tail branch;
+    - `refetch-keep-count` is the pure R6 keep-count policy (the 4 disjoint
+      branches + the window clamp edges);
+    - `entry-refetch-reset` truncates the accumulation to the kept window at
+      refetch-issue (the keep-all no-op default + the truncation opt-ins +
+      the guard arms);
     - `resolve-page->items` lifts the R3 accessor.
 
   The load-more EVENT (wave 3) + subs (wave 4) are out of scope."
@@ -221,3 +229,224 @@
     (is (nil? (state/page-param-for-spec {:initial-page-param nil}))))
   (testing "an :initial-page-param override is honoured"
     (is (= "p0" (state/page-param-for-spec {:initial-page-param "p0"})))))
+
+;; ---- entry-replace-page (R6 window-preserving in-place replace) ------------
+;;
+;; The settle a window-preserving refetch's replacement page-0 performs: the
+;; feed never collapses; page 0 is refreshed in place and the tail is kept. The
+;; event tests only ever replace page-0 with a DIFFERENT value, so the
+;; structural-sharing branch (identical refetch keeps the OLD value identical)
+;; and the delegate-to-append branch (index past the tail) are pinned here.
+
+(defn- accumulated-3
+  "A loaded 3-page infinite entry [p0 p1 p2] with cursors c1/c2/c3 and one
+  param per page ([nil c1 c2]). Built via the same pure appends the event
+  layer drives, so the structural-sharing assertions ride a realistic shape."
+  []
+  (-> (state/empty-infinite-entry :feed/timeline)
+      (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+                                :next-page-param-fn next-cursor
+                                :loaded-at 1000 :stale-at 2000})
+      (state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
+                                :next-page-param-fn next-cursor
+                                :loaded-at 1100 :stale-at 2100})
+      (state/entry-append-page {:page (page [:c] "c3") :page-param "c2"
+                                :next-page-param-fn next-cursor
+                                :loaded-at 1200 :stale-at 2200})))
+
+(deftest replace-page-in-place-preserves-window
+  (testing "replacing page-0 of a 3-page feed refreshes index 0 in place +
+            keeps the accumulated tail (window-preserving R6 settle)"
+    (let [e0 (accumulated-3)
+          e1 (state/entry-replace-page
+               e0 {:page (page [:a*] "c1") :page-param nil :page-index 0
+                   :next-page-param-fn next-cursor
+                   :loaded-at 9000 :stale-at 9999})]
+      (is (= 3 (state/page-count e1)) "feed NOT grown — replace, not append")
+      (is (= (page [:a*] "c1") (nth (:data e1) 0)) "page-0 replaced with the fresh value")
+      (is (= (page [:b] "c2") (nth (:data e1) 1)) "tail page-1 preserved")
+      (is (= (page [:c] "c3") (nth (:data e1) 2)) "tail page-2 preserved")
+      (is (= [nil "c1" "c2"] (:page-params e1)) "page-0 param replaced in step; tail params kept")
+      (is (= :loaded (:status e1)))
+      (is (= 9000 (:loaded-at e1)) ":loaded-at re-stamped")
+      (is (= 9999 (:stale-at e1)) ":stale-at re-stamped")
+      (is (nil? (:current-work e1)) ":current-work cleared")
+      (is (> (:revision e1) (:revision e0))
+          "authoritative durable write bumps revision UNCONDITIONALLY (EP-0019)"))))
+
+(deftest replace-page-structural-sharing-identical-value
+  (testing "a refetch that returns an = page-0 keeps the OLD page value identical
+            (identical?) so downstream stays quiet — only a different value is new"
+    (let [e0       (accumulated-3)
+          old-page (nth (:data e0) 0)
+          ;; a freshly-decoded, structurally-EQUAL but NOT identical page-0
+          fresh    (page [:a] "c1")]
+      (is (= old-page fresh) "the fresh page is value-equal to the old page-0")
+      (is (not (identical? old-page fresh)) "but it is a distinct object (a fresh decode)")
+      (let [e1 (state/entry-replace-page
+                 e0 {:page fresh :page-param nil :page-index 0
+                     :next-page-param-fn next-cursor
+                     :loaded-at 9000 :stale-at 9999})]
+        (is (identical? old-page (nth (:data e1) 0))
+            "structural sharing — the OLD page-0 object is retained, not the fresh decode")
+        (is (identical? (nth (:data e0) 1) (nth (:data e1) 1))
+            "untouched tail pages are shared by identity")
+        (is (> (:revision e1) (:revision e0))
+            "revision still bumps — the durable write happened even though the value shared"))))
+  (testing "a DIFFERENT page-0 value is taken as-is (no spurious sharing)"
+    (let [e0    (accumulated-3)
+          fresh (page [:a*] "c1")
+          e1    (state/entry-replace-page
+                  e0 {:page fresh :page-param nil :page-index 0
+                      :next-page-param-fn next-cursor
+                      :loaded-at 9000 :stale-at 9999})]
+      (is (identical? fresh (nth (:data e1) 0))
+          "a value-distinct page is stored as the fresh object"))))
+
+(deftest replace-page-recomputes-cursor-from-replaced-tail
+  (testing "replacing the LAST page re-derives :next-page-param from the new tail"
+    (let [e0 (accumulated-3)
+          ;; replace the terminal page-2 with one whose next-cursor differs
+          e1 (state/entry-replace-page
+               e0 {:page (page [:c*] "c3*") :page-param "c2" :page-index 2
+                   :next-page-param-fn next-cursor
+                   :loaded-at 9000 :stale-at 9999})]
+      (is (= "c3*" (:next-page-param e1)) "cursor recomputed from the replaced last page")
+      (is (= 3 (state/page-count e1))))))
+
+(deftest replace-page-clears-error-channels
+  (testing "an in-place replace clears :page-error / :refresh-error (a fresh authoritative write)"
+    (let [e0     (-> (accumulated-3)
+                     (state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
+          e1     (state/entry-replace-page
+                   e0 {:page (page [:a*] "c1") :page-param nil :page-index 0
+                       :next-page-param-fn next-cursor
+                       :loaded-at 9000 :stale-at 9999})]
+      (is (some? (:page-error e0)) "the prior failure recorded a page-error")
+      (is (nil? (:page-error e1)) "the replace cleared it")
+      (is (nil? (:refresh-error e1)))
+      (is (nil? (:invalidated-at e1))))))
+
+(deftest replace-page-past-tail-delegates-to-append
+  (testing "a replace at page-index >= page-count is an APPEND (replacement past the
+            tail — e.g. a window-preserving refetch of a feed emptied to page 0)"
+    (let [e0 (-> (state/empty-infinite-entry :feed/timeline)
+                 (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+                                           :next-page-param-fn next-cursor
+                                           :loaded-at 1 :stale-at 2}))
+          ;; page-index 1 == page-count (1) → delegates to entry-append-page
+          e1 (state/entry-replace-page
+               e0 {:page (page [:b] "c2") :page-param "c1" :page-index 1
+                   :next-page-param-fn next-cursor
+                   :loaded-at 3 :stale-at 4})]
+      (is (= 2 (state/page-count e1)) "the page was APPENDED (feed grew), not replaced")
+      (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e1)))
+      (is (= [nil "c1"] (:page-params e1)) "params appended in step")
+      (is (= "c2" (:next-page-param e1)) "cursor advanced from the appended tail")))
+  (testing "a replace into an EMPTY feed at index 0 appends page-0"
+    (let [e0 (state/empty-infinite-entry :feed/timeline)
+          e1 (state/entry-replace-page
+               e0 {:page (page [:a] "c1") :page-param nil :page-index 0
+                   :next-page-param-fn next-cursor
+                   :loaded-at 1 :stale-at 2})]
+      (is (= 1 (state/page-count e1)) "index 0 == count 0 → append page-0")
+      (is (= [(page [:a] "c1")] (:data e1))))))
+
+(deftest replace-page-nil-entry-noop
+  (testing "replace on a nil entry returns nil unchanged (no feed to replace into)"
+    (is (nil? (state/entry-replace-page nil {:page (page [:a] "c1") :page-index 0
+                                             :next-page-param-fn next-cursor
+                                             :loaded-at 1 :stale-at 2})))))
+
+;; ---- refetch-keep-count (R6 — the 4 disjoint branches + clamp edges) -------
+
+(deftest refetch-keep-count-empty-feed
+  (testing "an empty feed (page-count 0) keeps 0 — nothing to preserve"
+    (is (= 0 (state/refetch-keep-count nil 0)))
+    (is (= 0 (state/refetch-keep-count {:refetch-all-pages? true} 0)))
+    (is (= 0 (state/refetch-keep-count {:refetch-window 5} 0))
+        "window over an empty feed is still 0 (zero-page short-circuits first)")))
+
+(deftest refetch-keep-count-default-preserves-window
+  (testing "the ruled DEFAULT (no policy / empty policy) keeps EVERY accumulated page"
+    (is (= 3 (state/refetch-keep-count nil 3)))
+    (is (= 3 (state/refetch-keep-count {} 3)))
+    (is (= 1 (state/refetch-keep-count {} 1)))))
+
+(deftest refetch-keep-count-all-pages-opt-in
+  (testing ":refetch-all-pages? true keeps ONLY page 0 (re-accumulate from scratch)"
+    (is (= 1 (state/refetch-keep-count {:refetch-all-pages? true} 3)))
+    (is (= 1 (state/refetch-keep-count {:refetch-all-pages? true} 1)))
+    (testing "all-pages? wins over a co-present :refetch-window (cond order)"
+      (is (= 1 (state/refetch-keep-count {:refetch-all-pages? true :refetch-window 2} 3))))))
+
+(deftest refetch-keep-count-window-clamps
+  (testing ":refetch-window n bounds the kept window to the first n pages"
+    (is (= 2 (state/refetch-keep-count {:refetch-window 2} 3)) "in-range window kept verbatim"))
+  (testing "CLAMP HIGH — a window beyond the page count never invents pages"
+    (is (= 3 (state/refetch-keep-count {:refetch-window 5} 3))
+        "window > page-count clamps DOWN to page-count")
+    (is (= 3 (state/refetch-keep-count {:refetch-window 3} 3)) "window == page-count is exact"))
+  (testing "CLAMP LOW — a refetch always keeps at least page 0"
+    (is (= 1 (state/refetch-keep-count {:refetch-window 1} 3)) "window 1 keeps exactly page 0")
+    (is (= 1 (state/refetch-keep-count {:refetch-window 0} 3)) "window 0 clamps UP to 1")
+    (is (= 1 (state/refetch-keep-count {:refetch-window -4} 3)) "a negative window clamps UP to 1")))
+
+;; ---- entry-refetch-reset (R6 — guard arms + truncation in step) ------------
+
+(deftest refetch-reset-default-is-noop
+  (testing "the window-preserving DEFAULT keeps every page — a pure no-op
+            (the accumulated pages stay visible during the in-flight refetch)"
+    (let [e0 (accumulated-3)
+          e1 (state/entry-refetch-reset
+               e0 {:next-page-param-fn next-cursor :prev-page-param-fn prev-cursor
+                   :refetch-policy nil})]
+      (is (identical? e0 e1) "no policy → keep-all → the SAME entry object (true no-op)")
+      (is (= 3 (state/page-count e1))))
+    (testing "an explicit empty policy is also keep-all (a no-op)"
+      (let [e0 (accumulated-3)]
+        (is (identical? e0 (state/entry-refetch-reset
+                             e0 {:next-page-param-fn next-cursor :refetch-policy {}})))))))
+
+(deftest refetch-reset-window-truncates-tail-and-params
+  (testing ":refetch-window 2 truncates a 3-page feed to its first 2 pages +
+            truncates :page-params in step + recomputes the cursor from the tail"
+    (let [e0 (accumulated-3)
+          e1 (state/entry-refetch-reset
+               e0 {:next-page-param-fn next-cursor :prev-page-param-fn prev-cursor
+                   :refetch-policy {:refetch-window 2}})]
+      (is (= 2 (state/page-count e1)) "tail dropped to the kept window")
+      (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e1)))
+      (is (= [nil "c1"] (:page-params e1)) ":page-params truncated in step")
+      (is (= "c2" (:next-page-param e1)) "cursor recomputed from the kept tail's edge")
+      (is (identical? (nth (:data e0) 0) (nth (:data e1) 0))
+          "kept leading pages are shared by identity (only the dropped tail changes)")
+      (testing "the reset does NOT touch :status / :current-work / :revision
+                (entry-start-load already transitioned the entry)"
+        (is (= (:status e0) (:status e1)))
+        (is (= (:current-work e0) (:current-work e1)))
+        (is (= (:revision e0) (:revision e1)) "revision NOT bumped by the reset")))))
+
+(deftest refetch-reset-all-pages-truncates-to-page-0
+  (testing ":refetch-all-pages? truncates a 3-page feed to page 0 only"
+    (let [e1 (state/entry-refetch-reset
+               (accumulated-3)
+               {:next-page-param-fn next-cursor :prev-page-param-fn prev-cursor
+                :refetch-policy {:refetch-all-pages? true}})]
+      (is (= 1 (state/page-count e1)) "kept only page 0")
+      (is (= [(page [:a] "c1")] (:data e1)))
+      (is (= [nil] (:page-params e1)))
+      (is (= "c1" (:next-page-param e1)) "cursor recomputed from page 0's tail"))))
+
+(deftest refetch-reset-guard-arms
+  (testing "a nil entry is returned unchanged"
+    (is (nil? (state/entry-refetch-reset nil {:refetch-policy {:refetch-window 1}}))))
+  (testing "a non-infinite (ordinary) entry is returned unchanged (guard arm)"
+    (let [plain (state/empty-entry :res/plain)]
+      (is (identical? plain (state/entry-refetch-reset
+                              plain {:refetch-policy {:refetch-window 1}})))))
+  (testing "an empty (no-pages) infinite entry is returned unchanged (guard arm)"
+    (let [empty-feed (state/empty-infinite-entry :feed/timeline)]
+      (is (= 0 (state/page-count empty-feed)))
+      (is (identical? empty-feed (state/entry-refetch-reset
+                                   empty-feed {:refetch-policy {:refetch-all-pages? true}}))))))


### PR DESCRIPTION
Test-only. Closes the two EP-0021 testing-coverage gaps surfaced by the rf2-uvq8sq review.

## rf2-zttcem (P3) — direct pure-fn unit tests
Three R6 state transitions in `resources/state.cljc` were exercised only indirectly via the event layer. Added DIRECT pure-fn deftests in `resources_infinite_state_cljs_test.cljc`:

- **`entry-replace-page`** — in-place window-preserving replace (page-0 refresh keeps the tail); the **structural-sharing** branch (an `=` page-0 refetch retains the OLD object via `identical?`, with a value-distinct page taken as-is); cursor recompute from a replaced last page; error-channel clearing; the **delegate-to-append** branch when `page-index >= page-count` (incl. replace-into-empty-feed); nil-entry no-op.
- **`refetch-keep-count`** — all four disjoint branches + the **clamp edges**: window > page-count clamps DOWN to page-count, window < 1 (incl. 0 and negative) clamps UP to 1, `:refetch-all-pages?` wins over a co-present `:refetch-window`, zero-page short-circuits to 0.
- **`entry-refetch-reset`** — keep-all no-op default (asserts the SAME entry object via `identical?`); window / all-pages truncation with `:page-params` truncated in step and cursor recomputed from the kept tail; leading-pages identity sharing; untouched `:status`/`:current-work`/`:revision`; and the nil / non-infinite / empty-feed **guard arms**.

## rf2-sqro7j (P4) — `:initial-page-param` EVENT/runtime coverage
The override was pinned only at the pure `page-param-for-spec` boundary. A regression that hardcoded nil on the page-0 fetch would have passed every existing default-param test. New runtime test file `resources_infinite_initial_page_param_cljs_test.cljc` registers a feed with `:initial-page-param "p0"`, ensures it, and asserts:
- the captured page-0 request carries `:cursor "p0"` (the override rode into the fetch);
- after the reply settles, `:page-params` records `"p0"` (not nil) for page 0;
- a no-override baseline (no `:cursor`, `:page-params [nil]`) so the override assertions are meaningful.

It lives in its own runtime file because the `load-more` / example test surfaces are owned by a sibling worker; this is a new-file addition (parallel-safe surface). No source behaviour change.

## Quality gates
\`\`\`
cd implementation && npm run test:cljs
# 7966 tests, 33150 assertions, 0 failures, 0 errors

# resources JVM
cd implementation/resources && clojure -M:test
# 573 tests, 2440 assertions, 0 failures, 0 errors
\`\`\`