### PR TITLE
docs(spec): reconcile spec/016 load-more example to ownerless idiom (rf2-vsnht9)

### DIFF
--- a/spec/016-Resources.md
+++ b/spec/016-Resources.md
@@ -1274,9 +1274,10 @@ A new resource event extends the feed by one page. It is **causal** ([§Public A
  {:resource :feed/timeline
   :scope    {:from-db :app/session}     ;; resolved like any resource event
   :params   {:filter :recent}           ;; the FEED identity (not a page)
-  :owner    [:route :route/home nav-token]
-  :cause    [:user :feed/load-more]}]
+  :cause    [:user :feed/load-more]}]   ;; OWNERLESS — carries a :cause, not an :owner
 ```
+
+**Ownerless (MUST).** A `load-more` MUST be **ownerless**: it carries a `:cause`, never an `:owner`. The route (or whatever owner first-loaded the feed) already *owns* the one feed entry for its lifetime, keeping it alive; a load-more *extends* that one owned entry — it does not intend to keep anything alive on its own, so it omits `:owner` and supplies only `:cause` (owner keeps alive; cause explains why). This is the same owner-vs-cause distinction a manual refresh makes ([§Owners are liveness leases](#owners-are-liveness-leases) — an event that only extends data without intending to keep it active is a cause, not an owner). A **supplied `:owner` is warn-and-ignored**: the runtime drops it and emits `:rf.warning/resource-load-more-owner-ignored` (DCE'd in production) rather than minting a stray lease that would pin the feed alive past its real owner — a load-more never changes the active-owner set.
 
 FSM interaction (MUST) — **no 6th FSM state (R2)**; the five states are untouched:
 


### PR DESCRIPTION
## What

Reconciles the `spec/016-Resources.md` load-more example to the **ownerless** idiom ruled by rf2-bi8vg1.

The `:rf.resource/load-more` payload example (~:1277) still carried `:owner [:route :route/home nav-token]`, contradicting the rf2-bi8vg1 ruling that load-more is OWNERLESS (a supplied `:owner` is warn-and-ignored via `:rf.warning/resource-load-more-owner-ignored`). It was the one corpus site that invited the mistake — the runtime + Conventions + spec/009 catalogue + tests landed in PR #4587; this is the spec/016 reconciliation that PR explicitly descoped to stay focused (bi8vg1 IMPLEMENTATION GUIDANCE item 3).

## Changes

- **Remove** the `:owner` line from the load-more payload example; the `:cause` line now carries an `OWNERLESS` comment.
- **Add** an "Ownerless (MUST)" rule to §Causal event — `:rf.resource/load-more`: a load-more MUST be ownerless (carries `:cause`, not `:owner` — the route already owns the feed for its lifetime; a load-more only *extends* the one owned entry); a supplied `:owner` is warn-and-ignored via `:rf.warning/resource-load-more-owner-ignored` (DCE'd in production). Consistent with the guide `paginate-a-feed.md:221` and 016's own §Owners are liveness leases rule.

`spec/016` only. `docs/api/16-resources.md` checked — it has no `:owner`-on-load-more example (its `:owner` mentions are for `ensure`/`refetch`/`release-owner`, all legitimate), so it is untouched.

Verified: no remaining `:owner`-on-load-more in spec/016 — the only `load-more` + `:owner` co-occurrence is the new MUST that says "never an `:owner` … warn-and-ignored".

## Quality gates

\`\`\`
rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict   # PASS (built in 9.78s; new #owners-are-liveness-leases anchor resolves)
python scripts/check_ep_status_sync.py                              # PASS (exit 0)
\`\`\`