### PR TITLE
docs(api-review): fresh five-lens consolidation + per-file implementation routing

### DIFF
--- a/ai/findings/API-review/codex/README.md
+++ b/ai/findings/API-review/codex/README.md
@@ -59,3 +59,63 @@ The common philosophical point is very Clojure: the stable API should be small
 values and clear operations over those values. A framework can have a rich
 runtime, but the public language should not ask users to remember which of
 three aliases was canonical in the current context.
+
+## Fresh consolidation pass (2026-06-18)
+
+A second, fully independent five-lens pass (the same five lenses, blind to this
+corpus) was consolidated in. It re-discovered the areas above independently
+(cross-validation) and added three new findings plus a cross-cutting one. Each
+area file gained a `## Implementation` section.
+
+New files added this pass:
+- [frame-object-record-unification.md](frame-object-record-unification.md) -
+  highest-leverage frame finding and the most contentious (questions the graduated
+  EP-0023 internal structure: two `make-frame` constructors + two registries).
+- [elision-redaction-helpers.md](elision-redaction-helpers.md) - four-lens-
+  converged: 9 granular redaction helpers + 1 assembling tool + API.md drift; plus
+  the imperative-marks residue.
+- [listener-and-sink-registries.md](listener-and-sink-registries.md) - five
+  identical register/unregister registries -> one stream-parameterized verb + one
+  production sink.
+- [facade-accretion-and-removal.md](facade-accretion-and-removal.md) -
+  cross-cutting; the layered-accretion mechanism beneath ~half the findings, plus
+  the pre-alpha delete-not-demote disposition that governs them.
+
+### Governing disposition: pre-alpha removal, not demotion (Mike, 2026-06-18)
+
+re-frame2 is pre-alpha - no back-compat shims, no migration layers. A superseded
+or layered surface is either kept because the live internal design genuinely uses
+it (then internal-only: its own namespace, never facade / manifest / spec/API.md)
+or kept only so prior callers keep working (then removed outright). There is no
+"retained-for-migration" facade tier. Demotion-by-docstring is not enough: the
+disposition must fire on the export list, the api-manifest* rows, and the
+spec/API.md rows. This resolves the open facade ruling toward removal.
+
+### Implementation routing
+
+- **One EP - frame grammar + object model.** frame-targeting-and-lifecycle +
+  frame-object-record-unification + the :frame/:realm query split in
+  registrar-query-addressing are one coupled public-grammar change; land them as a
+  single EP (or EP-0023 amendment), not three. Needs owner adjudication first.
+- **Existing epic rf2-pl97nd.** retired-app-composition-vocabulary - the pre-alpha
+  disposition resolves its open ruling toward removal.
+- **One guardrail bead.** facade-accretion-and-removal - generalize the pl97nd.5
+  gate into a standing manifest-hygiene check. The disposition itself is ruled.
+- **Ordinary beads (docs-first or facade-pruning).** machine helpers, views,
+  resource/mutation reads, registration programmatic forms, frame-state, elision
+  helpers, listener/sink registries, boot/adapters - each with its own
+  Implementation section.
+
+### Overlap / conflict / new
+
+- **Overlap** (re-discovered, evidence strengthened): EP-0013 retired vocab,
+  :realm/:frame address fusion, partition readers / snapshot-of / compute-sub,
+  machine helpers, *-fn / reg-view* / removed-stubs, frame-bound-fn /
+  with-new-frame.
+- **Conflict** (one, adjudicated): the minimalist lens proposed moving
+  machine-has-tag? off the facade; the empirical lens (64 hits) + the corpus keep
+  it. Adoption wins; sub-machine is the only machine helper to drop.
+- **New**: the four files above, plus deltas - removed-stub data table, interceptor
+  context accessors, ->interceptor tier fix, schema validator cluster,
+  trace-projection re-exports, make-frame-handle -> frame-handle*, EP-0023
+  vocabulary near-synonyms, and the HTTP test-support pair.

--- a/ai/findings/API-review/codex/boot-config-and-adapters.md
+++ b/ai/findings/API-review/codex/boot-config-and-adapters.md
@@ -101,3 +101,25 @@ The re-frame2 ethos has been moving away from ambient defaults. Boot should
 reflect that. `init!` should not smell like it might create a hidden default
 frame, and adapter internals should not sit beside the everyday startup call as
 though they are peer choices.
+
+## Fresh consolidation pass additions (2026-06-18)
+
+**Schema validator-extension cluster: bless the bundle, demote the singletons**
+(empirical lens). `re-frame.schemas` offers four ways to install validation fns
+at boot - three single-fn setters `set-schema-validator!` / `set-schema-explainer!`
+/ `set-schema-printer!`, plus the atomic bundle `set-schema-fns!` that does all
+three. API.md notes the bundle is "the honest one-call substitute-Malli boot
+pattern (so they never drift mid-boot)" - i.e. the singletons are the drift-prone
+path the bundle exists to replace. All four are used (set-schema-validator! 68,
+set-schema-fns! 43, set-schema-printer! 29, set-schema-explainer! 9), so this is
+duplicate-idiom, not dead surface. Bless `set-schema-fns!`; demote the singletons.
+
+## Implementation
+
+- **Vehicle: docs/beads first, + one decision bead** if `configure!` moves from
+  keyed-arity to map shape. No EP.
+- Beads: (1) docs - the one boot sentence (init! adapter, then explicit frames);
+  (2) move adapter internals (install-adapter! / current-adapter / ...) to an
+  adapter-author section; (3) bless set-schema-fns!, demote the three schema
+  setter singletons; (4) decision - configure! map shape.
+- Behaviour-preserving; independent of the EP work.

