### PR TITLE
docs(api): teach canonical machine query and effect forms (rf2-3muamx)

### DIFF
--- a/docs/guide/concepts/machines.md
+++ b/docs/guide/concepts/machines.md
@@ -117,7 +117,7 @@ Registering the table is one line, and this is where people sometimes brace for 
 ;; (rf/reg-event :auth.login/flow (machines/make-machine-handler login-flow))
 ```
 
-> **One-time setup.** Machines ship in their own artefact, `day8/re-frame2-machines`, so apps without machines build a bundle clean of them. Add the dep and require `re-frame.machines` once at app boot — that registers the hooks through which `rf/reg-machine`, `rf/machine-transition`, and `rf/sub-machine` resolve.
+> **One-time setup.** Machines ship in their own artefact, `day8/re-frame2-machines`, so apps without machines build a bundle clean of them. Add the dep and require `re-frame.machines` once at app boot — that registers the hooks through which `rf/reg-machine`, `rf/machine-transition`, and the framework `:rf/machine` / `:rf/machine-has-tag?` subs resolve.
 
 A machine **is** an event handler. It's a `reg-event` whose body interprets the transition table: look up the snapshot, compute the transition, write it back, return the action's effects (the effects being the data describing what should happen in the world — the HTTP call, the storage write). Every event reaches it through the same `dispatch` — the call that sends an event into the system — and the same [cascade](events-and-the-cascade.md) as everything else. There's no actor object and no second messaging system, which is the point: one mechanism, used everywhere. (`reg-machine` is a macro that also stamps dev-only source coordinates so tools can jump from a diagram arrow to your code; production builds elide them.)
 
@@ -129,14 +129,14 @@ Dispatching routes through the machine's id, wrapping an inner event vector:
 
 If the current state has no transition for an event, it's a **silent no-op** — nothing throws, because XState v5 dropped strict mode too. The runtime emits a benign `:rf.machine.event/unhandled-no-op` trace so a debugger can still show that the event arrived and was ignored.
 
-The snapshot — `{:state :submitting :data {:attempts 1 :error nil}}` — lives in the frame's **runtime-db** at `[:rf.runtime/machines :snapshots :auth.login/flow]`, kept apart from your app data. A frame is one isolated instance of your running app, and the snapshot is just a value riding it, so undo, time-travel, persistence, and SSR hydration all work on machines for free. Views — the functions that turn state into UI — read the snapshot through a subscription, a reactive query that recomputes when its inputs change:
+The snapshot — `{:state :submitting :data {:attempts 1 :error nil}}` — lives in the frame's **runtime-db** at `[:rf.runtime/machines :snapshots :auth.login/flow]`, kept apart from your app data. A frame is one isolated instance of your running app, and the snapshot is just a value riding it, so undo, time-travel, persistence, and SSR hydration all work on machines for free. Views — the functions that turn state into UI — read the snapshot through a subscription, a reactive query that recomputes when its inputs change. The canonical read is the framework-registered `:rf/machine` sub, addressed by the machine's id:
 
 ```clojure
