### PR TITLE
chore(resources): dedupe abort-fx build + anchor abort-precedence docstring (rf2-xmvf1m)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -523,7 +523,13 @@
                                 :frame-id     frame-id
                                 :generation   generation
                                 :where        where}
-                               reply-overrides)))]
+                               reply-overrides)))
+            ;; rf2-sxyrzk — best-effort abort of the superseded prior attempt by
+            ;; the frame-QUALIFIED request-id (the token the prior lower
+            ;; registered); a bare work-id misses it. nil when not superseding or
+            ;; the transport has no abort capability (then no abort fx is added).
+            superseding-abort-fx (when superseding?
+                                   (work-ledger/abort-fx transport-id frame-id prior-work))]
         (trace/emit! :rf.event :rf.resource/work-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
@@ -554,10 +560,7 @@
                superseding?
                (-> (conj [:rf.resource/clear-work-handle
                           {:frame-id frame-id :work-id prior-work}])
-                   ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the
-                   ;; token the prior lower registered); a bare work-id misses it.
-                   (cond-> (work-ledger/abort-fx transport-id frame-id prior-work)
-                     (conj (work-ledger/abort-fx transport-id frame-id prior-work)))))}))))
+                   (cond-> superseding-abort-fx (conj superseding-abort-fx))))}))))
 
 (defn ensure-handler
   "`:rf.resource/ensure` — ensure a resource instance is loaded (load it
@@ -1931,9 +1934,9 @@
   an actor-destroy cancellation, or a timeout teardown to this kind). A
   failure envelope carrying this kind is a CANCELLATION, not a user-visible
   resource error (rf2-z70ujl). Note a `:request-id-superseded` abort never
-  even dispatches a reply (the transport suppresses it, Spec 014 §Abort
-  precedence) — so a superseded supersession is handled by the missing reply
-  + stale-suppression, not here."
+  even dispatches a reply — so a superseded supersession is handled by the
+  missing reply + stale-suppression, not here (Spec 014 §Abort precedence —
+  enforced by the transport, relied on here)."
   :rf.http/aborted)
 
 (defn- abort-failure?


### PR DESCRIPTION
Bead **rf2-xmvf1m** — resources clarity polish (P4, no behaviour change).

Two clarity-only edits in `implementation/resources/src/re_frame/resources/events.cljc`:

**(1) Dedupe the `ensure-load` superseding-abort fx build.**
The superseding branch of the `:fx` `cond->` built `(work-ledger/abort-fx transport-id frame-id prior-work)` twice — once as the `cond->` test, once in the body to `conj` it. `abort-fx` is pure + idempotent so this was no behaviour bug, but it read as a possible double-emit and called the builder twice. Now bound once into a `let` binding `superseding-abort-fx` (computed only when `superseding?`, exactly as before) and conj'd by `(cond-> superseding-abort-fx (conj superseding-abort-fx))` — the bind-once / `when-let` shape the sibling abort sites already use (`release-owner-handler`, `clear-scope-handler*`, `remove-handler`). Behaviour is identical: same fx vector for both the supersession-with-abort and supersession-without-abort-capability cases.

**(2) Anchor the `http-aborted-kind` abort-precedence docstring.**
The docstring described the `:request-id-superseded` reply-suppression as if it were a resources-side guarantee; it is enforced by the transport (Spec 014). Reworded the parenthetical to anchor the guarantee at its enforcing layer: "(Spec 014 §Abort precedence — enforced by the transport, relied on here)".

## Gates
- resources JVM suite (`clojure -M:test`): 591 tests / 2561 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 8021 tests / 33489 assertions, 0 failures, 0 errors
- clj-kondo: 0 errors (3 pre-existing single-file-lint warnings, none at edited lines)
- Splint `--fail-on-errors`: 0 errors (2 pre-existing style warnings at lines 1283/2516, unrelated)
- No facade / manifest change.