### PR TITLE
fix(core/events): deliver :rf.cofx/requires for inline image-loaded events (rf2-khi7xr)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -1224,17 +1224,36 @@
 
 (defn lower-inline-event
   "Lower an inline `:reg-event` descriptor's raw fn body into the runnable
-  event-handler slots (`:handler-fn` + the `:interceptors` chain carrying the
-  `:rf/event-handler` wrapper) — the same shape `register-event!` stores and
-  `event-handler-meta` produces. `_meta` is the inline entry's metadata map
-  (unused for events: the descriptor already carries the inline `:metadata`,
-  and the only event-meta slot affecting the runnable chain — author-declared
-  `:interceptors` references — is an advanced inline shape out of this slice's
-  scope); `impl` is the raw handler fn. Returns ONLY the two runnable slots
-  (`{:handler-fn … :interceptors …}`) so image-assembly merges them onto the
+  event-handler slots — the same shape `register-event!` stores and
+  `event-handler-meta` produces: `:handler-fn` + the `:interceptors` chain
+  carrying the `:rf/event-handler` wrapper, PLUS `:rf.cofx/requires-parsed`
+  when the inline entry declared `:rf.cofx/requires`.
+
+  `meta` is the inline entry's metadata map. The only AUTHORED meta slots this
+  lowering acts on are the cofx-requirements: `:rf.cofx/requires` is parsed via
+  `cofx/parse-requires` into `:rf.cofx/requires-parsed`, exactly as
+  `register-event!` does (EP-0017 §4/§5). This is load-bearing: the
+  satisfaction step (`router/assemble-initial-ctx`) reads the TOP-LEVEL
+  `:rf.cofx/requires-parsed` slot to deliver the declared coeffects, so an
+  inline image-loaded event MUST carry it or its declared facts are silently
+  dropped (rf2-khi7xr — a fail-open drop, violating EP-0017 §5 uniform
+  declared-only delivery and the EP-0023 §Image Fragments \"both paths lower to
+  the same runtime descriptor shape\" contract). A malformed / duplicate
+  declaration fails loud at lowering (`:rf.error/cofx-request-invalid` /
+  `:rf.error/cofx-name-collision`), mirroring registration.
+
+  The other event-meta slot affecting the runnable chain — author-declared
+  `:interceptors` references — remains an advanced inline shape out of this
+  slice's scope (the descriptor already carries the inline `:metadata` for
+  introspection). `impl` is the raw handler fn.
+
+  Returns ONLY the runnable slots so image-assembly merges them onto the
   descriptor, preserving `:impl` + provenance for replacement-winner
   coordinates and dedupe."
-  [_meta impl]
-  (event-handler-meta impl))
+  [meta impl]
+  (let [requires-parsed (cofx/parse-requires :rf/image-inline-event
+                                             (:rf.cofx/requires meta))]
+    (cond-> (event-handler-meta impl)
+      (seq requires-parsed) (assoc :rf.cofx/requires-parsed requires-parsed))))
 
 (late-bind/set-fn! :image/lower-inline-event lower-inline-event)

--- a/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
@@ -992,3 +992,67 @@
           gen  (asm/assemble [img] pool)]
       (is (= ::app-nav (:handler-fn (asm/resolve-descriptor gen :fx :rf.nav/push-url)))
           "the declared :replace-standard winner replaces the standard in the generation"))))
