### PR TITLE
fix(resources): EP-0021 page-0 first-load :error semantics + honour refetch-all-pages/window contract (rf2-byl7bk.3.1, rf2-byl7bk.3.3)

### DIFF
--- a/examples/reagent/infinite_feed/core.cljs
+++ b/examples/reagent/infinite_feed/core.cljs
@@ -25,12 +25,14 @@
    - THE TERMINAL IS `nil` — `:next-page-param` returning nil is the single
      end-of-feed signal; the view reads `:has-next-page?` and shows an
      end-of-feed marker instead of the button.
-   - THE PAGE-ERROR CHANNEL — a load-more failure keeps every accumulated
-     page visible and surfaces `:page-error` (\"couldn't load more — retry\")
-     while the feed stays `:loaded`. A feed's page fetches all lower the same
-     way, so a PAGE 0 first-load failure lands on `:page-error` too (the feed
-     never collapses to the scalar `:error` state); the view shows a full
-     error screen or the inline retry by reading `:has-data?` alongside it.
+   - THE THREE ERROR CHANNELS — a LOAD-MORE failure (page N>0) keeps every
+     accumulated page visible and surfaces `:page-error` (\"couldn't load more —
+     retry\") while the feed stays `:loaded` (the third channel). A PAGE 0
+     FIRST-load failure with no accumulated pages settles the first-load
+     `:error` channel + `:status :error` (Spec 016 reserves `:error` for
+     first-load, `:page-error` for load-more), so the view shows the full error
+     screen on `:error` and the inline retry on `:page-error` — distinct axes,
+     never conflated.
 
    The view reads the combined `[:rf.resource/infinite-state …]` view-model —
    `:items` (the merged flat list, the headline read), `:has-next-page?`,
@@ -273,13 +275,14 @@
        (:loading? feed)
        [:p {:data-testid "feed-skeleton"} "Loading the feed…"]
 
-       ;; First load (page 0) failed with no usable data → error screen. An
-       ;; infinite feed has ONE error axis — `:page-error` (page fetches all
-       ;; lower the same way, so page 0's failure lands there, keeping the
-       ;; feed `:loaded`); whether to show a full error screen or the inline
-       ;; "couldn't load more" affordance is decided by `:has-data?`. (The
-       ;; scalar `:error` / `:refresh-error` channels stay nil for a feed.)
-       (and (:page-error feed) (not (:has-data? feed)))
+       ;; First load (page 0) failed with no usable data → full error screen.
+       ;; A page-0 FIRST-load failure with no accumulated pages settles the
+       ;; first-load `:error` channel + `:status :error` (Spec 016 §Status
+       ;; semantics — `:error` is reserved for first-load failure), exactly
+       ;; like a scalar resource; it is NOT the `:page-error` load-more channel
+       ;; (which is reserved for a page N>0 failure that keeps the feed). The
+       ;; whole-feed `:refresh-error` channel stays nil here.
+       (:error feed)
        [:p.error {:data-testid "feed-error"} "Could not load the feed."]
 
        :else
@@ -291,10 +294,11 @@
               (for [item (:items feed)]
                 ^{:key (:id item)} [feed-row item]))
 
-        ;; A load-more FAILURE (we have data) keeps every page visible and
-        ;; surfaces :page-error — the inline "couldn't load more — retry"
-        ;; affordance (the same channel a no-data page-0 failure uses for the
-        ;; full error screen above; :has-data? is what splits the two).
+        ;; A LOAD-MORE failure (page N>0 — we have data) keeps every page
+        ;; visible and surfaces :page-error — the inline "couldn't load more —
+        ;; retry" affordance (the THIRD error channel, distinct from the
+        ;; first-load :error full-screen above; a load-more failure never
+        ;; collapses the feed).
         (when (:page-error feed)
           [:p.warn {:data-testid "feed-page-error"}
            "Couldn't load more — tap retry."])

--- a/implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs
@@ -288,23 +288,22 @@
       (is (= [{:id 0 :title "A"} {:id 1 :title "B"}] (:items vm)) "the retried page appended"))))
 
 ;; ============================================================================
-;; 5. A PAGE 0 failure with no data surfaces via :page-error (the FULL error
-;;    screen, split from the inline retry by :has-data?) — NOT the scalar :error
+;; 5. A PAGE 0 first-load failure with no data surfaces via the FIRST-LOAD
+;;    :error channel (the full error screen) — NOT :page-error (rf2-byl7bk.3.1)
 ;; ============================================================================
 
-(deftest page-0-failure-with-no-data-surfaces-via-page-error-not-scalar-error
-  (testing "examples/reagent/infinite_feed — a PAGE 0 failure with no prior data
-            surfaces via :page-error (an infinite feed's page fetches all lower
-            the same way, so page 0's failure is the SAME channel as a load-more
-            failure, keeping the feed :loaded; the scalar :error / :refresh-error
-            stay nil). The example's view splits the full error screen from the
-            inline retry by reading :has-data? alongside :page-error."
+(deftest page-0-first-load-failure-surfaces-via-scalar-error-channel
+  (testing "examples/reagent/infinite_feed — a PAGE 0 FIRST-load failure with no
+            prior data settles the first-load :error channel + :status :error
+            (Spec 016 reserves :error for first-load, :page-error for load-more
+            ONLY). The example's view shows the full error screen on :error; the
+            inline retry on :page-error — distinct axes."
     (rf/dispatch-sync [:rf.route/navigate :infinite-feed.app/timeline])
     (reply-failure! {:kind :rf.http/server :status 500})
     (let [vm (feed-state)]
-      (is (false? (:has-data? vm)) "no data loaded → the view shows the full error screen")
-      (is (= {:kind :rf.http/server :status 500} (:page-error vm))
-          "the page-0 failure surfaces via :page-error (a feed has one error axis)")
-      (is (nil? (:error vm)) "the scalar first-load :error channel is unused by a feed")
+      (is (false? (:has-data? vm)) "no data loaded")
+      (is (= {:kind :rf.http/server :status 500} (:error vm))
+          "the page-0 first-load failure surfaces via the first-load :error channel")
+      (is (nil? (:page-error vm)) "NOT the load-more :page-error channel (page 0 is not a load-more)")
       (is (nil? (:refresh-error vm)) "NOT the whole-feed :refresh-error channel either")
-      (is (= :loaded (:status (entry))) "the feed entry stays :loaded (never the scalar :error state)"))))
+      (is (= :error (:status (entry))) "the feed entry settles :status :error (first-load failure)"))))

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -414,6 +414,16 @@
 (events/reg-event :rf.resource/load-more
                      generation-meta
                      resource-events/load-more-handler)
