### PR TITLE
fix(resources): :has-data? false for empty infinite feeds on scalar subs (rf2-3fynns)

### DIFF
--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -340,7 +340,13 @@
          :loading?      (= :loading (:status e))
          :fetching?     (= :fetching (:status e))
          :stale?        (stale? e)
-         :has-data?     (some? (:data e))}
+         ;; `:has-data?` via the shared `state/has-data?` derivation, NOT the
+         ;; scalar `(some? :data)`: an infinite feed's `:data` is the page
+         ;; VECTOR seeded EMPTY (`[]`), which `some?` would wrongly read as
+         ;; usable data (rf2-3fynns). `state/has-data?` branches on the
+         ;; feed shape (`(seq data)`), so the scalar `:state` sub and
+         ;; `:infinite-state` never disagree.
+         :has-data?     (state/has-data? e)}
         ;; `:keep-previous?` projection — previous-key data shown while this
         ;; key first-loads, WITHOUT polluting this entry's cache / tags.
         (previous-projection rt e)))))
@@ -390,9 +396,13 @@
 
 (defn has-data?-sub-fn
   "Project `:rf.resource/has-data?` — usable data present. Per Spec 016
-  §Status semantics."
+  §Status semantics. Routed through the shared `state/has-data?` derivation
+  (NOT the scalar `(some? :data)`): an infinite feed's `:data` is the page
+  VECTOR seeded EMPTY (`[]`), which `some?` would wrongly read as usable data
+  (rf2-3fynns). `state/has-data?` branches on the feed shape (`(seq data)`),
+  so this scalar sub and `:rf.resource/infinite-state` never disagree."
   [frame-state [_id payload]]
-  (some? (:data (entry-for (runtime-of frame-state) (app-of frame-state) payload))))
+  (state/has-data? (entry-for (runtime-of frame-state) (app-of frame-state) payload)))
 
 (defn previous-data-sub-fn
   "Project `:rf.resource/previous-data` — the prior key's data projected

--- a/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
@@ -141,6 +141,54 @@
     (is (nil? (entry (feed-key :is1/feed))))))
 
 ;; ===========================================================================
+;; 1b. the SCALAR :has-data? / :state subs over an infinite feed (rf2-3fynns)
+;;
+;;   The scalar `:rf.resource/has-data?` and `:rf.resource/state` subs ALSO
+;;   apply to an infinite feed (Spec 016 §Subscriptions — the family is
+;;   resource-kind agnostic). An infinite feed's `:data` is the page VECTOR,
+;;   seeded EMPTY (`[]`) before page 0 lands, so the scalar `(some? :data)`
+;;   test would WRONGLY read an empty/never-loaded feed as `:has-data? true`
+;;   (and `:rf.resource/state` would return the self-contradictory
+;;   `{:status :loading … :has-data? true}`). Both scalar subs must route
+;;   through the shared `state/has-data?` derivation (the same one
+;;   `:rf.resource/infinite-state` uses), so the two PUBLIC sub families agree.
+;; ===========================================================================
+
+(deftest scalar-has-data?-false-for-empty-infinite-feed
+  (testing "an EMPTY (never-loaded) infinite feed has a live entry with :data []"
+    (rf/reg-resource :is1b/feed (feed-spec))
+    (ensure! :is1b/feed)                       ;; entry now exists, :status :loading
+    (let [e (entry (feed-key :is1b/feed))]
+      (is (some? e) "ensure created the durable feed entry")
+      (is (= [] (:data e)) "an unloaded infinite feed seeds the page vector empty")
+      (is (= :loading (:status e)) "first load, no usable data ⇒ :loading"))
+    (testing "the scalar :rf.resource/has-data? reads FALSE (empty page vector)"
+      (is (false? @(rf/subscribe [:rf.resource/has-data? (q :is1b/feed)]))
+          "an empty page vector is NO usable data — must match state/has-data?"))
+    (testing "the scalar :rf.resource/state's :has-data? agrees (and isn't self-contradictory)"
+      (let [vm @(rf/subscribe [:rf.resource/state (q :is1b/feed)])]
+        (is (= :loading (:status vm)) "still first-loading")
+        (is (false? (:has-data? vm))
+            ":has-data? false for an empty feed — not the self-contradictory true")
+        (is (true? (:loading? vm)) "first load with no usable data")))
+    (testing "the scalar and infinite-feed sub families AGREE on :has-data?"
+      (is (= @(rf/subscribe [:rf.resource/has-data? (q :is1b/feed)])
+             (:has-data? @(rf/subscribe [:rf.resource/state (q :is1b/feed)]))
+             (:has-data? @(rf/subscribe [:rf.resource/infinite-state (q :is1b/feed)]))
+             false)
+          "all three public :has-data? readings concur on the empty feed"))))
+
+(deftest scalar-has-data?-true-once-a-page-lands
+  (testing "once page 0 lands the scalar :has-data? flips TRUE (≥1 page)"
+    (load-page-0! :is1c/feed (page [:a :b] "c1"))
+    (is (true? @(rf/subscribe [:rf.resource/has-data? (q :is1c/feed)])))
+    (is (true? (:has-data? @(rf/subscribe [:rf.resource/state (q :is1c/feed)]))))
+    (is (= @(rf/subscribe [:rf.resource/has-data? (q :is1c/feed)])
+           (:has-data? @(rf/subscribe [:rf.resource/infinite-state (q :is1c/feed)]))
+           true)
+        "the scalar and infinite families agree on a loaded feed")))
+
+;; ===========================================================================
 ;; 2. :rf.resource/items merges pages in order (the headline read)
 ;; ===========================================================================
 