--- a/ai/findings/API-review/codex/elision-redaction-helpers.md
+++ b/ai/findings/API-review/codex/elision-redaction-helpers.md
@@ -1,0 +1,126 @@
+# Elision / Redaction Helper Family
+
+Status: draft finding — **new in the 2026-06-18 fresh consolidation pass**.
+This was the most-converged *new* area: four independent lenses (minimalist
+facade, technical taste, model coherence, empirical call-site) flagged it
+without prior corpus coverage.
+
+## Crowding Signal
+
+The public egress/redaction boundary is two primitives — `project-egress`
+(record-level boundary) and `elide-wire-value` (size-elision walk). Beneath them,
+the facade also exports a **9-member low-level toolkit** of collect/match/derived
+helpers, doubled across a sensitive-axis and a large-axis. They are the internal
+decomposition of `project-egress` leaked onto `re-frame.core`, exposed because
+exactly one in-repo consumer wanted to share a single collection pass across N
+output slots. SMALL-CORE-plus-COMPOSITION lost to a disassembled-gears surface.
+
+The facade members (`core.cljc:2871-2958`):
+
+- `redact-derived-values`, `redact-derived-large-values`
+- `redact-matching-values`, `redact-matching-large-values`
+- `elision-sensitive-value-set`, `elision-large-value-marker-map`
+- `elision-collect-sensitive-values`
+- `elision-declarations`, `elision-sensitive-declarations`
+
+## Implementation / call-site evidence (verified)
+
+- All 9 are exported at `core.cljc:2871-2958`, tier `:tooling`, `:facade? true`
+  in `spec/api-manifest.edn:112-165`.
+- **Spec drift:** none of the 9 are rowed in `spec/API.md` (only the higher-level
+  `elide-wire-value` and `project-egress` are documented). API.md's own
+  projection-maintenance rule (`API.md:37`) says every shipped facade surface
+  must be rowed — 9 `:facade? true` vars are unrowed.
+- **One assembling consumer.** Empirical counts across `examples/**` +
+  `tools/**/src/**`: examples = 0 for all 9. `tools/story-mcp/.../egress.cljc`
+  is the single tool that wires them — `scrub-rendered` (≈line 264) uses the two
+  high-level `redact-derived-*` forms, while `scrub-explain-values` (≈line 334)
+  re-implements the same thing from the four low-level primitives
+  (`elision-sensitive-value-set` + `redact-matching-values`,
+  `elision-large-value-marker-map` + `redact-matching-large-values`) purely to
+  collect once and substitute over N slots. `elision-declarations` = 0 tools / 7
+  tests; `elision-sensitive-declarations` = 0 tools / 1 test.
+- Contrast the real boundary primitives: `elide-wire-value` ≈ 19 tools-src / 73
+  tests; `project-egress` ≈ 4 tools-src / 28 tests. Those earn their facade slot;
+  the 9 do not.
+- The pair-mcp egress driver (`tools/re-frame2-pair-mcp/...`) is the same shape
+  of consumer.
+
+The pattern is textbook "every call site re-wraps the same way" → a **missing
+higher-level primitive**, not nine public ones.
+
+## Observed use cases
+
+1. Redacting a derived tree (rendered hiccup, snapshot body, plan-resolved
+   slots) against a frame's declared sensitive/large values, where the value
+   re-surfaces at a non-app-db position the path walker can't reach.
+2. Driving multi-slot redaction from **one** collection pass (the only reason
+   the four low-level gears are public).
+3. Tools/tests reach `project-egress` + `elide-wire-value` for the boundary;
+   nothing in app or example code touches the nine.
+
+## Proposed smaller API
+
+Keep the two boundary primitives on the facade: `project-egress`,
+`elide-wire-value` (plus `sensitive?`). Add **one** composed multi-slot helper —
+shape roughly `(redact-derived-slots m slot-keys db frame opts)` — that does the
+collect-once / substitute-many pass internally (sensitive then large, since
+sensitive always wins). Move the seven `redact-*` / `elision-*-value-set` /
+`*-marker-map` step helpers and the two `*-declarations` readers off the facade
+into `re-frame.elision` (their actual home — they are already `elision/…`
+aliases). story-mcp / pair-mcp call the one composed helper, or require
+`re-frame.elision` directly per the project's "tools reach canonical homes
+directly" rule (`API.md:83`).
+
+Net: 9 facade exports → ~1 new composed helper (or 0, if the tools require the
+ns), and the API.md projection-drift closes either by removing the rows or by
+documenting one family block in §Data classification.
+
+## Related: marks imperative residue (fold-in from the technical-taste pass)
+
+The same EP-0015 redaction surface carries a second, smaller smell. The public
+path is now frame-owned `:sensitive` / `:large` declaration + `project-egress`,
+and `elision.cljc:16` asserts "There are no imperative large-path APIs" — yet:
+
+- `re-frame.marks/add-marks` + `set-marks` survive as internal twins of the
+  removed public marks surface (`core.cljc:62-71` documents the facade removal
+  while keeping `re-frame.marks` as a side-effect require), and
+- `reg-fx` still pokes the imperative marks registry on every registration:
+  `(late-bind/get-fn :marks/register-marks!)` at `fx.cljc:96-101`.
+
+The *need* — registration-owned event-arg marks for
+`:marks/redact-event-by-registration` (`projection.cljc:221-232`) — is
+legitimate. The smell is that it is a live registry **mutated imperatively**
+rather than **derived from the registration metadata** the framework already
+holds. The project already chose "derive from the registration spec, no
+side-table" for machine guards (`core-machines.cljc:90-129`, "read it back rather
+than duplicating it into a second registrar entry"). Apply the same here: derive
+event/fx marks from the descriptor's `:sensitive` / `:large` at projection time,
+and delete the imperative `add-marks` / `set-marks` registry plus the `reg-fx`
+poke (DATA over FUNCTIONS).
+
+## Classification
+
+Beads after the boundary decision. The core move (9 → 1 composed helper +
+re-frame.elision home) is an ordinary facade-pruning bead once the single tool
+consumer is repointed; it also fixes the API.md projection drift. The marks
+residue is a separate small data-over-functions cleanup. Neither is EP-level.
+
+## Why this is better
+
+The public redaction language should be "name the egress boundary"
+(`project-egress`) and "elide a wire value" (`elide-wire-value`). When the only
+reason a primitive is public is "a consumer needs to share an intermediate
+result," the framework should expose the composed operation, not the
+disassembled gears — and it should derive marks from the registration data it
+already owns rather than mutating a parallel imperative registry.
+
+## Implementation
+
+- **Vehicle: ordinary beads.** No EP.
+- Beads: (1) add one composed multi-slot egress helper, move the 9 granular helpers
+  to `re-frame.elision`, repoint story-mcp/pair-mcp, and close the `spec/API.md`
+  projection drift; (2) derive event/fx marks from registration metadata and delete
+  the imperative `add-marks` / `set-marks` registry + the `reg-fx` poke.
+- Pre-alpha disposition: the granular facade exports are removed, not demoted.
+- Hot-zone: `core.cljc`, `api-manifest*.edn`, `spec/API.md`.