+;; EP-0021 R6 (rf2-byl7bk.3.3) — `:rf.resource.internal/refetch-page` re-fetches
+;; ONE page of a multi-page refetch sweep (`:refetch-all-pages?` /
+;; `:refetch-window`). Chained by `page-succeeded-handler` one leg at a time; it
+;; mints a fresh generation (the work-id derives from it, for per-leg stale
+;; suppression) and records the work `:started-at` from the causal `:rf/time-ms`,
+;; so it declares the recordable generation-allocation + time cofx exactly like
+;; load-more. User code MUST NOT dispatch it.
+(events/reg-event :rf.resource.internal/refetch-page
+                     generation-meta
+                     resource-events/refetch-page-handler)
 ;; EP-0017 (rf2-601ife): `invalidate-tags` writes the durable `:invalidated-at`
 ;; fact from the event's causal `:rf/time-ms`, so it declares the time cofx.
 (events/reg-event :rf.resource/invalidate-tags

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -408,20 +408,24 @@
             ;; mints the same `:started-at` / `:deadline-at`.
             started-at time-ms
             deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
-            ;; EP-0021 R6 — a forced REFETCH of an infinite feed resets the
-            ;; accumulation per the resource's `:refetch` policy BEFORE the
-            ;; replacement page-0 starts. The ruled DEFAULT is window-preserving
-            ;; (keep the visible pages until the replacement page-0 succeeds —
-            ;; a focus/reconnect/invalidation refetch never collapses a loaded
-            ;; feed to page 0); the opt-ins `:refetch-all-pages?` /
-            ;; `:refetch-window` are R6 day-one knobs handled at the reply layer
-            ;; (the replacement page-0 success determines what is kept). On an
-            ;; ENSURE (not force-new) the entry is left as-is — a fresh ensure of
-            ;; an infinite feed first-loads page 0 (empty `:data`), and an ensure
-            ;; of an already-loaded feed never reaches the `:else` fresh-load
-            ;; branch (fresh-skip / dedupe handle it). Window-preserving is a
-            ;; pure no-op on `entry'` here (the page vector simply stays), so the
-            ;; reset is recorded on the entry only when an opt-in discards.
+            ;; EP-0021 R6 — a forced REFETCH of an infinite feed re-fetches the
+            ;; refresh window per the resource's `:refetch` policy. The ruled
+            ;; DEFAULT is window-preserving — refresh PAGE 0 in place while the
+            ;; accumulated tail stays visible (a focus/reconnect/invalidation
+            ;; refetch never collapses a loaded feed to page 0), and start NO
+            ;; sweep. The day-one opt-ins re-fetch a MULTI-PAGE window IN
+            ;; SEQUENCE (rf2-byl7bk.3.3, Spec 016 §Refetch): `:refetch-all-pages?`
+            ;; refreshes every accumulated page param, `:refetch-window n` the
+            ;; first n. The issue-time path below ALWAYS re-fetches PAGE 0 (one
+            ;; in-flight fetch); a multi-page opt-in additionally ARMS a durable
+            ;; `:refetch-sweep` cursor (the pages beyond 0), which
+            ;; `page-succeeded-handler` then drives ONE LEG AT A TIME (each its
+            ;; own fresh generation + work-id) — replacing each page in place
+            ;; without ever truncating the accumulation. On an ENSURE (not
+            ;; force-new) the entry is left as-is — a fresh ensure of an infinite
+            ;; feed first-loads page 0 (empty `:data`), and an ensure of an
+            ;; already-loaded feed never reaches this `:else` fresh-load branch
+            ;; (fresh-skip / dedupe handle it).
             refetch-policy (when infinite? (:refetch spec))
             entry'     (cond-> (state/entry-start-load
                                  entry {:generation generation :work-id work-id
@@ -429,17 +433,12 @@
                          ;; `:keep-previous?` projection pointer (a pointer
                          ;; only — never this key's data / tags).
                          prev-key (assoc :previous-key prev-key)
-                         ;; EP-0021 R6 — a forced REFETCH of an infinite feed
-                         ;; resets the accumulation to the kept window per the
-                         ;; `:refetch` policy (window-preserving default = a
-                         ;; pure no-op; `:refetch-all-pages?` / `:refetch-window`
-                         ;; truncate the tail). An ensure (not force-new) leaves
-                         ;; the feed untouched (page-0 first load).
+                         ;; EP-0021 R6 — arm the multi-page sweep cursor for an
+                         ;; opt-in refetch (empty tail for the window-preserving
+                         ;; default = no cursor, no sweep). An ensure (not
+                         ;; force-new) arms nothing.
                          (and infinite? force-new?)
-                         (state/entry-refetch-reset
-                           {:next-page-param-fn (:next-page-param spec)
-                            :prev-page-param-fn (:prev-page-param spec)
-                            :refetch-policy     refetch-policy}))
+                         (state/entry-begin-refetch-sweep refetch-policy))
             ;; EP-0021 R8 — the page context for THIS fetch. A first ensure /
             ;; a refetch's replacement fetch a page-0 (`page-param-for-spec` —
             ;; the framework `nil` default, overridable via `:initial-page-param`
@@ -780,6 +779,138 @@
   `{:resource :scope :params :owner :cause}`."
   [cofx [_event-id payload]]
   (load-more-loaded cofx payload {:where 'rf.resource/load-more}))
+
+;; ---- refetch-page — a multi-page refetch sweep LEG (EP-0021 R6) -----------
+;;
+;; rf2-byl7bk.3.3: `:refetch-all-pages?` / `:refetch-window` re-fetch a
+;; multi-page window IN SEQUENCE. The issue-time `:rf.resource/refetch` fetches
+;; page 0 and arms a `:refetch-sweep` cursor (the pages beyond 0);
+;; `page-succeeded-handler` then chains this internal event ONE LEG AT A TIME —
+;; each leg re-fetches a SPECIFIC `(page-param page-index)` and REPLACES that
+;; page in place on success (via the page reply handlers' `entry-replace-page`).
+;; Single in-flight fetch per leg (one work-id, the existing substrate); the
+;; chain stops when the cursor empties or a leg fails. User code MUST NOT
+;; dispatch it.
+
+(defn- refetch-page-loaded
+  "Core of `:rf.resource.internal/refetch-page` (EP-0021 R6 sweep leg). Re-fetch
+  the page at the payload's `:rf.resource/page-param` / `:rf.resource/page-index`
+  (a SPECIFIC page, not the derived tail), transition the feed to `:fetching`
+  (pages stay visible), and address the PAGE reply handlers so the success
+  REPLACES that page in place (`entry-replace-page`) and chains the next sweep
+  leg. Mints a fresh generation (the recorded allocation, replay-stable) +
+  work-id like `load-more`. A vanished / non-infinite feed, or one with no live
+  sweep cursor, is a structural no-op (a superseded sweep — the feed was cleared
+  or re-loaded). Returns the reg-event effects map."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id
+    gen-allocation :rf.resource/generation-allocation
+    time-ms :rf/time-ms, app-db :db}
+   {:keys [resource owner cause] page-param :rf.resource/page-param
+    page-index :rf.resource/page-index :as payload} {:keys [where]}]
+  (let [runtime-db (or rt {})
+        spec       (registry/require-resource-spec! resource where)
+        scope      (registry/resolve-scope-for-event
+                     resource spec {:payload-scope (:scope payload) :db app-db} where)
+        cparams    (registry/validate+canonicalize-params
+                     resource spec (state/params-present? payload) where)
+        scoped-key (state/scoped-resource-key* scope resource cparams)
+        entry      (get-in runtime-db (state/entry-path scoped-key))]
+    (cond
+      ;; ----- the feed vanished / is no longer infinite — no-op -------------
+      (or (nil? entry) (not (state/infinite-entry? entry)))
+      (do
+        (trace/emit! :rf.event :rf.resource/load-more-skipped
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :reason :no-feed :owner owner :cause cause})
+        {:rf.db/runtime runtime-db})
+
+      ;; ----- the page index is past the (current) accumulation — no-op -----
+      ;; A sweep leg only refreshes a page the feed still has; a feed that
+      ;; shrank under the sweep (a clear / re-load) drops the stale leg.
+      (>= page-index (state/page-count entry))
+      (do
+        (trace/emit! :rf.event :rf.resource/load-more-skipped
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :reason :no-next-page :page-count (state/page-count entry)
+                      :owner owner :cause cause})
+        {:rf.db/runtime runtime-db})
+
+      ;; ----- issue the replacement fetch for THIS page (fresh generation) --
+      :else
+      (let [generation (:generation gen-allocation)
+            work-id    (work-ledger/resource-work-id scoped-key generation)
+            request-id (work-ledger/managed-request-id frame-id work-id)
+            started-at time-ms
+            deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
+            transport-id (or (:transport spec) transport/default-transport)
+            ;; the feed has data, so `entry-start-load` chooses `:fetching`
+            ;; (refresh-class — pages stay visible). The page vector is
+            ;; UNTOUCHED (a sweep leg replaces in place on its reply).
+            entry'     (state/entry-start-load
+                         entry {:generation generation :work-id work-id
+                                :request-id request-id :owner owner})
+            record     (work-ledger/work-record
+                         {:work-id      work-id
+                          :frame-id     frame-id
+                          :resource/key scoped-key
+                          :generation   generation
+                          :transport    transport-id
+                          :owner        owner
+                          :cause        cause
+                          :started-at   started-at
+                          :deadline-at  deadline
+                          ;; record the page index this leg refreshes (a
+                          ;; replacement, not a load-more append).
+                          :page-index   page-index})
+            rdb'       (-> runtime-db
+                           (assoc-in (state/entry-path scoped-key) entry')
+                           (work-ledger/put-record work-id record)
+                           (cond->
+                             owner (update-in (state/owner-index-path)
+                                              update owner (fnil conj #{}) (state/key-id scoped-key))))
+            req-ctx    (page-request-ctx page-param page-index)
+            http-args  (let [req-fn (:request spec)]
+                         (req-fn cparams req-ctx))
+            lower-fx   (do (transport/assert-managed-transport! transport-id where)
+                           (transport-http/lower
+                             {:http-args    http-args
+                              :request-id   request-id
+                              :work-id      work-id
+                              :resource/key scoped-key
+                              :scope        scope
+                              :frame-id     frame-id
+                              :generation   generation
+                              :where        where
+                              :on-success-id page-succeeded-reply
+                              :on-failure-id page-failed-reply
+                              :reply-payload (infinite-page-reply-payload
+                                               scoped-key scope generation
+                                               work-id page-param page-index)}))]
+        (trace/emit! :rf.event :rf.resource/work-started
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :generation generation :work/id work-id
+                      :status :running :owner owner :cause cause})
+        (trace/emit! :rf.event :rf.resource/fetch-started
+                     {:rf.frame/id frame-id :resource/key scoped-key
+                      :generation generation :work/id work-id
+                      :status (:status entry') :owner owner :cause cause})
+        {:rf.db/runtime rdb'
+         :fx [[:rf.resource/commit-generation {:value generation}]
+              [:rf.resource/record-work-handle
+               {:frame-id frame-id :work-id work-id
+                :transport transport-id :request-id request-id}]
+              lower-fx]}))))
+
+(defn refetch-page-handler
+  "`:rf.resource.internal/refetch-page` — re-fetch ONE page of a multi-page
+  refetch sweep (EP-0021 R6, rf2-byl7bk.3.3). Chained by `page-succeeded-handler`
+  off the `:refetch-sweep` cursor; fetches the payload's specific
+  `(:rf.resource/page-param :rf.resource/page-index)` and replaces it in place
+  on success. User code MUST NOT dispatch it. Payload:
+  `{:resource :scope :params :cause :rf.resource/page-param
+    :rf.resource/page-index}`."
+  [cofx [_event-id payload]]
+  (refetch-page-loaded cofx payload {:where 'rf.resource.internal/refetch-page}))
 
 ;; ---- focus / reconnect revalidation (rf2-vtblcq) --------------------------
 ;;
@@ -2221,12 +2352,21 @@
             stale-at  (state/stale-at-for spec loaded-at)
             stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
             gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))
-            entry'    (state/entry-replace-page
+            replaced  (state/entry-replace-page
                         entry {:page decoded :page-param page-param
                                :page-index page-index
                                :next-page-param-fn (:next-page-param spec)
                                :prev-page-param-fn (:prev-page-param spec)
                                :loaded-at loaded-at :stale-at stale-at})
+            ;; EP-0021 R6 sweep (rf2-byl7bk.3.3): if a multi-page refetch sweep
+            ;; is armed, chain the NEXT leg — pop its `[page-param page-index]`
+            ;; off the `:refetch-sweep` cursor and re-fetch it (one in-flight
+            ;; leg at a time, "in sequence"). `entry-replace-page` preserves the
+            ;; cursor, so it rides through to here.
+            sweep-leg (state/next-refetch-sweep-leg replaced)
+            entry'    (if sweep-leg
+                        (state/entry-advance-refetch-sweep replaced)
+                        replaced)
             poll-delay-ms (when (seq (:active-owners entry'))
                             (state/positive-or-nil (:poll-interval-ms spec)))
             rdb'      (-> runtime-db
@@ -2237,7 +2377,20 @@
                           (work-ledger/prune-terminal-for-key resource-key)
                           ;; route blocking: a route-owned blocking infinite feed
                           ;; blocks on page 0 — drain the slot when page 0 lands.
-                          (route/drain-blocking resource-key entry' :success))]
+                          (route/drain-blocking resource-key entry' :success))
+            ;; the chained sweep leg is a self-dispatched internal event so it
+            ;; re-enters the router and mints its own replay-stable generation
+            ;; (the generation-allocation cofx) — the framework's follow-up-fetch
+            ;; pattern (cf. poll-fired / focus-reconnect refetch dispatch).
+            sweep-fx  (when sweep-leg
+                        (let [[leg-param leg-index] sweep-leg]
+                          [:dispatch [:rf.resource.internal/refetch-page
+                                      {:resource (second resource-key)
+                                       :scope    (first resource-key)
+                                       :params   (nth resource-key 2)
+                                       :cause    [:rf.resource/refetch-sweep leg-index]
+                                       :rf.resource/page-param leg-param
+                                       :rf.resource/page-index leg-index}]]))]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
@@ -2248,31 +2401,54 @@
                       :page-index page-index :page-count (state/page-count entry')
                       :next-page-param (:next-page-param entry')
                       :terminal? (state/terminal? (:next-page-param entry'))})
-        (cond-> {:rf.db/runtime rdb'}
-          (or stale-delay-ms gc-delay-ms poll-delay-ms)
-          (assoc :fx [[:rf.resource/schedule-timers
-                       {:frame-id       frame-id
-                        :resource/key   resource-key
-                        :stale-delay-ms stale-delay-ms
-                        :gc-delay-ms    gc-delay-ms
-                        :poll-delay-ms  poll-delay-ms
-                        :server?        (state/server-frame? frame-id)}]]))))))
+        (let [timers-fx (when (or stale-delay-ms gc-delay-ms poll-delay-ms)
+                          [:rf.resource/schedule-timers
+                           {:frame-id       frame-id
+                            :resource/key   resource-key
+                            :stale-delay-ms stale-delay-ms
+                            :gc-delay-ms    gc-delay-ms
+                            :poll-delay-ms  poll-delay-ms
+                            :server?        (state/server-frame? frame-id)}])
+              fx        (cond-> []
+                          timers-fx (conj timers-fx)
+                          sweep-fx  (conj sweep-fx))]
+          (cond-> {:rf.db/runtime rdb'}
+            (seq fx) (assoc :fx fx)))))))
 
 (defn page-failed-handler
-  "`:rf.resource.internal/page-failed` — an infinite-feed page fetch failed
-  (EP-0021 R2 — the THIRD error channel). Verifies frame + work-id +
-  generation; on match the feed returns to `:loaded`, KEEPS ALL accumulated
-  pages, and records `:page-error` (`entry-page-failed`) — distinct from a
-  first-load `:error` and a whole-feed `:refresh-error`, so a view shows
-  \"couldn't load more — retry\" without losing the feed. A stale / superseded /
-  cross-frame reply is SUPPRESSED. An ABORT (`:rf.http/aborted`) is a
-  cancellation, not a page error: the feed settles to `:loaded` (data kept)
-  with NO `:page-error` written, and the work row settles `:cancelled`.
+  "`:rf.resource.internal/page-failed` — an infinite-feed page fetch failed.
+  Verifies frame + work-id + generation; on match SPLITS the settlement by
+  page identity (rf2-byl7bk.3.1, Spec 016 §Status semantics / §Infinite):
+
+    - a FIRST-LOAD (page 0) failure with NO accumulated pages is NOT a
+      load-more failure — it is a first load with no usable data. It settles
+      the FIRST-load `:error` channel (`entry-failed` → `:status :error`,
+      `:error` envelope, `:data nil`) and drains a blocking route as
+      `:failure`, so a blocking infinite route flips to route `:error` exactly
+      like a blocking SCALAR resource (`drain-blocking`'s `:status :error`
+      branch fires automatically — no route.cljc change). Spec 016 reserves
+      `:error` / `:status :error` for first-load (page 0) failure;
+
+    - a LOAD-MORE (page N>0) failure — OR a page-0 failure when the feed
+      ALREADY has accumulated pages (an R6 window-preserving refetch that
+      fails its replacement page 0 is NOT a first load — there is a feed to
+      keep) — is the THIRD error channel: the feed returns to `:loaded`, KEEPS
+      ALL accumulated pages, and records `:page-error` (`entry-page-failed`),
+      so a view shows \"couldn't load more — retry\" without losing the feed.
+      The blocking slot drains as `:success` (the route blocks on page 0 only,
+      which already landed). Spec 016 reserves `:page-error` for load-more
+      (page N>0) failure only.
+
+  A stale / superseded / cross-frame reply is SUPPRESSED. An ABORT
+  (`:rf.http/aborted`) is a cancellation, not a page error: the feed settles
+  to `:loaded` (data kept) with NO `:page-error` written, and the work row
+  settles `:cancelled`.
 
   Event shape: `[_ <verification-payload> <http-result>]` — the transport
   appends `{:kind :failure :failure <:rf.http/* envelope>}` as the last arg."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
-   [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload} http-result]]
+   [_event-id {work-id :work/id resource-key :resource/key :keys [generation]
+               page-index :rf.resource/page-index :as payload} http-result]]
   (let [runtime-db   (or rt {})
         error        (rreply/transport-failure-envelope payload http-result)
         completed-at time-ms
@@ -2280,7 +2456,14 @@
                                            {:work-kind rreply/work-kind-resource
                                             :completed-at completed-at})
         aborted?     (= :cancelled (:status reply))
-        entry        (live-entry-for-reply runtime-db frame-id payload)]
+        entry        (live-entry-for-reply runtime-db frame-id payload)
+        ;; rf2-byl7bk.3.1 — a FIRST-load failure is a page-0 fetch (`page-index`
+        ;; 0) that has NO accumulated pages to keep. A page-0 refetch over a
+        ;; feed that already has pages (R6 window-preserving) is NOT a first
+        ;; load — it keeps `:page-error` + `:loaded` (data to keep).
+        first-load?  (and (some? entry)
+                          (= 0 page-index)
+                          (zero? (state/page-count entry)))]
     (cond
       ;; STALE SUPPRESSION (mandatory) — stale wins over the natural status
       ;; (a stale abort settles :suppressed, never an accepted :cancelled).
@@ -2301,7 +2484,10 @@
       ;; its pages and returns to :loaded WITHOUT a :page-error (a cancellation
       ;; is not a load-more failure). The work row settles terminal :cancelled.
       aborted?
-      (let [entry' (assoc entry :status :loaded :current-work nil)
+      ;; an abort during a multi-page refetch sweep STOPS the sweep (clear the
+      ;; cursor — a cancelled leg does not chain the next; rf2-byl7bk.3.3).
+      (let [entry' (-> (assoc entry :status :loaded :current-work nil)
+                       state/clear-refetch-sweep)
             rdb'   (-> runtime-db
                        (assoc-in (state/entry-path resource-key) entry')
                        (work-ledger/update-record
@@ -2315,17 +2501,47 @@
                       :status-before (:status entry) :status-after (:status entry')})
         {:rf.db/runtime rdb'})
 
-      ;; PAGE FAILURE — the third error channel: keep the feed, record
-      ;; :page-error, return to :loaded. (`route/drain-blocking … :failure`
-      ;; only flips a blocking FIRST-load — a feed that already has pages keeps
-      ;; :loaded, so the slot drains like a success; a blocking page-0 failure
-      ;; with no prior pages surfaces the route error via entry-page-failed
-      ;; keeping :status :loaded — but a blocking infinite route blocks on page
-      ;; 0, which on first failure has no data, so drain-blocking keys on the
-      ;; entry's :status. entry-page-failed always returns :loaded, so a route
-      ;; never errors on a load-more page failure — exactly the intent.)
+      ;; FIRST-LOAD FAILURE (rf2-byl7bk.3.1) — a page-0 fetch with no
+      ;; accumulated pages failed: there is no feed to keep, so this is a first
+      ;; load with no usable data, NOT a load-more. Settle the FIRST-load
+      ;; `:error` channel (`entry-failed` → `:status :error`, `:error`
+      ;; envelope, `:data nil`) and drain a blocking route as `:FAILURE` —
+      ;; `drain-blocking`'s `(= :error (:status entry))` branch then flips the
+      ;; route to `:error` (parity with a blocking scalar resource; no
+      ;; route.cljc change). Trace the first-load `:rf.resource/failed` op (not
+      ;; `:rf.resource/page-failed`) so the channel and the trace agree.
+      first-load?
+      (let [entry' (state/entry-failed entry {:error error})
+            rdb'   (-> runtime-db
+                       (assoc-in (state/entry-path resource-key) entry')
+                       (work-ledger/update-record
+                         work-id work-ledger/mark-terminal
+                         :failed {:error error :completed-at completed-at})
+                       (route/drain-blocking resource-key entry' :failure))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-completed
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation :status :failed})
+        (trace/emit! :rf.event :rf.resource/failed
+                     {:rf.frame/id frame-id :resource/key resource-key
+                      :work/id work-id :generation generation
+                      :status-before (:status entry) :status-after (:status entry')
+                      :error error})
+        {:rf.db/runtime rdb'})
+
+      ;; LOAD-MORE PAGE FAILURE — the third error channel: keep the feed,
+      ;; record :page-error, return to :loaded. This is a page N>0 failure, OR
+      ;; a page-0 refetch over a feed that already has pages (R6 window-
+      ;; preserving — there is a feed to keep, so it is not a first load). The
+      ;; blocking slot drains as :success (the route blocks on page 0, which
+      ;; already landed for any feed that has accumulated pages). Spec 016
+      ;; reserves :page-error for load-more only.
       :else
-      (let [entry' (state/entry-page-failed entry {:error error})
+      ;; a failed leg STOPS any in-progress refetch sweep (clear the cursor —
+      ;; don't chain past a failure; rf2-byl7bk.3.3). The kept-feed +
+      ;; :page-error channel is unchanged.
+      (let [entry' (-> (state/entry-page-failed entry {:error error})
+                       state/clear-refetch-sweep)
             rdb'   (-> runtime-db
                        (assoc-in (state/entry-path resource-key) entry')
                        (work-ledger/update-record

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -1170,64 +1170,103 @@
               bump-revision))))
     entry))
 
-(defn refetch-keep-count
-  "PURE: how many leading pages a `refetch` of an infinite feed KEEPS, given
-  the resource's optional `:refetch` policy (R6) and the feed's current
-  `page-count`. The ruled DEFAULT is window-preserving — keep EVERY
-  accumulated page (`page-count`), so a focus/reconnect/invalidation refetch
-  never collapses a loaded feed to page 0. The day-one opt-ins:
+(defn refetch-window-count
+  "PURE: how many LEADING pages a `refetch` of an infinite feed REFRESHES,
+  given the resource's optional `:refetch` policy (R6) and the feed's current
+  `page-count`. Spec 016 §Refetch (R6 — the opt-ins are a multi-page refresh
+  of the accumulation IN SEQUENCE, NOT a truncate-the-tail; rf2-byl7bk.3.3):
 
-    - `:refetch-all-pages? true` — do NOT preserve the window: keep ONLY page 0
-      (the replacement page-0 re-accumulates the feed from scratch, the
-      TanStack-parity \"refresh the whole thing\" intent; v1 re-fetches page 0
-      and the user re-loads forward rather than a synchronous N-page sweep);
-    - `:refetch-window n` — bound the kept window to the first `n` pages
-      (clamped to `[1, page-count]` — a refetch always keeps at least page 0,
-      and never invents pages beyond what is loaded).
+    - the ruled DEFAULT (no policy / no opt-in) refreshes the FIRST page only
+      (`1` for a non-empty feed): a focus/reconnect/invalidation refetch
+      replaces page 0 IN PLACE while the accumulated tail stays visible (never
+      collapses to page 0), the window-preserving default;
+    - `:refetch-all-pages? true` — refresh EVERY accumulated page param in
+      sequence (`page-count`, TanStack parity): each page is re-fetched and
+      replaced in place, the feed length is PRESERVED;
+    - `:refetch-window n` — refresh the bounded leading window of the first `n`
+      pages (clamped to `[1, page-count]` — at least page 0, never beyond what
+      is loaded).
 
-  Returns the keep-count (always ≥ 1 for a non-empty feed; 0 for an empty
-  feed). Per Spec 016 §Refetch and invalidation of an infinite feed (R6)."
+  Returns the refresh-window size (≥ 1 for a non-empty feed; 0 for an empty
+  feed). The accumulation is never truncated — this counts how much of it gets
+  refreshed, not how much survives. Per Spec 016 §Refetch and invalidation of
+  an infinite feed (R6)."
   [refetch-policy page-count]
   (let [{:keys [refetch-all-pages? refetch-window]} refetch-policy]
     (cond
       (zero? page-count)          0
-      refetch-all-pages?          1
+      refetch-all-pages?          page-count
       (integer? refetch-window)   (max 1 (min refetch-window page-count))
-      :else                       page-count)))
+      :else                       1)))
 
-(defn entry-refetch-reset
-  "PURE infinite-feed REFETCH reset transition (R6), applied at refetch-ISSUE
-  (before the replacement page-0 fetch starts): truncate the feed's
-  accumulation to the first `keep-count` pages per `refetch-keep-count`, so the
-  in-flight refetch refreshes exactly the intended window. The ruled DEFAULT
-  (window-preserving) keeps EVERY page — a pure no-op here — so the accumulated
-  pages stay visible during the refetch (the feed is `:fetching`, not collapsed
-  to page 0). The opt-ins (`:refetch-all-pages?` / `:refetch-window`) truncate
-  the tail.
+(defn refetch-sweep-tail
+  "PURE: the ordered SWEEP TAIL for a multi-page `refetch` — the
+  `[page-param page-index]` pairs the chained sweep must re-fetch AFTER the
+  issue-time page-0 replacement, in order. The issue-time refetch always
+  re-fetches page 0 in place (a single in-flight fetch — the existing path);
+  this returns the pages beyond page 0 within the refresh window
+  (`refetch-window-count`), which `page-succeeded-handler` then drives ONE AT A
+  TIME (each leg its own fresh generation + work-id; \"in sequence\" — the
+  single-work-id substrate is reused, no parallel fan).
 
-  The `:next-page-param` is RECOMPUTED from the (possibly truncated) tail so a
-  windowed refetch resumes load-more from the kept window's edge; `:page-params`
-  is truncated in step. `:data` / `:page-params` keep their leading pages by
-  identity (structural sharing — only the dropped tail changes). Does NOT touch
-  `:status` / `:current-work` / `:revision` (the caller's `entry-start-load`
-  already transitioned the entry to `:fetching` and recorded the work). A nil /
-  non-infinite / empty entry is returned unchanged. Per Spec 016 §Refetch and
-  invalidation of an infinite feed (R6)."
-  [entry {:keys [next-page-param-fn prev-page-param-fn refetch-policy]}]
+  The DEFAULT (window 1) yields an EMPTY tail — a plain refetch refreshes page
+  0 only and starts no sweep (the window-preserving default is unchanged).
+  `:refetch-all-pages?` yields pages `1 … page-count-1`; `:refetch-window n`
+  yields pages `1 … n-1`. Each pair reads the page's durable `:page-params`
+  entry (the param the original fetch used) so the replacement re-fetches the
+  same page. A nil / non-infinite / empty entry yields `[]`. Per Spec 016
+  §Refetch and invalidation of an infinite feed (R6)."
+  [entry refetch-policy]
   (if (and entry (infinite-entry? entry) (seq (:data entry)))
-    (let [pages      (:data entry)
-          keep-count (refetch-keep-count refetch-policy (count pages))]
-      (if (>= keep-count (count pages))
-        entry                                   ;; window-preserving — keep all
-        (let [pages'  (subvec pages 0 keep-count)
-              params' (subvec (or (:page-params entry) []) 0
-                              (min keep-count (count (:page-params entry))))]
-          (assoc entry
-                 :data            pages'
-                 :page-params     params'
-                 :next-page-param (next-param-for next-page-param-fn pages')
-                 :prev-page-param (prev-param-for prev-page-param-fn pages')))))
-    entry))
+    (let [page-count   (count (:data entry))
+          window       (refetch-window-count refetch-policy page-count)
+          page-params  (or (:page-params entry) [])]
+      ;; pages 1 … (window-1) — page 0 is the issue-time replacement, excluded.
+      (mapv (fn [i] [(get page-params i) i]) (range 1 window)))
+    []))
+
+(defn entry-begin-refetch-sweep
+  "PURE: arm a multi-page refetch SWEEP on the feed `entry` by recording the
+  ordered remaining `[page-param page-index]` pairs (`refetch-sweep-tail`) under
+  the durable `:refetch-sweep` cursor — the pages the chained sweep will
+  re-fetch after the issue-time page-0 replacement. An EMPTY tail (the
+  window-preserving default, or an empty feed) writes NO cursor and returns the
+  entry unchanged, so a plain refetch starts no sweep. Does NOT touch `:status`
+  / `:current-work` / `:revision` (the caller's `entry-start-load` already
+  transitioned the entry to `:fetching` for the page-0 leg). Per Spec 016
+  §Refetch and invalidation of an infinite feed (R6 — rf2-byl7bk.3.3)."
+  [entry refetch-policy]
+  (let [tail (refetch-sweep-tail entry refetch-policy)]
+    (if (seq tail)
+      (assoc entry :refetch-sweep (vec tail))
+      entry)))
+
+(defn next-refetch-sweep-leg
+  "PURE: the NEXT `[page-param page-index]` pair a feed's in-progress refetch
+  sweep must re-fetch, or nil when no sweep is armed / it is exhausted. Read by
+  `page-succeeded-handler` to chain the sweep one leg at a time. Per Spec 016
+  §Refetch (R6 — rf2-byl7bk.3.3)."
+  [entry]
+  (first (:refetch-sweep entry)))
+
+(defn entry-advance-refetch-sweep
+  "PURE: pop the head leg off a feed's `:refetch-sweep` cursor (the leg just
+  issued). When the cursor empties, REMOVE the `:refetch-sweep` key entirely
+  (the sweep is done). Does NOT touch `:status` / `:current-work` / `:data` —
+  the chained leg's own `entry-start-load` + page reply settle those. Per Spec
+  016 §Refetch (R6 — rf2-byl7bk.3.3)."
+  [entry]
+  (let [rest- (vec (rest (:refetch-sweep entry)))]
+    (if (seq rest-)
+      (assoc entry :refetch-sweep rest-)
+      (dissoc entry :refetch-sweep))))
+
+(defn clear-refetch-sweep
+  "PURE: drop any in-progress `:refetch-sweep` cursor (a failure / abort during
+  a sweep STOPS it rather than dangling a cursor). Per Spec 016 §Refetch (R6 —
+  rf2-byl7bk.3.3)."
+  [entry]
+  (dissoc entry :refetch-sweep))
 
 (defn resolve-page->items
   "PURE: resolve a feed's `:page->items` accessor (a keyword key or a

--- a/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
@@ -19,8 +19,11 @@
        feed);
     6. a page-fetch failure is the THIRD error channel — the feed keeps its
        pages + records `:page-error` (NOT `:error` / `:refresh-error`);
-    7. `:rf.resource/refetch` preserves the visible window by default (R6); the
-       `:refetch-all-pages?` / `:refetch-window` opt-ins truncate the tail.
+    7. `:rf.resource/refetch` preserves the visible window by default (R6 —
+       refresh page 0 in place); the `:refetch-all-pages?` / `:refetch-window`
+       opt-ins refresh a MULTI-PAGE window IN SEQUENCE (rf2-byl7bk.3.3 — a
+       chained sweep, one leg at a time, replacing each page in place; the
+       accumulation is never truncated).
 
   The capturing transport REPLAYS the real reply-append shape (Spec 014 §Reply
   addressing — the live transport conj's its result as the LAST arg of the
@@ -368,33 +371,84 @@
         (is (= (page [:b] "c2") (nth (:data e) 1)) "tail preserved")
         (is (= (page [:c] "c3") (nth (:data e) 2)) "tail preserved")))))
 
-(deftest refetch-all-pages-opt-in-collapses-to-page-0
-  (testing ":refetch-all-pages? opts OUT of window-preserving — the tail is
-            dropped at refetch and the feed re-accumulates from page 0 (R6)"
+(deftest refetch-all-pages-opt-in-refreshes-every-page-in-sequence
+  ;; rf2-byl7bk.3.3 — :refetch-all-pages? re-fetches EVERY accumulated page
+  ;; param IN SEQUENCE (TanStack parity), replacing each in place. The feed
+  ;; never collapses — its length is preserved; one fetch is in flight at a
+  ;; time (the chained sweep). This INVERTS the prior truncate-to-page-0 test.
+  (testing ":refetch-all-pages? sweeps page 0, then page 1, then page 2 in order"
     (let [k (accumulate-3! :ra/feed {:refetch {:refetch-all-pages? true}})]
       (rf/dispatch-sync [:rf.resource/refetch
                          {:resource :ra/feed :scope :rf.scope/global
                           :params {:filter :recent} :cause [:test :refresh-all]}])
-      (let [e (entry k)]
-        (is (= 1 (state/page-count e)) "truncated to page 0 at refetch"))
+      (testing "the issue-time fetch is page 0; the feed is NOT truncated"
+        (is (= 3 (state/page-count (entry k))) "WINDOW PRESERVED — feed not collapsed")
+        (is (= 0 (:rf.resource/page-index (second (:on-success @last-managed-args))))
+            "the first fetch is page 0 (index 0)"))
+      ;; page-0 reply replaces in place, then CHAINS the page-1 leg.
       (reply-success! (page [:a*] "c1"))
       (let [e (entry k)]
-        (is (= 1 (state/page-count e)) "feed re-accumulates from page 0")
-        (is (= (page [:a*] "c1") (nth (:data e) 0)))))))
+        (is (= 3 (state/page-count e)) "still 3 pages after page-0 replacement")
+        (is (= (page [:a*] "c1") (nth (:data e) 0)) "page-0 replaced in place"))
+      (testing "the sweep CHAINED a page-1 fetch (the next leg, in sequence)"
+        (is (= 1 (:rf.resource/page-index (second (:on-success @last-managed-args))))
+            "the second fetch is page 1")
+        (is (= "c1" (:rf.resource/page-param (second (:on-success @last-managed-args))))
+            "page 1 re-fetched with its original :page-param"))
+      ;; page-1 reply replaces in place, then chains page-2.
+      (reply-success! (page [:b*] "c2"))
+      (let [e (entry k)]
+        (is (= 3 (state/page-count e)))
+        (is (= (page [:b*] "c2") (nth (:data e) 1)) "page-1 replaced in place"))
+      (testing "the sweep CHAINED a page-2 fetch (the final leg)"
+        (is (= 2 (:rf.resource/page-index (second (:on-success @last-managed-args))))
+            "the third fetch is page 2"))
+      ;; page-2 reply replaces in place — the sweep is now exhausted.
+      (reply-success! (page [:c*] "c3"))
+      (let [e (entry k)]
+        (is (= 3 (state/page-count e)) "all 3 pages refreshed; length preserved")
+        (is (= [(page [:a*] "c1") (page [:b*] "c2") (page [:c*] "c3")] (:data e))
+            "every page replaced in place, in order")
+        (is (not (contains? e :refetch-sweep)) "the sweep cursor is cleared when exhausted")
+        (is (= :loaded (:status e)) "feed settled :loaded")))))
 
-(deftest refetch-window-opt-in-bounds-the-kept-window
-  (testing ":refetch-window n keeps the first n pages, drops beyond (R6)"
+(deftest refetch-window-opt-in-refreshes-the-bounded-window-in-sequence
+  ;; rf2-byl7bk.3.3 — :refetch-window n refreshes the first n pages in place
+  ;; (page 0 + the chained legs up to n-1), keeping pages beyond n untouched.
+  (testing ":refetch-window 2 refreshes pages 0 and 1, leaves page 2 alone"
     (let [k (accumulate-3! :rwn/feed {:refetch {:refetch-window 2}})]
       (rf/dispatch-sync [:rf.resource/refetch
                          {:resource :rwn/feed :scope :rf.scope/global
                           :params {:filter :recent} :cause [:test :window]}])
-      (let [e (entry k)]
-        (is (= 2 (state/page-count e)) "kept the first 2 pages, dropped the 3rd")
-        (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e))))
+      (is (= 3 (state/page-count (entry k))) "feed NOT truncated — full window preserved")
+      (is (= 0 (:rf.resource/page-index (second (:on-success @last-managed-args)))) "page 0 first")
       (reply-success! (page [:a*] "c1"))
+      (testing "the sweep chained the page-1 leg (the bounded window)"
+        (is (= 1 (:rf.resource/page-index (second (:on-success @last-managed-args)))) "then page 1"))
+      (reply-success! (page [:b*] "c2"))
       (let [e (entry k)]
-        (is (= 2 (state/page-count e)) "window held after the replacement")
-        (is (= (page [:a*] "c1") (nth (:data e) 0)) "page-0 replaced in place")))))
+        (is (= 3 (state/page-count e)) "feed length preserved (page 2 kept untouched)")
+        (is (= (page [:a*] "c1") (nth (:data e) 0)) "page 0 refreshed")
+        (is (= (page [:b*] "c2") (nth (:data e) 1)) "page 1 refreshed")
+        (is (= (page [:c] "c3") (nth (:data e) 2)) "page 2 left UNTOUCHED (outside the window)")
+        (is (not (contains? e :refetch-sweep)) "sweep cleared (window exhausted)")))))
+
+(deftest refetch-sweep-failure-stops-the-sweep-keeps-pages
+  ;; rf2-byl7bk.3.3 — a page failure DURING a sweep stops the chain (clears the
+  ;; cursor) and records :page-error, keeping all accumulated pages.
+  (testing "a page-1 sweep-leg failure stops the sweep + records :page-error"
+    (let [k (accumulate-3! :rsf/feed {:refetch {:refetch-all-pages? true}})]
+      (rf/dispatch-sync [:rf.resource/refetch
+                         {:resource :rsf/feed :scope :rf.scope/global
+                          :params {:filter :recent} :cause [:test :refresh-all]}])
+      (reply-success! (page [:a*] "c1"))          ;; page 0 replaced ⇒ chains page 1
+      (is (= 1 (:rf.resource/page-index (second (:on-failure @last-managed-args)))) "page-1 leg in flight")
+      (reply-failure! {:kind :rf.http/server :status 503})
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "feed stays :loaded (pages kept)")
+        (is (= 3 (state/page-count e)) "all pages preserved")
+        (is (some? (:page-error e)) ":page-error recorded for the failed sweep leg")
+        (is (not (contains? e :refetch-sweep)) "the sweep cursor is cleared — chain stopped")))))
 
 ;; ===========================================================================
 ;; 8. ensure dedupe / fresh-skip still applies to an infinite feed's page-0

--- a/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
@@ -19,11 +19,13 @@
     - `entry-replace-page` refreshes a page IN PLACE (R6 window-preserving
       refetch settle) — incl. the structural-sharing identical-value branch
       and the delegate-to-append-past-tail branch;
-    - `refetch-keep-count` is the pure R6 keep-count policy (the 4 disjoint
-      branches + the window clamp edges);
-    - `entry-refetch-reset` truncates the accumulation to the kept window at
-      refetch-issue (the keep-all no-op default + the truncation opt-ins +
-      the guard arms);
+    - `refetch-window-count` is the pure R6 multi-page REFRESH-window policy
+      (default page-0-only + the all-pages / windowed opt-ins + clamp edges;
+      rf2-byl7bk.3.3 — replaces the old truncate-the-tail keep-count);
+    - `refetch-sweep-tail` / `entry-begin-refetch-sweep` /
+      `entry-advance-refetch-sweep` / `clear-refetch-sweep` arm + drive the
+      ordered multi-page sweep cursor (the pages beyond 0 a windowed/all-pages
+      refetch re-fetches in sequence, replacing in place — never truncating);
     - `resolve-page->items` lifts the R3 accessor.
 
   The load-more EVENT (wave 3) + subs (wave 4) are out of scope."
@@ -358,95 +360,115 @@
                                              :next-page-param-fn next-cursor
                                              :loaded-at 1 :stale-at 2})))))
 
