### PR TITLE
fix(machines): align history recording to XState v5 exit-set rule (strict <) + re-model fixtures (rf2-9eidiv)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1611,15 +1611,19 @@
   `lca-len`, write each history-bearing compound's last-active configuration
   into the snapshot's `:rf/history` slot.
 
-  A history-owning compound `C` records iff the exit cascade leaves the
-  child subtree beneath `C` — i.e. `C` is a prefix of `src-path` with an
-  active child below it (`(count src-path) > (count C-path)`) AND that
-  child is being exited (`lca-len <= (count C-path)`, so the child at depth
-  `(count C-path)` sits at-or-below the LCA boundary). The compound `C`
-  itself need not be exited — moving between two children of `C` (LCA = C)
-  still tears down `C`'s current child subtree, which is exactly what
-  history captures. A transition staying entirely within `C`'s current
-  child (LCA strictly below `C`'s child) records nothing for `C`.
+  A history-owning compound `C` records iff `C` is itself in the EXIT SET
+  — i.e. `C` is a prefix of `src-path` with an active child below it
+  (`(count src-path) > (count C-path)`) AND `C` itself is being exited
+  (`lca-len < (count C-path)`, so `C`'s node — at index `(count C-path) - 1`
+  along `src-path` — sits strictly below the surviving LCA boundary and is
+  torn down). This aligns with the XState v5 / W3C SCXML gold standard
+  (Appendix D writes the history value while iterating `statesToExit`):
+  history captures \"where this compound was when WE LEFT IT\", so the
+  compound must actually be left. A transition that merely moves between
+  two children of `C` (LCA = C, so `C` SURVIVES as the LCCA) records
+  NOTHING for `C` — `C` was never exited, so there is no last-active
+  configuration to remember (rf2-9eidiv: ruled ALIGN to the exit-set rule,
+  retiring the prior `<=` active-child-subtree-teardown trigger).
 
   Returns `[snapshot recorded]` where `recorded` is the seq of
   `{:compound-path :recorded-config :kind :prev-config}` maps (for the
@@ -1634,12 +1638,16 @@
   (let [src-path (vec src-path)
         n        (count src-path)]
     ;; Walk every prefix of `src-path` that could own history (depth 0..n-1;
-    ;; a leaf at depth n-1 has no child below it). A prefix `C-path` records
-    ;; iff its child at depth `(count C-path)` is exited: `lca-len <= depth`.
+    ;; a leaf at depth n-1 has no child below it). A prefix `C-path` of
+    ;; length `depth` records iff the compound `C` it names is itself in the
+    ;; EXIT SET — its node (index `depth - 1` along `src-path`) lies strictly
+    ;; below the surviving LCA boundary: `lca-len < depth`. (A move BETWEEN
+    ;; `C`'s children leaves `lca-len = depth`, so `C` survives as the LCCA
+    ;; and records nothing — the XState v5 / SCXML exit-set rule, rf2-9eidiv.)
     (reduce
       (fn [[snap recs] depth]
         (let [compound-path (subvec src-path 0 depth)
-              entry         (when (<= lca-len depth)
+              entry         (when (< lca-len depth)
                               (record-history-config machine compound-path src-path))]
           (if entry
             (let [[hkey config] entry

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -56,37 +56,45 @@
     (is (result/ok? r) (str "transition ok for event " (pr-str event)))
     (result/snap r)))
 
-;; A media-player compound with a DEEP history pseudo-state. `:play` from
-;; `:stopped` targets the history node, which restores the recorded leaf
-;; beneath `:player` (or `:default-target` on first entry).
+;; A media-player chart whose `:playing` COMPOUND owns a DEEP history
+;; pseudo-state. Per the XState v5 / SCXML exit-set rule (rf2-9eidiv), only
+;; a compound that is GENUINELY EXITED records history — so the history
+;; owner must be a compound the transition leaves. Here `:stop` exits the
+;; whole `:playing` subtree to its sibling `:stopped`, recording `:playing`'s
+;; last-active leaf; `:play` re-enters via `[:player :playing :hist]`, which
+;; restores the recorded leaf (or `:default-target` on first entry).
 (def deep-player
   {:initial :player
    :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history
-                                   :deep? true
-                                   :default-target :playing}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
                          :playing {:initial :at-start
                                    :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                   :states  {:hist      {:type :history
+                                                         :deep? true
+                                                         :default-target :at-start}
+                                             :at-start  {:on {:seek :mid-track}}
                                              :mid-track {:on {:stop [:player :stopped]}}}}
                          :paused  {:on {:resume [:player :playing]}}}}}})
 
-;; Same shape but SHALLOW (no `:deep?`). On restore the recorded DIRECT CHILD
-;; is descended through its own `:initial` chain — so a deep-leaf at exit
-;; restores only to the child's `:initial`, not the exact leaf.
+;; SHALLOW history that records `:player`'s DIRECT CHILD (`:playing`). Under
+;; the exit-set rule a SHALLOW recording of a direct child requires the
+;; OWNING compound (`:player`) to be genuinely exited — so this mirrors the
+;; SCXML test388 `:s0 -> :away` external-sibling shape: `:eject` leaves the
+;; whole `:player` subtree to its top-level sibling `:tray`, recording
+;; `:player`'s direct child; `:insert` re-enters via `[:player :hist]`, which
+;; restores the recorded child then descends ITS `:initial` chain (so a deep
+;; leaf at exit restores only to the child's `:initial`, not the exact leaf).
 (def shallow-player
   {:initial :player
-   :states  {:player
-              {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history
-                                   :default-target :playing}
-                         :playing {:initial :at-start
-                                   :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
-                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}})
+   :states  {:player {:initial :stopped
+                      :on      {:eject :tray}
+                      :states  {:hist    {:type :history :default-target :playing}
+                                :stopped {}
+                                :playing {:initial :at-start
+                                          :states  {:at-start  {:on {:seek :mid-track}}
+                                                    :mid-track {}}}}}
+             :tray   {:on {:insert [:player :hist]}}}})
 
 (defn- seed
   "A fresh pure-call snapshot positioned at `state`."
@@ -94,25 +102,29 @@
   {:state state :data {} :rf/spawn-counter {}})
 
 (deftest deep-history-records-and-restores-leaf
-  (testing "DEEP history records the full leaf path on exit and restores it on re-entry"
-    ;; Position deep into the subtree, then leave via :stop (absolute target,
-    ;; so the post-state is the vector [:player :stopped]).
+  (testing "DEEP history records the full leaf path on the OWNING compound's exit and restores it on re-entry"
+    ;; Position deep into :playing, then exit the whole :playing subtree via
+    ;; :stop (absolute target [:player :stopped]) — :playing is genuinely
+    ;; exited, so its deep history records the full leaf path.
     (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])]
       (is (= [:player :stopped] (:state after-stop)) "exited to :stopped")
-      (is (= [:player :playing :mid-track] (get-in after-stop [:rf/history [:player]]))
-          "deep history recorded the full absolute leaf path under :player")
-      ;; Re-enter via the history pseudo-state.
+      (is (= [:player :playing :mid-track] (get-in after-stop [:rf/history [:player :playing]]))
+          "deep history recorded the full absolute leaf path under :playing (the exited owner)")
+      ;; Re-enter via the history pseudo-state under :playing.
       (let [restored (step deep-player after-stop [:play])]
         (is (= [:player :playing :mid-track] (:state restored))
             "deep history restored the exact recorded leaf, not :initial")))))
 
 (deftest shallow-history-records-child-and-cascades-initial
   (testing "SHALLOW history records the direct child + cascades its :initial on restore"
-    (let [after-stop (step shallow-player (seed [:player :playing :mid-track]) [:stop])]
-      (is (= [:player :stopped] (:state after-stop)) "exited to :stopped")
-      (is (= :playing (get-in after-stop [:rf/history [:player]]))
+    ;; :eject exits the whole :player subtree to its sibling :tray — :player
+    ;; is genuinely exited (the SCXML test388 external-sibling shape), so its
+    ;; shallow history records the direct child (:playing).
+    (let [after-eject (step shallow-player (seed [:player :playing :mid-track]) [:eject])]
+      (is (= :tray (:state after-eject)) "ejected to the :tray sibling")
+      (is (= :playing (get-in after-eject [:rf/history [:player]]))
           "shallow history recorded the direct child keyword (:playing)")
-      (let [restored (step shallow-player after-stop [:play])]
+      (let [restored (step shallow-player after-eject [:insert])]
         ;; Shallow descends :playing's :initial (:at-start), NOT the exact
         ;; exit leaf (:mid-track).
         (is (= [:player :playing :at-start] (:state restored))
@@ -120,25 +132,29 @@
 
 (deftest default-target-on-first-entry
   (testing "first entry (nothing recorded) resolves the pseudo-state's :default-target"
-    ;; No prior exit ⇒ no recording ⇒ :default-target :playing → :at-start.
-    ;; (The restore transition ALSO records :stopped on its way out — leaving
-    ;; :stopped tears down :player's current child subtree — but the RESTORE
-    ;; reads the pre-transition (empty) history, so it falls to default.)
+    ;; No prior exit ⇒ no recording ⇒ :default-target :at-start. The restore
+    ;; transition (:stopped → :playing) does NOT exit :playing, so it records
+    ;; nothing; the RESTORE reads the (empty) history and falls to default.
     (let [restored (step deep-player (seed [:player :stopped]) [:play])]
       (is (= [:player :playing :at-start] (:state restored))
-          ":default-target :playing descended to its :initial leaf"))))
+          ":default-target :at-start resolved on first entry"))))
 
 (deftest default-target-absent-falls-back-to-initial
   (testing "when :default-target is absent the fallback is the compound's :initial"
+    ;; :playing owns deep history with NO :default-target; first entry falls
+    ;; back to :playing's own :initial (:at-start).
     (let [m {:initial :player
              :states  {:player
                         {:initial :stopped
-                         :states  {:stopped {:on {:play [:player :hist]}}
-                                   :hist    {:type :history :deep? true}
-                                   :playing {:on {:stop :stopped}}}}}}
+                         :states  {:stopped {:on {:play [:player :playing :hist]}}
+                                   :playing {:initial :at-start
+                                             :on      {:stop [:player :stopped]}
+                                             :states  {:hist      {:type :history :deep? true}
+                                                       :at-start  {}
+                                                       :mid-track {}}}}}}}
           restored (step m (seed [:player :stopped]) [:play])]
-      (is (= [:player :stopped] (:state restored))
-          "no :default-target ⇒ compound's :initial (:stopped) cascade"))))
+      (is (= [:player :playing :at-start] (:state restored))
+          "no :default-target ⇒ :playing's :initial (:at-start) cascade"))))
 
 (deftest dangling-recorded-path-falls-back
   (testing "a recorded leaf the (hot-reloaded) definition removed falls back to default (rf2-wgfv0)"
@@ -147,7 +163,7 @@
     ;; removed it. Restore must discard it and fall back, never entering the
     ;; dead path. Benign — no :rf.error/*.
     (let [snap     (assoc (seed [:player :stopped])
-                          :rf/history {[:player] [:player :playing :gone]})
+                          :rf/history {[:player :playing] [:player :playing :gone]})
           r        (machines/machine-transition deep-player snap [:play])]
       (is (result/ok? r) "dangling path is benign — no failure")
       (let [restored (result/snap r)]
@@ -164,25 +180,29 @@
         (is (= [:player :playing :mid-track] (:state restored))
             "history restore works off a round-tripped snapshot")))))
 
-;; A parallel machine with a history-bearing compound in EACH region.
+;; A parallel machine with a history-bearing compound (`:on`) in EACH region.
+;; Under the exit-set rule the history owner must be a compound the move
+;; genuinely exits — so `:on` (not `:group`) owns the deep history: `:off-*`
+;; exits the whole `:on` subtree to its sibling `:off`, recording `:on`'s
+;; last-active leaf; `:on-*` re-enters via `[:group :on :hist]`.
 (def parallel-history
   {:type    :parallel
    :regions {:left  {:initial :group
                      :states  {:group {:initial :off
-                                       :states  {:off {:on {:on-l [:group :hist]}}
-                                                 :hist {:type :history :deep? true}
-                                                 :on   {:initial :dim
-                                                        :on      {:off-l [:group :off]}
-                                                        :states  {:dim    {:on {:bright-l :bright}}
-                                                                  :bright {:on {:off-l [:group :off]}}}}}}}}
+                                       :states  {:off {:on {:on-l [:group :on :hist]}}
+                                                 :on  {:initial :dim
+                                                       :on      {:off-l [:group :off]}
+                                                       :states  {:hist   {:type :history :deep? true}
+                                                                 :dim    {:on {:bright-l :bright}}
+                                                                 :bright {:on {:off-l [:group :off]}}}}}}}}
              :right {:initial :group
                      :states  {:group {:initial :off
-                                       :states  {:off {:on {:on-r [:group :hist]}}
-                                                 :hist {:type :history :deep? true}
-                                                 :on   {:initial :dim
-                                                        :on      {:off-r [:group :off]}
-                                                        :states  {:dim    {:on {:bright-r :bright}}
-                                                                  :bright {:on {:off-r [:group :off]}}}}}}}}}})
+                                       :states  {:off {:on {:on-r [:group :on :hist]}}
+                                                 :on  {:initial :dim
+                                                       :on      {:off-r [:group :off]}
+                                                       :states  {:hist   {:type :history :deep? true}
+                                                                 :dim    {:on {:bright-r :bright}}
+                                                                 :bright {:on {:off-r [:group :off]}}}}}}}}}})
 
 (deftest per-region-history-is-region-qualified
   (testing "parallel history records region-qualified keys; restoring one region leaves siblings"
@@ -190,13 +210,13 @@
                          :right [:group :on :dim]}
                  :data  {}
                  :rf/spawn-counter {}}
-          ;; Turn both regions off — each records its own region-qualified
-          ;; history.
+          ;; Turn both regions off — each region's :on compound is exited, so
+          ;; each records its own region-qualified history.
           off-l (step parallel-history snap0 [:off-l])
           off   (step parallel-history off-l [:off-r])]
-      (is (= [:group :on :bright] (get-in off [:rf/history [:left :group]]))
+      (is (= [:group :on :bright] (get-in off [:rf/history [:left :group :on]]))
           ":left region recorded under its region-qualified key")
-      (is (= [:group :on :dim] (get-in off [:rf/history [:right :group]]))
+      (is (= [:group :on :dim] (get-in off [:rf/history [:right :group :on]]))
           ":right region recorded under its region-qualified key (no collision)")
       (is (= {:left [:group :off] :right [:group :off]} (:state off))
           "both regions off")
@@ -216,13 +236,13 @@
 
 (deftest recorded-trace-shape-deep
   (testing ":rf.machine.history/recorded carries the spec/009 deep tag bag"
-    ;; First-ever recording for [:player] — :prev-config ABSENT.
+    ;; First-ever recording for [:player :playing] — :prev-config ABSENT.
     (step deep-player (seed [:player :playing :mid-track]) [:stop])
     (let [evs (history-events :rf.machine.history/recorded)]
       (is (= 1 (count evs)) "exactly one recorded event")
       (let [tags (:tags (first evs))]
         (is (= :rf.machine (:op-type (first evs))) "machine-activity op-type")
-        (is (= [:player] (:compound-path tags)) ":compound-path = decl path")
+        (is (= [:player :playing] (:compound-path tags)) ":compound-path = exited owner's decl path")
         (is (= :deep (:kind tags)) ":kind :deep (not :deep?)")
         (is (= [:player :playing :mid-track] (:recorded-config tags))
             ":recorded-config = full leaf (renamed from :config)")
@@ -239,7 +259,7 @@
     ;; it), then exit again from a DIFFERENT leaf. The new :recorded event
     ;; reports :prev-config = the seeded value it overwrote.
     (let [snap0 (assoc (seed [:player :playing :mid-track])
-                       :rf/history {[:player] [:player :playing :at-start]})]
+                       :rf/history {[:player :playing] [:player :playing :at-start]})]
       (reset-capture!)
       (step deep-player snap0 [:stop])
       (let [tags (:tags (first (history-events :rf.machine.history/recorded)))]
@@ -260,7 +280,7 @@
             tags (:tags ev)]
         (is (= 1 (count evs)) "exactly one restored event")
         (is (= :rf.machine (:op-type ev)) "machine-activity op-type")
-        (is (= [:player] (:compound-path tags)) ":compound-path region-qualified decl path")
+        (is (= [:player :playing] (:compound-path tags)) ":compound-path = the restored owner's decl path")
         (is (= :deep (:kind tags)) ":kind :deep")
         ;; `:source` is hoisted to the envelope top level on the success path
         ;; (build-event strips it from :tags) — the spec's documented hoist.
@@ -296,9 +316,12 @@
     (let [m {:initial :player
              :states  {:player
                         {:initial :stopped
-                         :states  {:stopped {:on {:play [:player :hist]}}
-                                   :hist    {:type :history :deep? true}
-                                   :playing {:on {:stop :stopped}}}}}}]
+                         :states  {:stopped {:on {:play [:player :playing :hist]}}
+                                   :playing {:initial :at-start
+                                             :on      {:stop [:player :stopped]}
+                                             :states  {:hist      {:type :history :deep? true}
+                                                       :at-start  {}
+                                                       :mid-track {}}}}}}}]
       (step m (seed [:player :stopped]) [:play])
       (let [ev   (first (history-events :rf.machine.history/restored))
             tags (:tags ev)]
@@ -309,9 +332,9 @@
 
 (deftest restored-trace-shape-shallow-kind
   (testing "shallow history restore stamps :kind :shallow"
-    (let [after-stop (step shallow-player (seed [:player :playing :mid-track]) [:stop])]
+    (let [after-eject (step shallow-player (seed [:player :playing :mid-track]) [:eject])]
       (reset-capture!)
-      (step shallow-player after-stop [:play])
+      (step shallow-player after-eject [:insert])
       (let [ev   (first (history-events :rf.machine.history/restored))
             tags (:tags ev)]
         (is (= :shallow (:kind tags)) ":kind :shallow (no :deep?)")
@@ -350,3 +373,36 @@
           "no :source on entry steps of a non-history transition")
       (is (empty? (history-events :rf.machine.history/restored))
           "no restored event for a non-history transition"))))
+
+;; ---- exit-set boundary regression (rf2-9eidiv) ---------------------------
+;;
+;; The XState v5 / SCXML exit-set rule: a history-owning compound records
+;; ONLY when it is itself EXITED. A pure WITHIN-compound sibling move — where
+;; the history owner SURVIVES as the LCCA — records NOTHING. This was the OLD
+;; `<=` trigger (active-child-subtree teardown); the strict `<` gate retires
+;; it. This regression locks the boundary so it never silently slips back.
+
+;; `:player` itself owns deep history; `:swap` moves between its two children
+;; (:playing ↔ :stopped). `:player` is the LCA of that move — it SURVIVES (is
+;; never exited) — so under the exit-set rule it records nothing.
+(def surviving-owner
+  {:initial :player
+   :states  {:player {:initial :stopped
+                      :states  {:hist    {:type :history :deep? true :default-target :stopped}
+                                :stopped {:on {:swap [:player :playing]}}
+                                :playing {:initial :at-start
+                                          :on      {:swap [:player :stopped]}
+                                          :states  {:at-start  {:on {:seek :mid-track}}
+                                                    :mid-track {}}}}}}})
+
+(deftest within-compound-sibling-move-records-nothing
+  (testing "a within-compound sibling move (surviving LCCA — the old <= trigger) records NOTHING"
+    ;; :swap from [:player :playing :mid-track] → [:player :stopped] keeps
+    ;; :player as the surviving LCA. Under strict < (exit-set rule), :player
+    ;; is NOT exited, so nothing is recorded.
+    (let [after (step surviving-owner (seed [:player :playing :mid-track]) [:swap])]
+      (is (= [:player :stopped] (:state after)) "moved between :player's children")
+      (is (nil? (:rf/history after))
+          "the surviving-LCCA owner recorded NOTHING — :rf/history slot left untouched")
+      (is (empty? (history-events :rf.machine.history/recorded))
+          "no :rf.machine.history/recorded event for a pure within-compound sibling move"))))

--- a/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
@@ -87,36 +87,43 @@
 ;; absent — deep returns the exact leaf, shallow returns the recorded direct
 ;; child descended through its OWN `:initial` chain. This isolates the depth
 ;; semantic from every other variable. Spec 005 §Recording / §Restoration.
+;;
+;; The contrast intentionally records `:playing` as `:player`'s SHALLOW direct
+;; child, so the owning compound (`:player`) must be GENUINELY EXITED for the
+;; shallow recording to fire (the XState v5 / SCXML exit-set rule, rf2-9eidiv).
+;; This uses the external-sibling shape (mirroring SCXML test388 `:s0 -> :away`):
+;; `:leave` exits the whole `:player` subtree to a top-level sibling `:away`;
+;; `:resume` re-enters via `[:player :hist]`.
 ;; ===========================================================================
 
 (defn- player [deep?]
   {:initial :player
-   :states  {:player
-              {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    (cond-> {:type :history :default-target :playing}
-                                    deep? (assoc :deep? true))
-                         :playing {:initial :at-start
-                                   :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
-                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}})
+   :states  {:player {:initial :stopped
+                      :on      {:leave :away}
+                      :states  {:hist    (cond-> {:type :history :default-target :playing}
+                                           deep? (assoc :deep? true))
+                                :stopped {}
+                                :playing {:initial :at-start
+                                          :states  {:at-start  {:on {:seek :mid-track}}
+                                                    :mid-track {}}}}}
+             :away   {:on {:resume [:player :hist]}}}})
 
 (deftest deep-vs-shallow-diverge-from-identical-exit-leaf
   (testing "the SAME exit leaf restores to the exact leaf (deep) vs the child's :initial (shallow)"
     (let [deep-m    (player true)
           shallow-m (player false)
-          ;; Identical exit: from :mid-track, :stop → :stopped.
-          deep-stop    (step deep-m    (seed [:player :playing :mid-track]) [:stop])
-          shallow-stop (step shallow-m (seed [:player :playing :mid-track]) [:stop])]
+          ;; Identical exit: from :mid-track, :leave exits :player → :away.
+          deep-stop    (step deep-m    (seed [:player :playing :mid-track]) [:leave])
+          shallow-stop (step shallow-m (seed [:player :playing :mid-track]) [:leave])]
       ;; Recording differs: deep stores the full leaf path; shallow the child kw.
       (is (= [:player :playing :mid-track] (get-in deep-stop    [:rf/history [:player]]))
           "deep records the absolute leaf path")
       (is (= :playing                       (get-in shallow-stop [:rf/history [:player]]))
           "shallow records only the direct-child keyword")
       ;; Restore diverges from the IDENTICAL recorded exit point.
-      (is (= [:player :playing :mid-track] (:state (step deep-m    deep-stop    [:play])))
+      (is (= [:player :playing :mid-track] (:state (step deep-m    deep-stop    [:resume])))
           "deep restores the EXACT recorded leaf (:mid-track)")
-      (is (= [:player :playing :at-start]  (:state (step shallow-m shallow-stop [:play])))
+      (is (= [:player :playing :at-start]  (:state (step shallow-m shallow-stop [:resume])))
           "shallow restores the recorded child then its :initial (:at-start), NOT the exit leaf"))))
 
 ;; ===========================================================================
@@ -178,22 +185,25 @@
 (deftest restore-feeds-the-standard-lca-entry-cascade-in-order
   (testing "a deep restore fires exit-deepest-first / entry-shallowest-first along the LCA"
     (let [[log mk] (order-recorder)
+          ;; :playing owns the deep history (the compound :stop genuinely
+          ;; exits), so its last-active leaf records; :play re-enters via
+          ;; [:player :playing :hist].
           m {:initial :player
              :states
              {:player {:initial :stopped
                        :entry   (mk :en-player) :exit (mk :ex-player)
                        :states
                        {:stopped {:entry (mk :en-stopped) :exit (mk :ex-stopped)
-                                  :on    {:play [:player :hist]}}
-                        :hist    {:type :history :deep? true :default-target :playing}
+                                  :on    {:play [:player :playing :hist]}}
                         :playing {:initial :at-start
                                   :entry   (mk :en-playing) :exit (mk :ex-playing)
                                   :on      {:stop [:player :stopped]}
-                                  :states  {:at-start  {:entry (mk :en-at-start) :exit (mk :ex-at-start)
+                                  :states  {:hist      {:type :history :deep? true :default-target :at-start}
+                                            :at-start  {:entry (mk :en-at-start) :exit (mk :ex-at-start)
                                                         :on    {:seek :mid-track}}
                                             :mid-track {:entry (mk :en-mid) :exit (mk :ex-mid)
                                                         :on    {:stop [:player :stopped]}}}}}}}}
-          ;; Record :mid-track by stopping from it; then restore.
+          ;; Record :mid-track by stopping from it (exits :playing); then restore.
           after-stop (step m (seed [:player :playing :mid-track]) [:stop])]
       (reset! log [])
       (let [restored (step m after-stop [:play])]
@@ -212,27 +222,34 @@
 (deftest first-entry-no-recording-uses-default-target
   (testing "nothing recorded ⇒ the pseudo-state's :default-target (descended to its :initial)"
     (let [m (player true)
-          restored (step m (seed [:player :stopped]) [:play])]
+          ;; First entry into :player (from :away) via the history pseudo-state,
+          ;; nothing recorded ⇒ :default-target :playing → :at-start.
+          restored (step m (seed :away) [:resume])]
       (is (= [:player :playing :at-start] (:state restored))
           ":default-target :playing descended to its :initial :at-start"))))
 
 (deftest first-entry-no-default-target-falls-back-to-initial
   (testing "no :default-target ⇒ the OWNING COMPOUND's :initial"
+    ;; :player owns history with NO :default-target and is entered (from :away)
+    ;; via the pseudo-state on first entry ⇒ falls back to :player's :initial.
     (let [m {:initial :player
              :states  {:player {:initial :stopped
-                                :states  {:stopped {:on {:play [:player :hist]}}
-                                          :hist    {:type :history :deep? true}
-                                          :playing {:on {:stop :stopped}}}}}}
-          restored (step m (seed [:player :stopped]) [:play])]
+                                :on      {:leave :away}
+                                :states  {:hist    {:type :history :deep? true}
+                                          :stopped {}
+                                          :playing {:on {:stop :stopped}}}}
+                       :away   {:on {:resume [:player :hist]}}}}
+          restored (step m (seed :away) [:resume])]
       (is (= [:player :stopped] (:state restored))
           "no :default-target ⇒ :player's :initial (:stopped)"))))
 
 (deftest absent-deep-key-is-shallow
   (testing "a missing :deep? reads as shallow (records the direct child, descends :initial)"
-    ;; player(false) has no :deep? at all — proves missing ≡ shallow.
+    ;; player(false) has no :deep? at all — proves missing ≡ shallow. :leave
+    ;; exits :player (the owner) so the shallow recording fires.
     (let [m (player false)
-          after-stop (step m (seed [:player :playing :mid-track]) [:stop])]
-      (is (= :playing (get-in after-stop [:rf/history [:player]]))
+          after-leave (step m (seed [:player :playing :mid-track]) [:leave])]
+      (is (= :playing (get-in after-leave [:rf/history [:player]]))
           "missing :deep? records the direct child (shallow)"))))
 
 ;; ===========================================================================
@@ -247,9 +264,9 @@
 (deftest dangling-deep-leaf-falls-back-no-error
   (testing "a recorded DEEP leaf the definition removed falls back to :default-target; no error"
     (let [m    (player true)
-          snap (assoc (seed [:player :stopped])
+          snap (assoc (seed :away)
                       :rf/history {[:player] [:player :playing :gone]})
-          r    (machines/machine-transition m snap [:play])]
+          r    (machines/machine-transition m snap [:resume])]
       (is (result/ok? r) "dangling deep path is benign — no failure Result")
       (is (= [:player :playing :at-start] (:state (result/snap r)))
           "discarded the dead leaf ⇒ fell back to :default-target → :at-start")
@@ -260,8 +277,8 @@
   (testing "a recorded SHALLOW child the definition removed falls back; no error"
     (let [m    (player false)
           ;; :ghost is not a child of :player in the current definition.
-          snap (assoc (seed [:player :stopped]) :rf/history {[:player] :ghost})
-          r    (machines/machine-transition m snap [:play])]
+          snap (assoc (seed :away) :rf/history {[:player] :ghost})
+          r    (machines/machine-transition m snap [:resume])]
       (is (result/ok? r) "dangling shallow child is benign")
       (is (= [:player :playing :at-start] (:state (result/snap r)))
           "discarded the dead child ⇒ fell back to :default-target → :at-start")
@@ -277,15 +294,18 @@
 ;; Spec 005 §Composition with parallel regions — per-region history.
 ;; ===========================================================================
 
+;; The history-owning compound is `:on` (the dim/bright compound), which
+;; :turn-off genuinely EXITS to its sibling :off — so its last-active leaf
+;; records (the exit-set rule); :turn-on re-enters via [:group :on :hist].
 (defn- region []
   {:initial :group
    :states  {:group {:initial :off
-                     :states  {:off  {:on {:turn-on [:group :hist]}}
-                               :hist {:type :history :deep? true}
-                               :on   {:initial :dim
-                                      :on      {:turn-off [:group :off]}
-                                      :states  {:dim    {:on {:brighten :bright}}
-                                                :bright {:on {:turn-off [:group :off]}}}}}}}})
+                     :states  {:off {:on {:turn-on [:group :on :hist]}}
+                               :on  {:initial :dim
+                                     :on      {:turn-off [:group :off]}
+                                     :states  {:hist   {:type :history :deep? true}
+                                               :dim    {:on {:brighten :bright}}
+                                               :bright {:on {:turn-off [:group :off]}}}}}}}})
 
 (def parallel-history
   {:type    :parallel
@@ -298,10 +318,10 @@
           off   (step parallel-history snap0 [:turn-off])]
       (is (= {:left [:group :off] :right [:group :off]} (:state off))
           "both regions turned off")
-      (is (= [:group :on :bright] (get-in off [:rf/history [:left :group]]))
-          ":left recorded under [:left :group]")
-      (is (= [:group :on :dim]    (get-in off [:rf/history [:right :group]]))
-          ":right recorded under [:right :group] — no collision despite identical structure")
+      (is (= [:group :on :bright] (get-in off [:rf/history [:left :group :on]]))
+          ":left recorded under [:left :group :on]")
+      (is (= [:group :on :dim]    (get-in off [:rf/history [:right :group :on]]))
+          ":right recorded under [:right :group :on] — no collision despite identical structure")
       (is (= 2 (count (:rf/history off))) "two distinct region-qualified entries"))))
 
 (deftest parallel-restore-one-region-leaves-sibling-untouched
@@ -335,10 +355,10 @@
   (testing "re-running from an earlier captured snapshot value restores THAT value's history"
     (let [m  (player true)
           ;; Two captured snapshot values carrying DIFFERENT recorded leaves:
-          ;; S1 exits from :mid-track (records :mid-track); S2 exits from
-          ;; :at-start (records :at-start).
-          s1 (step m (seed [:player :playing :mid-track]) [:stop])
-          s2 (step m (seed [:player :playing :at-start])  [:stop])]
+          ;; S1 exits :player from :mid-track (records :mid-track); S2 exits
+          ;; from :at-start (records :at-start).
+          s1 (step m (seed [:player :playing :mid-track]) [:leave])
+          s2 (step m (seed [:player :playing :at-start])  [:leave])]
       ;; H1 ≠ H2 — the two captured values carry DIFFERENT recorded leaves.
       (is (= [:player :playing :mid-track] (get-in s1  [:rf/history [:player]])) "H1 = :mid-track")
       (is (= [:player :playing :at-start]  (get-in s2  [:rf/history [:player]])) "H2 = :at-start")
@@ -347,21 +367,21 @@
       ;; external history side-table is consulted, so a restore off S1 resolves
       ;; H1 and a restore off S2 resolves H2, totally independently. This is
       ;; exactly what restore-epoch! does when it rewinds the snapshot value.
-      (is (= [:player :playing :mid-track] (:state (step m s1 [:play])))
+      (is (= [:player :playing :mid-track] (:state (step m s1 [:resume])))
           "restore off the reverted S1 value resolves S1's recorded leaf (H1)")
-      (is (= [:player :playing :at-start]  (:state (step m s2 [:play])))
+      (is (= [:player :playing :at-start]  (:state (step m s2 [:resume])))
           "restore off S2 resolves S2's recorded leaf (H2) — histories revert with their values"))))
 
 (deftest history-slot-edn-round-trips
   (testing ":rf/history survives pr-str / read-string (SSR-serialisation + time-axis shape)"
     (let [m   (player true)
-          s1  (step m (seed [:player :playing :mid-track]) [:stop])
+          s1  (step m (seed [:player :playing :mid-track]) [:leave])
           ;; The whole snapshot (incl. :rf/history) round-trips =-equal.
           rt  #?(:clj  (read-string (pr-str s1))
                  :cljs (cljs.reader/read-string (pr-str s1)))]
       (is (= s1 rt) "snapshot incl. :rf/history round-trips =-equal")
       ;; And a restore off the round-tripped value resolves the recorded leaf.
-      (is (= [:player :playing :mid-track] (:state (step m rt [:play])))
+      (is (= [:player :playing :mid-track] (:state (step m rt [:resume])))
           "restore works off a round-tripped snapshot (server→client / epoch replay)"))))
 
 ;; ===========================================================================
@@ -416,9 +436,66 @@
           snap0 (assoc (seed [:player :playing :at-start])
                        :rf/history {[:player] [:player :playing :mid-track]})]
       (reset-capture!)
-      (step m snap0 [:stop])
+      (step m snap0 [:leave])
       (let [tags (:tags (first (history-events :rf.machine.history/recorded)))]
         (is (= [:player :playing :mid-track] (:prev-config tags))
             ":prev-config = the value the slot held before this write")
         (is (= [:player :playing :at-start] (:recorded-config tags))
             ":recorded-config = the value written by this exit")))))
+
+;; ===========================================================================
+;; §9. EXIT-SET BOUNDARY (rf2-9eidiv) — the surviving-LCCA owner records NOTHING
+;;
+;; The decisive regression for the XState v5 / SCXML alignment: a history-
+;; owning compound records ONLY when it is itself in the EXIT SET. A pure
+;; WITHIN-compound sibling move — where the owner SURVIVES as the LCCA — is
+;; the OLD `<=` (active-child-subtree-teardown) trigger that the strict `<`
+;; gate retires. These pin the new boundary on BOTH a flat single-machine
+;; chart AND a nested chart (where the surviving OUTER owner records nothing
+;; while a genuinely-exited INNER owner still does), so it can never silently
+;; slip back to `<=`.
+;; ===========================================================================
+
+;; `:player` owns deep history; `:swap` moves between its two children
+;; (:playing ↔ :stopped). `:player` is the LCA of that move — it SURVIVES —
+;; so under the exit-set rule it records nothing.
+(def surviving-owner
+  {:initial :player
+   :states  {:player {:initial :stopped
+                      :states  {:hist    {:type :history :deep? true :default-target :stopped}
+                                :stopped {:on {:swap [:player :playing]}}
+                                :playing {:initial :at-start
+                                          :on      {:swap [:player :stopped]}
+                                          :states  {:at-start  {:on {:seek :mid-track}}
+                                                    :mid-track {}}}}}}})
+
+(deftest within-compound-sibling-move-records-nothing
+  (testing "a within-compound sibling move (surviving LCCA — the old <= trigger) records NOTHING"
+    (reset-capture!)
+    ;; :swap from [:player :playing :mid-track] → [:player :stopped] keeps
+    ;; :player as the surviving LCA: it is NOT exited, so nothing records.
+    (let [after (step surviving-owner (seed [:player :playing :mid-track]) [:swap])]
+      (is (= [:player :stopped] (:state after)) "moved between :player's children")
+      (is (nil? (:rf/history after))
+          "the surviving-LCCA owner recorded NOTHING — slot left untouched")
+      (is (empty? (history-events :rf.machine.history/recorded))
+          "no :rf.machine.history/recorded event for a pure within-compound sibling move"))))
+
+(deftest surviving-outer-records-nothing-while-exited-inner-records
+  (testing "the exit-set boundary in a NESTED chart: a sibling move under :outer exits :b (records) but leaves :outer (records nothing)"
+    (reset-capture!)
+    ;; :to-a moves :b → its sibling :a (both children of :outer). :outer is
+    ;; the surviving LCA — records nothing — but :b IS in the exit set and
+    ;; records its last-active deep leaf.
+    (let [after (step nested (seed [:outer :b :b2]) [:to-a])]
+      (is (= [:outer :a] (:state after)) "moved to :outer's sibling child :a")
+      (is (not (contains? (:rf/history after) [:outer]))
+          "the surviving :outer owner recorded NOTHING")
+      (is (= [:outer :b :b2] (get-in after [:rf/history [:outer :b]]))
+          "the genuinely-exited :b owner DID record its last-active deep leaf")
+      (is (= 1 (count (:rf/history after)))
+          "exactly one recording — only the exited inner compound, not the surviving outer")
+      (let [recs (history-events :rf.machine.history/recorded)]
+        (is (= 1 (count recs)) "exactly one :recorded event (the exited inner compound)")
+        (is (= [:outer :b] (:compound-path (:tags (first recs))))
+            "the lone recording is the exited :b, not the surviving :outer")))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3099,15 +3099,17 @@ A history state is a **pseudo-state**: a node declared under a compound state's 
 ```clojure
 {:player
  {:initial :stopped
-  :states {:stopped {:on {:play [:player :hist]}}      ;; transition targets the pseudo-state to restore
-           :hist    {:type :history
-                     :deep? true                        ;; omit => SHALLOW history
-                     :default-target :playing}          ;; omit => falls back to :player's :initial
-           :playing {:initial :at-start
-                     :states {:at-start {:on {:seek :mid-track}}
-                              :mid-track {}}}
-           :paused  {:on {:resume [:player :playing]}}}}}
+  :states {:stopped {:on {:play [:player :playing :hist]}}  ;; transition targets the pseudo-state to restore
+           :playing {:initial :at-start                      ;; the history-OWNING compound — :stop exits it
+                     :on      {:stop [:player :stopped]}
+                     :states {:hist      {:type :history
+                                          :deep? true             ;; omit => SHALLOW history
+                                          :default-target :at-start} ;; omit => falls back to :playing's :initial
+                              :at-start  {:on {:seek :mid-track}}
+                              :mid-track {}}}}}}
 ```
+
+The history pseudo-state lives **under the compound it remembers** (`:playing`), so that a transition leaving that compound (here `:stop`, exiting `:playing` for its sibling `:stopped`) genuinely puts `:playing` in the exit set and records its last-active leaf — see [§Recording — on compound-state exit](#recording--on-compound-state-exit). Re-entering via `[:player :playing :hist]` restores it.
 
 The pseudo-state node carries exactly three keys, all owned by the history grammar:
 
@@ -3121,10 +3123,12 @@ A transition resolves to the pseudo-state by naming it the way any other state i
 
 ### Recording — on compound-state exit
 
-Every time the exit cascade (per [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca)) leaves a compound state that owns a history pseudo-state, the runtime **records that compound's last-active configuration** — the active substate path *beneath* the compound at the moment of exit — into the reserved snapshot slot `:rf/history` (per [§The `:rf/history` snapshot slot](#the-rfhistory-snapshot-slot) below). The recording is keyed by the compound's **declaration path** (the absolute prefix-path of the compound state-node in the transition table), so a machine with several history-bearing compounds records each independently.
+Whenever the exit cascade (per [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca)) **exits** a compound state that owns a history pseudo-state — i.e. that compound is in the transition's **exit set** — the runtime **records that compound's last-active configuration** — the active substate path *beneath* the compound at the moment of exit — into the reserved snapshot slot `:rf/history` (per [§The `:rf/history` snapshot slot](#the-rfhistory-snapshot-slot) below). The recording is keyed by the compound's **declaration path** (the absolute prefix-path of the compound state-node in the transition table), so a machine with several history-bearing compounds records each independently.
 
-- A **deep**-history compound records the **full leaf path** beneath itself (e.g. `[:playing :mid-track]` relative to `:player`'s subtree, stored as the absolute path).
-- A **shallow**-history compound records only its **direct child** (e.g. `:playing`); on restore the runtime cascades from that child through its own `:initial` chain.
+The trigger is the compound's own **exit**, not merely the teardown of its current child subtree. A compound records iff it lies **strictly below** the transition's LCA (its declaration path is longer than the LCA path) — that is, iff it is genuinely left. A transition that merely moves between two **children** of compound `C` keeps `C` as the LCA, so `C` **survives** and records **nothing**: there is no last-active configuration to remember because the compound was never left. This is the [XState v5](https://stately.ai/docs/history-states) / [W3C SCXML](https://www.w3.org/TR/scxml/#history) gold-standard semantic — a `<history>` value is written only for states in the exit set (SCXML Appendix D writes `historyValue` while iterating `statesToExit`); history means *"where this compound was when we left it"*, so the compound must actually be left.
+
+- A **deep**-history compound records the **full leaf path** the machine occupied beneath itself (e.g. the absolute path `[:player :playing :mid-track]` for `:playing`'s history).
+- A **shallow**-history compound records only its **direct child** (e.g. `:at-start`); on restore the runtime cascades from that child through its own `:initial` chain.
 
 Recording happens **as part of the exit cascade's commit**, on the same drain that exits the compound — there is no separate write phase. Because `:rf/history` lives inside the snapshot (a revertible value), the recording rides every persistence and time-axis path that the snapshot itself rides (per [§Composition with persistence, SSR, and time-travel](#composition-with-persistence-ssr-and-time-travel)).
 
@@ -3146,7 +3150,7 @@ In every case the **resolved** leaf path — not the pseudo-state — is what th
 
 History restoration is **not a new cascade mechanism** — it is a target-resolution step that feeds the existing entry-cascade machinery. Once the pseudo-state resolves to a concrete leaf path, the standard geometry applies unchanged:
 
-- **LCA + cascade ordering.** The transition's LCA is computed (per [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca)) between the source path and the **resolved** target leaf — exactly as if the author had written the resolved path as a literal `:target`. The exit cascade fires deepest-first from the source leaf back to the LCA; the transition `:action` runs at the LCA boundary; the entry cascade fires shallowest-first from below the LCA down to the resolved leaf, continuing through any `:initial` chain (shallow case). The recording write for the *source* compound (if it owns history and is being exited) happens as part of that same exit cascade.
+- **LCA + cascade ordering.** The transition's LCA is computed (per [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca)) between the source path and the **resolved** target leaf — exactly as if the author had written the resolved path as a literal `:target`. The exit cascade fires deepest-first from the source leaf back to the LCA; the transition `:action` runs at the LCA boundary; the entry cascade fires shallowest-first from below the LCA down to the resolved leaf, continuing through any `:initial` chain (shallow case). A history-owning compound on the source path records **only if it is in the exit set** — i.e. it lies strictly below the LCA and is therefore left by this transition. The LCA compound itself **survives** and records nothing, even though its current child subtree is torn down (per [§Recording — on compound-state exit](#recording--on-compound-state-exit) — the exit-set rule). Consequently a restore-to-history transition, which *enters* (rather than exits) the history-owning compound, records nothing for that compound — re-entry leaves the recorded slot untouched.
 - **Deep nesting.** A deep-history compound nested several levels down records and restores its full subtree path relative to itself; an outer compound's own history (if any) records independently, keyed by its own declaration path. The two never interfere — each compound's recording is a separate entry in the `:rf/history` map.
 - **Final states.** Entering a `:final?` leaf inside a history-bearing compound records normally on the way in only if a later exit occurs; in practice a singleton reaching `:final?` auto-destroys (per [§Final states](#final-states-final--on-done--output-key)) and the snapshot is dissoc'd, so its `:rf/history` goes with it. Restoring a recorded path whose leaf was `:final?` is a no-op edge the runtime handles via the dangling-path fallback (a `:final?` leaf the definition still declares restores like any other leaf; one the definition removed falls back to `:default-target` / `:initial`).
 - **`:always` / `:after`.** The resolved leaf's `:always` entries are checked after the restoring entry cascade settles (microstep loop, per [§Eventless `:always` transitions](#eventless-always-transitions)); its `:after` timers are scheduled at entry (per [§Delayed `:after` transitions](#delayed-after-transitions)) — identical to entering that leaf by any other path.
@@ -3160,10 +3164,10 @@ Under a `:type :parallel` machine each region runs an independent state-tree (pe
 The recorded history lives in a reserved snapshot-root slot, a sibling of `:rf/spawn-counter` and `:rf/machine-type` (per [§Reserved snapshot-internal keys](#reserved-snapshot-internal-keys)):
 
 ```clojure
-{:state :stopped
+{:state [:player :stopped]
  :data  {…}
- :rf/history {[:player]        [:playing :mid-track]    ;; deep — full leaf path beneath :player
-              [:player :inner] :paused}}                ;; shallow — recorded direct child
+ :rf/history {[:player :playing] [:player :playing :mid-track]  ;; deep — absolute leaf path; key = the exited compound
+              [:player :other]   :paused}}                      ;; shallow — recorded direct child
 ```
 
 `:rf/history` is a **map** keyed by **compound declaration path** (a vector of keywords) to that compound's **recorded configuration**. It is NOT a single config — a machine may own several history-bearing compounds, each recorded independently; and under `:type :parallel` the keys are region-qualified (head segment is the region name), so per-region recordings never collide. The recorded value is:

--- a/spec/conformance/fixtures/history-dangling-path-falls-back.edn
+++ b/spec/conformance/fixtures/history-dangling-path-falls-back.edn
@@ -9,6 +9,11 @@
 ;; runtime never enters a dead path. This is a benign, expected consequence of
 ;; hot reload — NOT an error; no `:rf.error/*` is raised.
 ;;
+;; The history-owning compound is `:playing` (the XState v5 / SCXML exit-set
+;; rule, rf2-9eidiv — only a genuinely-exited compound records). The restore
+;; ENTERS :playing (does not exit it), so it records nothing: the seeded
+;; dangling value is discarded for RESOLUTION but the slot is left untouched.
+;;
 ;; Per [005 §Dangling recorded paths after hot reload]
 ;; (../../005-StateMachines.md#dangling-recorded-paths-after-hot-reload).
 
@@ -23,47 +28,48 @@
  :fixture/calls
  [;; (1) DEEP dangling leaf: the seeded :rf/history references [:player :playing
   ;; :gone], which the current definition does not declare. The restore
-  ;; discards it and falls back to :default-target :playing → :at-start. The
-  ;; exit cascade overwrites the slot with the valid outgoing :stopped config.
+  ;; discards it and falls back to :default-target :at-start. The restore
+  ;; ENTERS :playing, so it records nothing — the slot keeps the dangling value.
   {:call         :machine-transition
    :definition
    {:initial :player
     :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :deep? true :default-target :playing}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
                          :playing {:initial :at-start
                                    :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                   :states  {:hist      {:type :history :deep? true :default-target :at-start}
+                                             :at-start  {:on {:seek :mid-track}}
                                              :mid-track {:on {:stop [:player :stopped]}}}}}}}}
    :snapshot     {:state    [:player :stopped]
                   :data     {}
-                  :rf/history {[:player] [:player :playing :gone]}}
+                  :rf/history {[:player :playing] [:player :playing :gone]}}
    :event        [:play]
    :expect-next-snapshot {:state    [:player :playing :at-start]
                           :data     {}
-                          :rf/history {[:player] [:player :stopped]}}
+                          :rf/history {[:player :playing] [:player :playing :gone]}}
    :expect-effects       []}
 
-  ;; (2) SHALLOW dangling child: the seeded :rf/history records the child :ghost,
-  ;; not a child of :player in the current definition. Discarded; falls back to
-  ;; :default-target :playing → :at-start.
+  ;; (2) SHALLOW dangling child: the seeded :rf/history records the child
+  ;; :ghost, not a child of :playing in the current definition. Discarded;
+  ;; falls back to :default-target :at-start. Slot untouched (the restore enters
+  ;; :playing rather than exiting it).
   {:call         :machine-transition
    :definition
    {:initial :player
     :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :default-target :playing}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
                          :playing {:initial :at-start
                                    :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                   :states  {:hist      {:type :history :default-target :at-start}
+                                             :at-start  {:on {:seek :mid-track}}
                                              :mid-track {:on {:stop [:player :stopped]}}}}}}}}
    :snapshot     {:state    [:player :stopped]
                   :data     {}
-                  :rf/history {[:player] :ghost}}
+                  :rf/history {[:player :playing] :ghost}}
    :event        [:play]
    :expect-next-snapshot {:state    [:player :playing :at-start]
                           :data     {}
-                          :rf/history {[:player] :stopped}}
+                          :rf/history {[:player :playing] :ghost}}
    :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-deep-restores-leaf-path.edn
+++ b/spec/conformance/fixtures/history-deep-restores-leaf-path.edn
@@ -2,15 +2,21 @@
 ;;
 ;; First-class DEEP history (rf2-mle6e). A `{:type :history :deep? true}`
 ;; pseudo-state under a compound's `:states` records that compound's FULL
-;; active leaf path on exit (into the revertible `:rf/history` snapshot slot,
-;; keyed by the compound's declaration path) and restores the EXACT recorded
-;; leaf on re-entry — NOT the compound's `:initial`.
+;; active leaf path on the compound's EXIT (into the revertible `:rf/history`
+;; snapshot slot, keyed by the compound's declaration path) and restores the
+;; EXACT recorded leaf on re-entry — NOT the compound's `:initial`.
+;;
+;; Per the XState v5 / W3C SCXML exit-set rule (rf2-9eidiv) only a compound
+;; that is GENUINELY EXITED records history. Here the deep-history owner is
+;; `:playing`: `:stop` exits the whole `:playing` subtree to its sibling
+;; `:stopped`, recording `:playing`'s last-active leaf under [:player :playing];
+;; `:play` re-enters via [:player :playing :hist].
 ;;
 ;; Mode B (`:machine-transition`) record→restore, expressed as two independent
-;; calls: call (1) EXITS the compound from a deep leaf and asserts the recorded
-;; `:rf/history` slot; call (2) RE-ENTERS via the history pseudo-state (its
-;; input snapshot = call (1)'s expected output) and asserts the full recorded
-;; leaf is restored.
+;; calls: call (1) EXITS the `:playing` compound from a deep leaf and asserts
+;; the recorded `:rf/history` slot; call (2) RE-ENTERS via the history
+;; pseudo-state (its input snapshot = call (1)'s expected output) and asserts
+;; the full recorded leaf is restored.
 ;;
 ;; Per [005 §History states](../../005-StateMachines.md#history-states-type-history--shallow--deep--default-target)
 ;; §Recording / §Restoration.
@@ -18,52 +24,53 @@
 {:fixture/id           :machine/history-deep-restores-leaf-path
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:fsm/hierarchical :fsm/history}
- :fixture/doc          "Deep history records the full active leaf path on the compound's exit (into :rf/history keyed by the compound's declaration path) and restores that EXACT leaf on re-entry, not the compound's :initial."
+ :fixture/doc          "Deep history records the full active leaf path on the OWNING compound's exit (into :rf/history keyed by the compound's declaration path) and restores that EXACT leaf on re-entry, not the compound's :initial."
 
  :fixture/registry {}
  :fixture/handlers  {}
 
  :fixture/calls
- [;; (1) RECORD: exit :player from the deep leaf [:player :playing :mid-track]
-  ;; via :stop. The deep history records the full leaf path under [:player].
+ [;; (1) RECORD: exit the :playing compound from the deep leaf
+  ;; [:player :playing :mid-track] via :stop. :playing is genuinely exited,
+  ;; so its deep history records the full leaf path under [:player :playing].
   {:call         :machine-transition
    :definition
    {:initial :player
     :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :deep? true :default-target :playing}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
                          :playing {:initial :at-start
                                    :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                   :states  {:hist      {:type :history :deep? true :default-target :at-start}
+                                             :at-start  {:on {:seek :mid-track}}
                                              :mid-track {:on {:stop [:player :stopped]}}}}}}}}
    :snapshot     {:state [:player :playing :mid-track] :data {}}
    :event        [:stop]
    :expect-next-snapshot {:state    [:player :stopped]
                           :data     {}
-                          :rf/history {[:player] [:player :playing :mid-track]}}
+                          :rf/history {[:player :playing] [:player :playing :mid-track]}}
    :expect-effects       []}
 
-  ;; (2) RESTORE: re-enter via the history pseudo-state ([:player :hist]). The
-  ;; recorded deep leaf is restored exactly. The restore ALSO records the
-  ;; outgoing config [:player :stopped] (the exit cascade overwrites the slot),
-  ;; so the post snapshot's :rf/history shows the now-overwritten value.
+  ;; (2) RESTORE: re-enter via the history pseudo-state ([:player :playing
+  ;; :hist]). The recorded deep leaf is restored exactly. The restore does NOT
+  ;; exit :playing (it ENTERS it), so it records nothing — the :rf/history slot
+  ;; keeps its recorded value.
   {:call         :machine-transition
    :definition
    {:initial :player
     :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :deep? true :default-target :playing}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
                          :playing {:initial :at-start
                                    :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                   :states  {:hist      {:type :history :deep? true :default-target :at-start}
+                                             :at-start  {:on {:seek :mid-track}}
                                              :mid-track {:on {:stop [:player :stopped]}}}}}}}}
    :snapshot     {:state    [:player :stopped]
                   :data     {}
-                  :rf/history {[:player] [:player :playing :mid-track]}}
+                  :rf/history {[:player :playing] [:player :playing :mid-track]}}
    :event        [:play]
    :expect-next-snapshot {:state    [:player :playing :mid-track]
                           :data     {}
-                          :rf/history {[:player] [:player :stopped]}}
+                          :rf/history {[:player :playing] [:player :playing :mid-track]}}
    :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-default-target-on-first-entry.edn
+++ b/spec/conformance/fixtures/history-default-target-on-first-entry.edn
@@ -6,6 +6,11 @@
 ;; `:default-target` — or, when `:default-target` is absent, to the compound's
 ;; `:initial`. Both arms are pinned here as two independent calls.
 ;;
+;; The history-owning compound is `:playing` (the XState v5 / SCXML exit-set
+;; rule, rf2-9eidiv — only a genuinely-exited compound records). On first entry
+;; the restore ENTERS :playing (it does not exit it), so nothing is recorded
+;; and the restore reads the empty history, falling to the default.
+;;
 ;; Per [005 §History states §Restoration](../../005-StateMachines.md#restoration--on-re-entry-resolving-the-pseudo-state):
 ;; "never-entered = `:default-target` (or `:initial`)".
 
@@ -18,41 +23,41 @@
  :fixture/handlers  {}
 
  :fixture/calls
- [;; (1) :default-target DECLARED, nothing recorded ⇒ :default-target :playing,
-  ;; descended to its :initial (:at-start). The restore transition records the
-  ;; outgoing :stopped on the way (the slot is allocated for the first time).
+ [;; (1) :default-target DECLARED, nothing recorded ⇒ :default-target :at-start
+  ;; (already a leaf). The restore ENTERS :playing, so it records nothing — the
+  ;; :rf/history slot is left untouched (empty).
   {:call         :machine-transition
    :definition
    {:initial :player
     :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :deep? true :default-target :playing}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
                          :playing {:initial :at-start
                                    :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                   :states  {:hist      {:type :history :deep? true :default-target :at-start}
+                                             :at-start  {:on {:seek :mid-track}}
                                              :mid-track {:on {:stop [:player :stopped]}}}}}}}}
    :snapshot     {:state [:player :stopped] :data {}}
    :event        [:play]
    :expect-next-snapshot {:state    [:player :playing :at-start]
-                          :data     {}
-                          :rf/history {[:player] [:player :stopped]}}
+                          :data     {}}
    :expect-effects       []}
 
   ;; (2) NO :default-target, nothing recorded ⇒ the owning compound's :initial
-  ;; (:stopped). The restore is a no-op move (already at :stopped), recording
-  ;; :stopped as the outgoing config.
+  ;; (:at-start). The restore ENTERS :playing, recording nothing.
   {:call         :machine-transition
    :definition
    {:initial :player
     :states  {:player
               {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :deep? true}
-                         :playing {:on {:stop :stopped}}}}}}
+               :states  {:stopped {:on {:play [:player :playing :hist]}}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:hist      {:type :history :deep? true}
+                                             :at-start  {}
+                                             :mid-track {}}}}}}}
    :snapshot     {:state [:player :stopped] :data {}}
    :event        [:play]
-   :expect-next-snapshot {:state    [:player :stopped]
-                          :data     {}
-                          :rf/history {[:player] [:player :stopped]}}
+   :expect-next-snapshot {:state    [:player :playing :at-start]
+                          :data     {}}
    :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-per-region-parallel.edn
+++ b/spec/conformance/fixtures/history-per-region-parallel.edn
@@ -5,7 +5,13 @@
 ;; pseudo-state inside a region's compound records THAT region's last-active
 ;; config and restores it independently of siblings. The `:rf/history` keys are
 ;; REGION-QUALIFIED — the head segment is the region name — so two regions with
-;; STRUCTURALLY-IDENTICAL within-region compound paths ([:group]) never collide.
+;; STRUCTURALLY-IDENTICAL within-region compound paths ([:group :on]) never
+;; collide.
+;;
+;; Per the XState v5 / W3C SCXML exit-set rule (rf2-9eidiv) only a GENUINELY
+;; EXITED compound records — so the history owner in each region is `:on` (the
+;; dim/bright compound), which :turn-off exits to its sibling :off; :turn-on
+;; re-enters via [:group :on :hist].
 ;;
 ;; Per [005 §Composition with parallel regions — per-region history]
 ;; (../../005-StateMachines.md#composition-with-parallel-regions--per-region-history).
@@ -13,72 +19,73 @@
 {:fixture/id           :machine/history-per-region-parallel
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:fsm/hierarchical :fsm/parallel-regions :fsm/history}
- :fixture/doc          "Parallel per-region deep history: each region records its own last-active config under a REGION-QUALIFIED key ([<region> :group]); structurally-identical region compounds never collide, and re-entry restores each region to its OWN recorded leaf."
+ :fixture/doc          "Parallel per-region deep history: each region records its own last-active config under a REGION-QUALIFIED key ([<region> :group :on]); structurally-identical region compounds never collide, and re-entry restores each region to its OWN recorded leaf."
 
  :fixture/registry {}
  :fixture/handlers  {}
 
  :fixture/calls
- [;; (1) RECORD: a :turn-off broadcast exits the :on subtree in BOTH regions.
-  ;; Each region records its OWN deep leaf, keyed by [<region> :group].
+ [;; (1) RECORD: a :turn-off broadcast exits the :on compound in BOTH regions.
+  ;; Each region records its OWN deep leaf, keyed by [<region> :group :on].
   {:call         :machine-transition
    :definition
    {:type    :parallel
     :regions {:left  {:initial :group
                       :states  {:group {:initial :off
-                                        :states  {:off  {:on {:turn-on [:group :hist]}}
-                                                  :hist {:type :history :deep? true}
-                                                  :on   {:initial :dim
-                                                         :on      {:turn-off [:group :off]}
-                                                         :states  {:dim    {:on {:brighten :bright}}
-                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}
+                                        :states  {:off {:on {:turn-on [:group :on :hist]}}
+                                                  :on  {:initial :dim
+                                                        :on      {:turn-off [:group :off]}
+                                                        :states  {:hist   {:type :history :deep? true}
+                                                                  :dim    {:on {:brighten :bright}}
+                                                                  :bright {:on {:turn-off [:group :off]}}}}}}}}
               :right {:initial :group
                       :states  {:group {:initial :off
-                                        :states  {:off  {:on {:turn-on [:group :hist]}}
-                                                  :hist {:type :history :deep? true}
-                                                  :on   {:initial :dim
-                                                         :on      {:turn-off [:group :off]}
-                                                         :states  {:dim    {:on {:brighten :bright}}
-                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}}}
+                                        :states  {:off {:on {:turn-on [:group :on :hist]}}
+                                                  :on  {:initial :dim
+                                                        :on      {:turn-off [:group :off]}
+                                                        :states  {:hist   {:type :history :deep? true}
+                                                                  :dim    {:on {:brighten :bright}}
+                                                                  :bright {:on {:turn-off [:group :off]}}}}}}}}}}
    :snapshot     {:state {:left [:group :on :bright] :right [:group :on :dim]} :data {}}
    :event        [:turn-off]
    :expect-next-snapshot
    {:state    {:left [:group :off] :right [:group :off]}
     :data     {}
-    :rf/history {[:left :group]  [:group :on :bright]
-                 [:right :group] [:group :on :dim]}}
+    :rf/history {[:left :group :on]  [:group :on :bright]
+                 [:right :group :on] [:group :on :dim]}}
    :expect-effects       []}
 
   ;; (2) RESTORE: a :turn-on broadcast re-enters each region via ITS OWN history.
   ;; :left restores :bright, :right restores :dim — no cross-region leak. The
-  ;; exit cascades re-record the outgoing :off config per region.
+  ;; restore ENTERS :on in each region, so it records nothing: the slot keeps
+  ;; its recorded value.
   {:call         :machine-transition
    :definition
    {:type    :parallel
     :regions {:left  {:initial :group
                       :states  {:group {:initial :off
-                                        :states  {:off  {:on {:turn-on [:group :hist]}}
-                                                  :hist {:type :history :deep? true}
-                                                  :on   {:initial :dim
-                                                         :on      {:turn-off [:group :off]}
-                                                         :states  {:dim    {:on {:brighten :bright}}
-                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}
+                                        :states  {:off {:on {:turn-on [:group :on :hist]}}
+                                                  :on  {:initial :dim
+                                                        :on      {:turn-off [:group :off]}
+                                                        :states  {:hist   {:type :history :deep? true}
+                                                                  :dim    {:on {:brighten :bright}}
+                                                                  :bright {:on {:turn-off [:group :off]}}}}}}}}
               :right {:initial :group
                       :states  {:group {:initial :off
-                                        :states  {:off  {:on {:turn-on [:group :hist]}}
-                                                  :hist {:type :history :deep? true}
-                                                  :on   {:initial :dim
-                                                         :on      {:turn-off [:group :off]}
-                                                         :states  {:dim    {:on {:brighten :bright}}
-                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}}}
+                                        :states  {:off {:on {:turn-on [:group :on :hist]}}
+                                                  :on  {:initial :dim
+                                                        :on      {:turn-off [:group :off]}
+                                                        :states  {:hist   {:type :history :deep? true}
+                                                                  :dim    {:on {:brighten :bright}}
+                                                                  :bright {:on {:turn-off [:group :off]}}}}}}}}}}
    :snapshot     {:state    {:left [:group :off] :right [:group :off]}
                   :data     {}
-                  :rf/history {[:left :group]  [:group :on :bright]
-                               [:right :group] [:group :on :dim]}}
+                  :rf/history {[:left :group :on]  [:group :on :bright]
+                               [:right :group :on] [:group :on :dim]}}
    :event        [:turn-on]
    :expect-next-snapshot
    {:state    {:left [:group :on :bright] :right [:group :on :dim]}
     :data     {}
-    :rf/history {[:left :group]  [:group :off]
-                 [:right :group] [:group :off]}}
+    :rf/history {[:left :group :on]  [:group :on :bright]
+                 [:right :group :on] [:group :on :dim]}}
    :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-shallow-restores-direct-child.edn
+++ b/spec/conformance/fixtures/history-shallow-restores-direct-child.edn
@@ -5,8 +5,15 @@
 ;; on exit; on re-entry the runtime restores that child then CASCADES through
 ;; the child's OWN `:initial` chain — so a deep leaf at exit restores only to
 ;; the child's `:initial`, NOT the exact exit leaf. This is the depth contrast
-;; with `history-deep-restores-leaf-path` (identical shape, identical exit leaf,
-;; different restore).
+;; with `history-deep-restores-leaf-path` (identical exit leaf, different
+;; restore).
+;;
+;; Per the XState v5 / W3C SCXML exit-set rule (rf2-9eidiv) only a GENUINELY
+;; EXITED compound records, and a SHALLOW recording of the direct child
+;; `:playing` requires the OWNING compound `:player` to be exited. This uses
+;; the SCXML test388 external-sibling shape: `:eject` exits the whole `:player`
+;; subtree to its top-level sibling `:tray`, recording `:player`'s direct child
+;; (:playing); `:insert` re-enters via [:player :hist].
 ;;
 ;; Per [005 §History states](../../005-StateMachines.md#history-states-type-history--shallow--deep--default-target):
 ;; "missing `:deep?` reads as `:deep? false`" (shallow is the default).
@@ -14,52 +21,53 @@
 {:fixture/id           :machine/history-shallow-restores-direct-child
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:fsm/hierarchical :fsm/history}
- :fixture/doc          "Shallow history records only the compound's direct child on exit; on re-entry it restores that child and descends the child's own :initial chain (NOT the exact deep exit leaf). A missing :deep? reads as shallow."
+ :fixture/doc          "Shallow history records only the compound's direct child on the owner's exit; on re-entry it restores that child and descends the child's own :initial chain (NOT the exact deep exit leaf). A missing :deep? reads as shallow."
 
  :fixture/registry {}
  :fixture/handlers  {}
 
  :fixture/calls
- [;; (1) RECORD: exit :player from the deep leaf [:player :playing :mid-track].
-  ;; Shallow history records ONLY the direct child keyword (:playing).
+ [;; (1) RECORD: exit :player from the deep leaf [:player :playing :mid-track]
+  ;; via :eject (to the :tray sibling). :player is genuinely exited, so its
+  ;; shallow history records ONLY the direct child keyword (:playing).
   {:call         :machine-transition
    :definition
    {:initial :player
-    :states  {:player
-              {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :default-target :playing}
-                         :playing {:initial :at-start
-                                   :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
-                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+    :states  {:player {:initial :stopped
+                       :on      {:eject :tray}
+                       :states  {:hist    {:type :history :default-target :playing}
+                                 :stopped {}
+                                 :playing {:initial :at-start
+                                           :states  {:at-start  {:on {:seek :mid-track}}
+                                                     :mid-track {}}}}}
+              :tray   {:on {:insert [:player :hist]}}}}
    :snapshot     {:state [:player :playing :mid-track] :data {}}
-   :event        [:stop]
-   :expect-next-snapshot {:state    [:player :stopped]
+   :event        [:eject]
+   :expect-next-snapshot {:state    :tray
                           :data     {}
                           :rf/history {[:player] :playing}}
    :expect-effects       []}
 
-  ;; (2) RESTORE: re-enter via [:player :hist]. The recorded direct child
-  ;; (:playing) is restored, then its :initial chain (:at-start) is descended —
-  ;; landing at [:player :playing :at-start], NOT the recorded-from :mid-track.
-  ;; The exit cascade overwrites the slot with the outgoing config (:stopped).
+  ;; (2) RESTORE: re-enter via [:player :hist] from :tray. The recorded direct
+  ;; child (:playing) is restored, then its :initial chain (:at-start) is
+  ;; descended — landing at [:player :playing :at-start], NOT the recorded-from
+  ;; :mid-track. The restore ENTERS :player, recording nothing.
   {:call         :machine-transition
    :definition
    {:initial :player
-    :states  {:player
-              {:initial :stopped
-               :states  {:stopped {:on {:play [:player :hist]}}
-                         :hist    {:type :history :default-target :playing}
-                         :playing {:initial :at-start
-                                   :on      {:stop [:player :stopped]}
-                                   :states  {:at-start  {:on {:seek :mid-track}}
-                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
-   :snapshot     {:state    [:player :stopped]
+    :states  {:player {:initial :stopped
+                       :on      {:eject :tray}
+                       :states  {:hist    {:type :history :default-target :playing}
+                                 :stopped {}
+                                 :playing {:initial :at-start
+                                           :states  {:at-start  {:on {:seek :mid-track}}
+                                                     :mid-track {}}}}}
+              :tray   {:on {:insert [:player :hist]}}}}
+   :snapshot     {:state    :tray
                   :data     {}
                   :rf/history {[:player] :playing}}
-   :event        [:play]
+   :event        [:insert]
    :expect-next-snapshot {:state    [:player :playing :at-start]
                           :data     {}
-                          :rf/history {[:player] :stopped}}
+                          :rf/history {[:player] :playing}}
    :expect-effects       []}]}

--- a/spec/conformance/fixtures/scxml-history-test579-default-only-first-entry.edn
+++ b/spec/conformance/fixtures/scxml-history-test579-default-only-first-entry.edn
@@ -48,8 +48,9 @@
    :expect-effects       []}
 
   ;; (2) RE-ENTRY (history recorded): the slot holds :s02 (a prior exit). The
-  ;; restore uses the STORED config (:s02), NOT the default (:s01). The exit
-  ;; cascade overwrites the slot with the outgoing :s02 (already there).
+  ;; restore uses the STORED config (:s02), NOT the default (:s01). The restore
+  ;; ENTERS :s0 (it does not exit it), so it records nothing — the slot is left
+  ;; untouched (still :s02), per the exit-set rule (rf2-9eidiv).
   {:call         :machine-transition
    :definition
    {:initial :s0


### PR DESCRIPTION
## What

Implements the **rf2-9eidiv** ruling: ALIGN machine history recording to the XState v5 / W3C SCXML gold standard — a history-owning compound records its last-active configuration **only when it is itself in the EXIT SET** (strict `<`), retiring the prior `<=` active-child-subtree-teardown trigger.

### The bug the ruling fixes
`record-exit-history` (transition.cljc) gated on `(<= lca-len depth)`, so a compound recorded whenever its current child subtree was torn down — **including a pure within-compound sibling move where the compound SURVIVES as the LCCA**. SCXML Appendix D writes `historyValue` only while iterating `statesToExit`; the `<=` trigger redefined history's meaning ("which child subtree we switched away from" vs "where this compound was when we left it") and made the `:rf.machine.history/recorded` trace incoherent (it fired for a compound the cascade model says was never exited).

## Changes

- **Engine (`transition.cljc:1642`)**: gate `(<= lca-len depth)` → `(< lca-len depth)`. A compound records iff it lies strictly below the LCA, i.e. is genuinely exited. Docstring (1608-1622) + inline comment rewritten from the teardown framing to the exit-set rule.
- **Re-modelled history charts/fixtures/tests** (Codex precision — no blanket owner-hoist):
  - "Resume internal position of `:playing`" → history pseudo-state lives **under** `:playing`, target `[:player :playing :hist]`; `:stop` genuinely exits `:playing`.
  - The **deep-vs-shallow contrast** (records `:playing` as `:player`'s shallow direct child) uses the external-sibling shape mirroring `scxml-history-test388` (`:player -> :away` / `:s0 -> :away`).
  - Per-region parallel history now owns `:on` (the genuinely-exited compound), keyed `[<region> :group :on]`.
  - Re-derived `:rf/history` / `:state` / `:source` / `:expect-next-snapshot` for every affected call. The already-external nested / per-region (lca-len 0) cases are unchanged.
- **Acceptance tests**: every legitimate compound EXIT still records + restores `:source :recorded` (re-modelled `:player`/`:playing` resume + existing `:outer->:away`). **ADDED regression assertions** (smoke `within-compound-sibling-move-records-nothing` + unit `within-compound-sibling-move-records-nothing` and `surviving-outer-records-nothing-while-exited-inner-records`) that a pure within-compound sibling move (surviving LCCA — the old `<=` trigger) records NOTHING.
- **spec/005 §History prose** aligned to the exit-set rule (§Recording, §LCA cascade ordering, grammar + slot examples), citing XState v5 + W3C SCXML Appendix D. (hot-zone — sole toucher this PR.)

## Quality gates
\`\`\`
cd implementation && npm run test:cljs
  -> Ran 7977 tests containing 33225 assertions. 0 failures, 0 errors.
     (includes the unit .cljc history matrix + the EDN conformance corpus + scxml-conformance-cljs-test)

cd implementation/machines && clojure -M:test
  -> Ran 777 tests containing 2563 assertions. 0 failures, 0 errors.
     (re-modelled history fixtures + smoke + unit; ~40 prior assertions re-derived, all green)

rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict
  -> Documentation built (exit 0; only pre-existing INFO-level link notices)
\`\`\`

The **within-compound-sibling-move regression assertion is present** (in both the smoke and the unit suites).

Closes rf2-9eidiv.