### PR TITLE
fix(pair-mcp): guard describe-image frame-generation for imageless frames (rf2-p6mwq3)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1114,42 +1114,77 @@
                     case.
 
    `:include-ns?` (default false) gates the per-registration provenance map.
-   FAILS LOUD up the eval boundary on an unresolvable explicit frame."
+
+   NO-GENERATION FRAME (post-EP-0024): only an EXPLICIT `:images` key triggers
+   image resolution, so a frame configured with NO `:images` is an ordinary
+   frame on the shared registrar that carries no composed image — and the public
+   `rf/frame-generation` read FAILS LOUD (`:rf.error/frame-no-generation`) for
+   it (the intended no-generation contract). That is not an error for THIS read:
+   an imageless frame simply runs no composed image, so `describe-image` reports
+   it gracefully — `{:ok? true … :images [] :kinds [] :requires [] :counts {}
+   :no-generation? true}` — rather than letting the fail-loud escape up the eval
+   boundary. The discriminator is the error's `:live-frame-ids`: a frame-id that
+   IS a live frame but carries no generation is the graceful imageless case; an
+   UNRESOLVABLE target (an id naming no live frame at all) still FAILS LOUD up
+   the eval boundary, the facade's no-silent-fallback contract."
   ([] (describe-image {}))
   ([opts]
    (let [{:keys [frame include-ns?]} opts
          frame-id (current-frame frame)]
      (if (nil? frame-id)
        (ambiguous-frame-error :describe-image)
-       (let [gen      (rf/frame-generation frame-id)
-             resolver (:rf.gen/resolver gen)
-             kinds    (vec (sort (:rf.gen/kinds gen)))
-             counts   (reduce-kv
-                        (fn [acc [k _id] _d] (update acc k (fnil inc 0)))
+       (let [gen      (try
+                        (rf/frame-generation frame-id)
+                        (catch :default e
+                          (let [{err-id :rf.error/id
+                                 live   :live-frame-ids} (ex-data e)]
+                            ;; A live frame that carries no generation (an
+                            ;; imageless frame — EP-0024) is the graceful
+                            ;; no-image case, NOT a read failure. Surface the
+                            ;; sentinel and let the caller report it cleanly.
+                            ;; Any other thrown error — including a :frame
+                            ;; target that names NO live frame — re-throws and
+                            ;; fails loud up the eval boundary unchanged.
+                            (if (and (= :rf.error/frame-no-generation err-id)
+                                     (some #(= % frame-id) live))
+                              ::no-generation
+                              (throw e)))))]
+         (if (= ::no-generation gen)
+           {:ok?            true
+            :frame          frame-id
+            :images         []
+            :kinds          []
+            :requires       []
+            :counts         {}
+            :no-generation? true}
+           (let [resolver (:rf.gen/resolver gen)
+                 kinds    (vec (sort (:rf.gen/kinds gen)))
+                 counts   (reduce-kv
+                            (fn [acc [k _id] _d] (update acc k (fnil inc 0)))
+                            {}
+                            resolver)]
+             (cond-> {:ok?      true
+                      :frame    frame-id
+                      ;; Each composed image reduces to its `:rf.image/id` when
+                      ;; it carries one (the named case); an ANONYMOUS image (no
+                      ;; `:id`) has none, so surface its `:include-ns` globs —
+                      ;; what the image selected — rather than the whole map.
+                      :images   (mapv (fn [img]
+                                        (or (:rf.image/id img)
+                                            (when (map? img)
+                                              {:rf.image/include-ns (:rf.image/include-ns img)})
+                                            img))
+                                      (:rf.gen/images gen))
+                      :kinds    kinds
+                      :requires (vec (sort (:rf.gen/requires gen)))
+                      :counts   counts}
+               include-ns?
+               (assoc :registrations
+                      (reduce-kv
+                        (fn [acc [k id] d]
+                          (assoc acc [k id] (coordinate-summary d)))
                         {}
-                        resolver)]
-         (cond-> {:ok?      true
-                  :frame    frame-id
-                  ;; Each composed image reduces to its `:rf.image/id` when it
-                  ;; carries one (the named case); an ANONYMOUS image (no
-                  ;; `:id`) has none, so surface its `:include-ns` globs — what
-                  ;; the image selected — rather than the whole normalized map.
-                  :images   (mapv (fn [img]
-                                    (or (:rf.image/id img)
-                                        (when (map? img)
-                                          {:rf.image/include-ns (:rf.image/include-ns img)})
-                                        img))
-                                  (:rf.gen/images gen))
-                  :kinds    kinds
-                  :requires (vec (sort (:rf.gen/requires gen)))
-                  :counts   counts}
-           include-ns?
-           (assoc :registrations
-                  (reduce-kv
-                    (fn [acc [k id] d]
-                      (assoc acc [k id] (coordinate-summary d)))
-                    {}
-                    resolver))))))))
+                        resolver))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Subscriptions

--- a/skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj
@@ -131,6 +131,32 @@
         "frame-capability-requires reports the image-declared :rf.gen/requires set.")))
 
 ;; ---------------------------------------------------------------------------
+;; describe-image guards the no-generation fail-loud (EP-0024 contract).
+;;
+;; Post-EP-0024 only an EXPLICIT :images key triggers image resolution, so an
+;; imageless frame carries NO generation and the public rf/frame-generation
+;; read FAILS LOUD (:rf.error/frame-no-generation) for it. describe-image must
+;; GUARD that call — catch the no-generation fail-loud for a LIVE frame and
+;; report it gracefully (:no-generation?), rather than letting it escape up the
+;; eval boundary — while still failing loud on a genuinely unresolvable target.
+;; ---------------------------------------------------------------------------
+
+(deftest describe-image-guards-no-generation-fail-loud
+  (let [f (defn-form 'describe-image)]
+    (is (calls? f 'try)
+        "describe-image MUST wrap the rf/frame-generation read in a `try` so the EP-0024 no-generation fail-loud can be guarded.")
+    (is (calls? f 'catch)
+        "describe-image MUST `catch` the rf/frame-generation throw rather than letting an imageless frame's fail-loud escape the eval boundary.")
+    (is (form-contains? (fn [n] (= :rf.error/frame-no-generation n)) f)
+        "describe-image MUST discriminate on :rf.error/frame-no-generation — the EP-0024 no-generation error id — so only the no-generation case is softened (any other throw re-raises).")
+    (is (form-contains? (fn [n] (= :live-frame-ids n)) f)
+        "describe-image MUST check the error's :live-frame-ids so a LIVE imageless frame degrades gracefully while a target naming NO live frame still fails loud.")
+    (is (form-contains? (fn [n] (= :no-generation? n)) f)
+        "describe-image MUST surface a :no-generation? graceful result for an imageless frame (it runs no composed image — not a read error).")
+    (is (calls? f 'throw)
+        "describe-image MUST re-`throw` any non-no-generation error so a genuinely unresolvable :frame target still fails loud up the eval boundary.")))
+
+;; ---------------------------------------------------------------------------
 ;; No internal-namespace leakage (EP-0023 forbids tools consuming these).
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/describe_image_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/describe_image_test.cljs
@@ -156,6 +156,38 @@
                        "each selected (kind, id) carries its provenance coordinate"))
                  (done))))))
 
