### PR TITLE
docs(impl): relabel internal realm/app/migration namespaces as internal substrate, not public vocabulary (rf2-pl97nd.4 cluster F)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -3,6 +3,26 @@
   accepted 2026-06-11, stage 6 public constructors + composition added on top
   of it; sequenced behind the merged D1 `re-frame.realm`).
 
+  ## EP-0023: this is INTERNAL substrate, NOT current public composition vocabulary
+
+  EP-0023 (graduated 2026-06-16) moves the PUBLIC model to
+  `image -> frame -> event stream`. The app/module construction surface this ns
+  ships is **superseded at the public surface, NOT deleted**: `rf/app` (the
+  app value) is publicly REPLACED by `rf/image`, and `rf/module` is RE-EXPRESSED
+  as an image fragment (EP-0023 §Surface dispositions). The `install!` /
+  `reinstall!` / `installed-app` seating + inspection surface is RETAINED as the
+  internal installation / migration / tooling substrate the realm registrar
+  backs — \"Tooling may still expose the internal installation boundary, but
+  should label it as such\" (EP-0023 §Surface dispositions). So where the
+  staging narrative below calls `rf/app` / `rf/module` / `rf/install!` \"PUBLIC\",
+  read that as the EP-0013 disposition: under EP-0023 these are retained-internal
+  / migration surfaces, NOT the current public composition vocabulary a new
+  reader should reach for. The public path is `rf/image` (select a
+  registration set by provenance) + `rf/make-frame` (load it into a frame); see
+  `re-frame.migration/migration-map` for the per-name EP-0013 -> EP-0023
+  disposition + replacement. The EP-0013 staging narrative below is preserved as
+  the design record of this retained substrate.
+
   > The program is a value; the runtime is a container you install it into.
 
   Per [EP-0013](docs/EP/EP-0013-app-values-and-runtime-realms.md) §D2 (the
@@ -28,7 +48,13 @@
       surface large-SPA code uses to compose + inspect a program before it is
       installed (see §Public construction + composition below).
 
-  ## Stage 5 (projection) is INTERNAL; stage 6 (construction) is PUBLIC
+  ## Stage 5 (projection) is INTERNAL; stage 6 (construction) is PUBLIC (EP-0013)
+
+  (EP-0023 re-classifies stage-6 construction as retained-internal / migration
+  vocabulary — `rf/app` is publicly replaced by `rf/image`, `rf/module` is
+  re-expressed as an image fragment; see the EP-0023 banner above. The
+  \"PUBLIC\" labels in this section are the EP-0013 disposition, preserved as the
+  design record.)
 
   Stage 5 shipped an internal app-value descriptor format + the projection
   seam, for the registrations that ALREADY exist in the default realm's
@@ -363,7 +389,11 @@
 
 (defn module
   "Construct a MODULE value — a composable app-value fragment (EP-0013 §Module
-  Values And Feature Ownership), as INERT data. PUBLIC (`rf/module`).
+  Values And Feature Ownership), as INERT data. EP-0013-PUBLIC (`rf/module`);
+  EP-0023 re-expresses `rf/module` as an image fragment, so this is now a
+  retained-internal / migration surface, not the current public vocabulary
+  (the public path is an `rf/image` `:include-ns` selector — see the EP-0023
+  banner + `re-frame.migration/migration-map`).
 
   `descriptor-map` carries:
 
@@ -490,7 +520,11 @@
 
 (defn app
   "Construct an APP value by composing module values (EP-0013 §App Values +
-  §Composition), as INERT data. PUBLIC (`rf/app`).
+  §Composition), as INERT data. EP-0013-PUBLIC (`rf/app`); EP-0023 publicly
+  REPLACES `rf/app` with `rf/image`, so this is now a retained-internal /
+  migration surface, not the current public vocabulary (construct an
+  `rf/image` and load it into a frame via `rf/make-frame` `:images` — see the
+  EP-0023 banner + `re-frame.migration/migration-map`).
 
   `app-map` carries:
 
@@ -592,14 +626,19 @@
 ;; The three inspectors the EP's "A Whole App As Data" example shows — read an
 ;; app value WITHOUT installing it: enumerate its registrations by kind, find
 ;; the module that owns an app-db path, read its capability requirements. Pure
