### PR TITLE
docs: resource parity-doc currency sweep — polling/optimistic/infinite are shipped, not deferred (rf2-l84z5x)

### DIFF
--- a/docs/EP/EP-0021-infinite-resources.md
+++ b/docs/EP/EP-0021-infinite-resources.md
@@ -600,12 +600,14 @@ item-reach needs vector traversal) is bounded and is itself the open question.
 
 ## Backwards Compatibility
 
-Pre-alpha; additive. `:infinite` is a reserved-but-unused key today
-([Spec 016 §Resource registration spec](../../spec/016-Resources.md#resource-registration-spec)),
-so no resource declares it. Numbered pagination (`:keep-previous?`) is untouched.
-No existing subscription or event changes shape. The only migration is
-*opportunity*: hand-rolled app-db feeds in examples (if any) may move to the
-primitive once it lands.
+Pre-alpha; additive. `:infinite` was a reserved key in Spec 016 before this EP;
+it is **now a live `reg-resource` key**
+([Spec 016 §Infinite resources and load-more feeds](../../spec/016-Resources.md#infinite-resources-and-load-more-feeds)),
+opt-in per feed. Numbered pagination (`:keep-previous?`) is untouched.
+No existing subscription or event changed shape (the infinite subscription
+family — `:rf.resource/items` / `:rf.resource/pages` / `:rf.resource/infinite-state`
+— and the `:rf.resource/load-more` event are purely additive). The only migration
+is *opportunity*: hand-rolled app-db feeds may move to the primitive.
 
 ## Bead Plan / Reference Implementation
 

--- a/docs/api/16-resources.md
+++ b/docs/api/16-resources.md
@@ -50,9 +50,9 @@ Resources are an **optional, post-v1 capability** — they ship in `day8/re-fram
 | `:request` | For `:transport :rf.http/managed`, returns a [Spec 014](../../spec/014-HTTPRequests.md) args map. MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the scoped key + generation (rejected if present). |
 | `:data-schema` | Validates successful data when transport decode supports it. |
 
-**Optional keys**: `:doc`, `:transport` (initial scope: `:rf.http/managed`), `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms` (the active-owner poll interval — see [Polling](#polling)), `:tags`, `:sensitive?` / `:large?` / schema-based classification.
+**Optional keys**: `:doc`, `:transport` (initial scope: `:rf.http/managed`), `:stale-after-ms`, `:gc-after-ms`, `:poll-interval-ms` (the active-owner poll interval — see [Polling](#polling)), `:infinite` + the infinite-only keys (`:next-page-param`, `:prev-page-param`, `:page->items`, `:initial-page-param`, `:page-data-schema`, `:refetch` — see [Infinite resources](#infinite-resources)), `:tags`, `:sensitive?` / `:large?` / schema-based classification.
 
-**Rejected / unused in v1**: `:revalidate`, `:placeholder`, `:cache-key`, `:select`, `:infinite`, transport extension protocols. (Interval polling landed as `:poll-interval-ms`, not the originally-reserved `:poll-ms` spelling.) The mutation-only keys (`:invalidates`, `:patches`, `:populates`, `:optimistic`, `:optimistic-tags`, `:on-conflict`) are **not resource-registration keys** — they live on `reg-mutation`.
+**Rejected / unused in v1**: `:revalidate`, `:placeholder`, `:cache-key`, `:select`, transport extension protocols. (Interval polling landed as `:poll-interval-ms`, not the originally-reserved `:poll-ms` spelling; the `:infinite` load-more kind landed via EP-0021 — see [Infinite resources](#infinite-resources).) The mutation-only keys (`:invalidates`, `:patches`, `:populates`, `:optimistic`, `:optimistic-tags`, `:on-conflict`) are **not resource-registration keys** — they live on `reg-mutation`.
 
 ### Scope policy
 
@@ -124,6 +124,12 @@ Resource events take a **map payload**, not a positional argument vector.
 - **Payload**: `{:resource :scope :params}`
 - **Description**: Remove a single resource instance's cache entry.
 
+### `[:rf.resource/load-more {…}]`
+
+- **Kind**: event (infinite resources only — see [Infinite resources](#infinite-resources))
+- **Payload**: `{:resource :scope :params :cause}` — **ownerless** (carries a `:cause`, never an `:owner`)
+- **Description**: Extend an `:infinite` feed by one page. Computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector (the feed stays `:loaded`; the pages stay visible — a load-more in flight is the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh). A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace; a load-more while a page fetch is already in flight dedupes. A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
+
 ### Focus/reconnect revalidation
 
 Active-stale revalidation is expressed as **resource events**, never subscription-driven fetching (rf2-vtblcq, landed). On window focus / tab-return / network reconnect, the frame's active-owner **stale** entries are rescanned and refetched by policy — a stale entry with no active owner is left alone (revalidation creates no liveness).
@@ -168,6 +174,47 @@ Semantics (per [016 §Polling](../../spec/016-Resources.md#polling)):
 - **Background-failure resilient.** A failed poll keeps prior `:data` + records `:refresh-error`, and the next poll still fires.
 
 A "just polling" view with no natural route/machine owner needs an app-minted `[:lease …]` owner (with a matching `[:rf.resource/release-owner {…}]`) to keep the poll alive — an owner-free entry never polls.
+
+### Infinite resources
+
+An **infinite resource** is the load-more / infinite-scroll feed counterpart of TanStack Query's `useInfiniteQuery` / SWR's `useSWRInfinite` (landed via [EP-0021](../EP/EP-0021-infinite-resources.md); normative source [016 §Infinite resources and load-more feeds](../../spec/016-Resources.md#infinite-resources-and-load-more-feeds)). It is a resource registered with `:infinite true` plus a pure `:next-page-param`; the user accumulates pages (1, then 1+2, then 1+2+3) rendered as one growing list, with the *next* page param derived from the last page's data. Numbered / cursor pagination (`:keep-previous?` + per-page entries) is untouched and orthogonal — an app picks per feed.
+
+```clojure
+(rf/reg-resource :feed/timeline
+  {:doc "Infinite home timeline (load-more)."
+   :infinite         true
+   :params-schema    [:map [:filter :keyword]]   ;; FEED identity (filter/sort) — NOT the page cursor
+   :scope            {:from-db :app/session}
+   :page-data-schema :app/timeline-page          ;; validates ONE page (decode target + per-page egress)
+   :request                                       ;; reserved ctx carries the page context (R8 — no new arity)
+   (fn [{:keys [filter]} {:rf.resource/keys [page-param]}]
+     {:request {:method :get :url "/api/timeline"
+                :params (cond-> {:filter filter :limit 20} page-param (assoc :cursor page-param))}
+      :decode  :app/timeline-page})
+   :next-page-param  (fn [last-page _all-pages]    ;; REQUIRED; nil = the single terminal
+                       (get-in last-page [:page-info :next-cursor]))
+   :page->items      :items                        ;; REQUIRED when a page is non-vector/enveloped (loud over guessing)
+   :tags             (fn [{:keys [filter]} _] #{[:feed filter]})})
+```
+
+Key semantics:
+
+- **`:infinite true` makes `:next-page-param` required** (a loud `:rf.error/infinite-missing-next-page-param` otherwise). It is pure `(last-page all-pages) → next-param-or-nil`; returning `nil` is the single canonical terminal, exposed as the derived `:has-next-page?`.
+- **One scoped entry per feed.** Pages accumulate as an ordered vector inside the one `:rf.runtime/resources` entry — **not** N per-page entries, **not** an app-db slice — so the feed has one owner set / freshness clock / GC clock / SSR-restore unit / Xray row. The per-page param is internal sequencing state, **never** part of the cache key; changing the identity params yields a different feed instance.
+- **`:page-data-schema` validates one page** and is the per-page egress/classification contract (applied per page on SSR/tool projection); `:data-schema` is not used for the accumulated vector.
+- **Other infinite-only keys**: `:prev-page-param` (the bidirectional derivation mirror — defined, but the `load-prev` prepend event is deferred; v1 ships next-direction load-more only), `:initial-page-param` (the first-page param, default `nil`), `:page->items` (required for non-vector pages), and `:refetch` (`{:refetch-all-pages? false}` by default — the conservative window-preserving refetch policy, with `:refetch-all-pages?` / `:refetch-window` opt-ins).
+
+A view reads the merged list and dispatches the causal `[:rf.resource/load-more {…}]`:
+
+```clojure
+[:rf.resource/items          {:resource :feed/timeline :scope … :params …}]   ;; merged flat list — the headline read
+[:rf.resource/pages          {…}]   ;; raw page boundaries
+[:rf.resource/has-next-page? {…}]   [:rf.resource/fetching-next? {…}]
+[:rf.resource/page-count     {…}]   [:rf.resource/page-error     {…}]
+[:rf.resource/infinite-state {…}]   ;; combined view-model (the feed analogue of :rf.resource/state)
+```
+
+`:rf.resource/items`, `:rf.resource/pages`, and `:rf.resource/infinite-state` are framework-owned memoised subscriptions; `:rf.resource/ensure` (and a route entry) loads **page 0 only**, and a mutation touching an item inside a feed **invalidates the whole feed** (coarse, correct; in-place item patching is on the deferred optimistic/patch axis).
 
 ## Subscriptions (passive)
 

--- a/docs/guide/explanation/resources-vs-query-libraries.md
+++ b/docs/guide/explanation/resources-vs-query-libraries.md
@@ -1,6 +1,6 @@
 # Resources vs TanStack Query, RTK Query, and SWR
 
-This page is the honest, feature-by-feature comparison between re-frame2 **managed resources** and the JavaScript server-state libraries you may already know — [TanStack Query](https://tanstack.com/query) (the React Query family), [RTK Query](https://redux-toolkit.js.org/rtk-query/overview), and [SWR](https://swr.vercel.app/). The conceptual model is in [Server state: resources](../concepts/server-state.md); this page is the scorecard. It tells you what is matched, what is *deliberately different*, what has *landed*, and — bluntly — what is **not built yet**.
+This page is the honest, feature-by-feature comparison between re-frame2 **managed resources** and the JavaScript server-state libraries you may already know — [TanStack Query](https://tanstack.com/query) (the React Query family), [RTK Query](https://redux-toolkit.js.org/rtk-query/overview), and [SWR](https://swr.vercel.app/). The conceptual model is in [Server state: resources](../concepts/server-state.md); this page is the scorecard. It tells you what is matched, what is *deliberately different*, what has *landed*, and — bluntly — what is **deliberately out of scope** for this phase.
 
 The one sentence to carry through every row:
 
@@ -10,7 +10,7 @@ If you want the design rationale rather than the comparison, read [Inside out: w
 
 !!! note "Resources are an optional artefact, and pre-alpha"
 
-    Server state in re-frame2 is the optional `day8/re-frame2-resources` artefact, and it is **pre-alpha**: the read path, the mutation path, and optimistic mutation rollback have all landed. Two parity-relevant features (polling, infinite feeds) are not built yet and are tracked as design proposals. Every "proposed" row below names its tracking proposal so you can see exactly where the edge is. Nothing here is back-compat-frozen.
+    Server state in re-frame2 is the optional `day8/re-frame2-resources` artefact, and it is **pre-alpha**: the read path, the mutation path, optimistic mutation rollback, active-owner polling, and infinite / load-more feeds have all landed. The remaining query-library features are *deliberately out of scope* for this HTTP-only phase — normalized/GraphQL caches and offline/cross-tab persistence — and each such row below names where that line sits. Nothing here is back-compat-frozen.
 
 ## How to read the status column
 
@@ -20,8 +20,8 @@ Each row carries a status. They mean precisely:
 |---|---|
 | **Landed** | Shipped in the reference implementation (`re-frame.resources`) and pinned by tests. |
 | **Different by design** | A capability the query libraries have, expressed differently here on purpose — usually because re-frame2 already has a more general mechanism (the subscription graph, the event loop) that subsumes it. |
-| **Proposed (EP-00NN)** | A real parity gap, *deferred*, with an open enhancement-proposal PR working out the design. Not in the shipped contract. The proposal numbers below — EP-0020 (active-owner polling), EP-0021 (infinite resources) — are landing as proposal PRs and are tracked under the [pre-alpha resource parity tranche]. Optimistic rollback (EP-0019) has since *landed* and moved out of this column. |
 | **Out of scope** | Deliberately not a resources concern — a different artefact, a different phase, or a non-goal. |
+| **Deferred (later slice)** | A real parity gap, deliberately held for a later slice, with no shipped contract yet. Used here only for offline persistence / cross-tab broadcast. The earlier parity-tranche proposals — optimistic rollback (EP-0019), active-owner polling (EP-0020), and infinite resources (EP-0021) — have all since *landed* and moved to **Landed**. |
 
 ## The parity matrix
 
@@ -40,14 +40,14 @@ Each row carries a status. They mean precisely:
 | **Mutation completion continuation** | `onSuccess` / `onError` callbacks | lifecycle callbacks | promise resolution | call-site `:reply-to` **event** (not a callback); fires only for the accepted terminal reply | **Landed** |
 | **Projection / `select`** | `select` option | `selectFromResult` | derived in component | no `:select` key — projections are ordinary subscriptions layered over `[:rf.resource/data …]` | **Different by design** |
 | **Optimistic updates + rollback** | `onMutate` snapshot + `onError` rollback | `updateQueryData` + `undo` patch | `optimisticData` + `rollbackOnError` | `:optimistic` (exact-target) / `:optimistic-tags` (tag-addressed) plan applied pre-request; runtime records the inverse; deterministic commit / rollback / reconcile on settle, with `:on-conflict` governing a contested rollback | **Landed** |
-| **Polling / refetch interval** | `refetchInterval` | `pollingInterval` | `refreshInterval` | **not built** — focus/reconnect revalidation has landed; *timed* polling has not | **Proposed (EP-0020)** |
+| **Polling / refetch interval** | `refetchInterval` | `pollingInterval` | `refreshInterval` | `:poll-interval-ms` — revalidates every N ms while the entry is *actively owned* and the tab is visible; the third freshness timer beside stale/GC | **Landed** |
 | **Refetch on window focus / reconnect** | `refetchOnWindowFocus` / `refetchOnReconnect` | `refetchOnFocus` / `refetchOnReconnect` | `revalidateOnFocus` / `revalidateOnReconnect` | `install-revalidation-listeners!` per frame; refetches only entries that are *stale AND owned* | **Landed** |
-| **Infinite / load-more** | `useInfiniteQuery` | `infiniteQuery` (recent) | `useSWRInfinite` | **not built** — numbered/cursor pages are ordinary resources with `:keep-previous?`; a canonical accumulating-feed model is deferred | **Proposed (EP-0021)** |
+| **Infinite / load-more** | `useInfiniteQuery` | `infiniteQuery` (recent) | `useSWRInfinite` | `:infinite true` + `:next-page-param` — one scoped feed entry accumulates an ordered page vector; a causal `:rf.resource/load-more` extends it; `:rf.resource/items` is the merged read (numbered/cursor pages stay ordinary resources with `:keep-previous?`) | **Landed** |
 | **Keep-previous-data while paging** | `placeholderData: keepPreviousData` | n/a (manual) | `keepPreviousData` | `:keep-previous?` on the route/resource; `:rf.resource/state` projects `:previous-data` / `:previous-key` | **Landed** |
 | **SSR / hydration** | `dehydrate` / `HydrationBoundary` | `getRunningQueries` + preload | fallback data | per-request frames; blocking route resources are the render wait point; allowlist projection serialized + hydrated under freshness rules; fresh hydrated entries are not re-fetched | **Landed** |
 | **Devtools / observability** | React Query Devtools | RTK devtools (Redux) | external | Xray Resources panel + a `:rf.resource/*` / `:rf.mutation/*` trace family; static registry, live instance table, work-ledger table, route/resource graph, scope-audit + orphaned-owner lints | **Landed** |
 | **Normalized / GraphQL cache** | normalizr (external) | partial | external | Apollo/Relay-class — not a resources concern; transport is HTTP-only this phase | **Out of scope** |
-| **Offline persistence / cross-tab** | persister plugins | n/a | external | not built; deferred | **Proposed (later slice)** |
+| **Offline persistence / cross-tab** | persister plugins | n/a | external | not built; held for a later slice | **Deferred (later slice)** |
 
 Every "Landed" claim above is grounded in [Spec 016 — Resources](../../../spec/016-Resources.md) and the reference implementation under `implementation/resources/`. The rest of this page expands the rows that carry the most surprise for someone arriving from a query library.
 
@@ -185,23 +185,21 @@ Three properties are worth holding onto, because they are where re-frame2 differ
 
 A view renders the in-flight optimistic state from the instance sub's derived **`:optimistic?`** flag (true between the pre-request apply and settle). The optimistic surface is exact-key or tag-within-named-scope only, both **fail-closed** on a nil-resolving `{:from-db …}` scope — there is no scope-agnostic optimistic write, so it cannot leak across viewers, tenants, or SSR requests. The normative contract is [Spec 016 §Optimistic mutations](../../../spec/016-Resources.md#optimistic-mutations); the worked write is in [Part 4 of the tutorial](../tutorial/04-mutations-and-invalidation.md).
 
-## The honest gaps
+## Polling and infinite feeds — both landed
 
-These are real parity gaps. They are deferred, tracked, and have open design proposals. Do not let the rest of this page's confidence obscure them.
+The two parity-relevant features once tracked as gaps here have since landed; they are recorded below for readers arriving from the query libraries.
 
-### Polling / refetch-interval — proposed (EP-0020)
+### Polling / refetch-interval — landed (EP-0020)
 
-TanStack's `refetchInterval`, RTK's `pollingInterval`, and SWR's `refreshInterval` make timed background refetching a one-line option. re-frame2 has the *adjacent* capability — focus/reconnect revalidation has landed (`install-revalidation-listeners!`, refetching stale-and-owned entries) — but **timed polling is not built**. There is no `:poll-ms` key; it is an explicitly rejected v1 key ([Spec 016 §Resource registration spec](../../../spec/016-Resources.md#resource-registration-spec)).
+TanStack's `refetchInterval`, RTK's `pollingInterval`, and SWR's `refreshInterval` make timed background refetching a one-line option. re-frame2 ships the same as **`:poll-interval-ms`** on `reg-resource` ([Spec 016 §Polling](../../../spec/016-Resources.md#polling)): a positive interval in ms that revalidates the entry while it is *actively owned* and the tab is visible — the third member of the freshness-timer family beside `:stale-after-ms` / `:gc-after-ms`. It is owner-gated by design: an owner-free entry never polls, so opening a devtool or leaving a stale tab cannot drive background traffic. (This is in addition to the focus/reconnect revalidation that landed earlier via `install-revalidation-listeners!`.)
 
-**Until it lands:** drive a refetch from an interval you own (an event dispatched on a timer, ensuring under an explicit owner). The design — how to express interval revalidation while preserving owner leases and stale-only refresh discipline — is under EP-0020 / bead `rf2-byl7bk.2`.
+### Infinite / load-more feeds — landed (EP-0021)
 
-### Infinite / load-more feeds — proposed (EP-0021)
+`useInfiniteQuery` (TanStack) and `useSWRInfinite` accumulate pages into one growing list with cursor management. re-frame2 ships this as a first-class **`:infinite`** resource ([Spec 016 §Infinite resources and load-more feeds](../../../spec/016-Resources.md#infinite-resources-and-load-more-feeds)): a resource registered with `:infinite true` plus a pure `:next-page-param` derivation (returning `nil` is the single terminal). One scoped feed entry accumulates an ordered page vector; a causal `:rf.resource/load-more` event extends it; the merged flat list is the headline read at `:rf.resource/items`, with `:rf.resource/pages` for boundaries and `:rf.resource/infinite-state` for the combined view-model. Numbered and cursor pagination stay exactly as before — every page is an ordinary resource keyed by its params, with `:keep-previous?` to avoid skeleton flashes ([Spec 016 §Paginated and previous data](../../../spec/016-Resources.md#paginated-and-previous-data)) — the infinite kind is the complementary accumulating-feed model, not a replacement.
 
-`useInfiniteQuery` (TanStack) and `useSWRInfinite` accumulate pages into one growing list with cursor management. re-frame2 handles *numbered and cursor pagination* well today — every page is an ordinary resource keyed by its params, with `:keep-previous?` to avoid skeleton flashes ([Spec 016 §Paginated and previous data](../../../spec/016-Resources.md#paginated-and-previous-data)) — but there is **no canonical accumulating-feed primitive**. A load-more feed currently falls back to app-db composition around the per-page resources.
+## The honest gaps — out of scope, on purpose
 
-**Until it lands:** compose pages in app-db (a subscription concatenating the per-page resource data). The canonical model — whether infinite feeds get a dedicated primitive or a documented composition pattern — is under EP-0021 / bead `rf2-byl7bk.3`.
-
-### Out of scope, on purpose
+These remain deliberately outside this HTTP-only phase. Do not let the rest of this page's confidence obscure them.
 
 - **Normalized / GraphQL caches** (Apollo, Relay, normalizr). The transport is HTTP-only this phase; a normalized entity cache is a separate later artefact gated on a GraphQL phase, not a resources gap ([Spec 016 §What Spec 016 does NOT cover](../../../spec/016-Resources.md#what-spec-016-does-not-cover)).
 - **Offline persistence and cross-tab broadcast.** Deferred later slices; not in the public-beta contract.
@@ -221,17 +219,14 @@ Reach for resources when cached server reads start multiplying and the per-read 
 
 **The summary, one more time:**
 
-- **Matched:** keyed cache, staleness, dedupe, GC, tag invalidation, mutations + consequences, optimistic updates with rollback, focus/reconnect revalidation, keep-previous paging, SSR/hydration, devtools — all **landed**.
+- **Matched:** keyed cache, staleness, dedupe, GC, tag invalidation, mutations + consequences, optimistic updates with rollback, focus/reconnect revalidation, active-owner polling, infinite / load-more feeds, keep-previous paging, SSR/hydration, devtools — all **landed**.
 - **Different by design:** per-frame cache, required structural scope, owners-vs-observers, passive views, subscriptions-instead-of-`select`, declarative causal invalidation, `:on-conflict :invalidate` as the contested-rollback default.
-- **Not built yet:** polling (EP-0020), infinite feeds (EP-0021).
-- **Out of scope:** normalized/GraphQL caches, offline/cross-tab.
+- **Out of scope (deliberately):** normalized/GraphQL caches, offline/cross-tab — held for later slices.
 
 ---
 
 **You can now:**
 
-- map any TanStack Query / RTK Query / SWR feature onto its re-frame2 resource counterpart, and read each row's landed / different / not-built status
+- map any TanStack Query / RTK Query / SWR feature onto its re-frame2 resource counterpart, and read each row's landed / different-by-design / out-of-scope status
 - explain the "same problem, different physics" line — a cache wired to causes, not to component lifecycle — and why scope is a required structural key
 - decide when a resource is the wrong tool, reaching instead for managed HTTP or a machine
-
-[pre-alpha resource parity tranche]: ../concepts/server-state.md


### PR DESCRIPTION
## What

Errata-class currency sweep (rf2-l84z5x): EP-0019 (optimistic rollback), EP-0020 (active-owner polling), and EP-0021 (infinite resources) all shipped and graduated `final`, but human-facing parity/api/EP docs still described them as "not built" / "deferred" / "reserved-but-unused". This corrects each to shipped reality. **No design change** — only status/currency.

## Files + lines corrected

**`docs/guide/explanation/resources-vs-query-libraries.md`**
- Line 3 (intro): "what is **not built yet**" → "what is **deliberately out of scope** for this phase".
- Line 13 (admonition): polling + infinite feeds moved from "not built yet / tracked as design proposals" into the landed list (alongside optimistic rollback); remaining gaps reframed as deliberately out-of-scope (GraphQL, offline/cross-tab).
- Line 23 (status legend): retired the "Proposed (EP-00NN)" row; added a "Deferred (later slice)" row used only for offline/cross-tab; noted EP-0019/0020/0021 all landed.
- Line 43 (matrix — Polling): "**not built** … Proposed (EP-0020)" → `:poll-interval-ms` description, **Landed**.
- Line 45 (matrix — Infinite/load-more): "**not built** … Proposed (EP-0021)" → `:infinite true` + `:next-page-param` description, **Landed**.
- Line 50 (matrix — Offline/cross-tab): genuinely-deferred; relabelled status to "Deferred (later slice)" (substance kept).
- "The honest gaps" section (lines ~188-202): retitled "Polling and infinite feeds — both landed"; the polling + infinite subsections rewritten as shipped (`:poll-interval-ms`; `:infinite` + `:next-page-param` + `:rf.resource/load-more` + `:rf.resource/items`). A new "The honest gaps — out of scope, on purpose" section retains the genuinely-deferred GraphQL + offline items.
- Summary block + "You can now" bullet: added polling + infinite to the landed list; removed the "Not built yet" line; reworded the status vocabulary.
- Removed the now-orphaned `[pre-alpha resource parity tranche]` reference-link definition.

**`docs/api/16-resources.md`**
- Line 55: removed `:infinite` from "**Rejected / unused in v1**"; added it (plus the infinite-only keys) to the **Optional keys** list (line 53).
- Added the `[:rf.resource/load-more {…}]` event to the events list.
- Added an **Infinite resources** section (registration example + key semantics + the infinite subscription family), mirroring the existing Polling section.

**`docs/EP/EP-0021-infinite-resources.md`**
- Backwards Compatibility (line ~603): `:infinite` is "a reserved-but-unused key today" → "**now a live `reg-resource` key**" (additive; subs/event purely additive).

## Verified left alone (genuinely deferred)
- GraphQL normalized cache (HTTP-only phase), offline persistence / cross-tab — still deferred per spec/016.
- `docs/EP/EP-0020-active-owner-polling.md:66` "reserved-but-unused key list" — historical **Motivation** prose (the EP's own pre-acceptance argument; header already marks it `final`). Left untouched.
- `docs/guide/concepts/effects-and-coeffects.md:146` "not built yet" — about a replayable-random-value supplier (coeffects/world inputs), **not** a resource feature. Left untouched.
- `spec/016-Resources.md` (hot-zone) — already current (correctly says `:infinite` is "now specified"). Untouched.

## Quality gates
```
$ python scripts/check_ep_status_sync.py    # EXIT 0 (stayed green)
$ rm -rf docs/spec && cp -r spec docs/spec && python -m mkdocs build --strict   # EXIT 0
```
mkdocs `--strict` passed; all new in-doc anchor links (`#infinite-resources`, `#polling`, `#infinite-resources-and-load-more-feeds`) resolved (no WARNING lines).