--- a/ai/findings/API-review/codex/facade-accretion-and-removal.md
+++ b/ai/findings/API-review/codex/facade-accretion-and-removal.md
@@ -1,0 +1,140 @@
+# Facade Accretion — The Cross-Cutting Pattern (Pre-Alpha Removal Discipline)
+
+Status: draft finding — **new in the 2026-06-18 fresh consolidation pass**.
+Cross-cutting: this is the single mechanism beneath roughly half the per-area
+findings in this corpus. Two independent lenses (minimalist facade, technical
+taste) raised it as a cross-cutting observation; it had no standalone write-up
+until now.
+
+## Crowding Signal
+
+The facade has accreted in **layers**. Each EP adds its new exports and leaves
+the prior generation in place, demoted only by a docstring note ("RETAINED as
+internal/migration surface", "publicly REPLACED by …"). The demotion **stops at
+the docstring**: it never reaches the export list (`def` still on
+`re-frame.core`), the manifest (`:facade? true` row still present), or the spec
+(`spec/API.md` still rows it as current public API). The result is a facade that
+reads as an archaeological dig — a reader meets two or three complete vocabularies
+for one fact and must perform history recovery to know which one is alive.
+
+The disposition data to do this correctly already exists. `migration.cljc:57-142`
+records every retired symbol's disposition as data (`:publicly-replaced`,
+`:re-expressed`, `:retained-internal`). That is the right tool. The gap is that
+the disposition **never fires on the export list, the manifest, or the spec** —
+it only annotates a docstring.
+
+## The pre-alpha correction (the load-bearing point)
+
+The natural-but-wrong remedy is "push every disposition through to `^:no-doc` +
+manifest removal, but keep the surface reachable for migration." That is still a
+back-compat reflex. **re-frame2 is pre-alpha: no back-compat shims, no migration
+layers, build it right the first time.** So the remedy is sharper:
+
+> For each retained surface, ask one question: **is it kept because the current
+> internal design genuinely uses it, or kept because old code / old callers would
+> otherwise break?** In pre-alpha the second answer is **delete**, not demote.
+
+This collapses the usual three-tier outcome (public / retained-internal-for-
+migration / gone) to **two**: a surface is either (a) genuinely used by the live
+internal architecture — then it is *internal* (its own namespace, never facade /
+manifest / API.md), or (b) kept only so prior callers keep working — then it is
+**removed outright**. There is no "retained-as-a-migration-bridge" middle tier in
+a pre-alpha framework with no external consumers to protect.
+
+What this does **not** delete: substrate the current design actually depends on.
+`re-frame.realm` backing SSR's internal `(realm, frame)` routing is "kept because
+the design uses it" — legitimate, but internal-only. Pre-alpha kills the
+retention-for-compat tier, not the in-use internal substrate.
+
+## Instances this pattern unifies
+
+Each of these is a layer left behind a docstring note; the per-area files carry
+the detail. Under the pre-alpha discriminator above:
+
+- **EP-0013 app/realm/module facade exports** —
+  [retired-app-composition-vocabulary.md](retired-app-composition-vocabulary.md),
+  [retired-vocab-inventory-classified.md](retired-vocab-inventory-classified.md).
+  `rf/app` / `rf/module` are `:publicly-replaced` → remove. The realm
+  install/query *facade* family is kept-for-compat → remove from the facade
+  (the realm *machinery* stays internal where SSR uses it). **This resolves the
+  inventory's explicit "Open ruling for Mike" (Cluster A) toward removal:**
+  "keep them as labelled-internal *facade* exports" is the non-pre-alpha option.
+- **Migration shims** (`migration-map` / `migration-explain` /
+  `assert-process-local-frame-id!`) — a migration *layer*. Once the `rf2-pl97nd`
+  scrub rewrites the internal call sites, they have no consumer. Pre-alpha keeps
+  no migration layer, so the inventory's "PRESERVE — Bead-Plan step 16" stance is
+  a pre-EP-0023-era hedge worth revisiting: delete with the scrub, don't enshrine.
+- **The two-layer frame model** —
+  [frame-object-record-unification.md](frame-object-record-unification.md). The
+  EP-0013 record kept alongside the EP-0023 object is the deepest instance of
+  accretion. Pre-alpha does not leave this "contentious / needs adjudication" —
+  collapsing the layers is exactly what pre-alpha mandates.
+- **Stale interceptor/cofx accessors** (EP-0017/0022 left `get-coeffect` /
+  `assoc-coeffect` / `get-effect` / `assoc-effect` after removing their audience)
+  — [registration-programmatic-forms.md](registration-programmatic-forms.md).
+  Remove (the setters are dead even in tests).
+- **Granular elision helpers** and **marks imperative residue** (EP-0015 layer
+  beneath `project-egress`) —
+  [elision-redaction-helpers.md](elision-redaction-helpers.md).
+- **Five listener/sink registries** (EP-0008/0015 observation layers with zero
+  production callers) —
+  [listener-and-sink-registries.md](listener-and-sink-registries.md).
+- **Schema setter singletons** beneath `set-schema-fns!`, **trace-projection
+  facade re-exports**, **`make-frame-handle`**, the **HTTP test-support
+  install/uninstall pair** — folded into boot/config, frame-state, and
+  frame-targeting.
+
+The one legitimate retention class is the **throwing removed-name stubs**
+(`reg-event-db`, `path`, `unwrap-interceptor`, …): they keep a stale call failing
+loudly with an actionable message. Even those are a developer-experience choice,
+not a compatibility obligation — and they should be data-table-driven, not N
+bespoke throwers (see registration-programmatic-forms.md).
+
+## Proposed remedy
+
+1. **Resolve every disposition to delete-or-genuinely-internal.** No
+   "retained-for-migration" facade tier survives. The `migration.cljc`
+   disposition data drives it; it must now fire on the export list, the manifest,
+   and the spec rows, not just the docstring.
+2. **Delete the migration shims with the scrub**, not after some indefinite
+   migration window — there is no external EP-0013 consumer, and internal callers
+   are being rewritten by `rf2-pl97nd` regardless.
+3. **Generalize the `pl97nd.5` guardrail into a standing manifest-hygiene gate.**
+   Today it fails only on *retired vocab* appearing as current public API.
+   Generalize the invariant: **no `:facade? true` manifest row may carry a
+   superseded / retained-for-compatibility disposition.** That makes the cleanup
+   permanent — the *next* EP cannot demote-by-docstring-and-leave-the-export, so
+   the facade stops re-accreting by construction.
+
+## Classification
+
+Posture/discipline finding + one generalized gate. It does not introduce new API;
+it resolves the open facade ruling (toward removal) and turns the per-area
+demote/remove recommendations into one enforceable rule. Most of the execution is
+already owned by `rf2-pl97nd` for the EP-0013 layer; the new piece is (a) applying
+the same delete-not-demote disposition to the non-EP-0013 layers above, and (b)
+the generalized manifest-hygiene gate so it holds for future EPs.
+
+## Why this is better
+
+A pre-alpha framework's public surface should teach exactly one live model. Every
+layer left behind "for now" is a tax the reader and every future agent pay
+forever, and a back-compat reflex the pre-alpha posture explicitly rejects. The
+project already has the data (dispositions) and a narrow gate; the move is to let
+the disposition mean what it says — gone — and to enforce it so the surface stays
+small as the design keeps moving.
+
+## Implementation
+
+- **Disposition: RULED (pre-alpha removal, Mike 2026-06-18).** Not a bead — the
+  governing posture is set. It flips the per-area findings from
+  demote-and-retain to delete-or-genuinely-internal.
+- **One guardrail bead (ordinary).** Generalize the `rf2-pl97nd.5` retired-vocab
+  gate into a standing manifest-hygiene check: *no `:facade? true` manifest row
+  may carry a superseded / retained-for-compat disposition.* This is the durable
+  enforcement that stops the next EP re-accreting; file it as a sibling of
+  pl97nd.5 or fold into it.
+- **No EP** — posture + a gate, no new public API.
+- Execution of the per-layer removals lives in each area file's Implementation
+  section; this file is the shared discriminator (use-by-the-live-design = keep
+  internal; kept-for-compat = delete).

