### PR TITLE
fix(core/frames): non-default-realm image-loaded addressing + vestigial cleanup (rf2-vnduo9, rf2-ji3tvy)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -154,7 +154,7 @@
   (testing "happy path: boot machine traverses :configuring → :loading-deps → :hydrating → :ready and all slices land"
     (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:on-create    [:boot/initialise]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
@@ -183,7 +183,7 @@
   (testing "per-child :data fns thread spawn-spec identity; no cross-talk between siblings"
     (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:on-create    [:boot/initialise]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
@@ -213,7 +213,7 @@
                          {:status 500
                           :body   "boot dependency unreachable"})
 
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:on-create    [:boot/initialise]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-fail}})]
@@ -288,7 +288,7 @@
     (let [frame  (atom nil)
           traces (collect-machine-data-traces!
                    #(reset! frame
-                      (frame/make-frame
+                      (frame/make-anon-frame-record!
                         {:on-create    [:boot/initialise]
                          :fx-overrides {:rf.http/managed
                                         :boot.test/canned-bad-config}})))]
@@ -317,7 +317,7 @@
                                           (= :app-db (-> ev :tags :where)))
                                  (swap! app-traces conj ev))))
       (try
-        (with-new-frame [f (frame/make-frame {})]
+        (with-new-frame [f (frame/make-anon-frame-record! {})]
           (rf/reg-app-schema [:config] [:maybe boot-schema/Config] {:frame f})
           (rf/dispatch-sync [::write-bad-config] {:frame f}))
         (finally (rf/unregister-listener! :trace ::app)))

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -276,10 +276,10 @@
           {:fx [[:rf.http/managed
                  {:request {:method :get :url "/articles/hello"}
                   :decode  :json}]]})))
-    (let [left  (frame/make-frame {:doc "left"
+    (let [left  (frame/make-anon-frame-record! {:doc "left"
                                 :fx-overrides
                                 {:rf.http/managed :rf.http/managed-canned-success}})
-          right (frame/make-frame {:doc "right"
+          right (frame/make-anon-frame-record! {:doc "right"
                                 :fx-overrides
                                 {:rf.http/managed :rf.http/managed-canned-success}})]
       (rf/dispatch-sync [:article/load] {:frame left})

--- a/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
@@ -100,7 +100,7 @@
   (testing "a failure reply whose message is non-string drives :record-error to write a bad :error, failing the :machine-data boundary and rolling back"
     (reg-sync-failure-override! :login.test/canned-bad-message
                                 {:status 401 :message {:not "a string"}})
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:fx-overrides {:rf.http/managed
                                          :login.test/canned-bad-message}})]
       ;; A valid submit drives :idle → :submitting and fires :issue-request;
@@ -132,7 +132,7 @@
   (testing "a normal failing login (string message) settles with no :machine-data trace"
     (reg-sync-failure-override! :login.test/canned-ok-message
                                 {:status 401 :message "Invalid credentials."})
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:fx-overrides {:rf.http/managed
                                          :login.test/canned-ok-message}})]
       (let [traces (collect-machine-data-traces!

--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -67,7 +67,7 @@
    Both reach the same end-state: parent machine at :idle with cleared
    :data."
   []
-  (frame/make-frame {:on-create [:work/flow [:reset]]}))
+  (frame/make-anon-frame-record! {:on-create [:work/flow [:reset]]}))
 
 ;; ============================================================================
 ;; (1) SPAWN CASCADE — :start spawns 3 children

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -76,7 +76,7 @@
   {:rf.http/managed :nine-states.http/managed-demo})
 
 (defn- new-frame []
-  (frame/make-frame
+  (frame/make-anon-frame-record!
     {:on-create    [:nine-states.app/initialise]
      :fx-overrides demo-overrides}))
 
@@ -200,7 +200,7 @@
     ;; setup event.
     (is (some? (rf/handler-meta :event :nine-states.story/load-failing))
         ":nine-states.story/load-failing registered (stories.cljs required)")
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:on-create    [:nine-states.app/initialise]
                           :fx-overrides story-failure-overrides})]
       ;; Drive the variant's setup load event. The canned-failure stub
@@ -226,7 +226,7 @@
     ;; with no per-variant override. Guards that success and failure stay
     ;; SEPARATELY represented (acceptance: keep the success lifecycle
     ;; variant proving canned-success).
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:on-create    [:nine-states.app/initialise]
                           :fx-overrides {:rf.http/managed
                                          :rf.http/managed-canned-success}})]

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -121,7 +121,7 @@
                                :bio      nil
                                :image    nil}})
 
-  (with-new-frame [f (frame/make-frame {:fx-overrides {:rf.http/managed      :realworld.test/login-success
+  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed      :realworld.test/login-success
                                                     :auth.session/persist :rf/no-op}})]
     ;; EP-0017 (rf2-16ck78): `:auth/initialise` consumes the RECORDABLE+PROVIDED
     ;; `:auth.session/token` coeffect — its value rides the dispatch token,
@@ -165,7 +165,7 @@
                        {:status 422
                         :body   {:errors {:body ["email or password is invalid"]}}})
 
-  (with-new-frame [f (frame/make-frame {:fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
+  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
     ;; EP-0017 (rf2-16ck78): supply the RECORDABLE+PROVIDED `:auth.session/token`
     ;; on the boot dispatch token (nil node-side), mirroring `realworld.core/run`.
     (rf/dispatch-sync [:auth/initialise]
@@ -197,7 +197,7 @@
                                              :following false}}]
                         :articlesCount 1})
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
     (is (= :idle (:status (rf/compute-sub [:articles/slice] (rf/frame-state-value f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
@@ -216,7 +216,7 @@
                        {:status 500
                         :body   "server error"})
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
     (is (= :error (:status (rf/compute-sub [:articles/slice] (rf/frame-state-value f)))))
@@ -239,7 +239,7 @@
                                   :favoritesCount 0
                                   :author {:username "alice" :bio nil :image nil :following false}}})
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     ;; The :mode region starts at :create; the :lifecycle region starts
@@ -262,7 +262,7 @@
     (is (false? (rf/compute-sub [:editor/dirty?] (rf/frame-state-value f))))))
 
 (defn- editor-can-leave-test []
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     (is (true? (rf/compute-sub [:editor/can-leave?] (rf/frame-state-value f))))
@@ -299,7 +299,7 @@
                                              :favoritesCount 0
                                              :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-article-and-comments}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -338,7 +338,7 @@
                                              :favoritesCount 0
                                              :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-comment-post}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -359,7 +359,7 @@
   ;; or a concurrent delete), a stale index can point past the current
   ;; vector. The rollback's `subvec` must NOT throw IndexOutOfBounds — it
   ;; clamps the index to the current length and re-inserts at the tail.
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     ;; Seed a single comment (the list is now length 1).
@@ -398,7 +398,7 @@
                        {:status 400
                         :body   {:errors {:body ["rollback"]}}})
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     ;; :article/toggle-favorite is auth-gated (rf2-ygh4m): a logged-out
@@ -448,7 +448,7 @@
                                                :favoritesCount 0
                                                :author {:username "eve" :bio nil :image nil :following false}}]})))
 
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-profile}})]
     (rf/dispatch-sync [:profile/initialise] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
@@ -486,7 +486,7 @@
                                :bio "New bio"
                                :image nil}})
 
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-save
                                                 :auth.session/persist :rf/no-op}})]
     ;; After :app/initialise → :settings/initialise → [:reset], the
@@ -550,7 +550,7 @@
   (reg-canned-failure! :realworld.test/canned-settings-failure
                        :rf.http/http-5xx
                        {:status 500 :body "server error"})
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-failure
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -582,7 +582,7 @@
   ;; validate inside :settings/submit would dispatch :submit-invalid
   ;; when the draft failed validation, matching Pattern-Forms'
   ;; §Standard events table.
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed       :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -630,7 +630,7 @@
                   (rf/frame-state-value frame)))
 
 (defn- tag-query-test []
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; rf2-e90vfv route-shape conformance: applying a tag navigates to the
     ;; official `/tag/:tag` PATH route, so the active tag is a route PARAM (read
@@ -646,7 +646,7 @@
   ;; The :tags lifecycle — load happy path through the machine.
   (reg-canned-success! :realworld.test/canned-tags
                        {:tags ["intro" "demo" "clojure"]})
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags}})]
     ;; After :app/initialise → :tags/initialise → [:reset], the machine
     ;; sits at :idle with empty :data.