-@(rf/sub-machine :auth.login/flow)
+@(rf/subscribe [:rf/machine :auth.login/flow])
 ;; => {:state :submitting :data {:attempts 1 :error nil}}  (nil before the first event)
 ```
 
-Named projections chain off the underlying framework sub — `(rf/reg-sub :auth.login/error :<- [:rf/machine :auth.login/flow] ...)` — like any other [subscription](subscriptions.md).
+There's nothing machine-special about that call — `[:rf/machine <id>]` is an ordinary subscription vector, the same shape you'd write for any registered sub, so it's traceable and introspectable like the rest of your signal graph. Named projections chain off it — `(rf/reg-sub :auth.login/error :<- [:rf/machine :auth.login/flow] ...)` — like any other [subscription](subscriptions.md).
 
 It's worth pausing on the async wiring in `:issue-request`. `:on-success [:auth.login/flow [:auth.login/success]]` is a two-element template. The HTTP effect appends its reply payload and the runtime folds it onto the *inner* event, so `:store-session` sees `[:auth.login/success {:kind :success :value v}]` — exactly the payload [managed HTTP](http.md) sends. Machines and async effects compose with no adapter layer in between.
 
@@ -151,7 +151,7 @@ XState v5 is the behaviour re-frame2 matches; the *expression* is re-frame-nativ
 | `context` (extended state) | `:data` | Same idea; "context" is already overloaded in re-frame2 (interceptor context, React context). |
 | `createActor(machine).start()`, then `actor.send({type: ...})` | the machine **is an event handler**; `(rf/dispatch [machine-id [event]])` | **The big one.** No actor object, no separate send mechanism — one router queue, one cascade. |
 | actions that imperatively `assign(...)` / fire effects | actions **return** `{:data ... :fx ...}` | The same data-shaped return as any `reg-event` handler; effects are data, actioned by the runtime. |
-| state lives in the actor; `actor.getSnapshot()` | the snapshot is a value in runtime-db, read via `@(rf/sub-machine id)` | Time-travel, undo, persistence, and SSR hydration extend to machines for free. |
+| state lives in the actor; `actor.getSnapshot()` | the snapshot is a value in runtime-db, read via `@(rf/subscribe [:rf/machine id])` | Time-travel, undo, persistence, and SSR hydration extend to machines for free. |
 | `setup({guards, actions})` | machine-local `:guards` / `:actions` maps inside the spec | Each machine carries its own, validated at registration; cross-machine reuse is ordinary Clojure vars, not a string registry. |
 
 The matches go deeper than the renames: run-to-completion, transition tables as data, tags, delayed transitions, final states, and v5's internal-by-default self-transitions (re-frame2's `:reenter? true` is v5's `reenter: true`). An XState v5 author ports their intuitions directly. The full divergence ledger is in the [machine construction guide](../../../spec/CP-5-MachineGuide.md).
@@ -179,9 +179,9 @@ Here's a turnstile with two states and a counter riding in `:data`, live in your
 
 (rf/reg-machine :turnstile/flow turnstile)
 
-;; sub-machine returns nil until the first event; render :initial until then.
+;; [:rf/machine ...] returns nil until the first event; render :initial until then.
 (defn turnstile-view []
-  (let [{:keys [state data]} (or @(rf/sub-machine :turnstile/flow)
+  (let [{:keys [state data]} (or @(rf/subscribe [:rf/machine :turnstile/flow])
                                  {:state (:initial turnstile) :data (:data turnstile)})
         open? (= state :unlocked)]
     [:div {:style {:font-family "sans-serif"}}
@@ -211,10 +211,10 @@ Here's a turnstile with two states and a counter riding in `:data`, live in your
 
 The fact arrives recorded on the event's causal token, so the decision replays the same way under time-travel and SSR hydration — [Effects and coeffects](effects-and-coeffects.md) has the general mechanism (a coeffect being a fact pulled *into* a handler, the mirror of an effect pushed out).
 
-**Tags answer the any-of-many question.** Once a machine has several "loading-ish" states, views stop asking "which exact state?" and start asking a predicate: *is it busy?* A state declares `:tags #{:auth/busy}` (as `:submitting` does above), and at every transition the runtime stamps the union of active states' tags onto the snapshot:
+**Tags answer the any-of-many question.** Once a machine has several "loading-ish" states, views stop asking "which exact state?" and start asking a predicate: *is it busy?* A state declares `:tags #{:auth/busy}` (as `:submitting` does above), and at every transition the runtime stamps the union of active states' tags onto the snapshot. The framework ships a derived predicate sub for the containment question — `[:rf/machine-has-tag? <machine-id> <tag>]` — that re-renders only when *this* tag's membership bit flips:
 
 ```clojure
-(when @(rf/machine-has-tag? :auth.login/flow :auth/busy)
+(when @(rf/subscribe [:rf/machine-has-tag? :auth.login/flow :auth/busy])
   [spinner])
 ```
 
@@ -282,7 +282,7 @@ The flat grammar above carries most machines. When a flow gets richer, the gramm
 **You can now:**
 
 - spot a state machine hiding in scattered `cond` clauses, and say which three diseases the transition-table rewrite cures
-- register a machine (`reg-machine` — sugar over an event handler), dispatch into it, and read it with `sub-machine` and `machine-has-tag?`
+- register a machine (`reg-machine` — sugar over an event handler), dispatch into it, and read it with the `[:rf/machine <id>]` and `[:rf/machine-has-tag? <id> <tag>]` subscription vectors
 - map your XState v5 vocabulary onto re-frame2's five deltas
 - test transitions as pure function calls with `machine-transition`
 - recognise when you need hierarchy, parallel regions, history, or spawned actors — and where their contracts live

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -134,7 +134,7 @@ For the registration `(rf/reg-event :drawer/editor (rf/make-machine-handler {...
 {:rf.runtime/machines {:snapshots {:drawer/editor {:state :idle :data {:circle-id nil ...}}}}}
 ```
 
