### PR TITLE
docs(api): document resource/mutation registration vs projection (rf2-5swq7d)

### DIFF
--- a/docs/api/16-resources.md
+++ b/docs/api/16-resources.md
@@ -336,7 +336,9 @@ A failure settles `:error` — there is **no `:refresh-error` analogue** (a writ
 
 > **Internal replies — do not dispatch.** The `:rf.mutation.internal/*` replies (and the `:rf.mutation/*` trace family — `started` / `succeeded` / `failed` / `cleared` / `stale-suppressed`, carrying the instance id) are framework-internal; user code MUST NOT dispatch them.
 
-## Introspection
+## Introspection and projection (tool/test lane)
+
+These direct functions are the **tool/test projection lane** — not an app-read API. `resource-meta` / `mutation-meta` project the **registration** (the registered spec); `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame. They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. **App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#subscriptions-passive)**, never through these functions, which do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [Guide ch.27 §Three lanes](../guide/concepts/server-state.md#three-lanes--registering-causing-projecting) and the [Spec 016 lane table](../../spec/016-Resources.md#public-api).
 
 `:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md) — no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed).
 

--- a/docs/guide/concepts/server-state.md
+++ b/docs/guide/concepts/server-state.md
@@ -66,6 +66,22 @@ Once it's registered, a **cause** is what makes it fetch — a cause is just the
        [article-view (:data state)]])))
 ```
 
+### Three lanes — registering, causing, projecting
+
+Those three steps are three different jobs, and the surface is much easier to hold once you stop reading them as competing APIs. **Registering a resource is not the same as reading its state**, and neither is the same as causing it to fetch:
+
+| Lane | What it does | The spelling | Who uses it |
+|---|---|---|---|
+| **Register** | Declare the handler, once, at boot | `(rf/reg-resource …)` / `(rf/reg-mutation …)` — plain functions | Author |
+| **Cause** | Make a fetch or a write happen | `(rf/dispatch [:rf.resource/ensure …])`, `[:rf.mutation/execute …]` — event vectors | Routes, events, machines |
+| **Project (app read)** | Read the runtime state into a view | `@(subscribe [:rf.resource/state …])` — subscription vectors | Views |
+
+`reg-resource` records a handler in the registrar — exactly like `reg-event` or `reg-sub` records one. It does **not** fetch anything and it does **not** read any cache; it only teaches the runtime *how* to. The cache only fills when a cause fires, and a view only sees it through a subscription. So "I registered the resource but my view is empty" almost always means a cause hasn't fired yet, not that registration failed.
+
+!!! note "`resource-state` and `mutation-state` are tool/test projections, not a second app-read API"
+
+    You'll also find direct functions — `(rf/resource-state {:resource … :scope … :params … :frame …})`, `(rf/resources {:frame …})`, `(rf/mutation-state {:instance … :frame …})`. These project the *same* runtime state the `[:rf.resource/*]` subscriptions read, but as a one-shot, non-reactive snapshot at an explicit frame. They exist for tools (Xray), unit tests, and SSR serialization — places with no reactive subscription context. **In a view, always project through a subscription**: a `resource-state` call won't re-render when the data changes, so reaching for it in UI is reading the right value through the wrong lane.
+
 ## Routes declare what a page needs
 
 The cleanest cause is the page itself, because a page already knows what data it needs. `:resources` is [route](routing.md) metadata that says, in effect, "this page needs this server state":

--- a/spec/016-Resources.md
+++ b/spec/016-Resources.md
@@ -555,6 +555,17 @@ Two ledger-design points govern what rides the restore/hydration/epoch wire:
 
 ## Public API
 
+The surface splits into **four lanes**, and they must not be read as competing read APIs. Keep them distinct:
+
+| Lane | Spelling | Who calls it |
+|---|---|---|
+| **Registration** | `reg-resource` / `clear-resource`, `reg-mutation` / `clear-mutation`, `reg-resource-scope` / `clear-resource-scope` (functions) | Author, once, at boot. Declares a handler; does **not** fetch or read state. |
+| **Commands (causal)** | `[:rf.resource/ensure …]`, `[:rf.resource/refetch …]`, `[:rf.mutation/execute …]`, … (dispatched event vectors) | App events / routes / machines. These **cause** work; they are not reads. |
+| **App reads (passive)** | `[:rf.resource/state …]`, `[:rf.resource/data …]`, `[:rf.mutation/state …]`, … (subscription vectors) | Views, via `subscribe`. The **only** lane app UI uses to project runtime state. |
+| **Tool/test projections** | `resource-meta`, `resource-state`, `resources`, `mutation-meta`, `mutation-state`, `mutations` (direct functions) | Tools (Xray), tests, SSR plumbing — an explicit-frame snapshot read. **Not** an app-UI alternative to the subscription lane. |
+
+The load-bearing distinction is between **registration** (the function that records a `:resource` / `:mutation` / `:resource-scope` handler in the registrar — analogous to `reg-event` / `reg-sub`) and **projection** (reading the runtime state that handler produces). Registering a resource never reads its cache, and projecting its state never registers anything. App code projects through the **passive subscription** lane; the direct `resource-state` / `mutation-state` functions are the **tool/test projection** of the same runtime state at an explicit frame, used where there is no reactive subscription context (Xray, a unit test, an SSR serializer) — they are deliberately **not** a second app-read API competing with the subs.
+
 ### Registration
 
 ```clojure
@@ -569,7 +580,7 @@ Two ledger-design points govern what rides the restore/hydration/epoch wire:
 (rf/resolve-resource-scope db scope-id)          ;; resolver helper: PURELY resolve a named scope against a db value (no trace)
 ```
 
-`clear-resource` is a **registration-lifecycle** operation, not the normal cache invalidation API. Application code uses `:rf.resource/invalidate-tags`, `:rf.resource/remove`, or `:rf.resource/clear-scope` for data-lifecycle work. When a resource registration is cleared, the implementation MUST also dispose resource-runtime state for that resource id in each affected frame: release owner indexes, cancel timers/host handles, abort in-flight requests where possible, suppress late replies by generation, remove tag-index rows, and emit a trace.
+`clear-resource` is a **registration-lifecycle** operation — the `clear-` registrar-removal inverse of `reg-resource`, per the [Conventions tear-down verb axis](Conventions.md#tear-down-verb-axis--clear--vs-destroy-) — **not** the normal cache-invalidation API. Application code uses the data-lifecycle **events** `:rf.resource/invalidate-tags`, `:rf.resource/remove`, or `:rf.resource/clear-scope` for cache work. The vocabulary overlap is deliberate and settled: `clear-resource` (a registration-lifecycle **function**, no bang) and `:rf.resource/clear-scope` (a causal cache **event vector**) live in different registers — a registrar-removal verb vs. a dispatched event — so they never collide at a call site, and the registration trio keeps the same `clear-*` spelling as the rest of the registrar family (`clear-event`, `clear-sub`, `clear-fx`, …). When a resource registration is cleared, the implementation MUST also dispose resource-runtime state for that resource id in each affected frame: release owner indexes, cancel timers/host handles, abort in-flight requests where possible, suppress late replies by generation, remove tag-index rows, and emit a trace.
 
 Three registrar kinds belong to this artefact: **`:resource`** (`reg-resource` / `clear-resource`), **`:mutation`** (`reg-mutation` / `clear-mutation`), and **`:resource-scope`** (`reg-resource-scope` / `clear-resource-scope`) — each a distinct kind in the [Spec 001 kind taxonomy](001-Registration.md#registry-model--the-canonical-kind-keyword-set), late-bound by the optional Resources artefact (an app that omits the artefact registers none of them), enumerable via `(rf/registrations :resource)` / `(rf/registrations :mutation)` / `(rf/registrations :resource-scope)` and inspectable via `(rf/handler-meta :resource-scope <id>)`. Do **not** add a `:query` public kind (it collides with route query params and prior-art names).
 
@@ -628,13 +639,15 @@ The internal replies — `:rf.resource.internal/succeeded` / `:rf.resource.inter
 
 **No v1 subscription fetches.** A subscription is a pure passive read; it resolves scope per [§Subscription-side scope resolution](#subscription-side-scope-resolution) and raises `:rf.error/resource-sub-unresolved-scope` rather than reading global or returning a silent `:idle`. A future `:rf.resource/live` side-effecting convenience, if added, MUST be explicitly documented as side-effecting and kept separate from the recommended route/event pattern.
 
-### Introspection
+### Introspection and projection (tool/test only)
 
 ```clojure
-(rf/resource-meta :article/by-slug)
-(rf/resource-state {:resource … :scope … :params … :frame :app/main})
-(rf/resources      {:frame :app/main})
+(rf/resource-meta :article/by-slug)                                  ;; registration projection: the registered spec
+(rf/resource-state {:resource … :scope … :params … :frame :app/main}) ;; runtime projection: one entry, explicit frame
+(rf/resources      {:frame :app/main})                                ;; registry + live entries for a frame
 ```
+
+These direct functions are the **tool/test projection lane**, not an app-read API. `resource-meta` projects the **registration** (the registered spec), while `resource-state` / `resources` project **runtime state** (the live cache entries) at an explicit frame — the same runtime state the `[:rf.resource/*]` subscriptions derive, read here without a reactive subscription context. Their callers are Xray, unit tests, and SSR/serialization plumbing. **App views MUST use the passive subscription lane** ([§Subscriptions](#subscriptions-passive)) — these functions take a one-shot, non-reactive snapshot and do not re-render on change, so reaching for them in a view is a category error (registering vs. projecting vs. subscribing are three different jobs; see the [lane table](#public-api)).
 
 `:frame` is an explicit, app-registered frame id (`:app/main` is illustrative). Per [EP-0002](../docs/EP/EP-0002-frame-target-resolution.md) there is no ambient `:rf/default` fallback: the frame target is carried explicitly, and a frameless introspection call with no resolvable context fails closed rather than silently inspecting the wrong frame.
 


### PR DESCRIPTION
## What

Makes the resource/mutation surface legible as **distinct lanes** so readers don't conflate *registering a handler* with *projecting its runtime state*. Closes the docs side of rf2-5swq7d.

The surface splits into four lanes, now documented as such everywhere:

| Lane | Spelling | Caller |
|---|---|---|
| Register | `reg-resource` / `reg-mutation` (functions) | author, at boot |
| Cause | `[:rf.resource/ensure …]`, `[:rf.mutation/execute …]` (event vectors) | events / routes / machines |
| App read (passive) | `[:rf.resource/state …]`, `[:rf.mutation/state …]` (subscription vectors) | views |
| Tool/test projection | `resource-state` / `resources` / `mutation-state` (direct fns) | Xray, tests, SSR |

The load-bearing fix the bead asked for: `resource-state` / `mutation-state` are now explicitly labelled as **tool/test projections**, not a second app-read API competing with the subscriptions.

## Changes (prose only)

- **`spec/016-Resources.md`** — four-lane table added to the *Public API* section; *Introspection* renamed to *Introspection and projection (tool/test only)* with explicit labelling; strengthened the `clear-resource` note to record the settled registration-removal-verb rule.
- **`docs/guide/concepts/server-state.md`** — new *Three lanes* subsection (register / cause / project) plus an admonition labelling `resource-state` / `mutation-state` as tool/test projections, never an in-view read.
- **`docs/api/16-resources.md`** — *Introspection* section reframed to the tool/test projection lane, cross-linked to the guide and spec lane tables.

## Related ruling — rf2-wgsyp3 (KEEP `clear-resource`/`clear-mutation`)

This PR reflects the **RULED KEEP** decision: the tear-down naming is unchanged. The strengthened `clear-resource` prose records *why* it's settled (a `clear-*` registrar-removal **function** vs. the `:rf.resource/clear-scope` causal **event vector** live in different registers; the trio keeps the registrar `clear-*` spelling). No rename, docs-only.

## Scope guards honoured

- **Untouched** (hot-zone, owned by an in-flight PR): `spec/API.md`, `implementation/core/src/re_frame/core.cljc`, `spec/api-manifest.edn`, `spec/api-manifest-metadata.edn`.
- No `rf2-` bead-ids in guide prose (gate is on `skills/re-frame2/`; guide prose kept clean regardless).

## Quality gate

`mkdocs build --strict` from repo root passes (exit 0; no WARNING/ERROR). All new cross-anchors (`#public-api`, `#subscriptions-passive`, `#three-lanes--registering-causing-projecting`, Conventions tear-down anchor) verified present in the built HTML.