+
+;; ===========================================================================
+;; SECTION 10 — Inline (image-loaded) events deliver :rf.cofx/requires
+;; (EP-0023 §Image Fragments — "Both paths should lower to the same runtime
+;;  descriptor shape"; Spec 002 §Satisfaction; EP-0017 §5 declared-only
+;;  delivery; rf2-khi7xr)
+;; ===========================================================================
+;;
+;; The bug (rf2-khi7xr): the normal `reg-event` path parses `:rf.cofx/requires`
+;; into `:rf.cofx/requires-parsed` on the registrar entry, and the satisfaction
+;; step (`router/assemble-initial-ctx`) reads that TOP-LEVEL slot to deliver the
+;; declared facts. The EP-0023 inline-image path lowers a `:reg-event` descriptor
+;; through `events/lower-inline-event`, which emitted ONLY `{:handler-fn
+;; :interceptors}` and NEVER parsed the inline `:metadata`'s `:rf.cofx/requires`
+;; — so an image-loaded event declaring `:rf.cofx/requires` ran with the declared
+;; facts MISSING (a fail-open silent drop). EP-0017 §5 requires uniform
+;; declared-only delivery for EVERY event regardless of registration path.
+;;
+;; The cofx supplier is ALSO declared inline (in the same image's
+;; `:registrations`) so it rides into the frame's generation — EP-0023
+;; §Frame-derived resolution is ALL-OR-NOTHING (a bound generation resolves
+;; ONLY its own descriptors, no registrar fallback; proven by
+;; `s5-generation-scope-is-all-or-nothing`), so a framework-registrar-only cofx
+;; would not be resolvable under the frame's generation. The whole event +
+;; cofx pair lives in the one image, exactly as a real image-loaded feature
+;; would ship them.
+
+(deftest s10-inline-image-event-receives-declared-cofx-requires
+  (testing "EP-0023 §Image Fragments: an INLINE (image-loaded) event declaring
+            `:rf.cofx/requires` RECEIVES the declared coeffect when dispatched —
+            the inline path lowers to the SAME runtime descriptor shape (with
+            `:rf.cofx/requires-parsed`) the `reg-event` path installs, so
+            declared-only delivery is uniform across both registration paths
+            (rf2-khi7xr)"
+    (let [seen (atom ::unset)
+          ;; The inline handler reads the DECLARED :inline.cofx/locale and
+          ;; stashes it (so the test can assert delivery) while writing app-db.
+          handler (fn [{:keys [db inline.cofx/locale]} _]
+                    (reset! seen locale)
+                    {:db (assoc db :ran? true)})
+          img   (rf/image
+                  {:id :inline/cofx
+                   :registrations
+                   {;; The ambient cofx supplier rides into the SAME generation.
+                    :reg-cofx
+                    [[:inline.cofx/locale
+                      {:doc "Inline ambient supplier."}
+                      (fn [] "en-AU")]]
+                    :reg-event
+                    [[:inline.cofx/touch
+                      {:doc "Inline event declaring a cofx requirement."
+                       :rf.cofx/requires [:inline.cofx/locale]}
+                      handler]]}})
+          ;; No :include-ns → no source pool needed; the inline entries are
+          ;; selected because the image was supplied.
+          frame (lf/make-frame {:id :inline/cofx-frame :images [img]} [])]
+      (rf/dispatch-sync [:inline.cofx/touch] {:frame :inline/cofx-frame})
+      (is (true? (:ran? (rf/app-db-value :inline/cofx-frame)))
+          "the inline image-loaded handler ran")
+      (is (= "en-AU" @seen)
+          "the DECLARED :inline.cofx/locale coeffect was delivered FLAT to the
+           inline handler (was silently DROPPED before rf2-khi7xr —
+           :rf.cofx/requires-parsed was never emitted by lower-inline-event)")
+      (rf/destroy-frame! frame))))


### PR DESCRIPTION
## Summary

Inline (EP-0023 image-loaded) event handlers silently dropped declared `:rf.cofx/requires` — the declared coeffects were never delivered to the handler.

**Root cause.** The normal `register-event!` path parses `:rf.cofx/requires` via `cofx/parse-requires` and stores `:rf.cofx/requires-parsed` on the registrar entry. The EP-0023 inline-image path lowers a `:reg-event` descriptor through `lower-inline-event`, which produced only `{:handler-fn :interceptors}` and never parsed requires — the author's `:rf.cofx/requires` survived only nested under the descriptor's `:metadata`. The satisfaction step (`router/assemble-initial-ctx`) reads `(:rf.cofx/requires-parsed handler-meta)` from the descriptor top level → `nil` for inline events → the delivery branch is skipped → an image-loaded event declaring `:rf.cofx/requires` ran with the facts MISSING (fail-open silent drop).

This violates EP-0017 §5 (uniform declared-only delivery for EVERY event), Spec 002 §Satisfaction, and the EP-0023 §Image Fragments contract that both paths lower to the same runtime descriptor shape.

## Fix

`lower-inline-event` now parses the inline `:metadata`'s `:rf.cofx/requires` via `cofx/parse-requires` and emits `:rf.cofx/requires-parsed` in its runnable slots, mirroring `register-event!`. Malformed / duplicate declarations fail loud at lowering (`:rf.error/cofx-request-invalid` / `:rf.error/cofx-name-collision`), as on the registration path. The fix is contained to the one lowering fn; the shared 2-arity hook contract (and the sibling sub/fx/cofx lowerings) is untouched.

## Test (TEST-FIRST)

Adds EP-0023 conformance Section 10 (`s10-inline-image-event-receives-declared-cofx-requires`): an inline image carrying a `:reg-event` declaring `:rf.cofx/requires` plus the matching inline `:reg-cofx` ambient supplier (so the cofx rides into the frame's generation — EP-0023 frame resolution is all-or-nothing). Dispatching into the frame now delivers the declared coeffect flat under its id.

- **Reproduced before fix**: with `lower-inline-event` at its original body, `s10` FAILS (`@seen` is nil — the declared coeffect was dropped) while all other tests pass.
- **Passes after fix**: `s10` green; the handler receives the declared coeffect.

## Quality gates (all green)

- `npm run test:cljs` — 8017 tests / 33476 assertions, 0 failures, 0 errors
- `sh scripts/test-jvm-implementation.sh` — every artefact green, 0/0
- clj-kondo `--fail-level error` on changed files — 0 errors (only pre-existing warnings)
- Splint `--fail-on-errors` on changed files — 0 errors
- API manifest drift-check — in sync (481 public vars); no facade/manifest change