--- a/ai/findings/API-review/codex/frame-object-record-unification.md
+++ b/ai/findings/API-review/codex/frame-object-record-unification.md
@@ -1,0 +1,181 @@
+# Frame Object / Record Unification
+
+Status: draft finding — **new in the 2026-06-18 fresh consolidation pass**.
+Highest-leverage structural finding, and the most contentious (it argues the
+graduated EP-0023 implementation realized the collapse *additively*). Needs
+validation against the EP-0023 implementers' intent before action.
+
+This file is the structural sibling of
+[frame-targeting-and-lifecycle.md](frame-targeting-and-lifecycle.md). That file
+treats the crowding as an **addressing-spelling** problem ("do I pass the id or
+the object?"). This file makes the deeper claim underneath it: there are
+**two frame constructors backed by two registries**, and most of the addressing
+crowding, the normalization seams, and several guard mechanisms are glue holding
+those two halves together. Fix the backing structure and much of the
+spelling-level crowding dissolves with it.
+
+## Crowding Signal
+
+EP-0023 promised to collapse the public model to `image -> frame -> event
+stream`, with `make-frame` returning the one thing that "owns app-db,
+runtime-db, queue, sub-cache, lifecycle, AND a reference to the resolved image
+generation" (EP-0023:300-315). The implementation instead grew a **second**
+frame type, a **second** registry, and a **second** creation path layered over
+the retained EP-0013 record — then invented normalization seams, dual-address
+guards, and a "create twice" idiom to keep the two coherent. At the code level
+the object does **not** own app-db; the record does. The object owns a
+*pointer* (`:rf.frame/runnable-id`) to the record.
+
+## Implementation evidence (verified)
+
+- Two `make-frame`:
+  - `implementation/core/src/re_frame/live_frame.cljc:469-587` — the object
+    constructor. Its body calls `frame/reg-frame runnable-id {}` (≈line 580) to
+    mint the backing EP-0013 record, then `register-live-frame!` (≈line 570)
+    into a **separate** `live-frames` atom (≈line 172).
+  - `implementation/core/src/re_frame/frame.cljc:1499-1505` — the other
+    `make-frame`: "Anonymous-instance creation. Generates a gensym'd id …
+    Returns the gensym'd id."
+- Two registries: `live-frame/live-frames` vs `frame/frames`. The object
+  docstring concedes the split (`live_frame.cljc:86-95`): "DELIBERATELY SEPARATE
+  from `re-frame.frame`'s EP-0013 `(realm, frame)`-addressed `frames` registry."
+- The object is a pointer, not the owner: every per-frame subsystem "keys
+  per-frame state through a frame-id ADDRESS keyed into `frames`"
+  (`frame.cljc:99-101`). `frame-target->id` (`frame.cljc:125-136`) strips the
+  object back to that id at every public entry point
+  (`core.cljc:2009/2024/2040`, dispatch via `build-envelope` `core.cljc:995`,
+  `destroy-frame!` `frame.cljc:2081`), and `object-marker` is **duplicated** in
+  `frame.cljc:108` and `live_frame.cljc:246` to dodge a require cycle.
+- The create-twice idiom: to build an image-frame that *also* carries config
+  (`:preset`/`:fx-overrides`/classification) a caller must invoke **both**
+  constructors on the same id in a load-bearing order —
+  `tools/story/src/re_frame/story/frames.cljc:629-642` does exactly this, with a
+  comment warning that reversing the order silently clobbers the Story config
+  back to empty. The facade hardcodes the split with `make-frame-opt-keys` +
+  `assert-make-frame-opts!` → `:rf.error/make-frame-record-only-key`
+  (`core.cljc:814-848`), a guard whose whole job is to reject keys the *other*
+  `make-frame` would accept.
+- Two opposite duplicate-id policies for one concept: `reg-frame` silently
+  surgical-updates an existing id (`frame.cljc:1481`, and `make-frame` *relies*
+  on this not clobbering, `live_frame.cljc:574-580`), while the object
+  `make-frame` fails loud on a duplicate id (`live_frame.cljc:386-419`,
+  `:rf.error/live-frame-id-conflict`).
+- Teardown is split across both registries: `destroy-frame!`
+  (`frame.cljc:2136-2230`) fires ~10 late-bound subsystem cleanups PLUS a realm
+  host-transient inventory walk PLUS a separate `:live-frame/forget!` hook
+  (`frame.cljc:2227`) purely to drop the EP-0023 registry entry the EP-0013
+  record doesn't know about.
+- The reprojection re-entrancy guard exists because `make-frame` secretly fires
+  `reg-frame`: `reproject-live-frames!` / `mark-dirty-and-schedule!`
+  (`live_frame.cljc:803-1016`) carries a `reprojecting?` guard
+  (`:891-902`) and a no-live-frame skip (`:964-974`) added specifically because
+  every object-frame creation now trips the `reg-*` reprojection hook. ~100
+  lines of machinery defending the framework against tripping its own hot-reload
+  hook.
+
+## Observed use cases
+
+1. EP-0023 image-loaded frames (tests, Story variants, SSR) want the object.
+2. `reg-frame`'s `:on-create`/`:preset`/`:fx-overrides` config surface and
+   gensym anonymous frames want the record.
+3. Story variant frames need **both** at once → the create-twice idiom.
+4. Hot reload needs `reg-frame` idempotency (preserve app-db on re-eval).
+5. Empirical adoption note: examples converge on `{:frame f}` ids + `make-frame`
+   for tests; no example holds a record vs object distinction consciously — the
+   fork is framework-internal, paid by the framework, not chosen by users.
+
+## Proposed smaller API
+
+Fold the image generation onto the EP-0013 record and let there be **one
+constructor over one registry**:
+
+- add one `:generation` slot to `new-frame-record` (`frame.cljc:1277`);
+- make `make-frame` *be* `reg-frame` with an `:images`-resolution front-end,
+  accepting `:images` **and** the record-config keys in one call;
+- the "frame object" becomes the record itself (or a frozen handle over it), so
+  `frame-object?` / `runnable-id` / `live-frames` / `frame-target->id` all
+  disappear;
+- one duplicate-id policy (pick `reg-frame`'s idempotent surgical-update for hot
+  reload, documented in Spec 002 §reg-frame is atomic), removing the
+  `make-frame` vs `reg-frame` contradiction.
+
+What that one move dissolves or shrinks:
+
+- the create-twice idiom + its ORDER footgun comment (Story collapses to one
+  `make-frame` call);
+- `assert-make-frame-opts!` + `make-frame-opt-keys` +
+  `:rf.error/make-frame-record-only-key` (no rival constructor to guard
+  against);
+- `frame-target->id` + the duplicated `object-marker` (no object/id round-trip;
+  dispatch/subscribe deref the record directly);
+- `:live-frame/forget!` (destroy dissocs one record from one registry);
+- the `reprojecting?` re-entrancy guard + the CI-hang no-live-frame skip
+  rationale (creation no longer trips the reprojection hook);
+- one home for "the set of live frames," so `live-frame`/`live-frame-ids`/
+  `forget-live-frame!` become derived reads over `frames`.
+
+This finishes, at the code level, what EP-0023 set out to do at the model level.
+It also lets the spelling-level cleanups in the sibling files land cleanly:
+`frame-provider` target unification (frame-targeting finding), `:realm` removal
+from public reads (registrar-addressing finding), and one resolve-once seam for
+the value reads (frame-state finding).
+
+## Vocabulary coherence (fold-in from the model-coherence pass)
+
+EP-0023's own new vocabulary already shows an EP-0007 one-name-per-fact wobble
+that this work should settle while the surface is young:
+
+- "image generation" / "resolved image generation" / "sealed image generation"
+  are used interchangeably for one fact (EP-0023:44 vs :93; the facade accessor
+  `frame-generation` returns the sealed set with `:rf.gen/*` keys). Pick **one**
+  canonical noun — "sealed image generation" matches the keys and the accessor.
+- "frame object" / "live frame" name one thing (EP-0023:105, :114). Use
+  **"frame"** for the live context; qualify only where contrasting with the
+  serializable "frame-state value." If the unification above lands, "frame
+  object" stops being a distinct concept anyway.
+
+## Classification
+
+**EP-level (or an EP-0023 erratum/amendment).** This questions a graduated
+implementation's internal structure, not just docs or facade tiering, so it
+needs explicit owner adjudication: is the two-constructor/two-registry split a
+deliberate transitional state with a planned convergence, or unrealized collapse
+debt? If deliberate-and-temporary, record the convergence as a tracked
+post-graduation slice. If not, this is the single highest-leverage frame
+simplification on the board.
+
+Caution for whoever picks this up: the claims above are read off the source as
+of 2026-06-18 and are strong; verify against the EP-0023 implementers' intent
+(some seams — e.g. the require-cycle `object-marker` mirror — may be load-bearing
+for reasons not visible in the code) before scheduling the refactor.
+
+## Why this is better
+
+EP-0023's mental model is one frame object that owns everything including its
+generation. The code's model is a generation-carrying pointer to a record that
+owns the rest, plus a second registry and the glue to keep them in step. Two
+registries for "the set of live frames" is the definition of sprawl; the spec's
+own model wants one. Realizing the spec in code removes more public-surface and
+internal complexity per line changed than any other frame finding in this
+review.
+
+## Implementation
+
+- **Vehicle: EP - specifically an EP-0023 amendment/erratum.** It changes the
+  graduated EP-0023 implementation's backing structure (one constructor, one
+  registry, generation-on-record). **Needs explicit owner adjudication first:** is
+  the two-layer split deliberate-transitional (with a planned convergence) or
+  unrealized-collapse debt? Record the answer before scheduling.
+- **Co-located with [frame-targeting-and-lifecycle.md](frame-targeting-and-lifecycle.md)**
+  in one EP: the unification is the structural core; the targeting / provider /
+  spelling cleanup is its surface. It also gates the smaller frame beads that
+  assume the unified model (provider object acceptance, one resolve-once
+  value-read seam).
+- **Pre-alpha makes "collapse the layers" the mandated path** - keeping the
+  EP-0013 record alongside the EP-0023 object is exactly the accretion the
+  posture rejects (see facade-accretion-and-removal.md). The only caveat is the
+  owner-intent check above (some seams may be load-bearing for non-obvious
+  reasons).
+- Sequence: adjudicate intent -> EP -> implementation slice. Hot-zone:
+  `core.cljc`, `frame.cljc`, `live_frame.cljc`, `tools/story/.../frames.cljc`,
+  `spec/002-Frames.md`.