-;; readers over the app-value data; no realm, no registrar. PUBLIC.
+;; readers over the app-value data; no realm, no registrar. EP-0013-PUBLIC;
+;; under EP-0023 these inspect a retained-internal / migration surface (the
+;; app value, superseded at the public surface by `rf/image`), not the current
+;; public composition vocabulary.
 
 (defn app-registrations
   "Return the registration descriptors an app value carries for `kind`
   (`kind → {id descriptor}` for that one kind), or `nil` when the app declares
   none of that kind. The enumerable registration view that makes static
   dispatch-coverage checks possible WITHOUT installing the app (EP-0013
-  §Validation/Conformance). PUBLIC (`rf/app-registrations`).
+  §Validation/Conformance). EP-0013-PUBLIC (`rf/app-registrations`) — under
+  EP-0023 a retained-internal / migration inspector over the app value
+  (superseded at the public surface by `rf/image`).
 
   Works over both constructed apps (`app`) and projected apps (`app-value`) —
   the `:registrations` shape is the same for both. Pure."
@@ -610,8 +649,10 @@
   "Return the set of `:rf.capability/*` requirements an app value declares —
   the union of its modules' `:rf.module/requires` (EP-0013 §Capability Maps),
   read off the app value's `:rf.app/requires` slot. The explicit dependency
