### PR TITLE
chore(tools): EP-0024 frame-provider name-family compliance sweep (rf2-bqynss)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -152,8 +152,9 @@ The workspace body's optional `:isolation` slot tunes the mount
 strategy for `:variants-grid`:
 
 - `:isolated` (default) — every cell mounts in parallel; each wraps
-  its rendered view in a per-variant frame-provider. Baseline
-  frame-isolation contract.
+  its rendered view in a per-variant scope provider (the
+  namespace-preserving `frame-provider-existing` twin — the variant
+  frame is already allocated). Baseline frame-isolation contract.
 - `:shared` — cells mount ONE at a time with a prev/next navigator
   (◀ N/total ▶). Same serialised-mount strategy `:tabs` (rf2-ktnl8)
   uses, scoped to the implicit `:variants-grid` enumeration.

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -62,8 +62,12 @@
 
 (defn frame-provider-ns-safe
   "A Reagent component that scopes a namespaced frame keyword to its
-  subtree via the React context backing `rf/frame-provider` — but
-  bypasses Reagent's prop-conversion so the namespace is preserved.
+  subtree via the React context backing `rf/frame-provider-existing` —
+  but bypasses Reagent's prop-conversion so the namespace is preserved.
+  Scope-only: the variant's frame is already allocated by `allocate!`'s
+  `rf/make-frame`, so this neither creates nor owns a frame (it is the
+  namespace-preserving twin of `rf/frame-provider-existing`, never the
+  owned-lifecycle `rf/frame-provider`).
 
   Usage:
     [frame-provider-ns-safe {:frame :story.counter/clicked-three-times}
@@ -608,13 +612,14 @@
        :else
        (let [resolved-view (rf/view view-id)]
          (if resolved-view
-           ;; The variant's frame is allocated; scope the rendered
-           ;; view's subscribe / dispatch to it via a frame-provider
-           ;; that preserves the namespace of a `:story.x/y`-shaped
+           ;; The variant's frame is already allocated; scope the
+           ;; rendered view's subscribe / dispatch to it (scope-only,
+           ;; like `rf/frame-provider-existing`) via a provider that
+           ;; preserves the namespace of a `:story.x/y`-shaped
            ;; variant id (per rf2-c5jz; the rf2-zme7 fix path). The
-           ;; standard `rf/frame-provider` uses Reagent's `:>` interop
-           ;; which calls `(name kw)` on prop values and drops the
-           ;; namespace before React sees it.
+           ;; standard `rf/frame-provider-existing` uses Reagent's `:>`
+           ;; interop which calls `(name kw)` on prop values and drops
+           ;; the namespace before React sees it.
            ;;
            ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on the
            ;; immediate wrapper around the user-authored decorated view

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -225,9 +225,9 @@
   active variant's app-db (e.g. `:counter-with-stories.views/parity-
   badge` reads `:count-parity` from the variant's frame). The panel
   view runs OUTSIDE the canvas's React subtree, so it needs its own
-  `frame-provider` scoped to `variant-id` — otherwise the view's
-  ambient `rf/subscribe` resolves `:rf/default` and the deref returns
-  nil, throwing in the view. We wrap each panel in
+  scope into the (already-allocated) variant frame — otherwise the
+  view's ambient `rf/subscribe` resolves `:rf/default` and the deref
+  returns nil, throwing in the view. We wrap each panel in
   `frame-provider-existing {:frame variant-id}`.
 
   Returns a hiccup vector wrapping the resolved panels."

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -338,9 +338,11 @@
 
      Per /spec/007-Stories.md §Relationship with frames + tools/story
      feature-set §4.2: each variant cell wraps the rendered view in a
-     `frame-provider` scoped to the variant id, so the view's
-     subscribe / dispatch (resolved via React context at render time)
-     target the per-variant frame the runtime allocated. Without the
+     `frame-provider-existing`-style scope (the namespace-preserving
+     `canvas/frame-provider-ns-safe`) on the variant id — the frame is
+     already allocated by the runtime — so the view's subscribe /
+     dispatch (resolved via React context at render time) target the
+     per-variant frame the runtime allocated. Without the
      wrap, subscriptions run under no carried frame and fail with
      `:rf.error/no-frame-context` (EP-0002). Before EP-0002, this same
      gap fell through to `:rf/default`, which is why the four counter
@@ -393,11 +395,13 @@
               ;; React-context default at the workspace's mount site,
               ;; and the variant body's :counter/initialise dispatches
               ;; (which DID route to the variant's frame) become
-              ;; invisible to the view. Plain `rf/frame-provider` goes
-              ;; through Reagent's `:>` interop which calls `(name kw)`
-              ;; on prop values and drops the namespace before React
-              ;; sees it; `canvas/frame-provider-ns-safe` bypasses that
-              ;; via a direct `React.createElement` call.
+              ;; invisible to the view. Plain
+              ;; `rf/frame-provider-existing` (scope-only — the frame is
+              ;; already allocated) goes through Reagent's `:>` interop
+              ;; which calls `(name kw)` on prop values and drops the
+              ;; namespace before React sees it;
+              ;; `canvas/frame-provider-ns-safe` bypasses that via a
+              ;; direct `React.createElement` call.
               ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on
               ;; the immediate wrapper around the decorated view (same
               ;; reason as canvas.cljs) so the a11y panel can scope

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -90,7 +90,8 @@
   ;; testbed's `:rf/default` app frame explicitly, then run the frame-local
   ;; boot work (seed dispatch + elision listener install) inside its scope.
   ;; The live-app render is frame-scoped via `live-app-root` (the
-  ;; `frame-provider` wrapper passed to the host below).
+  ;; `frame-provider-existing` wrapper passed to the host below — the
+  ;; `:rf/default` frame is already `reg-frame`'d above).
   ;;
   ;; EP-0015 §8: durable app-db size/sensitivity classification is FRAME-owned
   ;; — declared here as `:large {:app-db …}` so the `:user/avatar-pdf` slot

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -105,7 +105,9 @@
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:login/flow [:login/dismiss]]))
   ;; Wire the live-app↔Story-shell hash router (shared helper). The live-app
-  ;; root is frame-scoped via `live-app-root` (the `frame-provider` wrapper).
+  ;; root is frame-scoped via `live-app-root` (the
+  ;; `frame-provider-existing` wrapper — scope-only into the already-
+  ;; registered `:rf/default` frame).
   ;; The `:story-subdir` opt (rf2-77wqzi) hands the host this testbed's
   ;; tool-relative source subdir; the host resolves the on-disk
   ;; open-in-editor project-root (build-env define or `?project-root=`

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -36,8 +36,9 @@ ribbon-driven filters, and — load-bearing — the row-click →
 `:rf.xray/focus` (`018-Event-Spine.md` §4 + §6).
 
 It honours the same shape as every other mount fn — installs handlers,
-ensures the `:rf/xray` frame, wraps the view in `[rf/frame-provider
-{:frame :rf/xray} …]`, returns an `unmount`. Per `018-Event-Spine.md`
+ensures the `:rf/xray` frame, wraps the view in `[rf/frame-provider-existing
+{:frame :rf/xray} …]` (scope-only — the frame is ensured above, not
+created by the wrapper), returns an `unmount`. Per `018-Event-Spine.md`
 §4 the list owns its own height via `:rf.xray/events-list-height-px`;
 the host caps the visible band through its mount-point CSS (the contract
 is "the host owns the container size" — §Embed props inventory).

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -4146,7 +4146,7 @@ Registration is a single line in `registry.cljs`:
 
 …idempotent per the orchestrator's `compare-and-set!` sentinel.
 The shell-side mount sits alongside `[app-db-segment-inspector/Popup]`
-in `shell.cljs`'s overlay block, INSIDE the `rf/frame-provider
+in `shell.cljs`'s overlay block, INSIDE the `rf/frame-provider-existing
 {:frame :rf/xray}` wrapper so subscribes resolve to Xray's frame.
 
 ##### §10.0.7.2 Per-panel "open in popup" affordance (rf2-l4625 · rf2-7sdja)

--- a/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
@@ -2,8 +2,8 @@
   "Guard test for the EPIC rf2-1w07r frame-singleton class.
 
   Xray was historically locked to a singleton `:rf/xray` frame: the
-  shell hardcoded `[frame-provider {:frame :rf/xray}]` and every
-  out-of-render affordance dispatched a bare `{:frame :rf/xray}`
+  shell hardcoded a scope-only `[frame-provider-existing {:frame
+  :rf/xray}]` and every out-of-render affordance dispatched a bare `{:frame :rf/xray}`
   literal. Two shells on one page then collided on the one global
   app-db. The de-singleton refactor (rf2-lnluk + rf2-r0o63)
   parameterized the shell frame and made every out-of-render dispatch

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -99,7 +99,7 @@
 
 (deftest mount-epoch-panel-wraps-in-frame-provider-and-delegates-to-adapter
   (testing "rf2-crhr8 + rf2-5gl5r — mount-epoch-panel! installs
-            handlers, wraps epoch-panel/Panel in `[rf/frame-provider
+            handlers, wraps epoch-panel/Panel in `[rf/frame-provider-existing
             {:frame :rf/xray} [Panel]]`, delegates to substrate-
             adapter/render, and returns the adapter's unmount fn.
             (Replaces the prior mount-event-detail! coverage; the
@@ -192,9 +192,10 @@
 
 (deftest mount-shell-renders-shell-view-without-extra-wrapper
   (testing "rf2-crhr8 — mount-shell! delegates the full 4-layer shell.
-            The shell-view itself owns its `frame-provider` (per the
-            shell docstring) so the mount fn renders [shell-view {:mode
-            :inline}] directly — no outer wrapper."
+            The shell-view itself installs its own scope provider
+            (`frame-provider-existing`, per the shell docstring) so the
+            mount fn renders [shell-view {:mode :inline}] directly — no
+            outer wrapper."
     (let [[capture _ render-stub] (make-render-stub)]
       (with-redefs [substrate-adapter/render render-stub]
         (panels/mount-shell! :mount-point)
@@ -204,11 +205,11 @@
           (is (= :inline (:mode (second tree))))
           ;; The shell mounts via a reg-view-registered view; the
           ;; captured render-tree's first element is that view fn (not
-          ;; a frame-provider — the shell owns its own provider).
+          ;; a provider — the shell installs its own scope provider).
           (is (not= rf/frame-provider (first tree))
               "mount-shell! does NOT add an outer frame-provider — the
-               shell-view contains its own per spec/007 §The 4-layer
-               chrome"))))))
+               shell-view contains its own scope provider per spec/007
+               §The 4-layer chrome"))))))
 
 (deftest mount-shell-supports-mode-opt
   (let [[capture _ render-stub] (make-render-stub)]

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -567,7 +567,8 @@
   (rf/init! reagent-adapter/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — register the single, plain host frame, scope the boot
-  ;; dispatch, and wrap the render in a `frame-provider` (carried invariant).
+  ;; dispatch, and wrap the render in a `frame-provider-existing` (the
+  ;; frame is already created by `reg-frame`; carried invariant).
   (rf/reg-frame host-frame {})
   (rf/with-frame host-frame
     (rf/dispatch-sync [:edn-inspector/reset]))

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -954,7 +954,8 @@
   ;; dispatches to it. The per-track machine frames are reg-frame'd inside
   ;; the `:machine-epochs/select` handler (a real cascade — `*handler-scope*`
   ;; bound), so each track's `:on-create` async-queues correctly. The
-  ;; render is wrapped in a `frame-provider` on the shell frame.
+  ;; render is wrapped in a `frame-provider-existing` on the shell frame
+  ;; (scope-only — the shell frame is already `reg-frame`'d).
   (rf/reg-frame shell-frame {})
   ;; Seed the SHELL frame's bookkeeping, then auto-select the default track so
   ;; the operator lands on a live arc (the SHELL-FRAME-FIRST-PAINT smaller

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -499,7 +499,8 @@
   (rf/init! reagent-adapter/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — establish the host frame explicitly, run the boot dispatch
-  ;; under its scope, and wrap the render in a `frame-provider` so in-tree
+  ;; under its scope, and wrap the render in a `frame-provider-existing`
+  ;; (scope-only — the host frame is already `reg-frame`'d) so in-tree
   ;; dispatch/subscribe resolve to it (the carried invariant).
   (rf/reg-frame host-frame {})
   (rf/with-frame host-frame

--- a/tools/xray/testbeds/panel_gallery/gallery_chrome.cljs
+++ b/tools/xray/testbeds/panel_gallery/gallery_chrome.cljs
@@ -12,7 +12,8 @@
   `shell/shell-view` now takes a `:frame-id` opt (default
   `defaults/default-frame-id` = `:rf/xray`). The `chrome-shell` wrapper
   (`panel_views.cljs`) is `reg-view*`-registered, so its render runs
-  under the Story per-variant `frame-provider` and `(rf/current-frame-id)`
+  under the Story per-variant frame scope (the namespace-preserving
+  `frame-provider-existing` twin) and `(rf/current-frame-id)`
   resolves to the variant frame the canvas allocated for THIS cell. We
   thread that frame into `[shell/shell-view {:frame-id …}]`, so each
   chrome cell's app-db (focused epoch, selected tab, theme, modal

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -42,9 +42,10 @@
   Story per-variant frame into `[shell/shell-view {:frame-id …}]`, so
   the shell's app-db lives in the VARIANT frame — N chrome cells in one
   workspace are fully isolated and each variant's `:events` seed THAT
-  frame directly. (Pre rf2-1w07r the shell hardcoded `[frame-provider
-  {:frame :rf/xray}]`, so every cell's reads collided on the one global
-  `:rf/xray` app-db regardless of the variant frame.)
+  frame directly. (Pre rf2-1w07r the shell hardcoded a scope-only
+  `[frame-provider-existing {:frame :rf/xray}]`, so every cell's reads
+  collided on the one global `:rf/xray` app-db regardless of the
+  variant frame.)
 
   ## Facade-mount discipline (rf2-043uz)
 

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -834,7 +834,8 @@
   ;; run-step event. The runner cursor lives in app-db `:step`.
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — register the host frame, scope the boot dispatch, and wrap
-  ;; the render in a `frame-provider` (the carried invariant).
+  ;; the render in a `frame-provider-existing` (scope-only — the host
+  ;; frame is already `reg-frame`'d; the carried invariant).
   (rf/reg-frame host-frame {})
   (rf/with-frame host-frame
     (rf/dispatch-sync [:standard-epochs/reset]))


### PR DESCRIPTION
## Summary

Verification sweep of the `tools/` tree for stale frame vocabulary after PR #4631 landed the EP-0024 **frame-provider name family**:

- `rf/frame-provider` = OWNED lifecycle (creates on mount / destroys on unmount; `:id`/`:images`/`:initial-db`/`:on-create`)
- `rf/frame-provider-existing` = SCOPE-only for an already-created frame (`:frame` only; lifecycle opts fail loud)
- `rf/with-frame` = lexical / non-React ambient scope

#4631 already migrated the runtime call sites. This pass catches residual **scope-only descriptions that still named the owned `frame-provider`**, plus **two scope-style call forms in the Xray spec** that still spelled `[rf/frame-provider {:frame …}]` (no `:id`).

## What changed (no runtime behaviour change)

- **Story src** (`canvas.cljs` / `workspace.cljc` / `panels.cljs`): the per-variant scope wrap (`frame-provider-ns-safe`) and its comments/docstrings now name `frame-provider-existing` semantics (the variant frame is already allocated by `allocate!`'s `make-frame`).
- **Story spec** (`003-Render-Shell.md`): `:isolated` isolation note aligned to the scope-only provider.
- **Story/Xray testbeds**: the canonical boot pattern wraps the render in `frame-provider-existing` (frame already `reg-frame`'d) — corrected comments in `edn_inspector` / `machine_epochs` / `managed_http` / `standard_epochs` / `counter_with_stories` / `login_form` / `gallery_chrome` / `panel_views`.
- **Xray spec**: two scope-style call forms corrected to `frame-provider-existing` — `008-Embedding-Contract.md` (spine mount wrap) and `021-Dynamic-Panel-Designs.md` (segment-inspector overlay wrap).
- **Xray tests**: `frame_singleton_guard_test.clj` history note and `panels_mount_cljs_test.cljs` docstrings/comments aligned (assertions already check `frame-provider-existing`).

## Premises verified (NOT residue)

- `frame-bound-fn` / `frame-bound-fn*` / `subscribe*` are **current** public helpers in `re-frame.core` (with live tests) — NOT retired; references in `re-frame2-pair-mcp` are accurate.
- The retired pre-EP-0023 `:realm` map arity is correctly described as removed (the `mcp-conformance` `:realm` hits are guard tests asserting its removal).
- `make-frame` call sites use the EP-0024 single-call unified constructor; no two-constructor/create-twice residue.
- `with-frame` usages in tools wrap dispatch / event-handling / async callbacks (lexical scope) — none scopes React-rendered descendants.
- The xray frame-singleton guard scans only `tools/xray/src/**` `.cljs/.cljc` and strips comment + backtick lines; these edits don't touch that surface.

## Gates

- `sh scripts/test-jvm-tools.sh` — PASS (xray 1239, machines-viz 550, story 1705, story-mcp 284, mcp-base 247, wire-vocab 101; 0 failures / 0 errors)
- `npm run test:bundle-isolation` — PASS (tools absent from production bundles)
- clj-kondo over changed files — 0 errors (pre-existing warnings only)
- splint over `tools/story` + `tools/xray` — exit 0, no parse errors

Xray-spec rule: this PR updates `tools/xray/spec/*` (008 + 021) in the same change.