### PR TITLE
fix(xray): EP-0021 surface infinite :page-params + retain infinite trace facts in resource history (rf2-byl7bk.3.4, rf2-byl7bk.3.5)

### DIFF
--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -214,11 +214,16 @@ stacked sections:
    R1/R2/R3):** an `:infinite?` entry additionally carries `:page-count`
    (the accumulated page-vector length), the runtime-owned `:cursor`
    (the `:next-page-param` — egress-projected, since a cursor can carry
-   record ids), `:terminal?` (the derived `:has-next-page?` complement —
-   `nil` cursor is the single terminal), and `:page-error` (the THIRD
-   error channel — a load-more failure that KEPT the feed, summarized,
-   distinct from `:error` / `:refresh-error`). All are **pure functions
-   of the durable entry**. The `:fetching-next?` distinction (a load-more
+   record ids), `:page-params` (the ordered **per-page cursor chain** — the
+   durable record of how the accumulation advanced, page-0's `nil` seed then
+   each resolved next-page param; explicitly **NOT** part of the feed cache
+   key, so the only tool-facing record of the page-by-page fetch sequence —
+   each element egress-projected the SAME way `:cursor` is, since cursors
+   carry record ids; Spec 016 §Trace surfacing), `:terminal?` (the derived
+   `:has-next-page?` complement — `nil` cursor is the single terminal), and
+   `:page-error` (the THIRD error channel — a load-more failure that KEPT the
+   feed, summarized, distinct from `:error` / `:refresh-error`). All are
+   **pure functions of the durable entry**. The `:fetching-next?` distinction (a load-more
    in flight vs a whole-feed `:fetching?` refresh) is NOT a pure function
    of the entry — both leave the feed at `:fetching` (no 6th FSM state);
    the distinguishing durable fact is the in-flight work record's
@@ -272,7 +277,23 @@ stacked sections:
 5. **Lifecycle timeline** — the ordered `:rf.resource/*` trace rows
    (oldest-first), each carrying op label + semantic class colour,
    resource id, summarized resource key, generation, owner, summarized
