### PR TITLE
chore(core): subs marks docstring + router dispatch-sync! clarity (rf2-rd296f, rf2-6dcab5)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -422,10 +422,13 @@
 (defn- merge-schema-marks
   "Union the author-sourced `manual` marks entry with the schema-sourced
   `schema` marks entry into one resolved declaration. Both arguments are the
-  canonical `{:sensitive [...] :large [...] :sensitive? bool :large? bool}`
-  shape (or nil). Returns the union, or nil when both are nil/empty — so a
-  machine with neither manual nor schema marks reads as `nil` (the same
-  no-marks signal `marks-for` returned before this table existed).
+  canonical `{:sensitive [...] :large [...] :output-sensitivity <enum>
+  :large? bool}` shape (or nil) — `:output-sensitivity` is the closed
+  `:rf.egress/*` declassification enum that EP-0015 issue 9 substituted for the
+  rejected `:sensitive?` boolean, unioned here via `union-output-sensitivity`.
+  Returns the union, or nil when both are nil/empty — so a machine with neither
+  manual nor schema marks reads as `nil` (the same no-marks signal `marks-for`
+  returned before this table existed).
 
   Set-union of paths plus monotone-OR of whole-output flags — commutative,
   so the union does not depend on which source is treated as `existing`
@@ -500,8 +503,11 @@
 (defn declare-machine-schema-marks!
   "Record a machine's `:data-schema`-derived marks under `machine-id` in the
   schema-sourced table (rf2-qpibk0). `marks` is the canonical
-  `{:sensitive [paths] :large [paths] :sensitive? bool :large? bool}` shape
-  (snapshot-rooted under `[:data …]`), or nil to clear the entry. Returns nil.
+  `{:sensitive [paths] :large [paths] :output-sensitivity <enum> :large? bool}`
+  shape (snapshot-rooted under `[:data …]`), or nil to clear the entry —
+  `:output-sensitivity` is the closed `:rf.egress/*` declassification enum that
+  EP-0015 issue 9 substituted for the rejected `:sensitive?` boolean. Returns
+  nil.
 
   Kept separate from the author-sourced registrar `:event` entry so
   `marks-for :event machine-id` unions the two at read time — order-
@@ -980,7 +986,12 @@
   "Record the resolved sensitive/large state of a sub's most recent
   output. Called by the sub-cache after `compute-and-cache!` resolves
   the value. The flags fold into the propagation table; downstream
-  emit sites read via `sub-output-sensitive?` / `sub-output-large?`."
+  emit sites read via `sub-output-sensitive?` / `sub-output-large?`.
+
+  INVARIANT: the sub-cache only invokes this under `debug-enabled?`, so the
+  propagation table (`frame->sub-id->sensitive?` / `…->large?`) is EMPTY in
+  production. Any consumer reading it MUST be dev-gated too — an always-on
+  egress consumer would read empty and fail open."
   [frame-id sub-id sensitive? large?]
   (swap! frame->sub-id->sensitive?
          (fn [m]
@@ -1027,7 +1038,11 @@
   Size still uses the `:large?` whole-output override (size has no
   declassification analogue — EP-0015 issue 9 is sensitivity-only).
 
-  Returns `[sensitive? large?]`."
+  Returns `[sensitive? large?]`. INVARIANT: the input-signal propagation reads
+  go through `sub-output-sensitive?` / `sub-output-large?`, whose table is only
+  populated under `debug-enabled?` (see `mark-sub-output!`) — so this resolver,
+  and any consumer of its result, MUST be dev-gated; in production the table is
+  empty and propagation would silently fail open."
   [frame-id sub-id input-signals layer-1?]
   (let [marks       (sub-marks sub-id)
         output-sens (:output-sensitivity marks)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -3099,7 +3099,29 @@
          ;; Read the call-site from the envelope (already gated in
          ;; build-envelope) so the synchronous error emits below can
          ;; carry it without referencing the keyword a second time.
-         call-site    (:call-site envelope)]
+         call-site    (:call-site envelope)
+         ;; Nested-sync detection, hoisted out of the cond TEST position so
+         ;; the cond reads as flat test→result pairs. True when this call is
+         ;; reentering the SAME frame's running drain — either an explicit
+         ;; in-sync-drain flag is set, OR this thread is itself the active
+         ;; drainer (`same-thread-drain?`). nil frame-record is handled by the
+         ;; earlier cond clause, so deref-ing `(:router frame-record)` here is
+         ;; safe.
+         nested-sync?
+         (when frame-record
+           (let [router-state @(:router frame-record)
+                 ;; Per rf2-ynk7: `:in-drain?` now holds the drainer's
+                 ;; thread (or nil). Only flag as "nested" when the current
+                 ;; thread is the drainer — a different thread mid-drain is
+                 ;; a concurrent caller, which `drain-block!` handles
+                 ;; correctly by spin-CAS-waiting. CLJS: `:in-drain?` is
+                 ;; `true` or `nil`; the equality check still discriminates
+                 ;; (truthy = same-thread by construction on a single-
+                 ;; threaded host).
+                 same-thread-drain?
+                 #?(:clj  (identical? (:in-drain? router-state) (Thread/currentThread))
+                    :cljs (true? (:in-drain? router-state)))]
+             (or (:in-sync-drain? router-state) same-thread-drain?)))]
      (cond
        (nil? frame-record)
        ;; Per rf2-2hvga (= B + recover-but-emit): dispatch-sync into a
@@ -3109,19 +3131,7 @@
        (trace/with-call-site call-site
          (emit-frame-destroyed! (first event) event (:frame envelope)))
 
-       (let [router-state @(:router frame-record)
-             ;; Per rf2-ynk7: `:in-drain?` now holds the drainer's
-             ;; thread (or nil). Only flag as "nested" when the current
-             ;; thread is the drainer — a different thread mid-drain is
-             ;; a concurrent caller, which `drain-block!` handles
-             ;; correctly by spin-CAS-waiting. CLJS: `:in-drain?` is
-             ;; `true` or `nil`; the equality check still discriminates
-             ;; (truthy = same-thread by construction on a single-
-             ;; threaded host).
-             same-thread-drain?
-             #?(:clj  (identical? (:in-drain? router-state) (Thread/currentThread))
-                :cljs (true? (:in-drain? router-state)))]
-         (or (:in-sync-drain? router-state) same-thread-drain?))
+       nested-sync?
        ;; Per Spec 002 §dispatch-sync: nesting dispatch-sync inside the
        ;; SAME frame's running drain (sync or async) is an error — the
        ;; event would interleave with the outer handler's run-to-completion.

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -713,6 +713,9 @@
     ;; registration meta. Late-bound — when the marks
     ;; artefact is absent, this is a silent no-op. Gated by debug so
     ;; production builds DCE the lookup.
+    ;; INVARIANT: this `mark!` write only happens under `debug-enabled?`, so the
+    ;; sub-output marks table is EMPTY in production — any future egress consumer
+    ;; reading it MUST be dev-gated too, or it reads empty and fails open.
     (when interop/debug-enabled?
       (when sub-meta
         (when-let [resolve (late-bind/get-fn :marks/resolve-sub-output-marks)]
@@ -1280,11 +1283,16 @@
                           (try
                           (let [parametric? (= :parametric (:input-kind meta))
                                 raw (cond
-                                      ;; Layer-1 (`:db`) reads app-db directly;
+                                      ;; Layer-1-shaped (`:db` / `:runtime-db` /
+                                      ;; `:frame-state` — see the `layer-1?` set
+                                      ;; above): `:db` reads app-db directly,
                                       ;; `:runtime-db` reads the runtime-db
-                                      ;; partition. `partition-value-for-sub`
-                                      ;; extracts the right slice when `db` is a
-                                      ;; frame-state value (rf2-vzld77).
+                                      ;; partition, `:frame-state` reads the
+                                      ;; whole frame-state value (both
+                                      ;; partitions, EP-0016 D3).
+                                      ;; `partition-value-for-sub` extracts the
+                                      ;; right slice when `db` is a frame-state
+                                      ;; value (rf2-vzld77).
                                       layer-1?
                                       (body-fn (partition-value-for-sub db (:input-kind meta)) query-v)
 


### PR DESCRIPTION
Clarity / doc + guard-rail only — no behaviour change. Two core clarity beads, different files (no overlap).

## rf2-rd296f — subs.cljc / marks.cljc

1. **Marks-shape docstring drift (enum, not boolean).** `merge-schema-marks` and `declare-machine-schema-marks!` docstrings still described the canonical marks shape with a `:sensitive?` boolean. EP-0015 issue 9 replaced the boolean for derived outputs with the `:rf.egress/output-sensitivity` enum — the code already unions the enum (`union-output-sensitivity`); only the docstrings had drifted. Updated to the enum shape (consistent with `marks-for`'s docstring).
2. **Empty-in-production guard-rail.** Added a one-line invariant at the sub-output marks call site (`compute-and-cache!`) and on the marks-side writer/reader (`mark-sub-output!` / `resolve-sub-output-marks`): the propagation table is written only under `debug-enabled?`, so any future always-on egress consumer reading it MUST be dev-gated or it reads empty and fails open.
3. **`compute-sub*` raw cond comment.** Extended the `layer-1?` branch comment to name `:frame-state` (it flows that branch — receives the whole frame-state value, both partitions; it's in the `layer-1?` set alongside `:db` / `:runtime-db`).
4. **Optional `subscribe-resolved` extraction: SKIPPED.** The 2-arity `subscribe` body's deeply-nested dynamic-binding context (EP-0002 / EP-0013 / EP-0023 realm + image resolution, with a load-bearing paren-closing hand-comment) made the extraction riskier than the bead's "skip if risky" threshold. The required clarity edits stand on their own.

## rf2-6dcab5 — router.cljc

`dispatch-sync!` put a ~12-line `(let [...] (or (:in-sync-drain? …) same-thread-drain?))` in the `cond` TEST position with the `:rf.error/dispatch-sync-in-handler` emit as its result — correct but hard to scan. Hoisted the detection into a named `nested-sync?` `let` binding before the `cond` (guarded by `(when frame-record …)` since the nil-frame clause now precedes it, preserving the original "frame-record guaranteed non-nil at the test" behaviour), then wrote a flat `nested-sync? (emit …)` test→result pair. Behaviour-preserving.

## Quality gates (all green)
- `sh scripts/test-jvm-implementation.sh` — PASS, 0 failures / 0 errors across all artefacts (incl. security: 589 tests).
- `cd implementation && npm run test:cljs` — 8019 tests, 33478 assertions, 0 failures / 0 errors.
- clj-kondo — 0 errors (4 pre-existing warnings, none in edited regions).
- splint — 14 style warnings, identical to `origin/main` baseline (zero introduced).
- No facade / manifest change. Egress/redaction tests stay green (marks docstrings touched, not logic).