### PR TITLE
ci: add timeout-minutes guards to heavy unbounded jobs (rf2-tv7ow4)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,6 +105,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.docs_surface == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1265,6 +1265,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 18
     defaults:
       run:
         working-directory: implementation
@@ -1359,6 +1360,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_browser == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: implementation
@@ -1441,6 +1443,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_prod == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     defaults:
       run:
         working-directory: implementation
@@ -1507,6 +1510,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_prod == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     defaults:
       run:
         working-directory: implementation
@@ -1767,6 +1771,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.story_xray_browser == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: implementation
@@ -2332,6 +2337,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.template_expensive == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: tools/template


### PR DESCRIPTION
## What

Adds job-level `timeout-minutes` to the heavy, currently-unbounded CI jobs so a hang fails fast instead of running to GitHub's 6h default and blocking the merge queue (we have historically hit 30-61min browser-test + mkdocs hangs).

Bead: rf2-tv7ow4.

## Values chosen

Each timeout is ~2-3x the typical run (confirmed from recent successful run #27802443506 job durations) so a genuine hang fails fast but a normal slow run never trips.

**`.github/workflows/test.yml`**

| Job | Typical | timeout-minutes |
|---|---|---|
| `cljs` (:node-test) | ~6 min | 18 |
| `cljs-browser` (:browser-test headless Chromium) | ~12 min | 25 |
| `cljs-browser-schemas-boundary-prod` | ~1.5 min | 12 |
| `cljs-browser-prod-elision` | ~1.5 min | 12 |
| `story-xray-browser` | ~3 min | 15 |
| `jvm-tools-template` | ~9 min | 20 |

**`.github/workflows/docs.yml`**

| Job | Notes | timeout-minutes |
|---|---|---|
| `build` (MkDocs) | heavy SCI :advanced bundle rebuild, has hung before | 20 |

## Scope

- ONLY `timeout-minutes:` lines added (7 total). No job logic, steps, or `if:` gating changed.
- Jobs that already carried a `timeout-minutes` were left untouched.

## Gates

- `python -c "import yaml; yaml.safe_load(...)"` for both files: `yaml ok`.
- `git diff` confirms only added `timeout-minutes:` lines.
- actionlint not available in this environment.