### PR TITLE
docs(http): doc-accuracy + clarity cleanup (rf2-qq1lhe)

### DIFF
--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -277,6 +277,10 @@
                            :else                      requested-decode)
         parse-opts       (when max-decoded-keys {:max-decoded-keys max-decoded-keys})]
     (cond
+      ;; A custom `:decode` fn owns its own body handling: the empty-2xx
+      ;; body normalisation (the `:json`/`:auto` arms' `empty-2xx-json-body?`
+      ;; → nil) deliberately does NOT apply here — the fn receives the raw
+      ;; `body-text` (e.g. `""` for an empty 2xx body) and decides itself.
       (fn? requested-decode)
       (requested-decode body-text headers)
 

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -64,8 +64,10 @@
   both are nil the handle is unindexed and only reachable via natural
   completion.
 
-  rf2-ee38b.7 — the convenience 2-arity `[request-id handle]` was
-  dropped; it had no production caller (the single call site in
+  rf2-ee38b.7 — `record-in-flight!`'s own convenience 2-arity
+  `[request-id handle]` was dropped (this is distinct from
+  `clear-in-flight!`'s live 2-arity below, which is retained); it had no
+  production caller (the single call site in
   `http-transport/run-attempt!` always passes the 3-arity with an
   actor-id, possibly nil) and no test depended on it."
   [request-id actor-id handle]

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -56,7 +56,15 @@
   Managed-Effects §restore (\"epoch restore MUST NOT revive host work\") a
   pre-restore completion MUST NOT deliver to its original `:rf/reply-to` target.
   Both still emit their trace facts (the suppressed-attempt's stale envelope);
-  only the app dispatch is suppressed."
+  only the app dispatch is suppressed.
+
+  Cross-ref: this set gates only the REPLY. For `:request-id-superseded`
+  the canonical EP-0011 stale-trace is NOT emitted here — it is emitted
+  separately by `managed-handler` → `emit-superseded-stale-trace!` at
+  supersede time (the `:epoch-restored` sibling is emitted by
+  `http-registry/abort-in-flight-for-frame!`). `dispatch-aborted!` here
+  fires only the `:rf.http/aborted` error trace and then suppresses the
+  reply for these reasons."
   #{:request-id-superseded :epoch-restored})
 
 (defn reply-suppressing-abort-reason?
@@ -423,8 +431,11 @@
   clear the registry, then land here so an aborted request looks
   identical to consumers regardless of which lifecycle phase it was in.
   `reason` is `:user` / `:actor-destroyed` / `:request-id-superseded` /
-  `:timeout`. `ctx` must carry `:request-id`, `:actor-id`, `:url`,
-  `:sensitive?`.
+  `:epoch-restored` — the genuine cancellation reasons that flip the
+  handle's `:aborted?` cell and reach this path. A `:timeout` is NOT an
+  abort: it classifies to `:rf.http/timeout` (a failure kind) and routes
+  through `maybe-retry!` → `finalise-failure!`, never here. `ctx` must
+  carry `:request-id`, `:actor-id`, `:url`, `:sensitive?`.
 
   Per Managed-Effects §Cancellation (rf2-yrrpe2): an `:actor-destroyed`
   abort whose reply target is OBSOLETE — its event-id names the destroyed
@@ -467,8 +478,8 @@
              (reply-target-id ctx) (:actor-id ctx)))
       (emit-actor-destroy-stale-trace! (reply-ctx ctx))
 
-      ;; Other abort reasons (`:user`, `:timeout`) and actor-destroy aborts
-      ;; whose target is still meaningful (an ordinary event) deliver the
+      ;; Other abort reasons (`:user`) and actor-destroy aborts whose
+      ;; target is still meaningful (an ordinary event) deliver the
       ;; failure reply normally as a live `:status :cancelled`.
       :else
       (dispatch-failure! ctx failure))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -304,7 +304,7 @@ The cap is the SECOND line of defence; the FIRST line is `:request-content-type`
 > Cross-reference: see [Security.md §Input validation / boundary parsing](Security.md#input-validation--boundary-parsing) and [Security.md §DoS by input](Security.md#dos-by-input) for the framework-wide posture this section grounds.
 
 ### JSON decoder hardening
-The CLJS reference depends on a **hardened third-party JSON parser** (Cheshire on the JVM; the host's native `JSON.parse` on the browser) rather than a hand-rolled reader. Per : the project's hand-rolled JSON fallback was deleted in favour of the hardened dep; the framework does not own a parser it would have to keep hardened against malformed-input classes.
+The CLJS reference depends on a **hardened third-party JSON parser** (Cheshire on the JVM; the host's native `JSON.parse` on the browser) rather than a hand-rolled reader: the project's hand-rolled JSON fallback was deleted in favour of the hardened dep; the framework does not own a parser it would have to keep hardened against malformed-input classes.
 
 Ports that ship a **hand-rolled** JSON / EDN reader (rather than depending on a hardened third-party parser) own the input-bounds contract directly. the reader MUST bounds-check unicode-escape sequences (`\uXXXX`) and surface structured `:rf.error/malformed-json` with `:reason` slots (e.g., `:reason :truncated-unicode-escape`, `:reason :invalid-hex-digit`) rather than letting truncated or invalid escapes become opaque host errors.
 
@@ -409,7 +409,7 @@ Implementations **MUST validate `:retry :on` at fx-call time** (when the `:rf.ht
 
 Both parts catch the misuse at the dispatch site rather than silently letting a useless retry policy ride for the request's lifetime (or, for `:rf.http/aborted`, deferring the rejection to retry-attempt time inside the transport loop).
 
-Per the spec tighten: implementations MUST NOT accept the old open `:rf.http/*` set. The rejection is hard, not advisory.
+Implementations MUST NOT accept the old open `:rf.http/*` set. The rejection is hard, not advisory.
 
 Each retry advances the carried epoch (per Pattern-StaleDetection); a stale request (e.g. one whose target route changed mid-retry) is suppressed without dispatching the reply.
 


### PR DESCRIPTION
## Summary

Doc-accuracy + clarity cleanup for the HTTP transport/decode/registry namespaces and spec/014. **No behaviour change** — the http abort/retry/egress machinery is confirmed correct; these are docstring/comment/spec-prose fixes only (verified each against source).

Bead: rf2-qq1lhe.

## Changes

1. **`dispatch-aborted!` docstring + `:else` comment** (`http_transport.cljc`) — dropped `:timeout` from the abort-reason list. A timeout never flips the handle's `:aborted?` cell nor reaches the abort path: `classify-cljs-error` branches on `:rf.http/timeout?` FIRST and maps it to the `:rf.http/timeout` failure kind, routing through `maybe-retry!` → `finalise-failure!`. The `.abort internal-controller "timeout"` call passes the AbortController reason, not a `dispatch-aborted!` reason. The genuine reasons are `:user` / `:actor-destroyed` / `:request-id-superseded` / `:epoch-restored`.

2. **`decode-response-body` `(fn? requested-decode)` arm** (`http_decode.cljc`) — added a note that a custom `:decode` fn deliberately bypasses the empty-2xx-body normalisation (`empty-2xx-json-body?` → nil lives only in the `:json`/`:auto` arms) and receives the raw `body-text` (e.g. `""`).

3. **spec/014-HTTPRequests.md** (~L307, ~L412) — removed dangling `Per :` / `Per the spec tighten:` empty citations (stripped bead refs); both statements stand on their own.

4. **`record-in-flight!` docstring** (`http_registry.cljc`) — qualified the "2-arity dropped" note with the fn name so it isn't read against `clear-in-flight!`'s live 2-arity right below.

5. **`reply-suppressing-abort-reasons`** (`http_transport.cljc`) — added a cross-ref that this set gates only the REPLY; for `:request-id-superseded` the canonical EP-0011 stale-trace is emitted separately by `managed-handler` → `emit-superseded-stale-trace!` (the `:epoch-restored` sibling by `abort-in-flight-for-frame!`).

## Gates

- http JVM suite: **448 tests / 2071 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **8019 tests / 33478 assertions, 0 failures, 0 errors**
- clj-kondo on edited files: **0 errors** (only pre-existing warnings)
- splint on edited files: **0 errors** (`--fail-on-errors` passed)
- spec/014 edited → mkdocs `--strict` build: **passed (exit 0)**; doc-slug check: **passed**