### PR TITLE
ci: widen heavy-job timeout-minutes for growth headroom (rf2-tsbss9)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,7 +105,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.docs_surface == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1265,7 +1265,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 18
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: implementation
@@ -1360,7 +1360,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_browser == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: implementation
@@ -1443,7 +1443,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_prod == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: implementation
@@ -1510,7 +1510,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.cljs_prod == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: implementation
@@ -1771,7 +1771,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.story_xray_browser == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: implementation
@@ -2337,7 +2337,7 @@ jobs:
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.template_expensive == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: tools/template


### PR DESCRIPTION
Follow-up to #4632, which set the heavy-CI-job `timeout-minutes` too tight (~2-3x current duration).

**Intent:** these `timeout-minutes` exist *only* as a backstop against GitHub's 6-hour default when a job genuinely **hangs**. They are NOT a per-job SLA. They must be generous enough that organic growth (more tests, more examples, more adapters) never trips them and produces a false red that blocks the merge queue. #4632 was too tight; this widens them.

### Changes

`.github/workflows/test.yml`:
| job | old | new |
|---|---|---|
| `cljs` (CLJS :node-test) | 18 | **30** |
| `cljs-browser` (:browser-test headless Chromium) | 25 | **45** |
| `cljs-browser-schemas-boundary-prod` | 12 | **25** |
| `cljs-browser-prod-elision` | 12 | **25** |
| `story-xray-browser` | 15 | **30** |
| `jvm-tools-template` | 20 | **35** |

`.github/workflows/docs.yml`:
| job | old | new |
|---|---|---|
| MkDocs `build` | 20 | **30** |

`cljs-browser` gets the most headroom (45) — its example-compile pre-step + the browser run both grow over time.

### Scope
No job logic, steps, `if:` gating, or any other job's timeout changed. The pre-existing step-level/job-level 20/5/12 backstops elsewhere are untouched. Diff is **values-only**: 7 changed `timeout-minutes` lines.

YAML validated via `yaml.safe_load` on both files.