-  surface a realm must satisfy before a stage-7 `install!` succeeds. PUBLIC
-  (`rf/app-requires`). Pure — returns `#{}` for a projected app (load-order
+  surface a realm must satisfy before a stage-7 `install!` succeeds.
+  EP-0013-PUBLIC (`rf/app-requires`) — under EP-0023 a retained-internal /
+  migration inspector over the app value (superseded at the public surface by
+  `rf/image`). Pure — returns `#{}` for a projected app (load-order
   registrations declare no requirements)."
   [app-value]
   (get app-value :rf.app/requires #{}))
@@ -619,7 +660,9 @@
 (defn app-owns
   "Return the module id that owns app-db `path` in an app value, or `nil` when
   no module declares it (EP-0013 §Module Values And Feature Ownership /
-  §Examples `(rf/app-owns app [:cart])`). PUBLIC (`rf/app-owns`).
+  §Examples `(rf/app-owns app [:cart])`). EP-0013-PUBLIC (`rf/app-owns`) —
+  under EP-0023 a retained-internal / migration inspector over the app value
+  (superseded at the public surface by `rf/image`).
 
   Resolves against the modules' `:rf.module/owns {:app-db [...]}` declarations:
   returns the id of the module whose `:rf.module/owns :app-db` vector contains
@@ -885,7 +928,11 @@
 (defn install!
   "Seat an immutable app VALUE into a realm — make `app`'s registrations the
   program `realm-or-id` dispatches/subscribes/resolves against (EP-0013 D2
-  stage 7, §Installation). PUBLIC (`rf/install!`).
+  stage 7, §Installation). EP-0013-PUBLIC (`rf/install!`); EP-0023 RETAINS
+  `rf/install!` as the internal installation / migration / tooling surface —
+  it is no longer the taught public vocabulary (the public path is
+  `rf/make-frame` with `:images`; the realm registrar remains the backing
+  installation substrate during migration — EP-0023 §Surface dispositions).
 
   Steps, in order:
 
@@ -1119,7 +1166,10 @@
 (defn reinstall!
   "Hot-reload a realm by replacing its installed app VALUE with `new-app` —
   diff the new app value against the installed one and apply the delta
-  (EP-0013 D2 stage 7, §Hot Reload And Reinstall). PUBLIC (`rf/reinstall!`).
+  (EP-0013 D2 stage 7, §Hot Reload And Reinstall). EP-0013-PUBLIC
+  (`rf/reinstall!`); EP-0023 RETAINS `rf/reinstall!` as the internal /
+  migration surface — the public hot-reload path is `rf/reload-images!`
+  against a frame target (EP-0023 §Surface dispositions).
 
   Unlike `install!` (which seats a program into a realm that has none),
   `reinstall!` REPLACES the realm's current program with a minimal delta:

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -660,11 +660,15 @@
   `realm/default-realm-id` for every frame.
 
   The frame-side half of the (realm, frame) addressing model — the (realm,
-  frame) pair is the full address (EP-0013 disposition 3). Re-exported as the
-  PUBLIC `rf/frame-realm`: the realm-targeted query surface needs a public way
-  to learn a frame's realm so a tool can route a `{:realm …}` query to the
-  realm a given frame lives in; the realm enumeration half is
-  `re-frame.realm/realm-ids`."
+  frame) pair is the full address (EP-0013 disposition 3). Re-exported as
+  `rf/frame-realm`: the realm-targeted query surface needs a way to learn a
+  frame's realm so a tool can route a `{:realm …}` query to the realm a given
+  frame lives in; the realm enumeration half is `re-frame.realm/realm-ids`.
+  EP-0023 RETAINS this as an internal / tooling surface over the internal
+  installation boundary, NOT current public composition vocabulary — the
+  (realm, frame) address is publicly replaced by a single process-local frame
+  target (EP-0023 §Surface dispositions / §Id Spaces); a tool may still read a
+  frame's realm but should label it as internal substrate."
   [id]
   (when-let [f (frame id)]
     (or (:realm f) realm/default-realm-id)))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1039,7 +1039,7 @@
    {:key         :realm/frames-by-realm
     :producer-ns 're-frame.frame
     :design-bead "rf2-gkddyq"
-    :description "EP-0013 D1 realm-owned frame-registry view. Returns `realm-id → #{frame-id …}` over the live (non-destroyed) frames, grouped by each frame record's `:realm` slot. `re-frame.realm/realm-frames` consults it to answer the realm-owned membership query — `re-frame.frame` requires `re-frame.realm` for the frame record's default realm-id, so the back-read is late-bound to avoid a require cycle. Membership is DERIVED from `re-frame.frame/frames` (single source of truth; no separately-stored set), so the `(reset! frame/frames {})` test fixtures reset it for free."}
+    :description "EP-0013 D1 realm-owned frame-registry view (the realm is EP-0023 retained-INTERNAL installation substrate, not current public vocabulary). Returns `realm-id → #{frame-id …}` over the live (non-destroyed) frames, grouped by each frame record's `:realm` slot. `re-frame.realm/realm-frames` consults it to answer the realm-owned membership query — `re-frame.frame` requires `re-frame.realm` for the frame record's default realm-id, so the back-read is late-bound to avoid a require cycle. Membership is DERIVED from `re-frame.frame/frames` (single source of truth; no separately-stored set), so the `(reset! frame/frames {})` test fixtures reset it for free."}
    {:key         :frame/destroy-realm-frames!
     :producer-ns 're-frame.frame
     :design-bead "rf2-yueuvi"

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -2,6 +2,26 @@
   "The runtime realm — the container that owns the non-durable operational
   layer an app runs in (EP-0013 D1, accepted 2026-06-11).
 
+  ## EP-0023: this is INTERNAL substrate, NOT current public composition vocabulary
+
+  EP-0023 (graduated 2026-06-16) moves the PUBLIC model to
+  `image -> frame -> event stream` and **RETAINS this realm machinery as the
+  internal installation substrate** — it is NOT deleted, but it is also no
+  longer the taught public architecture (EP-0023 §Backwards Compatibility:
+  \"This EP retains EP-0013's D1 runtime-realm machinery as the internal
+  installation boundary\"; §Surface dispositions: the D1 realm container is
+  \"Retained internally … It stops being the beginner-facing public
+  architecture\"). The realm remains a valid implementation substrate for
+  registrar seating, adapter/capability storage, host-transient ownership,
+  disposal, and compatibility during migration. Where this ns re-exports names
+  through the `re-frame.core` facade (`rf/realm`, `rf/dispose-realm!`,
+  `rf/realm-ids`, `rf/installed-app`), those are retained-internal / migration
+  / tooling surfaces, NOT current public composition vocabulary — the public
+  path is `rf/image` + `rf/make-frame` (EP-0023 §Surface dispositions; the
+  EP-0013 names below describe the retained substrate, not the model a new
+  reader should compose against). The EP-0013 staging narrative below is
+  preserved as the design record of this retained substrate.
+
   Per [Runtime-Subsystems §Runtime realms](spec/Runtime-Subsystems.md) and
   Spec-Schemas §`:rf/realm`, a runtime realm owns the registrar it
   dispatches/subscribes/resolves against, the installed adapter SELECTION,
@@ -276,10 +296,15 @@
 
   The realm-side half of the (realm, frame) addressing model: a tool reads the
   installed realms here and a frame's realm via `re-frame.frame/frame-realm`,
-  the two together being the full address (EP-0013 disposition 3). PUBLIC
-  (`rf/realm-ids`) — the realm-targeted query surface needs a public way to
-  enumerate realms (the stage-8 `{:realm …}` query forms take a realm id but
-  nothing public told a tool WHICH ids exist)."
+  the two together being the full address (EP-0013 disposition 3).
+  EP-0013-PUBLIC (`rf/realm-ids`) — the realm-targeted query surface needs a
+  public way to enumerate realms (the stage-8 `{:realm …}` query forms take a
+  realm id but nothing public told a tool WHICH ids exist). Under EP-0023 this
+  is a retained-internal / tooling surface over the internal installation
+  boundary, NOT current public composition vocabulary (the `(realm, frame)`
+  address it serves is publicly replaced by a single process-local frame
+  target — EP-0023 §Surface dispositions / §Id Spaces); tooling may still
+  enumerate realms but should label them as internal substrate."
   []
   (set (keys @realms)))
 
@@ -365,9 +390,14 @@
   realm-map)
 
 (defn construct-realm
-  "Construct + register a PUBLIC realm — an explicit container a caller installs
-  an app value into and targets queries against (EP-0013 stage 9). PUBLIC
-  (`rf/realm`).
+  "Construct + register a realm — an explicit container a caller installs
+  an app value into and targets queries against (EP-0013 stage 9).
+  EP-0013-PUBLIC (`rf/realm`); EP-0023 RETAINS `rf/realm` as the INTERNAL
+  installation substrate — it stops being the beginner-facing public
+  architecture (the public model targets a FRAME via `rf/make-frame`, the
+  frame determines the image generation used for registration resolution —
+  EP-0023 §Surface dispositions). Retained-internal / migration / tooling
+  surface, not current public composition vocabulary.
 
   `opts` (a map) carries:
 
@@ -591,11 +621,15 @@
   stable across the stage-6/7 graduation; only its internals change (project,
   then overlay the seated provenance when a stored app exists).
 
-  PUBLICLY RE-EXPORTED as `rf/installed-app` (EP-0013 disposition 6, rf2-imquoq):
+  RE-EXPORTED as `rf/installed-app` (EP-0013 disposition 6, rf2-imquoq):
   the realm→installed-app read seam graduated from internal WHEN the Xray
   Module-view demanded the per-module provenance an `install!`-seated `:app`
   carries (`:modules` + `:rf.module/owns` / `:rf.module/requires` /
-  `:owner`-stamped descriptors).
+  `:owner`-stamped descriptors). EP-0023 RETAINS `rf/installed-app` as a
+  tooling / migration surface, NOT current public composition vocabulary — the
+  public model inspects a frame's resolved image generation; tools may still
+  read this internal installation boundary but should label it as
+  implementation structure (EP-0023 §Surface dispositions).
   A read of the LIVE registration value (provenance from the install-time
   snapshot) — it does NOT route live dispatch through a non-default realm (the
   deferred runtime-routing slice). This var stays the canonical implementation;