-   cause, and status before/after.
+   cause, and status before/after. **The infinite-feed page evidence
+   (EP-0021):** the four load-more family ops (`:rf.resource/load-more` /
+   `page-appended` / `page-failed` / `load-more-skipped`) additionally
+   carry a `:page` detail map with the op-specific facts the generic row
+   drops — `:page-param` (the resolved cursor, on `load-more`) /
+   `:next-page-param` (the derived cursor, on `page-appended`) **both
+   egress-projected** (a cursor carries record ids — same treatment as the
+   instance row's `:cursor`), the **raw** metadata `:page-index` /
+   `:page-count` / `:terminal?` (`page-appended`) / `:reason`
+   (`load-more-skipped` — `:no-feed` / `:no-next-page` terminal /
+   `:in-flight` deduped), and the summarized `:page-error` (`page-failed` —
+   the THIRD error channel). Without this the timeline shows that a load-more
+   happened but loses which cursor was used, which page index appended/failed,
+   terminal-vs-in-flight, and the resulting next cursor. The **same `:page`
+   detail rides `get-resource-history`**, so MCP/AI callers retain the page
+   evidence too (Spec 016 §Trace surfacing). A non-infinite op carries no
+   `:page` slot.
 6. **Invalidation / mutation graph** — the `:rf.resource/invalidated`
    rows: summarized scope, the invalidated tags, summarized cause, the
    matched scoped keys, the match count (distinguishes a broad-tag storm

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -289,6 +289,25 @@
           [:<>
            [:span {:style {:color (:text-tertiary tokens)}} "cursor"]
            (summary-chip (:cursor row) (str testid "-cursor"))])
+        ;; EP-0021 — the per-page cursor chain (egress-projected). The durable
+        ;; record of how the accumulation advanced, NOT part of the cache key
+        ;; (rf2-byl7bk.3.4). Rendered as an ordered, indexed run of summary
+        ;; chips so the page-by-page fetch sequence is inspectable.
+        (when (seq (:page-params row))
+          [:span {:data-testid (str testid "-page-params")
+                  :style {:display "flex" :gap "4px" :align-items "baseline"
+                          :flex-wrap "wrap"}}
+           [:span {:style {:color (:text-tertiary tokens)}} "page-params"]
+           (into [:<>]
+                 (map-indexed
+                   (fn [i p]
+                     ^{:key i}
+                     [:span {:style {:display "flex" :gap "2px"
+                                     :align-items "baseline"}}
+                      [:span {:style {:color (:text-tertiary tokens)}}
+                       (str "p" i)]
+                      (summary-chip p (str testid "-page-param-" i))])
+                   (:page-params row)))])
         (when (:page-error row)
           [:span {:data-testid (str testid "-page-error")
                   :style {:color (:error tokens)}}
@@ -574,7 +593,38 @@
     (:label row)]
    [:span {:style {:color mode-accent}} (str (:resource-id row))]
    (when (:generation row)
-     [:span {:style {:color (:text-tertiary tokens)}} "gen " (:generation row)])])
+     [:span {:style {:color (:text-tertiary tokens)}} "gen " (:generation row)])
+   ;; EP-0021 — the infinite-feed page evidence carried by the four load-more
+   ;; family ops (page param / index / count / next cursor / terminal / skip
+   ;; reason / page-error). Without this the timeline shows "load more"
+   ;; happened but loses which cursor, which page index, terminal-vs-in-flight,
+   ;; and the resulting next cursor (rf2-byl7bk.3.5). Cursor-bearing facts are
+   ;; egress-projected summaries; metadata rides raw.
+   (when-let [{:keys [page-param next-page-param page-index page-count
+                      terminal? reason page-error]} (:page row)]
+     (let [testid (str "rf-xray-resources-timeline-row-" (:id row) "-page")]
+       [:span {:data-testid testid
+               :style {:display "flex" :gap "6px" :align-items "baseline"
+                       :flex-wrap "wrap" :color (:text-tertiary tokens)}}
+        (when page-param
+          [:span {:style {:display "flex" :gap "2px" :align-items "baseline"}}
+           "param" (summary-chip page-param (str testid "-param"))])
+        (when (some? page-index)
+          [:span {:data-testid (str testid "-index")} "idx " page-index])
+        (when (some? page-count)
+          [:span {:data-testid (str testid "-count")} "pages " page-count])
+        (when next-page-param
+          [:span {:style {:display "flex" :gap "2px" :align-items "baseline"}}
+           "next" (summary-chip next-page-param (str testid "-next"))])
+        (when (some? terminal?)
+          [:span {:data-testid (str testid "-terminal")}
+           (if terminal? "terminal" "more")])
+        (when reason
+          [:span {:data-testid (str testid "-reason")} "reason " (str reason)])
+        (when page-error
+          [:span {:data-testid (str testid "-error")
+                  :style {:color (:error tokens)}}
+           "page-error " (:preview page-error)])]))])
 
 (defn- timeline-section [rows]
   (section

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -631,6 +631,14 @@
        ;; failure that KEPT the feed). `:page-count` is the page-vector length;
        ;; `:terminal?` is the derived `:has-next-page?` complement. The cursor is
        ;; egress-projected (a cursor can carry record ids — Spec 016 §Tooling).
+       ;; `:page-params` is the ORDERED per-page cursor chain — the durable
+       ;; record of how the accumulation advanced (page 0's nil seed, then each
+       ;; resolved next-page param). It is explicitly NOT part of the feed cache
+       ;; key, so it is the only tool-facing record of the page-by-page fetch
+       ;; sequence (Spec 016 §Tooling — "per-page params … since cursors can
+       ;; carry ids"; EP-0021). Each element is a cursor value the SAME shape as
+       ;; `:cursor`, so each is egress-projected `:params`-slot identically (the
+       ;; rf2-3tysyj cursor-egress treatment) — never the raw cursor.
        ;; `:fetching-next?` (a load-more vs a whole-feed refresh) is NOT a pure
        ;; function of the entry — it joins the in-flight work record's
        ;; `:page-index` (see `work-row` `:page-index`); the panel reads it off
@@ -640,6 +648,8 @@
                 {:infinite?      true
                  :page-count     (count (:data entry))
                  :cursor         (summarize (eg next-param :params))
+                 :page-params    (mapv #(summarize (eg % :params))
+                                       (:page-params entry))
                  :terminal?      (nil? next-param)
                  :has-next-page? (some? next-param)
                  :page-error     (when (:page-error entry)
@@ -952,6 +962,55 @@
 
 (defn- trace-tags [ev] (or (:tags ev) {}))
 
+(def ^:private infinite-trace-ops
+  "The four EP-0021 infinite-feed trace ops whose tags carry op-specific page
+  evidence beyond the generic lifecycle fields (Spec 016 §Trace surfacing,
+  Xray spec 024 §The `:rf.resource/*` trace family). The generic
+  `lifecycle-timeline` projection drops the per-op facts; these ops get an
+  extra `:page` detail map."
+  #{:rf.resource/load-more
+    :rf.resource/page-appended
+    :rf.resource/page-failed
+    :rf.resource/load-more-skipped})
+
+(defn- page-detail
+  "Project the EP-0021 infinite-feed page evidence carried in a load-more
+  family trace event's `tags` into a compact `:page` detail map (Spec 016
+  §Trace surfacing; Xray spec 024 rows for `:rf.resource/load-more` /
+  `page-appended` / `page-failed` / `load-more-skipped`). Returns nil for a
+  non-infinite op so the row carries no empty `:page` slot.
+
+  Per op (only the keys the runtime actually stamps):
+    - `:load-more`         → `:page-param` `:page-index` `:page-count`
+    - `:page-appended`     → `:page-index` `:page-count` `:next-page-param`
+                             `:terminal?`
+    - `:load-more-skipped` → `:reason` (+ `:page-count` on the terminal arm)
+    - `:page-failed`       → `:page-error` (the THIRD error channel)
+
+  EGRESS (rf2-3tysyj / 3.4): the CURSOR-bearing facts (`:page-param` on
+  load-more, `:next-page-param` on page-appended) and the `:page-error`
+  envelope (an error value that may carry mutation data) are value-bearing —
+  each routes through `eg` (the off-box `egress-value` walker on the off-box
+  path; `identity` in-panel) BEFORE `summarize`, IDENTICALLY to the way
+  `instance-row`'s `:cursor` and the generic `:cause` are projected. The
+  METADATA (`:page-index` / `:page-count` / `:terminal?` / `:reason`) is not
+  PII and rides raw. Only assoc's a key when the tag is present, so a
+  partially-stamped row (e.g. a `load-more-skipped` no-feed arm) carries only
+  the facts it has. Pure when `eg` is pure."
+  [op tags eg]
+  (when (infinite-trace-ops op)
+    (cond-> {}
+      (contains? tags :page-param)
+      (assoc :page-param (summarize (eg (:page-param tags))))
+      (contains? tags :next-page-param)
+      (assoc :next-page-param (summarize (eg (:next-page-param tags))))
+      (contains? tags :page-index)   (assoc :page-index (:page-index tags))
+      (contains? tags :page-count)   (assoc :page-count (:page-count tags))
+      (contains? tags :terminal?)    (assoc :terminal? (:terminal? tags))
+      (contains? tags :reason)       (assoc :reason (:reason tags))
+      (contains? tags :page-error)
+      (assoc :page-error (summarize (eg (:page-error tags)))))))
+
 (defn lifecycle-timeline
   "Project the resource trace rows in a trace buffer into a lifecycle
   TIMELINE — an ordered, render-safe row per `:rf.resource/*` event
@@ -967,7 +1026,15 @@
        :work-id     <id>
        :owner       <owner>
        :cause       <summary>        ; cause may carry data — summarized
-       :status      {:before … :after …}}
+       :status      {:before … :after …}
+       :page        {…}}             ; EP-0021 — only on the four infinite ops
+
+  The four EP-0021 infinite-feed ops (`:load-more` / `:page-appended` /
+  `:page-failed` / `:load-more-skipped`) additionally carry a `:page`
+  detail map with the op-specific page evidence (`:page-param` /
+  `:next-page-param` cursor — egress-projected; `:page-index` /
+  `:page-count` / `:terminal?` / `:reason` raw; `:page-error` summarized).
+  See `page-detail`. A non-infinite op carries no `:page` slot.
 
   Pure over the trace vector; preserves buffer order (oldest-first). The
   panel renders this as the per-resource lifecycle strip; filtering by
@@ -995,20 +1062,27 @@
                   (let [op   (trace-op ev)
                         tags (trace-tags ev)
                         rkey (:resource/key tags)]
-                    {:id           (:id ev)
-                     :operation    op
-                     :label        (op-label op)
-                     :class        (op-class op)
-                     :resource-id  (or (:resource-id tags)
-                                       (when (vector? rkey) (second rkey)))
-                     :resource/key (when rkey (scoped-key-summary rkey eg))
-                     :generation   (:generation tags)
-                     :work-id      (:work/id tags)
-                     :owner        (:owner tags)
-                     :cause        (when (contains? tags :cause)
-                                     (summarize (eg (:cause tags))))
-                     :status       {:before (:status-before tags)
-                                    :after  (or (:status-after tags) (:status tags))}})))))))
+                    (cond->
+                      {:id           (:id ev)
+                       :operation    op
+                       :label        (op-label op)
+                       :class        (op-class op)
+                       :resource-id  (or (:resource-id tags)
+                                         (when (vector? rkey) (second rkey)))
+                       :resource/key (when rkey (scoped-key-summary rkey eg))
+                       :generation   (:generation tags)
+                       :work-id      (:work/id tags)
+                       :owner        (:owner tags)
+                       :cause        (when (contains? tags :cause)
+                                       (summarize (eg (:cause tags))))
+                       :status       {:before (:status-before tags)
+                                      :after  (or (:status-after tags) (:status tags))}}
+                      ;; EP-0021 — the four infinite-feed ops carry op-specific
+                      ;; page evidence (cursor / page index / count / terminal /
+                      ;; skip reason / page-error) the generic fields drop. A
+                      ;; non-infinite op gets no `:page` slot (rf2-byl7bk.3.5).
+                      (page-detail op tags eg)
+                      (assoc :page (page-detail op tags eg))))))))))
 
 (defn invalidation-graph
   "Project the `:rf.resource/invalidated` trace rows into the

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -441,10 +441,30 @@
       ;; the cursor is egress-projected (summarized — a cursor can carry ids)
       (is (contains? live :cursor))
       (is (nil? (:page-error live))))
