### PR TITLE
chore(ci): public-facade manifest-hygiene guardrail (rf2-gqa7yv)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -332,6 +332,20 @@ jobs:
         working-directory: implementation/scripts/api-manifest
         run: clojure -M -m re-frame.api-manifest.api-md-check
 
+      # Public-facade manifest-hygiene gate (rf2-gqa7yv — the enforcement half
+      # of the rf2-ebbpia pre-alpha facade-REMOVAL discipline). FAILS if any
+      # `:facade? true` manifest row names a re-frame.core export whose
+      # EP-0013 -> EP-0023 disposition (re-frame.migration/migration-map)
+      # marks it superseded / retained-for-compat. A superseded export must
+      # become INTERNAL (its home namespace, :facade? false) or be REMOVED
+      # outright; there is no retained-for-migration facade tier. The manifest-
+      # data counterpart to the doc-surface retired-vocab grep
+      # (scripts/check_retired_composition_vocab.py) — complementary, not
+      # duplicative.
+      - name: Assert public-facade manifest hygiene (no superseded facade exports)
+        working-directory: implementation/scripts/api-manifest
+        run: clojure -M -m re-frame.api-manifest.facade-hygiene-check
+
       # Secondary projection drift-checks (rf2-gkp0t). Each validates a
       # surface's public-var references against the same manifest the way
       # api-md-check validates spec/API.md: Story API spec, Xray API spec