@@ -690,7 +690,7 @@
   (reg-canned-failure! :realworld.test/canned-tags-failure
                        :rf.http/http-5xx
                        {:status 500 :body "server error"})
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags-failure}})]
     (rf/dispatch-sync [:tags/load] {:frame f})
     (let [db   (rf/frame-state-value f)
@@ -706,7 +706,7 @@
 ;; ============================================================================
 
 (defn- routing-tests []
-  (with-new-frame [f (frame/make-frame {:on-create [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:rf.route/navigate :realworld.article/show {:slug "hello"}] {:frame f})
     (is (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))
@@ -733,7 +733,7 @@
   ;; (core.cljs) BY ID (EP-0022). Configure the test frame with the same
   ;; id-reference so the guard is exercised end-to-end. Its descriptor is
   ;; registered at `realworld.routing` ns-load (required below).
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     ;; Unauthenticated: navigating to a :requires-auth route
@@ -777,7 +777,7 @@
   ;; assert all three paths now redirect to login.
 
   ;; --- direct-URL / reload / popstate (`:rf.route/handle-url-change`) ---
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     ;; Logged-out direct URL (or reload) to a :requires-auth route.
@@ -803,7 +803,7 @@
         "logged-out direct-URL to a non-auth route is unaffected"))
 
   ;; --- anchor click (`:rf/url-requested`) ---
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     ;; An anchor whose href targets a :requires-auth route. The
@@ -832,7 +832,7 @@
         "logged-out anchor to a non-auth route is unaffected"))
 
   ;; --- authenticated: every entry point now PASSES through ---
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [:realworld.routing/auth-guard]})]
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
@@ -896,7 +896,7 @@
 ;; ============================================================================
 
 (defn- app-smoke-test []
-  (with-new-frame [f (frame/make-frame {:on-create    [:app/initialise]
+  (with-new-frame [f (frame/make-anon-frame-record! {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     ;; EP-0017 (rf2-16ck78): `:auth/initialise` is no longer in the

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -239,13 +239,13 @@
             [:auth :token] from the cascade's frame and injects
             `Authorization: Token <jwt>`; it is a no-op when logged out"
     ;; LOGGED OUT — the public reads must not carry an auth header.
-    (with-new-frame [f (frame/make-frame {})]
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
       (let [ctx {:frame f :request {:url "/articles"}}]
         (is (nil? (get-in (core/bearer-auth-interceptor ctx)
                           [:request :headers "Authorization"]))
             "no token → no Authorization header (logged-out reads unaffected)")))
     ;; AUTHED — the token in the frame's app-db is injected as a Bearer header.
-    (with-new-frame [f (frame/make-frame {})]
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt-xyz"}] {:frame f})
       (let [ctx {:frame f :request {:url "/articles/feed"}}]
         (is (= "Token jwt-xyz"
@@ -263,7 +263,7 @@
             global article tags AND the session feed in one set of per-target
             descriptors, and fires no extra wiring; the call-site :reply-to
             continuation fires exactly once on settle"
-    (with-new-frame [f (frame/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; log in so the session feed scope resolves
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -316,7 +316,7 @@
             valid-AND-dirty into app-db; a blank draft is invalid; a valid+dirty
             draft submits the save mutation; the :reply-to [:editor/replied]
             continuation re-seeds a clean draft and navigates to the saved article"
-    (with-new-frame [f (frame/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; create-mode entry registers the :editor/can-submit? flow against this frame
       (rf/dispatch-sync [:editor/initialise] {:frame f})
@@ -355,7 +355,7 @@
             auth slice, drops the session-scoped cache via :rf.resource/clear-scope
             (so the next user never reads the prior user's feed), and releases the
             principal-switch lease. Public global reads are untouched."
-    (with-new-frame [f (frame/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; ensure the session feed under the principal-switch lease the app uses
@@ -389,7 +389,7 @@
   (testing "examples/reagent/realworld_resources — the :auth/flow machine drives
             :idle → :submitting → :authed on a login success and stores the
             session (auth is a command/machine, deliberately NOT a read-resource)"
-    (with-new-frame [f (frame/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op
                                                       :realworld-resources.session/persist :rf/no-op}})]
       ;; boot the machine at :idle (token nil → the has-token? guard routes to no-op)

--- a/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
@@ -235,7 +235,7 @@
             :resources.app/preview-closed releases the lease so the entry can GC
             (the mandatory release path for an app-minted lease, Spec 016 §Active
             owners)"
-    (with-new-frame [f (frame/make-frame {:url-bound? true
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (let [lease-owner [:lease :resources.app/preview "fresh-skip"]
             dkey        (detail-key "fresh-skip")]

--- a/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
@@ -52,7 +52,7 @@
     ;;
     ;; Test isolation: a fresh frame so prior tests' [:rf.db/runtime :rf.runtime/routing :current]
     ;; slices don't leak in.
-    (let [f (frame/make-frame {:doc "isolated frame for this test"})]
+    (let [f (frame/make-anon-frame-record! {:doc "isolated frame for this test"})]
       (rf/reg-route :route.cljs/home
                     {:path "/cljs/home"})
       (rf/reg-route :route.cljs/article
@@ -102,8 +102,8 @@
                                               :params [:map [:id :string]]})
     (subs/reg-runtime-sub :rf.cljs2/route (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
 
-    (let [left  (frame/make-frame {:doc "left tab frame"})
-          right (frame/make-frame {:doc "right tab frame"})]
+    (let [left  (frame/make-anon-frame-record! {:doc "left tab frame"})
+          right (frame/make-anon-frame-record! {:doc "right tab frame"})]
 
       ;; Each frame navigates independently.
       (rf/dispatch-sync [:rf.route/transitioned "/cljs2/articles"]

--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -79,7 +79,7 @@
     ;; dispatch is issued explicitly here (not via :on-create, which does not
     ;; forward :rf.cofx) carrying the empty-localStorage / first-run value: an
     ;; empty sorted-map, exactly what the node-side boundary read yields.
-    (with-new-frame [f (frame/make-frame
+    (with-new-frame [f (frame/make-anon-frame-record!
                          {:fx-overrides {:todo.storage/save :rf/no-op}})]
       (rf/dispatch-sync [:todo/initialise]
                         {:frame   f

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -246,7 +246,7 @@
   ;; way. (We DO need the synthetic `[:rf.machine.timer/after-elapsed
   ;; delay epoch]` events to drive `:after` directly, which we do by
   ;; dispatching them ourselves.)
-  (frame/make-frame {:on-create    [:ws.app/initialise]
+  (frame/make-anon-frame-record! {:on-create    [:ws.app/initialise]
                   :fx-overrides {:dispatch-later nil}}))
 
 (defn- with-sync-mock! [f]

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
@@ -79,7 +79,7 @@
             and cleared by the same dispose-adapter! call"
     (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
-    (let [other (frame/make-frame {:doc "second frame"})]
+    (let [other (frame/make-anon-frame-record! {:doc "second frame"})]
       ;; Seed + subscribe in BOTH frames so each carries a live cache slot.
       ;; Frame targeting rides the opts map (`:frame`) via the fn-form
       ;; `dispatch-sync*` — the `dispatch-sync` macro has no frame-positional

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -772,7 +772,7 @@
 ;; on the object constructor): the unified single frame value backed by the one
 ;; registry removes the two-constructor split that motivated the redirect, so a
 ;; record-config key is now honoured, not rejected. The advanced
-;; `re-frame.frame/make-frame` is demoted to an INTERNAL no-`:id` record helper —
+;; `re-frame.frame/make-anon-frame-record!` is demoted to an INTERNAL no-`:id` record helper —
 ;; it is not facade-exported (`rf/make-frame` is the public path).
 
 (defn make-frame

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -16,7 +16,7 @@
                               never uses it as a resolution floor. A small
                               app, example, or test may register and select
                               it EXPLICITLY like any other id.
-    :rf.frame/<gensym>       — anonymous instances from make-frame"
+    :rf.frame/<gensym>       — anonymous instances from make-anon-frame-record!"
   (:require [clojure.string]
             [re-frame.error :as error]
             [re-frame.registrar :as registrar]
@@ -905,6 +905,32 @@
               (map (fn [[_ f]] (:id f))))
         @frames))
 
+(defn image-loaded-frame-addresses
+  "Return the image-loaded frames as `{:realm <realm-id> :id <frame-id>}` maps —
+  the realm-AWARE companion to `image-loaded-frame-ids` the hot-reload
+  reprojection path enumerates. SAME selection (a `frames`-registry record with a
+  non-nil `:generation`, not destroyed, public `:id` — the `:rf.frame/` gensym
+  namespace excluded), but each entry also carries the frame's OWN realm
+  reference, read off the record's `:realm` slot (default-realm when absent), NOT
+  off the dynamic `*current-realm*`.
+
+  Reprojection runs on a `next-tick` flush where `*current-realm*` has unwound to
+  nil, so a non-default-realm image-loaded frame can only be re-keyed correctly if
+  its realm travels WITH its id (EP-0013 — the registry key is the (realm, frame)
+  ADDRESS, and a frame REFERENCES its realm). `reproject-live-frames!` binds
+  `*current-realm*` per frame from this `:realm` (via `call-with-realm`) before the
+  per-frame generation read / capability read / `set-generation!` swap, so each of
+  those re-keys to the frame's OWN address rather than missing on a bare-id lookup.
+  INTERNAL."
+  []
+  (into #{}
+        (comp (filter (fn [[_ f]] (and (some? (:generation f))
+                                       (not (-> f :lifecycle :destroyed?))
+                                       (not= "rf.frame" (namespace (:id f))))))
+              (map (fn [[_ f]] {:realm (or (:realm f) realm/default-realm-id)
+                                :id    (:id f)})))
+        @frames))
+
 ;; ---- the internal value-read frame resolver seam (EP-0024, rf2-az1ct6) ----
 ;;
 ;; The value-read helpers below all share one shape: resolve the frame record
@@ -1660,15 +1686,21 @@
                        {:frame id :config stored-config})
           id)))))
 
-(defn make-frame
+(defn make-anon-frame-record!
   "INTERNAL anonymous-instance creation (EP-0024, rf2-tu2vr7): generate a
   gensym'd id under `:rf.frame/`, register a configured record under it, and
-  return the gensym'd id. This is NO LONGER a public constructor — the ONE
-  public constructor is `re-frame.live-frame/make-frame` (`rf/make-frame`),
-  which accepts both image-selection AND record-config opts and returns the
-  frame VALUE. This id-returning record helper survives as the internal
-  no-`:id` configured-record path the unified constructor and the test/SSR
-  harnesses build on. Per Spec 002 §Per-instance frames."
+  return the gensym'd id. This is NOT a public constructor — the ONE public
+  constructor is `re-frame.live-frame/make-frame` (`rf/make-frame`), which
+  accepts both image-selection AND record-config opts and returns the frame
+  VALUE. This id-returning record helper survives as the internal no-`:id`
+  configured-record path the unified constructor and the test/SSR harnesses build
+  on. Per Spec 002 §Per-instance frames.
+
+  rf2-ji3tvy — RENAMED from the bare `make-frame` so the internal record helper
+  no longer COLLIDES by short name with the public `re-frame.live-frame/make-frame`
+  (the frame-VALUE constructor): a reader who saw `frame/make-anon-frame-record!` could not tell
+  from the call which one ran. The `-record!` suffix names exactly what it
+  returns — an anonymous gensym-keyed RECORD's id, not a frame value."
   [config]
   (let [id (keyword "rf.frame" (str (gensym "")))]
     (reg-frame id config)

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -91,7 +91,7 @@
   (the realm-routed substrate). EP-0023 partially supersedes EP-0013's public
   app/realm surface while RETAINING the realm machinery as an internal
   substrate; this slice introduces the image-loaded public frame object without
-  disturbing the existing `reg-frame` / `re-frame.frame/make-frame` callers. The
+  disturbing the existing `reg-frame` / `re-frame.frame/make-anon-frame-record!` callers. The
   reload slice (.10) wires image replacement on the frame object this slice
   returns.
 
@@ -213,15 +213,6 @@
   reprojection path enumerates these."
   []
   (frame/image-loaded-frame-ids))
-
-(defn clear-live-frames!
-  "Reset the image-loaded frames' generation tracking. EP-0024 (rf2-tu2vr7): the
-  second live-frame registry dissolved into the ONE `frames` registry, so there
-  is no separate index to reset — the test fixtures' `(reset! frame/frames {})`
-  already clears every record (and thus every `:generation`). Retained as a
-  no-op for the fixtures that still call it; returns nil."
-  []
-  nil)
 
 (defn image-view-frames
   "Return `{frame-id frame-view}` for every image-loaded frame — the read
@@ -757,15 +748,27 @@
 
   Returns `{frame-id reload-diff}` for every frame that MOVED (empty when none
   did). EP-0024 (rf2-tu2vr7): with the registries collapsed, an image-loaded
-  frame is simply a `frames` record carrying a generation — `live-frame-ids`
-  enumerates them all from the ONE registry."
+  frame is simply a `frames` record carrying a generation.
+
+  rf2-vnduo9 — REALM-CORRECT enumeration. This flush runs on a `next-tick`
+  callback (`deferred-flush!`), by which point `*current-realm*` has unwound to
+  nil. The per-frame reads + the `set-generation!` swap inside
+  `reproject-live-frame!` all re-key the registry via `(frame-key *current-realm*
+  id)`, so a NON-default-realm image-loaded frame keyed by its `[realm-id
+  frame-id]` address would MISS a bare-id lookup → silent no-op → its generation
+  stays STALE. So enumerate `frame/image-loaded-frame-addresses` (each carrying the
+  frame's OWN `:realm`, read off the record, not the unwound dynamic var) and bind
+  `*current-realm*` to that realm per frame (via `frame/call-with-realm`) around
+  the reprojection, so every re-key resolves to the frame's own address. The
+  default-realm frame (every public `make-frame`, which is default-realm-only)
+  takes `call-with-realm`'s zero-binding fast path — byte-identical to before."
   []
-  (reduce (fn [moved frame-id]
-            (if-let [diff (reproject-live-frame! frame-id)]
-              (assoc moved frame-id diff)
+  (reduce (fn [moved {:keys [realm id]}]
+            (if-let [diff (frame/call-with-realm realm #(reproject-live-frame! id))]
+              (assoc moved id diff)
               moved))
           {}
-          (live-frame-ids)))
+          (frame/image-loaded-frame-addresses)))
 
 ;; ===========================================================================
 ;; Auto-reprojection on `reg-*` source-store change (EP-0023 §Default Image

--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -581,7 +581,7 @@
            id-sym         (gensym "frame-id")
            create-form    (if frame-id
                             `(re-frame.frame/reg-frame ~frame-id ~frame-cfg-sym)
-                            `(re-frame.frame/make-frame ~frame-cfg-sym))]
+                            `(re-frame.frame/make-anon-frame-record! ~frame-cfg-sym))]
        `(let [~opts-sym       ~opts
               ~install-sym    (:install      ~opts-sym)
               ~root-view-sym  (:root-view    ~opts-sym)

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -98,17 +98,14 @@
     that intent locally (the sleep IS the contract under test)."
   (:require [re-frame.registrar :as registrar]
             [re-frame.error :as error]
+            ;; The runtime fixture resets the ONE `frame/frames` registry, which
+            ;; (EP-0024 — the second live-frame registry dissolved into it) clears
+            ;; every record AND its `:generation`. A frame seated via
+            ;; `rf/make-frame {:id …}` registers there, and a stale entry leaking
+            ;; across tests would make the next `make-frame`/`seat-*` treat the id
+            ;; as already-seated (or fail loud on the duplicate id) — the single
+            ;; reset is the whole clear (rf2-32siq3.32 / rf2-rjml45 / rf2-ji3tvy).
             [re-frame.frame :as frame]
-            ;; EP-0023 live-frame registry (rf2-32siq3.32 / rf2-rjml45). The
-            ;; runtime fixture resets BOTH the runnable-record registry
-            ;; (`frame/frames`) AND the live-frame index together — a frame
-            ;; seated via `rf/make-frame {:id …}` registers in `live-frames`,
-            ;; and a stale entry leaking across tests would make the next
-            ;; `make-frame`/`seat-*` treat the id as already-seated (or fail
-            ;; loud on the duplicate id). A core spine ns, so required directly
-            ;; (no late-bind indirection); no cycle (live-frame does not depend
-            ;; on this ns).
-            [re-frame.live-frame :as live-frame]
             ;; The flows / schemas / machines / routing / http-managed /
             ;; epoch artefacts ship in separate Maven coordinates and are
             ;; reached only through late-bind hooks — see the
@@ -496,14 +493,14 @@
            restore-fn    (late-bind/get-fn :schemas/restore-by-frame!)
            schemas-snap  (when snapshot-fn (snapshot-fn))]
        (try
+         ;; Reset the ONE `frames` registry — clearing every record AND its
+         ;; `:generation`, so an image-loaded frame seated via `make-frame {:id …}`
+         ;; (e.g. the Xray production singleton) does not leak across tests
+         ;; (rf2-rjml45). With the second live-frame registry dissolved into this
+         ;; ONE registry (EP-0024), this reset is the whole job — there is no
+         ;; separate index to clear in lockstep (rf2-ji3tvy removed the vestigial
+         ;; live-frame-clearing no-op that used to follow this).
          (reset! frame/frames {})
-         ;; Reset the EP-0023 live-frame index in lockstep with the runnable-
-         ;; record registry (rf2-rjml45). A frame seated via `make-frame {:id …}`
-         ;; — e.g. the Xray production singleton — registers here; without this
-         ;; reset a stale `:rf/xray` (or any test frame id) leaks across tests,
-         ;; so the next `seat-*`/`make-frame` either skips its create (treating
-         ;; the id as already-live) or fails loud on the duplicate id.
-         (live-frame/clear-live-frames!)
          (run-reset-hooks! :pre-dispose)
          (adapter/dispose-adapter!)
          (run-reset-hooks! :post-dispose)
@@ -577,11 +574,11 @@
          (finally
            (restore-registrar! snap)
            (when restore-fn (restore-fn schemas-snap))
+           ;; Reset the ONE `frames` registry in the finally too (rf2-rjml45), so
+           ;; a frame (and its `:generation`) seated by the test body never
+           ;; survives into the next fixture run. The dissolved second registry
+           ;; means this single reset is the whole clear (rf2-ji3tvy).
            (reset! frame/frames {})
-           ;; Clear the live-frame index in the finally too (rf2-rjml45), in
-           ;; lockstep with the `frame/frames` reset, so a frame seated by the
-           ;; test body never survives into the next fixture run.
-           (live-frame/clear-live-frames!)
            (when-let [reset-flows! (late-bind/get-fn :flows/reset-flows!)]
              (reset-flows!)))))))))
 

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1232,7 +1232,7 @@
   resolve; :on-match dispatches; fresh nav-token per navigation."
   [{:keys [substrate-kw name]}]
   (testing (str name " — routing: :rf.route/transitioned drives the slice")
-    (let [f          (frame/make-frame {:doc "isolated frame for this test"})
+    (let [f          (frame/make-anon-frame-record! {:doc "isolated frame for this test"})
           home       (route-kw substrate-kw "home")
           article    (route-kw substrate-kw "article")
           load-ev    (mint-kw substrate-kw "article-load")
@@ -1280,8 +1280,8 @@
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
       (subs/reg-runtime-sub route-sub (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
 
-      (let [left  (frame/make-frame {:doc "left tab frame"})
-            right (frame/make-frame {:doc "right tab frame"})]
+      (let [left  (frame/make-anon-frame-record! {:doc "left tab frame"})
+            right (frame/make-anon-frame-record! {:doc "right tab frame"})]
         (rf/dispatch-sync [:rf.route/transitioned (route-path sk2 "/articles")] {:frame left})
         (rf/dispatch-sync [:rf.route/transitioned (route-path sk2 "/articles/intro")] {:frame right})
 
@@ -2060,9 +2060,9 @@
         (if-let [reply (:rf/reply msg)]
           {:db {:article (:value reply)}}
           {:fx [[:rf.http/managed {:request {:method :get :url "/articles/hello"} :decode :json}]]})))
-    (let [left  (frame/make-frame {:doc "left"
+    (let [left  (frame/make-anon-frame-record! {:doc "left"
                                 :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
-          right (frame/make-frame {:doc "right"
+          right (frame/make-anon-frame-record! {:doc "right"
                                 :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})]
       (rf/dispatch-sync [:article/load] {:frame left})
       (rf/dispatch-sync [:article/load] {:frame right})

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -103,7 +103,7 @@
   (testing "(with-new-frame [f (make-frame opts)] body) creates, binds, destroys"
     (let [captured-id (atom nil)
           observed-current (atom nil)]
-      (rf/with-new-frame [f (frame/make-frame {:doc "ephemeral"})]
+      (rf/with-new-frame [f (frame/make-anon-frame-record! {:doc "ephemeral"})]
         (reset! captured-id f)
         (reset! observed-current (rf/current-frame-id))
         (is (= f (rf/current-frame-id))
@@ -128,7 +128,7 @@
   (testing "(with-new-frame [f ...] body) destroys the frame even when body throws"
     (let [captured-id (atom nil)]
       (try
-        (rf/with-new-frame [f (frame/make-frame {:doc "ephemeral-throw"})]
+        (rf/with-new-frame [f (frame/make-anon-frame-record! {:doc "ephemeral-throw"})]
           (reset! captured-id f)
           (throw (ex-info "boom" {:kind ::boom})))
         (catch Exception e
@@ -144,7 +144,7 @@
             destroy runs after"
     (rf/reg-event :wf/initialise (fn [{:keys [db]} _] {:db {:counter 42}}))
     (let [captured-db (atom nil)]
-      (rf/with-new-frame [f (frame/make-frame {:on-create [:wf/initialise]})]
+      (rf/with-new-frame [f (frame/make-anon-frame-record! {:on-create [:wf/initialise]})]
         (reset! captured-db (rf/app-db-value f)))
       (is (= {:counter 42} @captured-db)
           "the body observed the on-create-seeded app-db"))))

--- a/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0023_conformance_cljs_test.cljc
@@ -99,12 +99,10 @@
   (fn [t]
     (asm/clear-standards!)
     (asm/clear-generation-cache!)
-    (lf/clear-live-frames!)
     (drop-non-default-realms!)
     (t)
     (asm/clear-standards!)
     (asm/clear-generation-cache!)
-    (lf/clear-live-frames!)
     (drop-non-default-realms!)))
 
 (defn- reg-desc

--- a/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_frame_scoping_cljs_test.cljs
@@ -176,7 +176,7 @@
   `:rf.cofx` token under `:rf.cofx/mint-policy :strict`. Returns the durable
   item id the handler folded in."
   [recorded]
-  (let [f (frame/make-frame {:doc          "nine-states replay frame"
+  (let [f (frame/make-anon-frame-record! {:doc          "nine-states replay frame"
                           :fx-overrides {:rf.http/managed
                                          :nine-states.http/managed-demo}})]
     ;; `:initialise` seeds the form slice + resets/spawns the :ui/nine-states
@@ -223,7 +223,7 @@
   the success path fires is stubbed to a no-op so no backend is needed.
   Returns the durable optimistic card id the handler folded in."
   [recorded]
-  (let [f (frame/make-frame {:doc "realworld replay frame"})]
+  (let [f (frame/make-anon-frame-record! {:doc "realworld replay frame"})]
     ;; Stub the managed-HTTP fx so the optimistic-post fx fires harmlessly
     ;; (the durable write under test is the temp card conj'd into
     ;; [:comments :data]; the request itself is irrelevant here).

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -395,7 +395,7 @@
             with the :rf/app-db slice"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (frame/make-frame {:doc "ssr-example client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-example client frame"
                                        :platform :client})
           payload      {:rf/version     1
                         :rf/render-hash "abc12345"
@@ -417,7 +417,7 @@
             payload's :rf/render-hash emits NO :rf.ssr/hydration-mismatch"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (frame/make-frame {:doc "ssr-example verify-match frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-example verify-match frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           client-tree  [:div.page [:h1 "Recent articles"]]
@@ -439,7 +439,7 @@
             (the verify step the example's `run` wires via :render-tree-fn)"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (frame/make-frame {:doc "ssr-example verify-divergent frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-example verify-divergent frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           payload      {:rf/version 1
@@ -462,7 +462,7 @@
             validate fail-closed before installation)"
     (require 'ssr.core :reload)
     (rf/init! ssr/adapter)
-    (let [client-frame (frame/make-frame {:doc "ssr-example fail-closed frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-example fail-closed frame"
                                        :platform :client})]
       ;; Seed a known app-db value first so we can prove it survives.
       (rf/dispatch-sync [:articles/loaded {:value [{:id "keep" :title "Keep" :body "b"}]}]
@@ -744,7 +744,7 @@
       ;; Full drain: registers the machine, dispatches into it, asserts the
       ;; app-db landed at :authed. Uses the `:fx-overrides` seam to swap
       ;; `:rf.http/managed` for the per-test canned-success stub.
-      (let [f (frame/make-frame {:fx-overrides {:rf.http/managed :auth.login/canned-success}})]
+      (let [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed :auth.login/canned-success}})]
         (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                               {:email "a@b.com"
                                                :password "secret"}]]
@@ -757,7 +757,7 @@
       ;; a fourth :submit fails the guard and lands at :locked-out. Uses
       ;; `rf/with-fx-overrides` — the lexical-scope counterpart to the
       ;; per-frame `:fx-overrides` opt on `make-frame`.
-      (let [f (frame/make-frame {})]
+      (let [f (frame/make-anon-frame-record! {})]
         (rf/with-fx-overrides {:rf.http/managed :auth.login/canned-failure}
           (dotimes [_ 3]
             (rf/dispatch-sync [:auth.login/flow [:auth.login/submit

--- a/implementation/core/test/re_frame/facade_frame_read_cljs_test.cljc
+++ b/implementation/core/test/re_frame/facade_frame_read_cljs_test.cljc
@@ -52,17 +52,16 @@
 ;; `make-frame`'s backing runnable record needs; the fixture also resets
 ;; `frame/frames`, so image-loaded frame records do not leak across cases).
 ;; EP-0024 (rf2-tu2vr7): the second live-frame registry dissolved into the ONE
-;; `frames` registry, so `clear-live-frames!` is now a no-op kept for the
-;; fixtures that call it. Mirrors live_frame_reload_cljs_test.
+;; `frames` registry, so the runtime fixture's `(reset! frame/frames {})` clears
+;; every record AND its generation — no separate live-frame index to clear
+;; (rf2-ji3tvy). Mirrors live_frame_reload_cljs_test.
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
   (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
-    (lf/clear-live-frames!)
     (asm/clear-standards!)
     (t)
-    (lf/clear-live-frames!)
     (asm/clear-standards!)))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -328,8 +328,8 @@
         (fn [_ [_ payload]]
           {:fx [[:http payload]]}))
 
-      (let [a (frame/make-frame {:fx-overrides {:http :http.stub-A}})
-            b (frame/make-frame {:fx-overrides {:http :http.stub-B}})]
+      (let [a (frame/make-anon-frame-record! {:fx-overrides {:http :http.stub-A}})
+            b (frame/make-anon-frame-record! {:fx-overrides {:http :http.stub-B}})]
         ;; Gensym contract: id is a keyword in the :rf.frame namespace,
         ;; the two ids differ, and neither collides with :rf/default.
         (is (keyword? a))
@@ -668,7 +668,7 @@
       (rf/reg-event :parent/spawn-sub-actor
         (fn [_ _]
           (swap! order conj :parent/before-make-frame)
-          (reset! child-id (frame/make-frame {:on-create [:sub-actor/boot]}))
+          (reset! child-id (frame/make-anon-frame-record! {:on-create [:sub-actor/boot]}))
           (swap! order conj :parent/after-make-frame)
           {}))
       (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]

--- a/implementation/core/test/re_frame/frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_resolution_cljs_test.cljc
@@ -48,9 +48,10 @@
 ;; — it creates its backing runnable record (app-db / queue / sub-cache) via
 ;; `reg-frame`, which needs a substrate adapter — so the plain-atom adapter is
 ;; installed. The resolved generation lives ON that record (the `:generation`
-;; slot), read by id; the two-registry model collapsed to ONE, so
-;; `clear-live-frames!` is a no-op and the runtime fixture's `(reset! frames {})`
-;; clears every record's generation. These cases exercise pure `(kind, id)`
+;; slot), read by id; the two-registry model collapsed to ONE, so the runtime
+;; fixture's `(reset! frames {})` clears every record AND its generation — no
+;; separate live-frame index to clear (rf2-ji3tvy). These cases exercise pure
+;; `(kind, id)`
 ;; resolution through the `call-with-frame-resolution` seam (they do not run a
 ;; cascade), but constructing the frame now allocates a state container.
 ;;
@@ -64,10 +65,8 @@
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
     (asm/clear-standards!)
-    (lf/clear-live-frames!)
     (t)
-    (asm/clear-standards!)
-    (lf/clear-live-frames!)))
+    (asm/clear-standards!)))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers — synthetic REGISTERED descriptors (the source-store output shape

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -163,20 +163,20 @@
 
       (testing "no overrides — registered fx fires"
         (reset! fired [])
-        (let [f (frame/make-frame {})]
+        (let [f (frame/make-anon-frame-record! {})]
           (rf/dispatch-sync [:fx-test/send] {:frame f})
           (is (= [:registered] @fired))))
 
       (testing "per-frame override applied"
         (reset! fired [])
-        (let [f (frame/make-frame
+        (let [f (frame/make-anon-frame-record!
                   {:fx-overrides {:fx-test/email :fx-test/email.frame}})]
           (rf/dispatch-sync [:fx-test/send] {:frame f})
           (is (= [:per-frame] @fired))))
 
       (testing "per-call override beats per-frame"
         (reset! fired [])
-        (let [f (frame/make-frame
+        (let [f (frame/make-anon-frame-record!
                   {:fx-overrides {:fx-test/email :fx-test/email.frame}})]
           (rf/dispatch-sync
             [:fx-test/send]
@@ -224,7 +224,7 @@
 
       (testing "per-call opt > lexical with-fx-overrides > per-frame"
         (reset! fired [])
-        (let [f (frame/make-frame
+        (let [f (frame/make-anon-frame-record!
                   {:fx-overrides {:fx-test/wo-email :fx-test/wo-email.stub}})]
           (rf/with-fx-overrides {:fx-test/wo-email :fx-test/wo-email.stub}
             ;; Per-call wins over both lexical and per-frame

--- a/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_cascade_frame_resolution_cljs_test.cljc
@@ -50,18 +50,15 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Fixture: install the plain-atom adapter (so frames are runnable), opt OUT of
-;; the ambient `:rf/default` scope (we drive explicit `{:frame …}` targets), and
-;; clear the live-frame registry between cases so an `:id` from one case does not
-;; collide with the next.
+;; the ambient `:rf/default` scope (we drive explicit `{:frame …}` targets). The
+;; runtime fixture resets the ONE `frame/frames` registry between cases — clearing
+;; every record AND its generation — so an `:id` from one case does not collide
+;; with the next (no separate live-frame index to clear, rf2-ji3tvy).
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter        plain-atom/adapter
-                                            :ambient-frame  nil})
-  (fn [t]
-    (lf/clear-live-frames!)
-    (t)
-    (lf/clear-live-frames!)))
+                                            :ambient-frame  nil}))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers — build a RUNNABLE event-handler descriptor for an image resolver.

--- a/implementation/core/test/re_frame/live_frame_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_cljs_test.cljc
@@ -44,8 +44,9 @@
   the store (never `clear-all!`, which would destroy real authored
   registrations). The ONE `frames` registry, the standard registry, the generation
   cache, and the source store are all process state, so the fixture
-  snapshot/restores or clears them per case (`lf/clear-live-frames!` is now a
-  no-op kept for fixtures — `frame/frames` is reset by the runtime fixture).
+  snapshot/restores or clears them per case (the runtime fixture resets
+  `frame/frames`, which clears every record AND its generation — no separate
+  live-frame index to clear, rf2-ji3tvy).
   `.cljc` ends `-cljs-test` so it rides `npm run test:cljs` AND `clojure -M:test`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
@@ -77,13 +78,11 @@
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
     (let [store-before @ss/kind->id->ns->descriptor]
-      (lf/clear-live-frames!)
       (asm/clear-standards!)
       (asm/clear-generation-cache!)
       (try
         (t)
         (finally
-          (lf/clear-live-frames!)
           (asm/clear-standards!)
           (asm/clear-generation-cache!)
           (reset! ss/kind->id->ns->descriptor store-before))))))

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -56,8 +56,9 @@
 ;; EP-0024 (rf2-tu2vr7): the two-registry model collapsed to ONE — the resolved
 ;; image GENERATION lives ON the frame record in the single `frame/frames`
 ;; registry (the `:generation` slot), and the former second live-frame registry
-;; dissolved, so `clear-live-frames!` is now a no-op kept for the fixtures that
-;; call it. `make-frame` creates/updates a RUNNABLE record (app-db / queue /
+;; dissolved, so the runtime fixture's `(reset! frame/frames {})` clears every
+;; record AND its generation — no separate live-frame index to clear
+;; (rf2-ji3tvy). `make-frame` creates/updates a RUNNABLE record (app-db / queue /
 ;; sub-cache) via `reg-frame`, which needs a substrate adapter — so the
 ;; plain-atom adapter is installed via the runtime fixture. These cases assert
 ;; the reload/diff/reproject contract; the backing record is an allocation side
@@ -67,10 +68,8 @@
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [t]
-    (lf/clear-live-frames!)
     (asm/clear-standards!)
     (t)
-    (lf/clear-live-frames!)
     (asm/clear-standards!)))
 
 ;; ---------------------------------------------------------------------------
@@ -488,6 +487,77 @@
         (finally
           (reset! source-store/kind->id->ns->descriptor snapshot))))))
 
+;; ---- the NON-DEFAULT-REALM leg (rf2-vnduo9) -------------------------------
+;;
+;; The reprojection flush runs on `interop/next-tick` (`deferred-flush!`), by
+;; which point the router's per-drain `*current-realm*` binding has UNWOUND to
+;; nil. `reproject-live-frame!`'s reads + `set-generation!` swap all re-key the
+;; registry via `(frame-key *current-realm* id)`. So a NON-default-realm
+;; image-loaded frame — keyed by its `[realm-id frame-id]` address — would be
+;; ENUMERATED by the old bare-`:id` `image-loaded-frame-ids`, but every
+;; subsequent per-frame re-key under nil `*current-realm*` would MISS its address
+;; → silent no-op → its generation stays STALE. The fix has
+;; `reproject-live-frames!` enumerate `image-loaded-frame-addresses` (carrying
+;; each frame's own `:realm`, read off the record) and bind `*current-realm*` per
+;; frame via `call-with-realm` so each re-key resolves the frame's OWN address.
+;;
+;; Not reachable via the public `make-frame` (default-realm-only per EP-0024);
+;; reachable via the internal substrate, which binds `*current-realm*` around a
+;; frame's creation when seating it into a realm (`seat-into-realm!`). This test
+;; mirrors that by binding `frame/*current-realm*` ONLY around creation + the
+;; read-backs, and running `reproject-live-frames!` with `*current-realm*` nil —
+;; exactly the next-tick-flush condition where the latent bug bites.
+
+(deftest reproject-swaps-a-non-default-realm-image-loaded-frame
+  (testing "reproject-live-frames! swaps a NON-default-realm image-loaded frame's
+            generation even though the flush runs with *current-realm* nil
+            (rf2-vnduo9): the frame is enumerated WITH its realm and re-keyed
+            under it, so the source-store change is actually picked up rather than
+            silently no-op'd against a bare-id miss."
+    (let [snapshot @source-store/kind->id->ns->descriptor
+          realm-id :rf.realm/vnduo9-test]
+      (try
+        (source-store/record-descriptor!
+          :event :nd/inc
+          {:rf.provenance/ns "nd.feature" :kind :event :id :nd/inc
+           :handler-fn ::nd-original})
+        (let [img (image/image {:id :nd/img :include-ns ["nd.feature"]})
+              ;; Create the image-loaded frame UNDER a non-default realm — the
+              ;; record is keyed `[realm-id :nd/main]` and stamped `:realm realm-id`
+              ;; (the internal seat-into-realm! shape). `make-frame` runs
+              ;; `reg-frame` which reads `*current-realm*` for the key + stamp.
+              _ (binding [frame/*current-realm* realm-id]
+                  (lf/make-frame {:id :nd/main :images [img]}))]
+          (testing "the frame is image-loaded under its non-default realm address"
+            (binding [frame/*current-realm* realm-id]
+              (is (= ::nd-original
+                     (:handler-fn (asm/resolve-descriptor
+                                    (frame/frame-generation :nd/main)
+                                    :event :nd/inc))))))
+          (testing "the bare-id (default-realm) lookup MISSES it — it is genuinely
+                    non-default-realm, so a realm-unaware flush would no-op"
+            (is (nil? (frame/frame-generation :nd/main))))
+          ;; Hot reload the selected source slot (new impl, same (kind,id,ns)).
+          (source-store/record-descriptor!
+            :event :nd/inc
+            {:rf.provenance/ns "nd.feature" :kind :event :id :nd/inc
+             :handler-fn ::nd-reloaded})
+          ;; THE FAILING PATH: reproject with *current-realm* nil (the next-tick
+          ;; flush condition). Pre-fix this returns {} (the non-default-realm frame
+          ;; is enumerated but its per-frame re-key misses → stale generation).
+          (let [moved (lf/reproject-live-frames!)]
+            (testing "reproject reports the non-default-realm frame as moved"
+              (is (contains? moved :nd/main))
+              (is (contains? (:changed (get moved :nd/main)) [:event :nd/inc])))
+            (testing "its generation actually swapped to the reloaded impl (not stale)"
+              (binding [frame/*current-realm* realm-id]
+                (is (= ::nd-reloaded
+                       (:handler-fn (asm/resolve-descriptor
+                                      (frame/frame-generation :nd/main)
+                                      :event :nd/inc))))))))
+        (finally
+          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+
 ;; ===========================================================================
 ;; 9. AUTO-reprojection: a `reg-*` change reprojects the affected explicit-image
 ;;    frame WITHOUT a manual reproject-live-frames! call (rf2-h4q6cy)
@@ -643,8 +713,9 @@
         (finally
           ;; Forget the live frame before draining (see register!-during-flush's
           ;; finally): a pending reproject of :burst/main must not re-assemble its
-          ;; image after the burst descriptors are unregistered.
-          (lf/clear-live-frames!)
+          ;; image after the burst descriptors are unregistered. The ONE registry
+          ;; reset clears the record AND its generation (rf2-ji3tvy).
+          (reset! frame/frames {})
           (lf/flush-pending-reprojection!)
           (doseq [n (range 5)]
             (registrar/unregister! :event (keyword "burst" (str "e" n))))
@@ -675,7 +746,8 @@
       (try
         ;; No live frame: clear the registry and drain any residual pending flush a
         ;; prior case left, so the flag starts clean and live-frame-ids is empty.
-        (lf/clear-live-frames!)
+        ;; The ONE registry reset clears every record AND its generation (rf2-ji3tvy).
+        (reset! frame/frames {})
         (lf/flush-pending-reprojection!)
         (with-redefs [interop/next-tick (fn [_f] (swap! scheduled inc) nil)]
           ;; A 50-reg-* burst with no reprojectable frame — the worst-case flood

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -406,7 +406,7 @@
                        (fn [_ _] {:fx [[:goum9x/real-fx]]}))
       ;; Per-call override redirects :goum9x/real-fx to an id that is NOT
       ;; registered → override-fallthrough; runtime uses :goum9x/real-fx.
-      (let [f (frame/make-frame {})]
+      (let [f (frame/make-anon-frame-record! {})]
         (rf/dispatch-sync [:goum9x/run-bad-override]
                           {:frame f
                            :fx-overrides {:goum9x/real-fx :goum9x/not-registered}})

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -120,7 +120,7 @@
                             :fx [[:dispatch [:app/ready]]]}))
     (rf/reg-event :app/ready
       (fn [{:keys [db]} _] {:db (assoc db :app/booted? true)}))
-    (let [f (frame/make-frame {:on-create [:app/init]})
+    (let [f (frame/make-anon-frame-record! {:on-create [:app/init]})
           db (rf/app-db-value f)]
       (is (true? (:app/booted? db)) "chained-events boot reached :app/ready")
       (is (= {:loaded? true} (:config db)))))
@@ -138,7 +138,7 @@
           :ready       {}}}))
     ;; :on-create kicks the boot machine; subsequent dispatched lifecycle
     ;; events drive the documented progression to :ready.
-    (let [f (frame/make-frame {:on-create [:app/boot [:configured {:url "/api"}]]})]
+    (let [f (frame/make-anon-frame-record! {:on-create [:app/boot [:configured {:url "/api"}]]})]
       (is (= :loading (get-in (rf/runtime-db-value f) [:rf.runtime/machines :snapshots :app/boot :state]))
           ":on-create transitioned :configuring → :loading")
       (rf/dispatch-sync [:app/boot [:loaded]] {:frame f})

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -350,7 +350,7 @@
       :<- [:diamond/a]
       :<- [:diamond/b]
       (fn [[a b] _] {:a a :b b}))
-    (let [f (frame/make-frame {})]
+    (let [f (frame/make-anon-frame-record! {})]
       (rf/dispatch-sync [:diamond/init] {:frame f})
       (is (= {:a 1 :b 2} (rf/compute-sub [:diamond/c] (rf/app-db-value f)))
           "initial state is fully consistent")
@@ -365,7 +365,7 @@
     (rf/reg-sub :chain/a (fn [db _] (:n db)))
     (rf/reg-sub :chain/b :<- [:chain/a] (fn [a _] (* a 2)))
     (rf/reg-sub :chain/c :<- [:chain/b] (fn [b _] (inc b)))
-    (let [f (frame/make-frame {})]
+    (let [f (frame/make-anon-frame-record! {})]
       (rf/dispatch-sync [:chain/init] {:frame f})
       (is (= 21 (rf/compute-sub [:chain/c] (rf/app-db-value f)))
           "initial: n=10 → b=20 → c=21")
@@ -380,7 +380,7 @@
                      (fn [{:keys [db]} _] {:db (assoc db :unrelated "z")}))   ;; same value
     (rf/reg-sub :stable/a (fn [db _] (:n db)))
     (rf/reg-sub :stable/squared :<- [:stable/a] (fn [a _] (* a a)))
-    (let [f (frame/make-frame {})]
+    (let [f (frame/make-anon-frame-record! {})]
       (rf/dispatch-sync [:stable/init] {:frame f})
       (is (= 25 (rf/compute-sub [:stable/squared] (rf/app-db-value f)))
           "initial value correct: 5*5 = 25")
@@ -774,7 +774,7 @@
 
       (testing "happy path: idle → submitting → authed; session token stored"
         (reset! stored nil)
-        (let [f (frame/make-frame {:fx-overrides {:http :http.canned-success}})]
+        (let [f (frame/make-anon-frame-record! {:fx-overrides {:http :http.canned-success}})]
           (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                                {:email "a@b.c" :password "secret"}]]
                             {:frame f})
@@ -785,7 +785,7 @@
 
       (testing "retry-then-lockout: 3 failures land in :error-shown, 4th in :locked-out"
         (reset! stored nil)
-        (let [f (frame/make-frame {:fx-overrides {:http :http.canned-failure}})]
+        (let [f (frame/make-anon-frame-record! {:fx-overrides {:http :http.canned-failure}})]
           (dotimes [_ 3]
             (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                                  {:email "x@y.z" :password "wrong"}]]
@@ -806,7 +806,7 @@
        :data    {:n 0}
        :actions {:bump (fn [{data :data}] {:data (update data :n inc)})}
        :states  {:idle {:on {:tick {:target :idle :action :bump}}}}})
-    (let [f (frame/make-frame {})]
+    (let [f (frame/make-anon-frame-record! {})]
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
       ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state.

--- a/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
@@ -62,8 +62,9 @@
   (an ambient scope would mask a frame-target-resolution regression). The
   registrar is snapshot/restored via `make-reset-runtime-fixture` (NOT
   `clear-all!`, which would destroy framework ns-load registrations a sibling ns
-  depends on); the process-local live-frame registry is cleared between cases so
-  an `:id` from one case does not collide with the next.
+  depends on); the ONE `frame/frames` registry is reset between cases — clearing
+  every record AND its generation — so an `:id` from one case does not collide
+  with the next (no separate live-frame index to clear, rf2-ji3tvy).
 
   `.cljc` ending `-cljs-test` rides `npm run test:cljs` AND `clojure -M:test`.
 
@@ -86,11 +87,7 @@
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter       plain-atom/adapter
-                                            :ambient-frame nil})
-  (fn [t]
-    (lf/clear-live-frames!)
-    (t)
-    (lf/clear-live-frames!)))
+                                            :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers — build a RUNNABLE image-resolver descriptor for an event / sub id.

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2019,7 +2019,7 @@
             tag, yielding two."
     (let [;; The head fragment as the pipeline produces it for a route
           ;; with no declared :head — default-head rendered to HTML.
-          f          (frame/make-frame {:doc "Charset probe" :platform :server})
+          f          (frame/make-anon-frame-record! {:doc "Charset probe" :platform :server})
           head-model (rf/active-head f)
           head-html  (rf/head-model->html head-model)
           html       (ssr-ring/default-html-shell "body" "{}" {:head head-html})

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -56,7 +56,7 @@
         ;; check-version probes compare integers, not semver strings.
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 1}]]}))
 
-    (let [f      (frame/make-frame {:platform :client})
+    (let [f      (frame/make-anon-frame-record! {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-version-match]
@@ -73,7 +73,7 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 2}]]}))
 
-    (let [f      (frame/make-frame {:platform :client})
+    (let [f      (frame/make-anon-frame-record! {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-version-mismatch]
@@ -111,7 +111,7 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:deadbeefcafef00d"}]]}))
 
-    (let [f      (frame/make-frame {:platform :client})
+    (let [f      (frame/make-anon-frame-record! {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-digest-match]
@@ -130,7 +130,7 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:0000000000000000"}]]}))
 
-    (let [f      (frame/make-frame {:platform :client})
+    (let [f      (frame/make-anon-frame-record! {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-digest-mismatch]
@@ -167,7 +167,7 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version 1]]}))
 
-    (let [f      (frame/make-frame {:platform :client})
+    (let [f      (frame/make-anon-frame-record! {:platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [::probe-check-version-scalar-no-hook]
@@ -196,7 +196,7 @@
         (fn [_ _]
           {:fx [[:rf.ssr/check-version 1]]}))
 
-      (let [f      (frame/make-frame {:platform :client})
+      (let [f      (frame/make-anon-frame-record! {:platform :client})
             traces (capture-traces!
                      (fn []
                        (rf/dispatch-sync [::probe-check-version-scalar-with-hook]
@@ -229,7 +229,7 @@
           (fn [_ _]
             {:fx [[:rf.ssr/check-schema-digest "sha256:deadbeefcafef00d"]]}))
 
-        (let [f      (frame/make-frame {:platform :client})
+        (let [f      (frame/make-anon-frame-record! {:platform :client})
               traces (capture-traces!
                        (fn []
                          (rf/dispatch-sync [::probe-check-digest-scalar-no-hook]

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -120,7 +120,7 @@
               ^{:key id} [:li [:h3 title] [:p body]])]])))
 
     ;; ---- (1) per-request server frame -------------------------------------
-    (let [server-frame (frame/make-frame
+    (let [server-frame (frame/make-anon-frame-record!
                          {:doc          "SSR request frame"
                           :platform     :server
                           :on-create    [:rf/server-init {:uri "/articles"}]
@@ -167,7 +167,7 @@
               "payload carries the resolved render-tree hash")
 
           ;; ---- (6) hydration on a separate "client" frame ---------------
-          (let [client-frame (frame/make-frame
+          (let [client-frame (frame/make-anon-frame-record!
                                {:doc      "Hydrated client frame"
                                 :platform :client})
                 ;; rf2-nv3mua: in a real SSR deployment the server and client
@@ -264,7 +264,7 @@
           {:fx [[:rf.server/set-status 401]
                 [:rf.server/set-status 403]]}))                          ;; second write replaces
 
-      (let [f (frame/make-frame {:platform :server})]
+      (let [f (frame/make-anon-frame-record! {:platform :server})]
         (rf/register-listener! :trace ::status (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:auth/forbid] {:frame f})
         (rf/unregister-listener! :trace ::status)
@@ -303,7 +303,7 @@
                                       :value   "off"
                                       :max-age 0}]]}))
 
-    (let [f (frame/make-frame {:platform :server})]
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:auth/establish] {:frame f})
 
       (let [cookies (:cookies (get-response f))]
@@ -337,7 +337,7 @@
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie {:name "session" :path "/"}]]}))
 
-    (let [f (frame/make-frame {:platform :server})]
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:auth/logout] {:frame f})
       (let [[c] (:cookies (get-response f))]
         (is (= "session" (:name c)))
@@ -363,7 +363,7 @@
         {:fx [[:rf.server/append-header {:name "Set-Cookie" :value "a=1"}]
               [:rf.server/append-header {:name "Set-Cookie" :value "b=2"}]]}))
 
-    (let [f (frame/make-frame {:platform :server})]
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:hdr/set-then-replace] {:frame f})
       (rf/dispatch-sync [:hdr/append-twice]     {:frame f})
       (let [hdrs  (:headers (get-response f))
@@ -440,7 +440,7 @@
                {:name  "X-Forwarded-For"
                 :value "1.2.3.4\r\nSet-Cookie: admin=1"}]]}))
 
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/inject-crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -452,7 +452,7 @@
       (rf/reg-event :hdr/probe-injection
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name "X-Probe" :value hostile}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:hdr/probe-injection] {:frame f})))]
         (expect-fx-error-keyword!
@@ -467,7 +467,7 @@
         {:fx [[:rf.server/append-header
                {:name  "X-Audit"
                 :value "ok\r\nSet-Cookie: forged=1"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/append-crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -483,7 +483,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect
                {:location "https://example.com\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:redirect/crlf-in-location] {:frame f})))]
       (expect-fx-error-keyword!
@@ -503,7 +503,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/ok"}]]}))
     (doseq [ev [:redirect/via-url :redirect/via-to]]
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [ev] {:frame f})))]
         (expect-fx-error-keyword!
@@ -519,7 +519,7 @@
     (rf/reg-event :redirect/retired-spelling
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/login"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:redirect/retired-spelling] {:frame f})))
           ex     (some (fn [ev]
@@ -555,7 +555,7 @@
       (rf/reg-event :redirect/shape-quirk
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f    (frame/make-frame {:platform :server :on-create [:redirect/shape-quirk]})
+      (let [f    (frame/make-anon-frame-record! {:platform :server :on-create [:redirect/shape-quirk]})
             resp (get-response f)]
         (is (= loc (-> resp :redirect :location))
             (str "raw URL-shape quirk passes through the caller-trusted "
@@ -575,7 +575,7 @@
       (rf/reg-event :redirect/well-formed
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f    (frame/make-frame {:platform :server :on-create [:redirect/well-formed]})
+      (let [f    (frame/make-anon-frame-record! {:platform :server :on-create [:redirect/well-formed]})
             resp (get-response f)]
         (is (= loc (-> resp :redirect :location))
             (str "well-formed redirect :location flows through: " loc))))))
@@ -592,7 +592,7 @@
       (rf/reg-event :redirect/crlf-nul
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:redirect/crlf-nul] {:frame f})))]
         (expect-fx-error-keyword!
@@ -609,7 +609,7 @@
       (rf/reg-event :safe-redirect/crlf-nul
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect {:location loc}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:safe-redirect/crlf-nul] {:frame f})))]
         (expect-fx-error-keyword!
@@ -627,7 +627,7 @@
               [:rf.server/set-header {:name "X-Whitespace"
                                       :value "tab\there space"}]
               [:rf.server/redirect    {:location "https://example.com/path?q=1&r=2"}]]}))
-    (let [f (frame/make-frame {:platform :server :on-create [:hdr/clean]})
+    (let [f (frame/make-anon-frame-record! {:platform :server :on-create [:hdr/clean]})
           resp (get-response f)
           hdrs (:headers resp)]
       (is (some (fn [[k v]]
@@ -649,7 +649,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
 
-    (let [f (frame/make-frame {:platform     :server
+    (let [f (frame/make-anon-frame-record! {:platform     :server
                             :on-create    [:auth/check-session]})]
       (let [resp     (get-response f)
             redirect (:redirect resp)]
@@ -678,7 +678,7 @@
     (rf/reg-event :auth/check-no-status
       (fn [_ _]
         {:fx [[:rf.server/redirect {:location "/login"}]]}))
-    (let [f (frame/make-frame {:platform  :server
+    (let [f (frame/make-anon-frame-record! {:platform  :server
                             :on-create [:auth/check-no-status]})]
       (is (= 302 (-> (get-response f) :redirect :status))
           ":rf.server/redirect defaults :status to 302 per Spec 011 §Redirect"))))
@@ -698,7 +698,7 @@
   (testing "routing's :rf.error/no-such-handler → default projector → 404"
     (rf/reg-route :route/home {:path "/"})
     (let [project-error  ssr/project-error
-          f              (frame/make-frame
+          f              (frame/make-anon-frame-record!
                            {:platform :server
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
                                   :dev-error-detail? false}})
@@ -738,7 +738,7 @@
     (let [project-error  ssr/project-error
           traces         (atom [])
           _              (rf/register-listener! :trace ::he (fn [ev] (swap! traces conj ev)))
-          f              (frame/make-frame
+          f              (frame/make-anon-frame-record!
                            {:platform :server
                             :on-create [:rf/server-init]
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
@@ -763,7 +763,7 @@
 (deftest ssr-error-projector-dev-mode-includes-details
   (testing ":dev-error-detail? true puts the raw trace under :details"
     (let [project-error ssr/project-error
-          f             (frame/make-frame
+          f             (frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :rf.ssr/default-error-projector
                                  :dev-error-detail? true}})
@@ -800,7 +800,7 @@
            :retryable? false})))
 
     (let [project-error ssr/project-error
-          f             (frame/make-frame
+          f             (frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/public-error
                                  :dev-error-detail? false}})]
@@ -827,7 +827,7 @@
         (throw (ex-info "projector bug" {}))))
 
     (let [project-error ssr/project-error
-          f             (frame/make-frame
+          f             (frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/buggy-projector
                                  :dev-error-detail? false}})
@@ -850,7 +850,7 @@
       (fn [_trace-event] {:wrong :shape}))
 
     (let [project-error ssr/project-error
-          f             (frame/make-frame
+          f             (frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/bad-shape}})
           traces        (atom [])
@@ -914,7 +914,7 @@
             peek-response (pure read) and only stamps :status when
             flush-response! / get-response drains it."
     (rf/reg-route :route/home {:path "/"})
-    (let [f (frame/make-frame
+    (let [f (frame/make-anon-frame-record!
               {:platform :server
                :ssr {:public-error-id   :rf.ssr/default-error-projector
                      :dev-error-detail? false}})]
@@ -950,7 +950,7 @@
       (fn [_ _]
         {:fx [[:rf.server/set-status 201]
               [:rf.server/set-status 202]]}))
-    (let [f (frame/make-frame {:platform :server})]
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:resp/multi-status] {:frame f})
       (doseq [[label resp] [["peek-response"  (ssr/peek-response f)]
                             ["get-response"   (ssr/get-response f)]]]
@@ -968,7 +968,7 @@
     ;; project. (The trace still fires; the projector just isn't called
     ;; for a client frame's response slot.)
     (rf/reg-route :route/home {:path "/"})
-    (let [client-f (frame/make-frame {:platform :client})]
+    (let [client-f (frame/make-anon-frame-record! {:platform :client})]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"]
                         {:frame client-f})
       (let [resp (get-response client-f)]
@@ -989,7 +989,7 @@
           {:fx [[:rf.server/redirect {:status 302 :location "/login"}]
                 [:rf.server/redirect {:status 301 :location "/canonical"}]]}))
 
-      (let [f (frame/make-frame {:platform :server})]
+      (let [f (frame/make-anon-frame-record! {:platform :server})]
         (rf/register-listener! :trace ::redir (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:auth/double-redirect] {:frame f})
         (rf/unregister-listener! :trace ::redir)
@@ -1042,7 +1042,7 @@
                      :rf/runtime-db  {:rf.runtime/routing {:current {:route-id :route/article :params {:id "123"}}}}
                      :rf/render-hash "head-hash-server-A"}
           traces    (atom [])
-          f         (frame/make-frame {:platform :client})]
+          f         (frame/make-anon-frame-record! {:platform :client})]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame f})
       (is (= "head-hash-server-A"
              (get-in (rf/runtime-db-value f) [:rf.runtime/ssr :hydration :server-hash]))
@@ -1182,7 +1182,7 @@
   (testing "rf2-dl9yg TC9: a synthetic error trace tagged with a server frame
             → error-projection-listener buffers → get-response flushes → response
             :status carries the default projector's 500"
-    (let [f (frame/make-frame
+    (let [f (frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]
@@ -1276,7 +1276,7 @@
     (rf/reg-event :retired/url-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/dashboard"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:retired/url-redirect] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1292,7 +1292,7 @@
     (rf/reg-event :retired/to-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/welcome" :status 301}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:retired/to-redirect] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1325,7 +1325,7 @@
 
     (let [traces (atom [])
           _      (rf/register-listener! :trace ::rpe (fn [ev] (swap! traces conj ev)))
-          f      (frame/make-frame
+          f      (frame/make-anon-frame-record!
                    {:platform  :server
                     :on-create [:redirect-then-error]
                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -1397,7 +1397,7 @@
         ;; not a legal scheme-specific character).
         {:fx [[:rf.server/safe-redirect
                {:location "https://example.com/path with space"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/unparseable] {:frame f})))
           resp   (get-response f)]
@@ -1416,7 +1416,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "javascript:alert(1)"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/javascript] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-scheme-rejected
@@ -1435,7 +1435,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "data:text/html,<script>alert(1)</script>"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/data] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1449,7 +1449,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "vbscript:msgbox(\"x\")"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/vbscript] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1464,7 +1464,7 @@
       (rf/reg-event :sr/probe-case
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect {:location hostile}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/probe-case] {:frame f})))]
         (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1481,7 +1481,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location       "https://evil.example.com/phish"
                 :relative-only? true}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/abs-with-relative-only] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1505,7 +1505,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location       "/dashboard"
                 :relative-only? true}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/relative-ok] {:frame f})))
           resp   (get-response f)]
@@ -1526,7 +1526,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://evil.example.com/phish"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/not-in-allow] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1552,7 +1552,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/in-allow] {:frame f})))
           resp   (get-response f)]
@@ -1571,7 +1571,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://APP.Example.COM/dashboard"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/in-allow-mixed-case] {:frame f})))
           resp   (get-response f)]
@@ -1593,7 +1593,7 @@
         ;; parser-fail must fire FIRST because step 1 runs before step 2.
         {:fx [[:rf.server/safe-redirect
                {:location "javascript: not a real url "}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/order-parse-first] {:frame f})))
           ops    (mapv :operation traces)]
@@ -1611,7 +1611,7 @@
     (rf/reg-event :sr/empty
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location ""}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/empty] {:frame f})))]
       (is (some #(= :rf.error/safe-redirect-invalid-url (:operation %))
@@ -1645,7 +1645,7 @@
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "http:evil.example.com"} policy)]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/opaque-http] {:frame f})))]
         (is (seq traces)
@@ -1662,7 +1662,7 @@
     (rf/reg-event :sr/opaque-https
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "https:evil.example.com"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/opaque-https] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-invalid-url (:operation %))
@@ -1679,7 +1679,7 @@
     (rf/reg-event :sr/mailto
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "mailto:user@example.com"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/mailto] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1696,7 +1696,7 @@
     (rf/reg-event :sr/ftp
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "ftp:example.com"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/ftp] {:frame f})))]
       (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1716,7 +1716,7 @@
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "//evil.example.com/path"} policy)]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/protocol-relative] {:frame f})))]
         (is (some #(and (= :rf.error/safe-redirect-host-disallowed (:operation %))
@@ -1735,7 +1735,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/account/settings" :relative-only? true}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/relative-control] {:frame f})))
           resp   (get-response f)]
@@ -1755,7 +1755,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
                 :allow    ["app.example.com"]}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/abs-control] {:frame f})))
           resp   (get-response f)]
@@ -1775,7 +1775,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/path\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:sr/crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1879,7 +1879,7 @@
         {:fx [[:rf.server/set-header
                {:name  "X-Test\r\nSet-Cookie: evil=1"
                 :value "ok"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/crlf-in-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1892,7 +1892,7 @@
       (rf/reg-event :hdr/probe-name
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name hostile :value "ok"}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:hdr/probe-name] {:frame f})))]
         (expect-fx-error-keyword!
@@ -1907,7 +1907,7 @@
         {:fx [[:rf.server/append-header
                {:name  "X-Audit\r\nSet-Cookie: forged=1"
                 :value "ok"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/append-crlf-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1922,7 +1922,7 @@
         {:fx [[:rf.server/set-cookie
                {:name  "session\r\nSet-Cookie: stolen=1"
                 :value "abc"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1936,7 +1936,7 @@
         {:fx [[:rf.server/set-cookie
                {:name  "session"
                 :value "abc\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-value] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1951,7 +1951,7 @@
                {:name  "session"
                 :value "abc"
                 :path  "/\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-path] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1966,7 +1966,7 @@
                {:name   "session"
                 :value  "abc"
                 :domain "example.com\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-domain] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1980,7 +1980,7 @@
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie
                {:name "session" :path "/admin\r\nbad"}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/del-crlf-path] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2003,7 +2003,7 @@
                  {:name    "session"
                   :value   "x"
                   :max-age "3600\r\nSet-Cookie: admin=1; Path=/"}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-max-age] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2019,7 +2019,7 @@
                  {:name      "session"
                   :value     "x"
                   :same-site "Lax\r\nSet-Cookie: admin=1"}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-same-site] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2033,7 +2033,7 @@
                  {:name    "session"
                   :value   "x"
                   :expires "Wed, 09 Jun 2027 10:18:14 GMT\r\nSet-Cookie: admin=1"}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-expires] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2046,7 +2046,7 @@
           (fn [_ _]
             {:fx [[:rf.server/set-cookie
                    {:name "s" :value "x" :max-age hostile}]]}))
-        (let [f      (frame/make-frame {:platform :server})
+        (let [f      (frame/make-anon-frame-record! {:platform :server})
               traces (capture-fx-traces!
                        (fn [] (rf/dispatch-sync [:ck/probe-max-age] {:frame f})))]
           (expect-fx-error-keyword!
@@ -2067,7 +2067,7 @@
                 :same-site "Strict"
                 :path      "/"
                 :expires   "Wed, 09 Jun 2027 10:18:14 GMT"}]]}))
-    (let [f       (frame/make-frame {:platform :server :on-create [:ck/clean-attrs]})
+    (let [f       (frame/make-anon-frame-record! {:platform :server :on-create [:ck/clean-attrs]})
           cookies (:cookies (get-response f))]
       (is (= 1 (count cookies))
           "the clean cookie lands on the accumulator")
@@ -2090,7 +2090,7 @@
                                        :path    "/"
                                        :domain  "example.com"}]
               [:rf.server/delete-cookie {:name "stale" :path "/"}]]}))
-    (let [f (frame/make-frame {:platform :server :on-create [:clean/all]})
+    (let [f (frame/make-anon-frame-record! {:platform :server :on-create [:clean/all]})
           resp (get-response f)]
       (is (some (fn [[k _]] (= "Cache-Control"   k)) (:headers resp)))
       (is (some (fn [[k _]] (= "X-Forwarded-For" k)) (:headers resp)))
@@ -2174,7 +2174,7 @@
       ;; defect into a proper 400.
       (rf/reg-event :bad/status
         (fn [_ _] {:fx [[:rf.server/set-status "not-an-int"]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/status] {:frame f})))
             status (:status (get-response f))]
@@ -2193,7 +2193,7 @@
     (testing ":rf.server/set-header missing :value → rejected + skipped"
       (rf/reg-event :bad/header
         (fn [_ _] {:fx [[:rf.server/set-header {:name "X-Foo"}]]}))   ;; :value absent
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/header] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2204,7 +2204,7 @@
     (testing ":rf.server/append-header with non-string :value → rejected"
       (rf/reg-event :bad/append
         (fn [_ _] {:fx [[:rf.server/append-header {:name "X-Bar" :value 42}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/append] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2213,7 +2213,7 @@
     (testing ":rf.server/set-cookie missing :value → rejected via [:ref :rf.server/cookie]"
       (rf/reg-event :bad/cookie
         (fn [_ _] {:fx [[:rf.server/set-cookie {:name "session"}]]})) ;; :value absent
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/cookie] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2227,7 +2227,7 @@
       (rf/reg-event :bad/cookie-samesite
         (fn [_ _] {:fx [[:rf.server/set-cookie
                          {:name "s" :value "v" :same-site :bogus}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/cookie-samesite] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2236,7 +2236,7 @@
     (testing ":rf.server/delete-cookie missing :name → rejected"
       (rf/reg-event :bad/delete
         (fn [_ _] {:fx [[:rf.server/delete-cookie {:path "/"}]]}))    ;; :name absent
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/delete] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2257,7 +2257,7 @@
       ;; shape check and does NOT reject the no-target redirect.
       (rf/reg-event :soft/redirect-no-target
         (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:soft/redirect-no-target] {:frame f})))]
         (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
@@ -2275,7 +2275,7 @@
     (testing ":rf.server/redirect with non-int :status → rejected"
       (rf/reg-event :bad/redirect-status
         (fn [_ _] {:fx [[:rf.server/redirect {:location "/x" :status "oops"}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/redirect-status] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2293,7 +2293,7 @@
       (rf/reg-event :bad/safe-redirect-status
         (fn [_ _] {:fx [[:rf.server/safe-redirect
                          {:location "/ok" :status "not-int"}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/safe-redirect-status] {:frame f})))
             resp   (get-response f)]
@@ -2312,7 +2312,7 @@
       ;; fails the shape gate.
       (rf/reg-event :bad/safe-redirect-no-location
         (fn [_ _] {:fx [[:rf.server/safe-redirect {:status 302}]]}))
-      (let [f      (frame/make-frame {:platform :server})
+      (let [f      (frame/make-anon-frame-record! {:platform :server})
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/safe-redirect-no-location] {:frame f})))]
         (expect-fx-args-schema-failure!
@@ -2334,7 +2334,7 @@
                                        :secure true :http-only true}]
               [:rf.server/delete-cookie {:name "stale" :path "/"}]
               [:rf.server/redirect    {:location "/dashboard" :status 302}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/all] {:frame f})))
           resp   (get-response f)]
@@ -2364,7 +2364,7 @@
                 :status         302
                 :relative-only? false
                 :allow          ["app.example.com"]}]]}))
-    (let [f      (frame/make-frame {:platform :server})
+    (let [f      (frame/make-anon-frame-record! {:platform :server})
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/safe-redirect] {:frame f})))
           resp   (get-response f)]
@@ -2419,7 +2419,7 @@
 
       (let [traces (atom [])]
         (rf/register-listener! :trace ::ssr (fn [ev] (swap! traces conj ev)))
-        (let [f  (frame/make-frame
+        (let [f  (frame/make-anon-frame-record!
                    {:on-create    [:rf/server-init {:uri "/articles"}]
                     :fx-overrides {:http/get :http/get.canned-articles}})
               db (rf/app-db-value f)]

--- a/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
@@ -241,7 +241,7 @@
                           :rf/runtime-db [:runtime :is :a :vector]}]]
       (let [seen-records (capture-records!)]
         (register-hydration-handlers!)
-        (let [client-frame (frame/make-frame {:doc "ep0008-hguive client frame"
+        (let [client-frame (frame/make-anon-frame-record! {:doc "ep0008-hguive client frame"
                                            :platform :client})]
           ;; Seed a recognisable pre-hydration client slice so we can prove
           ;; the rejection left both partitions untouched (fail-closed).

--- a/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
@@ -54,7 +54,7 @@
         {:fx [[:dispatch [:load/article]]]}))
 
     (with-redefs [interop/debug-enabled? false]
-      (let [f (frame/make-frame
+      (let [f (frame/make-anon-frame-record!
                 {:platform  :server
                  :on-create [:rf/server-init]
                  :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -74,7 +74,7 @@
             framework-private id used by both substrate installs). A
             tight error-record delivered through the substrate routes
             to the SSR projector buffer and stamps the response."
-    (let [f (frame/make-frame
+    (let [f (frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -76,7 +76,7 @@
                    (let [{:keys [title summary]} (get-in db [:articles (:id params)])]
                      {:title title
                       :meta  [{:name "description" :content summary}]})))
-    (let [f (frame/make-frame
+    (let [f (frame/make-anon-frame-record!
               {:doc       "head test frame"
                :platform  :server
                :on-create [:set-test-state]})]
@@ -99,14 +99,14 @@
   (testing "(render-head head-id frame-id) is sugar for (render-head head-id
             {:frame frame-id})"
     (rf/reg-head :head/simple (fn [_ _] {:title "bare"}))
-    (let [f (frame/make-frame {:doc "shorthand frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "shorthand frame" :platform :server})]
       (is (= {:title "bare"} (rf/render-head :head/simple f))))))
 
 (deftest render-head-accepts-explicit-route-override
   (testing ":route opt overrides the slice read from app-db — useful for
             tools that want a hypothetical-route preview"
     (rf/reg-head :head/echo (fn [_ route] {:title (str (:route-id route))}))
-    (let [f (frame/make-frame {:doc "explicit-route frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "explicit-route frame" :platform :server})]
       (is (= ":route/explicit"
              (:title (rf/render-head :head/echo
                                      {:frame f
@@ -114,7 +114,7 @@
 
 (deftest render-head-raises-on-unregistered-id
   (testing "render-head against an unknown id throws :rf.error/no-such-head"
-    (let [f (frame/make-frame {:doc "missing-head frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "missing-head frame" :platform :server})]
       (try
         (rf/render-head :head/nope {:frame f})
         (is false "expected exception")
@@ -129,7 +129,7 @@
             head-id) so head-snapshot reflects the latest output"
     (rf/reg-head :head/a (fn [_ _] {:title "A"}))
     (rf/reg-head :head/b (fn [_ _] {:title "B"}))
-    (let [f (frame/make-frame {:doc "snapshot frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "snapshot frame" :platform :server})]
       (rf/render-head :head/a {:frame f})
       (rf/render-head :head/b {:frame f})
       (let [snap (head/head-snapshot f)]
@@ -151,7 +151,7 @@
                   {:doc  "Article page"
                    :path "/articles/:id"
                    :head :head/article})
-    (let [f (frame/make-frame {:doc "active-route frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "active-route frame" :platform :server})]
       (rf/dispatch-sync
         [::seed-route] {:frame f})
       ;; The test sub-handler isn't registered; instead seed the runtime-db
@@ -171,7 +171,7 @@
     (rf/reg-route :route/no-head
                   {:doc  "Bare route"
                    :path "/"})
-    (let [f (frame/make-frame {:doc "Default-head probe" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "Default-head probe" :platform :server})]
       (rf/reg-event ::seed-route-no-head
                        (fn [{rt :rf.db/runtime} _]
                          {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/no-head})}))
@@ -187,7 +187,7 @@
 
 (deftest active-head-uses-default-when-no-route-at-all
   (testing "no route slice (e.g. a frame that hasn't routed yet) → default"
-    (let [f (frame/make-frame {:doc "Bare" :platform :server})
+    (let [f (frame/make-anon-frame-record! {:doc "Bare" :platform :server})
           model (rf/active-head f)]
       (is (= "Bare" (:title model)))
       (is (seq (:meta model))))))
@@ -508,7 +508,7 @@
             head bookkeeping must not leak across requests, per Spec 011
             §Per-request frame teardown and rf2-fcj33"
     (rf/reg-head :head/leaktest (fn [_ _] {:title "snapshot-A"}))
-    (let [f (frame/make-frame {:doc "teardown frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "teardown frame" :platform :server})]
       (rf/render-head :head/leaktest {:frame f})
       (is (= {:title "snapshot-A"}
              (get (head/head-snapshot f) :head/leaktest))
@@ -521,8 +521,8 @@
   (testing "two frames carry independent head-snapshots — destroying one
             doesn't touch the other"
     (rf/reg-head :head/iso (fn [_ _] {:title "x"}))
-    (let [f1 (frame/make-frame {:doc "frame-1" :platform :server})
-          f2 (frame/make-frame {:doc "frame-2" :platform :server})]
+    (let [f1 (frame/make-anon-frame-record! {:doc "frame-1" :platform :server})
+          f2 (frame/make-anon-frame-record! {:doc "frame-2" :platform :server})]
       (rf/render-head :head/iso {:frame f1})
       (rf/render-head :head/iso {:frame f2})
       (is (seq (head/head-snapshot f1)))
@@ -548,7 +548,7 @@
             the internal re-frame.ssr.head/head-snapshot returns"
     (rf/reg-head :head/pub-a (fn [_ _] {:title "Pub-A"}))
     (rf/reg-head :head/pub-b (fn [_ _] {:title "Pub-B"}))
-    (let [f (frame/make-frame {:doc "rf/head-snapshot frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "rf/head-snapshot frame" :platform :server})]
       (is (= {} (rf/head-snapshot f))
           "empty pre-render")
       (rf/render-head :head/pub-a {:frame f})
@@ -593,7 +593,7 @@
                   {:doc  "Article page"
                    :path "/articles/:id"
                    :head :head/article})
-    (let [f (frame/make-frame {:doc "article frame" :platform :server})]
+    (let [f (frame/make-anon-frame-record! {:doc "article frame" :platform :server})]
       (rf/dispatch-sync [:seed-article] {:frame f})
       (let [model (rf/active-head f)
             html  (rf/head-model->html model)]
@@ -637,7 +637,7 @@
                      (fn [{rt :rf.db/runtime} _]
                        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
                                                  {:route-id :route/article-fr :params {:id "1"}})}))
-    (let [f (frame/make-frame {:platform :server})]
+    (let [f (frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:seed-fr] {:frame f})
       (let [model (rf/active-head f)]
         (is (= "Article — fr-FR" (:title model)))

--- a/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
@@ -96,7 +96,7 @@
             The mismatch is a downstream trace, not a hydration
             blocker (Spec 011 — degraded-but-running posture)."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -122,7 +122,7 @@
             hoisted to the trace envelope's top level (per Spec 009
             §Error event shape's recovery-hoist branch)."
     (register-handlers!)
-    (let [client-frame   (frame/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame   (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                          :platform :client})
           ;; A second 8-hex string — anything other than \"deadbeef\".
           client-hash    "0badf00d"
@@ -162,7 +162,7 @@
             input and lock the shape + the not-equal-deadbeef
             invariant."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})
           ;; A non-trivial hiccup tree — its computed hash is whatever
           ;; FNV-1a resolves to; we lock the shape and the not-equal
@@ -210,7 +210,7 @@
             error-emit path is the producer site — see
             `re-frame.ssr.hydrate/verify-hydration!`)."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})
           _            (rf/dispatch-sync [:rf/hydrate mismatch-payload]
                                          {:frame client-frame})
@@ -239,7 +239,7 @@
             assertion here drives ::inc through `dispatch-sync`
             and reads :count via `subscribe-once`."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-mismatch client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -274,7 +274,7 @@
             hash + failing-id payload as the trace, and :recovery is
             :hard-error."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr strict-mode frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr strict-mode frame"
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -297,7 +297,7 @@
             trace (monitoring integrations rely on it) AND throws — the
             two are not mutually exclusive."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr strict-mode frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr strict-mode frame"
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -317,7 +317,7 @@
             short-circuits the hash comparison entirely (Spec 011 item 4):
             no trace, no throw, even when the hashes diverge."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr detection-off frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr detection-off frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? false}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -336,7 +336,7 @@
             warns. Pins the default so a future refactor can't silently
             flip detection off."
     (register-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr default frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr default frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
       (let [traces (capture-traces!

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -135,7 +135,7 @@
             post-hydrate values via subscribe-once (no view re-render
             machinery needed; the contract is the app-db state)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -170,7 +170,7 @@
             observed the same via DOM re-render; subscribe-once reads
             the post-drain app-db directly)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -202,7 +202,7 @@
             (resp-status, resp-ct, resp-cookies-count,
             resp-cookie-name)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -231,7 +231,7 @@
             compatibility check; absence of the hook is degraded-
             but-running, never crash)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)
           traces       (capture-traces!
@@ -270,7 +270,7 @@
             :rf.fx/skipped-on-platform warning per check on every server-
             side hydrate. The handler-level gate prevents that noise."
     (register-baseline-handlers!)
-    (let [server-frame (frame/make-frame {:doc "ssr-basic server frame"
+    (let [server-frame (frame/make-anon-frame-record! {:doc "ssr-basic server frame"
                                        :platform :server})
           ;; Add a :rf/schema-digest so BOTH checks would fire if the
           ;; handler enqueued them; otherwise only :rf.ssr/check-version
@@ -308,7 +308,7 @@
             and differing). Without this counter-assertion the
             server-side gate could silently strip both code paths."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)
           traces       (capture-traces!
@@ -336,7 +336,7 @@
             :rf.ssr/hydration-mismatch trace fires on the baseline
             surface (its payload's :rf/render-hash is nil)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -385,7 +385,7 @@
                          {:rf/app-db "slice-is-a-string"}
                          {:rf/app-db [:slice :is :a :vector]}
                          {:rf/app-db 99}]]
-      (let [client-frame (frame/make-frame {:doc "ssr-basic client frame"
+      (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                          :platform :client})]
         ;; Seed a recognisable pre-hydration client slice so we can prove
         ;; it SURVIVES (was not replaced by the malformed payload).
@@ -417,7 +417,7 @@
             neither emits the malformed diagnostic."
     (register-baseline-handlers!)
     ;; (a) full server slice → replaces app-db, no diagnostic.
-    (let [client-frame (frame/make-frame {:doc "client frame a" :platform :client})
+    (let [client-frame (frame/make-anon-frame-record! {:doc "client frame a" :platform :client})
           traces       (capture-traces!
                          (fn []
                            (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 7 :title "seeded"}}]
@@ -427,7 +427,7 @@
       (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
           "no malformed diagnostic on a well-formed payload"))
     ;; (b) map payload with no app-db slice → existing client data survives.
-    (let [client-frame (frame/make-frame {:doc "client frame b" :platform :client})]
+    (let [client-frame (frame/make-anon-frame-record! {:doc "client frame b" :platform :client})]
       (rf/dispatch-sync [::set-title "kept"] {:frame client-frame})
       (let [traces (capture-traces!
                      (fn []
@@ -479,7 +479,7 @@
                     [:runtime :is :a :vector]
                     42
                     false]]
-      (let [client-frame (frame/make-frame {:doc "non-map-runtime-db client frame"
+      (let [client-frame (frame/make-anon-frame-record! {:doc "non-map-runtime-db client frame"
                                          :platform :client})]
         ;; Seed recognisable pre-hydration state in BOTH partitions.
         (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
@@ -530,7 +530,7 @@
     (subs/reg-runtime-sub :route-current
       (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
     ;; (a) map runtime-db slice → installs the runtime-db partition.
-    (let [client-frame (frame/make-frame {:doc "rt-ok client frame" :platform :client})
+    (let [client-frame (frame/make-anon-frame-record! {:doc "rt-ok client frame" :platform :client})
           payload {:rf/app-db     {:count 7 :title "seeded"}
                    :rf/runtime-db {:rf.runtime/routing {:current {:route-id :home}}}}
           traces  (capture-traces!
@@ -542,7 +542,7 @@
       (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) traces)
           "no malformed diagnostic on a well-formed two-partition payload"))
     ;; (b) wholly-absent :rf/runtime-db key → no-server-runtime fallback.
-    (let [client-frame (frame/make-frame {:doc "rt-absent client frame" :platform :client})
+    (let [client-frame (frame/make-anon-frame-record! {:doc "rt-absent client frame" :platform :client})
           traces (capture-traces!
                    (fn []
                      (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 3}}]
@@ -574,7 +574,7 @@
             a retired alias that stays dead. It behaves as an unknown no-slice
             payload (app-db unchanged, client-only fallback), not as an alias."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "alias-dead client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "alias-dead client frame"
                                        :platform :client})]
       ;; Seed a recognisable pre-hydration client slice so we can prove it
       ;; SURVIVES (was not replaced by the :app-db-keyed payload).
@@ -629,7 +629,7 @@
             sub reflects the seeded slice — the server-build → hydrate! →
             sub round-trip. hydrate! returns the applied payload."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "boot-helper client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper client frame"
                                        :platform :client})
           ;; Server side: build the payload from the authoritative app-db
           ;; slice via the same payload-policy path the Ring adapter uses.
@@ -665,7 +665,7 @@
             first-load shape) does NOT dispatch :rf/hydrate and returns
             nil. The caller renders against the empty app-db."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "boot-helper client-only frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper client-only frame"
                                        :platform :client})
           returned     (ssr/hydrate! {:frame client-frame :payload nil})]
       (is (nil? returned)
@@ -686,7 +686,7 @@
             server's :emit-hash? marker."
     (register-baseline-handlers!)
     (rf/reg-view* ::boot-root (fn [] [:div.app [:span "client-render"]]))
-    (let [client-frame (frame/make-frame {:doc "boot-helper verify frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper verify frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Server hash is a DELIBERATELY divergent value so the verify
@@ -713,7 +713,7 @@
             successful hydration. Counter-test to the divergent-render case
             so the verify step can't be a false-positive generator."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "boot-helper verify-match frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper verify-match frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           client-tree   [:div.app [:span "client-render"]]
@@ -766,10 +766,10 @@
             :rf.error/hydration-frame-id-mismatch — the runtime never
             silently picks a side, and app-db is NOT replaced."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "mismatch client frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "mismatch client frame"
                                        :platform :client})
           ;; Payload stamped with a DIFFERENT frame id than the client target.
-          other-frame  (frame/make-frame {:doc "the server's other frame"
+          other-frame  (frame/make-anon-frame-record! {:doc "the server's other frame"
                                        :platform :server})
           payload      (build-server-payload
                          other-frame {:count 7 :title "seeded"} "deadbeef"
@@ -793,7 +793,7 @@
             conflict — there is nothing to disagree with, so the explicit
             client target stands and hydration proceeds normally."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "no-payload-frame-id client"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "no-payload-frame-id client"
                                        :platform :client})
           ;; A hand-built payload deliberately WITHOUT :rf/frame-id.
           payload      {:rf/version 1 :rf/app-db {:count 7 :title "seeded"}}
@@ -819,7 +819,7 @@
             This is the bypass the bead names: hydrate! throws pre-dispatch,
             but a direct dispatch hits ONLY the handler."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "nv3mua direct-dispatch client"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "nv3mua direct-dispatch client"
                                        :platform :client})]
       ;; Seed a recognisable pre-hydration client slice so we can prove it
       ;; SURVIVES (was not replaced by the wrong-frame payload).
@@ -863,7 +863,7 @@
             dispatch target installs the slice normally (the validation is
             precise — it rejects only present-and-DIFFERENT, never a match)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "nv3mua matching-frame client"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "nv3mua matching-frame client"
                                        :platform :client})
           ;; Stamp the payload's :rf/frame-id with the SAME frame we hydrate
           ;; into — server + client agree, so the slice lands. A render-hash
@@ -885,7 +885,7 @@
             slice installs (the documented client-only / no-server-slice
             fallback shape). This is the path the baseline tests rely on."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "nv3mua absent-frame-id client"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "nv3mua absent-frame-id client"
                                        :platform :client})
           ;; Deliberately NO :rf/frame-id key.
           payload      {:rf/app-db {:count 5 :title "no-frame-id"}}]
@@ -904,7 +904,7 @@
             host render happens between :rf/hydrate and the call. This locks
             the chosen contract in maintainer-visible terms."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-frame {:doc "boot-helper sync-contract frame"
+    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper sync-contract frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Records WHEN render-tree-fn ran + WHAT app-db it saw.

--- a/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_realm_address_test.clj
@@ -63,7 +63,7 @@
   (testing "a default-realm SSR frame's side-channel slots key by the BARE frame
             id (no realm key) — the round-trip is byte-identical to the pre-realm
             keying"
-    (let [f (frame/make-frame {:platform :server :doc "default-realm SSR frame"})]
+    (let [f (frame/make-anon-frame-record! {:platform :server :doc "default-realm SSR frame"})]
       ;; frame-address collapses to the bare id for the default realm.
       (is (= f (frame/frame-address f))
           "frame-address of a default-realm frame is the bare frame id")

--- a/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
@@ -42,7 +42,7 @@
                                               (:operation ev))
                                        (swap! traces conj ev))))
       (try
-        (let [f  (frame/make-frame
+        (let [f  (frame/make-anon-frame-record!
                    {:platform :server
                     :ssr      {:public-error-id   :rf.ssr/default-error-projector
                                :dev-error-detail? false}})
@@ -111,7 +111,7 @@
       (try
         ;; Default platform is :client; project-render-exception! checks
         ;; `server-frame?` and short-circuits.
-        (let [f      (frame/make-frame {})
+        (let [f      (frame/make-anon-frame-record! {})
               t      (ex-info "should not fire" {})
               result (ssr/project-render-exception! f t)]
           (is (nil? result)
@@ -134,7 +134,7 @@
                                         (:operation ev))
                                  (swap! traces conj ev))))
       (try
-        (let [f (frame/make-frame
+        (let [f (frame/make-anon-frame-record!
                   {:platform :server
                    :ssr      {:public-error-id   :rf.ssr/default-error-projector
                               :on-view-exception :throw}})
@@ -154,7 +154,7 @@
             production default) project-render-exception! projects as
             normal. Pins the default so the escape-hatch can't silently
             become the default."
-    (let [f (frame/make-frame
+    (let [f (frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id :rf.ssr/default-error-projector}})
           t (ex-info "normal failure" {})

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -66,7 +66,7 @@
 
 (deftest cofx-reads-populated-request
   (testing "(set-request! frame req) → :rf.cofx/requires [:rf.server/request] → handler reads req"
-    (let [server-frame (frame/make-frame
+    (let [server-frame (frame/make-anon-frame-record!
                          {:doc      "SSR request frame"
                           :platform :server})
           request      {:request-method :get
@@ -92,7 +92,7 @@
 
 (deftest get-request-mirrors-cofx
   (testing "ssr/get-request is the public read surface — same value as the cofx"
-    (let [server-frame (frame/make-frame {:platform :server})
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
           request      {:request-method :post
                         :uri            "/api/articles"
                         :body           "{\"title\":\"new\"}"}]
@@ -108,7 +108,7 @@
 
 (deftest cofx-injects-nil-when-slot-unpopulated
   (testing "cofx returns nil when no host adapter has populated the slot"
-    (let [server-frame (frame/make-frame {:platform :server})
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
           observed     (atom :unset)]
       (rf/reg-event :req-test/read-empty
         {:rf.cofx/requires [:rf.server/request]}
@@ -136,7 +136,7 @@
 (deftest cofx-is-skipped-on-client-frame
   (testing ":rf.server/request is skipped on a :platform :client frame
             and emits :rf.cofx/skipped-on-platform"
-    (let [client-frame (frame/make-frame {:platform :client})
+    (let [client-frame (frame/make-anon-frame-record! {:platform :client})
           traces       (collect-traces! ::req-client)
           observed     (atom :unset)]
       (rf/reg-event :req-test/read-on-client
@@ -176,8 +176,8 @@
 
 (deftest two-frames-carry-independent-request-data
   (testing "two simultaneous per-request frames have isolated request slots"
-    (let [frame-a    (frame/make-frame {:platform :server :doc "request A"})
-          frame-b    (frame/make-frame {:platform :server :doc "request B"})
+    (let [frame-a    (frame/make-anon-frame-record! {:platform :server :doc "request A"})
+          frame-b    (frame/make-anon-frame-record! {:platform :server :doc "request B"})
           request-a  {:uri "/articles/aaa" :headers {"cookie" "session=user-a"}}
           request-b  {:uri "/articles/bbb" :headers {"cookie" "session=user-b"}}
           observed-a (atom :unset)
@@ -208,7 +208,7 @@
 
 (deftest clear-request-removes-the-slot
   (testing "clear-request! removes the per-frame slot — subsequent reads return nil"
-    (let [server-frame (frame/make-frame {:platform :server})
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
           request      {:uri "/x"}]
       (ssr/set-request! server-frame request)
       (is (= request (ssr/get-request server-frame)))
@@ -238,7 +238,7 @@
 (deftest set-request-is-the-test-seam
   (testing "set-request! supplies the request for a harness-driven drain; the
             declared cofx reads it (replacing the retired 2-arity override)"
-    (let [server-frame (frame/make-frame {:platform :server})
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
           explicit     {:uri "/explicit" :headers {"x-test" "1"}}
           observed     (atom :unset)]
       (ssr/set-request! server-frame explicit)
@@ -260,7 +260,7 @@
 
 (deftest cofx-works-under-ssr-server-preset
   (testing "the cofx surfaces the request under a :preset :ssr-server frame"
-    (let [server-frame (frame/make-frame {:preset :ssr-server})
+    (let [server-frame (frame/make-anon-frame-record! {:preset :ssr-server})
           request      {:uri "/preset" :request-method :get}
           observed     (atom :unset)]
       (ssr/set-request! server-frame request)

--- a/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
@@ -42,7 +42,7 @@
   (testing "a setup handler writes durable app-db from a request-derived fact
             supplied as EVENT PAYLOAD — the fact rides :event (recorded), the
             handler never reads the ambient request cofx"
-    (let [server-frame (frame/make-frame {:platform :server})]
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})]
       ;; The handler reads the SANITIZED session off its event arg, NOT off the
       ;; ambient :rf.server/request cofx — so the durable write folds a recorded
       ;; fact (the event), replay-stable.
@@ -65,7 +65,7 @@
   (testing "a setup handler writes durable app-db from a PROVIDED recordable
             :rf.cofx leaf the host stamped onto the token after sanitizing the
             request — the value is recorded + replay-stable, delivered flat"
-    (let [server-frame (frame/make-frame {:platform :server})]
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})]
       (rf/reg-cofx :auth.session/user
         {:recordable? true :provided? true
          :doc "Sanitized session user, stamped by the SSR host adapter."})
@@ -88,7 +88,7 @@
   (testing "a PROVIDED recordable request fact absent from the token fails
             LOUDLY with :rf.error/missing-required-cofx — NOT a silent
             fall-back to get-request / nil (the strict-replay contract)"
-    (let [server-frame (frame/make-frame {:platform :server})
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
           traces       (collect-traces! ::missing)]
       (rf/reg-cofx :auth.session/user
         {:recordable? true :provided? true
@@ -119,7 +119,7 @@
             token's :rf.cofx record — proving it is unrecorded (replay re-runs
             the supplier), which is exactly why a DURABLE write must not fold it
             (it would diverge on replay / read nil after teardown)"
-    (let [server-frame (frame/make-frame {:platform :server})
+    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
           seen-cofx    (atom ::unset)]
       (ssr/set-request! server-frame {:request-method :get :uri "/x"
                                       :headers {"cookie" "session=raw-secret"}})

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -138,7 +138,7 @@
   Returns the rendered HTML for sanity-check assertions."
   [i]
   (let [server-frame
-        (frame/make-frame
+        (frame/make-anon-frame-record!
           {:doc       (str "load-test request " i)
            :platform  :server
            :on-create [:load-test/server-init {:i i}]})]
@@ -304,7 +304,7 @@
     ;; trace-emit so we don't have to engineer a real handler failure
     ;; — the cleanup contract is the same).
     (dotimes [i 50]
-      (let [fid (frame/make-frame
+      (let [fid (frame/make-anon-frame-record!
                   {:doc       (str "error-buffer test " i)
                    :platform  :server
                    :on-create [:load-test/server-init {:i i}]})]

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -402,8 +402,10 @@
   ;; unified single frame value backed by the one registry removes the
   ;; two-constructor split that motivated the redirect). A duplicate `:id` is now
   ;; idempotent replacement (preserving durable state). The advanced
-  ;; `re-frame.frame/make-frame` is demoted to an INTERNAL no-`:id` record helper;
-  ;; it is not facade-exported. Status `EP-0023` -> `EP-0024`.
+  ;; `re-frame.frame/make-anon-frame-record!` (rf2-ji3tvy renamed it from the bare
+  ;; `make-frame` to drop the short-name collision with this public constructor)
+  ;; is an INTERNAL no-`:id` record helper; it is not facade-exported. Status
+  ;; `EP-0023` -> `EP-0024`.
   ["re-frame.core" "make-frame"]          {:tier :advanced    :owner "002" :status "EP-0024"}
   ;; EP-0024 (rf2-tu2vr7): the single public accessor from a frame VALUE (the
   ;; lifecycle token `make-frame` returns) to its frame id (EP-0024 Open Issue #2

--- a/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/image_view_reads_cljs_test.cljs
@@ -30,8 +30,8 @@
 ;; Each case starts from a clean frame registry so an `:id` from one case never
 ;; carries over to the next. EP-0024 (rf2-tu2vr7): the registries collapsed —
 ;; an image-loaded frame is a `re-frame.frame/frames` record carrying a
-;; `:generation`, so resetting `frame/frames` clears the image-loaded frames
-;; (`clear-live-frames!` is now a no-op kept for back-compat). The frame-no-emit
+;; `:generation`, so resetting `frame/frames` clears the image-loaded frames —
+;; the single reset is the whole clear (rf2-ji3tvy). The frame-no-emit
 ;; gate (rf2-2qaqh) lives in a persistent `re-frame.trace` set the registry
 ;; reset does NOT touch, so the seating cases also clear the shell ids they
 ;; exercise so each starts un-gated.


### PR DESCRIPTION
## Summary

Two beads on the frames surface (`frame.cljc` / `live_frame.cljc`):

### rf2-vnduo9 — non-default-realm image-loaded reprojection (latent correctness)

The hot-reload reprojection flush runs on `interop/next-tick` (`deferred-flush!`), by which point the router's per-drain `*current-realm*` binding has unwound to nil. `reproject-live-frame!`'s per-frame reads (`frame-generation` / `frame-capabilities`) and the `set-generation!` swap all re-key the `frames` registry via `(frame-key *current-realm* id)`. So a **non-default-realm** image-loaded frame — keyed by its `[realm-id frame-id]` address — was *enumerated* by the old bare-`:id` `image-loaded-frame-ids`, but every subsequent per-frame re-key under nil `*current-realm*` **missed** its address → silent no-op → its generation stayed **stale**.

Not reachable via the public `make-frame` (default-realm-only per EP-0024); reachable via the internal substrate (`seat-into-realm!` binds `*current-realm*` around creation).

**Fix (option a — realm-correct enumeration):** added `frame/image-loaded-frame-addresses`, which returns each image-loaded frame carrying its **own** `:realm` (read off the record's `:realm` slot, not the unwound dynamic var). `reproject-live-frames!` now iterates those and binds `*current-realm*` per frame via `call-with-realm` before reprojecting, so each re-key resolves the frame's own address. The default realm (every public `make-frame`) takes `call-with-realm`'s zero-binding fast path — byte-identical to before. The public `image-loaded-frame-ids` contract (bare ids, consumed by tooling + many tests) is unchanged.

**Test:** `reproject-swaps-a-non-default-realm-image-loaded-frame` creates an image-loaded frame under a non-default realm, asserts the bare-id (default-realm) lookup misses it, then reprojects with `*current-realm*` nil (the next-tick-flush condition) and verifies the generation actually swapped to the reloaded impl. Pre-fix this returns `{}` (stale).

### rf2-ji3tvy — vestigial / naming cleanup (clarity)

1. **Rename** internal `re-frame.frame/make-frame` → `make-anon-frame-record!` — drops the bare-name collision with the public `re-frame.live-frame/make-frame` (a reader of `frame/make-frame` couldn't tell which ran). Updated every internal caller (~244 call sites across 37 files), the `with-new-frame` macro emit in `test_helpers.cljc`, and the manifest-metadata comment.
2. **Delete** the dead no-op `clear-live-frames!` (the second live-frame registry dissolved into the ONE `frames` registry per EP-0024). `test_support`'s two calls sat immediately after `(reset! frame/frames {})` and were removed as pure redundancy; fixture callers now rely on the runtime-reset fixture (or `(reset! frame/frames {})` where the intent is to forget a frame mid-test).
3. **`frame-object?` NOT deleted** — the brief's conditional ("if no callers remain, delete it") is not met: `router.cljc`, `subs.cljc`, and `core.cljc` still call it as the internal frame-value alias awaiting migration.

## Quality gates

- `sh scripts/test-jvm-implementation.sh` — **PASS** (all implementation JVM artefacts, 0 failures/errors)
- `cd implementation && npm run test:cljs` — **PASS** (8020 tests, 33483 assertions, 0 failures, 0 errors)
- clj-kondo over changed source + test files — 0 errors (pre-existing unused-binding warnings only)
- Manifest drift unaffected: the renamed internal fn is not facade-exported; the only `make-frame` manifest entry is the public `re-frame.core/make-frame`.

Do not merge.