-;; ---- refetch-keep-count (R6 — the 4 disjoint branches + clamp edges) -------
+;; ---- refetch-window-count (R6 — multi-page refresh window, rf2-byl7bk.3.3) --
+;;
+;; Spec 016 §Refetch defines the opt-ins as a multi-page REFRESH of the
+;; accumulation IN SEQUENCE (NOT a truncate-the-tail): the default refreshes
+;; page 0 in place; `:refetch-all-pages?` refreshes EVERY page; `:refetch-window
+;; n` the first n. The accumulation length is preserved; its contents are
+;; re-fetched. These tests assert the new contract (the prior tests pinned the
+;; truncate-to-page-0 BUG — rf2-byl7bk.3.3).
 
-(deftest refetch-keep-count-empty-feed
-  (testing "an empty feed (page-count 0) keeps 0 — nothing to preserve"
-    (is (= 0 (state/refetch-keep-count nil 0)))
-    (is (= 0 (state/refetch-keep-count {:refetch-all-pages? true} 0)))
-    (is (= 0 (state/refetch-keep-count {:refetch-window 5} 0))
+(deftest refetch-window-count-empty-feed
+  (testing "an empty feed (page-count 0) refreshes 0 pages — nothing to refresh"
+    (is (= 0 (state/refetch-window-count nil 0)))
+    (is (= 0 (state/refetch-window-count {:refetch-all-pages? true} 0)))
+    (is (= 0 (state/refetch-window-count {:refetch-window 5} 0))
         "window over an empty feed is still 0 (zero-page short-circuits first)")))
 
-(deftest refetch-keep-count-default-preserves-window
-  (testing "the ruled DEFAULT (no policy / empty policy) keeps EVERY accumulated page"
-    (is (= 3 (state/refetch-keep-count nil 3)))
-    (is (= 3 (state/refetch-keep-count {} 3)))
-    (is (= 1 (state/refetch-keep-count {} 1)))))
+(deftest refetch-window-count-default-refreshes-page-0-only
+  (testing "the ruled DEFAULT (no policy / empty policy) refreshes PAGE 0 only —
+            the window-preserving default (replace page 0 in place, keep tail)"
+    (is (= 1 (state/refetch-window-count nil 3)))
+    (is (= 1 (state/refetch-window-count {} 3)))
+    (is (= 1 (state/refetch-window-count {} 1)))))
 
-(deftest refetch-keep-count-all-pages-opt-in
-  (testing ":refetch-all-pages? true keeps ONLY page 0 (re-accumulate from scratch)"
-    (is (= 1 (state/refetch-keep-count {:refetch-all-pages? true} 3)))
-    (is (= 1 (state/refetch-keep-count {:refetch-all-pages? true} 1)))
+(deftest refetch-window-count-all-pages-opt-in
+  (testing ":refetch-all-pages? true refreshes EVERY accumulated page (TanStack parity)"
+    (is (= 3 (state/refetch-window-count {:refetch-all-pages? true} 3))
+        "all 3 pages refreshed (not collapsed to page 0)")
+    (is (= 1 (state/refetch-window-count {:refetch-all-pages? true} 1)))
     (testing "all-pages? wins over a co-present :refetch-window (cond order)"
-      (is (= 1 (state/refetch-keep-count {:refetch-all-pages? true :refetch-window 2} 3))))))
+      (is (= 3 (state/refetch-window-count {:refetch-all-pages? true :refetch-window 2} 3))))))
 
-(deftest refetch-keep-count-window-clamps
-  (testing ":refetch-window n bounds the kept window to the first n pages"
-    (is (= 2 (state/refetch-keep-count {:refetch-window 2} 3)) "in-range window kept verbatim"))
+(deftest refetch-window-count-window-clamps
+  (testing ":refetch-window n refreshes the first n pages"
+    (is (= 2 (state/refetch-window-count {:refetch-window 2} 3)) "in-range window verbatim"))
   (testing "CLAMP HIGH — a window beyond the page count never invents pages"
-    (is (= 3 (state/refetch-keep-count {:refetch-window 5} 3))
+    (is (= 3 (state/refetch-window-count {:refetch-window 5} 3))
         "window > page-count clamps DOWN to page-count")
-    (is (= 3 (state/refetch-keep-count {:refetch-window 3} 3)) "window == page-count is exact"))
-  (testing "CLAMP LOW — a refetch always keeps at least page 0"
-    (is (= 1 (state/refetch-keep-count {:refetch-window 1} 3)) "window 1 keeps exactly page 0")
-    (is (= 1 (state/refetch-keep-count {:refetch-window 0} 3)) "window 0 clamps UP to 1")
-    (is (= 1 (state/refetch-keep-count {:refetch-window -4} 3)) "a negative window clamps UP to 1")))
+    (is (= 3 (state/refetch-window-count {:refetch-window 3} 3)) "window == page-count is exact"))
+  (testing "CLAMP LOW — a refetch always refreshes at least page 0"
+    (is (= 1 (state/refetch-window-count {:refetch-window 1} 3)) "window 1 refreshes exactly page 0")
+    (is (= 1 (state/refetch-window-count {:refetch-window 0} 3)) "window 0 clamps UP to 1")
+    (is (= 1 (state/refetch-window-count {:refetch-window -4} 3)) "a negative window clamps UP to 1")))
 
-;; ---- entry-refetch-reset (R6 — guard arms + truncation in step) ------------
+;; ---- refetch-sweep-tail (R6 — the ordered pages beyond 0 to re-fetch) ------
 
-(deftest refetch-reset-default-is-noop
-  (testing "the window-preserving DEFAULT keeps every page — a pure no-op
-            (the accumulated pages stay visible during the in-flight refetch)"
+(deftest refetch-sweep-tail-default-is-empty
+  (testing "the window-preserving DEFAULT starts NO sweep — page 0 is the
+            issue-time replacement; there is no tail to chain"
+    (is (= [] (state/refetch-sweep-tail (accumulated-3) nil)))
+    (is (= [] (state/refetch-sweep-tail (accumulated-3) {})))))
+
+(deftest refetch-sweep-tail-all-pages
+  (testing ":refetch-all-pages? sweeps pages 1..N-1 in order (page 0 is issue-time),
+            each pair carrying that page's durable :page-param"
+    (let [tail (state/refetch-sweep-tail (accumulated-3) {:refetch-all-pages? true})]
+      ;; accumulated-3 :page-params == [nil "c1" "c2"]
+      (is (= [["c1" 1] ["c2" 2]] tail)
+          "pages 1 and 2, each with its original param + index, in order"))))
+
+(deftest refetch-sweep-tail-window
+  (testing ":refetch-window 2 sweeps only page 1 (the bounded leading window
+            minus the issue-time page 0)"
+    (is (= [["c1" 1]] (state/refetch-sweep-tail (accumulated-3) {:refetch-window 2})))
+    (testing ":refetch-window 1 is page-0-only ⇒ empty tail (no sweep)"
+      (is (= [] (state/refetch-sweep-tail (accumulated-3) {:refetch-window 1}))))))
+
+(deftest refetch-sweep-tail-guard-arms
+  (testing "a nil / non-infinite / empty-feed entry yields an empty tail"
+    (is (= [] (state/refetch-sweep-tail nil {:refetch-all-pages? true})))
+    (is (= [] (state/refetch-sweep-tail (state/empty-entry :res/plain) {:refetch-all-pages? true})))
+    (is (= [] (state/refetch-sweep-tail (state/empty-infinite-entry :feed/timeline)
+                                        {:refetch-all-pages? true})))))
+
+;; ---- entry-begin / advance / clear refetch sweep (R6 cursor) ---------------
+
+(deftest entry-begin-refetch-sweep-default-noop
+  (testing "the window-preserving DEFAULT arms NO sweep cursor (returns the entry
+            unchanged — a plain refetch refreshes page 0 only)"
+    (let [e0 (accumulated-3)]
+      (is (identical? e0 (state/entry-begin-refetch-sweep e0 nil)))
+      (is (identical? e0 (state/entry-begin-refetch-sweep e0 {})))
+      (is (not (contains? (state/entry-begin-refetch-sweep e0 nil) :refetch-sweep))))))
+
+(deftest entry-begin-refetch-sweep-opt-in-arms-cursor
+  (testing ":refetch-all-pages? arms the cursor with pages 1..N-1 (issue-time
+            page 0 excluded) WITHOUT touching :data / :status / :revision"
     (let [e0 (accumulated-3)
-          e1 (state/entry-refetch-reset
-               e0 {:next-page-param-fn next-cursor :prev-page-param-fn prev-cursor
-                   :refetch-policy nil})]
-      (is (identical? e0 e1) "no policy → keep-all → the SAME entry object (true no-op)")
-      (is (= 3 (state/page-count e1))))
-    (testing "an explicit empty policy is also keep-all (a no-op)"
-      (let [e0 (accumulated-3)]
-        (is (identical? e0 (state/entry-refetch-reset
-                             e0 {:next-page-param-fn next-cursor :refetch-policy {}})))))))
+          e1 (state/entry-begin-refetch-sweep e0 {:refetch-all-pages? true})]
+      (is (= [["c1" 1] ["c2" 2]] (:refetch-sweep e1)) "cursor armed with the sweep tail")
+      (is (= 3 (state/page-count e1)) ":data UNTOUCHED — never truncated")
+      (is (= (:data e0) (:data e1)))
+      (is (= (:status e0) (:status e1)))
+      (is (= (:revision e0) (:revision e1)) "revision NOT bumped by arming the cursor")))
+  (testing ":refetch-window 2 arms a cursor with only page 1"
+    (let [e1 (state/entry-begin-refetch-sweep (accumulated-3) {:refetch-window 2})]
+      (is (= [["c1" 1]] (:refetch-sweep e1))))))
 
