### PR TITLE
chore(routing): stamp :source :router on url-requested->transitioned re-dispatch (rf2-6si0sr)

### DIFF
--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -354,6 +354,21 @@
         ;; URL has NOT updated. The handler is responsible for pushing
         ;; the new URL (history pushState) and then synthesising the
         ;; :rf.route/transitioned event the slice + on-match write keys off.
+        ;;
+        ;; rf2-6si0sr: this re-dispatch INTENTIONALLY does NOT carry
+        ;; `:source :router` — unlike the link-click (`link.cljc`) and
+        ;; on-match-error (`on_match_error.cljc`) sites. Those two are
+        ;; IMPERATIVE `router/dispatch!` calls at a non-event boundary (a DOM
+        ;; click / an error-listener), where the source would otherwise
+        ;; default to `:ui` / `:unknown`, so they must stamp `:source :router`
+        ;; explicitly. This site is a `:dispatch` FX returned from inside an
+        ;; event handler: core's `:dispatch` fx-handler (`fx.cljc`)
+        ;; UNCONDITIONALLY stamps the child envelope `:source :fx-dispatch`
+        ;; (per rf2-ejtpd) — already a substrate-internal origin Xray's L2
+        ;; renders as "from fx :dispatch · parent epoch #N", never `:ui`. The
+        ;; `[:dispatch event]` effect form carries no `:source` opt slot, and
+        ;; the fx-handler hardcodes it regardless, so `:fx-dispatch` is both
+        ;; the correct tag and the only achievable one here.
         {:fx [[:rf.nav/push-url app-url]
               [:dispatch [:rf.route/transitioned app-url {:bypass-leave-guard? true}]]]})))
 


### PR DESCRIPTION
## rf2-6si0sr — routing: :source consistency on the url-requested->transitioned re-dispatch

**Resolution: option (b) — explanatory comment.** Option (a) (literally add `:source :router`) turned out to be architecturally impossible AND wrong; (b) documents why.

### Finding

The bead's premise conflates two structurally different dispatch mechanisms:

| Site | Mechanism | Default source | Needs explicit `:source :router`? |
|------|-----------|----------------|-----------------------------------|
| `link.cljc` (click) | imperative `router/dispatch!` at a DOM-click boundary | would be `:ui` | yes — stamps it |
| `on_match_error.cljc` (error re-dispatch) | imperative `router/dispatch!` at an error-listener boundary | would be `:unknown` | yes — stamps it |
| `can_leave.cljc:357` (transitioned re-dispatch) | `:dispatch` **FX** returned from inside an event handler | `:fx-dispatch` (hardcoded by core) | no — already substrate-origin |

Core's `:dispatch` fx-handler (`implementation/core/src/re_frame/fx.cljc:378-386`) **unconditionally** stamps the child envelope `:source :fx-dispatch` (rf2-ejtpd). `:source` is explicitly NOT inherited and NOT readable from the effect args — the `[:dispatch event]` effect form has no `:source` opt slot, and the handler overrides it regardless.

`:fx-dispatch` is its own first-class closed-set `:source` value. Xray's Epoch panel (`tools/xray/spec/021-Dynamic-Panel-Designs.md`, `panels/epoch/projection.cljc`) renders it as **"from fx :dispatch · parent epoch #N"** — a substrate-internal origin, definitively **not** `:ui`. So the re-dispatch already carries an informative substrate-origin tag automatically; the L2-tagging goal the bead describes is already met.

So `:fx-dispatch` is both the correct tag and the only achievable one at this site. Adding the comment (option b) is the right resolution.

### Change
- Comment-only addition (15 lines) at the `:else` branch of `url-requested-handler` explaining why this path intentionally omits `:source :router`.
- No test asserts `:source`/tags on this re-dispatch (tests dispatch `:rf.route/transitioned` directly via `dispatch-sync`), so no test changes needed.

### Gates
- routing JVM suite (`clojure -M:test`): 296 tests / 1420 assertions, **0 failures, 0 errors**
- `npm run test:cljs`: 8019 tests / 33478 assertions, **0 failures, 0 errors**
- splint on the changed file: only 2 warnings, both pre-existing `update-in` style smells in unrelated functions (lines 414/429 on origin/main), untouched by this change
- No facade/manifest change.