--- a/ai/findings/API-review/codex/frame-state-and-history.md
+++ b/ai/findings/API-review/codex/frame-state-and-history.md
@@ -112,3 +112,27 @@ The cleanup target is the front porch: app authors should see the small read
 surface they actually use; tools can import deeper state and cache readers from
 tooling namespaces. That keeps the public API small without flattening real
 semantic distinctions.
+
+## Fresh consolidation pass additions (2026-06-18)
+
+- **Trace-projection facade re-exports have zero callers** (empirical). `rf/group-cascades`,
+  `rf/group-cascades-with-events`, `rf/domino-bucket` are facade re-exports, but
+  every consumer calls `re-frame.trace.projection/<name>` directly (~9 Xray files
+  + pair-mcp); the rf/-prefixed copies are 0 everywhere. The trace-listener trio,
+  `emit-trace-event!`, and `clear-trace-buffer!` are likewise 0. Delete the unused
+  re-exports; keep `trace-buffer` (real JVM-tool alias).
+- **The value-read `frame-target->id` repetition is an internal-resolver refactor,
+  not an API change** (lifecycle + taste). Keep the three partition readers; hoist
+  normalization to one `resolve-frame-record` seam. If the object/record
+  unification lands, normalization disappears. `snapshot-of` app-db-only stays a
+  documented convenience.
+
+## Implementation
+
+- **Vehicle: ordinary beads** (grouping + facade-pruning, not grammar). No EP.
+- Beads: (1) docs - one privileged "state surgery" section for replace-* /
+  restore-epoch!; (2) move sub-cache / sub-topology + the unused trace-projection
+  re-exports off the facade; (3) internal - one resolve-frame-record seam shared
+  by the value reads (no public change). KEEP the three partition readers.
+- The resolver item folds into the frame-grammar EP if the object/record
+  unification lands; the rest is independent.

