### PR TITLE
fix(core/views): owned frame-provider survives StrictMode double-invoke (rf2-i02deh)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -77,16 +77,20 @@
   frame-scoped op reading that nil then raises
   `:rf.error/no-frame-context`. The corruption error event is its own
   distinct diagnostic surface."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [reagent.dom.client :as rdc]
             ["react" :as React]
             ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
+            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.views]
+            [re-frame.views.owned-frame :as owned-frame])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` OPTS OUT of the fixture's default
@@ -101,10 +105,38 @@
 ;; suite out keeps the resolution honest. (Scenario-3 + the prop-stringified
 ;; cases additionally `(binding [*current-frame* nil] …)` for belt-and-braces;
 ;; that is idempotent here.)
-(use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
-     :ambient-frame nil}))
+;; MAP-FORM fixture (not the fn-form `make-reset-runtime-fixture`): cljs.test
+;; requires `:each` fixtures to be `{:before … :after …}` maps when the ns
+;; contains ANY `async` test (a fn-form fixture's wrapper returns — running
+;; its teardown — before the async body's `done` fires). Scenario-6-owned +
+;; the genuine-unmount teardown test below are async (they must advance past
+;; the owned-frame's 0ms deferred destroy). The before/after pair replicates
+;; the runtime reset `make-reset-runtime-fixture` performs for THIS suite:
+;; snapshot + restore the registrar, reset the frame registry + live-frame
+;; index, dispose/reinstall the Reagent adapter, clear trace listeners,
+;; ensure `:rf/default`. There is NO ambient `*current-frame*` binding —
+;; this suite pins the React-context tier (the `:ambient-frame nil` opt-out
+;; the fn-form fixture carried); an ambient :rf/default would shadow tier 2.
+;; Mirrors the established async-DOM fixture idiom in
+;; react_click_handler_frame_routing_cljs_test / dispatch_frame_capture.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (trace-tooling/clear-listeners!)
+  (substrate-adapter/install-adapter! reagent-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -115,6 +147,22 @@
 (defn- make-mount-node! []
   (when (browser?)
     (.createElement js/document "div")))
+
+(defn- get-act
+  "Return React's act() if available, else nil. React 18 ships act in
+  react-dom/test-utils; React 19 promotes it to the React namespace
+  proper. Either is fine for our purposes — both are sync-or-async-
+  promise compatible with the same call shape. Used by Scenario 7
+  (concurrent re-render flush) and the owned-frame StrictMode scenarios
+  (act drives React's effect double-invoke deterministically — `flushSync`
+  does NOT run the StrictMode passive-effect cleanup/re-setup synchronously,
+  so the deferred-destroy race only surfaces under act)."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
 
 ;; ---- Scenario 1: nested-provider inheritance ------------------------------
 ;;
@@ -523,6 +571,199 @@
             (finally
               (try (rdc/unmount root) (catch :default _ nil)))))))))
 
+;; ---- Scenario 6 (OWNED): StrictMode must not destroy durable state --------
+;;
+;; rf2-i02deh. Scenario 6 above covers the SCOPE-only
+;; `frame-provider-existing` under StrictMode — a pure context read, so the
+;; double-invoke is harmless. This OWNED counterpart covers `rf/frame-provider`
+;; (the create-on-mount / destroy-on-unmount lifecycle boundary, EP-0024),
+;; where StrictMode's dev cycle is the dangerous one:
+;;
+;;   mount → effect-setup → effect-CLEANUP → effect-setup-AGAIN
+;;
+;; on the SAME fiber (the `useRef` persists). The owned-frame component
+;; (`re-frame.views.owned-frame/owned-frame-fc`) acquires the frame in the
+;; RENDER phase, gated on `id-ref.current` being nil, and arms an empty-deps
+;; `useEffect` whose cleanup calls `release-owned-frame!` (the DEFERRED 0ms
+;; destroy). The StrictMode contract (Spec 002 §002:1419 idempotent re-mount /
+;; §002:1424 StrictMode double-invoke) is: the extra cycle MUST NOT corrupt
+;; durable state (app-db / sub-cache / queue).
+;;
+;; The trap this test pins: the StrictMode cleanup schedules the deferred
+;; destroy, but the StrictMode effect-RE-SETUP does NOT re-run the render
+;; phase (the fiber's `id-ref.current` is still populated), so
+;; `acquire-owned-frame!` — the ONLY place `cancel-pending-destroy!` is
+;; reached — never runs again. The 0ms timer then fires on the next
+;; macrotask and `destroy-frame!` tears down durable state. The fix re-drives
+;; the cancel on every effect SETUP, so the remount's effect-setup cancels
+;; the pending destroy. This test mounts an owned `rf/frame-provider` under
+;; StrictMode, advances past the 0ms deferred destroy, and asserts the frame
+;; is STILL LIVE with its `:initial-db` intact.
+
+(deftest scenario-6-owned-strict-mode-preserves-durable-state
+  "Scenario 6 (OWNED) — StrictMode double-invoke must NOT destroy an owned
+   frame-provider's durable state (rf2-i02deh, Spec 002 §002:1419 / §002:1424).
+
+   Mount `[rf/frame-provider {:id :test/owned :initial-db {:n 7}} …]` inside
+   `React.StrictMode`. StrictMode runs the owned-frame effect's cleanup (which
+   SCHEDULES the deferred destroy) and re-setup on the same fiber. After the
+   0ms deferred destroy's macrotask window passes, the frame MUST still be live
+   with `{:n 7}` intact — the remount's effect-setup must have cancelled the
+   pending destroy. Fails on the pre-fix code: the cancel only ran from the
+   render-phase `acquire-owned-frame!`, which StrictMode's effect-re-setup does
+   NOT re-trigger, so the timer fired and `destroy-frame!` ran."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (async done
+      (let [target     :test/owned-strict
+            done?      (atom false)
+            ;; `done`-once guard: the act() thenable + nested macrotask chain
+            ;; has several exit paths (success, a thrown assertion, a promise
+            ;; rejection). Calling cljs.test's `done` twice aborts the suite
+            ;; ("Async test called done more than one time"), so funnel every
+            ;; exit through one guarded call.
+            done!      (fn [] (when (compare-and-set! done? false true) (done)))
+            mount-node (make-mount-node!)
+            ;; PURE React mount via `react-dom/client createRoot` (NOT Reagent's
+            ;; `rdc/create-root`): Reagent's own render scheduling commits the
+            ;; embedded `owned-frame-fc` on a Reagent reaction tick OUTSIDE
+            ;; React's StrictMode subtree pass, so React's StrictMode effect
+            ;; double-invoke never fires for the FC. Mounting a NATIVE React
+            ;; element tree — `StrictMode > owned-frame-react-element` — puts
+            ;; the FC directly under StrictMode, which is exactly the UIx/Helix
+            ;; substrate path (they build the owned provider via
+            ;; `owned-frame-react-element`, raw `createElement`). The bug is in
+            ;; the shared `owned-frame-fc`, so this faithfully exercises it for
+            ;; all React-shaped adapters.
+            root       (react-dom-client/createRoot mount-node)
+            cleanup!   (fn []
+                         (try (.unmount root) (catch :default _ nil))
+                         ;; Belt-and-braces: drop any frame the test left behind
+                         ;; so a later macrotask destroy can't leak across tests.
+                         (try (frame/destroy-frame! target) (catch :default _ nil)))
+            ;; The owned provider's children are an ordinary React element (the
+            ;; durable app-db is asserted directly via `app-db-value`; a probe
+            ;; subtree is not needed to exercise the lifecycle bug).
+            child      (React/createElement "div" #js {} "owned-strict")
+            owned-el   (owned-frame/owned-frame-react-element
+                         {:id target :initial-db {:n 7}}
+                         child
+                         'scenario-6-owned-strict-mode-preserves-durable-state)
+            tree       (React/createElement (.-StrictMode React) nil owned-el)
+            act-fn     (get-act)]
+        (if (nil? act-fn)
+          (do (is true "act() not reachable from this runner; scenario-6-owned skipped")
+              (done!))
+          ;; `act` flushes passive effects + drives StrictMode's effect
+          ;; double-invoke (setup → cleanup → setup) on the same fiber. Under
+          ;; StrictMode + `createRoot`, that cleanup runs in a passive-effect
+          ;; pass React schedules through act's returned thenable — so we MUST
+          ;; await it (a bare `act` call does not flush the StrictMode cleanup
+          ;; synchronously). The cleanup calls `release-owned-frame!`,
+          ;; scheduling the 0ms deferred destroy; the re-setup must cancel it.
+          ;; After awaiting, advance two macrotasks so the (un-cancelled,
+          ;; pre-fix) 0ms destroy timer fires before we assert. Every exit
+          ;; funnels through the guarded `done!` (cljs.test aborts the shared
+          ;; browser runtime on a double-done).
+          (-> (js/Promise.resolve (act-fn (fn [] (.render root tree))))
+              (.then
+                (fn [_]
+                  ;; Sanity: the frame was created + durable state seeded.
+                  (is (some? (frame/frame target))
+                      "owned frame-provider created the frame on mount")
+                  (is (= {:n 7} (rf/app-db-value target))
+                      ":initial-db seeded the durable app-db")
+                  (js/setTimeout
+                    (fn []
+                      (js/setTimeout
+                        (fn []
+                          (is (not (owned-frame/pending-destroy? target))
+                              (str "no deferred destroy left armed after the StrictMode "
+                                   "cycle (the remount's effect-setup cancelled it)"))
+                          (is (some? (frame/frame target))
+                              (str "the owned frame is STILL LIVE after the deferred-destroy "
+                                   "window — StrictMode double-invoke did not tear it down "
+                                   "(Spec 002 §002:1424)"))
+                          (is (= {:n 7} (rf/app-db-value target))
+                              (str "durable app-db survived the StrictMode cycle intact (got "
+                                   (pr-str (rf/app-db-value target))
+                                   ") — §002:1419 idempotent re-mount"))
+                          (cleanup!)
+                          (done!))
+                        4))
+                    4)))
+              (.catch
+                (fn [err]
+                  (is false (str "scenario-6-owned threw: " (pr-str err)))
+                  (cleanup!)
+                  (done!)))))))))
+
+;; ---- Scenario 6 (OWNED): genuine unmount STILL destroys -------------------
+;;
+;; rf2-i02deh — the fix must not break real teardown. A genuine unmount (no
+;; remount re-acquires the id) must let the deferred destroy fire and tear the
+;; frame down. This pins that the cancel-on-effect-setup change did not turn
+;; the owned provider into a leak: after a real unmount + the macrotask window,
+;; the frame is GONE.
+
+(deftest scenario-6-owned-genuine-unmount-destroys
+  "Scenario 6 (OWNED) — a genuine unmount still destroys the owned frame
+   (rf2-i02deh). The StrictMode fix re-drives the cancel on effect setup; it
+   must NOT suppress the destroy on a real unmount where nothing re-acquires
+   the id. Mount (no StrictMode), unmount, advance past the 0ms deferred
+   destroy, and assert the frame is torn down."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (async done
+      (let [target     :test/owned-teardown
+            done?      (atom false)
+            done!      (fn [] (when (compare-and-set! done? false true) (done)))
+            mount-node (make-mount-node!)
+            ;; Pure React mount (see scenario-6-owned for why — Reagent's render
+            ;; scheduling otherwise commits the FC outside React's effect passes).
+            root       (react-dom-client/createRoot mount-node)
+            child      (React/createElement "div" #js {} "owned-teardown")
+            owned-el   (owned-frame/owned-frame-react-element
+                         {:id target :initial-db {:n 3}}
+                         child
+                         'scenario-6-owned-genuine-unmount-destroys)
+            act-fn     (get-act)]
+        (if (nil? act-fn)
+          (do (is true "act() not reachable from this runner; genuine-unmount scenario skipped")
+              (done!))
+          ;; Mount under act so the owned-frame effect arms (NOT StrictMode —
+          ;; this is the genuine single-lifecycle path), then unmount under act
+          ;; so the effect cleanup runs (scheduling the deferred destroy). Await
+          ;; each act so the effect / cleanup passive passes flush (see
+          ;; scenario-6-owned for why awaiting matters), then advance the
+          ;; macrotask so the deferred destroy fires.
+          (-> (js/Promise.resolve (act-fn (fn [] (.render root owned-el))))
+              (.then
+                (fn [_]
+                  (is (some? (frame/frame target)) "frame created on mount")
+                  ;; Genuine unmount — nothing re-acquires the id.
+                  (js/Promise.resolve (act-fn (fn [] (.unmount root))))))
+              (.then
+                (fn [_]
+                  ;; Let the 0ms deferred destroy's macrotask fire.
+                  (js/setTimeout
+                    (fn []
+                      (js/setTimeout
+                        (fn []
+                          (is (nil? (frame/frame target))
+                              "genuine unmount tore the frame down (deferred destroy fired)")
+                          (is (not (owned-frame/pending-destroy? target))
+                              "no pending destroy left armed after the timer fired")
+                          (try (frame/destroy-frame! target) (catch :default _ nil))
+                          (done!))
+                        4))
+                    4)))
+              (.catch
+                (fn [err]
+                  (is false (str "genuine-unmount scenario threw: " (pr-str err)))
+                  (try (frame/destroy-frame! target) (catch :default _ nil))
+                  (done!)))))))))
+
 ;; ---- Scenario 7: concurrent rendering / suspense + act --------------------
 ;;
 ;; React 18+ concurrent rendering schedules renders asynchronously by
@@ -536,19 +777,9 @@
 ;; React's `act()` is exposed via `react-dom/test-utils` (React 18)
 ;; and on `react` directly (React 19). The harness uses whichever is
 ;; available; if neither is reachable the test SKIPS and files a bead
-;; (per the bead's "no new test infrastructure" rule).
-
-(defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper. Either is fine for our purposes — both are sync-or-async-
-  promise compatible with the same call shape."
-  []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+;; (per the bead's "no new test infrastructure" rule). `get-act` lives
+;; in the helpers section above (shared with the owned-frame StrictMode
+;; scenarios, which also need act() to drive React's effect double-invoke).
 
 (deftest scenario-7-concurrent-renders-survive-act-flush
   "Scenario 7 — React concurrent rendering survives across re-renders.

--- a/implementation/core/src/re_frame/views/owned_frame.cljs
+++ b/implementation/core/src/re_frame/views/owned_frame.cljs
@@ -246,7 +246,12 @@
 ;;     resolved id is stashed in a `useRef` so re-renders reuse it.
 ;;   - DESTROY on UNMOUNT via `useEffect` empty-deps cleanup, DEFERRED (see
 ;;     `release-owned-frame!`) so StrictMode's mount→unmount→mount and hot
-;;     reload do not tear down durable state.
+;;     reload do not tear down durable state. The effect SETUP re-drives
+;;     `cancel-pending-destroy!` (rf2-i02deh): StrictMode replays the effect as
+;;     setup → cleanup → setup on the SAME fiber WITHOUT re-running render, so
+;;     the render-phase acquire cannot cancel the remount's pending destroy —
+;;     the setup-phase cancel is what makes the deferred-destroy window
+;;     StrictMode-tolerant.
 
 (defn ^:no-doc owned-frame-fc
   "The React function component that owns one frame's UI lifetime — ONE
@@ -277,10 +282,17 @@
 
   Effect-phase destroy: an empty-deps `useEffect` arms a cleanup that calls
   `release-owned-frame!` (DEFERRED destroy) on unmount. Empty deps ⇒ the cleanup
-  runs once per genuine unmount; StrictMode's extra mount→unmount→mount cycle is
-  absorbed because the destroy is deferred and cancelled by the remount's
-  render-phase re-acquire (which re-runs `acquire-owned-frame!` before this
-  effect re-arms)."
+  runs once per genuine unmount. StrictMode's extra mount→unmount→mount cycle is
+  absorbed because the destroy is deferred AND the effect SETUP re-drives
+  `cancel-pending-destroy!` on every run: StrictMode replays the effect as
+  setup → cleanup → setup on the SAME fiber, and the render phase does NOT
+  re-run on the effect re-setup (the fiber's cached `id-ref.current` survives),
+  so the render-phase `acquire-owned-frame!` is NOT a reliable cancel site for
+  the remount. Cancelling in the effect setup (rf2-i02deh) is — the remount's
+  setup reclaims the still-live frame before the prior cleanup's 0ms timer can
+  fire. A genuine first mount finds no pending destroy (no-op); a genuine
+  unmount arms the deferred destroy with no re-setup to cancel it, so real
+  teardown is unaffected."
   [^js props]
   (let [opts     (.-rfOpts props)
         children (.-children props)
@@ -293,9 +305,21 @@
                        fid))]
     (React/useEffect
       (fn arm-owned-frame-teardown []
-        ;; StrictMode/hot-reload tolerance: on a remount the render phase above
-        ;; re-acquires (cancelling any pending destroy) before this effect runs
-        ;; again, so the create/destroy pair tolerates the extra cycle.
+        ;; StrictMode/hot-reload tolerance (rf2-i02deh). React StrictMode runs
+        ;; this effect as setup → cleanup → setup AGAIN on the SAME fiber (the
+        ;; `useRef` persists). The cleanup below schedules the DEFERRED destroy;
+        ;; the re-setup must CANCEL it, or the 0ms timer fires and tears down
+        ;; durable state between the two mounts. The render phase does NOT
+        ;; re-run on a StrictMode effect re-setup (the fiber's `id-ref.current`
+        ;; is still populated), so `acquire-owned-frame!` — the render-phase
+        ;; cancel site — never runs again. Re-drive the cancel HERE, on every
+        ;; effect setup, so the remount's effect-setup reclaims the still-live
+        ;; frame (Spec 002 §StrictMode double-invoke / §idempotent re-mount).
+        ;; A genuine first mount has no pending destroy, so this is a no-op
+        ;; there; a genuine unmount still arms the deferred destroy via the
+        ;; cleanup, and nothing re-acquires the id to cancel it — so real
+        ;; teardown is unaffected.
+        (cancel-pending-destroy! (.-current id-ref))
         (fn cleanup-owned-frame []
           (release-owned-frame! (.-current id-ref))))
       ;; Empty deps: arm once on mount, clean up once on unmount.


### PR DESCRIPTION
## Bug (rf2-i02deh)

The shared `owned-frame-fc` (`re-frame.views.owned-frame`) acquired the frame in the **render** phase (gated on a `useRef`) and armed an empty-deps `useEffect` whose cleanup called `release-owned-frame!` (the deferred 0ms `destroy-frame!`).

Under React StrictMode dev double-invoke, React replays the effect as **setup → cleanup → setup** on the **same fiber**. The cleanup scheduled the deferred destroy, but the re-setup did **not** re-run the render phase (the fiber's cached `id-ref.current` survives), so `acquire-owned-frame!` — the only call site of `cancel-pending-destroy!` — never ran again. The 0ms timer then fired and `destroy-frame!` tore down the owned frame's durable state (app-db / sub-cache / queue) between the two StrictMode mounts.

Spec 002 contract violated: StrictMode double-invoke must tolerate the extra cycle without corrupting durable state; idempotent re-mount must not destroy durable state. Universal across all four React-shaped adapters (the bug is in the shared `owned-frame-fc`).

## Fix

Re-drive `cancel-pending-destroy!` in the effect **setup** body, on every run. The StrictMode remount's effect-setup now reclaims the still-live frame before the prior cleanup's deferred destroy can fire. The render-phase acquire is retained for the "frame must exist before children render" guarantee.

- Genuine first mount: finds no pending destroy → no-op.
- Genuine unmount: still arms the deferred destroy, nothing re-acquires the id to cancel it → **real teardown unaffected**.

## Tests (test-first)

Two real-DOM scenarios added to the Reagent owned-frame DOM suite, mounting a **pure React** `StrictMode > owned-frame-react-element` tree via `react-dom/client createRoot` + `act` (Reagent's render scheduling otherwise commits the FC outside React's effect passes, masking the double-invoke — confirmed via instrumentation that only the pure-React mount triggers the StrictMode setup → cleanup → setup cycle).

- `scenario-6-owned-strict-mode-preserves-durable-state` — **FAILED on pre-fix** (frame destroyed, `app-db` nil after the 0ms window), **passes after the fix** (frame live, `{:n 7}` intact, no pending destroy left armed).
- `scenario-6-owned-genuine-unmount-destroys` — **passes on both** pre- and post-fix, pinning that real teardown still tears the frame down.

The suite fixture moved to map form (`:before`/`:after`) because cljs.test requires it once a namespace contains async tests (mirrors the established async-DOM fixture idiom in this adapter test dir).

## Gates

- `npm run test:browser` — **222 tests, 701 assertions, 0 failures** (stable across two runs; new tests included)
- `npm run test:cljs` — 8018 tests, 0 failures
- clj-kondo — 0 errors (6 pre-existing `unused binding db` warnings, none new)
- splint — 0 warnings, 0 errors
- API manifest drift-check — green (no facade change; CLJS-only `owned-frame-fc` internals)

No JVM-compiled namespaces touched (both files are `.cljs`; `owned-frame.cljs` is never loaded by the plain-atom JVM build).