### PR TITLE
fix(machines): validate spawned-actor :data-schema at macrostep boundary (rf2-2t9xn3)

### DIFF
--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -140,12 +140,43 @@
             false)))
     true))
 
+(defn- resolve-data-schema
+  "Resolve the `:data-schema` for `machine-id` whose live snapshot is
+  `snapshot` (the would-be-merged / freshly-committed value). A SINGLETON
+  resolves through the registered event handler (`:machines/machine-meta`);
+  a SPAWNED actor has NO per-instance handler — its TYPE rides the snapshot's
+  `:rf/machine-type` reserved slot, so it resolves through
+  `:machines/spec-from-snapshot` (rf2-a2sn1). Returns the schema or nil
+  (no schema / unresolvable spec).
+
+  Both resolvers are consumed through the late-bind table to keep this
+  leaf namespace free of a require cycle through `re-frame.machines` /
+  `lifecycle-fx.resolver`. When the machines facade has not yet bound the
+  hooks (cannot happen on the live fx / router path — the validator is
+  invoked FROM the loaded facade) the resolver short-circuits to nil = no
+  validation."
+  [machine-id snapshot]
+  (or (some-> (when-let [meta-fn (late-bind/get-fn-cached :machines/machine-meta)]
+                (meta-fn machine-id))
+              :data-schema)
+      (some-> (when-let [spec-fn (late-bind/get-fn-cached :machines/spec-from-snapshot)]
+                (spec-fn snapshot))
+              :data-schema)))
+
 (defn validate-machine-data!
   "Walk every snapshot under `[:rf.runtime/machines :snapshots]` in
-  `runtime-db` and validate its `:data` against the registered machine's
+  `runtime-db` and validate its `:data` against the resolved machine's
   `:data-schema`. Returns true iff every snapshot conformed (or carried no
   schema / no validator); false on first failure with the per-snapshot trace
   already emitted.
+
+  rf2-2t9xn3: schema resolution goes through `resolve-data-schema`, which
+  resolves a SINGLETON via `machine-meta` AND falls back to the snapshot's
+  `:rf/machine-type` (`:machines/spec-from-snapshot`) for a SPAWNED actor.
+  A spawned actor has no per-instance registration, so a `machine-meta`-only
+  lookup returned nil for it and its `:data` was never validated at the
+  macrostep boundary — a schema-violating action committed without rollback
+  (the spawn-time `validate-spawn-data!` only catches the INITIAL data).
 
   EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state, so
   this validator runs against the new RUNTIME-DB value (the `:rf.db/runtime`
@@ -163,22 +194,21 @@
   ;; `validate-app-schema!` so the late-bind hook the router consumes can
   ;; be invoked uniformly.
   (if interop/debug-enabled?
-    (if-let [machine-meta (late-bind/get-fn-cached :machines/machine-meta)]
-      ;; Per the validate-app-schema! pattern (rf2-wkxng): validate EVERY
-      ;; snapshot (no short-circuit) so each failing machine surfaces its
-      ;; own trace (consumers see the full set), AND-conjoining the per-
-      ;; snapshot conform decision so the router decides rollback
-      ;; deterministically. A snapshot whose machine declares no `:data-schema`
-      ;; (or whose spec `machine-meta` can't resolve) conforms vacuously.
-      (reduce-kv
-        (fn [ok? machine-id snapshot]
-          (and (if-let [schema (some-> (machine-meta machine-id) :data-schema)]
-                 (validate-snapshot-data! machine-id snapshot schema :macrostep)
-                 true)
-               ok?))
-        true
-        (get-in runtime-db (paths/snapshot-path)))
-      true)
+    ;; Per the validate-app-schema! pattern (rf2-wkxng): validate EVERY
+    ;; snapshot (no short-circuit) so each failing machine surfaces its
+    ;; own trace (consumers see the full set), AND-conjoining the per-
+    ;; snapshot conform decision so the router decides rollback
+    ;; deterministically. A snapshot whose machine declares no `:data-schema`
+    ;; (or whose spec resolves to nil for both a singleton AND a spawned
+    ;; actor) conforms vacuously.
+    (reduce-kv
+      (fn [ok? machine-id snapshot]
+        (and (if-let [schema (resolve-data-schema machine-id snapshot)]
+               (validate-snapshot-data! machine-id snapshot schema :macrostep)
+               true)
+             ok?))
+      true
+      (get-in runtime-db (paths/snapshot-path)))
     true))
 
 (defn validate-spawn-data!
@@ -202,27 +232,6 @@
       (validate-snapshot-data! spawned-id snapshot schema :spawn)
       true)
     true))
