### PR TITLE
docs(api): clarify boot, adapter-author, and frame startup lanes (rf2-ddf061)

### DIFF
--- a/docs/api/13-lifecycle.md
+++ b/docs/api/13-lifecycle.md
@@ -1,10 +1,27 @@
 # 13 — Lifecycle
 
-This chapter is about the surfaces that bring a re-frame2 process up and take it down. The core of it is **adapter selection at boot** — `init!` takes an adapter spec (Reagent / UIx / Helix / Plain Atom / SSR) and installs it; everything else hangs off that. The right call shape (`(rf/init! reagent/adapter)`, not `(rf/init!)`) is enforced at the language level so the missing-adapter mistake surfaces at compile / load time rather than as a runtime confusion.
+This chapter is about the surfaces that bring a re-frame2 process up and take it down. Three distinct lanes meet at startup, and almost every confusion here is a lane confusion — so this chapter keeps them apart on purpose:
 
-There's also a small inspection surface for "what's currently installed?" — `current-adapter`, `current-adapter-spec`, `adapter-disposed?` — and the symmetric `destroy-adapter!` for tear-down. Together these are the lifecycle vocabulary.
+| Lane | Who owns it | The surfaces | Where it's documented |
+|---|---|---|---|
+| **Application boot** | App authors | `init!`, then explicit `reg-frame` / `make-frame` + `frame-provider`; `configure!` to tune | [Application boot](#application-boot) (below) |
+| **Frame startup** | App authors (per frame) | `reg-frame` / `make-frame` and the `:on-create` event the new frame runs | [01 — Core §Frames](01-core.md#frames-the-scoping-primitive), [Pattern — Boot](../../spec/Pattern-Boot.md) |
+| **Adapter-author internals** | Adapter authors | `install-adapter!`, `destroy-adapter!`, `current-adapter`, `current-adapter-spec`, `adapter-disposed?`, the adapter-spec map | [For adapter authors](#for-adapter-authors) (below) |
 
-## Adapter selection
+An app author learns one boot sentence — **install an adapter with `init!`, then create your frame(s) explicitly** — and nothing else. The adapter-author surfaces (install / dispose / inspect, and the spec-map slots) are *not* peer choices beside `init!`; they sit one layer down and an ordinary app never touches them. The frame-startup lane is a third thing again: it's about what a *single frame* does when it comes alive (`:on-create`), independent of which substrate the process installed. Keep the three apart and the lifecycle reads cleanly.
+
+## Application boot
+
+This is the only lane an app author needs. It has exactly two steps: install the substrate adapter once, then create your app's frame(s) explicitly. Frame creation is always under your control — `init!` deliberately creates none.
+
+```clojure
+(rf/init! reagent/adapter)                          ;; 1. install the substrate (once)
+
+(rf/reg-frame :app/main {:on-create [:app/boot]})   ;; 2. create your frame explicitly
+;; …then establish it at your root with `frame-provider` (see the bootstrap pattern below).
+```
+
+Step 2's `:on-create` is the seam into the **frame-startup** lane — the first event a new frame runs. For trivial apps it seeds app-db; for real apps it's the head of a boot sequence ([Pattern — Boot](../../spec/Pattern-Boot.md) is the canonical recipe, from chained events up to a dedicated boot state machine). The frames concept guide walks the whole app-boot shape end to end: [Frames: isolated worlds](../guide/concepts/frames.md).
 
 ### `init!`
 
@@ -22,6 +39,21 @@ There's also a small inspection surface for "what's currently installed?" — `c
   ```
 - **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
+After `init!`, create your frame(s) — that's the next subsection.
+
+## Frame startup — the second boot step
+
+`init!` installs host capability and creates **no** frame; per [EP-0002](../../spec/002-Frames.md#frame-target-resolution--the-carried-invariant) frame ownership is always explicit. So the app author's second move is to create the frame and establish it at the root:
+
+- **`reg-frame`** / **`make-frame`** create a frame atomically and run its `:on-create` event synchronously — the frame's startup lifecycle. Both are rowed in [01 — Core §Frames](01-core.md#frames-the-scoping-primitive).
+- **`frame-provider`** establishes a created frame at a point in the view tree, so every bare `dispatch` / `subscribe` underneath resolves against it.
+
+The `:on-create` event is where the frame's own startup logic lives — seed app-db for a trivial app, or kick a boot sequence for a real one. That sequence is its own pattern, not a lifecycle surface: see [Pattern — Boot](../../spec/Pattern-Boot.md) for the chained-events and boot-state-machine forms, and [Frames: isolated worlds](../guide/concepts/frames.md) for the app-author narrative (including why `init!` doesn't create a frame for you).
+
+## For adapter authors
+
+Everything below is the **adapter-author lane**. An ordinary app never calls these — `init!` (above) drives them for you. Reach here only when you are *writing* a substrate adapter or a custom boot pipeline, or building tooling that has to inspect the install slot. The per-substrate surface tables live in [14 — Adapters](14-adapters.md); the normative contract is [Spec 006 — Reactive Substrate](../../spec/006-ReactiveSubstrate.md).
+
 ### `install-adapter!`
 
 - **Kind**: function
@@ -29,7 +61,7 @@ There's also a small inspection surface for "what's currently installed?" — `c
   ```clojure
   (install-adapter! adapter-map)
   ```
-- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; most consumers call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation.
+- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; ordinary apps call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation.
 
 ### `destroy-adapter!`
 
@@ -52,11 +84,13 @@ The adapter spec is a map with three keys:
 | `:render` | The substrate's mount fn. Reagent ships `r/render`; UIx ships `uix/render-root`; Helix ships its render. |
 | `:dispose-adapter!` | The teardown hook. Adapter-specific cleanup; called by `destroy-adapter!`. |
 
-Most app code never sees the spec map — you just pass the adapter's `adapter` Var into `init!` and forget about it.
+Most app code never sees the spec map — you just pass the adapter's `adapter` Var into `init!` (the application-boot lane) and forget about it.
 
-## Inspection
+### Inspection
 
-### `current-adapter`
+These reads answer "what's installed right now?" — for tooling and adapter-author code, not for app boot.
+
+#### `current-adapter`
 
 - **Kind**: function
 - **Signature**:
@@ -65,7 +99,7 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
   ```
 - **Description**: "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
 
-### `current-adapter-spec`
+#### `current-adapter-spec`
 
 - **Kind**: function
 - **Signature**:
@@ -74,7 +108,7 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
   ```
 - **Description**: "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`.
 
-### `adapter-disposed?`
+#### `adapter-disposed?`
 
 - **Kind**: function
 - **Signature**:
@@ -85,7 +119,7 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
 
 The split between `current-adapter` (keyword) and `current-adapter-spec` (map) is principled. The keyword is for switch-like code that branches on substrate identity. The spec map is for code that needs to call adapter fns or compare adapter identity across reinstalls.
 
-## The disposed-vs-never-installed distinction
+### The disposed-vs-never-installed distinction
 
 These two states surface as different errors because they have different recovery paths:
 
@@ -96,9 +130,9 @@ These two states surface as different errors because they have different recover
 
 The two states share the "no current adapter" surface but answer different questions about the process's history. Per [006 §Disposed-vs-never-installed](../../spec/006-ReactiveSubstrate.md#disposed-vs-never-installed).
 
-## Configuration
+## Configuration (application-boot lane)
 
-The `configure` fn is the lifecycle's adjacent surface — process-level data knobs that you typically set once at boot, possibly tweak in tests, and rarely touch in app code.
+Back in the app-author lane: the `configure` fn is application boot's adjacent surface — process-level data knobs you typically set once at boot, possibly tweak in tests, and rarely touch in app code. (It is *not* an adapter-author surface — it tunes the runtime, not the substrate.)
 
 ### `configure`
 
@@ -135,11 +169,19 @@ Full rationale: [Conventions §Configuration surfaces](../../spec/Conventions.md
     (js/document.getElementById "app")))
 ```
 
-That's the whole boot. `init!` installs the adapter and runtime capabilities (it creates no frame); the side-effecting requires register the handlers / subs / routes into the registrar; `reg-frame` + `frame-provider` establish the app frame so every bare `dispatch` / `subscribe` under the tree resolves against it; `configure` tunes the runtime; the substrate's render fn mounts the root view.
+That's the whole boot, and it stays inside the **application-boot** lane end to end: `init!` installs the adapter and runtime capabilities (it creates no frame); the side-effecting requires register the handlers / subs / routes into the registrar; `reg-frame` + `frame-provider` create the app frame and establish it at the root, so every bare `dispatch` / `subscribe` under the tree resolves against it (and the frame's `:on-create` `[:app/boot]` runs the **frame-startup** lane); `configure` tunes the runtime; the substrate's render fn mounts the root view. No adapter-author surface appears — `init!` stands in for the whole install lane.
 
 ## See also
 
+App-boot and frame-startup lanes (what app authors read):
+
 - [01 — Core](01-core.md) — `reg-frame` / `make-frame` / `configure` rowed in registration and configuration.
-- [02 — Views](02-views.md) — adapter-side surfaces (UIx / Helix hooks, the shared React Context).
+- [Frames: isolated worlds](../guide/concepts/frames.md) — the app-boot narrative, and why `init!` doesn't create a frame.
+- [Pattern — Boot](../../spec/Pattern-Boot.md) — the `:on-create` boot sequence, from chained events to a boot state machine.
+- [counter example](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter) — the minimal `init!` + `reg-frame` + `frame-provider` boot.
+
+Adapter-author lane (what substrate authors read):
+
 - [14 — Adapters](14-adapters.md) — per-substrate surface tables.
-- [Spec 006 — Reactive Substrate](../../spec/006-ReactiveSubstrate.md) — the adapter contract.
+- [02 — Views](02-views.md) — adapter-side surfaces (UIx / Helix hooks, the shared React Context).
+- [Spec 006 — Reactive Substrate](../../spec/006-ReactiveSubstrate.md) — the normative adapter contract.

--- a/docs/guide/concepts/frames.md
+++ b/docs/guide/concepts/frames.md
@@ -56,6 +56,10 @@ Almost every app is a one-frame app, and stays one. You register a frame at boot
 
 Notice that `init!` created no frame. Nothing is implicit about which frame your root uses; you say so, once, at the root.
 
+!!! note "Three lanes meet at startup — keep them apart"
+
+    The two lines above are the *whole* app-author boot lane: **install the substrate with `init!`, then create your frame(s) explicitly.** Two other lanes sit nearby but are not your concern as an app author. **Frame startup** is what each frame does as it comes alive — the `:on-create` event, which seeds app-db or kicks a boot sequence ([Pattern — Boot](../../../spec/Pattern-Boot.md)). **Adapter-author internals** — `install-adapter!`, `destroy-adapter!`, `current-adapter`, and the adapter-spec map — sit one layer *below* `init!`; you reach for them only when writing a substrate adapter, never for ordinary boot. The full three-lane breakdown is the [Lifecycle API chapter](../../api/13-lifecycle.md).
+
 ## When you want more than one
 
 The genuine multi-frame cases, roughly in the order you'll meet them:


### PR DESCRIPTION
## What

Clarifies the three distinct startup **lanes** in the docs so a reader knows which entry points belong to app authors, adapter authors, and the frame lifecycle. Implements bead rf2-ddf061 (source: `ai/findings/API-review/codex/boot-config-and-adapters.md`).

The Lifecycle API chapter previously presented `init!`, `install-adapter!`, `destroy-adapter!`, `current-adapter`, `current-adapter-spec`, and `adapter-disposed?` as flat peer surfaces — making adapter-author internals look like ordinary boot choices.

## Changes (prose only)

`docs/api/13-lifecycle.md`:
- New three-lane table + framing intro at the top (application boot / frame startup / adapter-author internals — who owns each).
- **Application boot** section leads: the one boot sentence — `init!` the adapter, then create frame(s) explicitly (`reg-frame`/`make-frame` + `frame-provider`). `configure!` stays in this lane.
- **Frame startup** section: `reg-frame`/`make-frame` + the `:on-create` event, cross-referenced to Pattern-Boot.
- **For adapter authors** section: `install-adapter!`, `destroy-adapter!`, the adapter-spec map, the inspection reads, and disposed-vs-never-installed all moved here under a clear fence ("an ordinary app never calls these").
- `See also` split by lane; examples/tools linked only where they reinforce a lane.

`docs/guide/concepts/frames.md`:
- Three-lane callout after the one-frame boot snippet, pointing app authors at the boot lane and away from adapter internals, with a link to the Lifecycle chapter.

## Acceptance criteria

- [x] App-facing docs have one clear boot path: adapter init, then explicit frame/image creation.
- [x] Adapter internals documented separately for adapter authors, not as part of ordinary app boot.
- [x] Existing examples/tools linked only where they reinforce those lanes.

## Scope

- Docs/spec prose only — no code or manifest changes.
- Hard-scope-guarded files untouched: `spec/API.md`, `implementation/core/src/re_frame/core.cljc`, `spec/api-manifest.edn`, `spec/api-manifest-metadata.edn`.
- **No deferred hot-zone change** — the lane restructure needed nothing in the guarded files.

## Quality gate

- `mkdocs build --strict` passes (zero warnings/errors; no link complaints about either edited file).