+(def ^:private no-generation-summary
+  ;; A frame configured with NO :images runs no composed image (EP-0024 — the
+  ;; no-generation contract). The runtime's describe-image guards the
+  ;; rf/frame-generation fail-loud for that case and returns this graceful
+  ;; summary instead of letting the read throw. It must ride through the wire
+  ;; as a successful, empty-image envelope (NOT a degraded error).
+  {:ok?            true
+   :frame          :main
+   :images         []
+   :kinds          []
+   :requires       []
+   :counts         {}
+   :no-generation? true})
+
+(deftest no-generation-frame-rides-through-as-ok
+  (async done
+    (stub-eval! nil no-generation-summary)
+    (-> (di/describe-image-tool (fresh-conn) (args-js {:frame ":main"}))
+        (.then (fn [r]
+                 (is (not (err? r))
+                     "an imageless frame is not a read error — it runs no image")
+                 (let [edn (read-result-text r)]
+                   (is (true? (:ok? edn)))
+                   (is (= :main (:frame edn)))
+                   (is (true? (:no-generation? edn))
+                       "the no-generation? flag tells the agent the frame runs no composed image")
+                   (is (= [] (:images edn)) "no images on an imageless frame")
+                   (is (= [] (:kinds edn)))
+                   (is (= [] (:requires edn)))
+                   (is (= {} (:counts edn))))
+                 (done))))))
+
 (deftest ambiguous-frame-rides-through-as-error
   (async done
     ;; The runtime returns the :ambiguous-frame refusal (a map with :ok?


### PR DESCRIPTION
## What

Post-EP-0024 (#4622), only an EXPLICIT `:images` key triggers image resolution, so a frame configured with NO `:images` carries no resolved generation and the public `rf/frame-generation` read FAILS LOUD (`:rf.error/frame-no-generation`) for it — the intended no-generation contract. The pair-MCP runtime `describe-image` called `frame-generation` UNGUARDED, so it threw for an imageless frame.

## Fix

Guard the `rf/frame-generation` call inside the runtime `describe-image`:

- **Imageless LIVE frame** → return a graceful `{:ok? true :images [] :kinds [] :requires [] :counts {} :no-generation? true}` instead of letting the fail-loud escape up the eval boundary. An imageless frame runs no composed image — that is not a read error.
- **Image-backed frame** → still projects the full generation (images / kinds / requires / counts / registrations) unchanged.
- **`:frame` target naming NO live frame** → still FAILS LOUD (re-throws). The discriminator is the error's `:live-frame-ids`: a frame-id present in that list is a live imageless frame (graceful); otherwise it is a genuinely unresolvable target (fail-loud preserved, the facade's no-silent-fallback contract).

## Changes

- `skills/re-frame2-pair/preload/.../runtime.cljs` — wrap the `frame-generation` read in `try`; discriminate `:rf.error/frame-no-generation` + `:live-frame-ids`; add the `:no-generation?` graceful branch. Still calls `rf/frame-generation` and reads `:rf.gen/resolver` / `:rf.gen/requires` on the image-backed path.
- `skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj` — structural pin (`describe-image-guards-no-generation-fail-loud`) locking the guard: try/catch + the `frame-no-generation` discriminator + `:live-frame-ids` check + the `:no-generation?` graceful shape + the re-throw.
- `tools/re-frame2-pair-mcp/test/.../describe_image_test.cljs` — wire test (`no-generation-frame-rides-through-as-ok`) confirming a `:no-generation?` summary rides through the MCP wire as `:ok? true`, not a degraded error.

## Gates

- Skill structural test (bb `frame_registrar_test.clj`): 9 tests / 30 assertions, 0 failures.
- Pair-mcp CLJS suite (`npm test`): 1114 tests / 3704 assertions, 0 failures.
- `check_skill_pair_authoring_drift.py --ci`, `check_skill_mcp_drift.py --ci`, and `re-frame.api-manifest.skills-check`: all green.
- Behavioural SCI reproduction of the `describe-image` path: imageless → graceful (no throw), image-backed → projects the generation, ghost frame → fails loud.

Scope: pair-MCP / pair-skill preload only — no `implementation/core/`, `core.cljc`, `spec/API.md`, or `api-manifest*` touched. No `rf2-` ids in skill prose.