--- a/ai/findings/API-review/codex/frame-targeting-and-lifecycle.md
+++ b/ai/findings/API-review/codex/frame-targeting-and-lifecycle.md
@@ -150,3 +150,35 @@ which functions coerce which shape.
 The Clojure move is to keep the value model small: an event vector plus an opts
 map. Optional routing information belongs in the map. Lifecycle belongs in a
 different operation. The result is less clever and easier to reason about.
+
+## Fresh consolidation pass additions (2026-06-18)
+
+**The deeper structural cause has its own file.** This file treats the crowding
+as an addressing-spelling problem ("id or object?"). The fresh lifecycle lens
+traced it to a backing-structure problem - two `make-frame` constructors backed by
+two registries - in
+[frame-object-record-unification.md](frame-object-record-unification.md), the
+highest-leverage frame finding and an EP-level/erratum candidate.
+
+Two smaller deltas:
+- **`make-frame-handle` is an off-pattern, undocumented public var** (minimalist +
+  model). `:facade? true` but unrowed; its docstring says "call `frame-handle`
+  instead"; only macro-expansion calls it. Rename to `frame-handle*` for `*`-twin
+  consistency and row as advanced, or de-fade to `^:no-doc`.
+- **HTTP test-support decomposition leaks onto the facade** (minimalist).
+  `with-managed-request-stubs` (macro) is the ergonomic surface; the raw
+  `install-managed-request-stubs!` / `uninstall-managed-request-stubs!` pair
+  belongs in `re-frame.http-test-support`. Move the pair off the facade.
+
+## Implementation
+
+- **Vehicle: EP** (public frame-target grammar, provider object acceptance,
+  owned-UI lifecycle, dispatch/subscribe spelling policy).
+- **Land as ONE EP with
+  [frame-object-record-unification.md](frame-object-record-unification.md)** (the
+  structural enabler) and the :frame/:realm query split from
+  [registrar-query-addressing.md](registrar-query-addressing.md). One coupled
+  grammar change, not three EPs.
+- Smaller items as beads under/after the EP: make-frame-handle -> frame-handle* +
+  rowing, the HTTP test-support move, unsubscribe target-normalization symmetry.
+- Hot-zone: core.cljc, spec/002-Frames.md, provider/adapter seams.

