### PR TITLE
fix(resources): EP-0021 apply :page-data-schema per page on egress/SSR projection (rf2-byl7bk.3.2)

### DIFF
--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -281,6 +281,28 @@
   [spec]
   (schema-marks (:data-schema spec)))
 
+(defn infinite-spec?
+  "True iff `spec` declares an infinite feed (`:infinite true` — EP-0021 R1).
+  The classification-local predicate behind `project-data`'s per-page
+  (`:page-data-schema`) vs whole-value (`:data-schema`) branch. Mirrors
+  `re-frame.resources.registry/infinite-resource?` but is defined HERE (a bare
+  `(true? (:infinite spec))` read) because `registry` already requires
+  `classification` — requiring it back would cycle (Spec 016 §Registration —
+  :infinite)."
+  [spec]
+  (true? (:infinite spec)))
+
+(defn page-data-schema-marks
+  "The per-slot `:sensitive?` / `:large?` classification an infinite resource
+  `spec`'s `:page-data-schema` declares for ONE PAGE value, as
+  `{:sensitive {path decl} :large {path decl}}` rooted at the page root (`[]`).
+  The per-page egress/classification contract (EP-0021 R5) — applied per page
+  over the accumulated `:data` vector by `project-data`, NOT over the whole
+  framework-owned page vector. Empty maps when no `:page-data-schema` or no
+  marks. Pure (modulo the memoised shared walker)."
+  [spec]
+  (schema-marks (:page-data-schema spec)))
+
 (defn params-schema-marks
   "The per-slot `:sensitive?` / `:large?` classification a resource /
   mutation `spec`'s `:params-schema` declares for its PARAMS value, as
@@ -349,26 +371,74 @@
 ;; is the FINE-GRAINED complement for a `:serialize` entry with a large leaf.
 ;; ---------------------------------------------------------------------------
 
+(defn- project-value
+  "Project ONE owner-decoded `value` (a whole resource data value, or a SINGLE
+  page of an infinite feed) for egress against `frame-id` / `boundary-profile`,
+  applying the owner per-slot `marks` (`{:sensitive {path …} :large {path …}}`,
+  rooted at the value root) in the two composed layers:
+
+    (a) the owner `:sensitive?` / `:large?` per-slot marks project through the
+        shared `re-frame.marks/redact-with-paths` walker (sensitive →
+        `:rf/redacted`, large → `:rf.size/large-elided`, sensitive wins at a
+        co-marked slot) — frame-independent;
+    (b) the result is projected through the merged frame-owned
+        `re-frame.projection/project-egress` under `boundary-profile` when a
+        `frame-id` is present, so any path the FRAME classifies composes as
+        defense-in-depth. A nil `frame-id` skips layer (b) (the owner
+        classification is the authority — see `project-data`).
+
+  No marks AND no frame → `value` rides unchanged. Pure."
+  [value marks frame-id boundary-profile]
+  (let [{:keys [sensitive large]} marks
+        owner-projected (if (or (seq sensitive) (seq large))
+                          (marks/redact-with-paths value (keys sensitive) (keys large))
+                          value)]
+    (if frame-id
+      (projection/project-egress owner-projected
+                                 {:frame             frame-id
+                                  :rf.egress/profile boundary-profile})
+      owner-projected)))
+
 (defn project-data
   "Project a resource entry's / mutation instance's serialized DATA value for
   egress across `boundary-profile` (a `:rf.egress/*` profile, e.g.
   `:rf.egress/ssr-hydration` at the SSR boundary, `:rf.egress/off-box-tool`
   at a tool boundary) against `frame-id`'s classification and the resource
-  `spec`'s OWNER per-slot `:data-schema` marks (EP-0015 §6).
+  `spec`'s OWNER per-slot classification (EP-0015 §6 / EP-0021 R5).
 
-  Two composed layers, both shared primitives:
+  THE single classification entry point for resource data egress — it branches
+  on `spec`'s `:infinite` marker so the per-page (`:page-data-schema`) vs
+  whole-value (`:data-schema`) contract is decided in one place (rather than a
+  forked parallel projector):
 
-    (a) the resource-owned `:data-schema` `:sensitive?` AND `:large?` per-slot
-        marks (`data-schema-marks`) project through the shared
+  - **Ordinary resource** (`:infinite` absent / not true): `data` is the whole
+    decoded value. The resource-owned `:data-schema` `:sensitive?` / `:large?`
+    per-slot marks (`data-schema-marks`) project over it (layer (a)), then the
+    merged frame-owned `project-egress` composes any frame-classified path
+    (layer (b)) — the existing contract.
+
+  - **Infinite feed** (`:infinite true` — EP-0021 R1/R5): `data` is the
+    FRAMEWORK-OWNED VECTOR OF PAGES, and the per-page egress/classification
+    contract is `:page-data-schema` (`page-data-schema-marks`), applied PER PAGE
+    — each page is projected through the SAME two layers (owner marks + frame
+    `project-egress`), and the page-vector SHAPE is preserved. `:data-schema` is
+    NOT consulted for the accumulated vector (R5: the framework page vector must
+    not be classified as if it were one app-decoded value, and a sensitive /
+    large page field must not bypass per-page classification). A non-vector
+    `data` on an infinite entry (an empty / not-yet-loaded feed whose `:data`
+    is `[]`, or a nil) rides through the per-page mapping harmlessly.
+
+  Both branches compose two SHARED primitives (never a family-private elider):
+
+    (a) the owner per-slot `:sensitive?` AND `:large?` marks through the shared
         `re-frame.marks/redact-with-paths` walker — `:sensitive?` slots redact
         to the `:rf/redacted` sentinel, `:large?` slots elide to the
         `:rf.size/large-elided` marker (sensitive wins at a co-marked slot) —
         the OWNER's fine-grained declaration, firing regardless of frame app-db
         classification (the CO-EQUAL counterpart to `project-params`);
-    (b) the result is projected through the merged frame-owned
-        `re-frame.projection/project-egress` (over `elide-wire-value`) under
-        `boundary-profile`, so any path the FRAME classifies composes as
-        defense-in-depth.
+    (b) the merged frame-owned `re-frame.projection/project-egress` (over
+        `elide-wire-value`) under `boundary-profile`, so any path the FRAME
+        classifies composes as defense-in-depth.
 
   When `frame-id` is nil (a frameless / pure projection — a test harness or
   a tool with no resolvable frame), layer (b) is SKIPPED and the owner-projected
@@ -377,27 +447,24 @@
   redact / omit, so a frameless serialized entry must not be over-redacted to
   the frame walker's fail-closed sentinel merely because no frame scope is
   carried (that fail-closed posture is for app-db egress, not the
-  resource-owned decision) — but the OWNER's own `:data-schema` `:sensitive?` /
+  resource-owned decision) — but the OWNER's own per-slot `:sensitive?` /
   `:large?` marks STILL fire (layer (a) is frame-independent). `spec` nil / no
