### PR TITLE
migrate(pair-mcp): drop {:realm} registrar-query eval-form, use internal seam (rf2-fhz1h8)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3158,9 +3158,13 @@ installation's registrar — it is **not a public address**. **Omit it for the
 default container** — the overwhelming single-realm common case, where the
 response is byte-identical (no `:realm` key, no behaviour change; absence =
 the default container). When supplied, the lookup routes through the
-**map-shaped** form `(re-frame.core/handler-meta {:realm r :kind k :id id})`
-and reads **only that container's** registrar; the resolved container is
-stamped onto the response as `:realm`. `realm` is **not valid with
+**internal generation-bypass seam** `(re-frame.realm/realm-handler-meta r kind
+id)` and reads **only that container's** registrar; the resolved container is
+stamped onto the response as `:realm`. rf2-10nggz REMOVED the public `:realm`
+registrar-query map arity from the facade (a registrar-query map is now ALWAYS
+frame-targeted); the honestly-named `re-frame.realm/realm-*` readers survive as
+the internal/tooling seam (the same host-registry seam Xray reads). `realm` is
+**not valid with
 `kind=machine`** (machine specs derive from the default container's `:event`
 handlers) — that combination returns
 `{:ok? false :reason :realm-unsupported-for-machine …}` rather than silently
@@ -3185,10 +3189,11 @@ consumes the **public** facade read `(re-frame.core/handler-meta {:frame f
 ```
 
 `frame` and `realm` are **distinct address families** (EP-0023 §Id Spaces):