-> **Snapshot is lazily initialised.** Registration creates the *handler*, not the snapshot. The first time the machine handler runs (the first dispatched event addressed to this id), the runtime resolves the snapshot via `(or (get-in runtime-db [:rf.runtime/machines :snapshots <id>]) <initial-from-spec>)` — so before the first event, `(get-in (rf/runtime-db-value frame-id) [:rf.runtime/machines :snapshots :drawer/editor])` returns `nil` and `@(rf/sub-machine :drawer/editor)` returns `nil`. The lifecycle trace `:rf.machine.lifecycle/created` (per [009](009-Instrumentation.md)) is emitted at registration to mark the handler's appearance in the registry — it does NOT imply the snapshot exists in runtime-db yet. Views that need to render before any event reaches the machine should treat `nil` as "not yet initialised" and tolerate it (or bring the snapshot alive ahead of any user event with the eager `[:machine-id [:rf.machine/start]]` kick, per [§When creation happens — eager start vs lazy first event](#when-creation-happens--eager-start-vs-lazy-first-event), if appearance-without-event is required).
+> **Snapshot is lazily initialised.** Registration creates the *handler*, not the snapshot. The first time the machine handler runs (the first dispatched event addressed to this id), the runtime resolves the snapshot via `(or (get-in runtime-db [:rf.runtime/machines :snapshots <id>]) <initial-from-spec>)` — so before the first event, `(get-in (rf/runtime-db-value frame-id) [:rf.runtime/machines :snapshots :drawer/editor])` returns `nil` and `@(rf/subscribe [:rf/machine :drawer/editor])` returns `nil`. The lifecycle trace `:rf.machine.lifecycle/created` (per [009](009-Instrumentation.md)) is emitted at registration to mark the handler's appearance in the registry — it does NOT imply the snapshot exists in runtime-db yet. Views that need to render before any event reaches the machine should treat `nil` as "not yet initialised" and tolerate it (or bring the snapshot alive ahead of any user event with the eager `[:machine-id [:rf.machine/start]]` kick, per [§When creation happens — eager start vs lazy first event](#when-creation-happens--eager-start-vs-lazy-first-event), if appearance-without-event is required).
 
 For a spawned actor whose gensym'd id is `:request/protocol#42`:
 