-(deftest refetch-reset-window-truncates-tail-and-params
-  (testing ":refetch-window 2 truncates a 3-page feed to its first 2 pages +
-            truncates :page-params in step + recomputes the cursor from the tail"
-    (let [e0 (accumulated-3)
-          e1 (state/entry-refetch-reset
-               e0 {:next-page-param-fn next-cursor :prev-page-param-fn prev-cursor
-                   :refetch-policy {:refetch-window 2}})]
-      (is (= 2 (state/page-count e1)) "tail dropped to the kept window")
-      (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e1)))
-      (is (= [nil "c1"] (:page-params e1)) ":page-params truncated in step")
-      (is (= "c2" (:next-page-param e1)) "cursor recomputed from the kept tail's edge")
-      (is (identical? (nth (:data e0) 0) (nth (:data e1) 0))
-          "kept leading pages are shared by identity (only the dropped tail changes)")
-      (testing "the reset does NOT touch :status / :current-work / :revision
-                (entry-start-load already transitioned the entry)"
-        (is (= (:status e0) (:status e1)))
-        (is (= (:current-work e0) (:current-work e1)))
-        (is (= (:revision e0) (:revision e1)) "revision NOT bumped by the reset")))))
-
-(deftest refetch-reset-all-pages-truncates-to-page-0
-  (testing ":refetch-all-pages? truncates a 3-page feed to page 0 only"
-    (let [e1 (state/entry-refetch-reset
-               (accumulated-3)
-               {:next-page-param-fn next-cursor :prev-page-param-fn prev-cursor
-                :refetch-policy {:refetch-all-pages? true}})]
-      (is (= 1 (state/page-count e1)) "kept only page 0")
-      (is (= [(page [:a] "c1")] (:data e1)))
-      (is (= [nil] (:page-params e1)))
-      (is (= "c1" (:next-page-param e1)) "cursor recomputed from page 0's tail"))))
-
-(deftest refetch-reset-guard-arms
-  (testing "a nil entry is returned unchanged"
-    (is (nil? (state/entry-refetch-reset nil {:refetch-policy {:refetch-window 1}}))))
-  (testing "a non-infinite (ordinary) entry is returned unchanged (guard arm)"
-    (let [plain (state/empty-entry :res/plain)]
-      (is (identical? plain (state/entry-refetch-reset
-                              plain {:refetch-policy {:refetch-window 1}})))))
-  (testing "an empty (no-pages) infinite entry is returned unchanged (guard arm)"
-    (let [empty-feed (state/empty-infinite-entry :feed/timeline)]
-      (is (= 0 (state/page-count empty-feed)))
-      (is (identical? empty-feed (state/entry-refetch-reset
-                                   empty-feed {:refetch-policy {:refetch-all-pages? true}}))))))
+(deftest entry-advance-and-clear-refetch-sweep
+  (testing "advance pops the head leg; clearing the last leg removes the key"
+    (let [e0 (state/entry-begin-refetch-sweep (accumulated-3) {:refetch-all-pages? true})]
+      (is (= ["c1" 1] (state/next-refetch-sweep-leg e0)) "head leg is page 1")
+      (let [e1 (state/entry-advance-refetch-sweep e0)]
+        (is (= [["c2" 2]] (:refetch-sweep e1)) "page 1 popped, page 2 remains")
+        (is (= ["c2" 2] (state/next-refetch-sweep-leg e1)))
+        (let [e2 (state/entry-advance-refetch-sweep e1)]
+          (is (not (contains? e2 :refetch-sweep)) "last leg popped ⇒ cursor removed")
+          (is (nil? (state/next-refetch-sweep-leg e2)) "no next leg on an exhausted sweep")))))
+  (testing "clear-refetch-sweep drops an in-progress cursor (a failed/aborted leg stops it)"
+    (let [e0 (state/entry-begin-refetch-sweep (accumulated-3) {:refetch-all-pages? true})]
+      (is (not (contains? (state/clear-refetch-sweep e0) :refetch-sweep)))))
+  (testing "next-refetch-sweep-leg on an unarmed entry is nil"
+    (is (nil? (state/next-refetch-sweep-leg (accumulated-3))))))

