### PR TITLE
fix(core): point internal realm/app-value error guidance at live entrypoints (rf2-sy6ig7)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -436,8 +436,8 @@
     (when (nil? id)
       (error/throw-error!
         :rf.error/invalid-module
-        'rf/module
-        "rf/module requires an :id — supply a module id (the provenance key every registration is owned by)."
+        're-frame.app-value/module
+        "re-frame.app-value/module requires an :id — supply a module id (the provenance key every registration is owned by)."
         {:recovery :supply-a-module-id
          :extra    {:descriptor descriptor-map}}))
     (let [registrations
@@ -455,8 +455,8 @@
                   acc
                   (error/throw-error!
                     :rf.error/invalid-module
-                    'rf/module
-                    (str "rf/module: unknown section key " section
+                    're-frame.app-value/module
+                    (str "re-frame.app-value/module: unknown section key " section
                          " — remove or correct the section key (it is neither a"
                          " registry-section name nor a reserved module key).")
                     {:recovery :remove-or-correct-the-section-key
@@ -501,8 +501,8 @@
           (if-let [existing (get-in acc [kind id])]
             (error/throw-error!
               :rf.error/app-composition-collision
-              'rf/app
-              (str "rf/app composition collision: two modules register "
+              're-frame.app-value/app
+              (str "re-frame.app-value/app composition collision: two modules register "
                    kind " " id " — composition is order-stable, never"
                    " last-writer-wins; rename one or explicitly replace it.")
               {:recovery :rename-or-explicitly-replace
@@ -563,16 +563,16 @@
     (when (nil? id)
       (error/throw-error!
         :rf.error/invalid-app
-        'rf/app
-        "rf/app requires an :id — supply an app id for the composed program."
+        're-frame.app-value/app
+        "re-frame.app-value/app requires an :id — supply an app id for the composed program."
         {:recovery :supply-an-app-id
          :extra    {:app app-map}}))
     (doseq [m modules]
       (when-not (and (map? m) (contains? m :rf.module/id))
         (error/throw-error!
           :rf.error/invalid-app
-          'rf/app
-          "rf/app :modules entries must be module values (from rf/module) — wrap the descriptor in rf/module first."
+          're-frame.app-value/app
+          "re-frame.app-value/app :modules entries must be module values (from re-frame.app-value/module) — wrap the descriptor in re-frame.app-value/module first."
           {:recovery :wrap-the-descriptor-in-rf-module
            :extra    {:app        id
                       :bad-module m}})))
@@ -594,8 +594,8 @@
                                 acc            ; exact-equal duplicate — idempotent
                                 (error/throw-error!
                                   :rf.error/app-composition-collision
-                                  'rf/app
-                                  (str "rf/app: two distinct modules share the id "
+                                  're-frame.app-value/app
+                                  (str "re-frame.app-value/app: two distinct modules share the id "
                                        mid " — module id is the provenance key, so a"
                                        " divergent duplicate makes composition"
                                        " order-dependent (not last-writer-wins);"
@@ -741,7 +741,7 @@
                           realm id (the byte-identical single-realm path).
     * the default id     — explicit default. Always valid (it is seeded at boot).
     * a realm MAP        — the caller holds the constructed realm value; trust its
-                          `:rf.realm/id` (the `(-> (rf/realm …) (rf/install! app))`
+                          `:rf.realm/id` (the `(-> (re-frame.realm/construct-realm …) (re-frame.app-value/install! app))`
                           compose path hands the map straight through).
     * any other keyword  — an EXPLICIT id. Must be registered in `realm/realms`,
                           else THROW `:rf.error/unknown-realm` (the ex-data IS the
@@ -758,12 +758,12 @@
     :else
     (error/throw-error!
       :rf.error/unknown-realm
-      'rf/install!
-      (str "rf/install!: realm " realm-or-id
+      're-frame.app-value/install!
+      (str "re-frame.app-value/install!: realm " realm-or-id
            " is not registered — an explicit realm must be"
-           " constructed (rf/realm) before an app value can be"
-           " installed into it. Absence defaults to the default"
-           " realm; an unknown explicit id does not.")
+           " constructed (re-frame.realm/construct-realm) before an"
+           " app value can be installed into it. Absence defaults to"
+           " the default realm; an unknown explicit id does not.")
       {:recovery :construct-the-realm-first
        :extra    {:realm        realm-or-id
                   :known-realms (realm/realm-ids)}})))
@@ -787,8 +787,8 @@
       (when-not (contains? have cap)
         (error/throw-error!
           :rf.error/missing-capability
-          'rf/install!
-          (str "rf/install!: realm " rid
+          're-frame.app-value/install!
+          (str "re-frame.app-value/install!: realm " rid
                " does not satisfy required capability " cap
                " — install the capability into the realm before installing the app.")
           {:recovery :install-capability
@@ -1149,8 +1149,8 @@
         (when (seq blocking)
           (error/throw-error!
             :rf.error/live-frame-removal-unsupported
-            'rf/reinstall!
-            (str "rf/reinstall!: cannot remove the live frame(s) "
+            're-frame.app-value/reinstall!
+            (str "re-frame.app-value/reinstall!: cannot remove the live frame(s) "
                  (pr-str (sort blocking)) " from realm " rid
                  " — a :frame descriptor still backs a live frame"
                  " container. Removing it through the descriptor"

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -253,11 +253,12 @@
     (when-not (contains? snapshot rid)
       (error/throw-error!
         :rf.error/unknown-realm
-        'rf/install!
-        (str "rf/realm " rid " is not registered — a realm-owned"
+        're-frame.realm/construct-realm
+        (str "realm " rid " is not registered — a realm-owned"
              " mutation cannot target a realm that was never"
-             " constructed. Absence defaults to the default realm;"
-             " an unknown explicit id does not.")
+             " constructed (re-frame.realm/construct-realm). Absence"
+             " defaults to the default realm; an unknown explicit id"
+             " does not.")
         {:recovery :construct-the-realm-first
          :extra    {:realm        rid
                     :known-realms (set (keys snapshot))}})))
@@ -424,10 +425,10 @@
   registrar does not hold, and the FIRST `reinstall!` would diff against that
   phantom app and only apply the delta — never populating the registrar with the
   base program. So `construct-realm` does NOT accept `:app`; seat a program with
-  `(-> (rf/realm {:id …}) (rf/install! app))`.
+  `(-> (re-frame.realm/construct-realm {:id …}) (re-frame.app-value/install! app))`.
 
   Returns the constructed realm map (now in the `realms` registry), so the call
-  composes: `(-> (rf/realm {:id …}) (rf/install! app))`.
+  composes: `(-> (re-frame.realm/construct-realm {:id …}) (re-frame.app-value/install! app))`.
 
   Throws `:rf.error/invalid-realm` when `:id` is missing or when an `:app` key is
   supplied (install-owned state is not a constructor input), and
@@ -437,8 +438,8 @@
     (when (nil? id)
       (error/throw-error!
         :rf.error/invalid-realm
-        'rf/realm
-        "rf/realm requires an :id — supply a realm id (the process-unique key the realm is registered under)."
+        're-frame.realm/construct-realm
+        "re-frame.realm/construct-realm requires an :id — supply a realm id (the process-unique key the realm is registered under)."
         {:recovery :supply-a-realm-id
          :extra    {:opts opts}}))
     ;; An `:app` here would create a FALSE installed-app state — the value is
@@ -447,18 +448,21 @@
     (when (contains? opts :app)
       (error/throw-error!
         :rf.error/invalid-realm
-        'rf/realm
-        (str "rf/realm: :app is install-owned state, not a constructor"
-             " input — an app value is inert until rf/install! seats it."
-             " Use (-> (rf/realm {:id " id "}) (rf/install! app)).")
+        're-frame.realm/construct-realm
+        (str "re-frame.realm/construct-realm: :app is install-owned state,"
+             " not a constructor input — an app value is inert until"
+             " re-frame.app-value/install! seats it. Use"
+             " (-> (re-frame.realm/construct-realm {:id " id "})"
+             " (re-frame.app-value/install! app)).")
         {:recovery :install-the-app-with-rf-install
          :extra    {:realm id}}))
     (when (contains? @realms id)
       (error/throw-error!
         :rf.error/realm-id-conflict
-        'rf/realm
-        (str "rf/realm: a realm with id " id " is already registered"
-             " — use a unique realm id or dispose the existing realm first.")
+        're-frame.realm/construct-realm
+        (str "re-frame.realm/construct-realm: a realm with id " id
+             " is already registered — use a unique realm id or dispose"
+             " the existing realm first (re-frame.realm/dispose-realm!).")
         {:recovery :use-a-unique-realm-id-or-dispose-the-existing-realm
          :extra    {:realm id}}))
     (let [;; Hermetic by default: a fresh OWN registrar atom unless the caller


### PR DESCRIPTION
## What

The `wjqewk` scrub surfaced internal-substrate error messages in `re-frame.realm` and `re-frame.app-value` whose `:where` symbols and `reason` prose named **PUBLIC facade fns that were REMOVED in EP-0023** (`rf/install!`, `rf/realm`, `rf/reinstall!`, `rf/module`, `rf/app`). Those fns are internal-only now, so the guidance pointed users at unreachable public names.

This rewrites those messages to name the **live internal entrypoints** the substrate actually invokes:

| removed facade name | live internal entrypoint |
|---|---|
| `rf/realm` | `re-frame.realm/construct-realm` |
| `rf/install!` | `re-frame.app-value/install!` |
| `rf/reinstall!` | `re-frame.app-value/reinstall!` |
| `rf/module` | `re-frame.app-value/module` |
| `rf/app` | `re-frame.app-value/app` |
| (dispose hint) | `re-frame.realm/dispose-realm!` |

13 error sites updated (4 in realm.cljc, 9 in app_value.cljc) — both the `:where` symbol (now fully-qualified `'re-frame.<ns>/<fn>`, matching the existing convention for internal throw sites) and the `reason`/recovery prose. The adjacent docstring composition examples that named the same removed facade fns were updated to match.

## Behaviour-safety

Error keywords (`:rf.error/*`) and ex-data slots (`:realm`, `:kind`, `:id`, `:capability`, …) are **unchanged**. The realm/app-value conformance + install tests branch on `:rf.error/id` and ex-data slots, never on `:where` or message text — verified by sweeping the test trees. No test assertions needed updating.

## Gates run (all green)

- `python scripts/check_thrown_error_messages.py` — exit 0
- `sh scripts/test-jvm-implementation.sh` — all artefacts 0 failures (core: 1820 tests)
- `cd implementation && npm run test:cljs` — 8016 tests, 0 failures
- clj-kondo over both files — 0 errors, 0 warnings
- splint — only 2 pre-existing warnings (verified on baseline), no new ones
- Facade/manifest untouched → Public-API manifest drift-check unaffected