### PR TITLE
fix(ssr): gate 400 projector arm to :event/:cofx + fix stale hydration example (rf2-37o5by)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -103,17 +103,34 @@
   "The runtime's default projector. Implements Spec 011 §Default
   projector verbatim:
 
-    :rf.error/no-such-handler            → 404 :not-found
-    :rf.error/no-such-route              → 404 :not-found
-    :rf.error/schema-validation-failure  → 400 :bad-request
-    anything else                        → 500 :internal-error
-                                           (fallback-public-error)
+    :rf.error/no-such-handler                  → 404 :not-found
+    :rf.error/no-such-route                    → 404 :not-found
+    :rf.error/schema-validation-failure
+      AND (get-in trace-event [:tags :where])
+          ∈ #{:event :cofx}                    → 400 :bad-request
+    anything else                              → 500 :internal-error
+                                                 (fallback-public-error)
+
+  The 400 arm is GATED on the failure's `:where` tag (rf2-37o5by). A
+  `:rf.error/schema-validation-failure` is client-facing — a 400
+  `:bad-request` — only when the rejected value entered through a
+  client-supplied surface: an inbound EVENT payload (`:where :event`)
+  or a request COFX (`:where :cofx`), per Spec 011 §Default projector.
+  Server-side schema surfaces — notably server-fx arg schemas
+  (`:where :fx-args`, per Spec 010 §Validation order step 5) — fail
+  validation because of a SERVER-side defect (a handler built a
+  malformed fx args map), not because the client sent bad input. A
+  client-facing 400 would mislabel a server bug as a user error, so a
+  non-:event/:cofx schema-validation-failure falls through to the
+  locked generic-500.
 
   The non-enumerated default covers the 500-class trace events
   (:rf.error/handler-exception, :rf.error/sub-exception,
-  :rf.error/fx-handler-exception, :rf.error/drain-depth-exceeded) and
-  any future :rf.error/* category that should fall through to the
-  locked generic-500 shape — no new case arm required.
+  :rf.error/fx-handler-exception, :rf.error/drain-depth-exceeded), the
+  server-side `:where :fx-args` (and any other non-client) schema-
+  validation-failure, and any future :rf.error/* category that should
+  fall through to the locked generic-500 shape — no new case arm
+  required.
 
   Pure: takes a trace event, returns a public-error map. No I/O, no
   config. Custom projectors may inject auth-specific 401/403 codes
@@ -129,10 +146,15 @@
      :retryable? false}
 
     :rf.error/schema-validation-failure
-    {:status     400
-     :code       :bad-request
-     :message    "Invalid input"
-     :retryable? false}
+    ;; GATED (rf2-37o5by): only a client-surface failure
+    ;; (`:where :event` / `:cofx`) is a client-facing 400. A server-side
+    ;; failure (`:where :fx-args`, etc.) falls through to the 500 default.
+    (if (#{:event :cofx} (get-in trace-event [:tags :where]))
+      {:status     400
+       :code       :bad-request
+       :message    "Invalid input"
+       :retryable? false}
+      fallback-public-error)
 
     ;; default — generic 500. Reuses the locked fallback shape so the
     ;; "anything not enumerated → 500" mapping is the literal default

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -884,11 +884,37 @@
       (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
              (ssr/default-error-projector-fn {:operation :rf.error/no-such-route}))
           "no-such-route shares the 404 :not-found mapping with no-such-handler"))
-    (testing ":rf.error/schema-validation-failure → 400 :bad-request
-              (previously untested)"
+    (testing ":rf.error/schema-validation-failure with a CLIENT-surface
+              :where (:event / :cofx) → 400 :bad-request (rf2-37o5by)"
       (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
-             (ssr/default-error-projector-fn {:operation :rf.error/schema-validation-failure}))
-          "schema-validation-failure is the only 400 arm"))
+             (ssr/default-error-projector-fn
+               {:operation :rf.error/schema-validation-failure
+                :tags      {:where :event}}))
+          "an inbound-event payload failure is client-facing → 400")
+      (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
+             (ssr/default-error-projector-fn
+               {:operation :rf.error/schema-validation-failure
+                :tags      {:where :cofx}}))
+          "a request-cofx failure is client-facing → 400"))
+    (testing ":rf.error/schema-validation-failure with a SERVER-surface
+              :where (:fx-args) → 500 (rf2-37o5by — gated 400 arm)"
+      (is (= ssr/fallback-public-error
+             (ssr/default-error-projector-fn
+               {:operation :rf.error/schema-validation-failure
+                :tags      {:where :fx-args}}))
+          "a server-fx arg-schema failure is a SERVER-side defect, not bad
+           client input — it falls through to the locked generic-500 rather
+           than mislabelling a server bug as a client 400")
+      (is (= ssr/fallback-public-error
+             (ssr/default-error-projector-fn
+               {:operation :rf.error/schema-validation-failure}))
+          "a schema-validation-failure with NO :where tag also falls through
+           to 500 — the 400 arm is opt-in on a client-surface :where, fail-safe")
+      (is (= ssr/fallback-public-error
+             (ssr/default-error-projector-fn
+               {:operation :rf.error/schema-validation-failure
+                :tags      {:where :sub-return}}))
+          "a sub-return failure is likewise non-client → 500"))
     (testing "any other category → the locked generic-500 fallback"
       (is (= ssr/fallback-public-error
              (ssr/default-error-projector-fn {:operation :rf.error/handler-exception}))
@@ -2160,18 +2186,21 @@
             fires on malformed server fx args (Spec 011 §Standard fx /
             Spec-Schemas §Standard fx args schemas / Spec 010 §step 5)"
 
-    (testing ":rf.server/set-status with a non-int arg → rejected + skipped + projected 400"
+    (testing ":rf.server/set-status with a non-int arg → rejected + skipped + projected 500"
       ;; The bead's concrete failing scenario: a string status that
       ;; pre-rf2-kjf3m.2 rode straight onto the wire (Ring then emitted a
       ;; non-integer status). Now the :schema boundary rejects it before
       ;; set-status-fx runs, so the malformed "not-an-int" NEVER reaches
       ;; the accumulator. The fired :rf.error/schema-validation-failure
-      ;; ALSO routes through the always-on SSR error-projection substrate,
-      ;; which maps that category to 400 :bad-request (Spec 011 §Server
-      ;; error projection / error_projector.cljc line 65) and stamps 400
-      ;; onto the response — a clean, surfaced failure instead of a
-      ;; malformed wire status. End-to-end, the fix turns a silent wire
-      ;; defect into a proper 400.
+      ;; ALSO routes through the always-on SSR error-projection substrate.
+      ;;
+      ;; rf2-37o5by — the default projector's 400 arm is GATED on a
+      ;; CLIENT-surface `:where` (`:event` / `:cofx`). This failure is
+      ;; `:where :fx-args` — a SERVER-side defect: a server handler built a
+      ;; malformed fx args map. That is not bad client input, so it must
+      ;; NOT mislabel as a client-facing 400; it falls through to the
+      ;; locked generic-500. End-to-end, the fix still turns a silent wire
+      ;; defect into a clean surfaced failure — now correctly a 500.
       (rf/reg-event :bad/status
         (fn [_ _] {:fx [[:rf.server/set-status "not-an-int"]]}))
       (let [f      (frame/make-frame {:platform :server})
@@ -2185,10 +2214,12 @@
             "the malformed status was skipped — never reached the accumulator")
         (is (integer? status)
             "the wire status is an integer (the gap this bead closes)")
-        ;; … and the schema failure surfaced as a proper 400 :bad-request
-        ;; via the SSR error-projection substrate.
-        (is (= 400 status)
-            "schema-validation-failure projected to 400 :bad-request")))
+        ;; … and the schema failure surfaced as a 500 via the SSR
+        ;; error-projection substrate — a server-fx arg failure is a
+        ;; server-side defect, NOT a client 400 (rf2-37o5by gated arm).
+        (is (= 500 status)
+            "schema-validation-failure :where :fx-args projected to 500
+             :internal-error — the 400 arm is gated to :where :event/:cofx")))
 
     (testing ":rf.server/set-header missing :value → rejected + skipped"
       (rf/reg-event :bad/header

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -390,7 +390,7 @@ Other-language ports may pick a different hash *as long as the canonical-EDN tra
  :op-type      :error
  :tags         {:server-hash "abc123"
                 :client-hash "def456"
-                :frame       :rf/default
+                :frame       :app/main             ;; the app's carried frame-id (placeholder; the runtime stamps the active frame)
                 :failing-id  :rf/hydrate           ;; the only value the bundled v1 runtime emits (see §Mismatch detection — head)
                 :first-diff-path [...]}            ;; optional: path into the render tree where divergence first occurs
  :start        (...)
@@ -747,6 +747,8 @@ The runtime ships a default projector (`:rf.ssr/default-error-projector`) implem
 | anything not enumerated above | `500` | `:internal-error` |
 
 The two `404` rows are **condition-gated**: only a `:rf.error/no-such-handler` raised *in routing context* (a request URL that resolved to no route handler) and a `:rf.error/no-such-route` map to `404`. A `:rf.error/no-such-handler` raised *outside* routing context — a `dispatch` to an unregistered event id mid-render — is not a missing-page condition; it falls through the unenumerated tail row to `500`. The non-condition fall-through is the locked default: when a category's gating condition does not hold, it is treated as unenumerated and projects `500`.
+
+The `400` row is likewise **condition-gated — on the failure's `:where` tag**, and the default projector *enforces* the gate: a `:rf.error/schema-validation-failure` maps to `400` `:bad-request` **only** when `(get-in trace-event [:tags :where])` is `:event` (an inbound event payload) or `:cofx` (a request cofx) — the surfaces through which *client-supplied* input enters the cascade. A schema-validation-failure on any other surface — notably `:where :fx-args` (a server-fx args schema, per [010 §Validation order](010-Schemas.md) step 5) or `:where :sub-return` — is a **server-side defect**: the server's own handler built a malformed fx args map or a sub returned a non-conforming value. Projecting such a failure as a client-facing `400` would mislabel a server bug as bad user input, so it falls through the unenumerated tail row to `500`. A schema-validation-failure that carries **no** `:where` tag also falls through to `500` (the `400` arm is opt-in on a client-surface `:where` — fail-safe). The default projector encodes exactly this gate; custom projectors that want `:where :fx-args` to stay `400` may override the arm, but the runtime default does not.
 
 Plus app-level conventions a custom projector typically adds:
 


### PR DESCRIPTION
Closes rf2-37o5by.

## (1) Gate the 400 error-projector arm to client surfaces — FLAGGED FOR MIKE

**This is the reviewer's recommended resolution of an open question — Mike can veto if he wants `:where :fx-args` to stay 400.**

`default-error-projector-fn` (`implementation/ssr/src/re_frame/ssr/error_projector.cljc`) cased on `:operation` alone, so EVERY `:rf.error/schema-validation-failure` mapped to a client-facing `400 :bad-request`. But server-fx arg schemas can fail with `:where :fx-args` — and that is a **server-side defect** (a server handler built a malformed fx args map), not bad client input. Projecting it as a `400` mislabels a server bug as a user error; it should fall through to `500`.

Spec 011 §Default-projector already documented the 400 row as `(:where :event or :cofx)`. The projector now **enforces** that:

```clojure
:rf.error/schema-validation-failure
(if (#{:event :cofx} (get-in trace-event [:tags :where]))
  {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
  fallback-public-error)   ;; → locked generic-500
```

So a `:where :fx-args` (or `:sub-return`, or untagged) schema-validation-failure now falls through to the 500 default; `:where :event` / `:cofx` (inbound event payload, request cofx — the client-supplied surfaces) still project 400.

**The open question:** the reviewer recommends `:where :fx-args` → 500 (server defect ≠ client error). The alternative is to keep all schema-validation-failures at 400. Mike rules.

Spec prose updated to make the qualifier explicit + enforced in the Default-projector section.

### Tests
- Extended the pure-unit `default-error-projector-fn-maps-all-enumerated-categories` test: `:where :event` → 400, `:where :cofx` → 400; `:where :fx-args` → 500, `:where :sub-return` → 500, untagged → 500.
- Flipped the `ssr-server-fx-args-schema-boundary` end-to-end test (`:rf.server/set-status` with a string arg → `:where :fx-args`): now asserts the projected status is **500** (was 400).
- The `:where :event` navigate-reject paths (ssr two-frame-attribution + ssr-ring draintime tests) correctly still project 400 — unchanged.

## (2) Stale hydration-mismatch example

`spec/011-SSR.md` §Hydration-mismatch detection hardcoded `:frame :rf/default` — a frame the runtime no longer synthesises (EP-0002). Changed the example's `:frame` to a generic placeholder `:app/main`, consistent with the carried-frame model. Example-only; impl is already correct.

## Gates
- ssr JVM suite: 366 tests, 1469 assertions, 0 failures
- ssr-ring JVM suite: 165 tests, 755 assertions, 0 failures
- `npm run test:cljs`: 8019 tests, 33478 assertions, 0 failures
- `mkdocs build --strict` (staged spec→docs/spec, reverted): EXIT 0
- `check_doc_slugs.py`: EXIT 0
- clj-kondo on changed files: 0 errors (2 pre-existing warnings, unrelated lines)

No facade/manifest change.