--- a/implementation/resources/test/re_frame/resources_route_infinite_blocking_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_infinite_blocking_cljs_test.cljc
@@ -17,22 +17,30 @@
   route but only asserts the entry `:status` / view `:loading?` — it never
   reads the route blocking-slot or asserts the route TRANSITION completes.
 
-  THE GAP this pins (rf2-uvq8sq finding):
+  THE CONTRACT this pins (rf2-byl7bk.3.1 — spec-correct first-load semantics,
+  superseding the rf2-kz90ep characterisation that pinned the divergence):
 
     1. a blocking infinite route holds the transition `:loading` on PAGE 0
        in flight, and DRAINS (transition → `:idle`) when page-0 SUCCEEDS via
        the PAGE reply handler (`entry-replace-page` append path), NOT the
        scalar succeeded-handler;
 
-    2. the SUBTLE page-failed-handler contract (events.cljc ~lines 2318-2326):
-       a blocking page-0 FAILURE with NO prior data still DRAINS the slot as
-       `:success` — because `entry-page-failed` ALWAYS returns `:status
-       :loaded`, and `page-failed-handler` ALWAYS calls `drain-blocking …
-       :success`. So a blocking infinite route NEVER flips to route `:error`
-       on a page-0 failure (the feed settles `:loaded` with `:page-error`),
-       UNLIKE a blocking SCALAR resource. This divergence is INTENTIONAL but
-       was completely untested: a regression that errored the route on an
-       infinite page-0 failure would have passed every existing test.
+    2. a blocking page-0 FIRST-load FAILURE (no accumulated pages) uses the
+       FIRST-LOAD `:error` channel, NOT the load-more `:page-error` channel:
+       Spec 016 reserves `:error` / `:status :error` for first-load (page 0)
+       failure and `:page-error` for load-more (page N>0) failure only. So a
+       blocking infinite route whose required page 0 fails flips to route
+       `:error` (the feed settles `:status :error`, `:error` envelope, no
+       data) — EXACTLY like a blocking SCALAR resource, restoring parity. The
+       rf2-kz90ep test pinned the OPPOSITE (`:loaded` + `:page-error` + route
+       `:idle`), which tested the implementation against itself, not against
+       Spec 016; this fix inverts it;
+
+    3. a LOAD-MORE (page N>0) FAILURE with accumulated pages still uses the
+       `:page-error` channel: the feed stays `:loaded`, KEEPS all pages, and
+       the route (already drained on page-0 success) is undisturbed — the
+       third error channel is intact for the case the spec actually reserves
+       it for.
 
   The capturing transport REPLAYS the live managed-HTTP reply-append shape
   (the transport conj's its result as the LAST arg of the internal reply
@@ -187,23 +195,21 @@
           "the blocking slot drained when page 0 landed"))))
 
 ;; ===========================================================================
