### PR TITLE
docs: sweep stale rf/make-frame record-config examples to the EP-0023 object constructor (rf2-k3vorf)

### DIFF
--- a/docs/api/02-views.md
+++ b/docs/api/02-views.md
@@ -203,7 +203,8 @@ Full async-boundary contract (the four routing patterns and the React click-hand
     (rf/dispatch [::action chosen])))
 
 ;; Eval-bind-run-destroy form — create a throwaway frame for the body
-(rf/with-new-frame [f (rf/make-frame {:on-create [:test/initialise]})]
+(rf/with-new-frame [f (rf/make-frame {:images [test-image]})]
+  (rf/dispatch-sync [:test/initialise])   ;; seed via a setup dispatch
   (rf/dispatch [::action f]))   ;; frame destroyed on exit
 ```
 

--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -20,7 +20,8 @@ The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces li
 - **Description**: The canonical server-side render. Walks the hiccup tree once, emits a string. JVM-runnable. Test-friendly because it's pure.
 - **Example**:
   ```clojure
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:app/server-init]})]
+  (rf/with-new-frame [f (rf/make-frame {:images [app-image]})]
+    (rf/dispatch-sync [:app/server-init] {:frame f})   ;; setup dispatch, not :on-create
     (ssr/render-to-string [app-root] {:frame f}))
   ```
 - **In the wild**: [ssr](https://github.com/day8/re-frame2/tree/main/examples/reagent/ssr)

--- a/docs/guide/how-to/test-a-cascade.md
+++ b/docs/guide/how-to/test-a-cascade.md
@@ -144,7 +144,8 @@ A user reports: "I favorited an article, then unfavorited it, and the count stuc
             [my-app.articles]))
 
 (deftest issue-217-unfavorite-leaves-count-stale
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:app/init]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:app/init])   ;; seed via a setup dispatch, not :on-create
     (ts/dispatch-sequence [[:article/loaded {:slug "ten-tips" :favorites-count 0}]
                            [:article/favorite "ten-tips"]
                            [:article/unfavorite "ten-tips"]])

--- a/docs/guide/tutorial/05-test-and-ship.md
+++ b/docs/guide/tutorial/05-test-and-ship.md
@@ -115,7 +115,7 @@ Pure handler tests catch most bugs. But Part 3's login is a *flow*: an event hit
 
 ```clojure
 (deftest cold-boot-with-saved-token-lands-authed
-  (rf/with-new-frame [f (rf/make-frame {:preset :test})]
+  (rf/with-new-frame [f (re-frame.frame/make-frame {:preset :test})]  ;; :preset is record-config — rides re-frame.frame/make-frame, not rf/make-frame
     (rf/with-managed-request-stubs
       {[:get "https://api.realworld.io/api/user"]          ;; the URL Part 3's restore requests
        {:reply {:ok {:user {:username "ada"
@@ -138,7 +138,7 @@ The unhappy path — the one your users will actually hit — is the same shape 
 
 ```clojure
 (deftest wrong-password-shows-the-error
-  (rf/with-new-frame [f (rf/make-frame {:preset :test})]
+  (rf/with-new-frame [f (re-frame.frame/make-frame {:preset :test})]  ;; :preset is record-config — rides re-frame.frame/make-frame
     (rf/with-managed-request-stubs
       {[:post "https://api.realworld.io/api/users/login"]
        {:reply {:failure {:kind :rf.http/http-4xx :status 422}}}}

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3816,8 +3816,9 @@ The handler resolves its id from the inbound event vector's first element (`:dra
 ### Level 3 — registered in a test frame
 
 ```clojure
-(rf/with-new-frame [f (rf/make-frame {:on-create [:my/init]})]
+(rf/with-new-frame [f (rf/make-frame {})]
   (rf/reg-event :my/editor {} (rf/make-machine-handler {...}))
+  (rf/dispatch-sync [:my/init] {:frame f})   ;; seed via a setup dispatch
   (rf/dispatch-sync [:my/editor [:event]] {:frame f})
   (assert ...))
 ```

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -119,8 +119,9 @@ The most common shape. Each test creates a frame, runs assertions, tears down.
 (rf/reg-event :auth/init-idle (fn [_ _] {:db {:auth/state :idle}}))
 
 (deftest auth-flow
-  (let [f (rf/make-frame {:on-create [:auth/init-idle]})]
+  (let [f (rf/make-frame {})]
     (try
+      (rf/dispatch-sync [:auth/init-idle] {:frame f})   ;; seed via a setup dispatch
       (rf/dispatch-sync [:auth/login-pressed] {:frame f})
       (is (= :validating (get-in (rf/app-db-value f) [:auth :state])))
       (finally
@@ -133,7 +134,8 @@ For tests that don't need explicit teardown logic, `with-new-frame` handles the 
 
 ```clojure
 (deftest auth-flow
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:auth/init-idle])             ;; seed via a setup dispatch (uses :frame f)
     (rf/dispatch-sync [:auth/login-pressed])         ;; uses :frame f via the binding
     (is (= :validating (get-in (rf/app-db-value f) [:auth :state])))))
 ```
@@ -198,7 +200,7 @@ The macro:
 5. Runs `body`.
 6. In a `finally`, destroys the frame regardless of whether `body` returned normally or threw — no leaked frames across tests.
 
-`opts-map` keys (all optional): `:install`, `:root-view`, `:root-view-args`, `:frame-config` (passed through to `make-frame` / `reg-frame` — `:on-create`, `:fx-overrides`, `:interceptor-overrides`, `:interceptors` and the rest of the frame-shape contract per [Spec 002 §`reg-frame`](002-Frames.md#reg-frame--atomic-create-and-register-and-the-canonical-metadata-grammar)).
+`opts-map` keys (all optional): `:install`, `:root-view`, `:root-view-args`, `:frame-config` (the record-config map seated onto the fixture frame — `:on-create`, `:fx-overrides`, `:interceptor-overrides`, `:interceptors` and the rest of the frame-shape contract per [Spec 002 §`reg-frame`](002-Frames.md#reg-frame--atomic-create-and-register-and-the-canonical-metadata-grammar); these are record-config keys, so the fixture seats them via `reg-frame` / the advanced `re-frame.frame/make-frame`, not the EP-0023 object constructor `rf/make-frame`).
 
 The companion helpers:
 
@@ -331,8 +333,9 @@ A test frame declares its intent — and gets the deterministic defaults — wit
 
 ```clojure
 (rf/reg-frame :test/auth-flow {:preset :test})
-;; or anonymous:
-(rf/with-new-frame [f (rf/make-frame {:preset :test :on-create [:auth/init-idle]})]
+;; or anonymous — :preset is a record-config key, so it rides the advanced
+;; record-config `re-frame.frame/make-frame`, not the EP-0023 object constructor:
+(rf/with-new-frame [f (re-frame.frame/make-frame {:preset :test :on-create [:auth/init-idle]})]
   ...)
 ```
 
@@ -527,7 +530,7 @@ Sixteen public defs, organised by role. Every entry except `with-app-fixture` (w
 | `find-by-testid-prefix` | Fn | `(find-by-testid-prefix tree prefix) → vector` | Every node whose `:data-testid` STARTS with `prefix`. Equivalent to `(find-by-attr-prefix tree :data-testid prefix)`. |
 | `invoke-handler` | Fn | `(invoke-handler node event-key & args) → any` | Find the handler under `event-key` on `node` and call it. Returns the handler's return value (typically `nil` for `dispatch`-side-effecting `:on-click`s). **Throws** when `node` is not a hiccup vector, the node has no attrs map, or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug, not a passing case). |
 | `testid` | Fn | `(testid id)` / `(testid id extra) → map` | Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Use at the view call site: `[:button (testid "counter-inc" {:on-click ...}) "+"]`. |
-| `with-app-fixture` | Macro | `(with-app-fixture opts-map frame-id body+)` / `(with-app-fixture opts-map body+)` | Single-frame e2e fixture. Creates the frame, binds `*current-frame*` for the body's dynamic extent, calls `:install` (zero-arg) inside the scope, stashes `:root-view` / `:root-view-args` for `expect-text` / `wait-until`, and destroys the frame on exit (success or exception). Frame-id is positional and optional; omitting it gensym's an anonymous `:rf.frame/*` id. Opts keys: `:install`, `:root-view`, `:root-view-args`, `:frame-config` (passed through to `make-frame` / `reg-frame`). See [§Pattern 5 — single-frame e2e fixture](#pattern-5--single-frame-e2e-fixture). |
+| `with-app-fixture` | Macro | `(with-app-fixture opts-map frame-id body+)` / `(with-app-fixture opts-map body+)` | Single-frame e2e fixture. Creates the frame, binds `*current-frame*` for the body's dynamic extent, calls `:install` (zero-arg) inside the scope, stashes `:root-view` / `:root-view-args` for `expect-text` / `wait-until`, and destroys the frame on exit (success or exception). Frame-id is positional and optional; omitting it gensym's an anonymous `:rf.frame/*` id. Opts keys: `:install`, `:root-view`, `:root-view-args`, `:frame-config` (record-config seated via `reg-frame` / the advanced `re-frame.frame/make-frame`). See [§Pattern 5 — single-frame e2e fixture](#pattern-5--single-frame-e2e-fixture). |
 | `expect-text` | Fn | `(expect-text testid expected)` / `(expect-text tree testid expected) → bool?` | Locate `:data-testid testid` in the (fixture-stashed) root view's rendered hiccup and assert `(text-content node) = expected` via `clojure.test/is` (`do-report`). `testid` accepts a keyword (coerced via `name`) or a string. The 2-arity reads the fixture-stashed root view from `*current-root-view*`; the 3-arity walks an explicit tree. Throws (with a clear `ex-info` message) if neither a fixture nor an explicit tree is present. |
 | `wait-until` | Fn | `(wait-until pred)` / `(wait-until pred opts)` / `(wait-until testid expected)` / `(wait-until testid expected opts)` | Bounded-deadline poll for async-stable assertions. JVM: synchronous — returns the truthy value, throws `ex-info` carrying `:rf.error/id` `:rf.error/wait-until-timeout` (the canonical discriminator, per [Spec 009](009-Instrumentation.md)) on timeout. CLJS: returns a `js/Promise` that resolves with the truthy value or rejects on timeout. The testid form polls the fixture-stashed root view until `(text-content (find-by-testid tree testid)) = expected`; the predicate form polls an arbitrary fn. `opts`: `:timeout-ms` (2000), `:interval-ms` (5), `:label`. Sister of `re-frame.test-support/poll-until` — same shape, tuned for the hiccup-walk pattern. |
 
@@ -552,7 +555,8 @@ Drive a click and assert state changed downstream:
 
 ```clojure
 (deftest counter-inc
-  (rf/with-new-frame [_ (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [_ (rf/make-frame {})]
+    (rf/dispatch-sync [:counter/init])   ;; seed via a setup dispatch
     (let [tree (counter-view {})
           btn  (th/find-by-testid tree "counter-inc")]
       (th/invoke-handler btn :on-click)
@@ -563,7 +567,8 @@ Assert rendered text after dispatching:
 
 ```clojure
 (deftest counter-label
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:counter/init])   ;; seed via a setup dispatch
     (rf/dispatch-sync [:counter/set 5])
     (let [tree  (counter-view {})
           label (th/find-by-testid tree "counter-label")]
@@ -663,7 +668,8 @@ When you want to verify what *would* dispatch without actually running the casca
 
 ```clojure
 (let [dispatched (atom [])]
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:auth/init-idle])   ;; seed via a setup dispatch
     (rf/dispatch-sync [:auth/login-pressed]
                       {:frame        f
                        :fx-overrides {:dispatch (fn [_m ev] (swap! dispatched conj ev))}})
@@ -672,7 +678,7 @@ When you want to verify what *would* dispatch without actually running the casca
 
 `:dispatch` (and `:dispatch-later`) are in the **OVERRIDABLE** tier of the reserved fx-ids (per [Conventions §Reserved fx-id override tiering](Conventions.md#reserved-fx-id-override-tiering)): a fn-value override pre-empts the reserved body, so the captured event vector is recorded and **not** queued — the cascade does not run. This is the canonical "assert what would dispatch" affordance.
 
-**Scope the `:dispatch` override per-call, not per-frame.** A `:dispatch` override placed on a frame's `:fx-overrides` config (via `make-frame` / `reg-frame`) is re-merged into the envelope on **every** dispatch routed to that frame for the frame's whole lifetime — including framework-internal dispatches (machine actor messages, spawned-actor `:start`, router internals, HTTP reply settles). That silently re-routes traffic the test never meant to touch and is a sharp footgun. The per-call form above scopes the stub to the single event you are asserting on.
+**Scope the `:dispatch` override per-call, not per-frame.** A `:dispatch` override placed on a frame's `:fx-overrides` config (a record-config key, so via `reg-frame` / the advanced `re-frame.frame/make-frame`) is re-merged into the envelope on **every** dispatch routed to that frame for the frame's whole lifetime — including framework-internal dispatches (machine actor messages, spawned-actor `:start`, router internals, HTTP reply settles). That silently re-routes traffic the test never meant to touch and is a sharp footgun. The per-call form above scopes the stub to the single event you are asserting on.
 
 **State-installing reserved fxs cannot be stubbed.** The `:fx-overrides` map is tiered: the routing primitives (`:dispatch`, `:dispatch-later`, `:rf.machine/dispatch-to-system`) and the navigation primitives (`:rf.nav/*`) are OVERRIDABLE, but the **state-installing** reserved fxs — `:rf.machine/spawn`, `:rf.machine/destroy`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`, `:rf.route/with-nav-token` — are **HARD-REJECTED**. An override targeting one of those is ignored (the runtime emits [`:rf.error/reserved-fx-override`](009-Instrumentation.md#error-event-catalogue) and runs the real reserved body), because stubbing them would leave the frame's runtime-db in an inconsistent state that breaks later behaviour far from the override site (e.g. a spawned actor whose snapshot was never installed → every later actor dispatch is `:rf.error/no-such-handler`). To assert on *those* operations, drive the real fx and read the resulting runtime-db state (machine snapshot, flow registry) directly.
 
@@ -681,7 +687,8 @@ When you want to verify what *would* dispatch without actually running the casca
 For tests that exercise event sequences and want to assert at intermediate points, dispatch one event at a time and assert between dispatches:
 
 ```clojure
-(rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+(rf/with-new-frame [f (rf/make-frame {})]
+  (rf/dispatch-sync [:auth/init-idle])   ;; seed via a setup dispatch
   (rf/dispatch-sync [:auth/email-changed "alice@example.com"])
   (is (= "alice@example.com" (get-in (rf/app-db-value f) [:auth :form :email])))
   (rf/dispatch-sync [:auth/password-changed "hunter2"])
@@ -736,7 +743,8 @@ The `day8/re-frame-test` library provides `run-test-sync` and similar helpers. r
 
 A test fixture is a story-variant minus the rendering — the story library's `run-variant` consumes the same primitives a test does (see [007 §Portable into tests](007-Stories.md#portable-into-tests)). The testing surface guarantees these shapes for 007:
 
-- `(make-frame {:on-create [:event-id] :fx-overrides {…} :interceptor-overrides {…} :interceptors [...]})` — exact opts shape.
+- `(make-frame {:images [...] :id … :initial-db {…} :capabilities {…} :adapter …})` — the EP-0023 object-constructor opts shape (record-config keys like `:on-create` / `:fx-overrides` / `:interceptor-overrides` / `:interceptors` fail loud here; they ride `reg-frame` / the advanced `re-frame.frame/make-frame`).
+- `(reg-frame :id {:on-create [:event-id] :fx-overrides {…} :interceptor-overrides {…} :interceptors [...]})` — exact record-config opts shape.
 - `(dispatch-sync ev {:frame f :fx-overrides {…}})` — exact opts shape.
 - `(app-db-value f)` — current `app-db` value (a plain map) for the named frame.
 - `(snapshot-of path {:frame f})` — exact opts arg.

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -101,7 +101,7 @@ The single-opt shape is deliberate: a single value holds exactly one policy, so 
 HTTP request arrives
     │
     ▼
-make-frame { :on-create [:rf/server-init request-context] }
+re-frame.frame/make-frame { :on-create [:rf/server-init request-context] }   ;; record-config path: :on-create rides reg-frame / re-frame.frame/make-frame
     │
     ▼
 :on-create dispatched-sync
@@ -716,9 +716,11 @@ Lock: **both** a registry-first projector and a per-frame `:ssr` metadata map na
 
 ;; Wire the projector at frame-creation time — server frames opt in
 ;; via `:ssr` metadata; the runtime reads it through `frame-meta`.
-(rf/make-frame {:platform :server
-                :ssr {:public-error-id   :myapp/public-error
-                      :dev-error-detail? true}})           ;; dev: include :details with full trace
+;; `:platform` and `:ssr` are record-config keys, so they ride `reg-frame` /
+;; the advanced `re-frame.frame/make-frame`, not the EP-0023 object constructor.
+(re-frame.frame/make-frame {:platform :server
+                            :ssr {:public-error-id   :myapp/public-error
+                                  :dev-error-detail? true}})   ;; dev: include :details with full trace
 ```
 
 `reg-error-projector` adds a new registry kind `:error-projector` (per [001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set)). The query API surfaces it: `(rf/registrations :error-projector)` returns `id → metadata`. The runtime consults exactly one projector per response — the one named in the frame's `:ssr {:public-error-id ...}` metadata. If unset, the runtime uses its **default projector** (below).
@@ -869,7 +871,7 @@ The request URL is fed in via `:rf/server-init`, which dispatches `:rf.route/han
 
 Concrete handshake:
 
-1. Server's `handle-request` calls `make-frame` with `:on-create [:rf/server-init request]`.
+1. Server's `handle-request` creates the per-request frame with `:on-create [:rf/server-init request]` (a record-config key, so via `reg-frame` / the advanced `re-frame.frame/make-frame` — the EP-0023 object constructor `rf/make-frame` rejects it; the equivalent object-constructor shape is `rf/make-frame {:images […]}` plus a `dispatch-sync [:rf/server-init request]`).
 2. `:rf/server-init` (`:platforms #{:server}`) reads the request's URI and dispatches `[:rf.route/handle-url-change uri]`.
 3. `:rf.route/handle-url-change` (universal — runs on both platforms) calls `(rf/match-url uri)`, sets the route slice in `app-db` at `[:rf.runtime/routing :current]`. Per [012-Routing](012-Routing.md).
 4. Per-route data fetches happen via the route's matched-state side-effects: a registered fx like `[:route/fetch-data route-id params]` is dispatched as part of `:rf.route/handle-url-change`'s effects.
@@ -896,7 +898,7 @@ The session feeds **durable** app-db that ships in the hydration payload, so it 
 Concrete:
 
 1. Server middleware (Ring/Pedestal/etc.) extracts + **sanitizes** the session from the request — cookie-based, JWT-based, whatever the host uses — to a wire-safe derived projection (e.g. `{:user "alice" :authed? true}`), never the raw cookie / token.
-2. The host adapter supplies the sanitized session as a **recordable** fact, either as event payload — `make-frame` with `:on-create [:auth/server-init {:user … :authed? …}]` — or by stamping a provided recordable `:rf.cofx` leaf (`:auth.session/user`) onto the boot token.
+2. The host adapter supplies the sanitized session as a **recordable** fact, either as event payload — the per-request frame's `:on-create [:auth/server-init {:user … :authed? …}]` (a record-config key, so via `reg-frame` / the advanced `re-frame.frame/make-frame`; the object-constructor equivalent is `rf/make-frame {:images […]}` plus a `dispatch-sync [:auth/server-init {…}]`) — or by stamping a provided recordable `:rf.cofx` leaf (`:auth.session/user`) onto the boot token.
 3. `:auth/server-init` (`:platforms #{:server}`) reads the fact off `:event` (or declares `:rf.cofx/requires [:auth.session/user]`) and sets the relevant `app-db` slice: `{:auth/user (or user nil) :auth/state (if authed? :authed :idle)}`. A missing provided fact fails loudly with `:rf.error/missing-required-cofx` rather than silently re-reading the host.
 4. The client side is hydrated with this slice; the user's authed-state survives the round-trip, and epoch-restore / replay re-presents the SAME session fact off the token.
 

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -75,7 +75,8 @@ Each entry below is one CP:
 
 ```clojure
 (deftest feature-verb-noun-test
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:feature/initialise] {:frame f})   ;; seed via a setup dispatch
     (rf/dispatch-sync [:feature/verb-noun "value"] {:frame f})
     (is (= "value" (get-in (rf/app-db-value f) [:feature :path])))))
 ```
@@ -233,9 +234,11 @@ Each entry below is one CP:
     (when-let [on-success (:on-success args)]
       (rf/dispatch (conj on-success {:status 200 :body "test"})))))
 
-;; in a test
-(rf/with-new-frame [f (rf/make-frame {:fx-overrides {:http :http.canned-200}
-                                  :on-create [:feature/load]})]
+;; in a test — :fx-overrides and :on-create are record-config keys, so they ride
+;; the advanced record-config `re-frame.frame/make-frame`, not the EP-0023 object
+;; constructor `rf/make-frame` (which takes :images and fails loud on a record-only key)
+(rf/with-new-frame [f (re-frame.frame/make-frame {:fx-overrides {:http :http.canned-200}
+                                                  :on-create    [:feature/load]})]
   ...)
 ```
 
@@ -316,7 +319,8 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
 ```clojure
 (deftest feature-component-name-renders
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:feature/initialise] {:frame f})   ;; seed via a setup dispatch
     (let [hiccup [component-name "test-label" 42]
           html   (rf/render-to-string hiccup {:frame f})]
       (is (str/includes? html "test-label"))
@@ -550,7 +554,8 @@ After this action, `(:pending-request data)` is the new actor's id; subsequent t
 
 ;; Level 3 — registered in a test frame (full integration; required for spawn lifecycle).
 (deftest auth-login-happy-path-l3
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:auth/init] {:frame f})   ;; seed via a setup dispatch
     (rf/dispatch-sync [:auth.login/flow [:submit {:email "..."}]] {:frame f})
     ;; Read via the framework-registered :rf/machine sub:
     (is (= :submitting (:state @(rf/subscribe [:rf/machine :auth.login/flow] {:frame f}))))))
@@ -712,7 +717,8 @@ test/my_app/
 
 ```clojure
 (deftest cart-feature-happy-path
-  (rf/with-new-frame [f (rf/make-frame {:on-create [:cart/initialise]})]
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:cart/initialise] {:frame f})   ;; seed via a setup dispatch
     (let [item {:id (random-uuid) :sku "ABC-1" :qty 2 :price 9.99}]
       (rf/dispatch-sync [:cart.item/add item] {:frame f})
       (is (= [item] (rf/compute-sub [:cart/items] (rf/app-db-value f))))
@@ -953,9 +959,11 @@ Routing has two co-equal URL-change events. Popstate and the initial sync (above
 (defn handle-request [request]
   (let [frame-id (gensym :ssr-frame)]
     (rf/with-new-frame [f (rf/make-frame
-                       {:id           frame-id
-                        :on-create    [:rf/server-init request]})]
-      ;; rebound to f
+                       {:id     frame-id
+                        :images [app-image]})]
+      ;; rebound to f. EP-0023 object constructor takes :images; run the
+      ;; per-request setup via a dispatch (not the record-only :on-create key).
+      (rf/dispatch-sync [:rf/server-init request] {:frame f})
       (let [final-db (rf/app-db-value f)
             hiccup   ((rf/view :app/root))                ;; the registered root view
             html     (rf/render-to-string hiccup {:frame f})


### PR DESCRIPTION
## What

Sweeps the REMAINING stale `rf/make-frame` examples in `docs/` + `spec/` that called the EP-0023 **object constructor** with record-only config keys (`:on-create`, `:preset`, `:fx-overrides`, `:platform`, `:ssr`). Under EP-0023, `rf/make-frame` is the object constructor (`:images` / `:id` / `:initial-db` / `:capabilities` / `:adapter`) and those record-only keys now fail loud with `:rf.error/make-frame-record-only-key`.

This follows rf2-nw2m05 (which fixed only `docs/api/01-core.md`) and matches the canonical wording now on main in `docs/api/01-core.md` and `spec/002-Frames.md`.

## How each was repointed

- **Frame init via `:on-create`** → `rf/make-frame {:images […]}` / `rf/make-frame {}` plus a setup `dispatch-sync` (the authoritative EP-0023 SSR/test pattern, EP-0023 §SSR and spec/002 §771 fixture pattern).
- **Genuinely-intended record-config** (`:preset :test`, per-frame `:fx-overrides`, `:platform`, `:ssr`) → the advanced record-config `re-frame.frame/make-frame`, per spec/002 §Frame presets / §Per-instance frames. (Named `reg-frame` examples that already carried record-config were left as-is — those are correct.)
- **Prose/diagram references** describing the host-adapter's per-request frame construction → qualified to `re-frame.frame/make-frame` / `reg-frame` with the object-constructor equivalent noted.

## Files corrected

| File | Stale example(s) fixed |
|---|---|
| `docs/api/02-views.md` | `with-new-frame` example: `{:on-create …}` → `{:images …}` + setup dispatch |
| `docs/api/09-ssr.md` | `render-to-string` example: `{:on-create …}` → `{:images …}` + setup dispatch |
| `docs/guide/how-to/test-a-cascade.md` | regression-test fixture: `{:on-create …}` → `{}` + setup dispatch |
| `docs/guide/tutorial/05-test-and-ship.md` | two `{:preset :test}` tests → `re-frame.frame/make-frame` |
| `spec/005-StateMachines.md` | L3 test-frame example: `{:on-create …}` → `{}` + setup dispatch |
| `spec/008-Testing.md` | Patterns 1/2, `:test`-preset anon form, two view-test examples, time-travel + dispatch-assert examples; `:frame-config` passthrough prose (×2), `:dispatch`-override footgun prose, and the Story forward-compat opts shape |
| `spec/011-SSR.md` | error-projector `{:platform :server :ssr …}` → `re-frame.frame/make-frame`; flow diagram + two handshake prose refs qualified |
| `spec/Construction-Prompts.md` | five test smoke-tests + the canned-fx test + the SSR `handle-request` template |

## Scope guard

- **`spec/API.md` left untouched** — owned by the in-flight `pl97nd.2` (#4600, facade removal). Its only `rf/make-frame` mentions are as the object-constructor return value (not stale).
- Left intact: historical EP text (`docs/EP/EP-0023-…`), the canonical-rule prose in `spec/002-Frames.md` §745/§767, the `:rf.error/make-frame-record-only-key` error-catalogue row in `spec/009-Instrumentation.md`, and all `re-frame.frame/make-frame` (record) references.

## Quality gates

```
rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict   # PASS (Documentation built in 14.35 s, no warnings under --strict)
python scripts/check_ep_status_sync.py                              # PASS (exit 0)
```

Closes rf2-k3vorf.