@@ -142,7 +142,7 @@ For a spawned actor whose gensym'd id is `:request/protocol#42`:
 {:rf.runtime/machines {:snapshots {:request/protocol#42 {:state :loading :data {:url "/foo"}}}}}
 ```
 
-`:rf.runtime/machines` is a **reserved runtime-db child** (per [Conventions §Reserved runtime-db keys](Conventions.md#reserved-runtime-db-keys)); inside it, `:snapshots` holds the per-machine snapshot map — a `[:map-of :keyword :rf/machine-snapshot]` keyed by the machine's registered id. User code MUST NOT write under `[:rf.runtime/machines ...]`; it reads machine state through `sub-machine` / `[:rf/machine <id>]`, never raw runtime-db paths.
+`:rf.runtime/machines` is a **reserved runtime-db child** (per [Conventions §Reserved runtime-db keys](Conventions.md#reserved-runtime-db-keys)); inside it, `:snapshots` holds the per-machine snapshot map — a `[:map-of :keyword :rf/machine-snapshot]` keyed by the machine's registered id. User code MUST NOT write under `[:rf.runtime/machines ...]`; it reads machine state through the `[:rf/machine <id>]` subscription, never raw runtime-db paths.
 
 Why the locked path — the load-bearing reason is [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility): locating snapshots in the **runtime-db partition** (part of the one frame-state container) is the named mechanism by which machine state inherits revertibility. When a frame's frame-state reverts, every machine snapshot reverts with it. A parallel ActorRef registry or a per-machine atom would put machine state outside frame-state and break the goal. The five concrete consequences below all flow from that:
 
@@ -795,7 +795,7 @@ What this gives:
 - **One id, one registration.** Reuses the `:event` registry kind. `(registrations :event)` enumerates every machine alongside every other event handler; `(handler-meta :event :drawer/editor)` carries `:rf/machine? true` so tooling can identify it. The snapshot's location in `runtime-db` is fixed and runtime-managed (see [§Where snapshots live](#where-snapshots-live)).
 - **Standard dispatch.** `dispatch` and `dispatch-sync` route to a machine the same way they route to any handler.
 - **Hot-reload.** Re-eval of the registration replaces the table; live snapshots pick up the new interpretation on their next event.
-- **Reading the snapshot.** Views read the snapshot via the framework-shipped `:rf/machine` sub or its `sub-machine` wrapper — `@(rf/sub-machine :drawer/editor)` yields `{:state ... :data ...}` (or `nil` if not yet initialised). See [§Subscribing to machines via `sub-machine`](#subscribing-to-machines-via-sub-machine).
+- **Reading the snapshot.** Views read the snapshot via the framework-shipped `:rf/machine` sub — `@(rf/subscribe [:rf/machine :drawer/editor])` yields `{:state ... :data ...}` (or `nil` if not yet initialised). See [§Subscribing to machines via `sub-machine`](#subscribing-to-machines-via-sub-machine).
 
 Sub-events are how the machine receives its inputs:
 
@@ -1576,7 +1576,7 @@ The initial snapshot's `:state` is the map of region-name → that region's init
 
 ```clojure
 ;; given the :ui/nine-states example above:
-(@(rf/sub-machine :ui/nine-states))
+@(rf/subscribe [:rf/machine :ui/nine-states])
 ;; => {:state {:data :nothing :form :neutral :mode :active}
 ;;     :data  {:items [] :error nil}
 ;;     :tags  #{:data/idle :form/neutral :mode/active}}
@@ -1991,22 +1991,18 @@ The framework ships one sub:
     (contains? (get-in db [:rf.runtime/machines :snapshots machine-id :tags]) tag)))
 ```
 
-User call sites:
+User call site — the canonical predicate is the subscription vector:
 
 ```clojure
 ;; predicate
 @(rf/subscribe [:rf/machine-has-tag? :ui/nine-states :data/loading])
 ;; => true | false
-
-;; sugar matching sub-machine's pattern
-(rf/machine-has-tag? :ui/nine-states :data/loading)
-;; => reaction wrapping the registered sub
 ```
 
 Reading the whole tag set is the normal snapshot read:
 
 ```clojure
-@(rf/sub-machine :ui/nine-states)
+@(rf/subscribe [:rf/machine :ui/nine-states])
 ;; => {:state ... :data ... :tags #{:data/loading :form/neutral :mode/active}}
 ```
 
@@ -2049,7 +2045,7 @@ That works for the flat-status case; it doesn't scale to "loading, OR validating
  :validating  {:tags #{:data/loading} :on {...}}
  :retrying    {:tags #{:data/loading :data/retry} :on {...}}}
 
-(when @(rf/machine-has-tag? :todos/editor :data/loading)
+(when @(rf/subscribe [:rf/machine-has-tag? :todos/editor :data/loading])
   [view-loading])
 ```
 
@@ -2354,7 +2350,7 @@ Symmetry between singleton and spawned:
 | Singleton | `:drawer/editor` (explicit) | `[:rf.runtime/machines :snapshots :drawer/editor]` | a registrar entry registered at boot via `reg-event`; outlives any one frame's value |
 | Spawned actor | `:request/protocol#42` (gensym'd) | `[:rf.runtime/machines :snapshots :request/protocol#42]` | the SNAPSHOT's presence — no per-instance registrar entry; resolved on dispatch from the snapshot's `:rf/machine-type`; reverts with the frame value |
 
-Both are addressable by `dispatch` (`[<id> <event>]`). Both readable through the framework-registered `:rf/machine` sub (per [§Subscribing to machines via `sub-machine`](#subscribing-to-machines-via-sub-machine)) — the actor-id is just the argument: `@(rf/sub-machine actor-id)`. A singleton appears in `(registrations :event)`; a spawned actor does not (its liveness is its snapshot) — enumerate live actors via `[:rf.runtime/machines :snapshots]` instead, per [§Querying machines](#querying-machines).
+Both are addressable by `dispatch` (`[<id> <event>]`). Both readable through the framework-registered `:rf/machine` sub (per [§Subscribing to machines via `sub-machine`](#subscribing-to-machines-via-sub-machine)) — the actor-id is just the argument: `@(rf/subscribe [:rf/machine actor-id])`. A singleton appears in `(registrations :event)`; a spawned actor does not (its liveness is its snapshot) — enumerate live actors via `[:rf.runtime/machines :snapshots]` instead, per [§Querying machines](#querying-machines).
 
 ### Spawn lifecycle — ordering
 
@@ -2645,12 +2641,12 @@ The standard cross-machine pattern remains `[:fx [[:dispatch [<other-id> [:event
           {:fx [[:dispatch [(rf/machine-by-system-id :primary-request)
                             [:cancel]]]]})
 
-;; Sugar — dispatches via the lookup, no-ops when the name is unbound:
+;; Canonical — dispatches via the lookup, no-ops when the name is unbound:
 :action (fn [_]
           {:fx [[:rf.machine/dispatch-to-system [:primary-request [:cancel]]]]})
 ```
 
-The `:rf.machine/dispatch-to-system` fx is the action-side counterpart to the `dispatch-to-system` **fn** (`re-frame.core`): the fn is for direct call sites, the fx is what a machine action emits from `:fx`. Its args are the single 2-element pair `[<system-id> <event-vector>]` — the framework fx contract is a `[fx-id args]` pair (the `do-fx` walk drops arity-≥3 entries with `:rf.error/effect-map-shape`), so the system-id and event ride together in the one `args` slot, exactly as `:dispatch`'s args is a single event vector and `:rf.machine/spawn`'s is a single spec map. The fx-id is namespaced under `:rf.machine/*` per [Conventions §Fx-id namespacing rule](Conventions.md#fx-id-namespacing-rule--three-reserved-fx-id-sub-namespaces) (surface-specific machine fx).
+The `:rf.machine/dispatch-to-system` fx tuple is the **canonical** cross-machine-by-name surface — the action-side address a machine emits from `:fx`. (It performs the same name-resolve-then-dispatch as the explicit `[:dispatch [(rf/machine-by-system-id ...) ...]]` form above, with no-op-when-unbound semantics folded in.) Its args are the single 2-element pair `[<system-id> <event-vector>]` — the framework fx contract is a `[fx-id args]` pair (the `do-fx` walk drops arity-≥3 entries with `:rf.error/effect-map-shape`), so the system-id and event ride together in the one `args` slot, exactly as `:dispatch`'s args is a single event vector and `:rf.machine/spawn`'s is a single spec map. The fx-id is namespaced under `:rf.machine/*` per [Conventions §Fx-id namespacing rule](Conventions.md#fx-id-namespacing-rule--three-reserved-fx-id-sub-namespaces) (surface-specific machine fx).
 
 The sender doesn't have to capture the gensym'd id at the spawn site, doesn't have to carry it through `:data`, doesn't even have to be the spawning machine — anything in the frame that knows the name can address the actor.
 
@@ -2719,7 +2715,7 @@ The keys mirror [§Spawn-spec keys](#spawn-spec-keys), with two additions:
    ```
 
    This is the re-frame2 spelling of XState v5's `const ref = spawn(child)` captured into `context` — except the id rides the (revertible, SSR-survivable) snapshot rather than a live object. No atom, no runtime-db path coupling. It is the REVERSE direction of the child-lineage stamps (`:rf/self-id` / `:rf/parent-id` / `:rf/invoke-id`) the runtime writes onto the CHILD's `:data`: here the PARENT captures the CHILD's id, keyed by the SAME `<invoke-id>` the child records under `:rf/invoke-id`. See [§Reserved snapshot-internal keys](#reserved-snapshot-internal-keys) for the `:rf/spawned` row.
-2. **`:system-id`.** Declare `:system-id :my-name` on the `:spawn` / `:rf.machine/spawn` spec; resolve anywhere in the frame with `(rf/machine-by-system-id :my-name)`, call `(rf/dispatch-to-system :my-name [...])` from a direct call site, or — from a machine action's `:fx` — emit `[:rf.machine/dispatch-to-system [:my-name [...]]]`. Best when you want a stable *name* rather than the gensym'd id. See [§Named addressing via `:system-id`](#named-addressing-via-system-id).
+2. **`:system-id`.** Declare `:system-id :my-name` on the `:spawn` / `:rf.machine/spawn` spec; from a machine action's `:fx` emit the canonical effect tuple `[:rf.machine/dispatch-to-system [:my-name [...]]]` to message the bound actor by name, or — from a direct call site outside an action context — resolve the id with `(rf/machine-by-system-id :my-name)` and `(rf/dispatch [(rf/machine-by-system-id :my-name) [...]])`. Best when you want a stable *name* rather than the gensym'd id. See [§Named addressing via `:system-id`](#named-addressing-via-system-id).
 3. **Read the runtime registry slot.** The id is also always at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` (`<invoke-id>` is the absolute prefix-path of the `:spawn`-bearing state) — read it directly when you have the parent-id and state path but are *outside* the machine's own action context (where mechanism 1 is unavailable). The `:rf/spawned` `:data` slot (mechanism 1) mirrors this registry slot exactly, in-snapshot.
 4. **`:rf.machine/update-snapshot`.** From a regular `:action`'s `:fx` vector, emit `[:rf.machine/update-snapshot {:rf/machine-id <id> :rf/patch {:data {...}}}]` to write a *user-domain* copy of the id into the parent's `:data` under your own key — only when you need it under a domain-specific name distinct from the framework's `:rf/spawned` slot. See the snapshot-level escape hatch in [§Path conventions in machine bodies](#path-conventions-in-machine-bodies).
 
@@ -3702,31 +3698,19 @@ Machines are read like any other slice of frame-state — through a registered s
 
 Returns the whole snapshot `{:state <kw> :data <map>}` for the named machine, or `nil` if the machine is not yet initialised. The argument is **just the machine-id** — no varargs, no path-drilling. Granularity is the user's job via derived subs.
 
-### Two equivalent surfaces
+### The canonical surface is the subscription vector
 
-The framework exposes two surfaces, both equivalent:
-
-- **`(rf/sub-machine :drawer/editor)`** — the canonical user-facing call site. Lives in `re-frame.core` alongside `subscribe`, `dispatch`, `reg-event`. Single-arg; returns a Reagent reaction over the snapshot. The verb-noun name reads as "subscribe to a machine."
-
-  ```clojure
-  (defn sub-machine [machine-id]
-    (rf/subscribe [:rf/machine machine-id]))
-  ```
-
-  > **Name parse — the `sub-` prefix is the subscription family, NOT child-machine.** Per audit-of-audits state-machines #11, `sub-machine` returns a **reactive subscription** on the named machine's state. The `sub-` prefix is re-frame's subscription-family verb (sibling of `subscribe`, `sub-once`) — it does NOT denote a child-machine / sub-machine relationship. Declarative child-machine binding uses `:spawn`, not `sub-machine`. If you're looking for "spawn a child actor of this state," see [§Declarative `:spawn`](#declarative-spawn); if you're looking for "read this machine's snapshot reactively from a view," `sub-machine` is the call.
-
-- **`(rf/subscribe [:rf/machine :drawer/editor])`** — explicit registry use. The `:rf/machine` sub is in `(registrations :sub)`, traceable, introspectable. Power-users and tools use this form.
-
-`sub-machine` is sugar over the registered sub. Both surfaces resolve on the surrounding frame; `@(rf/sub-machine :drawer/editor)` reads from that frame's `[:rf.runtime/machines :snapshots :drawer/editor]`.
+The canonical user-facing read is the ordinary subscription vector `[:rf/machine <machine-id>]` — there is no machine-special call site to learn:
 
 ```clojure
 ;; usage in a view:
-@(rf/sub-machine :drawer/editor)
-;; → {:state :idle :data {:circle-id nil ...}}      (or nil before initialisation)
-
-;; equivalent explicit form:
 @(rf/subscribe [:rf/machine :drawer/editor])
+;; → {:state :idle :data {:circle-id nil ...}}      (or nil before initialisation)
 ```
+
+The `:rf/machine` sub is in `(registrations :sub)`, traceable and introspectable like every other registered subscription; both the sub and any derived subs that chain off it resolve on the surrounding frame, reading that frame's `[:rf.runtime/machines :snapshots :drawer/editor]`. Reading a machine is *exactly* "subscribe to a registered sub" — the same shape the rest of your signal graph already uses — so the substrate stays one mechanism, not two.
+
+> **Reading a machine's snapshot is not the same as a child machine.** A subscription on `[:rf/machine <id>]` is a **reactive read** of the named machine's state. Declarative child-machine binding — spawning a child actor of a state — uses `:spawn`, an entirely separate surface. If you're looking for "spawn a child actor of this state," see [§Declarative `:spawn`](#declarative-spawn); if you're looking for "read this machine's snapshot reactively from a view," subscribe to `[:rf/machine <id>]`.
 
 ### The `:rf/machine-has-tag?` predicate sub
 
@@ -3742,15 +3726,12 @@ Alongside `:rf/machine` the framework ships **`:rf/machine-has-tag?`** — a pre
 
 **Return contract.** Strictly `true` | `false`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`. Returns `false` for every other case — `tag` absent, snapshot present but `:tags` elided (no active state declares tags), or no snapshot at all (unknown or not-yet-initialised machine). Never returns `nil`; the predicate shape is total over `(machine-id, tag)` pairs.
 
-**Re-render granularity.** The sub is **derived** — it reads the snapshot via `get-in` rather than chaining off `:rf/machine` — so the reaction emits only when *this tag's containment-bit* flips. A view that asks `(rf/machine-has-tag? :ui/nine-states :data/loading)` does not re-render when `:state`, `:data`, `:meta`, or *other* tags change; only when `:data/loading` is added to or removed from `:tags`. Reagent's built-in equality dedup gates the boolean return.
+**Re-render granularity.** The sub is **derived** — it reads the snapshot via `get-in` rather than chaining off `:rf/machine` — so the reaction emits only when *this tag's containment-bit* flips. A view that subscribes to `[:rf/machine-has-tag? :ui/nine-states :data/loading]` does not re-render when `:state`, `:data`, `:meta`, or *other* tags change; only when `:data/loading` is added to or removed from `:tags`. Reagent's built-in equality dedup gates the boolean return.
 
 ```clojure
-;; canonical sugar — single call site
-@(rf/machine-has-tag? :ui/nine-states :data/loading)
-;; => true | false
-
-;; equivalent explicit form
+;; canonical surface — the subscription vector
 @(rf/subscribe [:rf/machine-has-tag? :ui/nine-states :data/loading])
+;; => true | false
 ```
 
 For the full tag-set narrative — what `:tags` is, how the runtime computes it at every transition, what the user-vs-runtime ownership boundary looks like — see [§State tags](#state-tags). This section catalogues only the subscription surface.
@@ -3990,7 +3971,7 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
 (rf/reg-sub :drawer/circles      (fn [db _] (get-in db [:drawer :circles])))
 ;; The framework-registered :rf/machine sub returns the snapshot {:state :data}
 ;; for any machine — we parameterise it on :drawer/editor and compose against
-;; it via :<-. (Equivalently: @(rf/sub-machine :drawer/editor).)
+;; it via :<-. (Read directly with @(rf/subscribe [:rf/machine :drawer/editor]).)
 (rf/reg-sub :drawer/editor-state :<- [:rf/machine :drawer/editor] (fn [snap _] (:state snap)))
 (rf/reg-sub :drawer/editor-data  :<- [:rf/machine :drawer/editor] (fn [snap _] (:data snap)))
 (rf/reg-sub :drawer/editing? :<- [:drawer/editor-state] (fn [s _] (= s :editing)))
@@ -4014,8 +3995,8 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
 
 (rf/reg-view main []
   (let [circles                @(rf/subscribe [:drawer/circles-with-preview])
-        ;; sub-machine returns the whole snapshot; inline-destructure it.
-        {state :state ed :data} @(rf/sub-machine :drawer/editor)
+        ;; the :rf/machine sub returns the whole snapshot; inline-destructure it.
+        {state :state ed :data} @(rf/subscribe [:rf/machine :drawer/editor])
         editing?               (= state :editing)
         can-undo?              @(rf/subscribe [:drawer/can-undo?])
         can-redo?              @(rf/subscribe [:drawer/can-redo?])]
@@ -4256,7 +4237,7 @@ The v1 ship-list and the post-v1 follow-up are itemised below.
 - The `:raise` reserved fx-id inside `:fx` (machine-internal); the `:rf.machine/spawn` and `:rf.machine/destroy` fx-ids registered globally for actor lifecycle.
 - `[:rf.runtime/machines :snapshots <id>]` as the reserved runtime-db storage scheme; `:rf/machine?` registration-metadata flag.
 - `(rf/machines)` and `(rf/machine-meta id)` — discovery lens over the event registry per [§Querying machines](#querying-machines).
-- The framework-registered `:rf/machine` parametric sub and its `sub-machine` wrapper.
+- The framework-registered `:rf/machine` parametric sub — the canonical `[:rf/machine <id>]` read surface.
 - Four-level drain semantics per [§Drain semantics](#drain-semantics) — including the gotchas listed in [§Drain semantics gotchas](#drain-semantics-gotchas).
 - The v1 transition-table grammar subset per [§Capability matrix](#capability-matrix) and [§Transition table grammar](#transition-table-grammar).
 - The snapshot shape (`{:state :data :meta?}`) and the persist/restore stability invariants per [§Snapshot shape](#snapshot-shape).


### PR DESCRIPTION
## What

Reorients the machines teaching surfaces to lead with the **canonical machine query + effect forms**, honoring the **rf2-gkt25a** ruling (machine-helper facade tiering, mayor-ruled 2026-06-18). The canonical surfaces are:

- the subscription vector `[:rf/machine <machine-id>]` (snapshot read),
- the subscription vector `[:rf/machine-has-tag? <machine-id> <tag>]` (tag predicate),
- the effect tuple `[:rf.machine/dispatch-to-system [<system-id> <event-vector>]]` (cross-machine-by-name).

Docs now teach those substrate forms first rather than the convenience helpers, since `sub-machine` and the `dispatch-to-system` **fn** are being removed/demoted off the facade by the separate facade-pruning bead.

## Changes

**`docs/guide/concepts/machines.md`**
- Snapshot read taught as `@(rf/subscribe [:rf/machine id])` (was `sub-machine`), with a note that it's an ordinary subscription vector.
- Tag predicate taught as the `[:rf/machine-has-tag? id tag]` vector.
- Live `cljs-rf2` turnstile example, the XState v5 delta table, the one-time-setup note, and the closing "you can now" summary all updated off the dropped helpers.

**`spec/005-StateMachines.md`**
- Example/worked-view read sites (lazy-init note, nine-states example, the drawer worked view, the spawned-actor read) now use `(subscribe [:rf/machine ...])`.
- Tag-query examples lead with the `[:rf/machine-has-tag? ...]` vector.
- The `:system-id` named-addressing enumeration and the cross-machine messaging section now present `[:rf.machine/dispatch-to-system ...]` as the **canonical** action-side surface, with the `machine-by-system-id` + `dispatch` resolve as the direct-call path; dropped the framing that promoted the `dispatch-to-system` fn as a `re-frame.core` peer.
- `machine-has-tag?` is **kept** as a tier-advanced convenience per the ruling — its existence in the capabilities ledger is preserved; only the teaching emphasis moved to the vector.

## Honors gkt25a

Per the ruling: `sub-machine` DROP (zero adopters), `machine-has-tag?` KEEP (tier-advanced, 64 example adopters), `dispatch-to-system` fn DEMOTE off facade, canonical effect tuple untouched. This is the docs-first half; the facade pruning + manifest/API.md retier is the separate clustering bead.

## Deferred (hot-zone / out of scope)

- **Section-title + cross-link rename deferred.** The spec section header `## Subscribing to machines via \`sub-machine\`` was intentionally **left unchanged** to preserve its anchor `#subscribing-to-machines-via-sub-machine`, which is referenced from 8 other files — including hot-zone (`spec/002-Frames.md`, `spec/006-ReactiveSubstrate.md`, `spec/Conventions.md`, `spec/API.md`) plus `spec/008-Testing.md`, `spec/Construction-Prompts.md`, `spec/Pattern-Boot.md`, `spec/Pattern-WebSocket.md`, `docs/api/04-machines.md`. The section *body* now teaches the canonical vector; renaming the header + fixing every cross-link should ride with the facade-pruning bead (it co-touches API.md anyway).
- **`docs/api/04-machines.md` untouched.** It documents the facade surface row-by-row (parallel to `spec/API.md`); reconciling its `sub-machine` / `dispatch-to-system` fn rows belongs to the facade-pruning bead, not this docs-first teaching pass.
- **No hot-zone edits.** `spec/API.md`, `implementation/core/src/re_frame/core.cljc`, `spec/api-manifest.edn`, `spec/api-manifest-metadata.edn` were not touched.

## Quality gate

`python -m mkdocs build --strict` from repo root: passes (exit 0, no warnings/errors).