-`realm` reads an installation container's flat registrar atom, `frame`
-resolves through a live frame's sealed generation. Passing **both** is
-rejected — `{:ok? false :reason :frame-realm-mixed-address …}` — the same
-fail-loud the facade enforces, surfaced before the eval round-trip. `frame`
+`realm` reads an installation container's flat registrar atom (via the internal
+`re-frame.realm/realm-*` seam), `frame` resolves through a live frame's sealed
+generation. Passing **both** is rejected by a tool-local guard —
+`{:ok? false :reason :frame-and-realm-mutually-exclusive …}` — two different
+reads, only one can apply, surfaced before the eval round-trip. `frame`
 is **not valid with `kind=machine`** (machines are not in the image
 generation resolver — they derive from `:event` handlers; Spec 005), and
 that combination returns `{:ok? false :reason :frame-unsupported-for-machine
@@ -3252,7 +3257,7 @@ On a miss:
 - `{:ok? false :reason :invalid-id-edn :id <raw> :hint "..."}` — `id` failed `cljs.reader/read-string`.
 - `{:ok? false :reason :invalid-realm-edn :realm <raw> :hint "..."}` — non-blank `realm` failed to read as EDN.
 - `{:ok? false :reason :realm-unsupported-for-machine :realm <r> :kind :machine :hint "..."}` — `realm` given with `kind=machine`.
-- `{:ok? false :reason :frame-realm-mixed-address :frame <f> :realm <r> :hint "..."}` — both `frame` and `realm` supplied (distinct address families, EP-0023 §Id Spaces).
+- `{:ok? false :reason :frame-and-realm-mutually-exclusive :frame <f> :realm <r> :hint "..."}` — both `frame` and `realm` supplied (distinct address families, EP-0023 §Id Spaces).
 - `{:ok? false :reason :frame-unsupported-for-machine :frame <f> :kind :machine :hint "..."}` — `frame` given with `kind=machine` (machines are not in the image generation resolver).
 - `{:ok? false :reason :handler-meta-failed :message "..."}` — runtime threw (including the facade's `:rf.error/frame-no-generation` when `frame` names no live frame carrying a generation).
 
@@ -3288,7 +3293,7 @@ running image generation carries** for the kind — routing through
 the public `(re-frame.core/handler-ids {:frame f :kind k})` read (rf2-wkw8na).
 This is the **selected universe** that frame actually runs, not the
 realm-wide namespace-union the flat registrar holds. `frame` and `realm` are
-mutually exclusive (`:frame-realm-mixed-address`); `frame` is not valid with
+mutually exclusive (`:frame-and-realm-mutually-exclusive`); `frame` is not valid with
 `kind=machine` (`:frame-unsupported-for-machine`). The resolved frame is
 stamped onto the response as `:frame`. Omit it for the default-registrar path.
 
@@ -3296,9 +3301,9 @@ stamped onto the response as `:frame`. Omit it for the default-registrar path.
 contract as `handler-meta`. The optional `realm` arg names an internal
 installation container (not a public address); omit it for the default
 container (byte-identical). When supplied, the enumeration routes through the
-map-shaped `(re-frame.core/registrations {:realm r :kind k})` form and lists
-**only that container's** ids, stamping `:realm` on the response. Not valid
-with `kind=machine`.
+internal generation-bypass seam `(re-frame.realm/realm-registrations r kind)`
+and lists **only that container's** ids, stamping `:realm` on the response. Not
+valid with `kind=machine`.
 
 **Supported kinds**: same closed v1 registrar set as `handler-meta`
 (including the resources-artefact `:resource` / `:mutation` /
@@ -3335,7 +3340,7 @@ empty case.
 - `{:ok? false :reason :invalid-kind :kind <raw> :hint "..."}` — unrecognised / missing `kind` arg.
 - `{:ok? false :reason :invalid-realm-edn :realm <raw> :hint "..."}` — non-blank `realm` failed to read as EDN.
 - `{:ok? false :reason :realm-unsupported-for-machine :realm <r> :kind :machine :hint "..."}` — `realm` given with `kind=machine`.
-- `{:ok? false :reason :frame-realm-mixed-address :frame <f> :realm <r> :hint "..."}` — both `frame` and `realm` supplied.
+- `{:ok? false :reason :frame-and-realm-mutually-exclusive :frame <f> :realm <r> :hint "..."}` — both `frame` and `realm` supplied.
 - `{:ok? false :reason :frame-unsupported-for-machine :frame <f> :kind :machine :hint "..."}` — `frame` given with `kind=machine`.
 - `{:ok? false :reason :list-handlers-failed :message "..."}` — runtime threw (including `:rf.error/frame-no-generation`).
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -1717,8 +1717,8 @@
                                                         "naming WHICH source won. Omit for the default "
                                                         "registrar (byte-identical). Distinct from "
                                                         ":realm — passing both is rejected "
-                                                        "(:frame-realm-mixed-address). Not valid with "
-                                                        "kind=machine.")}
+                                                        "(:frame-and-realm-mutually-exclusive). Not valid "
+                                                        "with kind=machine.")}
                               :realm {:type "string"
                                       :description (str "OPTIONAL internal installation-container id "
                                                         "keyword, e.g. \":shop/realm\". This is the "
@@ -1729,9 +1729,10 @@
                                                         "installation's registrar. Omit for the default "
                                                         "container (the common single-realm case — byte-"
                                                         "identical). When given, reads ONLY that "
-                                                        "container's registrar via the map-shaped "
-                                                        "(rf/handler-meta {:realm r :kind k :id id}) "
-                                                        "form. Not valid with kind=machine.")}
+                                                        "container's registrar via the internal "
+                                                        "generation-bypass seam "
+                                                        "(re-frame.realm/realm-handler-meta r kind id). "
+                                                        "Not valid with kind=machine.")}
                               :build {:type "string"}}
                  :required ["kind" "id"]
                  :additionalProperties false}})
@@ -1792,8 +1793,8 @@
                                                         "namespace-union the flat registrar holds. Omit "
                                                         "for the default registrar (byte-identical). "
                                                         "Distinct from :realm — passing both is rejected "
-                                                        "(:frame-realm-mixed-address). Not valid with "
-                                                        "kind=machine.")}
+                                                        "(:frame-and-realm-mutually-exclusive). Not valid "
+                                                        "with kind=machine.")}
                               :realm {:type "string"
                                       :description (str "OPTIONAL internal installation-container id "
                                                         "keyword, e.g. \":shop/realm\". This is the "
@@ -1804,8 +1805,9 @@
                                                         "installation's registrar. Omit for the default "
                                                         "container (the common single-realm case — byte-"
                                                         "identical). When given, enumerates ONLY that "
-                                                        "container's registrar via the map-shaped "
-                                                        "(rf/registrations {:realm r :kind k}) form. "
+                                                        "container's registrar via the internal "
+                                                        "generation-bypass seam "
+                                                        "(re-frame.realm/realm-registrations r kind). "
                                                         "Not valid with kind=machine.")}
                               :build {:type "string"}}
                  :required ["kind"]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -21,10 +21,14 @@
   ABSENT (the overwhelming common case) the tools resolve through the
   default registrar exactly as before — byte-identical (absence = the
   default container, the documented default-resolution rule). When PRESENT,
-  the eval form routes through the MAP-SHAPED realm-targeted query forms
-  (retained from EP-0013) — `(rf/handler-meta {:realm r :kind k :id id})` /
-  `(rf/registrations {:realm r :kind k})` — so the tool reads ONLY that
-  container's registrar. It's additive and degrades to the default path.
+  the eval form routes through the INTERNAL generation-bypass seam
+  `(re-frame.realm/realm-handler-meta r kind id)` /
+  `(re-frame.realm/realm-registrations r kind)` — so the tool reads ONLY that
+  container's registrar. rf2-10nggz REMOVED the public `:realm` registrar-query
+  map arity from the facade (a registrar-query map is now ALWAYS frame-targeted);
+  the honestly-named `re-frame.realm/realm-*` readers survive as the
+  internal/tooling seam (the same host-registry seam Xray reads). It's additive
+  and degrades to the default path.
 
   ## Frame-targeting — the EP-0023 forward direction (rf2-srobm0)
 
@@ -43,11 +47,12 @@
   WHICH source won) the realm/default reads can't.
 
   `:frame` and `:realm` are DISTINCT ADDRESS FAMILIES (EP-0023 §Id Spaces):
-  `:realm` reads an installation container's flat registrar atom; `:frame`
-  resolves through a live frame's sealed generation. Passing BOTH is rejected
-  (`:frame-realm-mixed-address`) — the same fail-loud the facade enforces,
-  surfaced before the eval round-trip. `list-subscriptions` is the per-frame
-  exemplar these now mirror.
+  `:realm` reads an installation container's flat registrar atom (the internal
+  `re-frame.realm/realm-*` seam); `:frame` resolves through a live frame's sealed
+  generation. Passing BOTH is rejected by a tool-local guard
+  (`:frame-and-realm-mutually-exclusive`), surfaced before the eval round-trip —
+  the two are different reads and only one can apply. `list-subscriptions` is the
+  per-frame exemplar these now mirror.
 
   ## handler-meta
 
@@ -268,13 +273,15 @@
   the `:rf.image/coordinate` rollup. Same `:not-registered` / `handler-fn`
   hygiene as `registrar-describe`.
 
-  EXPLICIT internal container (`realm` set): route through the map-shaped form
-  `(re-frame.core/handler-meta {:realm r :kind k :id id})` so the read hits
-  ONLY that installation container's registrar. Wrap the result to match
-  `registrar-describe`'s shape — drop the unserialisable `:handler-fn`
-  Function ref (rf2-l7vnd) and emit the `{:ok? false :reason
-  :not-registered …}` envelope on a miss — so the tool's response is
-  uniform across the default, frame-, and realm-targeted paths."
+  EXPLICIT internal container (`realm` set): route through the INTERNAL
+  generation-bypass seam `(re-frame.realm/realm-handler-meta r kind id)` so the
+  read hits ONLY that installation container's registrar. rf2-10nggz REMOVED the
+  public `:realm` registrar-query map arity from the facade; the honestly-named
+  `re-frame.realm/realm-*` readers survive as the internal/tooling seam (the same
+  host-registry seam Xray reads). Wrap the result to match `registrar-describe`'s
+  shape — drop the unserialisable `:handler-fn` Function ref (rf2-l7vnd) and emit
+  the `{:ok? false :reason :not-registered …}` envelope on a miss — so the tool's
+  response is uniform across the default, frame-, and realm-targeted paths."
   [realm frame kind id]
   (cond
     (some? frame)
@@ -284,8 +291,8 @@
     (ef/emit (ef/rt-call 'registrar-describe kind id))
 
     :else
-    (let [q (ef/emit (ef/rt-call* 're-frame.core/handler-meta
-                                  {:realm realm :kind kind :id id}))]
+    (let [q (ef/emit (ef/rt-call* 're-frame.realm/realm-handler-meta
+                                  realm kind id))]
       (str "(if-let [m " q "] (dissoc m :handler-fn) "
            "{:ok? false :reason :not-registered :kind " (pr-str kind)
            " :id " (pr-str id) "})"))))
@@ -344,12 +351,13 @@
                         :hint   "realm must be an EDN-readable keyword, e.g. \":shop/realm\"."}))
 
       ;; rf2-srobm0 — :frame + :realm are DISTINCT address families (EP-0023
-      ;; §Id Spaces); the facade fails loud on a mix. Reject here before the
-      ;; eval round-trip rather than ship a form the runtime will throw on.
+      ;; §Id Spaces): two different reads, only one can apply. Reject here before
+      ;; the eval round-trip — they target distinct code paths (a live frame's
+      ;; image generation vs. an installation container's registrar).
       (and (some? frame-val) (some? realm-val))
       (js/Promise.resolve
         (wire/err-text {:ok?    false
-                        :reason :frame-realm-mixed-address
+                        :reason :frame-and-realm-mutually-exclusive
                         :frame  frame-val
                         :realm  realm-val
                         :hint   (str ":frame and :realm are distinct address families "
@@ -462,19 +470,22 @@
   `(rf/handler-ids {:frame f :kind k})` read). `:machine` is rejected before
   reaching here when a frame is supplied (machines are not in the resolver).
 
-  EXPLICIT internal container (`realm` set): route through the map-shaped form
-  `(re-frame.core/registrations {:realm r :kind k})` and lift the sorted
-  id vector off it, so the enumeration covers ONLY that installation
-  container's registrar. `:machine` is rejected before reaching here when a
-  realm is supplied (machines derive from the default container)."
+  EXPLICIT internal container (`realm` set): route through the INTERNAL
+  generation-bypass seam `(re-frame.realm/realm-registrations r kind)` and lift
+  the sorted id vector off it, so the enumeration covers ONLY that installation
+  container's registrar. rf2-10nggz REMOVED the public `:realm` registrar-query
+  map arity from the facade; the honestly-named `re-frame.realm/realm-*` readers
+  survive as the internal/tooling seam (the same host-registry seam Xray reads).
+  `:machine` is rejected before reaching here when a realm is supplied (machines
+  derive from the default container)."
   [realm frame kind]
   (cond
     (= :machine kind) "(vec (sort (re-frame.core/machines)))"
     (some? frame)     (ef/emit (ef/rt-call 'frame-registrar-list frame kind))
     (nil? realm)      (ef/emit (ef/rt-call 'registrar-list kind))
     :else             (str "(->> "
-                           (ef/emit (ef/rt-call* 're-frame.core/registrations
-                                                 {:realm realm :kind kind}))
+                           (ef/emit (ef/rt-call* 're-frame.realm/realm-registrations
+                                                 realm kind))
                            " keys sort vec)")))
 
 (defn list-handlers-tool [conn args]
@@ -501,11 +512,11 @@
                         :hint   "realm must be an EDN-readable keyword, e.g. \":shop/realm\"."}))
 
       ;; rf2-srobm0 — :frame + :realm are distinct address families; reject
-      ;; the mix before the eval round-trip (the facade fails loud too).
+      ;; the mix before the eval round-trip (two different reads, only one applies).
       (and (some? frame-val) (some? realm-val))
       (js/Promise.resolve
         (wire/err-text {:ok?    false
-                        :reason :frame-realm-mixed-address
+                        :reason :frame-and-realm-mutually-exclusive
                         :frame  frame-val
                         :realm  realm-val
                         :hint   (str ":frame and :realm are distinct address families "

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -357,10 +357,13 @@
 ;; registrar queries retained as tooling surface, labeled as such).
 ;;
 ;; The OPTIONAL `:realm` arg names an INTERNAL installation container (not a
-;; public address) and threads its id into the map-shaped query forms
-;; `(rf/handler-meta {:realm r :kind k :id id})` / `(rf/registrations
-;; {:realm r :kind k})`. ABSENT ⇒ the byte-identical default-container path
-;; (no `:realm` key on the response).
+;; public address) and threads its id into the INTERNAL generation-bypass seam
+;; `(re-frame.realm/realm-handler-meta r kind id)` /
+;; `(re-frame.realm/realm-registrations r kind)` — rf2-10nggz removed the public
+;; `:realm` registrar-query map arity from the facade; the honestly-named
+;; `re-frame.realm/realm-*` readers are the surviving internal/tooling seam.
+;; ABSENT ⇒ the byte-identical default-container path (no `:realm` key on the
+;; response).
 ;; ---------------------------------------------------------------------------
 
 (defn- with-form-capture!
@@ -402,8 +405,8 @@
                              (done))))))
             (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
 
-(deftest handler-meta-explicit-realm-uses-map-shaped-core-form
-  (testing "an explicit :realm ⇒ the form uses the public (rf/handler-meta {:realm … :kind … :id …}) form and stamps :realm"
+(deftest handler-meta-explicit-realm-uses-internal-seam-form
+  (testing "an explicit :realm ⇒ the form uses the internal (re-frame.realm/realm-handler-meta r kind id) seam and stamps :realm"
     (async done
       (let [form (atom nil)
             canned {:ns 'app.x :line 1 :handler-fn-hash 7}]
@@ -414,10 +417,12 @@
                                                         :realm ":shop/realm"}))
                     (.then (fn [result]
                              (let [edn (extract-edn result)]
-                               (is (str/includes? @form "re-frame.core/handler-meta")
-                                   "realm path routes through the public core map-shaped form")
-                               (is (str/includes? @form ":realm :shop/realm")
-                                   "the realm-id is threaded into the query map")
+                               (is (str/includes? @form "re-frame.realm/realm-handler-meta")
+                                   "realm path routes through the internal generation-bypass seam")
+                               (is (not (str/includes? @form "re-frame.core/handler-meta"))
+                                   "the removed public {:realm …} facade arity is no longer emitted")
+                               (is (str/includes? @form ":shop/realm")
+                                   "the realm-id is threaded as a positional arg")
                                (is (true? (:ok? edn)))
                                (is (= :shop/realm (:realm edn))
                                    "the resolved realm is stamped on the response"))
@@ -449,8 +454,8 @@
                      (is (= :invalid-realm-edn (:reason edn))))
                    (done)))))))
 
-(deftest list-handlers-explicit-realm-uses-map-shaped-core-form
-  (testing "list-handlers with :realm ⇒ (rf/registrations {:realm … :kind …}) form and stamps :realm"
+(deftest list-handlers-explicit-realm-uses-internal-seam-form
+  (testing "list-handlers with :realm ⇒ (re-frame.realm/realm-registrations r kind) internal seam and stamps :realm"
     (async done
       (let [form (atom nil)]
         (-> (with-form-capture! form [:a :b]
@@ -458,9 +463,11 @@
                 (-> (hm/list-handlers-tool nil (args-js {:kind "event" :realm ":shop/realm"}))
                     (.then (fn [result]
                              (let [edn (extract-edn result)]
-                               (is (str/includes? @form "re-frame.core/registrations")
-                                   "realm path routes through the public core map-shaped form")
-                               (is (str/includes? @form ":realm :shop/realm"))
+                               (is (str/includes? @form "re-frame.realm/realm-registrations")
+                                   "realm path routes through the internal generation-bypass seam")
+                               (is (not (str/includes? @form "re-frame.core/registrations"))
+                                   "the removed public {:realm …} facade arity is no longer emitted")
+                               (is (str/includes? @form ":shop/realm"))
                                (is (true? (:ok? edn)))
                                (is (= :shop/realm (:realm edn))))
                              (done))))))
@@ -743,7 +750,7 @@
             (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
 
 (deftest handler-meta-rejects-frame-plus-realm
-  (testing ":frame + :realm ⇒ structured :frame-realm-mixed-address (distinct address families)"
+  (testing ":frame + :realm ⇒ structured :frame-and-realm-mutually-exclusive (distinct address families)"
     (async done
       (-> (hm/handler-meta-tool nil (args-js {:kind  "event"
                                               :id    ":counter/inc"
@@ -752,7 +759,7 @@
           (.then (fn [result]
                    (is (is-error? result))
                    (let [edn (extract-edn result)]
-                     (is (= :frame-realm-mixed-address (:reason edn)))
+                     (is (= :frame-and-realm-mutually-exclusive (:reason edn)))
                      (is (= :blue/main (:frame edn)))
                      (is (= :shop/realm (:realm edn))))
                    (done)))))))
@@ -789,7 +796,7 @@
             (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
 
 (deftest list-handlers-rejects-frame-plus-realm
-  (testing "list-handlers :frame + :realm ⇒ :frame-realm-mixed-address"
+  (testing "list-handlers :frame + :realm ⇒ :frame-and-realm-mutually-exclusive"
     (async done
       (-> (hm/list-handlers-tool nil (args-js {:kind  "event"
                                                :frame ":blue/main"
@@ -797,7 +804,7 @@
           (.then (fn [result]
                    (is (is-error? result))
                    (let [edn (extract-edn result)]
-                     (is (= :frame-realm-mixed-address (:reason edn))))
+                     (is (= :frame-and-realm-mutually-exclusive (:reason edn))))
                    (done)))))))
 
 (deftest list-handlers-rejects-frame-with-machine


### PR DESCRIPTION
## What

PR #4624 dropped the public `:realm` map-arity from the `re-frame.core` registrar-query trio (`registrations` / `handler-meta` / `handler-ids`). A registrar-query map is now **always frame-targeted**; a map without `:frame` throws `:rf.error/registrar-query-needs-frame`, and `:rf.error/frame-realm-mixed-address` no longer exists.

`tools/re-frame2-pair-mcp`'s `handler-meta` / `list-handlers` still **emitted** the removed runtime eval forms for their explicit-realm path:
- `(re-frame.core/handler-meta {:realm r :kind k :id id})`
- `(re-frame.core/registrations {:realm r :kind k})`

…plus referenced the retired `:frame-realm-mixed-address` structured reason. Both now break against any inspected app on current `main`.

## Change

- **Repoint the realm-targeted path to the internal generation-bypass seam** — `(re-frame.realm/realm-handler-meta r kind id)` / `(re-frame.realm/realm-registrations r kind)` (positional args), the same honestly-named internal reader Xray's `host-registry` uses. This is the seam EP-0023 / #4624 retained for tooling that requires the namespace directly.
- The `{:frame f}` public arity (frame-targeted reads) is **unchanged** — it is the now-canonical map shape.
- **Retire `:frame-realm-mixed-address`.** The tool-local mutual-exclusion guard (rejecting both `:frame` and `:realm` in one call before the eval round-trip) now reports `:frame-and-realm-mutually-exclusive` — two distinct reads, only one can apply.
- Updated `spec/003-Tool-Catalogue.md`, `descriptors_data.cljs` arg descriptions, and `handler_meta_test.cljs` form-capture + reason assertions to match.

## Scope

Edits confined to `tools/re-frame2-pair-mcp/**` (4 files). No touch to `implementation/core/`, `core.cljc`, `spec/API.md`, or `spec/api-manifest*` (the dzxixe lane owns `core.cljc` concurrently). The shared pair-skill preload (`skills/re-frame2-pair/preload/.../runtime.cljs`) needed no change — it only emits the still-valid positional and `{:frame …}` map forms, never the removed `{:realm …}` arity.

## Gates

- `npm test` (pair-mcp suite incl. conformance): **1114 tests / 3706 assertions, 0 failures, 0 errors**
- `npm run check:descriptors`: **in sync (30 tools)**
- Reproduced the previously-broken path via the form-capture tests: the emitted realm form now contains `re-frame.realm/realm-handler-meta` / `realm-registrations` and **no longer** `re-frame.core/handler-meta {:realm …}` / `registrations {:realm …}`, so it no longer throws against current `main`.