### PR TITLE
test: migrate dedicated suites off retired realm/app/module public APIs onto EP-0023 frame/image (rf2-pl97nd.4 cluster G)

### DIFF
--- a/implementation/core/test/re_frame/app_value_compose_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_compose_cljs_test.cljc
@@ -4,8 +4,8 @@
 
   Stage 6 graduates the CONSTRUCTION half of the app value: build a program
   as INERT data from explicit feature modules, then inspect it before any
-  realm. The public surface (re-exported from `re-frame.core` as `rf/module`
-  / `rf/app` / `rf/app-registrations` / `rf/app-owns` / `rf/app-requires`):
+  realm. The public surface (re-exported from `re-frame.core` as `av/module`
+  / `av/app` / `av/app-registrations` / `av/app-owns` / `av/app-requires`):
 
     (1) `module` lowers a module-descriptor map into a module value — the
         descriptor-grouped shape, owner-stamped, with `:rf.module/owns` /
@@ -53,7 +53,7 @@
             with the module id as :owner, carries :rf.module/owns /
             :rf.module/requires (owner-qualified FACT keys, EP-0007 / EP-0017
             v5), and is keyed by the singular registry kind"
-    (let [m (rf/module
+    (let [m (av/module
               {:id :shop/cart
                :rf.module/owns {:app-db [[:cart]] :resources [:shop.cart/items]}
                :rf.module/requires #{:rf.capability/http}
@@ -79,7 +79,7 @@
 
 (deftest module-requires-defaults-empty
   (testing "a module with no :rf.module/requires gets #{}"
-    (let [m (rf/module {:id :m :events {:e {:handler cart-add}}})]
+    (let [m (av/module {:id :m :events {:e {:handler cart-add}}})]
       (is (= #{} (:rf.module/requires m)))
       (is (= {} (:rf.module/owns m)) ":rf.module/owns defaults to {}"))))
 
@@ -89,7 +89,7 @@
             supply coords); the module's own :source is carried top-level"
     (let [src {:ns 'shop.cart.events :file "src/shop/cart/events.cljs" :line 22 :column 1}
           msrc {:ns 'shop.cart :file "src/shop/cart.cljs" :line 12 :column 1}
-          m (rf/module
+          m (av/module
               {:id :shop/cart
                :source msrc
                :events {:cart/add {:doc "Add." :handler cart-add :source src}}})
@@ -103,9 +103,9 @@
   (testing "module throws :rf.error/invalid-module on a missing :id (the one
             construction precondition) and on an unknown section key"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                 (rf/module {:events {:e {:handler cart-add}}}))
+                 (av/module {:events {:e {:handler cart-add}}}))
         "missing :id throws")
-    (let [ed (try (rf/module {:id :m :bogus {:x {:handler cart-add}}})
+    (let [ed (try (av/module {:id :m :bogus {:x {:handler cart-add}}})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/invalid-module (:rf.error/id ed)))
@@ -119,7 +119,7 @@
   ;; spellings are no longer reserved module keys, so they are rejected loudly
   ;; as unknown section keys (fail-closed — never silently honoured nor dropped).
   (testing "the QUALIFIED keys carry the fact onto the module value"
-    (let [m (rf/module {:id :shop/cart
+    (let [m (av/module {:id :shop/cart
                         :rf.module/owns     {:app-db [[:cart]]}
                         :rf.module/requires #{:rf.capability/http}
                         :events {:cart/add {:handler cart-add}}})]
@@ -132,7 +132,7 @@
       (is (not (contains? m :requires)) "no bare :requires slot on the module value")))
   (testing "the BARE :owns key is REJECTED as an unknown section (not silently
             honoured, not silently dropped) — the rename is fail-closed"
-    (let [ed (try (rf/module {:id :m :owns {:app-db [[:cart]]}})
+    (let [ed (try (av/module {:id :m :owns {:app-db [[:cart]]}})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/invalid-module (:rf.error/id ed))
@@ -140,7 +140,7 @@
       (is (= :owns (:unknown-section ed))
           "the bare key is named as the offending unknown section")))
   (testing "the BARE :requires key is likewise REJECTED"
-    (let [ed (try (rf/module {:id :m :requires #{:rf.capability/http}})
+    (let [ed (try (av/module {:id :m :requires #{:rf.capability/http}})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/invalid-module (:rf.error/id ed))
@@ -149,16 +149,16 @@
           "the bare key is named as the offending unknown section")))
   (testing "the app value's union capability set is the owner-qualified
             :rf.app/requires — and no bare :requires slot survives on the app"
-    (let [a (rf/app {:id :shop/app
-                     :modules [(rf/module {:id :shop/cart
+    (let [a (av/app {:id :shop/app
+                     :modules [(av/module {:id :shop/cart
                                            :rf.module/requires #{:rf.capability/http}
                                            :events {:cart/add {:handler cart-add}}})]})]
       (is (= #{:rf.capability/http} (:rf.app/requires a))
           ":rf.app/requires carries the union capability set")
       (is (not (contains? a :requires))
           "no bare :requires slot on the app value")
-      (is (= #{:rf.capability/http} (rf/app-requires a))
-          "rf/app-requires reads it off the qualified slot"))))
+      (is (= #{:rf.capability/http} (av/app-requires a))
+          "av/app-requires reads it off the qualified slot"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (2) app — composes module values into an app value
@@ -168,15 +168,15 @@
   (testing "app composes module values: :registrations is the union of every
             module's descriptors, :rf.app/requires is the union of the modules'
             :rf.module/requires, and :modules is keyed by module id"
-    (let [auth (rf/module {:id :shop/auth
+    (let [auth (av/module {:id :shop/auth
                            :rf.module/requires #{:rf.capability/http}
                            :events {:auth/login {:handler auth-login}}})
-          cart (rf/module {:id :shop/cart
+          cart (av/module {:id :shop/cart
                            :rf.module/owns {:app-db [[:cart]]}
                            :rf.module/requires #{:rf.capability/schemas}
                            :events {:cart/add {:handler cart-add}}
                            :subs   {:cart/items {:handler cart-items}}})
-          a (rf/app {:id :shop/app :modules [auth cart]})]
+          a (av/app {:id :shop/app :modules [auth cart]})]
       (is (= :shop/app (:rf.app/id a)) "the app carries the declared id")
       (is (= #{:shop/auth :shop/cart} (set (keys (:modules a))))
           ":modules is keyed by module id")
@@ -189,7 +189,7 @@
 
 (deftest app-of-zero-modules-is-valid-empty-app
   (testing "an app of zero modules is a valid, empty app value"
-    (let [a (rf/app {:id :empty/app})]
+    (let [a (av/app {:id :empty/app})]
       (is (= :empty/app (:rf.app/id a)))
       (is (= {} (:modules a)))
       (is (= {} (:registrations a)))
@@ -199,9 +199,9 @@
   (testing "app throws :rf.error/invalid-app on a missing :id or a :modules
             entry that is not a module value"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                 (rf/app {:modules []}))
+                 (av/app {:modules []}))
         "missing :id throws")
-    (let [ed (try (rf/app {:id :a :modules [{:not :a-module}]})
+    (let [ed (try (av/app {:id :a :modules [{:not :a-module}]})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/invalid-app (:rf.error/id ed))
@@ -217,9 +217,9 @@
             sources (never last-writer-wins) — EP-0013 §Composition"
     (let [a-src {:ns 'a :file "a.cljs" :line 1 :column 1}
           b-src {:ns 'b :file "b.cljs" :line 9 :column 1}
-          ma (rf/module {:id :a :events {:shared/save {:handler cart-add :source a-src}}})
-          mb (rf/module {:id :b :events {:shared/save {:handler auth-login :source b-src}}})
-          ed (try (rf/app {:id :bad/app :modules [ma mb]})
+          ma (av/module {:id :a :events {:shared/save {:handler cart-add :source a-src}}})
+          mb (av/module {:id :b :events {:shared/save {:handler auth-login :source b-src}}})
+          ed (try (av/app {:id :bad/app :modules [ma mb]})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/app-composition-collision (:rf.error/id ed)))
@@ -234,9 +234,9 @@
 (deftest app-collision-is-cross-kind-safe
   (testing "the SAME id under DIFFERENT kinds is NOT a collision — collision
             is per-(kind,id)"
-    (let [ma (rf/module {:id :a :events {:shared/x {:handler cart-add}}})
-          mb (rf/module {:id :b :subs   {:shared/x {:handler cart-items}}})
-          a (rf/app {:id :ok/app :modules [ma mb]})]
+    (let [ma (av/module {:id :a :events {:shared/x {:handler cart-add}}})
+          mb (av/module {:id :b :subs   {:shared/x {:handler cart-items}}})
+          a (av/app {:id :ok/app :modules [ma mb]})]
       (is (identical? cart-add   (get-in a [:registrations :event :shared/x :handler])))
       (is (identical? cart-items (get-in a [:registrations :sub   :shared/x :handler]))
           "same id, different kind — both compose without collision"))))
@@ -251,9 +251,9 @@
             :rf.error/app-composition-collision (:kind :module) — module id is
             the provenance key, so silently keeping one would make composition
             order-dependent (rf2-c6armm.1 #4)"
-    (let [ma (rf/module {:id :dup/m :events {:dup/a {:handler cart-add}}})
-          mb (rf/module {:id :dup/m :events {:dup/b {:handler auth-login}}})
-          ed (try (rf/app {:id :dup/app :modules [ma mb]})
+    (let [ma (av/module {:id :dup/m :events {:dup/a {:handler cart-add}}})
+          mb (av/module {:id :dup/m :events {:dup/b {:handler auth-login}}})
+          ed (try (av/app {:id :dup/app :modules [ma mb]})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/app-composition-collision (:rf.error/id ed)))
@@ -265,12 +265,12 @@
             both orderings throw, so composition is not last-writer-wins
             (rf2-c6armm.3 #3 — would have silently kept whichever module came
             last in the vector)"
-    (let [ma (rf/module {:id :dup/m :events {:dup/a {:handler cart-add}}})
-          mb (rf/module {:id :dup/m :events {:dup/b {:handler auth-login}}})
-          ed-ab (try (rf/app {:id :dup/app :modules [ma mb]}) :no-throw
+    (let [ma (av/module {:id :dup/m :events {:dup/a {:handler cart-add}}})
+          mb (av/module {:id :dup/m :events {:dup/b {:handler auth-login}}})
+          ed-ab (try (av/app {:id :dup/app :modules [ma mb]}) :no-throw
                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                        (:rf.error/id (ex-data e))))
-          ed-ba (try (rf/app {:id :dup/app :modules [mb ma]}) :no-throw
+          ed-ba (try (av/app {:id :dup/app :modules [mb ma]}) :no-throw
                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                        (:rf.error/id (ex-data e))))]
       (is (= :rf.error/app-composition-collision ed-ab) "[ma mb] throws")
@@ -281,8 +281,8 @@
             re-listing is harmless) — the same module value contributes its
             registrations once, not a spurious same-(kind,id) collision
             (rf2-c6armm.1 #4)"
-    (let [m (rf/module {:id :idem/m :events {:idem/e {:handler cart-add}}})
-          a (rf/app {:id :idem/app :modules [m m]})]
+    (let [m (av/module {:id :idem/m :events {:idem/e {:handler cart-add}}})
+          a (av/app {:id :idem/app :modules [m m]})]
       (is (= #{:idem/m} (set (keys (:modules a))))
           "the deduped module appears once in :modules")
       (is (identical? cart-add (get-in a [:registrations :event :idem/e :handler]))
@@ -295,10 +295,10 @@
 (deftest law-empty-module-is-identity
   (testing "composing with an empty module is identity — the app value equals
             the app value composed without it"
-    (let [cart  (rf/module {:id :cart :events {:cart/add {:handler cart-add}}})
-          empty (rf/module {:id :empty})
-          with    (rf/app {:id :app :modules [cart empty]})
-          without (rf/app {:id :app :modules [cart]})]
+    (let [cart  (av/module {:id :cart :events {:cart/add {:handler cart-add}}})
+          empty (av/module {:id :empty})
+          with    (av/app {:id :app :modules [cart empty]})
+          without (av/app {:id :app :modules [cart]})]
       (is (= (:registrations without) (:registrations with))
           "an empty module contributes no registrations")
       (is (= (:rf.app/requires without) (:rf.app/requires with))
@@ -307,12 +307,12 @@
 (deftest law-grouping-order-does-not-change-the-value
   (testing "grouping modules in a different ORDER does not change the resulting
             app value — composition is order-stable (EP-0013 §Composition)"
-    (let [auth (rf/module {:id :auth :rf.module/requires #{:rf.capability/http}
+    (let [auth (av/module {:id :auth :rf.module/requires #{:rf.capability/http}
                            :events {:auth/login {:handler auth-login}}})
-          cart (rf/module {:id :cart :rf.module/requires #{:rf.capability/schemas}
+          cart (av/module {:id :cart :rf.module/requires #{:rf.capability/schemas}
                            :events {:cart/add {:handler cart-add}}})
-          a1 (rf/app {:id :app :modules [auth cart]})
-          a2 (rf/app {:id :app :modules [cart auth]})]
+          a1 (av/app {:id :app :modules [auth cart]})
+          a2 (av/app {:id :app :modules [cart auth]})]
       (is (= (:registrations a1) (:registrations a2))
           "registrations are independent of module order")
       (is (= (:rf.app/requires a1) (:rf.app/requires a2))
@@ -322,10 +322,10 @@
 (deftest law-every-input-descriptor-preserved-once
   (testing "successful composition preserves every input descriptor exactly
             once — the composed event set is the union of the modules' ids"
-    (let [auth (rf/module {:id :auth :events {:auth/login {:handler auth-login}}})
-          cart (rf/module {:id :cart :events {:cart/add {:handler cart-add}
+    (let [auth (av/module {:id :auth :events {:auth/login {:handler auth-login}}})
+          cart (av/module {:id :cart :events {:cart/add {:handler cart-add}
                                               :cart/clear {:handler cart-add}}})
-          a (rf/app {:id :app :modules [auth cart]})]
+          a (av/app {:id :app :modules [auth cart]})]
       (is (= #{:auth/login :cart/add :cart/clear}
              (set (keys (get-in a [:registrations :event]))))
           "every input event descriptor is present, exactly once"))))
@@ -338,20 +338,20 @@
   (testing "app-registrations / app-requires / app-owns read a constructed app
             value without installing it (EP-0013 §Examples 'A Whole App As
             Data')"
-    (let [cart (rf/module {:id :shop/cart
+    (let [cart (av/module {:id :shop/cart
                            :rf.module/owns {:app-db [[:cart]]}
                            :rf.module/requires #{:rf.capability/http}
                            :events {:cart/add {:handler cart-add}}})
-          a (rf/app {:id :shop/app :modules [cart]})]
-      (is (= #{:cart/add} (set (keys (rf/app-registrations a :event))))
+          a (av/app {:id :shop/app :modules [cart]})]
+      (is (= #{:cart/add} (set (keys (av/app-registrations a :event))))
           "app-registrations enumerates the app's events by kind")
-      (is (nil? (rf/app-registrations a :route))
+      (is (nil? (av/app-registrations a :route))
           "app-registrations is nil for a kind the app declares none of")
-      (is (= #{:rf.capability/http} (rf/app-requires a))
+      (is (= #{:rf.capability/http} (av/app-requires a))
           "app-requires reads the capability dependency surface")
-      (is (= :shop/cart (rf/app-owns a [:cart]))
+      (is (= :shop/cart (av/app-owns a [:cart]))
           "app-owns resolves the module owning an app-db path")
-      (is (nil? (rf/app-owns a [:unowned]))
+      (is (nil? (av/app-owns a [:unowned]))
           "app-owns is nil for an unowned path"))))
 
 ;; ---------------------------------------------------------------------------
@@ -364,8 +364,8 @@
             is inert data per EP-0013 issue 10)"
     (is (nil? (registrar/lookup :event :cart/add))
         "no :cart/add in the registrar before construction")
-    (let [m (rf/module {:id :cart :events {:cart/add {:handler cart-add}}})]
-      (rf/app {:id :app :modules [m]})
+    (let [m (av/module {:id :cart :events {:cart/add {:handler cart-add}}})]
+      (av/app {:id :app :modules [m]})
       (is (nil? (registrar/lookup :event :cart/add))
           "STILL no :cart/add in the registrar after module + app — construction
            registered nothing"))))
@@ -377,8 +377,8 @@
             :owner (which the projection never carries)"
     (rf/reg-event :av/proj {:doc "projected"} cart-add)
     (let [proj-d (get-in (av/app-value) [:registrations :event :av/proj])
-          cons-d (get-in (rf/app {:id :a :modules
-                                  [(rf/module {:id :m :events
+          cons-d (get-in (av/app {:id :a :modules
+                                  [(av/module {:id :m :events
                                                {:av/cons {:doc "constructed"
                                                           :handler cart-add}}})]})
                          [:registrations :event :av/cons])]

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -5,7 +5,7 @@
 
   Stage 7 closes the D2 loop — the program is a value (stage 6 construction),
   and the runtime is a container you install it into (stage 7). The public
-  surface (re-exported from `re-frame.core` as `rf/install!` / `rf/reinstall!`):
+  surface (re-exported from `re-frame.core` as `av/install!` / `av/reinstall!`):
 
     (1) `install!` seats an app value as a realm's program — lowers every
         descriptor back into the realm's registrar (the inverse of the stage-5/6
@@ -85,11 +85,11 @@
             module under :owner"
     (is (nil? (registrar/lookup :event :cart/add))
         "no :cart/add in the registrar before install")
-    (let [cart (rf/module {:id :shop/cart
+    (let [cart (av/module {:id :shop/cart
                            :events {:cart/add {:doc "Add." :handler cart-add}}
                            :subs   {:cart/items {:doc "Items." :handler cart-items}}})
-          a    (rf/app {:id :shop/app :modules [cart]})]
-      (rf/install! a)
+          a    (av/app {:id :shop/app :modules [cart]})]
+      (av/install! a)
       ;; The handler is resolvable through the ordinary registrar lookup — the
       ;; program is now installed (not merely constructed).
       (is (identical? cart-add (registrar/handler :event :cart/add))
@@ -106,9 +106,9 @@
             value verbatim) so the call composes, and installed-app reconciles
             that seated value with the live projection — reporting the seated
             identity + :modules provenance over the live registrar (rf2-77ewnm)"
-    (let [cart (rf/module {:id :shop/cart :events {:cart/add {:handler cart-add}}})
-          a    (rf/app {:id :shop/app :modules [cart]})
-          ret  (rf/install! a)]
+    (let [cart (av/module {:id :shop/cart :events {:cart/add {:handler cart-add}}})
+          a    (av/app {:id :shop/app :modules [cart]})
+          ret  (av/install! a)]
       (is (= a (:app ret)) "install! returns the realm with the app in :app (verbatim)")
       (is (= :shop/app (:rf.app/id (realm/installed-app)))
           "installed-app reports the seated app's identity")
@@ -126,11 +126,11 @@
             naming the realm + capability, and registers NOTHING (the under-
             provisioned app never becomes partially visible)"
     (clear-default-realm-capabilities!)
-    (let [needs-http (rf/module {:id :shop/cart
+    (let [needs-http (av/module {:id :shop/cart
                                  :rf.module/requires #{:rf.capability/http}
                                  :events {:cart/add {:handler cart-add}}})
-          a  (rf/app {:id :shop/app :modules [needs-http]})
-          ed (try (rf/install! a)
+          a  (av/app {:id :shop/app :modules [needs-http]})
+          ed (try (av/install! a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/missing-capability (:rf.error/id ed))
@@ -152,7 +152,7 @@
             (rf2-9swh84, EP-0013 §Installation step 4 'attach atomically')"
     ;; A hermetic constructed realm so its OWN registrar is cleanly inspectable
     ;; (empty before install; rollback must return it to empty).
-    (let [r (rf/realm {:id :atomic/r})]
+    (let [r (realm/construct-realm {:id :atomic/r})]
       (try
         (is (= {} @(realm/registrar r))
             "the hermetic realm's registrar starts empty")
@@ -162,8 +162,8 @@
         ;; force a throw on the SECOND register! so the first descriptor has
         ;; ALREADY landed in the realm's registrar when the loop blows up — the
         ;; exact partial-install edge: registrar half-populated, :app not yet set.
-        (let [a (rf/app {:id :atomic/app :modules
-                         [(rf/module {:id :m
+        (let [a (av/app {:id :atomic/app :modules
+                         [(av/module {:id :m
                                       :events {:atomic/e1 {:handler cart-add}
                                                :atomic/e2 {:handler cart-add}
                                                :atomic/e3 {:handler cart-add}}})]})
@@ -179,7 +179,7 @@
                                    (throw (ex-info "boom: malformed descriptor mid-loop"
                                                    {:error/id :atomic.test/boom :kind kind :id id}))
                                    (real-register! kind id metadata)))]
-                   (try (rf/install! r a)
+                   (try (av/install! r a)
                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                           (ex-data e))))]
           (is (= :atomic.test/boom (:error/id ed))
@@ -201,17 +201,17 @@
           ;; program (the rolled-back registrar), confirming no leak.
           (is (= {} (:registrations (realm/installed-app r)))
               "the realm's installed-app projects an empty program after rollback"))
-        (finally (rf/dispose-realm! :atomic/r))))))
+        (finally (realm/dispose-realm! :atomic/r))))))
 
 (deftest install-succeeds-when-the-realm-satisfies-requires
   (testing "install! succeeds once the realm provides the required capability"
     (with-default-realm-capabilities! {:rf.capability/http {:request! identity}})
     (try
-      (let [needs-http (rf/module {:id :shop/cart
+      (let [needs-http (av/module {:id :shop/cart
                                    :rf.module/requires #{:rf.capability/http}
                                    :events {:cart/add {:handler cart-add}}})
-            a (rf/app {:id :shop/app :modules [needs-http]})]
-        (rf/install! a)
+            a (av/app {:id :shop/app :modules [needs-http]})]
+        (av/install! a)
         (is (identical? cart-add (registrar/handler :event :cart/add))
             "the descriptor is seated once the capability is satisfied"))
       (finally (clear-default-realm-capabilities!)))))
@@ -220,9 +220,9 @@
   (testing "an app that requires nothing installs into a realm with no
             capabilities — the check is a no-op"
     (clear-default-realm-capabilities!)
-    (let [a (rf/app {:id :shop/app
-                     :modules [(rf/module {:id :m :events {:e {:handler cart-add}}})]})]
-      (rf/install! a)
+    (let [a (av/app {:id :shop/app
+                     :modules [(av/module {:id :m :events {:e {:handler cart-add}}})]})]
+      (av/install! a)
       (is (identical? cart-add (registrar/handler :event :e))
           "no :rf.module/requires means no capability gate"))))
 
@@ -237,8 +237,8 @@
     ;; Sugar path: ordinary reg-event writes the default realm's registrar.
     (rf/reg-event :sugar/inc {:doc "sugar"} cart-add)
     ;; Explicit path: install! seats a descriptor into the SAME registrar.
-    (rf/install! (rf/app {:id :a :modules
-                          [(rf/module {:id :m :events {:installed/inc {:handler cart-add}}})]}))
+    (av/install! (av/app {:id :a :modules
+                          [(av/module {:id :m :events {:installed/inc {:handler cart-add}}})]}))
     ;; Both resolve identically through registrar/handler — one registrar, two
     ;; ways to populate it.
     (is (identical? cart-add (registrar/handler :event :sugar/inc))
@@ -252,26 +252,26 @@
           "the projection reflects the sugar-path registration")
       (is (contains? (get-in proj [:registrations :event]) :installed/inc)
           "the projection reflects the installed registration"))
-    ;; rf2-77ewnm: the PUBLIC read seam (rf/installed-app) must see BOTH too —
+    ;; rf2-77ewnm: the PUBLIC read seam (realm/installed-app) must see BOTH too —
     ;; not just av/app-value. After a stored :app exists, the reconciled read is
     ;; the live projection enriched with provenance, so it agrees with
     ;; av/app-value on the registration set (no public-vs-internal desync).
-    (let [public-events (get-in (rf/installed-app) [:registrations :event])]
+    (let [public-events (get-in (realm/installed-app) [:registrations :event])]
       (is (contains? public-events :sugar/inc)
-          "rf/installed-app reflects the coexisting sugar registration")
+          "realm/installed-app reflects the coexisting sugar registration")
       (is (contains? public-events :installed/inc)
-          "rf/installed-app reflects the installed registration")
+          "realm/installed-app reflects the installed registration")
       (is (= (set (keys (get-in (av/app-value) [:registrations :event])))
              (set (keys public-events)))
-          "rf/installed-app and av/app-value agree on the event set (no desync)"))))
+          "realm/installed-app and av/app-value agree on the event set (no desync)"))))
 
 (deftest install-fires-the-registration-trace-like-the-sugar-path
   (testing "install! routes through registrar/register!, so a seated descriptor
             is dispatchable exactly as a reg-* one — full end-to-end through the
             default-realm frame (the zero-ergonomic-regression headline)"
     (rf/reg-frame :install/app {:doc "install app"})
-    (rf/install! (rf/app {:id :a :modules
-                          [(rf/module {:id :m
+    (av/install! (av/app {:id :a :modules
+                          [(av/module {:id :m
                                        :events {:install/set {:handler (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)})}}
                                        :subs   {:install/read {:handler (fn [db _] (:n db))}}})]}))
     (rf/dispatch-sync [:install/set 42] {:frame :install/app})
@@ -290,16 +290,16 @@
             applies the delta: :added registered, :changed re-registered,
             :removed unregistered (the EP's hot-reload diff value)"
     ;; v1: cart/add + cart/legacy.
-    (rf/install! (rf/app {:id :shop/app :modules
-                          [(rf/module {:id :shop/cart
+    (av/install! (av/app {:id :shop/app :modules
+                          [(av/module {:id :shop/cart
                                        :events {:cart/add    {:handler cart-add}
                                                 :cart/legacy {:handler cart-add}}})]}))
     (is (identical? cart-add (registrar/handler :event :cart/legacy)))
     ;; v2: cart/add CHANGED (new handler), cart/remove ADDED, cart/legacy REMOVED.
-    (let [diff (rf/reinstall!
+    (let [diff (av/reinstall!
                  realm/default-realm-id
-                 (rf/app {:id :shop/app :modules
-                          [(rf/module {:id :shop/cart
+                 (av/app {:id :shop/app :modules
+                          [(av/module {:id :shop/cart
                                        :events {:cart/add    {:handler cart-remove}
                                                 :cart/remove {:handler cart-remove}}})]})
                  {:reason :hot-reload})]
@@ -330,17 +330,17 @@
     ;; dispatch raises :rf.error/no-frame-context earlier).
     (rf/reg-frame :q4x5zz/app {:doc "drop-then-dispatch"})
     ;; v1: install an event id that mutates app-db, and prove it dispatches.
-    (rf/install! :rf.realm/default
-                 (rf/app {:id :q4x5zz/app :modules
-                          [(rf/module {:id :m
+    (av/install! :rf.realm/default
+                 (av/app {:id :q4x5zz/app :modules
+                          [(av/module {:id :m
                                        :events {:q4x5zz/ev {:handler (fn [{:keys [db]} _] {:db (assoc db :ran? true)})}}})]}))
     (rf/dispatch-sync [:q4x5zz/ev] {:frame :q4x5zz/app})
     (is (true? (:ran? (rf/app-db-value :q4x5zz/app)))
         "the installed handler ran while registered")
     ;; v2: reinstall WITHOUT :q4x5zz/ev — it is :removed (unregistered).
-    (let [diff (rf/reinstall! :rf.realm/default
-                              (rf/app {:id :q4x5zz/app :modules
-                                       [(rf/module {:id :m
+    (let [diff (av/reinstall! :rf.realm/default
+                              (av/app {:id :q4x5zz/app :modules
+                                       [(av/module {:id :m
                                                     :events {:q4x5zz/other {:handler (fn [_ _] {})}}})]}))]
       (is (= [[:event :q4x5zz/ev]] (:removed diff)) ":q4x5zz/ev is dropped"))
     ;; Structural proxy (what the existing test asserts): the slot is gone.
@@ -379,16 +379,16 @@
             :on-destroy / machine teardown / sub-cache disposal SKIPPED)."
     ;; v1: install an app whose only registration is a :frame — a real live
     ;; container exists in the core frame registry after install.
-    (rf/install! :rf.realm/default
-                 (rf/app {:id :fr0/app :modules
-                          [(rf/module {:id :m :frames {:fr0/live {:doc "live frame"}}})]}))
+    (av/install! :rf.realm/default
+                 (av/app {:id :fr0/app :modules
+                          [(av/module {:id :m :frames {:fr0/live {:doc "live frame"}}})]}))
     (is (some? (frame/frame :fr0/live)) "the installed :frame is a live container")
     (is (contains? (frame/frame-ids) :fr0/live) "and appears in the live registry")
     ;; v2: reinstall WITHOUT :fr0/live — the diff would :removed it, but the
     ;; container is live → refuse loudly before any mutation.
-    (let [ed (try (rf/reinstall! :rf.realm/default
-                                 (rf/app {:id :fr0/app :modules
-                                          [(rf/module {:id :m2
+    (let [ed (try (av/reinstall! :rf.realm/default
+                                 (av/app {:id :fr0/app :modules
+                                          [(av/module {:id :m2
                                                        :events {:fr0/ev {:handler (fn [_ _] {})}}})]}))
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
@@ -410,17 +410,17 @@
             frame is explicitly destroyed (destroy-frame!, the proper teardown),
             its container is no longer live, so a reinstall! that removes the
             :frame descriptor succeeds and the slot is dropped cleanly."
-    (rf/install! :rf.realm/default
-                 (rf/app {:id :fr1/app :modules
-                          [(rf/module {:id :m :frames {:fr1/live {:doc "to be destroyed"}}})]}))
+    (av/install! :rf.realm/default
+                 (av/app {:id :fr1/app :modules
+                          [(av/module {:id :m :frames {:fr1/live {:doc "to be destroyed"}}})]}))
     (is (some? (frame/frame :fr1/live)) "the frame is live after install")
     ;; The documented recovery: destroy the frame first (full teardown), THEN
     ;; reinstall without it.
     (frame/destroy-frame! :fr1/live)
     (is (nil? (frame/frame :fr1/live)) "destroy-frame! tore the container down")
-    (let [diff (rf/reinstall! :rf.realm/default
-                              (rf/app {:id :fr1/app :modules
-                                       [(rf/module {:id :m2
+    (let [diff (av/reinstall! :rf.realm/default
+                              (av/app {:id :fr1/app :modules
+                                       [(av/module {:id :m2
                                                     :events {:fr1/ev {:handler (fn [_ _] {})}}})]}))]
       ;; The :frame is :removed (its registrar slot dropped) — no live container
       ;; blocks it, so the reinstall applies the delta cleanly.
@@ -471,9 +471,9 @@
         ;; sibling slot's, nor the :frame refusal) is the one whose :removed we
         ;; assert below — every previously-seeded slot survived its own refusal so
         ;; it would ALSO be :removed, so we assert membership, not equality.
-        (let [ed (try (rf/reinstall! :rf.realm/default
-                                     (rf/app {:id :cquy9u/app :modules
-                                              [(rf/module {:id :m
+        (let [ed (try (av/reinstall! :rf.realm/default
+                                     (av/app {:id :cquy9u/app :modules
+                                              [(av/module {:id :m
                                                            :events {ev-id {:handler (fn [_ _] {})}}})]}))
                       (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                         (ex-data e)))]
@@ -516,7 +516,7 @@
     ;; cleanest expression: reinstall the SAME projected app (a no-op diff).
     (registrar/register! :resource :cquy9u/feed {:handler-fn (fn [& _] nil)})
     (let [current (av/app-value :rf.realm/default)
-          diff    (rf/reinstall! :rf.realm/default current)]
+          diff    (av/reinstall! :rf.realm/default current)]
       (is (= [] (:removed diff))
           "reinstalling the current projection removes nothing — no step-8 kind in :removed")
       (is (some? (registrar/lookup :resource :cquy9u/feed))
@@ -536,16 +536,16 @@
             — proving the live cache refreshed, not that app-db moved."
     (rf/reg-frame :s7dcu8/app {:doc "live-sub-reload"})
     ;; v1: a sub that yields a constant :v1.
-    (rf/install! :rf.realm/default
-                 (rf/app {:id :s7dcu8/app :modules
-                          [(rf/module {:id :m :subs {:s7dcu8/read {:handler (fn [_db _] :v1)}}})]}))
+    (av/install! :rf.realm/default
+                 (av/app {:id :s7dcu8/app :modules
+                          [(av/module {:id :m :subs {:s7dcu8/read {:handler (fn [_db _] :v1)}}})]}))
     ;; Hold an ACTIVE subscription and deref it — this POPULATES the live cache.
     (let [reaction (rf/subscribe :s7dcu8/app [:s7dcu8/read])]
       (is (= :v1 @reaction) "the active subscription yields v1 (cache populated)")
       ;; v2: the SAME sub id, a CHANGED handler yielding :v2 — :changed in the diff.
-      (let [diff (rf/reinstall! :rf.realm/default
-                                (rf/app {:id :s7dcu8/app :modules
-                                         [(rf/module {:id :m :subs {:s7dcu8/read {:handler (fn [_db _] :v2)}}})]}))]
+      (let [diff (av/reinstall! :rf.realm/default
+                                (av/app {:id :s7dcu8/app :modules
+                                         [(av/module {:id :m :subs {:s7dcu8/read {:handler (fn [_db _] :v2)}}})]}))]
         (is (= [[:sub :s7dcu8/read]] (:changed diff))
             ":s7dcu8/read is :changed (a different handler descriptor)"))
       ;; Registrar slot rotated (the assertion the existing tests already make).
@@ -560,10 +560,10 @@
 (deftest reinstall-one-arity-defaults-to-the-default-realm
   (testing "the 1-arity (reinstall! new-app) targets the default realm and
             defaults :reason to :hot-reload"
-    (rf/install! (rf/app {:id :app :modules
-                          [(rf/module {:id :m :events {:e {:handler cart-add}}})]}))
-    (let [diff (rf/reinstall! (rf/app {:id :app :modules
-                                       [(rf/module {:id :m :events {:e2 {:handler cart-add}}})]}))]
+    (av/install! (av/app {:id :app :modules
+                          [(av/module {:id :m :events {:e {:handler cart-add}}})]}))
+    (let [diff (av/reinstall! (av/app {:id :app :modules
+                                       [(av/module {:id :m :events {:e2 {:handler cart-add}}})]}))]
       (is (= :rf.realm/default (:realm diff)) "defaults to the default realm")
       (is (= :hot-reload (:reason diff)) ":reason defaults to :hot-reload")
       (is (= [[:event :e2]] (:added diff)))
@@ -573,16 +573,16 @@
   (testing "reinstall! records the new app value in the realm's :app slot — the
             stored slot is the new value verbatim, and installed-app reflects the
             reloaded handler through the live projection (rf2-77ewnm)"
-    (let [v1 (rf/app {:id :app :modules
-                      [(rf/module {:id :m :events {:e {:handler cart-add}}})]})
-          v2 (rf/app {:id :app :modules
-                      [(rf/module {:id :m :events {:e {:handler cart-remove}}})]})]
-      (rf/install! v1)
+    (let [v1 (av/app {:id :app :modules
+                      [(av/module {:id :m :events {:e {:handler cart-add}}})]})
+          v2 (av/app {:id :app :modules
+                      [(av/module {:id :m :events {:e {:handler cart-remove}}})]})]
+      (av/install! v1)
       (is (= v1 (:app (realm/realm realm/default-realm-id)))
           "the stored :app slot holds v1 verbatim after install")
       (is (identical? cart-add (registrar/handler :event :e))
           "and v1's handler resolves")
-      (rf/reinstall! v2)
+      (av/reinstall! v2)
       (is (= v2 (:app (realm/realm realm/default-realm-id)))
           "the realm's stored :app slot now holds the reinstalled value verbatim")
       (is (= :app (:rf.app/id (realm/installed-app)))
@@ -594,13 +594,13 @@
   (testing "reinstall! re-runs the capability check — a reload that adds an
             unmet requirement throws before any mutation"
     (clear-default-realm-capabilities!)
-    (rf/install! (rf/app {:id :app :modules
-                          [(rf/module {:id :m :events {:e {:handler cart-add}}})]}))
-    (let [v2 (rf/app {:id :app :modules
-                      [(rf/module {:id :m
+    (av/install! (av/app {:id :app :modules
+                          [(av/module {:id :m :events {:e {:handler cart-add}}})]}))
+    (let [v2 (av/app {:id :app :modules
+                      [(av/module {:id :m
                                    :rf.module/requires #{:rf.capability/http}
                                    :events {:e {:handler cart-remove}}})]})
-          ed (try (rf/reinstall! v2)
+          ed (try (av/reinstall! v2)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/missing-capability (:rf.error/id ed))
@@ -617,7 +617,7 @@
     (rf/reg-event :boot/a {:doc "a"} cart-add)
     ;; Reinstall a new app value derived FROM the live projection: drop the
     ;; sugar-booted :boot/a event and add :boot/b, leaving every other projected
-    ;; slot in place. Building from the projection (rather than a fresh `rf/app`)
+    ;; slot in place. Building from the projection (rather than a fresh `av/app`)
     ;; keeps the fixture's live `:rf/default` :frame AND the artefact-load step-8
     ;; slots (`:view :route/link`, `:error-projector …`) present in BOTH old and
     ;; new — so they are NEITHER :removed (which would correctly refuse: a live
@@ -628,7 +628,7 @@
                         (update-in [:registrations :event] dissoc :boot/a)
                         (assoc-in  [:registrations :event :boot/b]
                                    {:kind :event :id :boot/b :handler cart-add}))
-          diff      (rf/reinstall! new-app)]
+          diff      (av/reinstall! new-app)]
       (is (some #{[:event :boot/b]} (:added diff))
           ":boot/b is added relative to the projected installed app")
       (is (some #{[:event :boot/a]} (:removed diff))
@@ -648,12 +648,12 @@
             the same handler / metadata / source — descriptor->registration-
             metadata is the inverse of the projection's normalisation"
     (let [src {:ns 'shop.cart :file "cart.cljs" :line 9 :column 1}
-          a   (rf/app {:id :app :modules
-                       [(rf/module {:id :m
+          a   (av/app {:id :app :modules
+                       [(av/module {:id :m
                                     :events {:rt/e {:doc "round-trip"
                                                     :handler cart-add
                                                     :source src}}})]})]
-      (rf/install! a)
+      (av/install! a)
       (let [proj-d (get-in (av/app-value) [:registrations :event :rt/e])]
         (is (identical? cart-add (:handler proj-d))
             "the handler survives the lower→register→project round-trip")
@@ -703,7 +703,7 @@
     (let [full   (av/app-value :rf.realm/default)
           proj-d (get-in full [:registrations :event :untip9/sugar])
           proj   (assoc full :registrations {:event {:untip9/sugar proj-d}})
-          ed     (try (rf/install! proj) nil
+          ed     (try (av/install! proj) nil
                       (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                         (ex-data e)))]
       (is (nil? ed)
@@ -736,14 +736,14 @@
     (let [full      (av/app-value :rf.realm/default)
           proj-d    (get-in full [:registrations :event :untip9.re/e])
           installed (assoc full :registrations {:event {:untip9.re/e proj-d}})]
-      (rf/install! installed)
+      (av/install! installed)
       ;; Build a new app that CHANGES :untip9.re/e by swapping its handler — the
       ;; descriptor still carries the PROJECTED :metadata (effective interceptor
       ;; chain + the inline wrapper). Exactly a projected registrar-shaped event
       ;; descriptor fed back through reinstall! on the :changed path.
       (let [changed (assoc proj-d :handler cart-remove)
             new-app (assoc-in installed [:registrations :event :untip9.re/e] changed)
-            ed      (try (rf/reinstall! new-app) nil
+            ed      (try (av/reinstall! new-app) nil
                          (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                            (ex-data e)))]
         (is (nil? ed)
@@ -782,8 +782,8 @@
           sub-h  (fn [_db _] :sub-val)
           fx-h   (fn [_] nil)
           cofx-h (fn [coeffects] coeffects)]
-      (rf/install! (rf/app {:id :xms/wired :modules
-                            [(rf/module {:id :m
+      (av/install! (av/app {:id :xms/wired :modules
+                            [(av/module {:id :m
                                          :events {:xms/ev   {:handler ev-h}}
                                          :subs   {:xms/sub  {:handler sub-h}}
                                          :fx     {:xms/fx   {:handler fx-h}}
@@ -808,8 +808,8 @@
             `:event/kind` sub-discriminator is gone, so every module event seats
             through the one shape with the unified `:rf/event-handler` wrapper
             and the interceptor chain (rf2-xmslkr × EP-0018 Z)"
-    (rf/install! (rf/app {:id :xms/evfx :modules
-                          [(rf/module {:id :m
+    (av/install! (av/app {:id :xms/evfx :modules
+                          [(av/module {:id :m
                                        :events {:xms/evfx {:handler (fn [_cofx _ev] {})}}})]}))
     (is (some? (registrar/handler :event :xms/evfx))
         "the event descriptor is seated as a resolvable event handler")
@@ -829,8 +829,8 @@
       (with-redefs [events/reg-event (fn [id & args]
                                        (swap! calls inc)
                                        (apply real-reg-event id args))]
-        (rf/install! (rf/app {:id :xhfxcs/d :modules
-                              [(rf/module {:id :m
+        (av/install! (av/app {:id :xhfxcs/d :modules
+                              [(av/module {:id :m
                                            :events {:xhfxcs/ev {:handler (fn [{:keys [db]} _] {:db db})}}})]})))
       (is (= 1 @calls)
           "the install seam lowered the event descriptor through events/reg-event")
@@ -847,8 +847,8 @@
             re-introduced a per-kind wrapper or the `:event/kind` tag would fail
             here, and the handler is proven dispatch-ready end-to-end."
     (rf/reg-frame :xhfxcs.d/app {:doc "event-lowering app"})
-    (rf/install! (rf/app {:id :xhfxcs.d/app :modules
-                          [(rf/module {:id :m
+    (av/install! (av/app {:id :xhfxcs.d/app :modules
+                          [(av/module {:id :m
                                        :events {:xhfxcs.d/set
                                                 {:handler (fn [{:keys [db]} [_ v]]
                                                             {:db (assoc db :n v)})}}})]}))
@@ -873,12 +873,12 @@
             an arbitrary unknown explicit id; the old fallback polluted the
             default registrar while recording no installed app on the requested
             realm."
-    ;; :xms/ghost was never `rf/realm`-constructed, so it has no registry entry.
+    ;; :xms/ghost was never `realm/construct-realm`-constructed, so it has no registry entry.
     (is (nil? (realm/realm :xms/ghost)) "the realm id was never constructed")
     (let [h  (fn [db _] db)
-          a  (rf/app {:id :xms/ghost-app :modules
-                      [(rf/module {:id :m :events {:xms/ghost-ev {:handler h}}})]})
-          ed (try (rf/install! :xms/ghost a)
+          a  (av/app {:id :xms/ghost-app :modules
+                      [(av/module {:id :m :events {:xms/ghost-ev {:handler h}}})]})
+          ed (try (av/install! :xms/ghost a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/unknown-realm (:rf.error/id ed))
@@ -896,24 +896,24 @@
             sugar and the realm-map compose form — only an EXPLICIT unknown id
             throws"
     ;; (a) nil / absent realm → the default realm (the byte-identical sugar path).
-    (rf/install! (rf/app {:id :ok/default :modules
-                          [(rf/module {:id :m :events {:ok/absent {:handler cart-add}}})]}))
+    (av/install! (av/app {:id :ok/default :modules
+                          [(av/module {:id :m :events {:ok/absent {:handler cart-add}}})]}))
     (is (identical? cart-add (registrar/handler :event :ok/absent))
         "absent realm seats into the default realm (sugar preserved)")
     ;; (b) explicit default-realm id → also fine (seeded at boot).
-    (rf/install! :rf.realm/default
-                 (rf/app {:id :ok/expl :modules
-                          [(rf/module {:id :m :events {:ok/explicit {:handler cart-add}}})]}))
+    (av/install! :rf.realm/default
+                 (av/app {:id :ok/expl :modules
+                          [(av/module {:id :m :events {:ok/explicit {:handler cart-add}}})]}))
     (is (identical? cart-add (registrar/handler :event :ok/explicit))
         "explicit default realm id seats fine")
     ;; (c) a constructed realm MAP composes through.
-    (let [r (rf/realm {:id :ok/constructed})]
+    (let [r (realm/construct-realm {:id :ok/constructed})]
       (try
-        (rf/install! r (rf/app {:id :ok/c :modules
-                                [(rf/module {:id :m :events {:ok/in-realm {:handler cart-add}}})]}))
+        (av/install! r (av/app {:id :ok/c :modules
+                                [(av/module {:id :m :events {:ok/in-realm {:handler cart-add}}})]}))
         (is (identical? cart-add (get-in @(realm/registrar r) [:event :ok/in-realm :handler-fn]))
             "a constructed realm map seats into its own registrar")
-        (finally (rf/dispose-realm! :ok/constructed))))))
+        (finally (realm/dispose-realm! :ok/constructed))))))
 
 ;; ---------------------------------------------------------------------------
 ;; (5b) :frame descriptors into a non-default realm SEAT into that realm
@@ -932,17 +932,17 @@
   (testing "EP-0013 step 4 (rf2-a15n62): a :frame descriptor seated into a
             NON-default realm creates a REAL frame stamped + keyed by that realm
             — not a default-stamped, globally-keyed mis-seat"
-    (let [r (rf/realm {:id :rf-frame/r})]
+    (let [r (realm/construct-realm {:id :rf-frame/r})]
       (try
-        (rf/install! r (rf/app {:id :rf-frame/app :modules
-                                [(rf/module {:id :m :frames {:rf-frame/f {:doc "realm-owned frame"}}})]}))
+        (av/install! r (av/app {:id :rf-frame/app :modules
+                                [(av/module {:id :m :frames {:rf-frame/f {:doc "realm-owned frame"}}})]}))
         ;; The frame is owned by the constructed realm (not default-stamped).
         ;; `frame-realm` resolves the frame id WITHIN its realm scope (the bare
         ;; id is unique only within a realm — no default-realm :rf-frame/f exists).
         (is (= :rf-frame/r (frame/call-with-realm :rf-frame/r
-                             (fn [] (rf/frame-realm :rf-frame/f))))
+                             (fn [] (frame/frame-realm :rf-frame/f))))
             "the seated frame's realm is the constructed realm, not the default")
-        (is (nil? (rf/frame-realm :rf-frame/f))
+        (is (nil? (frame/frame-realm :rf-frame/f))
             "the bare (default-scope) read finds no default-realm frame of that id")
         ;; The realm's membership view includes it.
         (is (contains? (realm/realm-frames :rf-frame/r) :rf-frame/f)
@@ -951,15 +951,15 @@
         (is (not (contains? (realm/realm-frames realm/default-realm-id) :rf-frame/f))
             "no default-realm frame of the same id was created (no global collision)")
         (finally
-          (rf/dispose-realm! :rf-frame/r))))))
+          (realm/dispose-realm! :rf-frame/r))))))
 
 (deftest same-frame-id-in-two-realms-stays-isolated
   (testing "EP-0013 step 4 (rf2-a15n62) — the headline: the SAME frame id +
             SAME event/sub/fx/cofx ids installed into two realms stay ISOLATED
             across event dispatch, subscription, fx AND cofx — each frame
             resolves its OWN realm's program"
-    (let [ra (rf/realm {:id :iso/a})
-          rb (rf/realm {:id :iso/b})
+    (let [ra (realm/construct-realm {:id :iso/a})
+          rb (realm/construct-realm {:id :iso/b})
           ;; realm-distinguishing handler / sub / fx / cofx bodies
           fx-log (atom [])
           ;; A per-realm cofx supplier (`:iso/c` → the realm tag), DECLARED on the
@@ -969,8 +969,8 @@
           ;; the effect-map police gate. Both `:iso/c` (cofx) and `:iso/fx` (fx)
           ;; are realm-installed — resolution must route to the owning realm.
           app-for (fn [tag]
-                    (rf/app {:id :iso/app :modules
-                             [(rf/module
+                    (av/app {:id :iso/app :modules
+                             [(av/module
                                 {:id :m
                                  :frames {:iso/f {:doc "shared id"}}
                                  :events {:iso/e {:rf.cofx/requires [:iso/c]
@@ -982,8 +982,8 @@
                                                               (swap! fx-log conj [tag args]))}}
                                  :cofx   {:iso/c {:handler (fn [] tag)}}})]}))]
       (try
-        (rf/install! ra (app-for :a))
-        (rf/install! rb (app-for :b))
+        (av/install! ra (app-for :a))
+        (av/install! rb (app-for :b))
         ;; EVENT + COFX: dispatch the SAME event id into each realm's frame;
         ;; each runs ITS realm's handler + injects ITS realm's cofx supplier.
         (rf/dispatch-sync [:iso/e] {:realm :iso/a :frame :iso/f})
@@ -1009,46 +1009,46 @@
                          (fn [] (rf/subscribe-once :iso/f [:iso/s]))))
             "realm b's frame resolves realm b's :iso/s")
         (finally
-          (rf/dispose-realm! :iso/a)
-          (rf/dispose-realm! :iso/b))))))
+          (realm/dispose-realm! :iso/a)
+          (realm/dispose-realm! :iso/b))))))
 
 (deftest install-frame-into-default-realm-still-works
   (testing "rf2-c6armm.1 #3: the refusal is scoped to NON-default realms — a
             :frame descriptor into the DEFAULT realm still lowers through
             reg-frame (the rf2-chc8vs wiring is unchanged)"
-    (rf/install! (rf/app {:id :df-frame/app :modules
-                          [(rf/module {:id :m :frames {:df-frame/f {:doc "default frame"}}})]}))
+    (av/install! (av/app {:id :df-frame/app :modules
+                          [(av/module {:id :m :frames {:df-frame/f {:doc "default frame"}}})]}))
     (is (contains? (frame/frame-ids) :df-frame/f)
         "a default-realm :frame install creates a real frame container as before")))
 
 ;; ---------------------------------------------------------------------------
-;; (5c) rf/realm rejects a public :app (no false installed-app state)
+;; (5c) realm/construct-realm rejects a public :app (no false installed-app state)
 ;;      (rf2-c6armm.2 #1)
 ;; ---------------------------------------------------------------------------
 
 (deftest realm-rejects-public-app-key
-  (testing "rf2-c6armm.2 #1: rf/realm with an :app key THROWS :rf.error/invalid-realm
+  (testing "rf2-c6armm.2 #1: realm/construct-realm with an :app key THROWS :rf.error/invalid-realm
             — :app is install-owned state, not a constructor input. A public :app
             would record an installed-app VALUE without seating its descriptors,
             so installed-app would report a program the registrar does not hold
             and the first reinstall! would diff against that phantom"
-    (let [app (rf/app {:id :false/app :modules
-                       [(rf/module {:id :m :events {:false/e {:handler cart-add}}})]})
-          ed  (try (rf/realm {:id :false/r :app app})
+    (let [app (av/app {:id :false/app :modules
+                       [(av/module {:id :m :events {:false/e {:handler cart-add}}})]})
+          ed  (try (realm/construct-realm {:id :false/r :app app})
                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                      (ex-data e)))]
       (is (= :rf.error/invalid-realm (:rf.error/id ed))
-          "a public :app on rf/realm is rejected")
+          "a public :app on realm/construct-realm is rejected")
       (is (= :false/r (:realm ed)) "the diagnostic names the realm")
       (is (nil? (realm/realm :false/r))
           "no realm was registered — the constructor threw before register-realm!")
-      ;; The bead's exact phantom scenario — (rf/realm {:app app}) then reinstall!
+      ;; The bead's exact phantom scenario — (realm/construct-realm {:app app}) then reinstall!
       ;; — is structurally IMPOSSIBLE: the constructor threw, so :false/r has no
       ;; registry entry, and a follow-up reinstall! against it would itself throw
       ;; :rf.error/unknown-realm (it never reaches a diff against a phantom :app).
-      (let [v2 (rf/app {:id :false/v2 :modules
-                        [(rf/module {:id :m :events {:false/e2 {:handler cart-add}}})]})
-            re-ed (try (rf/reinstall! :false/r v2)
+      (let [v2 (av/app {:id :false/v2 :modules
+                        [(av/module {:id :m :events {:false/e2 {:handler cart-add}}})]})
+            re-ed (try (av/reinstall! :false/r v2)
                        (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                          (ex-data e)))]
         (is (= :rf.error/unknown-realm (:rf.error/id re-ed))
@@ -1060,14 +1060,14 @@
             install! — seats descriptors AND records the app, so installed-app
             and the registrar AGREE (no phantom installed-app, no reinstall! that
             skips registrar population)"
-    (let [r   (rf/realm {:id :seat/r})
-          app (rf/app {:id :seat/app :modules
-                       [(rf/module {:id :m :events {:seat/e {:handler cart-add}}})]})]
+    (let [r   (realm/construct-realm {:id :seat/r})
+          app (av/app {:id :seat/app :modules
+                       [(av/module {:id :m :events {:seat/e {:handler cart-add}}})]})]
       (try
         ;; A fresh realm has no installed app beyond its empty projection.
         (is (= {} (:registrations (realm/installed-app r)))
             "a fresh realm projects an empty program (no false :app)")
-        (rf/install! r app)
+        (av/install! r app)
         ;; install! seated the descriptor into the registrar AND recorded the app.
         (is (identical? cart-add (get-in @(realm/registrar r) [:event :seat/e :handler-fn]))
             "install! actually seated the descriptor into the realm's registrar")
@@ -1076,15 +1076,15 @@
         (is (contains? (get-in (realm/installed-app r) [:registrations :event]) :seat/e)
             "and the seated registration is visible in the reconciled read")
         ;; reinstall! now diffs against a REAL installed app, not a phantom.
-        (let [v2   (rf/app {:id :seat/app :modules
-                            [(rf/module {:id :m :events {:seat/e2 {:handler cart-items}}})]})
-              diff (rf/reinstall! r v2)]
+        (let [v2   (av/app {:id :seat/app :modules
+                            [(av/module {:id :m :events {:seat/e2 {:handler cart-items}}})]})
+              diff (av/reinstall! r v2)]
           (is (= [[:event :seat/e2]] (:added diff)) ":seat/e2 added")
           (is (= [[:event :seat/e]] (:removed diff))
               ":seat/e removed — the diff saw the genuinely-seated base program")
           (is (identical? cart-items (get-in @(realm/registrar r) [:event :seat/e2 :handler-fn]))
               "the reinstall actually populated the registrar with the new program"))
-        (finally (rf/dispose-realm! :seat/r))))))
+        (finally (realm/dispose-realm! :seat/r))))))
 
 (deftest install-wires-the-frame-kind-through-reg-frame
   (testing "rf2-chc8vs: :frame is an EP-0013 step-7 FIRST-format kind, so a
@@ -1094,8 +1094,8 @@
             appears in `frame-ids`, `frame/frame` resolves a live container, and
             it is dispatchable. This FLIPS the rf2-xmslkr characterization test
             that pinned `frame/frame -> nil` as a known limitation."
-    (rf/install! (rf/app {:id :xms/frame-app :modules
-                          [(rf/module {:id :m :frames {:xms/frame {:doc "constructed frame"}}})]}))
+    (av/install! (av/app {:id :xms/frame-app :modules
+                          [(av/module {:id :m :frames {:xms/frame {:doc "constructed frame"}}})]}))
     ;; The registrar slot is written (reg-frame's first step) — the frame kind is
     ;; a registrar kind, so the (kind,id) table carries the config.
     (is (some? (registrar/lookup :frame :xms/frame))
@@ -1116,9 +1116,9 @@
     ;; so the diff leaves it untouched; dropping it would correctly refuse, as the
     ;; live frame is not orphanable through install! any more than through
     ;; reinstall!) and ADDS the handlers in a second module :m2.
-    (rf/install! (rf/app {:id :xms/frame-prog :modules
-                          [(rf/module {:id :m :frames {:xms/frame {:doc "constructed frame"}}})
-                           (rf/module {:id :m2
+    (av/install! (av/app {:id :xms/frame-prog :modules
+                          [(av/module {:id :m :frames {:xms/frame {:doc "constructed frame"}}})
+                           (av/module {:id :m2
                                        :events {:xms/frame-set {:handler (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)})}}
                                        :subs   {:xms/frame-read {:handler (fn [db _] (:n db))}}})]}))
     (rf/dispatch-sync [:xms/frame-set 7] {:frame :xms/frame})
@@ -1143,10 +1143,10 @@
                             [:views :view]
                             [:heads :head]
                             [:error-projectors :error-projector]]]
-      (let [a  (rf/app {:id :xms/deferred-app :modules
-                        [(rf/module (assoc {:id :m}
+      (let [a  (av/app {:id :xms/deferred-app :modules
+                        [(av/module (assoc {:id :m}
                                            section {:xms/deferred {:handler (fn [& _] nil)}}))]})
-            ed (try (rf/install! a)
+            ed (try (av/install! a)
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                       (ex-data e)))]
         (is (= :rf.error/unsupported-descriptor-kind (:rf.error/id ed))
@@ -1181,14 +1181,14 @@
             leaks."
     (is (not (contains? (frame/frame-ids) :leak/frame))
         "the frame does not exist before the failed install")
-    (let [a  (rf/app {:id :leak/app :modules
-                      [(rf/module {:id :m
+    (let [a  (av/app {:id :leak/app :modules
+                      [(av/module {:id :m
                                    ;; A :frame (wired — would lower through reg-frame
                                    ;; and create a live container) AND a deferred
                                    ;; :route in the SAME app.
                                    :frames {:leak/frame {:doc "would-leak frame"}}
                                    :routes {:leak/route {:handler (fn [& _] nil)}}})]})
-          ed (try (rf/install! a)
+          ed (try (av/install! a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/unsupported-descriptor-kind (:rf.error/id ed))
@@ -1223,11 +1223,11 @@
             truth for the realm registrar. Full replacement (EP-0013 §Installation
             'derive the realm registrar from the app value' / 'value replacement
             at the realm boundary') restores it."
-    (let [r (rf/realm {:id :stale/r})]
+    (let [r (realm/construct-realm {:id :stale/r})]
       (try
         ;; app1: two events.
-        (rf/install! r (rf/app {:id :stale/app1 :modules
-                                [(rf/module {:id :m
+        (av/install! r (av/app {:id :stale/app1 :modules
+                                [(av/module {:id :m
                                              :events {:stale/keep {:handler cart-add}
                                                       :stale/drop {:handler cart-add}}})]}))
         (is (identical? cart-add (get-in @(realm/registrar r) [:event :stale/keep :handler-fn]))
@@ -1236,8 +1236,8 @@
             "app1's :stale/drop is seated")
         ;; app2: re-declares :stale/keep (changed handler), DROPS :stale/drop,
         ;; ADDS :stale/new.
-        (rf/install! r (rf/app {:id :stale/app2 :modules
-                                [(rf/module {:id :m
+        (av/install! r (av/app {:id :stale/app2 :modules
+                                [(av/module {:id :m
                                              :events {:stale/keep {:handler cart-remove}
                                                       :stale/new  {:handler cart-items}}})]}))
         ;; THE FIX: :stale/drop (in app1, not app2) is CLEARED — no longer resolvable.
@@ -1256,7 +1256,7 @@
             "the realm registrar's events equal app2's exactly — no stale leak")
         (is (= :stale/app2 (:rf.app/id (realm/installed-app r)))
             "installed-app reports app2 (and the registrar matches it)")
-        (finally (rf/dispose-realm! :stale/r))))))
+        (finally (realm/dispose-realm! :stale/r))))))
 
 (deftest repeated-install-preserves-coexisting-sugar-registrations
   (testing "rf2-c6armm.7 #1: replacement is scoped to the PRIOR INSTALLED app, not
@@ -1267,10 +1267,10 @@
     ;; Sugar registration into the default realm (NOT an installed app value).
     (rf/reg-event :coexist/sugar {:doc "sugar"} cart-add)
     ;; install! app1 (its own event), then install! app2 dropping app1's event.
-    (rf/install! (rf/app {:id :coexist/app1 :modules
-                          [(rf/module {:id :m :events {:coexist/a1 {:handler cart-add}}})]}))
-    (rf/install! (rf/app {:id :coexist/app2 :modules
-                          [(rf/module {:id :m :events {:coexist/a2 {:handler cart-add}}})]}))
+    (av/install! (av/app {:id :coexist/app1 :modules
+                          [(av/module {:id :m :events {:coexist/a1 {:handler cart-add}}})]}))
+    (av/install! (av/app {:id :coexist/app2 :modules
+                          [(av/module {:id :m :events {:coexist/a2 {:handler cart-add}}})]}))
     ;; app1's :coexist/a1 was cleared (the stale-replacement fix)...
     (is (nil? (registrar/lookup :event :coexist/a1))
         "app1's dropped event was cleared by the replacement")

--- a/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
@@ -65,6 +65,7 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.image          :as image]
             [re-frame.image-assembly :as asm]
+            [re-frame.app-value      :as av]
             [re-frame.source-store   :as ss]
             [re-frame.registrar      :as registrar]
             [re-frame.live-frame     :as lf]
@@ -86,7 +87,7 @@
 ;; live-frame registry) — these are this wave's own defonces, not framework
 ;; ns-load state a sibling depends on, so a direct reset is safe and gives every
 ;; case a known baseline. The plain-atom adapter is installed so the migration
-;; section's `rf/install!` realm path works (it mirrors `migration-cljs-test`);
+;; section's `av/install!` realm path works (it mirrors `migration-cljs-test`);
 ;; the assembly/selection sections never render.
 
 (defn- drop-non-default-realms! []
@@ -790,8 +791,8 @@
   "An EP-0013 app value carrying a single :frames section for `frame-id` — the
   shape install! lowers into a realm-owned :frame descriptor."
   [frame-id]
-  (rf/app {:id :mig/app
-           :modules [(rf/module {:id :mig/m
+  (av/app {:id :mig/app
+           :modules [(av/module {:id :mig/m
                                  :frames {frame-id {:doc "migration shared id"}}})]}))
 
 (deftest s8-cross-realm-frame-id-fails-loud
@@ -799,11 +800,11 @@
             EP-0013 (realm, frame) addressing is rejected
             :rf.error/cross-realm-frame-id by the EP-0023 process-local frame-id
             contract; the same realm in-place case does NOT collide"
-    (let [ra (rf/realm {:id :mig/a})
-          rb (rf/realm {:id :mig/b})]
+    (let [ra (realm/construct-realm {:id :mig/a})
+          rb (realm/construct-realm {:id :mig/b})]
       (try
-        (rf/install! ra (app-with-frame :mig/shared))
-        (rf/install! rb (app-with-frame :mig/shared))
+        (av/install! ra (app-with-frame :mig/shared))
+        (av/install! rb (app-with-frame :mig/shared))
         (is (= #{:mig/a :mig/b} (migration/frame-id-realms :mig/shared))
             "the shared id is live in both realms (the EP-0013 affordance)")
         (is (= :rf.error/cross-realm-frame-id
@@ -813,8 +814,8 @@
                   does not collide"
           (is (= :mig/never-live (migration/assert-process-local-frame-id! :mig/never-live))))
         (finally
-          (rf/dispose-realm! :mig/a)
-          (rf/dispose-realm! :mig/b))))))
+          (realm/dispose-realm! :mig/a)
+          (realm/dispose-realm! :mig/b))))))
 
 (deftest s8-make-frame-repointed-to-the-object-constructor
   (testing "EP-0023 collapse FINALE (rf2-32siq3.48): rf/make-frame is REPOINTED

--- a/implementation/core/test/re_frame/installed_app_read_seam_cljs_test.cljc
+++ b/implementation/core/test/re_frame/installed_app_read_seam_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.installed-app-read-seam-cljs-test
   "EP-0013 disposition 6 — the PUBLIC realm→installed-app READ seam
-  (`rf/installed-app`, rf2-imquoq).
+  (`realm/installed-app`, rf2-imquoq).
 
   This is the NAMED GRADUATION: the per-module provenance/ownership/capability
   facts an `install!`-seated app value carries (`:modules` + each module's
@@ -9,10 +9,10 @@
   internal WHEN a tool demands them — which the Xray Module-view now does. Before
   this seam, `re-frame.realm/installed-app` was internal (no `rf/*` re-export) and
   nothing public yielded a RUNNING realm's installed app value to feed to the
-  existing `rf/app-registrations` / `rf/app-owns` / `rf/app-requires` inspectors
+  existing `av/app-registrations` / `av/app-owns` / `av/app-requires` inspectors
   (those operate on an app value you already HOLD).
 
-  `rf/installed-app` closes that: it returns a running realm's installed app
+  `realm/installed-app` closes that: it returns a running realm's installed app
   value. The contract this test pins:
 
     (1) the public facade var EXISTS and re-exports the internal seam unchanged;
@@ -23,7 +23,7 @@
         returns the recomputable projection — registrations by kind, but an
         empty `:modules` / `:rf.app/requires` (load-order registrations declare
         no module). The Module-view shows the honest awaiting-seam caption there;
-    (4) it is a STATIC read of the install-time value — `(rf/installed-app)`
+    (4) it is a STATIC read of the install-time value — `(realm/installed-app)`
         without a realm reads the default realm (absence = default realm).
 
   Dual-runtime `*_cljs_test.cljc` — both `npm run test:cljs` (node) and
@@ -31,6 +31,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
+            [re-frame.app-value :as av]
             [re-frame.realm :as realm]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
@@ -53,14 +54,21 @@
 (defn- cart-items [db _] (:items db))
 
 ;; ---------------------------------------------------------------------------
-;; (1) the public facade var exists and re-exports the internal seam
+;; (1) the internal installed-app read seam exists and yields the projection
+;;     (EP-0023: this is the retained-INTERNAL realm substrate — no longer a
+;;     `rf/*` public facade re-export; tools reach it via `re-frame.realm`.)
 ;; ---------------------------------------------------------------------------
 
-(deftest public-installed-app-re-exports-the-internal-seam
-  (testing "rf/installed-app is the SAME var value as re-frame.realm/installed-app
-            — the facade re-export, not a re-implementation"
-    (is (identical? rf/installed-app realm/installed-app)
-        "the facade export is the internal seam, byte-identical")))
+(deftest installed-app-read-seam-yields-the-default-realm-projection
+  (testing "re-frame.realm/installed-app is a callable read seam that yields the
+            default realm's live installed-app value — the retained-internal
+            substrate read (EP-0023) tools consume, not a public facade var"
+    (rf/reg-event :seam/probe (fn [{:keys [db]} _] {:db db}))
+    (let [running (realm/installed-app)]
+      (is (map? running)
+          "the seam returns the realm's installed-app value")
+      (is (contains? (av/app-registrations running :event) :seam/probe)
+          "the projection reflects the live default-realm registrations"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (2) an install!-seated realm returns the RICH value with :modules provenance,
@@ -69,41 +77,41 @@
 
 (deftest installed-app-of-a-seated-realm-carries-module-provenance
   (testing "a realm seated via install! returns the rich constructed app value —
-            its :modules provenance is present, so rf/app-registrations /
-            rf/app-owns / rf/app-requires read the per-module facts off the
+            its :modules provenance is present, so av/app-registrations /
+            av/app-owns / av/app-requires read the per-module facts off the
             running realm WITHOUT installing anything (EP-0013 disposition 6)"
-    (let [cart (rf/module {:id                 :shop/cart
+    (let [cart (av/module {:id                 :shop/cart
                            :rf.module/owns     {:app-db [[:cart]]}
                            :rf.module/requires #{:rf.capability/http}
                            :events   {:cart/add   {:doc "Add."   :handler cart-add}}
                            :subs     {:cart/items {:doc "Items." :handler cart-items}}})
-          a    (rf/app {:id :shop/app :modules [cart]})
+          a    (av/app {:id :shop/app :modules [cart]})
           ;; The default realm's capability map must satisfy the app's :rf.app/requires
           ;; for install! to proceed; seat it, then dispose on the way out.
           _    (swap! realm/realms update realm/default-realm-id
                       assoc :capabilities {:rf.capability/http :stub})]
       (try
-        (rf/install! a)
+        (av/install! a)
         ;; The PUBLIC read yields the running realm's installed app value:
         ;; the LIVE registrar projection enriched with the seated app's
         ;; provenance (rf2-77ewnm). With NO coexisting sugar the registration
         ;; set is exactly the seated app's, so it round-trips to the seated id +
         ;; modules + requires, with registrations re-projected off the registrar.
-        (let [running (rf/installed-app)]
+        (let [running (realm/installed-app)]
           (is (= :shop/app (:rf.app/id running))
-              "rf/installed-app reports the seated app's identity")
+              "realm/installed-app reports the seated app's identity")
           (is (= {:shop/cart cart} (:modules running))
               "the rich constructed value's :modules provenance is present
                (NOT the module-less projection)")
           ;; The whole point of disposition 6: feed the running value to the
           ;; existing public inspectors and read per-module facts.
-          (is (contains? (rf/app-registrations running :event) :cart/add)
+          (is (contains? (av/app-registrations running :event) :cart/add)
               "app-registrations reads the seated event descriptor")
-          (is (= :shop/cart (:owner (get (rf/app-registrations running :event) :cart/add)))
+          (is (= :shop/cart (:owner (get (av/app-registrations running :event) :cart/add)))
               "the descriptor carries its owning module (provenance)")
-          (is (= :shop/cart (rf/app-owns running [:cart]))
+          (is (= :shop/cart (av/app-owns running [:cart]))
               "app-owns resolves the owning module of an app-db path")
-          (is (= #{:rf.capability/http} (rf/app-requires running))
+          (is (= #{:rf.capability/http} (av/app-requires running))
               "app-requires reads the module's capability requirements"))
         (finally
           (swap! realm/realms update realm/default-realm-id dissoc :capabilities))))))
@@ -121,14 +129,14 @@
             no-provenance case."
     ;; reg-* sugar — writes the default realm's registrar in place, no install!.
     (rf/reg-event :sugar/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [running (rf/installed-app)]
-      (is (contains? (rf/app-registrations running :event) :sugar/inc)
+    (let [running (realm/installed-app)]
+      (is (contains? (av/app-registrations running :event) :sugar/inc)
           "the projection enumerates the sugar-registered event")
       (is (nil? (:modules running))
           "a projected (sugar/load-order) app carries NO :modules provenance")
-      (is (= #{} (rf/app-requires running))
+      (is (= #{} (av/app-requires running))
           "a projected app declares no capability requirements")
-      (is (nil? (rf/app-owns running [:cart]))
+      (is (nil? (av/app-owns running [:cart]))
           "app-owns is nil for a projected app (no ownership declarations)"))))
 
 ;; ---------------------------------------------------------------------------
@@ -138,10 +146,10 @@
 (deftest installed-app-no-arg-reads-the-default-realm
   (testing "the no-arg form reads the default realm (absence = default realm)"
     (rf/reg-event :default/e (fn [{:keys [db]} _] {:db db}))
-    (is (= (rf/installed-app)
-           (rf/installed-app realm/default-realm-id))
+    (is (= (realm/installed-app)
+           (realm/installed-app realm/default-realm-id))
         "(installed-app) and (installed-app default-realm-id) agree")
-    (is (contains? (rf/app-registrations (rf/installed-app) :event) :default/e)
+    (is (contains? (av/app-registrations (realm/installed-app) :event) :default/e)
         "the no-arg read is the default realm's program")))
 
 ;; ---------------------------------------------------------------------------
@@ -150,7 +158,7 @@
 ;;     stored :app, the public read seam must STILL reflect coexisting sugar
 ;;     (the registrar is the single source of truth, EP-0013:138/:838), while
 ;;     preserving the seated value's per-module provenance. Before the fix,
-;;     `rf/installed-app` returned the frozen install-time snapshot, so a sugar
+;;     `realm/installed-app` returned the frozen install-time snapshot, so a sugar
 ;;     registration live in the registrar (and visible to `av/app-value` /
 ;;     dispatch) was INVISIBLE here. These are the adversarial regressions.
 ;; ---------------------------------------------------------------------------
@@ -167,22 +175,22 @@
 
 (deftest installed-app-mixed-sugar-BEFORE-install-shows-both
   (testing "rf2-77ewnm: a reg-* sugar registration made BEFORE install! is
-            visible in rf/installed-app alongside the installed app's events —
+            visible in realm/installed-app alongside the installed app's events —
             the public read is the LIVE registrar, not the frozen snapshot. The
             seated app's :modules / :rf.app/requires provenance is preserved."
     ;; Sugar FIRST — writes the default realm's registrar in place, no module.
     (rf/reg-event :sugar/before (fn [{:keys [db]} _] {:db db}))
     (with-default-realm-http!
       (fn []
-        (let [cart (rf/module {:id                 :shop/cart
+        (let [cart (av/module {:id                 :shop/cart
                                :rf.module/owns     {:app-db [[:cart]]}
                                :rf.module/requires #{:rf.capability/http}
                                :events   {:cart/add {:doc "Add." :handler cart-add}}
                                :subs     {:cart/items {:doc "Items." :handler cart-items}}})
-              a    (rf/app {:id :shop/app :modules [cart]})]
-          (rf/install! a)
-          (let [running (rf/installed-app)
-                events  (rf/app-registrations running :event)]
+              a    (av/app {:id :shop/app :modules [cart]})]
+          (av/install! a)
+          (let [running (realm/installed-app)
+                events  (av/app-registrations running :event)]
             ;; BOTH the coexisting sugar AND the installed event are visible.
             (is (contains? events :sugar/before)
                 "the pre-install sugar event is visible in the public read seam
@@ -190,9 +198,9 @@
             (is (contains? events :cart/add)
                 "the installed event is visible too")
             ;; The reconciled read agrees with the live projection's registrar
-            ;; view — no desync between rf/installed-app and av/app-value.
+            ;; view — no desync between realm/installed-app and av/app-value.
             (is (= (set (keys events))
-                   (set (keys (rf/app-registrations (rf/installed-app realm/default-realm-id) :event))))
+                   (set (keys (av/app-registrations (realm/installed-app realm/default-realm-id) :event))))
                 "the public read enumerates exactly the live registrar's events")
             ;; Provenance survives: the installed event carries its owner; the
             ;; sugar event has none (load-order declares no module).
@@ -205,9 +213,9 @@
                 "the read reports the seated app's identity")
             (is (= {:shop/cart cart} (:modules running))
                 ":modules provenance from the seated app is preserved")
-            (is (= #{:rf.capability/http} (rf/app-requires running))
+            (is (= #{:rf.capability/http} (av/app-requires running))
                 ":rf.app/requires from the seated app is preserved")
-            (is (= :shop/cart (rf/app-owns running [:cart]))
+            (is (= :shop/cart (av/app-owns running [:cart]))
                 "app-owns resolves through the overlaid :modules")))))))
 
 (deftest installed-app-mixed-sugar-AFTER-install-shows-both
@@ -218,38 +226,38 @@
             without any re-install or invalidation step."
     (with-default-realm-http!
       (fn []
-        (let [a (rf/app {:id :shop/app
-                         :modules [(rf/module {:id                 :shop/cart
+        (let [a (av/app {:id :shop/app
+                         :modules [(av/module {:id                 :shop/cart
                                                :rf.module/requires #{:rf.capability/http}
                                                :events   {:cart/add {:handler cart-add}}})]})]
-          (rf/install! a)
+          (av/install! a)
           ;; Sugar AFTER the install — must still surface in the public read.
           (rf/reg-event :sugar/after (fn [{:keys [db]} _] {:db db}))
-          (let [events (rf/app-registrations (rf/installed-app) :event)]
+          (let [events (av/app-registrations (realm/installed-app) :event)]
             (is (contains? events :sugar/after)
                 "a post-install sugar registration is visible (live recompute,
                  no frozen snapshot)")
             (is (contains? events :cart/add)
                 "the installed event remains visible alongside it")
-            (is (= :shop/app (:rf.app/id (rf/installed-app)))
+            (is (= :shop/app (:rf.app/id (realm/installed-app)))
                 "the seated identity/provenance is still overlaid")))))))
 
 (deftest installed-app-repeated-install-public-view-keeps-coexisting-sugar
   (testing "rf2-77ewnm + rf2-c6armm.7 #1: a repeated install! clears the prior
             installed app's dropped registrations but PRESERVES coexisting sugar
-            — and the PUBLIC read surface (rf/installed-app), not just the
+            — and the PUBLIC read surface (realm/installed-app), not just the
             registrar, reflects that. AC3: assert how the chosen read exposes
             the coexisting sugar through a replacement."
     (rf/reg-event :coexist/sugar (fn [{:keys [db]} _] {:db db}))
     (with-default-realm-http!
       (fn []
         ;; install app1 (its own event), then install app2 dropping app1's event.
-        (rf/install! (rf/app {:id :coexist/app1
-                              :modules [(rf/module {:id :m :events {:coexist/a1 {:handler cart-add}}})]}))
-        (rf/install! (rf/app {:id :coexist/app2
-                              :modules [(rf/module {:id :m :events {:coexist/a2 {:handler cart-add}}})]}))
-        (let [running (rf/installed-app)
-              events  (rf/app-registrations running :event)]
+        (av/install! (av/app {:id :coexist/app1
+                              :modules [(av/module {:id :m :events {:coexist/a1 {:handler cart-add}}})]}))
+        (av/install! (av/app {:id :coexist/app2
+                              :modules [(av/module {:id :m :events {:coexist/a2 {:handler cart-add}}})]}))
+        (let [running (realm/installed-app)
+              events  (av/app-registrations running :event)]
           (is (not (contains? events :coexist/a1))
               "app1's dropped event is GONE from the public read (replacement)")
           (is (contains? events :coexist/a2)

--- a/implementation/core/test/re_frame/migration_cljs_test.cljc
+++ b/implementation/core/test/re_frame/migration_cljs_test.cljc
@@ -25,13 +25,14 @@
   message bytes — Spec 009 §The thrown-error shape rule 3).
 
   The cross-realm case builds the EP-0013 `(realm, frame)` scenario the same way
-  `realm-conformance-cljs-test` does: `rf/install!` an app carrying a `:frames`
+  `realm-conformance-cljs-test` does: `av/install!` an app carrying a `:frames`
   section into two constructed realms so the SAME frame id is a real frame in
   each. `.cljc` ends `-cljs-test` so it rides `npm run test:cljs` AND
   `clojure -M:test`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core       :as rf]
+            [re-frame.app-value  :as av]
             [re-frame.migration  :as migration]
             [re-frame.live-frame :as lf]
             [re-frame.image      :as image]
@@ -73,8 +74,8 @@
   shape `install!` lowers into a realm-owned `:frame` descriptor (mirrors
   realm-conformance-cljs-test's `app-for`)."
   [frame-id]
-  (rf/app {:id :mig/app
-           :modules [(rf/module {:id     :mig/m
+  (av/app {:id :mig/app
+           :modules [(av/module {:id     :mig/m
                                  :frames {frame-id {:doc "migration shared id"}}})]}))
 
 ;; ---------------------------------------------------------------------------
@@ -87,7 +88,7 @@
     (doseq [surface [:rf/app :rf/module :rf/install! :rf/reinstall!
                      :rf/installed-app :rf/realm
                      :rf.realm/frame-address :rf.realm/scoped-query]]
-      (let [entry (get rf/migration-map surface)]
+      (let [entry (get migration/migration-map surface)]
         (is (some? entry) (str surface " has a migration disposition"))
         (is (contains? #{:publicly-replaced :re-expressed :retained-internal}
                        (:status entry))
@@ -99,16 +100,16 @@
 
 (deftest migration-explain-returns-the-guidance-string
   (testing "explain reads the guidance for a known surface and nil for unknown"
-    (is (= (get-in rf/migration-map [:rf/app :guidance])
-           (rf/migration-explain :rf/app))
+    (is (= (get-in migration/migration-map [:rf/app :guidance])
+           (migration/explain :rf/app))
         "explain returns the :rf/app guidance verbatim")
-    (is (re-find #"rf/image" (rf/migration-explain :rf/app))
+    (is (re-find #"rf/image" (migration/explain :rf/app))
         "the :rf/app guidance points at the rf/image replacement")
-    (is (re-find #"image fragment" (rf/migration-explain :rf/module))
+    (is (re-find #"image fragment" (migration/explain :rf/module))
         "the :rf/module guidance points at the image-fragment re-expression")
-    (is (re-find #"frame" (rf/migration-explain :rf.realm/frame-address))
+    (is (re-find #"frame" (migration/explain :rf.realm/frame-address))
         "the (realm, frame) address guidance points at the frame target")
-    (is (nil? (rf/migration-explain :rf/not-a-surface))
+    (is (nil? (migration/explain :rf/not-a-surface))
         "an unknown surface returns nil")))
 
 ;; ---------------------------------------------------------------------------
@@ -119,11 +120,11 @@
   (testing "EP-0023 §Id Spaces: a frame id already live in ANOTHER realm under
             EP-0013 (realm, frame) addressing is rejected by the EP-0023
             process-local frame-id contract"
-    (let [ra (rf/realm {:id :mig/a})
-          rb (rf/realm {:id :mig/b})]
+    (let [ra (realm/construct-realm {:id :mig/a})
+          rb (realm/construct-realm {:id :mig/b})]
       (try
-        (rf/install! ra (app-with-frame :mig/shared))
-        (rf/install! rb (app-with-frame :mig/shared))
+        (av/install! ra (app-with-frame :mig/shared))
+        (av/install! rb (app-with-frame :mig/shared))
         ;; The same frame id is now live in BOTH :mig/a and :mig/b (the EP-0013
         ;; affordance the EP-0023 model removes).
         (is (= #{:mig/a :mig/b} (migration/frame-id-realms :mig/shared))
@@ -131,10 +132,10 @@
         ;; Asserting the EP-0023 process-local contract for a NEW realm target
         ;; surfaces the collision the new model forbids.
         (is (= :rf.error/cross-realm-frame-id
-               (err-id #(rf/assert-process-local-frame-id! :mig/shared :mig/c)))
+               (err-id #(migration/assert-process-local-frame-id! :mig/shared :mig/c)))
             "a frame id live in other realms fails the process-local assertion")
         ;; The ex-data names the conflicting realms (actionable diagnostic).
-        (let [data (try (rf/assert-process-local-frame-id! :mig/shared :mig/c)
+        (let [data (try (migration/assert-process-local-frame-id! :mig/shared :mig/c)
                         nil
                         (catch #?(:clj clojure.lang.ExceptionInfo
                                   :cljs cljs.core/ExceptionInfo) e
@@ -142,30 +143,30 @@
           (is (= #{:mig/a :mig/b} (set (:other-realms data)))
               "the ex-data names every realm the id is already live in"))
         (finally
-          (rf/dispose-realm! :mig/a)
-          (rf/dispose-realm! :mig/b))))))
+          (realm/dispose-realm! :mig/a)
+          (realm/dispose-realm! :mig/b))))))
 
 (deftest same-realm-reassertion-is-not-a-collision
   (testing "re-asserting a frame id in the realm it already lives in is the
             in-place case, not a cross-realm collision"
-    (let [ra (rf/realm {:id :mig/solo})]
+    (let [ra (realm/construct-realm {:id :mig/solo})]
       (try
-        (rf/install! ra (app-with-frame :mig/only))
+        (av/install! ra (app-with-frame :mig/only))
         (is (= #{:mig/solo} (migration/frame-id-realms :mig/only))
             "the id is live only in :mig/solo")
         ;; Targeting the SAME realm — the id is allowed to remain live there.
-        (is (= :mig/only (rf/assert-process-local-frame-id! :mig/only :mig/solo))
+        (is (= :mig/only (migration/assert-process-local-frame-id! :mig/only :mig/solo))
             "re-asserting in the same realm returns the id (no collision)")
         (finally
-          (rf/dispose-realm! :mig/solo))))))
+          (realm/dispose-realm! :mig/solo))))))
 
 (deftest a-fresh-frame-id-passes-the-process-local-assertion
   (testing "a frame id live in no realm passes the process-local assertion"
     (is (= #{} (migration/frame-id-realms :mig/never-live))
         "an unregistered id is live in no realm")
-    (is (= :mig/never-live (rf/assert-process-local-frame-id! :mig/never-live))
+    (is (= :mig/never-live (migration/assert-process-local-frame-id! :mig/never-live))
         "a fresh id passes and is returned")
-    (is (= :mig/never-live (rf/assert-process-local-frame-id! :mig/never-live :mig/x))
+    (is (= :mig/never-live (migration/assert-process-local-frame-id! :mig/never-live :mig/x))
         "a fresh id passes for any target realm")))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/core/test/re_frame/realm_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_cljs_test.cljc
@@ -4,7 +4,7 @@
   rf2-gkddyq), and the realm-owned adapter SELECTION + host-transient
   subsystem inventory (stage 4, rf2-0lq5cd).
 
-  D1 is INTERNAL: no public `rf/realm` constructor and no realm-targeted
+  D1 is INTERNAL: no public `realm/construct-realm` constructor and no realm-targeted
   public query ship. The headline acceptance is **zero ergonomic regression**
   — everything routes through one default realm so a single-realm app's
   surface is byte-identical. These tests pin:
@@ -468,9 +468,9 @@
         "a default-realm mutation still seats (absence resolves to the default)")
     (realm/clear-host-transient!)
     ;; (b) an explicitly constructed realm.
-    (let [r (rf/realm {:id :known/realm})]
+    (let [r (realm/construct-realm {:id :known/realm})]
       (try
         (realm/set-installed-app! :known/realm {:rf.app/id :seated})
         (is (= {:rf.app/id :seated} (:app (realm/realm :known/realm)))
             "a constructed realm's :app mutates normally — only UNKNOWN ids throw")
-        (finally (rf/dispose-realm! :known/realm))))))
+        (finally (realm/dispose-realm! :known/realm))))))

--- a/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
@@ -1,9 +1,9 @@
 (ns re-frame.realm-conformance-cljs-test
-  "EP-0013 D1 stage 9 (rf2-swrf4k) — the PUBLIC `rf/realm` constructor +
+  "EP-0013 D1 stage 9 (rf2-swrf4k) — the PUBLIC `realm/construct-realm` constructor +
   MULTI-REALM / MULTI-ADAPTER-ROOT conformance (the LAST EP-0013 impl slice).
 
-  Stage 9 graduates the reserved `rf/realm` vocabulary (EP-0013 issue 1; ruled
-  `rf/realm`, NEVER `rf/runtime`) into a public BUILD-AND-REGISTER constructor:
+  Stage 9 graduates the reserved `realm/construct-realm` vocabulary (EP-0013 issue 1; ruled
+  `realm/construct-realm`, NEVER `rf/runtime`) into a public BUILD-AND-REGISTER constructor:
   a caller stands up an explicit realm to `install!` an app value into and
   target the stage-8 `{:realm …}` queries against. A constructed realm is
 
@@ -102,8 +102,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest realm-requires-an-id
-  (testing "rf/realm throws :rf.error/invalid-realm when :id is missing"
-    (let [ed (try (rf/realm {})
+  (testing "realm/construct-realm throws :rf.error/invalid-realm when :id is missing"
+    (let [ed (try (realm/construct-realm {})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/invalid-realm (:rf.error/id ed)))
@@ -112,7 +112,7 @@
 (deftest realm-is-hermetic-and-registered
   (testing "a constructed realm gets its OWN fresh registrar atom (not the
             process-global one) and joins the process realm registry under :id"
-    (let [r (rf/realm {:id :conf/r1})]
+    (let [r (realm/construct-realm {:id :conf/r1})]
       (is (= :conf/r1 (:rf.realm/id r)) "the realm carries its id")
       (is (= r (realm/realm :conf/r1)) "it resolves by id through the registry")
       ;; Its registrar is its OWN atom, not the process-global default.
@@ -127,8 +127,8 @@
 (deftest realm-id-must-be-unique
   (testing "constructing a realm whose id is already registered throws
             :rf.error/realm-id-conflict (no silent clobber of a live realm)"
-    (rf/realm {:id :conf/dup})
-    (let [ed (try (rf/realm {:id :conf/dup})
+    (realm/construct-realm {:id :conf/dup})
+    (let [ed (try (realm/construct-realm {:id :conf/dup})
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/realm-id-conflict (:rf.error/id ed)))
@@ -137,47 +137,47 @@
 (deftest dispose-realm-drops-it-default-is-never-disposed
   (testing "dispose-realm! drops a constructed realm from the registry; the
             default realm is never disposed (a no-op)"
-    (rf/realm {:id :conf/temp})
+    (realm/construct-realm {:id :conf/temp})
     (is (some? (realm/realm :conf/temp)))
-    (rf/dispose-realm! :conf/temp)
+    (realm/dispose-realm! :conf/temp)
     (is (nil? (realm/realm :conf/temp)) "the constructed realm is gone")
     ;; Disposing the default realm is a no-op — it backs the single-realm path.
-    (rf/dispose-realm! realm/default-realm-id)
+    (realm/dispose-realm! realm/default-realm-id)
     (is (some? (realm/default-realm)) "the default realm survives a dispose call")))
 
 ;; ---------------------------------------------------------------------------
 ;; the PUBLIC realm-enumeration surface (rf2-f1xa3k) — the (realm, frame)
-;; address read halves: rf/realm-ids enumerates the installed realms,
-;; rf/frame-realm reads the realm a frame lives in.
+;; address read halves: realm/realm-ids enumerates the installed realms,
+;; frame/frame-realm reads the realm a frame lives in.
 ;; ---------------------------------------------------------------------------
 
 (deftest realm-ids-enumerates-the-installed-realms
-  (testing "rf/realm-ids returns the set of installed realm ids — always
+  (testing "realm/realm-ids returns the set of installed realm ids — always
             including the default realm; constructed realms join, disposed
             realms drop out (the live enumeration)"
     ;; A single-realm app sees exactly the default realm.
-    (is (= #{realm/default-realm-id} (rf/realm-ids))
+    (is (= #{realm/default-realm-id} (realm/realm-ids))
         "with no constructed realms, realm-ids is exactly the default realm")
-    (rf/realm {:id :conf/e1})
-    (rf/realm {:id :conf/e2})
-    (is (= #{realm/default-realm-id :conf/e1 :conf/e2} (rf/realm-ids))
+    (realm/construct-realm {:id :conf/e1})
+    (realm/construct-realm {:id :conf/e2})
+    (is (= #{realm/default-realm-id :conf/e1 :conf/e2} (realm/realm-ids))
         "constructed realms join the enumeration")
-    (rf/dispose-realm! :conf/e1)
-    (is (= #{realm/default-realm-id :conf/e2} (rf/realm-ids))
+    (realm/dispose-realm! :conf/e1)
+    (is (= #{realm/default-realm-id :conf/e2} (realm/realm-ids))
         "a disposed realm drops out of the enumeration")
     ;; The default realm is never disposed, so it never leaves the set.
-    (rf/dispose-realm! realm/default-realm-id)
-    (is (contains? (rf/realm-ids) realm/default-realm-id)
+    (realm/dispose-realm! realm/default-realm-id)
+    (is (contains? (realm/realm-ids) realm/default-realm-id)
         "the default realm is always present (never disposed)")))
 
 (deftest frame-realm-reads-a-frames-realm
-  (testing "rf/frame-realm reads the realm a frame belongs to — the default
+  (testing "frame/frame-realm reads the realm a frame belongs to — the default
             realm for a frame registered with no explicit realm, nil for an
             unknown frame"
     (rf/reg-frame :conf/frame-a {:doc "a frame"})
-    (is (= realm/default-realm-id (rf/frame-realm :conf/frame-a))
+    (is (= realm/default-realm-id (frame/frame-realm :conf/frame-a))
         "a frame with no explicit realm lives in the default realm")
-    (is (nil? (rf/frame-realm :conf/never-registered))
+    (is (nil? (frame/frame-realm :conf/never-registered))
         "an unknown frame has no realm")
     (rf/destroy-frame! :conf/frame-a)))
 
@@ -185,14 +185,14 @@
   (testing "the two read halves compose into the (realm, frame) address —
             every frame's realm is an installed realm id"
     (rf/reg-frame :conf/addr-frame {:doc "addr frame"})
-    (let [rid (rf/frame-realm :conf/addr-frame)]
-      (is (contains? (rf/realm-ids) rid)
+    (let [rid (frame/frame-realm :conf/addr-frame)]
+      (is (contains? (realm/realm-ids) rid)
           "a frame's realm is always one of the installed realm ids"))
     (rf/destroy-frame! :conf/addr-frame)))
 
 (deftest realm-carries-its-capabilities
   (testing "a constructed realm carries the :capabilities map it was built with"
-    (let [r (rf/realm {:id :conf/caps
+    (let [r (realm/construct-realm {:id :conf/caps
                        :capabilities {:rf.capability/http {:request! identity}}})]
       (is (contains? (:capabilities r) :rf.capability/http)
           "the capability map rides the realm"))))
@@ -209,7 +209,7 @@
           ;; shape substrate.adapter/dispose-adapter! runs for the default realm.
           adapter {:kind            :rf.adapter/conformance-teardown
                    :dispose-adapter! (fn [] (reset! adapter-disposed? true))}
-          r       (rf/realm {:id :conf/teardown :adapter adapter})]
+          r       (realm/construct-realm {:id :conf/teardown :adapter adapter})]
       ;; Seat a host-transient inventory of two subsystems, each with a
       ;; :teardown token the realm-dispose walk must run (one :frame-scoped,
       ;; one :realm-scoped) — Spec-Schemas §:rf/host-transient-descriptor.
@@ -228,7 +228,7 @@
              (set (keys (realm/host-transient :conf/teardown))))
           "the host-transient inventory carries both subsystems before dispose")
       ;; Dispose: the teardown seams fire.
-      (rf/dispose-realm! :conf/teardown)
+      (realm/dispose-realm! :conf/teardown)
       (is (true? @adapter-disposed?)
           "dispose-realm! ran the seated adapter's own :dispose-adapter! fn")
       (is (= #{:rf.test/in-flight :rf.test/timers} @torn-down-subsystems)
@@ -254,8 +254,8 @@
         {:id            :rf.test/default-guard
          :storage-class :host-transient :scope :realm :durability :none
          :teardown      (fn [_rid] (reset! default-torn-down? true))})
-      (rf/dispose-realm! realm/default-realm-id)
-      (rf/dispose-realm! nil)
+      (realm/dispose-realm! realm/default-realm-id)
+      (realm/dispose-realm! nil)
       (is (false? @default-torn-down?)
           "the default realm's host-transient teardown never ran (dispose is a no-op)")
       (is (some? (realm/realm-adapter realm/default-realm-id))
@@ -272,11 +272,11 @@
 (deftest install-into-a-realm-seats-only-that-realms-registrar
   (testing "install! into a constructed realm seats descriptors into that
             realm's OWN registrar — the default realm + sibling realms see none"
-    (let [r1   (rf/realm {:id :conf/r1})
-          app  (rf/app {:id :conf/app1 :modules
-                        [(rf/module {:id :m :events {:e/x {:handler add-a}}
+    (let [r1   (realm/construct-realm {:id :conf/r1})
+          app  (av/app {:id :conf/app1 :modules
+                        [(av/module {:id :m :events {:e/x {:handler add-a}}
                                      :subs {:s/y {:handler read-who}}})]})]
-      (rf/install! r1 app)
+      (av/install! r1 app)
       ;; The realm's own registrar holds the program.
       (is (= add-a (get-in @(realm/registrar r1) [:event :e/x :handler-fn]))
           "the event handler is seated in the realm's own registrar")
@@ -305,13 +305,13 @@
   (testing "the SAME event/sub id installed into two realms carries genuinely
             different handlers, resolved per-realm — the EP-0013 §Realm
             Conformance headline (no collision, no cross-realm bleed)"
-    (let [ra (rf/realm {:id :conf/a})
-          rb (rf/realm {:id :conf/b})
-          app-of (fn [h] (rf/app {:id :conf/shared :modules
-                                  [(rf/module {:id :m
+    (let [ra (realm/construct-realm {:id :conf/a})
+          rb (realm/construct-realm {:id :conf/b})
+          app-of (fn [h] (av/app {:id :conf/shared :modules
+                                  [(av/module {:id :m
                                                :events {:shared/e {:handler h}}})]}))]
-      (rf/install! ra (app-of add-a))
-      (rf/install! rb (app-of add-b))
+      (av/install! ra (app-of add-a))
+      (av/install! rb (app-of add-b))
       ;; Each realm resolves ITS OWN handler for the shared id.
       (is (= add-a (:handler-fn (rf/handler-meta {:realm :conf/a :kind :event :id :shared/e})))
           "realm a holds add-a for :shared/e")
@@ -331,15 +331,15 @@
 (deftest realm-targeted-queries-isolate-across-the-matrix
   (testing "across an N-realm matrix, {:realm r …} registrations / handler-ids
             return ONLY realm r's registrations — no realm sees another's ids"
-    (let [r1 (rf/realm {:id :conf/m1})
-          r2 (rf/realm {:id :conf/m2})
-          r3 (rf/realm {:id :conf/m3})]
-      (rf/install! r1 (rf/app {:id :a1 :modules
-                               [(rf/module {:id :m :events {:only/e1 {:handler add-a}}})]}))
-      (rf/install! r2 (rf/app {:id :a2 :modules
-                               [(rf/module {:id :m :events {:only/e2 {:handler add-a}}})]}))
-      (rf/install! r3 (rf/app {:id :a3 :modules
-                               [(rf/module {:id :m :events {:only/e3 {:handler add-a}}})]}))
+    (let [r1 (realm/construct-realm {:id :conf/m1})
+          r2 (realm/construct-realm {:id :conf/m2})
+          r3 (realm/construct-realm {:id :conf/m3})]
+      (av/install! r1 (av/app {:id :a1 :modules
+                               [(av/module {:id :m :events {:only/e1 {:handler add-a}}})]}))
+      (av/install! r2 (av/app {:id :a2 :modules
+                               [(av/module {:id :m :events {:only/e2 {:handler add-a}}})]}))
+      (av/install! r3 (av/app {:id :a3 :modules
+                               [(av/module {:id :m :events {:only/e3 {:handler add-a}}})]}))
       ;; Each realm's id set is exactly its own one id.
       (is (= #{:only/e1} (rf/handler-ids {:realm :conf/m1 :kind :event})))
       (is (= #{:only/e2} (rf/handler-ids {:realm :conf/m2 :kind :event})))
@@ -362,8 +362,8 @@
 (deftest each-realm-carries-its-own-adapter-selection
   (testing "N realms can each carry their OWN :adapter selection — the
             multi-adapter-root direction (a realm owns its adapter/root)"
-    (let [r-plain (rf/realm {:id :conf/plain :adapter plain-atom/adapter})
-          r-fake  (rf/realm {:id :conf/fake  :adapter fake-adapter})]
+    (let [r-plain (realm/construct-realm {:id :conf/plain :adapter plain-atom/adapter})
+          r-fake  (realm/construct-realm {:id :conf/fake  :adapter fake-adapter})]
       (is (= plain-atom/adapter (realm/realm-adapter :conf/plain))
           "the plain realm carries the plain-atom adapter selection")
       (is (= fake-adapter (realm/realm-adapter :conf/fake))
@@ -386,9 +386,9 @@
     ;; Seed the default realm via the ordinary sugar path.
     (rf/reg-event :default/seed {:doc "seed"} add-a)
     (let [before (registrar/registrations :event)
-          r      (rf/realm {:id :conf/hermetic})]
-      (rf/install! r (rf/app {:id :h :modules
-                              [(rf/module {:id :m :events {:hermetic/e {:handler add-b}}})]}))
+          r      (realm/construct-realm {:id :conf/hermetic})]
+      (av/install! r (av/app {:id :h :modules
+                              [(av/module {:id :m :events {:hermetic/e {:handler add-b}}})]}))
       ;; The default realm's event registrations are byte-identical — the
       ;; hermetic install wrote only the constructed realm's own registrar.
       (is (= before (registrar/registrations :event))
@@ -403,12 +403,12 @@
 (deftest install-capability-check-on-a-constructed-realm
   (testing "install! into a constructed realm capability-checks FIRST — an unmet
             requirement throws before any mutation to the realm's own registrar"
-    (let [r  (rf/realm {:id :conf/needs-caps})
-          a  (rf/app {:id :c :modules
-                      [(rf/module {:id :m
+    (let [r  (realm/construct-realm {:id :conf/needs-caps})
+          a  (av/app {:id :c :modules
+                      [(av/module {:id :m
                                    :rf.module/requires #{:rf.capability/http}
                                    :events {:c/e {:handler add-a}}})]})
-          ed (try (rf/install! r a)
+          ed (try (av/install! r a)
                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                     (ex-data e)))]
       (is (= :rf.error/missing-capability (:rf.error/id ed)))
@@ -418,10 +418,10 @@
       (is (= {} @(realm/registrar r))
           "the realm's own registrar is empty — the failed install was atomic"))
     (testing "and it succeeds once the realm provides the capability"
-      (let [r (rf/realm {:id :conf/has-caps
+      (let [r (realm/construct-realm {:id :conf/has-caps
                          :capabilities {:rf.capability/http {:request! identity}}})]
-        (rf/install! r (rf/app {:id :c2 :modules
-                                [(rf/module {:id :m
+        (av/install! r (av/app {:id :c2 :modules
+                                [(av/module {:id :m
                                              :rf.module/requires #{:rf.capability/http}
                                              :events {:c/e {:handler add-a}}})]}))
         (is (= add-a (get-in @(realm/registrar r) [:event :c/e :handler-fn]))
@@ -435,8 +435,8 @@
   (testing "install! against the default realm seats into the process-global
             registrar exactly as before (the realm-scoped seam is a no-op rebind
             to the same atom when the realm IS the default)"
-    (rf/install! (rf/app {:id :d :modules
-                          [(rf/module {:id :m :events {:default/e {:handler add-a}}})]}))
+    (av/install! (av/app {:id :d :modules
+                          [(av/module {:id :m :events {:default/e {:handler add-a}}})]}))
     ;; The default-realm install resolves through the ordinary global lookup.
     (is (= add-a (registrar/handler :event :default/e))
         "the default-realm install seats the process-global registrar")
@@ -463,15 +463,15 @@
 (deftest reinstall-into-a-realm-touches-only-that-realm
   (testing "reinstall! diffs + applies the delta against the constructed realm's
             OWN registrar — the default realm and siblings are untouched"
-    (let [r  (rf/realm {:id :conf/reload})
-          v1 (rf/app {:id :rl :modules
-                      [(rf/module {:id :m :events {:rl/keep {:handler add-a}
+    (let [r  (realm/construct-realm {:id :conf/reload})
+          v1 (av/app {:id :rl :modules
+                      [(av/module {:id :m :events {:rl/keep {:handler add-a}
                                                    :rl/drop {:handler add-a}}})]})
-          v2 (rf/app {:id :rl :modules
-                      [(rf/module {:id :m :events {:rl/keep {:handler add-b}
+          v2 (av/app {:id :rl :modules
+                      [(av/module {:id :m :events {:rl/keep {:handler add-b}
                                                    :rl/new  {:handler add-b}}})]})]
-      (rf/install! r v1)
-      (let [diff (rf/reinstall! r v2 {:reason :hot-reload})]
+      (av/install! r v1)
+      (let [diff (av/reinstall! r v2 {:reason :hot-reload})]
         (is (= :conf/reload (:realm diff)) "the diff names the constructed realm")
         (is (= [[:event :rl/new]] (:added diff)))
         (is (= [[:event :rl/keep]] (:changed diff)))
@@ -512,27 +512,27 @@
             realms with realm-owned :frame descriptors creates two isolated live
             frames — frame-realm matches the owning realm, dispatch runs that
             realm's handler, and subs resolve that realm's sub"
-    (let [ra (rf/realm {:id :live/a})
-          rb (rf/realm {:id :live/b})
+    (let [ra (realm/construct-realm {:id :live/a})
+          rb (realm/construct-realm {:id :live/b})
           app-for (fn [tag]
-                    (rf/app {:id :live/app :modules
-                             [(rf/module
+                    (av/app {:id :live/app :modules
+                             [(av/module
                                 {:id :m
                                  :frames {:live/f {:doc "shared id"}}
                                  :events {:live/set {:handler (fn [{:keys [db]} _] {:db (assoc db :who tag)})}}
                                  :subs   {:live/who {:handler (fn [db _] [tag (:who db)])}}})]}))]
       (try
-        (rf/install! ra (app-for :a))
-        (rf/install! rb (app-for :b))
+        (av/install! ra (app-for :a))
+        (av/install! rb (app-for :b))
         ;; The same frame id is a REAL frame in each realm — owned by that realm.
         ;; A bare `frame-realm` read (no realm scope) finds NO default-realm
         ;; :live/f, so it returns nil — the id is unambiguous only WITHIN a realm.
-        (is (nil? (rf/frame-realm :live/f))
+        (is (nil? (frame/frame-realm :live/f))
             "no default-realm :live/f exists, so the bare read is nil (id unique within a realm)")
         ;; frame-realm with the realm scope reads the realm's own frame.
-        (is (= :live/a (frame/call-with-realm :live/a (fn [] (rf/frame-realm :live/f))))
+        (is (= :live/a (frame/call-with-realm :live/a (fn [] (frame/frame-realm :live/f))))
             "realm a owns :live/f")
-        (is (= :live/b (frame/call-with-realm :live/b (fn [] (rf/frame-realm :live/f))))
+        (is (= :live/b (frame/call-with-realm :live/b (fn [] (frame/frame-realm :live/f))))
             "realm b owns :live/f")
         ;; DISPATCH the SAME event id into each realm's frame: each runs ITS
         ;; realm's handler (realm-routed event resolution).
@@ -554,8 +554,8 @@
         (is (not (contains? (realm/realm-frames realm/default-realm-id) :live/f))
             "the default realm owns no :live/f frame (no global collision)")
         (finally
-          (rf/dispose-realm! :live/a)
-          (rf/dispose-realm! :live/b))))))
+          (realm/dispose-realm! :live/a)
+          (realm/dispose-realm! :live/b))))))
 
 ;; ---------------------------------------------------------------------------
 ;; (9b) dispose-realm! ends the LIFECYCLE of the frames the realm OWNS
@@ -577,24 +577,24 @@
   (testing "rf2-yueuvi: dispose-realm! destroys the frames the realm OWNS, so
             post-dispose neither (frame realm-id id) nor realm/realm-frames
             exposes them — while a SIBLING realm's same-id frame is untouched"
-    (let [ra (rf/realm {:id :disp/a})
-          rb (rf/realm {:id :disp/b})
+    (let [ra (realm/construct-realm {:id :disp/a})
+          rb (realm/construct-realm {:id :disp/b})
           app-for (fn [tag]
-                    (rf/app {:id :disp/app :modules
-                             [(rf/module
+                    (av/app {:id :disp/app :modules
+                             [(av/module
                                 {:id :m
                                  :frames {:disp/f {:doc "shared id"}}
                                  :events {:disp/set {:handler (fn [{:keys [db]} _] {:db (assoc db :who tag)})}}})]}))]
       (try
-        (rf/install! ra (app-for :a))
-        (rf/install! rb (app-for :b))
+        (av/install! ra (app-for :a))
+        (av/install! rb (app-for :b))
         ;; Both realms own a live :disp/f frame, addressable by their address.
         (is (some? (frame/frame :disp/a :disp/f)) "realm a's frame is live pre-dispose")
         (is (some? (frame/frame :disp/b :disp/f)) "realm b's frame is live pre-dispose")
         (is (contains? (realm/realm-frames :disp/a) :disp/f) "realm a owns :disp/f")
         (is (contains? (realm/realm-frames :disp/b) :disp/f) "realm b owns :disp/f")
         ;; Dispose realm a ONLY.
-        (rf/dispose-realm! :disp/a)
+        (realm/dispose-realm! :disp/a)
         ;; realm a's frame is no longer addressable — fail-closed, not a stale
         ;; resolve of a dead frame.
         (is (nil? (frame/frame :disp/a :disp/f))
@@ -609,8 +609,8 @@
         (is (contains? (realm/realm-frames :disp/b) :disp/f)
             "realm b still owns :disp/f")
         (finally
-          (rf/dispose-realm! :disp/a)
-          (rf/dispose-realm! :disp/b))))))
+          (realm/dispose-realm! :disp/a)
+          (realm/dispose-realm! :disp/b))))))
 
 (deftest recreating-disposed-realm-and-frame-starts-fresh
   (testing "rf2-yueuvi: after dispose-realm!, recreating the same realm id and
@@ -618,46 +618,46 @@
             app-db state from the disposed realm (not a re-registration that
             keeps the dead realm's runtime state)"
     (let [app-with (fn [seed]
-                     (rf/app {:id :recr/app :modules
-                              [(rf/module
+                     (av/app {:id :recr/app :modules
+                              [(av/module
                                  {:id :m
                                   :frames {:recr/f {:doc "x"}}
                                   :events {:recr/seed {:handler (fn [{:keys [db]} _]
                                                                   {:db (assoc db :seed seed)})}}})]}))]
       (try
         ;; First incarnation: install, then write state into the frame's app-db.
-        (let [r1 (rf/realm {:id :recr/r})]
-          (rf/install! r1 (app-with :first))
+        (let [r1 (realm/construct-realm {:id :recr/r})]
+          (av/install! r1 (app-with :first))
           (rf/dispatch-sync [:recr/seed] {:realm :recr/r :frame :recr/f})
           (is (= :first (frame/call-with-realm :recr/r
                           (fn [] (:seed (frame/frame-app-db-value :recr/f)))))
               "the first incarnation's handler wrote :seed :first"))
         ;; Dispose the realm — this MUST end the frame's lifecycle.
-        (rf/dispose-realm! :recr/r)
+        (realm/dispose-realm! :recr/r)
         (is (nil? (frame/frame :recr/r :recr/f))
             "the disposed realm's frame is unaddressable")
         ;; Recreate the SAME realm id + install the SAME frame id WITHOUT
         ;; re-running the seed event: a fresh frame must start with EMPTY app-db,
         ;; NOT the disposed realm's preserved {:seed :first}.
-        (let [r2 (rf/realm {:id :recr/r})]
-          (rf/install! r2 (app-with :second))
+        (let [r2 (realm/construct-realm {:id :recr/r})]
+          (av/install! r2 (app-with :second))
           (is (nil? (frame/call-with-realm :recr/r
                       (fn [] (:seed (frame/frame-app-db-value :recr/f)))))
               "the recreated frame starts FRESH — no preserved :seed from the
                disposed realm (a re-registration would have kept :first)"))
         (finally
-          (rf/dispose-realm! :recr/r))))))
+          (realm/dispose-realm! :recr/r))))))
 
 (deftest child-dispatch-and-fx-preserve-the-realm
   (testing "EP-0013 step 4 (rf2-a15n62): a child dispatch emitted from a handler's
             :fx [[:dispatch …]] STAYS in the parent's realm — the child resolves
             its event handler in the SAME realm, not the default (realm preserved
             across the cascade continuation)"
-    (let [r (rf/realm {:id :child/r})]
+    (let [r (realm/construct-realm {:id :child/r})]
       (try
-        (rf/install! r
-          (rf/app {:id :child/app :modules
-                   [(rf/module
+        (av/install! r
+          (av/app {:id :child/app :modules
+                   [(av/module
                       {:id :m
                        :frames {:child/f {:doc "x"}}
                        ;; :parent emits a child :dispatch (NO explicit realm) — it
@@ -669,7 +669,7 @@
         (is (= :child/r (frame/call-with-realm :child/r
                           (fn [] (:child-ran (frame/frame-app-db-value :child/f)))))
             "the :fx-dispatched child stayed in the parent's realm and ran its handler")
-        (finally (rf/dispose-realm! :child/r))))))
+        (finally (realm/dispose-realm! :child/r))))))
 
 (deftest non-default-realm-handlers-do-not-leak-into-default-live-dispatch
   (testing "rf2-c6armm.3 #1: a handler installed ONLY into a constructed realm is
@@ -677,10 +677,10 @@
             isolation half that holds today (a default-realm frame dispatching
             the id is recovered as a no-op, not silently running the constructed
             realm's handler)"
-    (let [r (rf/realm {:id :leak/r})]
+    (let [r (realm/construct-realm {:id :leak/r})]
       (try
-        (rf/install! r (rf/app {:id :leak/app :modules
-                                [(rf/module {:id :m
+        (av/install! r (av/app {:id :leak/app :modules
+                                [(av/module {:id :m
                                              :events {:leak/only-in-r {:handler add-a}}})]}))
         ;; The handler lives in the constructed realm's own registrar.
         (is (= add-a (:handler-fn (rf/handler-meta {:realm :leak/r :kind :event :id :leak/only-in-r})))
@@ -691,7 +691,7 @@
             "the constructed realm's handler does not leak into the default registrar")
         (is (nil? (rf/handler-meta :event :leak/only-in-r))
             "the default-realm query also does not see it (live dispatch resolves here)")
-        (finally (rf/dispose-realm! :leak/r))))))
+        (finally (realm/dispose-realm! :leak/r))))))
 
 ;; ---------------------------------------------------------------------------
 ;; (10) reinstall! APPLY-PHASE rollback into a constructed realm (rf2-c6armm.3 #2)
@@ -704,15 +704,15 @@
             state — the seat-into-realm! snapshot/restore covers reinstall too,
             not just install. Old slots, removed slots, and installed-app all
             stay unchanged"
-    (let [r  (rf/realm {:id :rb/r})
-          v1 (rf/app {:id :rb/app :modules
-                      [(rf/module {:id :m :events {:rb/keep {:handler add-a}
+    (let [r  (realm/construct-realm {:id :rb/r})
+          v1 (av/app {:id :rb/app :modules
+                      [(av/module {:id :m :events {:rb/keep {:handler add-a}
                                                    :rb/drop {:handler add-a}}})]})
-          v2 (rf/app {:id :rb/app :modules
-                      [(rf/module {:id :m :events {:rb/keep {:handler add-b}
+          v2 (av/app {:id :rb/app :modules
+                      [(av/module {:id :m :events {:rb/keep {:handler add-b}
                                                    :rb/new  {:handler add-b}}})]})]
       (try
-        (rf/install! r v1)
+        (av/install! r v1)
         (let [reg-before @(realm/registrar r)
               calls (atom 0)
               real-register! registrar/register!
@@ -727,7 +727,7 @@
                                        (throw (ex-info "boom mid-apply"
                                                        {:error/id :rb.test/boom})))
                                    (real-register! kind id metadata)))]
-                   (try (rf/reinstall! r v2)
+                   (try (av/reinstall! r v2)
                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
                           (ex-data e))))]
           (is (= :rb.test/boom (:error/id ed)) "the mid-apply throw propagated")
@@ -750,4 +750,4 @@
           (is (= #{:rb/keep :rb/drop}
                  (set (keys (get-in (realm/installed-app r) [:registrations :event]))))
               "installed-app reconciles to v1's program (no partial v2 :rb/new seating)"))
-        (finally (rf/dispose-realm! :rb/r))))))
+        (finally (realm/dispose-realm! :rb/r))))))

--- a/implementation/core/test/re_frame/realm_query_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_query_cljs_test.cljc
@@ -7,7 +7,7 @@
     (rf/registrations {:realm r :kind :event})
     (rf/handler-meta   {:realm r :kind :event :id :cart/add})
     (rf/handler-ids    {:realm r :kind :event})
-    (rf/app-registrations {:app app :kind :event})
+    (av/app-registrations app :event)   ; retained-internal positional inspector
 
   ruled map-shaped in EP-0013 open-issue 11 (unambiguous against the existing
   keyword arities, extensible). The headline acceptance, mirroring D1 §Realm
@@ -34,6 +34,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
+            [re-frame.app-value :as av]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -191,20 +192,22 @@
         "handler-ids on an unknown realm is empty")))
 
 ;; ---------------------------------------------------------------------------
-;; (5) app-registrations grows the map-shaped form
+;; (5) app-registrations enumerates a constructed app's descriptors
+;;
+;; EP-0023 (rf2-pl97nd.4): the facade-only `{:app :kind}` map-shaped arity is
+;; removed with the public facade; the retained-internal
+;; `re-frame.app-value/app-registrations` keeps the positional `[app kind]`
+;; substrate inspector, which this exercises.
 ;; ---------------------------------------------------------------------------
 
-(deftest app-registrations-map-form
-  (testing "(app-registrations {:app app :kind k}) parallels the positional
-            form and the realm-targeted registrar queries"
-    (let [m   (rf/module {:id :rq/mod
+(deftest app-registrations-positional-form
+  (testing "(app-value/app-registrations app kind) enumerates a constructed
+            app value's descriptors for a kind, nil for a kind it declares none of"
+    (let [m   (av/module {:id :rq/mod
                           :events {:rq/m-evt {:doc "mod event"
                                               :handler (fn [db _] db)}}})
-          app (rf/app {:id :rq/app :modules [m]})]
-      (is (= (rf/app-registrations app :event)
-             (rf/app-registrations {:app app :kind :event}))
-          "the map form equals the positional form")
-      (is (contains? (rf/app-registrations {:app app :kind :event}) :rq/m-evt)
-          "the map form enumerates the constructed app's descriptors")
-      (is (nil? (rf/app-registrations {:app app :kind :sub}))
-          "a kind the app declares none of is nil, as the positional form"))))
+          app (av/app {:id :rq/app :modules [m]})]
+      (is (contains? (av/app-registrations app :event) :rq/m-evt)
+          "the positional form enumerates the constructed app's descriptors")
+      (is (nil? (av/app-registrations app :sub))
+          "a kind the app declares none of is nil"))))

--- a/implementation/core/test/re_frame/realm_source_store_isolation_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_source_store_isolation_cljs_test.cljc
@@ -36,6 +36,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
+            [re-frame.app-value :as av]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.source-store :as source-store]
@@ -69,8 +70,8 @@
 (defn- add-b [{:keys [db]} _] {:db (assoc db :who :b)})
 
 (defn- app-of [id handler]
-  (rf/app {:id id :modules
-           [(rf/module {:id :m :events {:shared/e {:handler handler}}})]}))
+  (av/app {:id id :modules
+           [(av/module {:id :m :events {:shared/e {:handler handler}}})]}))
 
 ;; ---------------------------------------------------------------------------
 ;; (b) A constructed realm OWNS its own source-store atom, distinct from default
@@ -80,14 +81,14 @@
   (testing "rf2-9fn4is — a hermetic constructed realm resolves to its OWN
             source-store atom (not the process-default), mirroring its OWN
             registrar atom"
-    (let [r (rf/realm {:id :ss/r1})]
+    (let [r (realm/construct-realm {:id :ss/r1})]
       (is (not (identical? (realm/source-store r)
                            source-store/kind->id->ns->descriptor))
           "the constructed realm's source store is NOT the process-default atom")
       (is (not (identical? (realm/registrar r)
                            registrar/kind->id->metadata))
           "the constructed realm's registrar is NOT the process-default atom (control)")
-      (rf/dispose-realm! :ss/r1))))
+      (realm/dispose-realm! :ss/r1))))
 
 ;; ---------------------------------------------------------------------------
 ;; (a) Installing the same (kind, id) into two realms does NOT pollute default
@@ -97,12 +98,12 @@
   (testing "rf2-9fn4is — installing the SAME (kind, id) into two hermetic realms
             adds NEITHER descriptor to the process-default source store; each
             realm's own source store holds only its own descriptor"
-    (let [ra (rf/realm {:id :ss/a})
-          rb (rf/realm {:id :ss/b})]
+    (let [ra (realm/construct-realm {:id :ss/a})
+          rb (realm/construct-realm {:id :ss/b})]
       (is (empty? (source-store/descriptors-for :event :shared/e))
           "the process-default source store has no :shared/e before any install")
-      (rf/install! ra (app-of :ss/app-a add-a))
-      (rf/install! rb (app-of :ss/app-b add-b))
+      (av/install! ra (app-of :ss/app-a add-a))
+      (av/install! rb (app-of :ss/app-b add-b))
       ;; THE BUG: pre-fix the realm installs wrote :shared/e into the
       ;; process-default source store (the *source-store* binding was missing),
       ;; so this map was non-empty.
@@ -122,8 +123,8 @@
           (is (= 1 (count descs)) "realm b's own source store holds one :shared/e slot")
           (is (= add-b (-> descs vals first :handler-fn))
               "realm b's own source store holds add-b's descriptor")))
-      (rf/dispose-realm! :ss/a)
-      (rf/dispose-realm! :ss/b))))
+      (realm/dispose-realm! :ss/a)
+      (realm/dispose-realm! :ss/b))))
 
 ;; ---------------------------------------------------------------------------
 ;; (c) A non-default reinstall/removal does NOT delete a default source descriptor
@@ -139,19 +140,19 @@
     (rf/reg-event :shared/e add-a)
     (is (seq (source-store/descriptors-for :event :shared/e))
         "the default realm's source store holds the sugar-registered :shared/e")
-    (let [r (rf/realm {:id :ss/reinst})]
+    (let [r (realm/construct-realm {:id :ss/reinst})]
       ;; Install :shared/e into the hermetic realm, then reinstall an app that
       ;; DROPS it (the removal path that previously deleted the default slot).
-      (rf/install!   r (app-of :ss/reinst-app add-b))
-      (rf/reinstall! r (rf/app {:id :ss/reinst-app :modules
-                                [(rf/module {:id :m :events {:other/e {:handler add-a}}})]}))
+      (av/install!   r (app-of :ss/reinst-app add-b))
+      (av/reinstall! r (av/app {:id :ss/reinst-app :modules
+                                [(av/module {:id :m :events {:other/e {:handler add-a}}})]}))
       ;; THE BUG: pre-fix the reinstall's `forget-id!` for the removed :shared/e
       ;; ran against the process-default source store, deleting the default
       ;; realm's own :shared/e descriptor.
       (is (seq (source-store/descriptors-for :event :shared/e))
           "the default realm's :shared/e source descriptor SURVIVES the
            non-default realm's removal of the same (kind, id)")
-      (rf/dispose-realm! :ss/reinst))))
+      (realm/dispose-realm! :ss/reinst))))
 
 ;; ---------------------------------------------------------------------------
 ;; (d) Failed install seating is ATOMIC for the source store too
@@ -161,15 +162,15 @@
   (testing "rf2-9fn4is — a throw PART-WAY through install seating leaves no
             partial writes in the realm's source store (atomic across BOTH the
             registrar and the source store)"
-    (let [r (rf/realm {:id :ss/atomic})
+    (let [r (realm/construct-realm {:id :ss/atomic})
           ;; An app whose second descriptor names a step-8-DEFERRED kind so the
           ;; seating throws AFTER the first descriptor would otherwise land.
           ;; install! preflights the kinds and throws before lowering anything,
           ;; so to force a MID-LOOP throw we install a good app first, then a
           ;; reinstall whose apply loop throws part-way.
-          good (rf/app {:id :ss/atomic-app :modules
-                        [(rf/module {:id :m :events {:ok/e1 {:handler add-a}}})]})]
-      (rf/install! r good)
+          good (av/app {:id :ss/atomic-app :modules
+                        [(av/module {:id :m :events {:ok/e1 {:handler add-a}}})]})]
+      (av/install! r good)
       ;; Sanity: the good descriptor is in the realm's own source store.
       (binding [source-store/*source-store* (realm/source-store r)]
         (is (seq (source-store/descriptors-for :event :ok/e1))
@@ -178,12 +179,12 @@
             ;; A reinstall whose NEW app adds a descriptor of a deferred kind —
             ;; the apply loop throws part-way. (Deferred kinds throw
             ;; :rf.error/unsupported-descriptor-kind on lowering.)
-            bad (rf/app {:id :ss/atomic-app :modules
-                         [(rf/module {:id :m
+            bad (av/app {:id :ss/atomic-app :modules
+                         [(av/module {:id :m
                                       :events {:ok/e1 {:handler add-a}
                                                :ok/e2 {:handler add-b}}
                                       :flows  {:bad/flow {:output (fn [_] nil)}}})]})
-            threw? (try (rf/reinstall! r bad) false
+            threw? (try (av/reinstall! r bad) false
                         (catch #?(:clj Throwable :cljs :default) _ true))]
         (is threw? "the reinstall threw on the deferred-kind descriptor")
         (binding [source-store/*source-store* (realm/source-store r)]
@@ -199,7 +200,7 @@
         ;; unchanged store is a safe cache false-miss, never a stale hit).
         (is (= store-value-before @(realm/source-store r))
             "the realm source store value is restored after the rolled-back reinstall"))
-      (rf/dispose-realm! :ss/atomic))))
+      (realm/dispose-realm! :ss/atomic))))
 
 ;; ---------------------------------------------------------------------------
 ;; (e) The realm store's generation bumps on its OWN mutations, default's does not
@@ -210,14 +211,14 @@
             generation while leaving the process-default store's generation
             untouched (image assembly reads the intended store under the binding)"
     (let [default-gen-before (source-store/store-generation)
-          r                  (rf/realm {:id :ss/gen})
+          r                  (realm/construct-realm {:id :ss/gen})
           realm-gen-before   (binding [source-store/*source-store* (realm/source-store r)]
                                (source-store/store-generation))]
-      (rf/install! r (app-of :ss/gen-app add-a))
+      (av/install! r (app-of :ss/gen-app add-a))
       (is (= default-gen-before (source-store/store-generation))
           "the process-default source store's generation is UNCHANGED by the realm install")
       (let [realm-gen-after (binding [source-store/*source-store* (realm/source-store r)]
                               (source-store/store-generation))]
         (is (> realm-gen-after realm-gen-before)
             "the realm source store's OWN generation bumped on its install"))
-      (rf/dispose-realm! :ss/gen))))
+      (realm/dispose-realm! :ss/gen))))

--- a/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/thrown_error_message_conformance_cljs_test.cljc
@@ -233,26 +233,26 @@
 ;; app-value / realm throws (rf2-p7kwpt) — the app-as-value and realm surface
 ;; exemplars. Both previously threw with the legacy `:error/id` discriminator;
 ;; they now route through the central builder so the message is a human sentence
-;; naming the public concept (rf/app / rf/realm) carrying the [:rf.error/<id>]
+;; naming the public concept (app-value/app / realm/construct-realm) carrying the [:rf.error/<id>]
 ;; token, with the canonical discriminator in `:rf.error/id`.
 ;; ============================================================================
 
 (deftest app-value-throw-emits-conformant-shape
-  ;; rf2-p7kwpt — the app-as-value surface exemplar. A bad rf/app input (a
+  ;; rf2-p7kwpt — the app-as-value surface exemplar. A bad app-value/app input (a
   ;; non-module :modules entry) routes through the central builder, so the
-  ;; message is a human sentence naming the public concept (rf/app) carrying
+  ;; message is a human sentence naming the public concept (app-value/app) carrying
   ;; the [:rf.error/<id>] token, with the canonical discriminator in
   ;; :rf.error/id (NOT the legacy :error/id slot).
   (assert-conformant-throw!
-    "rf/app (non-module :modules entry)"
+    "app-value/app (non-module :modules entry)"
     :rf.error/invalid-app
     #(app-value/app {:id :conf/app :modules [{:not :a-module}]})))
 
 (deftest realm-throw-emits-conformant-shape
-  ;; rf2-p7kwpt — the realm surface exemplar. A bad rf/realm input (a missing
-  ;; :id) routes through the central builder: the message names rf/realm and
+  ;; rf2-p7kwpt — the realm surface exemplar. A bad realm/construct-realm input (a missing
+  ;; :id) routes through the central builder: the message names realm/construct-realm and
   ;; carries the token, with :rf.error/id as the SOLE discriminator.
   (assert-conformant-throw!
-    "rf/realm (missing :id)"
+    "realm/construct-realm (missing :id)"
     :rf.error/invalid-realm
     #(realm/construct-realm {})))

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -66,6 +66,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
+            [re-frame.app-value :as av]
             [re-frame.cofx :as cofx]
             [re-frame.error-emit :as error-emit]
             [re-frame.event-emit :as event-emit]
@@ -1369,12 +1370,12 @@
             reg-event id installed into two realms carries genuinely different
             handlers, each resolved through ITS realm's registrar — no
             cross-realm bleed, and the default realm never sees them"
-    (let [_ra (rf/realm {:id :evt-conf/ra})
-          _rb (rf/realm {:id :evt-conf/rb})
-          app-of (fn [h] (rf/app {:id :evt-conf/shared :modules
-                                  [(rf/module {:id :m :events {:shared/e {:handler h}}})]}))]
-      (rf/install! (realm/realm :evt-conf/ra) (app-of add-a))
-      (rf/install! (realm/realm :evt-conf/rb) (app-of add-b))
+    (let [_ra (realm/construct-realm {:id :evt-conf/ra})
+          _rb (realm/construct-realm {:id :evt-conf/rb})
+          app-of (fn [h] (av/app {:id :evt-conf/shared :modules
+                                  [(av/module {:id :m :events {:shared/e {:handler h}}})]}))]
+      (av/install! (realm/realm :evt-conf/ra) (app-of add-a))
+      (av/install! (realm/realm :evt-conf/rb) (app-of add-b))
       (is (= add-a (:handler-fn (rf/handler-meta {:realm :evt-conf/ra :kind :event :id :shared/e})))
           "realm ra resolves ITS handler for the shared reg-event id")
       (is (= add-b (:handler-fn (rf/handler-meta {:realm :evt-conf/rb :kind :event :id :shared/e})))
@@ -1390,7 +1391,7 @@
             routes to the active realm registrar — calling `rf/reg-event` inside
             a non-default realm's registrar binding seats the handler into THAT
             realm's own registrar, invisible to the default realm"
-    (let [r (rf/realm {:id :evt-conf/bound})]
+    (let [r (realm/construct-realm {:id :evt-conf/bound})]
       ;; Bind the active registrar to the constructed realm's OWN atom — the
       ;; exact seam (`registrar/*registrar*`) the router's
       ;; `call-with-frame-realm-registrar` binds around a realm-routed dispatch

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/realm_routing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/realm_routing_test.clj
@@ -78,7 +78,7 @@
             resolve."
     (let [rid :nu5w48/err-realm
           fid :nu5w48/err-frame]
-      (rf/realm {:id rid :adapter ssr/adapter})
+      (realm/construct-realm {:id rid :adapter ssr/adapter})
       (try
         ;; Seat a per-request SERVER frame + the realm-only error view into
         ;; the realm's registrar, under the realm scope.
@@ -114,7 +114,7 @@
           (is (not (str/includes? body "internal-render-boom"))
               "rf2-kzvwq: the throwable message never reaches the wire"))
         (finally
-          (rf/dispose-realm! rid))))))
+          (realm/dispose-realm! rid))))))
 
 (deftest default-realm-error-view-still-resolves-byte-identically
   (testing "rf2-nu5w48: the realm binding is a no-op for a default-realm
@@ -171,7 +171,7 @@
             realm-registrar binding is what resolves it cross-thread."
     (let [rid :nu5w48/stream-realm
           fid :nu5w48/stream-frame]
-      (rf/realm {:id rid :adapter ssr/adapter})
+      (realm/construct-realm {:id rid :adapter ssr/adapter})
       (try
         (with-realm-registrar rid
           (fn []
@@ -249,7 +249,7 @@
             (frame/call-with-realm rid
               (fn [] (lifecycle/destroy-frame-quietly! fid)))))
         (finally
-          (rf/dispose-realm! rid))))))
+          (realm/dispose-realm! rid))))))
 
 ;; ===========================================================================
 ;; (3) FINAL __rf_payload reflects the NON-DEFAULT realm frame's app-db /
@@ -280,7 +280,7 @@
             HTML came from the realm frame."
     (let [rid :tbr67x/payload-realm
           fid :tbr67x/payload-frame]
-      (rf/realm {:id rid :adapter ssr/adapter})
+      (realm/construct-realm {:id rid :adapter ssr/adapter})
       (try
         (with-realm-registrar rid
           (fn []
@@ -334,7 +334,7 @@
         (finally
           (frame/call-with-realm rid
             (fn [] (lifecycle/destroy-frame-quietly! fid)))
-          (rf/dispose-realm! rid))))))
+          (realm/dispose-realm! rid))))))
 
 (deftest streaming-final-payload-default-realm-unchanged
   (testing "rf2-tbr67x: the final-payload realm rebinding is a no-op for a

--- a/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
@@ -30,6 +30,7 @@
       head / route registrations."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.app-value :as av]
             [re-frame.frame :as frame]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
@@ -48,9 +49,9 @@
 ;; "same frame id in two realms" shape). `:shared/frame` mirrors the bead's
 ;; `:shared/frame` example.
 (defn- shared-app [tag]
-  (rf/app {:id :addr/app
+  (av/app {:id :addr/app
            :modules
-           [(rf/module
+           [(av/module
               {:id     :m
                :frames {:shared/frame {:doc "shared id across realms"}}
                :events {:addr/touch
@@ -83,11 +84,11 @@
 (deftest request-slots-isolate-by-realm
   (testing "the same frame id in two realms carries INDEPENDENT request data —
             and round-trips through set-request!→get-request with its realm"
-    (let [ra (rf/realm {:id :addr/a})
-          rb (rf/realm {:id :addr/b})]
+    (let [ra (realm/construct-realm {:id :addr/a})
+          rb (realm/construct-realm {:id :addr/b})]
       (try
-        (rf/install! ra (shared-app :a))
-        (rf/install! rb (shared-app :b))
+        (av/install! ra (shared-app :a))
+        (av/install! rb (shared-app :b))
         ;; The side-channel ops run UNDER the frame's realm scope, exactly as the
         ;; router binds `*current-realm*` around a real drain.
         (frame/call-with-realm :addr/a
@@ -109,8 +110,8 @@
         (is (contains? @request/request-slots [:addr/b :shared/frame])
             "realm b's slot is keyed by the [realm frame] address")
         (finally
-          (rf/dispose-realm! :addr/a)
-          (rf/dispose-realm! :addr/b))))))
+          (realm/dispose-realm! :addr/a)
+          (realm/dispose-realm! :addr/b))))))
 
 ;; ---- two realms, same frame id: response slot isolation + teardown ----------
 
@@ -118,11 +119,11 @@
   (testing "the same frame id in two realms accumulates INDEPENDENT responses,
             and tearing down one realm's frame leaves the other realm's same-id
             response intact"
-    (let [ra (rf/realm {:id :addr/a})
-          rb (rf/realm {:id :addr/b})]
+    (let [ra (realm/construct-realm {:id :addr/a})
+          rb (realm/construct-realm {:id :addr/b})]
       (try
-        (rf/install! ra (shared-app :a))
-        (rf/install! rb (shared-app :b))
+        (av/install! ra (shared-app :a))
+        (av/install! rb (shared-app :b))
         (frame/call-with-realm :addr/a
           (fn [] (response/swap-response! :shared/frame (fn [r] (assoc r :status 418)))))
         (frame/call-with-realm :addr/b
@@ -146,8 +147,8 @@
                      (fn [] (:status (response/response-of :shared/frame)))))
             "realm b's response is untouched by realm a's teardown")
         (finally
-          (rf/dispose-realm! :addr/a)
-          (rf/dispose-realm! :addr/b))))))
+          (realm/dispose-realm! :addr/a)
+          (realm/dispose-realm! :addr/b))))))
 
 ;; ---- two realms, same frame id: error-trace buffer isolation ----------------
 ;;
@@ -158,11 +159,11 @@
 (deftest pending-error-traces-isolate-by-realm
   (testing "the pending-error-traces buffer keys by the (realm, frame) address —
             clearing one realm's frame leaves the other realm's buffered traces"
-    (let [ra (rf/realm {:id :addr/a})
-          rb (rf/realm {:id :addr/b})]
+    (let [ra (realm/construct-realm {:id :addr/a})
+          rb (realm/construct-realm {:id :addr/b})]
       (try
-        (rf/install! ra (shared-app :a))
-        (rf/install! rb (shared-app :b))
+        (av/install! ra (shared-app :a))
+        (av/install! rb (shared-app :b))
         ;; Seed each realm's buffer directly at its address (mirrors what the
         ;; always-on error listener does under the realm-bound drain).
         (swap! error-listener/pending-error-traces
@@ -181,8 +182,8 @@
                        [:addr/b :shared/frame])
             "realm b's error-trace buffer survives realm a's teardown")
         (finally
-          (rf/dispose-realm! :addr/a)
-          (rf/dispose-realm! :addr/b))))))
+          (realm/dispose-realm! :addr/a)
+          (realm/dispose-realm! :addr/b))))))
 
 ;; ---- two realms, same frame id: head-snapshot isolation ---------------------
 
@@ -200,12 +201,12 @@
   (testing "render-head records the produced head-model under the (realm, frame)
             address, so the same frame id in two realms keeps independent head
             snapshots — and resolves each realm's OWN head registration"
-    (let [ra (rf/realm {:id :addr/a})
-          rb (rf/realm {:id :addr/b})]
+    (let [ra (realm/construct-realm {:id :addr/a})
+          rb (realm/construct-realm {:id :addr/b})]
       (try
         ;; install! seats the frame (a wired kind) into each realm.
-        (rf/install! ra (shared-app :a))
-        (rf/install! rb (shared-app :b))
+        (av/install! ra (shared-app :a))
+        (av/install! rb (shared-app :b))
         ;; Each realm registers a DIFFERENT head fn under the SAME head id into
         ;; its OWN registrar — proves the render-head lookup is realm-scoped.
         (reg-head-in-realm! :addr/a :addr/title (fn [_db _route] {:title "realm-a"}))
@@ -234,17 +235,17 @@
         (is (contains? @head-registry/head-snapshots [:addr/b :shared/frame])
             "realm b's snapshot keys by the [realm frame] address")
         (finally
-          (rf/dispose-realm! :addr/a)
-          (rf/dispose-realm! :addr/b))))))
+          (realm/dispose-realm! :addr/a)
+          (realm/dispose-realm! :addr/b))))))
 
 ;; ---- frame-address resolution semantics ------------------------------------
 
 (deftest frame-address-resolves-carried-then-frame-realm
   (testing "frame-address keys a non-default-realm frame by [realm frame] under
             the carried realm, and a default-realm frame by the bare id"
-    (let [ra (rf/realm {:id :addr/a})]
+    (let [ra (realm/construct-realm {:id :addr/a})]
       (try
-        (rf/install! ra (shared-app :a))
+        (av/install! ra (shared-app :a))
         ;; Under the carried realm: the [realm frame] address.
         (is (= [:addr/a :shared/frame]
                (frame/call-with-realm :addr/a
@@ -254,4 +255,4 @@
         (is (= :rf/default (frame/frame-address :rf/default))
             "a default-realm frame keys by its bare id (no realm key)")
         (finally
-          (rf/dispose-realm! :addr/a))))))
+          (realm/dispose-realm! :addr/a))))))


### PR DESCRIPTION
## What

Migrates the **13 G1 dedicated test suites** off the retired `re-frame.core` public-facade composition exports onto their **retained-internal substrate namespaces** (EP-0023). This is the consumer-migration step that lets `rf2-pl97nd.2` remove the facade exports while keeping `test:cljs` green.

Per the `pl97nd.2` ruling (Mike, 2026-06-18): `rf/app`, `rf/module`, and the whole realm install/query family leave the public facade, but the **machinery stays as internal substrate** (`re-frame.app-value`, `re-frame.realm`, `re-frame.frame`, `re-frame.migration`). These dedicated suites exercise that substrate, so the correct migration is to **re-point** the retired `rf/` facade calls at their internal backing fns — byte-identical behaviour now, and still green after `.2` removes the now-unused re-exports. No coverage lost.

## Mapping applied (facade → internal backing)

| Facade | Internal backing |
|---|---|
| `rf/app` / `rf/module` | `app-value/app` / `app-value/module` |
| `rf/install!` / `rf/reinstall!` | `app-value/install!` / `app-value/reinstall!` |
| `rf/app-registrations` / `-requires` / `-owns` | `app-value/*` |
| `rf/realm` | `realm/construct-realm` |
| `rf/dispose-realm!` / `rf/realm-ids` / `rf/installed-app` | `realm/*` |
| `rf/frame-realm` | `frame/frame-realm` |
| `rf/migration-map` / `rf/migration-explain` / `rf/assert-process-local-frame-id!` | `migration/*` |

## Suites migrated (13)

`app_value_install`, `realm_conformance`, `app_value_compose`, `installed_app_read_seam`, `realm_source_store_isolation`, `migration`, `ep0023_conformance`, `realm_query`, `app_value`, `realm`, `thrown_error_message_conformance` (core); `event_model_conformance` (event-conformance); `ssr_realm_address` (ssr); `ssr/ring/realm_routing` (ssr-ring).

## Special cases

- **installed_app_read_seam** — dropped the facade-var-identity tautology (`(identical? rf/installed-app realm/installed-app)`); the public re-export is going away. Rewrote test (1) to verify the internal `realm/installed-app` read seam yields the live projection.
- **realm_query** — the `{:app :kind}` map-form arity of `app-registrations` lives **only on the facade `defn`**, not the internal ns, so it disappears with the facade. Converted the test to the retained-internal positional `[app kind]` inspector.

## Scope guards honoured

- `tools/xray/` untouched (owned by concurrent `rf2-xopt7b`).
- `implementation/core/src/re_frame/core.cljc` untouched (facade removal is `pl97nd.2`).
- G2 incidental hits (~90) were `app-db` / keyword false positives per the inventory — not churned. The genuine retired-facade call-sites lived exactly in these 13 dedicated suites.

## Note for pl97nd.2

`migration_cljs_test` and `ep0023_conformance` now consume the internal `re-frame.migration` ns. They are off the **facade** (build-safe), but if `.2` deletes `re-frame.migration` outright (per the inventory's pre-alpha shim-deletion disposition), those suites are `.2`'s to retire then.

## Quality gates

```
cd implementation && npm run test:cljs   # 8008 tests, 33427 assertions, 0 failures, 0 errors
```

JVM spot-checks (dual-runtime cljc + JVM-only ssr suites):
- migrated core cljc suites: 187 tests / 852 assertions / 0 failures
- `event-model-conformance` (JVM): 52 tests / 156 assertions / 0 failures
- `ssr-realm-address-test` (JVM): 6 tests / 24 assertions / 0 failures
- `ssr.ring.realm-routing-test` (JVM): 5 tests / 25 assertions / 0 failures

Refs rf2-pl97nd.4