--- a/ai/findings/API-review/codex/listener-and-sink-registries.md
+++ b/ai/findings/API-review/codex/listener-and-sink-registries.md
@@ -1,0 +1,109 @@
+# Listener And Sink Registries
+
+Status: draft finding — **new in the 2026-06-18 fresh consolidation pass**
+(technical-taste + empirical-call-site lenses; no prior corpus coverage).
+
+## Crowding Signal
+
+The facade carries **five structurally identical id-keyed register/unregister
+registries**, each as its own pair (or trio) of public vars, differing only in
+the record shape and the always-on/dev-only axis:
+
+- trace: `register-listener!` / `unregister-listener!` / `clear-listeners!`
+- handled events: `register-event-listener!` / `unregister-event-listener!`
+- errors: `register-error-listener!` / `unregister-error-listener!`
+- observability sink: `register-observability-sink!` /
+  `unregister-observability-sink!`
+- epoch: `register-epoch-listener!` / `unregister-epoch-listener!`
+
+Ten-plus facade vars for one shape — `(register-X! id f)` with same-id-replace
+semantics and a returned id. CONSISTENCY achieved by repetition rather than by a
+parameter; the difference between them is **data** (which stream), not API shape.
+
+## Implementation / call-site evidence (verified)
+
+- Exports: trace `core.cljc:2716-2728`, event + error `2759-2807`, observability
+  sink `2845-2860`, epoch `3010-3020`. Each docstring repeats "Same-id
+  registration replaces. Returns id."
+- **Adoption is near-zero at the facade.** Across `examples/**` +
+  `tools/**/src/**`: `register-observability-sink!` 0/0,
+  `register-event-listener!` 0/0, `register-error-listener!` 0/0. tests-impl:
+  24 / 20 / 93, all in `*_emit_*`, `always_on_axis_conformance`,
+  `ep0008_producers_*`, `core_api_additions` suites. The docstrings name
+  Datadog/Sentry/Honeybadger as the intended consumers; none exists in-repo and
+  no example wires one.
+- The *mechanisms* earn their keep internally — the router fan-out and the
+  frame-teardown error discriminator reuse the error-emit registry via
+  `late-bind` — but no caller registers through the **facade** export.
+- The observability-sink pair is documented as "the normal production path"
+  while event/error-listener are "advanced corpus-wide"
+  (`core.cljc:2768-2775`): two tiers doing overlapping jobs, both with zero
+  production callers.
+
+## Observed use cases
+
+1. Off-box shippers (the intended but absent observability-sink consumer).
+2. Xray / Story / pair subscribe to the trace stream.
+3. Epoch recorders subscribe to epoch records.
+4. The error stream is consumed internally (router + teardown), not via the
+   facade register fn.
+
+The streams are genuinely distinct (handled-event vs error vs trace vs epoch),
+so collapsing them to **one** registry would over-merge — the always-on vs
+DCE-gated axes differ. The waste is the **per-stream name-mangled pairs** on the
+facade, plus the redundant second production-observation surface.
+
+## Proposed smaller API
+
+Two moves:
+
+1. **Stream-parameterize the verb.** Keep one register/unregister shape and pass
+   the stream as data:
+
+   ```clojure
+   (rf/register-listener! :trace  id f)
+   (rf/register-listener! :events id f)
+   (rf/register-listener! :errors id f)
+   (rf/register-listener! :epoch  id f)
+   ```
+
+   The per-stream registries stay where they are (they have different always-on
+   / DCE characteristics); the facade gains a `stream` argument instead of N
+   name-mangled pairs. Collapses ~8 vars to ~2.
+
+2. **One production-observation surface.** Keep
+   `register-observability-sink!` / `unregister-observability-sink!` as the
+   single blessed production path (frame-routed, projected through
+   `project-egress`). Drop the corpus-wide `register-event-listener!` /
+   `register-error-listener!` from the facade; retain them internally for the
+   router's own fan-out, reachable via `re-frame.event-emit` /
+   `re-frame.error-emit` for the rare cross-frame case. Merge the API.md
+   §Event-emit / §Error-emit sections into one "Production observability"
+   section pointing at the sink.
+
+## Classification
+
+Decision bead + ordinary beads. The stream-parameterization is a facade-shape
+decision (one verb + data vs N pairs); the observability-sink consolidation is a
+facade-pruning bead once the two unused corpus-listener pairs are confirmed
+movable. Neither changes the underlying per-stream registry mechanisms.
+
+## Why this is better
+
+When five surfaces share a verb, an argument, and a replace-on-same-id contract,
+the thing that varies between them is the stream — that is data, and it belongs
+in an argument, not in five hand-mangled names. And a "normal production path"
+plus an "advanced corpus-wide" path for the same job — both with zero production
+callers — is one observation surface too many for a pre-alpha with no consumers
+to keep both honest.
+
+## Implementation
+
+- **Vehicle: one decision bead (facade shape) + ordinary beads.** No EP.
+- Decision: stream-parameterize the verb (`register-listener! :trace id f`) vs keep
+  N named pairs.
+- Beads: (1) collapse to one production-observation surface
+  (`register-observability-sink!`), drop the corpus event/error-listener pairs from
+  the facade (0 callers); (2) apply the stream-parameter outcome to
+  trace/event/error/epoch.
+- Pre-alpha disposition: the zero-caller pairs are removed, not demoted.

--- a/ai/findings/API-review/codex/machine-helper-surfaces.md
+++ b/ai/findings/API-review/codex/machine-helper-surfaces.md
@@ -81,3 +81,22 @@ they can be recorded, displayed, analyzed, compared, and generated.
 Clojure APIs become durable when values carry the meaning. Wrapper functions
 can be pleasant, but they should not hide the one algebra all tooling depends
 on.
+
+## Fresh consolidation pass note (2026-06-18)
+
+The fresh empirical lens reconfirms this file's ruling: `machine-has-tag?` = 64
+example hits (keep), `sub-machine` = 0 anywhere (drop or move to re-frame.machines),
+`dispatch-to-system` = 1 test, `defmachine` tests-only. One cross-lens conflict,
+resolved here: the minimalist lens proposed moving all three helpers including
+`machine-has-tag?` off the facade - overruled by adoption; `machine-has-tag?`
+stays, and the minimalist recommendation holds only for `sub-machine`.
+
+## Implementation
+
+- **Vehicle: docs-first beads + one small facade-pruning bead.** No EP.
+- Beads: (1) docs - teach `[:rf/machine ...]` vectors and the
+  `:rf.machine/dispatch-to-system` effect tuple as canonical; label helpers as
+  Reagent convenience; (2) drop `sub-machine` from the facade (0 callers);
+  (3) optional - demote `dispatch-to-system` / `defmachine` to `re-frame.machines`.
+  KEEP `machine-has-tag?`.
+- Low risk; independent of the frame-grammar EP.

--- a/ai/findings/API-review/codex/registrar-query-addressing.md
+++ b/ai/findings/API-review/codex/registrar-query-addressing.md
@@ -119,3 +119,16 @@ The retired map form is especially expensive because it teaches a model EP-0023
 replaced. If the public model is image/frame, a registrar query should either
 read the default source store, an image, or a frame's resolved generation. Those
 are three facts. Clojure is better when three facts get three honest names.
+
+## Implementation
+
+- **Vehicle: decision bead, escalating to the frame-grammar EP if new names land.**
+  (a) if `:realm` is dropped and `:frame` kept (the pre-alpha facade ruling removes
+  `:realm` from the public surface regardless), ordinary beads + the `rf2-pl97nd`
+  scrub; (b) if source-store / image / frame-generation reads get distinct names,
+  that is public grammar -> fold into the one frame-grammar EP (with frame-targeting
+  + frame-object-record-unification).
+- **The `:realm` public query arity is removed** under the pre-alpha facade ruling
+  (it re-exposes the (realm, frame) model EP-0023 hid). Xray's `{:realm nil}`
+  generation-bypass gets an honestly-named internal/tooling seam.
+- Hot-zone: core.cljc, spec/API.md.