-;; 2. blocking infinite route page-0 FAILURE drains as :loaded, does NOT error
-;;    the route (the wave-7 divergence from a scalar resource)
+;; 2. blocking infinite route page-0 FIRST-load FAILURE errors the route
+;;    (the FIRST-load :error channel — parity with a scalar blocking resource)
 ;; ===========================================================================
 
-(deftest blocking-infinite-route-page-0-failure-drains-as-loaded-not-error
-  ;; rf2-kz90ep (2) — THE documented divergence (events.cljc ~2318-2326):
-  ;; a blocking infinite page-0 FAILURE with no prior data still DRAINS the
-  ;; slot as :success because entry-page-failed always returns :status :loaded
-  ;; and page-failed-handler always calls (drain-blocking … :success). So the
-  ;; feed settles :loaded with :page-error set, and the route lands :idle — it
-  ;; is NEVER flipped to :error, UNLIKE a blocking SCALAR resource (whose
-  ;; first-load failure → route :error, see resources_route_cljs_test
-  ;; 'blocking-first-load-failure-flips-route-to-error').
-  ;;
-  ;; If the runtime ever ERRORS the route on a page-0 infinite failure, THIS
-  ;; test fails loudly — the contract is intentional but was untested, so a
-  ;; regression that errored the route would have passed every existing test.
+(deftest blocking-infinite-route-page-0-failure-errors-route
+  ;; rf2-byl7bk.3.1 — THE spec-correct contract (Spec 016 §Status semantics +
+  ;; §Infinite resources): a blocking infinite page-0 FIRST-load FAILURE (no
+  ;; accumulated pages) settles the FIRST-load :error channel (`entry-failed`
+  ;; → :status :error, :error envelope, :data nil), and `page-failed-handler`
+  ;; drains the blocking slot as :FAILURE. drain-blocking then flips the route
+  ;; to :error (its (= :error (:status entry)) branch fires automatically) —
+  ;; EXACTLY like a blocking SCALAR resource. This INVERTS the rf2-kz90ep
+  ;; characterisation test (which pinned :loaded + :page-error + route :idle):
+  ;; Spec 016 reserves :error for first-load (page 0) and :page-error for
+  ;; load-more (page N>0) ONLY — page 0 is a first load, never a load-more.
   (register-blocking-infinite-route!)
   (rf/dispatch-sync [:rf.route/navigate :route/feed {:slug "intro"}])
   (let [nav-token (:nav-token (slice))
@@ -213,34 +219,34 @@
       (is (= :loading (:transition (slice))))
       (is (contains? (blocking-slot nav-token) k)))
     (reply-page-failure! failure)
-    (testing "the feed settles :loaded with :page-error — NOT the :error channel"
+    (testing "the feed settles :status :error with the :error channel — NOT :page-error"
       (let [e (entry k)]
-        (is (= :loaded (:status e))
-            "a page-0 failure leaves the feed :loaded (the third error channel), never :error")
-        (is (= failure (:page-error e)) ":page-error records the page-0 failure envelope")
-        (is (nil? (:error e)) "NOT the scalar first-load :error channel")
+        (is (= :error (:status e))
+            "a page-0 first-load failure (no pages) is :status :error, never :loaded")
+        (is (= failure (:error e)) ":error records the first-load failure envelope")
+        (is (nil? (:page-error e)) "NOT the load-more :page-error channel (page 0 is not a load-more)")
         (is (nil? (:refresh-error e)) "NOT the whole-feed :refresh-error channel")
+        (is (nil? (:data e)) "first-load failure clears data (no usable data)")
         (is (= 0 (state/page-count e)) "no page accumulated — page 0 never landed")))
-    (testing "the BLOCKING ROUTE is NOT errored / NOT blocked — it drains to :idle"
-      (is (not= :error (:transition (slice)))
-          "the blocking infinite route did NOT flip to :error on the page-0 failure")
-      (is (= :idle (:transition (slice)))
-          "the page-0 failure drained the slot as :success → route :idle (the documented divergence)")
-      (is (nil? (:error (slice)))
-          "no :rf.route/error written — a scalar first-load failure WOULD set one")
+    (testing "the BLOCKING ROUTE flips to :error (parity with a scalar blocking resource)"
+      (is (= :error (:transition (slice)))
+          "the blocking infinite route flips to :error on the page-0 first-load failure")
+      (is (= :rf.error/resource-route-blocking (:rf.error/id (:error (slice))))
+          ":rf.route/error carries the structured blocking-failure error")
       (is (empty? (blocking-slot nav-token))
           "the blocking slot drained on the page-0 failure (slot does not leak / hang the route)"))))
 
 ;; ===========================================================================
-;; 3. contrast guard — a SCALAR blocking first-load failure DOES error the
-;;    route (so #2 is a genuine divergence, not a no-op assertion)
+;; 3. contrast guard — a SCALAR blocking first-load failure errors the route
+;;    too, so #2 now confirms PARITY (infinite page-0 == scalar first load)
 ;; ===========================================================================
 
 (deftest scalar-blocking-first-load-failure-still-errors-route-contrast
-  ;; A guard so the divergence asserted above is meaningful: the SAME route
-  ;; shape with a SCALAR (non-infinite) blocking resource DOES flip to :error
-  ;; on a first-load failure. If both errored or both drained, #2 would prove
-  ;; nothing — this pins the contrast.
+  ;; A guard so #2's assertion has a parity baseline: the SAME route shape with
+  ;; a SCALAR (non-infinite) blocking resource ALSO flips to :error on a
+  ;; first-load failure. Post-fix #2 and #3 agree — a blocking infinite page-0
+  ;; first-load failure errors the route exactly like a scalar one (parity
+  ;; restored, the divergence rf2-kz90ep pinned is removed).
   (rf/reg-resource :article/by-slug
                    {:scope         :rf.scope/global
                     :params-schema [:map [:slug :string]]
@@ -260,8 +266,50 @@
     ;; settle the scalar via the SCALAR failed handler (its live reply shape)
     (rf/dispatch-sync (conj (:on-failure @last-managed-args)
                             {:kind :failure :failure {:status 503 :message "upstream down"}}))
-    (testing "a SCALAR blocking first-load failure flips the route to :error (contrast to #2)"
+    (testing "a SCALAR blocking first-load failure flips the route to :error (parity with #2)"
       (is (= :error (:transition (slice)))
-          "scalar first-load failure DOES error the route — the divergence in #2 is real")
+          "scalar first-load failure errors the route — infinite page-0 (#2) now matches it")
       (is (= :rf.error/resource-route-blocking (:rf.error/id (:error (slice))))
           ":rf.route/error carries the structured blocking-failure error"))))
+
+;; ===========================================================================
+;; 4. LOAD-MORE (page N>0) FAILURE keeps the :page-error channel intact — the
+;;    third error channel still applies where the spec reserves it (data kept)
+;; ===========================================================================
+
+(deftest blocking-infinite-route-load-more-failure-keeps-page-error-channel
+  ;; rf2-byl7bk.3.1 — the OTHER side of the split: a page N>0 (load-more)
+  ;; failure with accumulated pages is STILL the third error channel
+  ;; (`entry-page-failed` → :loaded + :page-error, all pages kept). Only page 0
+  ;; with no pages uses the first-load :error channel; a load-more failure must
+  ;; NOT error the route (the route already drained on the page-0 success) and
+  ;; must NOT lose the feed.
+  (register-blocking-infinite-route!)
+  (rf/dispatch-sync [:rf.route/navigate :route/feed {:slug "intro"}])
+  (let [nav-token (:nav-token (slice))
+        k         (feed-key "intro")
+        failure   {:kind :rf.http/server :status 503 :message "load-more down"}]
+    ;; page 0 SUCCEEDS first (cursor "c1" ⇒ a next page exists) — the route
+    ;; drains to :idle, then the feed has one accumulated page.
+    (reply-page-success! (page [:a :b] "c1"))
+    (is (= :idle (:transition (slice))) "route drained on page-0 success")
+    (is (= 1 (state/page-count (entry k))) "page 0 accumulated")
+    ;; now a load-more (page 1) is dispatched and FAILS.
+    (rf/dispatch-sync [:rf.resource/load-more {:resource :feed/articles
+                                               :scope    :rf.scope/global
+                                               :params   {:slug "intro"}}])
+    (let [args @last-managed-args]
+      (is (= 1 (:rf.resource/page-index (second (:on-failure args))))
+          "the load-more fetches page index 1 (a positive page, not page 0)")
+      (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure})))
+    (testing "a load-more (N>0) failure keeps the feed :loaded + records :page-error"
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "load-more failure leaves the feed :loaded (data kept)")
+        (is (= failure (:page-error e)) ":page-error records the load-more failure envelope")
+        (is (nil? (:error e)) "NOT the first-load :error channel")
+        (is (= 1 (state/page-count e)) "the accumulated page-0 is KEPT (no data lost)")
+        (is (= [(page [:a :b] "c1")] (:data e)) "page-0 data still present")))
+    (testing "the route is undisturbed by the load-more failure (already :idle)"
+      (is (= :idle (:transition (slice)))
+          "a load-more failure does NOT error the route (route blocks on page 0 only)")
+      (is (nil? (:error (slice))) "no :rf.route/error written on a load-more failure"))))


### PR DESCRIPTION
Two post-graduation EP-0021 correctness patches where **Spec 016 is authoritative and the implementation diverged**. Same module → one PR; the two fixes are cleanly separated in the diff (bead-tagged comments + distinct functions). Both decision docs recommended **(A) FIX THE IMPLEMENTATION**.

## rf2-byl7bk.3.1 (P1) — infinite page-0 first-load failure uses the first-load `:error` channel

Spec 016 reserves `:error` / `:status :error` for first-load (page 0) failure and `:page-error` for load-more (page N>0) **only**. The impl wrongly routed every page-0 failure through `entry-page-failed` (→ `:loaded` + `:page-error`) and drained a blocking route as **success** — a failed required first page looked like a settled empty feed (route `:idle`).

Fix: `page-failed-handler` now splits by page identity. A page-0 failure with **no accumulated pages** settles `state/entry-failed` (→ `:status :error`, `:error` envelope, `:data nil`) and drains a blocking route as `:failure`; `drain-blocking`'s existing `(= :error (:status entry))` branch then flips the route to `:error` (parity with a scalar blocking resource — **route.cljc unchanged**). The trace op aligns (`:rf.resource/failed`). **R6 window-preserving refetch preserved**: a page-0 refetch over a feed that already has pages is NOT a first load → stays `:loaded` + `:page-error`. The route-infinite-blocking test is rewritten to assert the spec-correct semantics (blocking page-0 failure → route `:error`; N>0 load-more failure → `:page-error` + data kept), inverting the rf2-kz90ep characterisation that pinned the bug.

## rf2-byl7bk.3.3 (P2) — `:refetch-all-pages?` / `:refetch-window` honour their contract

Spec 016 + the closed Spec-Schemas schema + R6 define `:refetch-all-pages?` = re-fetch every accumulated page param **in sequence** (TanStack parity), `:refetch-window N` = refresh the bounded leading window. The impl instead truncated the tail and issued one page-0 request.

Fix: the truncating `refetch-keep-count` / `entry-refetch-reset` are replaced with `refetch-window-count` (multi-page refresh window) + a **chained sweep** cursor (`refetch-sweep-tail` / `entry-begin-refetch-sweep` / `next-refetch-sweep-leg` / `entry-advance-refetch-sweep` / `clear-refetch-sweep`). The issue-time refetch fetches page 0 and arms a `:refetch-sweep` cursor; `page-succeeded-handler` chains the next leg **one at a time** via a self-dispatched `:rf.resource.internal/refetch-page` event (registered with `generation-meta`, so each leg mints its own replay-stable generation + work-id — the single-work-id substrate is reused, **no parallel fan**, "in sequence"). Each page is replaced in place; the accumulation is never truncated. A failed/aborted leg clears the cursor and stops the sweep. **The window-preserving DEFAULT (R6) is intact**: no opt-in → empty sweep tail → one page-0 replace-in-place, no sweep.

Also aligns the reagent `infinite_feed` example view + its test to the first-load `:error` vs load-more `:page-error` split (the example pinned the old single-channel behaviour).

## Did each bug reproduce before the fix?

- **3.1: YES.** With the spec-correct test in place, a blocking page-0 failure produced `:status :loaded` + `:page-error` + route `:idle` (6 assertions failed) — the bug, confirmed real, not a stale build.
- **3.3: YES.** With the contract tests in place, `:refetch-all-pages?` left the feed at 1 page (truncate-to-page-0) and `:refetch-window 2` truncated to 2 pages, issuing one page-0 request — confirmed via 5 failing assertions before the fix.

## R6 window-preserving default

**Confirmed still holds.** `refetch-preserves-window-by-default` (event-level) and `refetch-window-count-default-refreshes-page-0-only` / `entry-begin-refetch-sweep-default-noop` (pure) all pass: a plain refetch issues one page-0 fetch, replaces in place, keeps the tail, arms no sweep.

## Spec

Unchanged — Spec 016 already describes both contracts; the impl is brought into conformance. (No spec/016 hot-zone touch.)

## Scope

Resources-only (`events.cljc` / `state.cljc` / `resources.cljc` + resources tests) plus the reagent infinite-feed example and its test. `route.cljc` needed no change. Did not touch `ssr.cljc` / `classification.cljc` (owned by the 3.2 worker), spec, or `.beads`.

## Quality gates

```
cd implementation/resources && clojure -M:test
# Ran 583 tests containing 2518 assertions. 0 failures, 0 errors.

cd implementation && npm run test:cljs
# Ran 7976 tests containing 33228 assertions. 0 failures, 0 errors.
```