-  data-schema → layer (a) is a no-op. Pure."
+  governing schema → layer (a) is a no-op. Pure."
   [data spec frame-id boundary-profile]
-  (let [{:keys [sensitive large]} (data-schema-marks spec)
-        ;; layer (a): BOTH owner axes through the SAME shared frame-independent
-        ;; `re-frame.marks/redact-with-paths` walker the CO-EQUAL `project-params`
-        ;; uses (sensitive → `:rf/redacted`, large → `:rf.size/large-elided`,
-        ;; sensitive wins over large at the same slot). A per-slot `:data-schema`
-        ;; `:large?` leaf is therefore ELIDED to the size marker on the wire
-        ;; rather than riding RAW — the fine-grained owner complement to the
-        ;; coarse whole-resource-large `:omit` (rf2-260yhk). No marks → `data`
-        ;; rides unchanged into layer (b).
-        owner-projected (if (or (seq sensitive) (seq large))
-                          (marks/redact-with-paths data (keys sensitive) (keys large))
-                          data)]
-    (if frame-id
-      (projection/project-egress owner-projected
-                                 {:frame             frame-id
-                                  :rf.egress/profile boundary-profile})
-      owner-projected)))
+  (if (infinite-spec? spec)
+    ;; INFINITE feed (EP-0021 R5): `data` is the framework-owned page VECTOR;
+    ;; apply the per-page `:page-data-schema` contract PER PAGE, preserving the
+    ;; vector shape. `:data-schema` is deliberately NOT consulted here.
+    (let [page-marks (page-data-schema-marks spec)]
+      (if (sequential? data)
+        (mapv (fn [page] (project-value page page-marks frame-id boundary-profile))
+              data)
+        ;; a non-vector / nil `:data` (empty / not-yet-loaded feed) — project it
+        ;; as a single value so a frame layer (b) still composes; per-page marks
+        ;; rooted at the page root no-op against a non-page shape.
+        (project-value data page-marks frame-id boundary-profile)))
+    ;; ORDINARY resource: the existing whole-value `:data-schema` contract.
+    (project-value data (data-schema-marks spec) frame-id boundary-profile)))
 
 ;; ---------------------------------------------------------------------------
 ;; Params projection — the CO-EQUAL fine-grained owner surface for the scoped

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -366,6 +366,14 @@
                       ;; UNCHANGED so the coarse owner classification (not
                       ;; frame-presence) governs serialize-vs-redact for a pure /
                       ;; test-harness projection outside a frame scope.