--- a/ai/findings/API-review/codex/registration-programmatic-forms.md
+++ b/ai/findings/API-review/codex/registration-programmatic-forms.md
@@ -136,3 +136,28 @@ actually need that distinction.
 The Clojure ethos is not "avoid macros"; it is "use macros where syntax is the
 point". Where syntax is not the point, functions over maps are easier to
 compose, generate, test, and inspect.
+
+## Fresh consolidation pass additions (2026-06-18)
+
+Three deltas in the interceptor/registration boundary:
+1. **Removed-API stubs should be data-table-driven** (taste): collapse the N
+   bespoke `*-removed!` throwers (reg-event-db/-fx/-ctx, path, unwrap-interceptor)
+   into one `defremoved` / removals table; the next removal is a data edit (the
+   migration-map at migration.cljc:57 is already this shape).
+2. **Interceptor context accessors are stale post-EP-0017/0022** (empirical):
+   get-coeffect / assoc-coeffect / get-effect / assoc-effect lost their audience;
+   counts are 0-1 and the setters are fully dead. Remove assoc-coeffect /
+   assoc-effect; reassess the getters.
+3. **`->interceptor` carries a self-contradicting tier** (model): api-manifest
+   rows it `:internal-public`, but API.md says that tier's "sole instance" is the
+   Xray mount family; retier `->interceptor` to `:implementation`.
+
+## Implementation
+
+- **Vehicle: ordinary beads after call-site confirmation, + one small decision
+  bead** for `->interceptor` / `reg-interceptor*`. No EP.
+- Beads: (1) prune zero-adoption `*`-fn aliases (reg-error-projector, reg-flow,
+  reg-mutation, reg-head); keep adopted reg-view* / dispatch*; (2) defremoved
+  data-table; (3) remove stale interceptor context accessors; (4) retier
+  `->interceptor` to `:implementation`.
+- Hot-zone: core.cljc, api-manifest*.edn.

--- a/ai/findings/API-review/codex/resource-and-mutation-reads.md
+++ b/ai/findings/API-review/codex/resource-and-mutation-reads.md
@@ -125,3 +125,13 @@ The Clojure-friendly API is the one where commands are data vectors, reads are
 data query vectors, and metadata inspection is a registrar read. A direct helper
 function can exist for tooling, but it should not compete with the data-shaped
 language that makes replay, inspection, and tests work.
+
+## Implementation
+
+- **Vehicle: docs-first beads, + one decision bead** for `clear-resource` /
+  `clear-mutation` naming (`unreg-*` vs keep-and-relocate). No EP - the surface is
+  large but mostly justified.
+- Beads: (1) docs - the three lanes (authoring / command / app-read); label direct
+  `resource-state` / `mutation-state` as tool/test projections; (2) decision -
+  reserve "clear" for one domain.
+- Independent of the frame-grammar EP.

--- a/ai/findings/API-review/codex/retired-app-composition-vocabulary.md
+++ b/ai/findings/API-review/codex/retired-app-composition-vocabulary.md
@@ -138,3 +138,15 @@ history recovery before writing code.
 This cleanup is also the most direct way to honor "one name per fact". The fact
 is not an app installed into a realm. The public fact is an image loaded into a
 frame.
+
+## Implementation
+
+- **Vehicle: existing epic `rf2-pl97nd`** (the EP-0023 vocabulary scrub). No EP.
+- **The open facade ruling is resolved (Mike, 2026-06-18, pre-alpha -> remove):**
+  strip the EP-0013 construction/install/query family from re-frame.core, the
+  api-manifest* rows, and the current spec/API.md rows. The realm machinery stays
+  as internal substrate (its own ns) only where the live design uses it (SSR
+  routing) - never a facade/manifest/spec surface.
+- **Migration shims deleted with the scrub**, not preserved - see
+  [facade-accretion-and-removal.md](facade-accretion-and-removal.md).
+- Hot-zone: core.cljc, api-manifest*.edn, several specs; Xray is its own slice.

--- a/ai/findings/API-review/codex/view-registration-and-rendering.md
+++ b/ai/findings/API-review/codex/view-registration-and-rendering.md
@@ -99,3 +99,13 @@ native component and hook idioms.
 The simpler API respects host idiom instead of forcing one view abstraction to
 pretend it covers every substrate. The shared re-frame2 contract remains the
 dataflow: frames, subscriptions, dispatch, source metadata, and registry ids.
+
+## Implementation
+
+- **Vehicle: docs/tooling beads.** No EP; do NOT remove `reg-view*` (real
+  Story/Xray pressure).
+- Beads: (1) docs - the two-lane split (registered Reagent view vs programmatic
+  tooling view via `reg-view*`); (2) keep internal panel components out of
+  app-facing view docs; (3) document host mount/registry entry points separately
+  for tools.
+- Independent of the frame-grammar EP.


### PR DESCRIPTION
Folds the fresh independent five-lens API review (minimalist facade, empirical call-site, model coherence, lifecycle/ownership, technical taste) into the codex corpus.

**New findings:**
- `frame-object-record-unification.md` — EP-0023's collapse was implemented additively (two make-frame constructors + two registries); highest-leverage frame finding, EP-level/erratum candidate.
- `elision-redaction-helpers.md` — four-lens-converged: 9 granular redaction helpers + 1 assembling tool + API.md drift.
- `listener-and-sink-registries.md` — five identical register/unregister registries → one stream-parameterized verb.
- `facade-accretion-and-removal.md` — cross-cutting accretion mechanism + the **pre-alpha removal disposition** (delete-not-demote) governing the corpus.

**Plus:** a per-file `## Implementation` section (EP / decision-bead / ordinary-bead) on every file, and the implementation routing in the README.

Docs-only, under the (temporarily tracked) `ai/` working tree. Recovers work lost when a concurrent fold + pull reset the mayor checkout.