### PR TITLE
chore(adapters): consistent frame-provider twin docstrings + dedupe owned-frame-opts (rf2-8b3ctf)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -85,9 +85,10 @@
   `:rf.error/owned-frame-provider-missing-id` (a `:frame` key with no `:id`
   is the common mistake and trips this guard — switch to `:id`, or use
   `frame-provider-existing {:frame …}` to merely scope). The three
-  React-shaped adapters share one React Context (per rf2-2qit Decision 2)
-  so a subtree under any frame-provider sees the right frame regardless of
-  which substrate rendered the provider.
+  React-shaped adapters share one React Context (the shared-context
+  decision — rf2-3yij Decision 2, carried into the Helix adapter as
+  rf2-2qit Decision 2) so a subtree under any frame-provider sees the
+  right frame regardless of which substrate rendered the provider.
 
   Idempotent re-mount (hot reload / React StrictMode dev double-invoke /
   Story re-evaluation): re-mounting under the same `:id` MUST NOT destroy
@@ -111,7 +112,7 @@
   under `$` for the element macro to mangle."
   [props]
   (owned-frame/owned-frame-react-element
-    (dissoc props :children)
+    props
     (:children props)
     're-frame.adapter.helix/frame-provider))
 

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -82,9 +82,10 @@
   `:rf.error/owned-frame-provider-missing-id` (a `:frame` key with no `:id`
   is the common mistake and trips this guard — switch to `:id`, or use
   `frame-provider-existing {:frame …}` to merely scope). The three
-  React-shaped adapters share one React Context (per rf2-3yij Decision 2)
-  so a subtree under any frame-provider sees the right frame regardless of
-  which substrate rendered the provider.
+  React-shaped adapters share one React Context (the shared-context
+  decision — rf2-3yij Decision 2, carried into the Helix adapter as
+  rf2-2qit Decision 2) so a subtree under any frame-provider sees the
+  right frame regardless of which substrate rendered the provider.
 
   Idempotent re-mount (hot reload / React StrictMode dev double-invoke /
   Story re-evaluation): re-mounting under the same `:id` MUST NOT destroy
@@ -109,7 +110,7 @@
   for the element macro to mangle."
   [props]
   (owned-frame/owned-frame-react-element
-    (dissoc props :children)
+    props
     (:children props)
     're-frame.adapter.uix/frame-provider))
 


### PR DESCRIPTION
## Bead
rf2-8b3ctf — adapters twin-docstring drift + redundant helper (P4, clarity only).

## What changed (clarity only; no behaviour change)

**(1) Frame-provider twin-docstring parity.** The UIx (`adapters/uix`) and Helix (`adapters/helix`) owned `frame-provider` docstrings cited different bead ids for the **same** shared-React-Context decision — uix: `rf2-3yij Decision 2`; helix: `rf2-2qit Decision 2` — so a parity diff between the two byte-twin providers read as drift. Both now carry an **identical** cross-cite naming the shared origin: *"the shared-context decision — rf2-3yij Decision 2, carried into the Helix adapter as rf2-2qit Decision 2"*. This mirrors the established `adapters/helix/deps.edn` phrasing (*"Per rf2-2qit Decision 2 (transferred from rf2-3yij)"*). The per-substrate home-bead convention for the other Decision N cites (Decision 1 / 6) is intentionally left intact — those naturally differ by substrate.

**(2) Dedupe the opts-extraction.** Both shells passed `(dissoc props :children)` as the first arg to `owned-frame/owned-frame-react-element`, which **already** normalises the prop map via `owned-frame-opts` internally (when building `:rfOpts`). The adapter-level pre-strip was redundant. The shells now pass raw `props`, so the `:children` extraction happens exactly once — in the core fn that owns it. The `owned-frame-opts` helper keeps its place: it is called by `owned-frame-react-element` (hook substrates) and by `views/provider.cljs` (the Reagent path), so it earns its keep.

The scope-only `frame-provider-existing` sites that pass `(dissoc props :children)` to `reject-lifecycle-opts!` are a different concern (stripping children purely to feed the lifecycle-opt rejection guard, not building make-frame opts) and are intentionally untouched.

No facade/manifest change. No `rf2-...` ids in non-comment positions.

## Gates (all green)
- `npm run test:cljs` — 8019 tests / 33478 assertions, 0 failures, 0 errors
- `npm run test:browser` — 222 tests / 701 assertions, 0 failures, 0 errors
- `scripts/test-jvm-implementation.sh` — PASS (all artefacts, 0 failures/errors)
- clj-kondo — 0 errors, 0 warnings on touched files
- splint — 0 style warnings on touched files