+                      ;;
+                      ;; rf2-byl7bk.3.2 / EP-0021 R5: for an INFINITE feed the
+                      ;; `:data` is the framework-owned VECTOR OF PAGES, so
+                      ;; `project-data` branches on `spec`'s `:infinite` marker
+                      ;; and applies the per-page `:page-data-schema` contract
+                      ;; PER PAGE (a sensitive / large page field redacts /
+                      ;; elides on every page) rather than treating the page
+                      ;; vector as one `:data-schema`-governed value.
                       :serialize
                       (assoc entry :data
                              (classification/project-data

--- a/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
@@ -413,6 +413,124 @@
           "no raw sensitive params value rides in the wire key"))))
 
 ;; ===========================================================================
+;; 4b. infinite-feed per-page :page-data-schema egress (rf2-byl7bk.3.2)
+;; ===========================================================================
+;;
+;; EP-0021 R5 / Spec 016 §Registration — :infinite: an infinite feed's
+;; `:data` is the framework-owned VECTOR OF PAGES, and its per-page
+;; egress/classification contract is `:page-data-schema` (NOT `:data-schema`,
+;; which is unused for the accumulated vector). SSR / tool / trace projection
+;; MUST apply `:page-data-schema` PER PAGE so a sensitive / large page field is
+;; classified before it crosses a boundary. Mirrors the load-more cursor egress
+;; fix (rf2-3tysyj) but on the page BODY.
+
+(defn- infinite-entry-with-pages
+  "Build a `:loaded` infinite-feed entry for `resource-id` carrying `pages` (a
+  vector of decoded page values) as its durable `:data` page vector. Mirrors
+  the `entry` helper but seeds the `:infinite?` marker + the page-params
+  alongside the page vector so the projection's infinite branch fires."
+  [resource-id pages]
+  (merge (state/empty-infinite-entry resource-id)
+         {:status      :loaded
+          :data        (vec pages)
+          :page-params (vec (repeat (count pages) nil))
+          :loaded-at   1000
+          :stale-at    9.0e15}))
+
+(deftest project-data-applies-page-data-schema-per-page-sensitive
+  (testing "rf2-byl7bk.3.2: an :infinite resource's :data is a VECTOR of pages;
+            the per-page :page-data-schema :sensitive? mark redacts that field
+            on EVERY page — the :data-schema is NOT used for the accumulated
+            vector (EP-0021 R5)"
+    (let [spec  {:infinite         true
+                 :page-data-schema [:map
+                                    [:token {:sensitive? true} :string]
+                                    [:title :string]]}
+          pages [{:token "tok-0" :title "page-0"}
+                 {:token "tok-1" :title "page-1"}]
+          projected (classification/project-data
+                      pages spec nil :rf.egress/ssr-hydration)]
+      (is (vector? projected) "the page-vector SHAPE is preserved")
+      (is (= 2 (count projected)) "every page is preserved")
+      (is (= privacy/redacted-sentinel (:token (nth projected 0)))
+          "page-0's owner-marked :token is redacted")
+      (is (= privacy/redacted-sentinel (:token (nth projected 1)))
+          "page-1's owner-marked :token is redacted")
+      (is (= "page-0" (:title (nth projected 0))) "page-0's unmarked sibling rides")
+      (is (= "page-1" (:title (nth projected 1))) "page-1's unmarked sibling rides")
+      (is (not (str/includes? (pr-str projected) "tok-0"))
+          "no raw page-0 sensitive value rides")
+      (is (not (str/includes? (pr-str projected) "tok-1"))
+          "no raw page-1 sensitive value rides"))))
+
+(deftest project-data-applies-page-data-schema-per-page-large
+  (testing "rf2-byl7bk.3.2: a per-page :page-data-schema :large? mark ELIDES
+            that field to the :rf.size/large-elided marker on every page"
+    (let [big   (apply str (repeat 500 "x"))
+          spec  {:infinite         true
+                 :page-data-schema [:map
+                                    [:body {:large? true} :string]
+                                    [:title :string]]}
+          pages [{:body big :title "p0"} {:body big :title "p1"}]
+          projected (classification/project-data
+                      pages spec nil :rf.egress/ssr-hydration)]
+      (is (contains? (:body (nth projected 0)) :rf.size/large-elided)
+          "page-0's large field is elided to the size marker")
+      (is (contains? (:body (nth projected 1)) :rf.size/large-elided)
+          "page-1's large field is elided to the size marker")
+      (is (not (str/includes? (pr-str projected) big))
+          "no raw large page value rides"))))
+
+(deftest project-data-infinite-ignores-data-schema
+  (testing "rf2-byl7bk.3.2: an :infinite resource's :data-schema is NOT used as
+            the accumulated-vector classifier (EP-0021 R5) — only
+            :page-data-schema governs the page bodies"
+    (let [spec  {:infinite    true
+                 ;; an accidental :data-schema on an infinite resource must not
+                 ;; classify the page vector itself.
+                 :data-schema [:map [:token {:sensitive? true} :string]]}
+          pages [{:token "tok-0"}]
+          projected (classification/project-data
+                      pages spec nil :rf.egress/ssr-hydration)]
+      ;; no :page-data-schema marks → pages ride verbatim; the :data-schema
+      ;; (which would match a single page map's :token) is deliberately ignored.
+      (is (= pages projected)
+          "the page vector rides verbatim — :data-schema is not consulted for it"))))
+
+(deftest ssr-infinite-feed-redacts-sensitive-page-field-per-page
+  (reg! :feed/timeline {:infinite         true
+                        :next-page-param  (fn [_last _all] nil)
+                        :page-data-schema [:map
+                                           [:author-email {:sensitive? true} :string]
+                                           [:body :string]]})
+  (testing "rf2-byl7bk.3.2 END-TO-END: an infinite feed whose :page-data-schema
+            marks a page field :sensitive? redacts that field on EVERY page
+            during SSR projection — the page body must not ship RAW across the
+            SSR/hydration + tool/trace AI boundary (the leak this fix closes)"
+    (let [k    (state/scoped-resource-key :rf.scope/global :feed/timeline {:slug "t"})
+          e    (infinite-entry-with-pages
+                 :feed/timeline
+                 [{:author-email "alice@example.com" :body "hello"}
+                  {:author-email "bob@example.com" :body "world"}])
+          [_ we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))
+          pages  (:data we)]
+      (is (= :serialize (classification/whole-entry-disposition
+                          (rf/resource-meta :feed/timeline)))
+          "no coarse claim → :serialize (the per-page schema is the surface)")
+      (is (vector? pages) "the page-vector shape is preserved on the wire")
+      (is (= 2 (count pages)) "every accumulated page rides")
+      (is (= privacy/redacted-sentinel (get-in pages [0 :author-email]))
+          "page-0's sensitive field is redacted on the wire")
+      (is (= privacy/redacted-sentinel (get-in pages [1 :author-email]))
+          "page-1's sensitive field is redacted on the wire")
+      (is (= "hello" (get-in pages [0 :body])) "page-0's unmarked field rides verbatim")
+      (is (= "world" (get-in pages [1 :body])) "page-1's unmarked field rides verbatim")
+      (is (not (str/includes? (pr-str we) "alice@example.com"))
+          "no raw page-0 sensitive value rides anywhere on the entry")
+      (is (not (str/includes? (pr-str we) "bob@example.com"))
+          "no raw page-1 sensitive value rides anywhere on the entry"))))
+
+;; ===========================================================================
 ;; 5. load-bearing Spec 016 rules preserved (the projection contract)
 ;; ===========================================================================
 