@@ -826,8 +860,11 @@
   its own registrar for GC). nil / the default realm id is a NO-OP — the
   default realm is never disposed (it backs the byte-identical single-realm
   path). Returns nil. The teardown counterpart of `construct-realm` for
-  hermetic-test cleanup and multi-tenant realm lifecycle. PUBLIC
-  (`rf/dispose-realm!`).
+  hermetic-test cleanup and multi-tenant realm lifecycle. EP-0013-PUBLIC
+  (`rf/dispose-realm!`); EP-0023 RETAINS `rf/dispose-realm!` as the
+  retained-internal / migration / tooling surface (the realm is the internal
+  installation boundary, not the public model — EP-0023 §Surface
+  dispositions). The public disposal boundary is a frame (`destroy-frame!`).
 
   Per EP-0013 §Realm Conformance disposing a realm MUST release the operational
   resources the realm owns, not merely drop the registry entry (a bare `dissoc`

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -47,7 +47,10 @@
   so `head-snapshot` reflects the most recent render-head output. Keyed by the
   frame ADDRESS (rf2-bzw8gd) so the same frame id in two realms records
   independent head snapshots — `frame-address` collapses to the bare
-  `frame-id` for the default realm (byte-identical single-realm path)."
+  `frame-id` for the default realm (byte-identical single-realm path). The
+  (realm, frame) address is the EP-0023 retained-INTERNAL routing seam
+  (`re-frame.frame/frame-address`), not current public vocabulary — see
+  `re-frame.realm`'s EP-0023 banner."
   [frame-id head-id head-model]
   (when frame-id
     (swap! head-snapshots assoc-in [(frame/frame-address frame-id) head-id]


### PR DESCRIPTION
## What

Ruling-INDEPENDENT slice of **rf2-pl97nd.4** — cluster F of the pl97nd.1 classified inventory. Relabels the INTERNAL substrate namespaces' **docstrings + comments** so a reader of the internal code understands `realm` / `app` / `module` are EP-0023 **retained internals**, NOT current public composition vocabulary.

EP-0023 (graduated 2026-06-16) moves the public model to `image -> frame -> event stream` and **RETAINS** the EP-0013 realm/app/module installation machinery as the internal installation substrate (EP-0023 §Backwards Compatibility, §Surface dispositions): *"This EP retains EP-0013's D1 runtime-realm machinery as the internal installation boundary … Tooling may still expose the internal installation boundary, but should label it as such."* The scrub here is **relabel, not delete**.

## Files relabelled

- `implementation/core/src/re_frame/realm.cljc` — EP-0023 retained-internal banner on the ns docstring; relabel `realm-ids` / `construct-realm` (`rf/realm`) / `installed-app` / `dispose-realm!` PUBLIC markers as EP-0013-public, EP-0023 retained-internal/migration/tooling surfaces.
- `implementation/core/src/re_frame/app_value.cljc` — EP-0023 banner (`rf/app` publicly replaced by `rf/image`; `rf/module` re-expressed as an image fragment; `install!`/`reinstall!`/`installed-app` retained-internal); relabel the `module` / `app` / `app-registrations` / `app-requires` / `app-owns` / `install!` / `reinstall!` PUBLIC markers and the stage-5/6 comment block.
- `implementation/core/src/re_frame/frame.cljc` — relabel `frame-realm`'s PUBLIC re-export note as an EP-0023 retained-internal/tooling seam over the internal installation boundary (the `(realm, frame)` address is publicly replaced by a single process-local frame target).
- `implementation/core/src/re_frame/late_bind/directory.cljc` — note the realm-owned `:realm/frames-by-realm` hook is EP-0023 retained-internal substrate.
- `implementation/ssr/src/re_frame/ssr/head/registry.cljc` — note the `(realm, frame)` keying is the EP-0023 retained-internal routing seam (`frame/frame-address`).

`re-frame.migration` was reviewed and already cites EP-0023 thoroughly (it is the sanctioned migration-shim home) — no change needed. The remaining SSR / ssr-ring inline `(realm, frame)` routing comments are accurate internal-implementation rationale already citing EP-0013 §Realm Conformance and routing through the now-relabelled `frame/frame-address` (INTERNAL) seam.

## Constraints honoured

- Comments/docstrings ONLY — no symbol renames, no signature or behaviour changes.
- Did NOT touch the public facade `re_frame/core.cljc` (that is pl97nd.2, gated on an un-ruled operator decision).
- Did NOT touch tests (cluster G), docs/spec prose (pl97nd.3), tool descriptors/Xray, or the api-manifest.

## Quality gate

\`\`\`
cd implementation && npm run test:cljs   # 8008 tests, 33427 assertions — 0 failures, 0 errors
\`\`\`

Note: pl97nd.4 also has cluster G (test migration) which is GATED on the pl97nd.2 facade ruling — NOT done here; the mayor files it as a follow-up. **pl97nd.4 is NOT closed.**