--- a/implementation/scripts/api-manifest/facade-hygiene-allowlist.edn
+++ b/implementation/scripts/api-manifest/facade-hygiene-allowlist.edn
@@ -1,0 +1,47 @@
+;; ===========================================================================
+;; Public-facade manifest-hygiene allowlist (rf2-gqa7yv)
+;; ===========================================================================
+;;
+;; The enforcement-allowlist for the facade-hygiene gate
+;; (re-frame.api-manifest.facade-hygiene-check). The gate FAILS when a
+;; `:facade? true` row in spec/api-manifest.edn names a re-frame.core facade
+;; export whose EP-0013 -> EP-0023 disposition (re-frame.migration/migration-map)
+;; marks it superseded / retained-for-compat (`:publicly-replaced`,
+;; `:re-expressed`, `:retained-internal`, or any future removed/superseded
+;; marker). That is the codified pre-alpha REMOVAL discipline (rf2-ebbpia):
+;; a superseded or accidental facade export has exactly TWO fates — it either
+;; becomes internal (its own namespace, off the facade / off the `:facade? true`
+;; manifest row) or it is REMOVED OUTRIGHT. There is no retained-for-migration
+;; facade tier; the deprecated tier stays empty in pre-alpha.
+;;
+;; Because a correctly-resolved disposition produces NO `:facade? true` row
+;; (the export has left re-frame.core), this allowlist is EXPECTED TO BE EMPTY.
+;; It exists only for transitional / edge cases. The three legitimate exception
+;; classes per rf2-ebbpia do NOT, in normal operation, produce an entry here:
+;;
+;;   (i)   Historical-doc prose mentions — handled by the doc-surface grep
+;;         (scripts/check_retired_composition_vocab.py), not the manifest gate.
+;;   (ii)  `^:no-doc` throwing removed-name stubs — the generator drops
+;;         `^:no-doc` vars, so they carry NO manifest row and are excluded by
+;;         construction.
+;;   (iii) Genuinely-internal-but-public substrate that correctly LEFT the
+;;         facade — it lives in its home namespace at tier :implementation /
+;;         :internal-public with `:facade? false`, so it is not a
+;;         `:facade? true` row.
+;;
+;; SHAPE: a vector of entry maps. Each entry MUST be self-documenting.
+;;   {:var       "<bare facade var name>"   ; the re-frame.core export name
+;;    :status    <superseded-status-kw>     ; the disposition it is exempted for
+;;    :reason    "<one line tying the exemption to a bead / finding>"}
+;;
+;; The gate matches an allowlist entry to a violation by (`:var`, `:status`).
+;; An entry whose (var, status) the gate never hits is reported as STALE — a
+;; cleared transitional exception must be removed, so the allowlist does not
+;; silently rot into a permanent escape hatch.
+;;
+;; To ADD an entry: it must name a real transitional case and tie it to an
+;; open bead / finding. To REMOVE the underlying violation instead (the
+;; preferred path under the removal discipline): demote the export to its home
+;; namespace (`:facade? false`) or delete it outright, regenerate the manifest,
+;; and the gate goes green with no allowlist entry.
+[]

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/facade_hygiene_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/facade_hygiene_check.clj
@@ -1,0 +1,230 @@
+(ns re-frame.api-manifest.facade-hygiene-check
+  "Public-facade manifest-hygiene gate (rf2-gqa7yv — the enforcement half of
+  the rf2-ebbpia pre-alpha facade-REMOVAL discipline).
+
+  THE INVARIANT. NO `:facade? true` row in spec/api-manifest.edn may name a
+  re-frame.core facade export whose EP-0013 -> EP-0023 disposition marks it
+  SUPERSEDED / retained-for-compat. The ADD side of the facade is already
+  governed (spec/Conventions.md §Facade policy: diff-time classify-and-justify,
+  backed by the api-manifest drift-check). This is the missing SYMMETRIC
+  removal rule — the gate that catches a superseded export that STAYS
+  `:facade? true` instead of being demoted to its home namespace or removed.
+
+  THE RULE IT ENFORCES (rf2-ebbpia, Mike-ruled 2026-06-18). A superseded or
+  accidental public facade export has exactly TWO fates, never three: it
+  either (a) becomes INTERNAL (its own namespace, tier :implementation /
+  :internal-public, LEAVING the facade and the `:facade? true` manifest row),
+  or (b) is REMOVED OUTRIGHT. There is no retained-for-migration facade tier;
+  the deprecated tier stays empty in pre-alpha. Migration data/diagnostics, if
+  retained, live behind re-frame.migration (its own ns), NEVER re-exported
+  from re-frame.core. A correctly-resolved disposition therefore produces NO
+  `:facade? true` row — so the gate is GREEN on a clean tree, and the allowlist
+  (facade-hygiene-allowlist.edn) is expected to be near-empty.
+
+  THE JOIN. The disposition data already exists as INSPECTABLE DATA in
+  `re-frame.migration/migration-map` ({surface-kw {:status … :replacement …
+  :guidance …}}), the EP-0013 -> EP-0023 surface dispositions. We load it on
+  the JVM (the api-manifest classpath carries day8/re-frame2) rather than
+  copying it, so the gate tracks the live source. Each migration-map entry
+  whose KEY is `:rf`-namespaced (`:rf/app`, `:rf/install!`, …) names a facade
+  export by its keyword's NAME (`:rf/install!` -> the `install!` export). For
+  each such entry whose `:status` is in the superseded set, we FAIL if a
+  `:facade? true` manifest row carries that bare var name (unless the
+  (var, status) pair is on the checked-in allowlist). Entries keyed in OTHER
+  namespaces (`:rf.realm/frame-address`, `:rf.realm/scoped-query`) name
+  conceptual surfaces, not a single facade var, so they contribute no
+  candidate.
+
+  WHY THIS GENERALISES pl97nd.5. The narrow EP-0023 retired-vocab grep
+  (scripts/check_retired_composition_vocab.py) is a DOC-SURFACE gate: it scans
+  markdown fenced code for a retired spelling reappearing as live,
+  copy-pasteable teaching API. This gate is the MANIFEST-DATA counterpart: it
+  joins the same dispositions against the generated manifest to catch a
+  superseded export staying on the facade. The two are COMPLEMENTARY (different
+  surfaces — teaching prose vs. the manifest), not duplicative; the grep keeps
+  the doc teaching surface clean, this keeps the facade-export set clean. Both
+  are driven from the same EP-0013 -> EP-0023 retirement; neither subsumes the
+  other.
+
+  Invoked exactly like the sibling checks (gen --check, api-md-check):
+    clojure -M -m re-frame.api-manifest.facade-hygiene-check  ; (from this dir)"
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [re-frame.api-manifest.gen :as gen]))
+
+(def superseded-statuses
+  "The disposition `:status` values that mark a facade export as superseded /
+   retained-for-compat — the statuses that MUST NOT coexist with a
+   `:facade? true` manifest row. `:publicly-replaced` (the public name moved
+   to the EP-0023 replacement), `:re-expressed` (the concept survives under
+   image vocabulary), `:retained-internal` (kept as an implementation /
+   migration / tooling surface, NOT the taught public vocabulary). A future
+   per-EP disposition table may add `:removed` / `:superseded` markers; they
+   belong here too, which is why the gate reads this set rather than the three
+   literals inline."
+  #{:publicly-replaced :re-expressed :retained-internal :removed :superseded})
+
+(def ^:private migration-map-sym
+  "The inspectable disposition data the gate joins against. Resolved at
+   runtime so the gate tracks the LIVE source (re-frame.migration is on the
+   api-manifest classpath via day8/re-frame2) rather than copying it."
+  're-frame.migration/migration-map)
+
+(def ^:private allowlist-file
+  (delay (io/file (System/getProperty "user.dir") "facade-hygiene-allowlist.edn")))
+
+(def ^:private min-dispositions
+  "Non-vacuous floor for the joined disposition source (rf2-utvst class). The
+   live migration-map carries 8 entries (6 of them `:rf`-namespaced facade
+   names). If the join recovers ZERO superseded `:rf`-named dispositions the
+   gate would report a vacuous OK no matter how many superseded exports sit on
+   the facade — a migration-map ns rename / shape change / require failure
+   would silently disarm the gate. This floor (set below the live count) trips
+   only on a near-total collapse, never on ordinary migration-map churn."
+  1)
+
+;; ---------------------------------------------------------------------------
+;; Pure pieces (unit-testable with synthetic inputs).
+;; ---------------------------------------------------------------------------
+
+(defn superseded-facade-names
+  "From a `migration-map` value, the `{facade-var-name -> status}` map of
+   facade exports a superseded disposition names. Only entries whose KEY is in
+   the `rf` namespace name a single facade var (the keyword's NAME is the
+   export name); a `:rf.realm/…`-keyed entry names a conceptual surface, not a
+   var, so it is skipped. Only `superseded` statuses contribute."
+  [migration-map superseded]
+  (reduce-kv
+    (fn [acc surface-kw {:keys [status]}]
+      (if (and (= "rf" (namespace surface-kw))
+               (contains? superseded status))
+        (assoc acc (name surface-kw) status)
+        acc))
+    {}
+    migration-map))
+
+(defn reconcile
+  "Pure reconciler. Returns `[problems stale-allowlist]`:
+
+   `problems`        — `{:var :status :namespace :tier}` for each `:facade? true`
+                       manifest row whose bare var name has a superseded
+                       disposition AND is NOT allowlisted (the gate FAILS).
+   `stale-allowlist` — allowlist `{:var :status}` entries that matched no
+                       violation (a cleared transitional exception that must be
+                       removed so the allowlist does not rot).
+
+   `rows`      — manifest `:vars` rows (each `{:namespace :var :facade? :tier …}`).
+   `name->status` — `{facade-var-name -> superseded-status}` from
+                    `superseded-facade-names`.
+   `allow`     — set of `[var status]` pairs from the checked-in allowlist."
+  [{:keys [rows name->status allow]}]
+  (let [facade-rows (filter :facade? rows)
+        problems    (keep
+                      (fn [{:keys [namespace var tier]}]
+                        (when-let [status (get name->status var)]
+                          (when-not (contains? allow [var status])
+                            {:var var :status status
+                             :namespace namespace :tier tier})))
+                      facade-rows)
+        ;; which (var, status) pairs the facade actually presents (allowlisted
+        ;; or not) — an allowlist entry naming a pair NOT present is stale.
+        present     (set (for [{:keys [var]} facade-rows
+                               :let [status (get name->status var)]
+                               :when status]
+                           [var status]))
+        stale       (filter #(not (contains? present (vec %))) allow)]
+    [(vec problems) (vec stale)]))
+
+(defn floor-violation?
+  "True when the joined superseded-disposition map recovered fewer than the
+   non-vacuous floor — the join collapsed (migration-map rename / shape change
+   / require failure) and an OK verdict would be vacuous."
+  [name->status]
+  (< (count name->status) min-dispositions))
+
+;; ---------------------------------------------------------------------------
+;; IO + entry point.
+;; ---------------------------------------------------------------------------
+
+(defn- read-allowlist
+  "The checked-in allowlist as a set of `[var status]` pairs. Each EDN entry
+   is `{:var <str> :status <kw> :reason <str>}`."
+  []
+  (let [f @allowlist-file]
+    (if (.exists ^java.io.File f)
+      (with-open [r (io/reader f)]
+        (->> (edn/read (java.io.PushbackReader. r))
+             (map (fn [{:keys [var status]}] [var status]))
+             set))
+      #{})))
+
+(defn- live-migration-map
+  "Resolve + deref the live disposition data, requiring its ns. Kept behind a
+   fn so a require/resolve failure surfaces as a loud error, not a silent nil
+   that would vacuum-green the gate."
+  []
+  (require (symbol (namespace migration-map-sym)))
+  (if-let [v (resolve migration-map-sym)]
+    @v
+    (throw (ex-info (str "facade-hygiene-check: " migration-map-sym
+                         " did not resolve — the disposition source moved or "
+                         "was renamed. The gate cannot run without it.")
+                    {:sym migration-map-sym}))))
+
+(defn check!
+  "Validate that no `:facade? true` manifest row names a superseded facade
+   export. Returns true (prints OK) when clean; false (prints a report) on any
+   violation, a stale allowlist entry, or a collapsed disposition join."
+  []
+  (let [rows         (:vars (gen/read-committed-manifest))
+        migration    (live-migration-map)
+        name->status (superseded-facade-names migration superseded-statuses)
+        allow        (read-allowlist)
+        [problems stale] (reconcile {:rows rows
+                                     :name->status name->status
+                                     :allow allow})]
+    (cond
+      (floor-violation? name->status)
+      (do (binding [*out* *err*]
+            (println (format (str "DRIFT: facade-hygiene disposition join collapsed — only %d "
+                                  "superseded `:rf`-named disposition(s) recovered from "
+                                  "re-frame.migration/migration-map, below the non-vacuous "
+                                  "floor of %d.")
+                             (count name->status) min-dispositions))
+            (println "  An OK verdict would be vacuous (the gate would pass no matter how")
+            (println "  many superseded exports sit on the facade). Likely a migration-map")
+            (println "  rename / shape change / require failure. Investigate before GREEN."))
+          false)
+
+      (or (seq problems) (seq stale))
+      (do (binding [*out* *err*]
+            (when (seq problems)
+              (println (str "DRIFT: spec/api-manifest.edn carries `:facade? true` row(s) for "
+                            "SUPERSEDED facade export(s)."))
+              (println "Per the pre-alpha facade-REMOVAL discipline (spec/Conventions.md")
+              (println "§Removing or demoting a facade export), a superseded export must either")
+              (println "become INTERNAL (its home namespace, tier :implementation /")
+              (println ":internal-public, :facade? false — off the facade) or be REMOVED")
+              (println "outright. There is no retained-for-migration facade tier. Demote or")
+              (println "remove the export + regenerate the manifest. Violations:")
+              (doseq [{:keys [var status namespace tier]} problems]
+                (println (format "  `%s` (ns %s, tier %s) — disposition %s but still :facade? true"
+                                 var namespace tier status))))
+            (when (seq stale)
+              (println "STALE allowlist: facade-hygiene-allowlist.edn names exemption(s) that")
+              (println "match no current violation — the transitional case has cleared. Remove")
+              (println "them so the allowlist does not rot into a permanent escape hatch:")
+              (doseq [[var status] stale]
+                (println (format "  `%s` (status %s)" var status)))))
+          false)
+
+      :else
+      (do (println (format (str "OK: facade-hygiene clean — %d superseded `:rf`-named "
+                                "disposition(s) joined against the manifest; no "
+                                "`:facade? true` row names a superseded export.")
+                           (count name->status)))
+          true))))
+
+(defn -main [& _]
+  (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/facade_hygiene_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/facade_hygiene_check_test.clj
@@ -1,0 +1,107 @@
+(ns re-frame.api-manifest.facade-hygiene-check-test
+  "Regression tests for the public-facade manifest-hygiene gate (rf2-gqa7yv —
+  the enforcement half of the rf2-ebbpia pre-alpha facade-REMOVAL discipline).
+
+  The pure reconcilers (`superseded-facade-names`, `reconcile`,
+  `floor-violation?`) are driven with synthetic inputs so the join contract is
+  locked without depending on the live migration-map / manifest shape:
+
+    * a `:rf`-namespaced superseded disposition names a facade var by the
+      keyword's NAME; a `:rf.realm/…`-keyed entry names no single var and is
+      skipped;
+    * a `:facade? true` row whose bare name has a superseded disposition FAILS
+      unless its (var, status) pair is allowlisted;
+    * an allowlist entry that matches no current violation is reported STALE;
+    * a collapsed disposition join trips the non-vacuous floor.
+
+  A live smoke confirms the committed manifest + migration-map reconcile clean
+  (the realm-family facade removals are done, so the gate is GREEN)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.facade-hygiene-check :as fh]))
+
+;; A minimal synthetic disposition map mirroring re-frame.migration's shape:
+;; `:rf`-namespaced superseded entries (name a facade var), a `:rf`-namespaced
+;; non-superseded sentinel (must be ignored), and an other-namespaced entry
+;; (names a conceptual surface, no single var → skipped).
+(def ^:private synthetic-migration
+  {:rf/install!            {:status :retained-internal}
+   :rf/app                 {:status :publicly-replaced}
+   :rf/module              {:status :re-expressed}
+   ;; non-superseded :rf entry — never contributes a candidate.
+   :rf/healthy-export      {:status :live}
+   ;; namespaced surface key — no single facade var, must be skipped.
+   :rf.realm/frame-address {:status :publicly-replaced}})
+
+(deftest superseded-facade-names-maps-rf-keyed-superseded-only
+  (let [m (fh/superseded-facade-names synthetic-migration fh/superseded-statuses)]
+    (testing "every superseded :rf-keyed entry contributes its keyword NAME"
+      (is (= {"install!" :retained-internal
+              "app"      :publicly-replaced
+              "module"   :re-expressed}
+             m)))
+    (testing "a non-superseded :rf entry is excluded"
+      (is (not (contains? m "healthy-export"))))
+    (testing "a non-:rf-namespaced surface key names no var and is skipped"
+      (is (not (contains? m "frame-address"))))))
+
+(def ^:private name->status
+  {"install!" :retained-internal
+   "app"      :publicly-replaced})
+
+(defn- reconcile-with
+  [{:keys [rows allow] :or {allow #{}}}]
+  (fh/reconcile {:rows rows :name->status name->status :allow allow}))
+
+(deftest facade-row-with-superseded-disposition-fails
+  (let [rows [{:namespace "re-frame.core" :var "install!"
+               :tier :advanced :facade? true}
+              ;; a non-facade row with the same bare name must NOT fire — the
+              ;; retained-internal substrate that correctly LEFT the facade.
+              {:namespace "re-frame.realm" :var "install!"
+               :tier :implementation :facade? false}
+              ;; a facade row with no superseded disposition is clean.
+              {:namespace "re-frame.core" :var "make-frame"
+               :tier :advanced :facade? true}]
+        [problems stale] (reconcile-with {:rows rows})]
+    (testing "the :facade? true superseded export is flagged"
+      (is (= [{:var "install!" :status :retained-internal
+               :namespace "re-frame.core" :tier :advanced}]
+             problems)))
+    (testing "the :facade? false same-name substrate row does not fire"
+      (is (= 1 (count problems))))
+    (testing "no stale allowlist entries when the allowlist is empty"
+      (is (empty? stale)))))
+
+(deftest allowlisted-violation-is-suppressed
+  (let [rows [{:namespace "re-frame.core" :var "install!"
+               :tier :advanced :facade? true}]
+        [problems stale] (reconcile-with
+                           {:rows rows
+                            :allow #{["install!" :retained-internal]}})]
+    (testing "an allowlisted (var, status) pair suppresses the violation"
+      (is (empty? problems)))
+    (testing "an allowlist entry that DOES match a present pair is not stale"
+      (is (empty? stale)))))
+
+(deftest stale-allowlist-entry-reported
+  (let [rows [{:namespace "re-frame.core" :var "make-frame"
+               :tier :advanced :facade? true}]
+        ;; the allowlist names install!, but no facade row presents that pair.
+        [problems stale] (reconcile-with
+                           {:rows rows
+                            :allow #{["install!" :retained-internal]}})]
+    (testing "a cleared transitional exception is flagged stale"
+      (is (= [["install!" :retained-internal]] (vec stale))))
+    (testing "no live violation in this fixture"
+      (is (empty? problems)))))
+
+(deftest floor-trips-on-collapsed-join
+  (testing "an empty disposition map trips the non-vacuous floor"
+    (is (fh/floor-violation? {})))
+  (testing "a populated disposition map does not"
+    (is (not (fh/floor-violation? name->status)))))
+
+(deftest live-committed-tree-reconciles-clean
+  (testing "the committed manifest + live migration-map carry NO superseded
+            :facade? true row (realm-family removals are done)"
+    (is (true? (fh/check!)))))

--- a/scripts/check_retired_composition_vocab.py
+++ b/scripts/check_retired_composition_vocab.py
@@ -69,10 +69,18 @@ one-line note tying the exemption to the inventory finding
 (ai/findings/API-review/codex/retired-app-composition-vocabulary.md) or the
 EP/migration policy.
 
-NOTE — a broader facade-hygiene gate (rf2-gqa7yv) will later GENERALISE this
-check into a manifest-driven retired-vocabulary sweep. This guard is kept
-deliberately small and modular so it folds in cleanly; do not grow it into the
-general manifest-hygiene gate here.
+NOTE — the broader facade-hygiene gate (rf2-gqa7yv,
+implementation/scripts/api-manifest/src/re_frame/api_manifest/facade_hygiene_check.clj)
+is the MANIFEST-DATA counterpart of this DOC-SURFACE gate, and the two are
+COMPLEMENTARY rather than one subsuming the other. This grep keeps the public
+TEACHING surface clean — a retired spelling reappearing as live, copy-pasteable
+API inside markdown fenced code. The manifest-hygiene gate keeps the
+FACADE-EXPORT set clean — it joins the same EP-0013 -> EP-0023 dispositions
+(re-frame.migration/migration-map) against spec/api-manifest.edn and fails if a
+superseded export stays `:facade? true` instead of being demoted to its home
+namespace or removed. Different surfaces (teaching prose vs. the manifest),
+both driven from the same retirement; neither duplicates the other. Keep this
+guard deliberately small and modular; do not grow it into the manifest gate.
 
 SCAN SURFACE
 


### PR DESCRIPTION
## What

Adds the **enforcement half** of the ruled pre-alpha facade-REMOVAL discipline (rf2-ebbpia). A new CI check FAILS when a `:facade? true` row in `spec/api-manifest.edn` names a `re-frame.core` export whose EP-0013 → EP-0023 disposition (`re-frame.migration/migration-map`) marks it superseded / retained-for-compat. The **add** side of the facade is already gated (Conventions.md §Facade policy + the api-manifest drift-check); this is the missing **symmetric removal** rule.

The codified rule (Conventions.md §"Removing or demoting a facade export", landed by #4616): a superseded or accidental facade export has exactly two fates — become **internal** (its home namespace, `:facade? false`, off the facade) or be **removed outright**. No retained-for-migration facade tier; the deprecated tier stays empty in pre-alpha.

## Check design

- **New check fn**: `re-frame.api-manifest.facade-hygiene-check` (under `implementation/scripts/api-manifest/`), invoked like the sibling `gen --check` / `api-md-check`.
- **The join**: loads the live `re-frame.migration/migration-map` on the JVM (no copy — the api-manifest classpath carries `day8/re-frame2`). Each `:rf`-namespaced disposition names a facade var by the keyword's `name` (`:rf/install!` → the `install!` export). For each whose `:status` is superseded (`:publicly-replaced` / `:re-expressed` / `:retained-internal`, plus future `:removed` / `:superseded`), FAIL if a `:facade? true` row carries that bare var name — unless the `(var, status)` pair is allowlisted. Other-namespaced keys (`:rf.realm/frame-address`) name conceptual surfaces, not a single var, and are skipped.
- **Non-vacuous floor**: a collapsed disposition join (ns rename / shape change / require failure) trips RED rather than passing vacuously.
- **Allowlist** (`facade-hygiene-allowlist.edn`): checked-in, self-documenting, **expected near-empty** (a correctly-resolved disposition produces no `:facade? true` row). Stale entries (matching no current violation) are reported so the allowlist cannot rot.
- **CI wiring**: a step in the existing `api-manifest` job in `lint.yml`, alongside gen-check / api-md-check.
- **Tests**: unit tests for the pure reconcilers (`superseded-facade-names`, `reconcile`, `floor-violation?`) + a live committed-tree smoke, on the existing `:test` alias.

## Folding in pl97nd.5

The narrow EP-0023 retired-vocab grep (`scripts/check_retired_composition_vocab.py`) is a **doc-surface** gate (scans markdown fenced code for stale teaching API). This gate is the **manifest-data** counterpart (joins the same dispositions against the export set). They are **complementary, not duplicative** — kept as siblings, cross-referenced both ways in the docstrings.

## Gate results

- **GREEN on the current tree**: realm-family facade removals are done (pl97nd.2), so no `:facade? true` row carries a superseded disposition. 6 superseded `:rf`-named dispositions join cleanly.
- **Planted-violation verified**: temporarily marked `re-frame.core/make-frame` (a live `:facade? true` row) with a `:publicly-replaced` disposition in `migration.cljc` → gate went **RED** (exit 1, named the row) → reverted → **GREEN** again (migration.cljc byte-identical).
- `gen --check`, `api-md-check`: green. `clojure -M:test` (54 tests / 108 assertions incl. the 6 new): green. Python grep self-test (13 cases) + full run: green.

Scope: touched only `implementation/scripts/api-manifest/`, `lint.yml`, the allowlist EDN, and the grep docstring. No `core.cljc` / `spec/API.md` / `provider.cljs` / adapter surfaces.