### PR DESCRIPTION
## What

P1 privacy/correctness fix for EP-0021 / Spec 016 infinite resources (rf2-byl7bk.3.2).

An infinite feed's `:data` is the framework-owned **vector of pages**, and its per-page egress/classification contract is **`:page-data-schema`** (EP-0021 R5 / Spec 016 §Registration — `:infinite`). The projection path only consulted `:data-schema` and projected the whole `:data` page-vector as one opaque value — so a feed whose `:page-data-schema` marked a page field `:sensitive?` / `:large?` shipped those page fields **RAW** across the SSR/hydration + tool/trace AI boundary. Same leak class as the load-more cursor fix (rf2-3tysyj), but on the page **body**.

## The leak reproduced before the fix

The new end-to-end SSR test failed before the change — a sensitive page field shipped raw on every page:

```
FAIL ssr-infinite-feed-redacts-sensitive-page-field-per-page
  expected: (= privacy/redacted-sentinel (get-in pages [0 :author-email]))
  actual:   (not (= :rf/redacted "alice@example.com"))
  ... no raw page-0/1 sensitive value rides anywhere on the entry — FAILED
```

(4 failures on the SSR test alone; 9 across the new suite.)

## The fix

`classification/project-data` is now **the single classification entry point** and branches on `spec`'s `:infinite` marker:

- **Infinite feed** — maps the per-page `:page-data-schema` marks over each page in the `:data` vector (preserving vector shape); `:data-schema` is **not** consulted for the accumulated vector (R5).
- **Ordinary resource** — keeps the whole-value `:data-schema` contract unchanged.

Both branches reuse the same two shared primitives (owner `redact-with-paths` marks + frame `project-egress`) via a small extracted `project-value` helper — no forked parallel projector. The SSR `project-entry` call site is unchanged (the spec it already passes carries `:infinite`). No spec change: Spec 016 §SSR + R5 already document per-page `:page-data-schema` application.

## Tests

Regression suite mirroring the rf2-3tysyj cursor egress shape: per-page sensitive redaction + large elision (unit `project-data` path), `:data-schema`-ignored-on-infinite, and an end-to-end SSR test asserting a sensitive page field is redacted on every page while the page-vector shape + unmarked siblings ride.

## Quality gates

```
cd implementation && npm run test:cljs       # 7975 tests, 0 failures, 0 errors
resources JVM: clojure -M:test               # 582 tests, 2504 assertions, 0 failures, 0 errors
npm run test:mcp-conformance                 # all 6 gates GREEN
```

Resources-only, not hot-zone. Disjoint from the 3.1/3.3 surfaces (events/state/route + their resources tests).