+    ;; rf2-byl7bk.3.4 — the per-page cursor CHAIN (the ordered record of how the
+    ;; accumulation advanced; NOT part of the cache key). Each element is a
+    ;; cursor egress-projected the SAME way :cursor is — a summary map, never
+    ;; the raw cursor.
+    (testing "the durable :page-params vector is projected as egress-summaries"
+      (is (vector? (:page-params live)))
+      (is (= 2 (count (:page-params live)))
+          "one summary per accumulated page (page-0 seed + 1 next-cursor)")
+      (is (every? map? (:page-params live)) "each element is a summary map")
+      (is (every? #(contains? % :preview) (:page-params live))
+          "each is a render-safe summary, not the raw cursor value")
+      (is (= ["nil" "\"cursor-1\""]
+             (mapv :preview (:page-params live)))
+          "the ordered cursor chain (page-0 nil seed, then \"cursor-1\")
+           survives projection verbatim — plain feed, non-sensitive owner,
+           no redaction")
+      (is (every? #(false? (:redacted? %)) (:page-params live))
+          "a non-sensitive feed's cursors are NOT over-redacted"))
     (testing "a TERMINAL feed: nil cursor → :terminal?, no :has-next-page?"
       (is (= 1 (:page-count term)))
       (is (true? (:terminal? term)))
-      (is (false? (:has-next-page? term))))
+      (is (false? (:has-next-page? term)))
+      (is (= 1 (count (:page-params term)))
+          "the terminal feed's single-page chain is projected too"))
     (testing "the THIRD error channel — a load-more :page-error is surfaced
               (summarized, distinct from :error / :refresh-error)"
       (is (some? (:page-error term)))
@@ -454,7 +474,30 @@
       (let [ordinary (first (h/project-instances entries now))]
         (is (not (contains? ordinary :infinite?)))
         (is (not (contains? ordinary :page-count)))
-        (is (not (contains? ordinary :cursor)))))))
+        (is (not (contains? ordinary :cursor)))
+        (is (not (contains? ordinary :page-params)))))))
+
+;; rf2-byl7bk.3.4 — page-params are cursor values; a SENSITIVE-owner feed must
+;; redact each cursor in the chain the SAME way the live-cache scope/params /
+;; the `:cursor` are redacted on the off-box path (the rf2-3tysyj treatment).
+(deftest infinite-page-params-egress-redaction-test
+  (let [;; an egress-fn that redacts the :params slot (mirrors the off-box
+        ;; `resource-egress-fn` for a `:sensitive?` owner) and passes other
+        ;; slots through — page-params + the cursor project through `:params`.
+        egress-fn     (fn [v slot] (if (= :params slot) h/redacted-sentinel v))
+        rows          (h/project-instances infinite-entries now egress-fn)
+        live          (first (filter #(= {:tag "clj"} (get-in % [:scoped-key 2])) rows))]
+    (testing "each VALUE-bearing page-param in the chain is redacted off-box"
+      (is (= 2 (count (:page-params live))))
+      ;; the page-0 seed is nil (nothing to redact — stays nil, as the live
+      ;; :data/scope nil slots do); every NON-nil cursor in the chain redacts.
+      (is (= [false true] (mapv :redacted? (:page-params live)))
+          "the nil seed has nothing to redact; the real cursor redacts")
+      (is (= "[redacted]" (:preview (second (:page-params live))))
+          "no raw cursor value leaks off-box")
+      ;; the cursor (current :next-page-param) routes through the SAME :params
+      ;; slot, so it redacts identically — page-params are not a new leak path.
+      (is (:redacted? (:cursor live))))))
 
 (deftest infinite-work-ledger-page-index-test
   (let [ledger (byte-keyed-ledger
@@ -676,6 +719,95 @@
         (is (= :article/by-slug (:resource-id fs)))
         (is (= :lifecycle (:class fs)))
         (is (= "vector" (get-in fs [:resource/key :scope :type])))))))
+
+;; rf2-byl7bk.3.5 — the four EP-0021 infinite-feed trace ops carry op-specific
+;; page evidence (param/index/count/next/terminal/reason/page-error). The
+;; generic lifecycle projection dropped them; the `:page` detail must retain
+;; them, with cursor-bearing facts egress-projected (3.4/3tysyj).
+(def ^:private infinite-trace-buffer
+  [;; a load-more issued the next-page fetch (carries the resolved cursor +
+   ;; the page index it appends at + the count so far)
+   {:id 20 :operation :rf.resource/load-more
+    :tags {:resource/key [session-scope :feed/articles {:tag "clj"}]
+           :generation 4 :work/id [:rf.work/resource :feed 4]
+           :page-param "cursor-1" :page-index 1 :page-count 1}}
+   ;; the page-fetch succeeded + appended (new count + derived next cursor)
+   {:id 21 :operation :rf.resource/page-appended
+    :tags {:resource/key [session-scope :feed/articles {:tag "clj"}]
+           :generation 4 :work/id [:rf.work/resource :feed 4]
+           :page-index 1 :page-count 2
+           :next-page-param "cursor-2" :terminal? false}}
+   ;; a TERMINAL page-appended (no next cursor → terminal? true)
+   {:id 22 :operation :rf.resource/page-appended
+    :tags {:resource/key [session-scope :feed/articles {:tag "clj"}]
+           :generation 5 :page-index 2 :page-count 3
+           :next-page-param nil :terminal? true}}
+   ;; a load-more no-op (terminal feed → :no-next-page skip reason)
+   {:id 23 :operation :rf.resource/load-more-skipped
+    :tags {:resource/key [session-scope :feed/articles {:tag "clj"}]
+           :reason :no-next-page :page-count 3}}
+   ;; a deduped in-flight load-more skip
+   {:id 24 :operation :rf.resource/load-more-skipped
+    :tags {:resource/key [session-scope :feed/articles {:tag "clj"}]
+           :reason :in-flight :work/id [:rf.work/resource :feed 4]}}
+   ;; the THIRD error channel — a load-more page fetch FAILED (feed kept)
+   {:id 25 :operation :rf.resource/page-failed
+    :tags {:resource/key [session-scope :feed/articles {:tag "clj"}]
+           :generation 4 :status-before :loaded :status-after :loaded
+           :page-error {:kind :rf.http/server-error :status 500}}}])
+
+(deftest infinite-lifecycle-timeline-page-detail-test
+  (let [rows   (h/lifecycle-timeline infinite-trace-buffer)
+        by-id  (fn [id] (first (filter #(= id (:id %)) rows)))
+        lm     (by-id 20) appended (by-id 21) terminal (by-id 22)
+        skip-t (by-id 23) skip-if  (by-id 24) failed   (by-id 25)]
+    (testing "the four infinite ops are projected (in buffer order)"
+      (is (= [:rf.resource/load-more :rf.resource/page-appended
+              :rf.resource/page-appended :rf.resource/load-more-skipped
+              :rf.resource/load-more-skipped :rf.resource/page-failed]
+             (mapv :operation rows))))
+    (testing ":rf.resource/load-more retains param (egress-projected) + index + count"
+      (is (map? (:page lm)))
+      (is (= "\"cursor-1\"" (get-in lm [:page :page-param :preview]))
+          "the resolved cursor is egress-projected (summarized), not raw")
+      (is (= 1 (get-in lm [:page :page-index])))
+      (is (= 1 (get-in lm [:page :page-count])))
+      (is (not (contains? (:page lm) :next-page-param))
+          "load-more carries no next-page-param tag"))
+    (testing ":rf.resource/page-appended retains index/count/next-cursor/terminal"
+      (is (= 1 (get-in appended [:page :page-index])))
+      (is (= 2 (get-in appended [:page :page-count])))
+      (is (= "\"cursor-2\"" (get-in appended [:page :next-page-param :preview]))
+          "the derived next cursor is egress-projected")
+      (is (false? (get-in appended [:page :terminal?]))))
+    (testing "a TERMINAL page-appended surfaces :terminal? true + nil next"
+      (is (true? (get-in terminal [:page :terminal?])))
+      (is (= "nil" (get-in terminal [:page :next-page-param :preview]))))
+    (testing ":rf.resource/load-more-skipped retains the skip :reason"
+      (is (= :no-next-page (get-in skip-t [:page :reason])))
+      (is (= 3 (get-in skip-t [:page :page-count])))
+      (is (= :in-flight (get-in skip-if [:page :reason]))))
+    (testing ":rf.resource/page-failed surfaces the :page-error (summarized,
+              the THIRD error channel)"
+      (is (some? (get-in failed [:page :page-error])))
+      (is (contains? (get-in failed [:page :page-error]) :preview)))
+    (testing "a NON-infinite op (the plain lifecycle buffer) carries no :page"
+      (is (not (contains? (first (h/lifecycle-timeline trace-buffer)) :page))))))
+
+(deftest infinite-lifecycle-timeline-page-param-egress-test
+  ;; the cursor-bearing facts route through the single-arg egress-fn the way
+  ;; the off-box `get-resource-history` threads `resource-trace-egress-fn`.
+  (let [egress-fn (fn [_v] h/redacted-sentinel)   ; redact every value
+        rows      (h/lifecycle-timeline infinite-trace-buffer egress-fn)
+        by-id     (fn [id] (first (filter #(= id (:id %)) rows)))]
+    (testing "page-param / next-page-param / page-error redact off-box"
+      (is (:redacted? (get-in (by-id 20) [:page :page-param])))
+      (is (:redacted? (get-in (by-id 21) [:page :next-page-param])))
+      (is (:redacted? (get-in (by-id 25) [:page :page-error]))))
+    (testing "the metadata facts ride raw (NOT egressed)"
+      (is (= 1 (get-in (by-id 20) [:page :page-index])))
+      (is (= :no-next-page (get-in (by-id 23) [:page :reason])))
+      (is (true? (get-in (by-id 22) [:page :terminal?]))))))
 
 (deftest invalidation-graph-test
   (let [rows (h/invalidation-graph trace-buffer)]

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -1476,6 +1476,51 @@
           (is (not (preview-has? scope ":rf.size/large-elided"))
               ":include-large? true ⇒ the large leaf is no longer elided"))))))
 
+;; rf2-byl7bk.3.5 — get-resource-history MUST carry the EP-0021 infinite-feed
+;; page evidence (the `:page` detail) so MCP/AI callers can explain page
+;; accumulation, not just see that "load more" happened. The cursor-bearing
+;; facts (`:page-param` / `:next-page-param`) are egress-projected; the metadata
+;; (`:page-index` / `:page-count` / `:terminal?` / `:reason`) rides raw.
+(deftest get-resource-history-carries-ep0021-page-detail
+  (testing "rf2-byl7bk.3.5 — the four infinite ops surface their page facts"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (let [rkey [{:region "ap-southeast"} :feed/articles {:tag "clj"}]]
+      (emit-resource-trace-into-ring! :rf.resource/load-more
+                                      {:resource/key rkey :generation 4
+                                       :page-param "cursor-1"
+                                       :page-index 1 :page-count 1})
+      (emit-resource-trace-into-ring! :rf.resource/page-appended
+                                      {:resource/key rkey :generation 4
+                                       :page-index 1 :page-count 2
+                                       :next-page-param "cursor-2"
+                                       :terminal? false})
+      (emit-resource-trace-into-ring! :rf.resource/load-more-skipped
+                                      {:resource/key rkey
+                                       :reason :no-next-page :page-count 2})
+      (emit-resource-trace-into-ring! :rf.resource/page-failed
+                                      {:resource/key rkey :generation 4
+                                       :page-error {:kind :rf.http/server-error
+                                                    :status 500}})
+      (let [result (runtime/get-resource-history {:resource-id :feed/articles})
+            by-op  (fn [op] (first (filter #(= op (:operation %))
+                                           (:history result))))]
+        (is (true? (:ok? result)))
+        (testing "load-more carries the resolved cursor (egress-summarized) + index/count"
+          (let [page (:page (by-op :rf.resource/load-more))]
+            (is (preview-has? (:page-param page) "cursor-1")
+                "a non-sensitive cursor rides through verbatim in the summary")
+            (is (= 1 (:page-index page)))
+            (is (= 1 (:page-count page)))))
+        (testing "page-appended carries the derived next cursor + terminal flag"
+          (let [page (:page (by-op :rf.resource/page-appended))]
+            (is (preview-has? (:next-page-param page) "cursor-2"))
+            (is (= 2 (:page-count page)))
+            (is (false? (:terminal? page)))))
+        (testing "load-more-skipped carries the skip reason (raw metadata)"
+          (is (= :no-next-page (:reason (:page (by-op :rf.resource/load-more-skipped))))))
+        (testing "page-failed carries the page-error envelope (summarized)"
+          (is (some? (:page-error (:page (by-op :rf.resource/page-failed))))))))))
+
 (deftest list-resource-invalidations-redacts-value-bearing-fields-by-default
   (testing "rf2-e0mq7a — :scope (PII), :cause (may carry data), and each
             :matched key's scope are routed through egress-value BEFORE


### PR DESCRIPTION
Two EP-0021 Xray tooling correctness fixes on the same `tools/xray` surface (the spec was already correct; the panel projection lagged).

## rf2-byl7bk.3.4 — Xray omitted the infinite feed `:page-params`
The instance-row projection surfaced `:infinite?` / `:page-count` / `:cursor` / `:terminal?` / `:has-next-page?` / `:page-error` but **dropped the durable `:page-params` vector** — the ordered per-page cursor chain that explains how the accumulation advanced (explicitly NOT part of the feed cache key, so the only tool-facing record of the page-by-page fetch sequence; Spec 016 ~L1368, EP-0021 ~L573-575).

- `panels/resources_helpers.cljc` `instance-row` — project the entry's `:page-params`, **egress-projecting each cursor the SAME way `:cursor` is** (`(summarize (eg % :params))` — the rf2-3tysyj `:params`-slot cursor-egress treatment; cursors carry record ids → never ship raw).
- `panels/resources.cljs` — render the indexed chain (`p0 … pN`) as summary chips on the infinite instance row.
- helper tests — assert the chain projects (ordered, egress-summaries, non-sensitive feed rides verbatim) **and** redacts page-by-page on the off-box path (a `:sensitive?` owner); the nil page-0 seed has nothing to redact (stays nil).

**Reproduced before the fix:** yes. The fixture (`infinite-entries`) already set `:page-params [nil "cursor-1"]` / `[nil]`, but `instance-row` never read the slot, so the projected rows had no `:page-params` key at all — the new assertions fail on `origin/main`.

## rf2-byl7bk.3.5 — resource history dropped infinite trace details
`lifecycle-timeline` projected only the generic fields (operation/label/class/resource-id/key/generation/work-id/owner/cause/status), and `get-resource-history` returns that same projection — so MCP/AI callers lost the page evidence too (Spec 016 ~L1361-1368, `tools/xray/spec/024` ~L423-426).

- `panels/resources_helpers.cljc` — new `page-detail` helper + `lifecycle-timeline` retains a `:page` detail map for the four load-more family ops (`load-more` / `page-appended` / `page-failed` / `load-more-skipped`): cursor-bearing facts `:page-param` / `:next-page-param` + the `:page-error` envelope **egress-projected** (consistent with 3.4 / 3tysyj); raw metadata `:page-index` / `:page-count` / `:terminal?` / `:reason` ride verbatim. A non-infinite op carries no `:page` slot.
- `runtime.cljs` `get-resource-history` — **unchanged**; it already threads the `egress-fn` into `lifecycle-timeline`, so it now carries the `:page` detail automatically.
- `panels/resources.cljs` `timeline-row-view` — render the page facts (param / idx / pages / next / terminal / reason / page-error).
- helper + runtime tests — assert the `:page` detail retains all four ops' facts; cursor-bearing facts egress-project (and redact off-box); metadata rides raw; `get-resource-history` carries the detail through end-to-end.

**Reproduced before the fix:** yes. `lifecycle-timeline` built the row map with no `:page` key for any op, so the new assertions (`get-in row [:page :page-param]` etc.) all fail on `origin/main`.

## Xray spec currency
spec/024 was **not** fully current after all: the trace-family emit table (L423-426) listed the per-op facts, but the §2 Live-instances surface had not enumerated `:page-params` and the §5 Lifecycle-timeline section had not enumerated the `:page` detail. Both are genuine panel-spec gaps that the normative Spec 016 / EP-0021 text already required, so they are updated in this PR (per the Xray-spec-currency rule). No spec/016 or EP-0021 edits — those were already correct.

## Quality gates (all green)
```
cd implementation && npm run test:cljs          # Ran 7975 tests, 33238 assertions — 0 failures, 0 errors
npm run test:xray-feature-gate                   # 15 scenarios (nightly-full sweep), 0 failures, 13 matrix rows
npm run test:mcp-conformance                     # ALL MCP-CONFORMANCE GATES GREEN (incl. get-resource-history wire-vocab)
```
