### PR TITLE
fix(schemas): align schema-validation elision marker to :reason :frame + :hint; scrub retired spec/010 egress route (rf2-9wvwpa)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -105,7 +105,8 @@
   `:event` (duplicate of `:received`) and `:malli-error` (duplicate of
   `:explain`) tags have been dropped — consumers reach for `:received`
   / `:value` / `:explain`."
-  (:require [re-frame.error :as error]
+  (:require [re-frame.elision :as elision]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -154,42 +155,38 @@
 ;; schema declares any `:large?` slot and NO `:sensitive?` slot governs the
 ;; redaction — a sensitive failure already scrubs to `:rf/redacted`, and a
 ;; sensitive marker would itself leak the secret's `:path` / `:bytes` size
-;; signature. Mirrors `re-frame.marks/large-marker`'s shape (kept local so the
-;; schemas artefact carries no dependency on the core `marks` ns + its elision
-;; / substrate-adapter graph).
-
-(defn- ->bytes
-  "Byte-count of a value's printed representation. The `:bytes` slot of the
-  `:rf.size/large-elided` marker (mirrors `re-frame.marks/->bytes`)."
-  [v]
-  #?(:clj  (count (.getBytes ^String (pr-str v) "UTF-8"))
-     :cljs (count (pr-str v))))
-
-(defn- value-type
-  [v]
-  (cond
-    (map? v)    :map
-    (vector? v) :vector
-    (set? v)    :set
-    (string? v) :string
-    :else       :scalar))
+;; signature. The marker is built by the canonical `re-frame.elision/->marker`
+;; (core, NOT the `marks` ns) so the shape physically cannot drift from the
+;; `:rf/elision-marker` contract again (rf2-9wvwpa). `re-frame.elision` lives in
+;; core — the artefact the schemas surface already depends on (cf.
+;; `re-frame.frame` above) — and carries no concrete substrate-adapter
+;; dependency (it `:require`s only the `re-frame.substrate.adapter` *contract*
+;; ns, a sibling of `re-frame.frame`).
 
 (defn- large-marker
   "Build the `:rf.size/large-elided` marker for the whole failing value `v`.
-  Per Spec-Schemas §`:rf/elision-marker` / Spec 009 §Wire marker. `:reason
-  :schema` records that the elision was nominated by a `:large?` schema slot
-  (distinct from the `:marks` / `:frame` provenance the app-db egress path
-  carries). `:path []` — the marker substitutes the WHOLE value-bearing slot,
-  matching the whole-payload nature of these slots (a single marker, not a
-  path-walk; the value-bearing slots carry the whole checked value, not a
-  leaf)."
+  Conforms to Spec-Schemas §`:rf/elision-marker` / Spec 009 §Wire marker by
+  delegating to the canonical `re-frame.elision/->marker` — the marker shape
+  (`:path`, `:bytes`, `:type`, `:reason`, `:hint`, `:handle`) is therefore
+  identical to every other framework emission and cannot drift (rf2-9wvwpa).
+
+  `:reason :frame` — post-EP-0015 §8 the egress `:reason` enum is
+  `[:frame :marks]` (Spec-Schemas §`:rf/elision-marker`); `:frame` is the
+  declarative/registration-time default in `->marker`. No imperative mark
+  created this elision, and the validation-failure provenance is already on
+  the enclosing trace envelope (`:operation
+  :rf.error/schema-validation-failure` + `:where` + `:tags :large? true`), so
+  the marker carries no `:reason :schema` carve-out.
+
+  `:hint nil` — the slot is REQUIRED by the contract (Spec 009 §Wire marker
+  permits a nil value); the whole-value substitution has no human-facing
+  re-fetch hint distinct from the trace envelope.
+
+  `:path []` — the marker substitutes the WHOLE value-bearing slot, matching
+  the whole-payload nature of these slots (a single marker, not a path-walk;
+  the value-bearing slots carry the whole checked value, not a leaf)."
   [v]
-  {:rf.size/large-elided
-   {:path   []
-    :bytes  (->bytes v)
-    :type   (value-type v)
-    :reason :schema
-    :handle [:rf.elision/at []]}})
+  (elision/->marker v [] {:reason :frame :hint nil}))
 
 (defn- elide-large-slots
   "Substitute the `:rf.size/large-elided` marker (for `v`, the whole checked

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -1680,8 +1680,10 @@
         ":sensitive? is not :large? — the flags are independent")))
 
 (deftest large-marker-fields
-  (testing "rf2-vmhu4i — the elided value-bearing slot carries a well-formed
-            :rf.size/large-elided marker with :reason :schema provenance"
+  (testing "rf2-vmhu4i / rf2-9wvwpa — the elided value-bearing slot carries a
+            well-formed :rf.size/large-elided marker conformant to the
+            post-EP-0015 §8 [:frame :marks] :reason enum (NOT the retired
+            :reason :schema), with the REQUIRED :hint slot present"
     (let [blob   (apply str (repeat 200 "X"))
           traces (atom [])]
       (rf/register-listener! ::lgm (fn [ev] (swap! traces conj ev)))
@@ -1694,7 +1696,9 @@
             marker (-> v :tags :value :rf.size/large-elided)]
         (is (some? v) "a validation-failure trace fired")
         (is (map? marker) ":value carries a :rf.size/large-elided marker")
-        (is (= :schema (:reason marker)) ":reason :schema (schema-nominated elision)")
+        (is (= :frame (:reason marker))
+            ":reason :frame — conforms to the post-EP-0015 [:frame :marks] enum")
+        (is (contains? marker :hint) ":hint slot present (REQUIRED by the contract)")
         (is (integer? (:bytes marker)) ":bytes is a byte count")
         (is (= [:rf.elision/at []] (:handle marker)) ":handle is the fetch handle")
         (is (true? (-> v :tags :large?)) ":tags :large? stamped")

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -282,7 +282,12 @@ Inside the schema value passed to `reg-app-schema`, individual slots may carry p
 
 ### `:large?` — schema-driven size-elision nomination
 
-Slots marked `:large? true` are the **canonical AI-discoverable entry point** for the size-elision nomination contract catalogued at [009 §Size elision in traces](009-Instrumentation.md#size-elision-in-traces). The runtime walks every registered **app-db** schema at boot (and on `reg-app-schema` re-registration), and writes a `{:large? true :hint <str-or-nil> :source :schema}` entry into the frame's runtime-db `[:rf.runtime/elision :declarations <path>]` slot for every flagged path (the declarations describe app-db paths but the records are runtime bookkeeping). The framework's `rf/elide-wire-value` walker (per [API.md §`rf/elide-wire-value`](API.md#elide-wire-value-the-wire-boundary-walker)) consults the merged registry on every wire-boundary emit and substitutes the `:rf.size/large-elided` marker (per [Spec-Schemas §`:rf/elision-marker`](Spec-Schemas.md#rfelision-marker)) in place of the elided value.
+Slots marked `:large? true` declare, on a schema, that the value at the slot is **large** — a structural fact about the data's shape, for use by the owner-local size-elision classifiers that consume a schema (catalogued at [009 §Size elision in traces](009-Instrumentation.md#size-elision-in-traces)). Per **EP-0015 §8 (Schemas Describe Shape, Not Public Egress Policy)** — normative in [015 §Frame-owned durable classification](015-Data-Classification.md#frame-owned-durable-classification) — a `reg-app-schema` `{:large? true}` slot prop is **NOT** a route into the frame's durable app-db egress registry: durable app-db classification is **frame-owned** (`(rf/reg-frame :app/main {:large {:app-db [[:user :uploaded-pdf]]}})`, installed under `:source :frame`), and the `rf/elide-wire-value` wire-boundary walker consults that frame-owned registry only. Schemas describe shape and validation; frames own durable public egress.
+
+The walker that extracts a schema's `:large?` paths — `re-frame.schemas/extract-large-paths-from-schema`, published through the late-bind hook table as `:schemas/extract-large-paths-from-schema` so `re-frame.core` reaches it without statically requiring the schemas artefact — has exactly **two** live consumers:
+
+1. **Owner-local egress classifiers (EP-0015 §8).** The http resource, `reg-pull` resource, and machine `:data` surfaces each consult their own `:data-schema`'s `:large?` slots to size-elide their own egress products (`re-frame.http.privacy-body`, `re-frame.resources.classification`, `re-frame.machines.lifecycle-fx.registration`). The elision is owner-local — it scopes to that owner's egress value, not to a shared app-db registry.
+2. **The validation-failure size-safety arm** (immediately below) — the schema's own egress product, the `:rf.error/schema-validation-failure` trace.
 
 ```clojure
 (rf/reg-app-schema
@@ -291,20 +296,16 @@ Slots marked `:large? true` are the **canonical AI-discoverable entry point** fo
    [:profile     [:map [:name :string] [:email :string]]]
    [:uploaded-pdf {:large? true :hint "Upload preview blob"} :string]])
 
-;; At boot, the framework populates (in runtime-db):
-;;   {:rf.runtime/elision
-;;     {:declarations
-;;       {[:user :uploaded-pdf] {:large? true
-;;                               :source :schema
-;;                               :hint   "Upload preview blob"}}}}
+;; `extract-large-paths-from-schema` yields the schema's large-path
+;; declarations for an owner-local classifier to consume:
+;;   {[:user :uploaded-pdf] {:large? true
+;;                           :source :schema
+;;                           :hint   "Upload preview blob"}}
 ;;
-;; Every wire-boundary emit thereafter substitutes the path with:
-;;   {:rf.size/large-elided {:path   [:user :uploaded-pdf]
-;;                            :bytes  5242880
-;;                            :type   :string
-;;                            :reason :schema
-;;                            :hint   "Upload preview blob"
-;;                            :handle [:rf.elision/at [:user :uploaded-pdf]]}}
+;; This does NOT populate the frame's durable app-db elision registry
+;; (EP-0015 §8 — that registry is frame-owned, `:source :frame`). To
+;; size-elide an app-db path on the wire, declare it on the FRAME:
+;;   (rf/reg-frame :app/main {:large {:app-db [[:user :uploaded-pdf]]}})
 ```
 
 The `:large?` flag may live in two structural positions inside the schema:
@@ -335,15 +336,13 @@ Nesting works as expected — `:large?` on a deeply-nested slot resolves to the 
 
 Combinators (`:or`, `:and`, `:maybe`, `:tuple`, `:multi`, `:vector`, `:set`) descend at the parent path — these ops don't introduce a new app-db path segment. `:multi` branch slot-level props apply to the dispatched-value's path (the `:multi`'s own path); the inner branch schema's name slots add further sub-paths.
 
-**Conflict resolution.** Schema metadata is canonical. Re-running schema-driven registry population replaces the schema-owned declaration slot from the current schema set; re-registering a schema with a new `:hint` refreshes the marker hint, and removing `:large?` prunes the stale declaration.
+**Registration is a single atomic write.** Per **EP-0015 §8** (rf2-d2r3um) a `reg-app-schema` is a bare atomic write to the per-frame schema side-table and nothing more — schemas no longer feed any app-db egress registry, so there is **no second schema→elision/sensitive population step** and no per-frame linearization lock guarding it. (The pre-EP-0015 two-step write — side-table, then a derived registry refresh — and the per-frame monitor that ordered them are both retired: the off-box-redaction-loss race that lock guarded cannot exist when no registry is populated from the schema. The `extract-large-paths-from-schema` walker is now invoked only by the owner-local classifiers and the validation-failure arm, at their own emit/registration sites, against the schema directly.)
 
-**Per-frame linearizability.** Each `reg-app-schema` performs two writes — the per-frame schema side-table, then the schema-derived elision/sensitive registry refresh computed from it — and `reg-app-schemas` performs a batch of side-table writes followed by one final refresh. These MUST be **linearizable per frame**: a registration's refresh always reflects a schema-table snapshot that already includes that registration's own write, and the last refresh to land on a frame reflects the latest committed table. Without this, two concurrent registrations against the same frame can interleave so a stale snapshot's refresh lands last and DROPS another registration's just-added declaration from the runtime registry while the schema table still holds it — leaving a `:sensitive?`-marked slot un-redacted (or a `:large?` slot un-elided) on a wire / trace / epoch / hydration emit that fires before the next full repopulate, an off-box privacy leak. The CLJS reference enforces this with a per-frame registration monitor held across the side-table write and the refresh (JVM-only; CLJS is single-threaded so no interleaving is possible). Disjoint frames never contend.
+**Idempotency.** The `extract-large-paths-from-schema` walker is pure data — re-running it against the same schema produces the same large-path declarations, so an owner-local classifier that re-derives them on re-registration sees a stable result.
 
-**Idempotency.** The walker is pure data and the population is idempotent — re-running it against the same `(db, schema-set)` pair produces the same result. Schemas registered, then re-registered, then walked again yield the same declarations.
+**Other ports.** The `:large?` mechanism is portable in spirit: any port whose schema language carries per-slot properties (Zod's `.describe` / refinements; Pydantic's `Field`'s arbitrary kwargs; dry-rb's metadata) can plug the same predicate into the same walker shape. The CLJS reference's walker lives in the schemas artefact (`re-frame.schemas/extract-large-paths-from-schema`) and is published through the late-bind hook table — its consumers (the owner-local classifiers, per the [§`:large?` consumers](#large--schema-driven-size-elision-nomination) list above) call it without statically requiring the schemas artefact (per the per-feature artefact split).
 
-**Other ports.** The `:large?` mechanism is portable in spirit: any port whose schema language carries per-slot properties (Zod's `.describe` / refinements; Pydantic's `Field`'s arbitrary kwargs; dry-rb's metadata) can plug the same predicate into the same registry shape. The CLJS reference's walker lives in the schemas artefact (`re-frame.schemas/extract-large-paths-from-schema`) and is published through the late-bind hook table — `re-frame.core` calls it without statically requiring the schemas artefact (per the per-feature artefact split).
-
-**`:large?` in validation-failure traces — the size-safety arm.** A `:rf.error/schema-validation-failure` trace carries the **whole checked value verbatim** in its value-bearing slots (`:value` / `:received` / `:explain`, plus the per-surface `:rf.fx/args` / `:rf.sub/query-v`). A validation error is an egress surface like any other, so a `:large?`-flagged blob inside the failing value would ride the whole payload into the trace bus / epoch / MCP / log sinks unless the emit-site elides it. Symmetric with the `:sensitive?` redaction below: when the registered schema declares **any** `:large?` slot (and no `:sensitive?` slot governs the redaction), the validation emit-site substitutes the `:rf.size/large-elided` marker (per [Spec-Schemas §`:rf/elision-marker`](Spec-Schemas.md#rfelision-marker), `:reason :schema`) for the whole value-bearing slots and stamps `:tags :large? true`. **Sensitive wins** over large — see [§Composition with `:large?`](#sensitive--privacy-in-schema-validation-error-traces) — a both-flagged or sensitive slot redacts to `:rf/redacted` instead (the size marker itself would leak a secret's `:path` / `:bytes` signature). A non-`:large?`, non-`:sensitive?` failure rides verbatim, exactly as before — the elision is precise, not a blanket marker. The CLJS reference's whole-schema predicate is `re-frame.schemas/schema-has-large?` (the mirror of `schema-has-sensitive?`).
+**`:large?` in validation-failure traces — the size-safety arm.** A `:rf.error/schema-validation-failure` trace carries the **whole checked value verbatim** in its value-bearing slots (`:value` / `:received` / `:explain`, plus the per-surface `:rf.fx/args` / `:rf.sub/query-v`). A validation error is an egress surface like any other, so a `:large?`-flagged blob inside the failing value would ride the whole payload into the trace bus / epoch / MCP / log sinks unless the emit-site elides it. Symmetric with the `:sensitive?` redaction below: when the registered schema declares **any** `:large?` slot (and no `:sensitive?` slot governs the redaction), the validation emit-site substitutes the canonical `:rf.size/large-elided` marker (per [Spec-Schemas §`:rf/elision-marker`](Spec-Schemas.md#rfelision-marker)) for the whole value-bearing slots and stamps `:tags :large? true`. The marker is built by the canonical `re-frame.elision/->marker` and carries `:reason :frame` (the post-EP-0015 §8 `[:frame :marks]` enum default — schemas no longer carry a distinct `:reason :schema` egress vocabulary; the validation-failure provenance is already on the enclosing trace's `:operation` / `:where` / `:tags :large?`) plus the required `:hint` slot. **Sensitive wins** over large — see [§Composition with `:large?`](#sensitive--privacy-in-schema-validation-error-traces) — a both-flagged or sensitive slot redacts to `:rf/redacted` instead (the size marker itself would leak a secret's `:path` / `:bytes` signature). A non-`:large?`, non-`:sensitive?` failure rides verbatim, exactly as before — the elision is precise, not a blanket marker. The CLJS reference's whole-schema predicate is `re-frame.schemas/schema-has-large?` (the mirror of `schema-has-sensitive?`).
 
 ### `:sensitive?` — privacy in schema-validation error traces
 

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -113,5 +113,21 @@
                        ;; classpath dependency intentional, mirroring the
                        ;; diff-encode + de-dupe live-emission gates.
                        day8/re-frame2
-                       {:local/root "../../../implementation/core"}}
+                       {:local/root "../../../implementation/core"}
+                       ;; rf2-9wvwpa — the SECOND framework emitter of the
+                       ;; `:rf.size/large-elided` marker:
+                       ;; `re-frame.schemas.validate/validate-event!`'s
+                       ;; validation-failure size-safety arm (Spec 010
+                       ;; §`:large?`). hvn83u's live gate drove only the
+                       ;; `re-frame.elision/elide-wire-value` walker; the
+                       ;; schemas-artefact emitter sat fixture-free — exactly
+                       ;; the blind spot that let `validate.cljc` ship a
+                       ;; non-conformant `:reason :schema` / no-`:hint`
+                       ;; marker. `:local/root` to the schemas artefact puts
+                       ;; `re-frame.schemas` on the JVM classpath so the gate
+                       ;; below can drive the REAL validation-failure emitter
+                       ;; LIVE and validate its marker against the same
+                       ;; canonical `ElisionMarker` schema.
+                       day8/re-frame2-schemas
+                       {:local/root "../../../implementation/schemas"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -101,6 +101,14 @@
             [re-frame.elision :as elision]
             [re-frame.frame  :as frame]
             [re-frame.frame-classification :as frame-class]
+            ;; rf2-9wvwpa — the SECOND framework emitter of the
+            ;; `:rf.size/large-elided` marker: the schemas-artefact
+            ;; validation-failure size-safety arm (Spec 010 §`:large?`).
+            ;; Required so the gate below can drive `validate-event!`
+            ;; LIVE over a `:large?`-flagged schema and validate the
+            ;; emitted failure-trace marker against `ElisionMarker`.
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.overflow :as mcp-overflow]
@@ -736,6 +744,77 @@
                          :hint   nil
                          :handle [:rf.elision/at [:user :uploaded-pdf]]}}))
       ":reason :schema is the retired pre-EP-0015 shape and MUST NOT validate"))
+
+;; ---------------------------------------------------------------------------
+;; :rf.size/large-elided — SECOND live emitter (rf2-9wvwpa).
+;;
+;; hvn83u's gate above drives the wire-elision walker
+;; (`re-frame.elision/elide-wire-value`). But the framework has a SECOND
+;; runtime emitter of the same marker: the schemas-artefact validation-
+;; failure size-safety arm. When a `:large?`-flagged schema slot fails
+;; validation, `re-frame.schemas.validate/validate-event!` substitutes the
+;; `:rf.size/large-elided` marker into the value-bearing trace slots
+;; (Spec 010 §`:large?`) so the raw blob never rides the
+;; `:rf.error/schema-validation-failure` trace.
+;;
+;; That emitter sat FIXTURE-FREE — exactly the blind spot that let
+;; `validate.cljc` ship a non-conformant marker (`:reason :schema`, outside
+;; the post-EP-0015 [:frame :marks] enum, and the REQUIRED `:hint` slot
+;; omitted) while its docstring falsely claimed `:rf/elision-marker`
+;; conformance. The fix delegates to the canonical `elision/->marker`; this
+;; gate drives the REAL `validate-event!` emitter LIVE and validates the
+;; emitted marker against the SAME canonical `ElisionMarker` schema, so a
+;; future drift on the schemas-artefact path turns red here — symmetric to
+;; hvn83u's `elide-wire-value` gate.
+
+(defn- schema-validation-failure-marker
+  "Drive `re-frame.schemas.validate/validate-event!` LIVE over a
+  `:large?`-flagged schema slot whose value fails validation, capture the
+  `:rf.error/schema-validation-failure` trace, and return the
+  `:rf.size/large-elided` marker substituted into its `:value` slot."
+  [blob]
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (let [traces (atom [])]
+    (rf/register-listener! ::sv (fn [ev] (swap! traces conj ev)))
+    (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
+                             {:schema [:cat [:= :upload/save]
+                                       [:map [:blob {:large? true} :int]]]})
+    (rf/unregister-listener! ::sv)
+    (-> (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                       @traces))
+        :tags :value)))
+
+(deftest schema-validation-failure-marker-emitted-live-validates
+  ;; Drive the REAL schemas-artefact validation-failure emitter and assert
+  ;; the substituted marker (a) is the canonical single-key wrapper and (b)
+  ;; validates against `ElisionMarker` — the gate that would have caught the
+  ;; `:reason :schema` / missing-`:hint` non-conformance this bead fixed.
+  (let [blob   (apply str (repeat 200 "X"))
+        marker (schema-validation-failure-marker blob)]
+    (testing "validate-event! substitutes a :rf.size/large-elided marker on a :large? failure"
+      (is (elision/marker? marker)
+          (str "validate-event! MUST substitute a :rf.size/large-elided "
+               "marker for a :large?-flagged slot's failure. Got: "
+               (pr-str marker))))
+    (testing "the live-emitted validation-failure marker validates against ElisionMarker"
+      (is (m/validate ElisionMarker marker)
+          (str "Live-emitted schema-validation-failure marker failed "
+               "ElisionMarker validation — the schemas-artefact emitter has "
+               "drifted from the canonical contract (rf2-9wvwpa):\n"
+               (me/humanize (m/explain ElisionMarker marker)))))
+    (testing "the live :reason is the post-EP-0015 frame-owned default, NOT the retired :schema"
+      (is (= :frame (get-in marker [:rf.size/large-elided :reason]))
+          (str "The validation-failure marker MUST emit :reason :frame "
+               "(post-EP-0015 §8 [:frame :marks] enum). Got: "
+               (pr-str (get-in marker [:rf.size/large-elided :reason])))))
+    (testing "the marker carries the REQUIRED :hint slot"
+      (is (contains? (:rf.size/large-elided marker) :hint)
+          ":hint is REQUIRED by ElisionMarkerBody (was previously omitted)"))
+    (testing "the large blob survives nowhere verbatim in the marker"
+      (is (not (str/includes? (pr-str marker) blob))
+          "the whole-value substitution must not re-leak the blob"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Source-text vocabulary pin. The literal marker key MUST appear in


### PR DESCRIPTION
Implements the RULED decision **rf2-9wvwpa** (Option B — ALIGN, do not widen the enum).

## Problem
The schemas-artefact validation-failure size-safety arm (`re-frame.schemas.validate/large-marker`) hand-built a `:rf.size/large-elided` marker with `:reason :schema` — a THIRD value outside the post-EP-0015 §8 `:rf/elision-marker` `:reason` enum `[:frame :marks]` — and **omitted the REQUIRED `:hint` slot**, while its docstring falsely claimed `§:rf/elision-marker` conformance. A test (`large-marker-fields`) pinned the wrong shape, and no conformance gate validated this second framework emitter (hvn83u's live gate covered only `re-frame.elision/elide-wire-value`).

## Change (Option B)
- **`validate.cljc`** — `large-marker` now **delegates to the canonical `re-frame.elision/->marker`** with `{:reason :frame :hint nil}`, so the marker shape physically cannot drift from the contract again. `re-frame.elision` lives in core (already on the schemas classpath via `re-frame.frame`) and pulls no concrete substrate adapter — only the `re-frame.substrate.adapter` *contract* ns. Dead local `->bytes` / `value-type` helpers removed; the "kept local" head comment dropped. Docstring rewritten to cite `[:frame :marks]` + EP-0015 §8.
- **`schemas_sensitive_test.clj`** — fixed `large-marker-fields` (was asserting `(= :schema (:reason marker))`) to assert `:reason :frame` + `(contains? marker :hint)`.
- **wire-vocab conformance** — added a live-emission gate `schema-validation-failure-marker-emitted-live-validates` that drives the REAL `validate-event!` emitter over a `:large?`-flagged schema and validates the emitted failure-trace marker against the canonical `ElisionMarker` schema. Symmetric to hvn83u's `elide-wire-value` gate; closes the schemas-artefact blind spot. Adds `day8/re-frame2-schemas` as a test-only `:local/root` dep. **Proven load-bearing**: reverting to the pre-fix `:reason :schema`/no-`:hint` shape turns it RED (3 failures).
- **`spec/010-Schemas.md`** (hot-zone) — scrubbed the RETIRED schema→app-db-egress-registry route (boot-walk → `[:rf.runtime/elision :declarations]` write + the two-step linearization-lock paragraph), both abolished by EP-0015 §8 and contradicted by live `storage.cljc:675-679`. Rewrote §`:large?` to describe only the live mechanisms (frame-owned `:large` decls + the two `extract-large-paths-from-schema` consumers: owner-local egress classifiers + the validation-failure arm), and changed the validation-failure `:reason :schema` → `:frame`.

`spec/Spec-Schemas.md` needed no edit — its `:rf/elision-marker` `:reason` enum was already `[:enum :frame :marks]` and carried no `:reason :schema` residue.

## Quality gates (all green)
```
cd implementation/schemas && clojure -M:test
#   Ran 311 tests containing 18809 assertions. 0 failures, 0 errors.

cd tools/mcp-conformance/wire-vocab && clojure -M:test
#   Ran 101 tests containing 1059 assertions. 0 failures, 0 errors.
#   (new gate proven RED on the pre-fix non-conformant shape, then restored green)

cd implementation && npm run test:cljs
#   Ran 7975 tests containing 33214 assertions. 0 failures, 0 errors.

rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict
#   Documentation built in 12.32 seconds (no warnings)
```