### PR TITLE
docs(EP): apply the two deferred uniformity tweaks (rf2-pgvfgw)

### DIFF
--- a/docs/EP/EP-0001-frame-partitions.md
+++ b/docs/EP/EP-0001-frame-partitions.md
@@ -2,7 +2,14 @@
 
 Status: final
 
-> **`final` means the decisions are settled.** The fourteen deferred calls were
+> **`final` means the decisions are settled.** The two-partition frame contract
+> graduated into its normative home,
+> [`spec/002-Frames.md` §The two-partition frame contract](../../spec/002-Frames.md#the-two-partition-frame-contract);
+> where this EP and the spec differ, the **spec governs**, and this EP remains the
+> design record. (The `:rf.runtime/*` children this partition reserves are
+> organized by the follow-on [Runtime Subsystem Contract EP](EP-0006-runtime-subsystem-contract.md)
+> in [`spec/Runtime-Subsystems.md`](../../spec/Runtime-Subsystems.md), without
+> reopening this contract.) The fourteen deferred calls were
 > ruled by Mike on 2026-06-08 (see [Resolved Decisions](#resolved-decisions)).
 > The design-review follow-ups were also closed before finalization: Appendix
 > A's concrete recommendations are disposed by Resolved Decisions 3, 4, 7, and

--- a/docs/EP/EP-0019-optimistic-mutation-rollback.md
+++ b/docs/EP/EP-0019-optimistic-mutation-rollback.md
@@ -745,6 +745,24 @@ Proposed sequence (not a one-PR requirement):
    `:optimistic` (forward exact) + `:optimistic-tags` (forward tag-addressed),
    per EP-0007 one-name-per-fact. Operator to confirm the spelling.
 
+## Resolved Decisions
+
+Ruled by Mike at graduation (`proposal → final`, 2026-06-17; bead `rf2-pyahbf`),
+adopting the recommended cut. One row per Open Issue (Open Issue 5 carries its own
+load-bearing inline ruling, `byl7bk`, 2026-06-15). These rows are normative; the
+[§Open Issues](#open-issues) above carry the full rationale, and the §Specification
+body has been reconciled to them.
+
+| # | Decision | Resolution |
+|---|----------|-----------|
+| **R1** | Author-written inverse vs runtime snapshot inverse? (Open Issue 1) | **Runtime snapshot-of-touched-entries inverse** as the only public form — truthful by construction, no author drift. A semantic-inverse opt-in is revisited only if a Linearlite-class entry proves the snapshot cost real. |
+| **R2** | `:on-conflict` default — `:invalidate` vs `:force`? (Open Issue 2) | **`:invalidate` (default):** defer a contested rollback to the read path; never resurrect a stale value. **`:force`** ships as an opt-in (single-writer entries) with a tooling warning. This is the load-bearing correctness divergence from TanStack/SWR's unconditional context restore. |
+| **R3** | Optimistic apply on epoch-restore dangle? (Open Issue 3) | **Yes — a dangle rolls back the optimistic apply.** A `:pending`-on-restore dangle is an accepted-error-shaped terminal, so it triggers the same conflict-aware rollback as an `:error` reply. |
+| **R4** | Per-call optimistic opt-out shape? (Open Issue 4) | Reserve **`{:optimistic? false}`** on `:rf.mutation/execute` as the only per-call override — a boolean disable, not a per-call plan (a per-call forward plan would re-introduce call-site cache logic the EP-0016 doctrine pushes onto the registration). |
+| **R5** | Revision token scope — per-entry vs reuse `:generation`? (Open Issue 5) | **`byl7bk` ruling (load-bearing):** a **distinct `:revision` fact** (NOT a reuse of `:generation`), bumped on **every authoritative durable entry write a rollback could clobber** — unconditionally, never gated on `(= old new)` of `:data`. `:generation` bumps at load *start* and would false-conflict on every in-flight refetch. Bias to over-bump (a false conflict costs one refetch; a missed conflict is silent corruption). |
+| **R6** | Optimistic `:removes` and `:populates`-of-absent? (Open Issue 6) | **Yes — both ship in Decision 1's grammar.** Optimistic remove (vanish on apply, restore on failure) and optimistic seed of an absent entry both fall out of the snapshot inverse (`:absent` sentinel) at no extra mechanism. |
+| **R7** | Naming: `:optimistic` vs `:optimistic-patches`? (Open Issue 7) | **`:optimistic`** (forward exact) + **`:optimistic-tags`** (forward tag-addressed), per EP-0007 one-name-per-fact; reads better at the call site and matches SWR's `optimisticData`. |
+
 ## Recommendation
 
 Accept this EP as the optimistic-rollback follow-on EP-0016 issue 9 defers,

--- a/docs/EP/EP-0020-active-owner-polling.md
+++ b/docs/EP/EP-0020-active-owner-polling.md
@@ -527,6 +527,24 @@ they are kept verbatim as the record of what was ruled.
    causes; no further taxonomy needed. (Trivial, listed only for completeness so
    the cause enum stays a closed documented set.)
 
+## Resolved Decisions
+
+Ruled by Mike at graduation (`accepted → final`, 2026-06-17; bead `rf2-7mj7mt`),
+adopting the recommended cut. One row per Open Question. These rows are normative;
+the [§Open Issues](#open-issues) above carry the full rationale, and the
+§Specification body has been reconciled to them.
+
+| # | Decision | Resolution |
+|---|----------|-----------|
+| **R1** | Owner ergonomics for a "just polling" read with no natural owner? (Open Question 1) | Keep the v1 primitive **owner-driven** with the existing `[:lease …]` path; **file a separate adapter-ergonomics bead** for a `use-resource-lease` / `with-resource-lease` mount-lifecycle helper. The runtime contract stays clean; the component-observer model re-enters only at the adapter layer. |
+| **R2** | Hidden-tab polling opt-in — ship in v1 or reserve? (Open Question 2) | **Ship default-pause-when-hidden in v1; reserve `:poll-when-hidden?`** for the first true-background-monitor consumer. Default safe, defer the escape hatch. |
+| **R3** | Is a poll tick unconditional or stale-gated? (Open Question 3) | **(a) unconditional** — every interval refetches an active-owned entry regardless of `:stale?` (matches all prior-art tools; the interval *is* the cadence). `:stale-after-ms` stays the separate "don't refetch on focus/route-entry unless older than X" knob. The single most load-bearing semantic ruling. |
+| **R4** | Data-derived dynamic interval / stop predicate? (Open Question 4) | **Non-Goal for v1, reserved.** When a consumer needs it, shape it as an EP-0014 declared derivation (inputs → next-interval-or-stop), not an anonymous closure. A static integer interval covers the dashboard/notification/presence majority. |
+| **R5** | Repeated poll-failure back-off? (Open Question 5) | **Reserve, do not ship in v1.** A poll that keeps firing on a flaky endpoint is correct (it is a monitor); transport retry belongs to the transport adapter / managed-HTTP retry policy, not the poll timer. |
+| **R6** | Per-use route/ensure override, or resource-level only? (Open Question 6) | **Resource-level `:poll-interval-ms` only in v1;** reserve the per-use override for a follow-up if a consumer proves the resource-level interval too coarse. Keeps the ensure/route resolution path unchanged. |
+| **R7** | Spelling: `:poll-interval-ms` vs reserved `:poll-ms`? (Open Question 7) | Adopt **`:poll-interval-ms`** (reads as an interval, aligns with RTK's `pollingInterval`, parallels `:stale-after-ms` / `:gc-after-ms`); update the reserved-key note. |
+| **R8** | Does polling need its own `:cause` entry? (Open Question 8) | Add the single cause keyword **`:poll`** to the enumerated causes; no further taxonomy. |
+
 ## Recommendation
 
 Accept this EP as a focused, additive Spec 016 amendment that completes the


### PR DESCRIPTION
Action **rf2-pgvfgw** — the two explicitly-optional EP-doc uniformity items deferred from the rf2-s8tmfk EP-corpus coherence sweep (PR #4584). Both were marked LOW / "not a violation" in s8tmfk, so deferred rather than actioned. Errata-class: no normative/status/decision changes.

## What changed

**Item 1 — EP-0019 + EP-0020: dedicated "Resolved Decisions" table.**
Folded the kept Open-Issue dispositions into a `## Resolved Decisions` table (the EP-0021 / EP-0001-0002 pattern: `| # | Decision | Resolution |`, one row per Open Issue, `R1…Rn`). The dispositions were *already* stated inline in each Open Issue's adopted recommendation, so this is presentation-uniformity only, not a coherence fix. The existing `## Open Issues` sections (full rationale, incl. EP-0019 Open Issue 5's load-bearing `byl7bk` inline ruling) are kept verbatim. Table inserted between Open Issues and Recommendation, matching EP-0021's section order.

**Item 2 — EP-0001: single spec graduation home + "spec governs" line.**
Added a normative-home sentence to the preamble matching EP-0002/0003's formulation: the two-partition frame contract graduated into [`spec/002-Frames.md` §The two-partition frame contract](../../spec/002-Frames.md#the-two-partition-frame-contract), "where this EP and the spec differ, the **spec governs**." The cross-cutting `:rf.runtime/*` children home (`spec/Runtime-Subsystems.md`, via EP-0006) is noted parenthetically — addressing s8tmfk's "no one obvious single spec home" caveat without overclaiming.

Both items applied (neither was already consistent on current main).

## Quality gates
\`\`\`
python scripts/check_ep_status_sync.py        # PASS (EXIT=0)
rm -rf docs/spec && cp -r spec docs/spec && python -m mkdocs build --strict   # PASS (EXIT=0)
\`\`\`
mkdocs is invoked via \`python -m mkdocs\` (1.6.1) — not on PATH as a bare command in this environment; \`--strict\` passes (only INFO-level pre-existing external-link notes, no warnings/errors). New intra-doc anchors resolve.

Surface: \`docs/EP/*.md\` only (3 files, +44/-1). No \`spec/\`, no \`.beads/issues.jsonl\`.