-
-(defn- resolve-data-schema
-  "Resolve the `:data-schema` for `machine-id` whose live snapshot is
-  `snapshot` (the would-be-merged value). A SINGLETON resolves through the
-  registered event handler (`:machines/machine-meta`); a SPAWNED actor has
-  NO per-instance handler — its TYPE rides the snapshot's `:rf/machine-type`
-  reserved slot, so it resolves through `:machines/spec-from-snapshot`
-  (rf2-a2sn1). Returns the schema or nil (no schema / unresolvable spec).
-
-  Both resolvers are consumed through the late-bind table to keep this
-  leaf namespace free of a require cycle through `re-frame.machines` /
-  `lifecycle-fx.resolver`. When the machines facade has not yet bound the
-  hooks (cannot happen on the live fx path — the fx is dispatched FROM the
-  loaded facade) the resolver short-circuits to nil = no validation."
-  [machine-id snapshot]
-  (or (some-> (when-let [meta-fn (late-bind/get-fn-cached :machines/machine-meta)]
-                (meta-fn machine-id))
-              :data-schema)
-      (some-> (when-let [spec-fn (late-bind/get-fn-cached :machines/spec-from-snapshot)]
-                (spec-fn snapshot))
-              :data-schema)))
 
 (defn validate-update-snapshot-data!
   "rf2-wrrvs7 — sibling validator for the `:rf.machine/update-snapshot`

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -123,6 +123,75 @@
                        [:rf.runtime/machines :snapshots :rf.machine-schema/macrostep]))
             "the machine's snapshot returns to its pre-handler value")))))
 