### PR DESCRIPTION
## Bug (rf2-3fynns)

The scalar `:rf.resource/has-data?` and `:rf.resource/state` subs computed `:has-data?` as `(some? (:data e))`. An infinite feed's `:data` is the page **vector**, seeded **empty** (`[]`) by `empty-infinite-entry` before page 0 lands — so `(some? [])` wrongly reported an empty/never-loaded feed as `:has-data? true`, and `:rf.resource/state` returned the self-contradictory `{:status :loading … :has-data? true}`.

Meanwhile `:rf.resource/infinite-state` already delegated to the shared `state/has-data?` derivation (which branches on `infinite-entry?`, returning `(boolean (seq data))`), so **two public sub families disagreed** on the same feed. Spec 016 §Subscriptions: the scalar `:rf.resource/state`/`:has-data?` family applies to infinite feeds too.

## Fix

Route both scalar subs through the existing shared `state/has-data?`:
- `state-sub-fn`: `:has-data?` now `(state/has-data? e)` (was `(some? (:data e))`)
- `has-data?-sub-fn`: now `(state/has-data? (entry-for …))` (was `(some? (:data …))`)

`data-sub-fn` unchanged. Scalar (non-feed) entries are unchanged — `state/has-data?` falls back to `(some? data)` for them; the no-entry path stays `false` (nil entry ⇒ not infinite ⇒ `(some? nil)` ⇒ false). `state-sub-fn` keeps its explicit nil-entry empty-state branch.

## Tests (test-first)

Added two deftests to `resources_infinite_subs_cljs_test.cljc`:
- `scalar-has-data?-false-for-empty-infinite-feed` — an ensured-but-unreplied feed (live entry, `:data []`, `:status :loading`) reads `:has-data? false` on `:rf.resource/has-data?` AND on `:rf.resource/state`, and all three public `:has-data?` readings (`has-data?`, `state`, `infinite-state`) agree on `false`. **Confirmed failing on main** (reported `true`) before the fix.
- `scalar-has-data?-true-once-a-page-lands` — guards the post-load case (≥1 page ⇒ `true`, families still agree).

## Gates

- Resources JVM suite: **591 tests / 2561 assertions, 0 failures**
- `npm run test:cljs`: **8021 tests / 33489 assertions, 0 failures**
- clj-kondo / splint over changed files: only pre-existing warnings (unused `re-frame.frame` require + test-file style nits that exist on main); no new warnings in the fix or added test block

No facade/manifest change.