+;; ---- (2b) macrostep boundary on a SPAWNED actor (rf2-2t9xn3) -------------
+
+(deftest spawned-actor-macrostep-violation-rolls-back-and-emits
+  (testing "a SPAWNED actor (no per-instance handler) whose transition action
+            returns schema-violating :data must roll back the macrostep and
+            emit :where :machine-data — the schema resolves off the snapshot's
+            :rf/machine-type, not via machine-meta (rf2-2t9xn3)"
+    (let [ChildSchema [:map [:n pos-int?]]
+          ;; The child boots with valid :data {:n 1}; a :tick transition runs
+          ;; the :break action returning {:data {:n 0}} (violates pos-int?) via
+          ;; the ordinary macrostep path (NOT the escape hatch).
+          child-spec  {:initial     :booting
+                       :data        {:n 1}                ;; valid at spawn
+                       :data-schema ChildSchema
+                       :actions     {:break (fn [_] {:data {:n 0}})}
+                       :states      {:booting {:on {:tick {:target :running
+                                                           :action :break}}}
+                                     :running {}}}
+          parent-spec {:initial :start
+                       :data    {}
+                       :states  {:start    {:on {:go :spawning}}
+                                 :spawning {:entry
+                                            (fn [_]
+                                              {:fx [[:rf.machine/spawn
+                                                     {:fixed-actor-id :rf.machine-schema/spawned-macrostep
+                                                      :definition     child-spec}]]})}}}]
+      (rf/reg-machine :rf.machine-schema/spawn-macrostep-parent parent-spec)
+      (rf/dispatch-sync [:rf.machine-schema/spawn-macrostep-parent [:noop]])
+      ;; Spawn the child (valid :data {:n 1} → installs).
+      (rf/dispatch-sync [:rf.machine-schema/spawn-macrostep-parent [:go]])
+      (is (= 1 (:n (:data (get-in (rf/runtime-db-value :rf/default)
+                                  [:rf.runtime/machines :snapshots
+                                   :rf.machine-schema/spawned-macrostep]))))
+          "precondition: the spawned child installed with valid :data {:n 1}")
+      (let [snap-before (get-in (rf/runtime-db-value :rf/default)
+                                [:rf.runtime/machines :snapshots
+                                 :rf.machine-schema/spawned-macrostep])
+            db-before   (rf/runtime-db-value :rf/default)
+            traces      (collect-traces!
+                          #(rf/dispatch-sync [:rf.machine-schema/spawned-macrostep [:tick]]))
+            trace-ev    (first traces)
+            tag         (:tags trace-ev)]
+        (is (= 1 (count traces))
+            "exactly one :where :machine-data trace fired on the violating macrostep")
+        (is (= :machine-data (:where tag))
+            "trace's :where tag pins the boundary")
+        (is (= :rf.machine-schema/spawned-macrostep (:machine-id tag))
+            "tag carries :machine-id identifying the failing spawned actor")
+        (is (= :macrostep (:phase tag))
+            "tag's :phase pins the macrostep lifecycle position")
+        (is (zero? (:n (:value tag)))
+            "tag carries the offending :data value (:n 0)")
+        (is (true? (:rollback? tag))
+            "tag declares :rollback? true (commit must be rolled back)")
+        ;; The whole point: the macrostep ROLLS BACK — the violating :data
+        ;; does not commit. Pre-fix, machine-meta returns nil for the spawned
+        ;; actor → validation is skipped → {:n 0} commits and no rollback fires.
+        (is (= snap-before
+               (get-in (rf/runtime-db-value :rf/default)
+                       [:rf.runtime/machines :snapshots
+                        :rf.machine-schema/spawned-macrostep]))
+            "the spawned actor's snapshot returns to its pre-handler value (rolled back)")
+        (is (= 1 (:n (:data (get-in (rf/runtime-db-value :rf/default)
+                                    [:rf.runtime/machines :snapshots
+                                     :rf.machine-schema/spawned-macrostep]))))
+            "the violating :data {:n 0} did NOT commit — :n stays the valid 1")
+        (is (= db-before (rf/runtime-db-value :rf/default))
+            "post-rollback runtime-db equals pre-handler runtime-db")))))
+
 ;; ---- (3) bootstrap-time validation: initial :data violates --------------
 
 (deftest bootstrap-violation-emits-and-rolls-back


### PR DESCRIPTION
## Summary

Fixes **rf2-2t9xn3** — a spawned-actor `:data-schema` was not validated at the macrostep boundary (fail-open: schema-violating `:data` committed without rollback).

`validate-machine-data!` (`implementation/machines/src/re_frame/machines/data_validation.cljc`) resolved each snapshot's `:data-schema` only via `machine-meta`, which is a registrar `:event` lookup = registered **singletons**. A **spawned** actor (rf2-a2sn1) has no per-instance registration; its type lives at the snapshot's `:rf/machine-type`. So `machine-meta` returned nil for spawned-actor snapshots, the `if-let` took the vacuous-pass branch, and the spawned actor's `:data` was never validated at the macrostep boundary. A transition `:action` writing schema-violating `:data` committed and the cascade was **not** rolled back. (The spawn-time `validate-spawn-data!` only catches the INITIAL data.)

Spec 005 §Schema validation + §Snapshot egress require the written snapshot to be validated against the child type's `:data-schema`.

## Fix

Route macrostep schema resolution through `resolve-data-schema` — the same resolver the `:update-snapshot` escape-hatch validator (`validate-update-snapshot-data!`) already uses. It tries `machine-meta` first (singleton), then falls back to `:machines/spec-from-snapshot` (reads `:rf/machine-type`) for the spawned-actor case. `resolve-data-schema` is hoisted above `validate-machine-data!` and the duplicate definition removed. **Singleton validation is unchanged.**

## Test-first reproduction

Added `spawned-actor-macrostep-violation-rolls-back-and-emits` to `machine_schema_test.clj`: spawns an actor whose child type declares a `:data-schema`, fires a transition whose `:action` returns schema-violating `:data`, and asserts the macrostep **rolls back** (violating `:data` does not commit) and emits `:where :machine-data :phase :macrostep :rollback? true`.

- **On main (pre-fix):** FAILS — `{:n 0}` commits, no trace, no rollback (9 assertions fail).
- **With fix:** PASSES.

## Gates

- `clojure -M:test` (machines JVM suite): **778 tests, 2573 assertions, 0 failures**
- `npm run test:cljs` (CLJS node): **8016 tests, 33474 assertions, 0 failures**
- clj-kondo over changed files: 0 errors (1 pre-existing macro-binding warning on the unchanged `collect-traces!` helper)
- splint over changed files: 0 warnings

No facade/manifest change.