### PR TITLE
ci: split example-compile coverage gate + post-merge playground bundle freshness (rf2-9cw850, rf2-3yufij)

### DIFF
--- a/.github/workflows/post-merge-playground-freshness.yml
+++ b/.github/workflows/post-merge-playground-freshness.yml
@@ -1,0 +1,201 @@
+# Post-merge playground SCI-bundle freshness gate (rf2-3yufij).
+#
+# # Why this exists
+#
+# The docs' live `cljs-rf2` cells run on docs/cljs/playground-rf2.js — a
+# committed, vendored shadow-cljs :advanced bundle that BAKES IN re-frame2
+# core + reagent-slim + machines + react@19 (the eval engine for every
+# `cljs-rf2` cell). Because the baked-in source is committed as a binary, the
+# committed snapshot is only as fresh as its last hand-rebuild.
+#
+# The PR-time freshness gate (the `tools-playground` job in test.yml) only
+# fires when report-changed-surfaces.sh sets `playground=true` — which, for the
+# baked-in implementation surfaces, happens ONLY on an implementation/machines/*
+# change (a deliberate cost tradeoff: firing playground on every core change
+# would add a heavy JVM+Node+Playwright job to most PRs). So a change to
+# implementation/core/** or implementation/adapters/reagent-slim/** silently
+# staleness the committed bundle with NO PR-time gate — it surfaces only when
+# the nightly full matrix runs, or when the next `mark_all` PR's playground gate
+# goes red against the stale committed bundle. This recurring papercut has bitten
+# twice: rf2-ssxvg1 (the committed bundle had drifted ~36 impl commits behind,
+# predating the whole EP-0003 resources wave) and again after PR #4631 (the
+# EP-0024 frame-provider rename made the committed bundle's mount shape invalid
+# against current core — rf2-qhu72t).
+#
+# # What it does (and why this shape)
+#
+# On every push to `main` that touches a baked-in surface OR the playground
+# build itself, this job:
+#
+#   1. Rebuilds BOTH playground bundles fresh from the merged main
+#      (`npm run build` in docs/tools/playground — esbuild bootstrap +
+#      the sci/ shadow-cljs :advanced re-frame2 bundle).
+#   2. Runs the headless-Chromium smoke against the FRESHLY-BUILT bundles
+#      (`npm run smoke`). This is the authoritative current-source check:
+#      it renders the live re-frame2 counter cell + both machine cells. If
+#      the committed bundle's source no longer COMPOSES against current
+#      implementation source (the EP-0024 / rf2-qhu72t class — the renamed
+#      provider made the old mount shape throw at render), the fresh build
+#      throws at render and the smoke FAILS here, immediately post-merge.
+#   3. Runs the deterministic committed-bundle drift checks against the
+#      committed (not the freshly-rebuilt) artefacts:
+#        - the esbuild bootstrap bundles (playground.js/.css) are
+#          byte-deterministic across machines (EOL-pinned via .gitattributes),
+#          so a strict `git diff --exit-code` after the rebuild catches an
+#          un-rebundled bootstrap source edit;
+#        - the shadow-cljs SCI bundle (playground-rf2.js) is a Closure
+#          :advanced build whose minified-symbol allocation is NOT byte-stable
+#          across build environments, so byte-diffing it against a fresh
+#          rebuild is inherently flaky and meaningless (see the long note in
+#          test.yml's tools-playground job + scripts/check-playground-sci-freshness.sh).
+#          It is instead gated by the smoke above (which rendered a fresh
+#          rebuild) PLUS the deterministic source-marker freshness guard
+#          (scripts/check-playground-sci-freshness.sh) run against the COMMITTED
+#          bundle — the same gate the PR-time job runs.
+#
+# When the gate fails, the fix is always: rebuild + recommit the bundle —
+#   cd docs/tools/playground && npm run build
+#   git add docs/cljs/playground.js docs/cljs/playground.css docs/cljs/playground-rf2.js
+#   git commit
+#
+# # What it does NOT do
+#
+# - It does NOT block any merge. The merge already happened on `main`. This is
+#   a fast-feedback canary that surfaces committed-bundle staleness within
+#   minutes of the merge, instead of waiting for the nightly full matrix or the
+#   next mark_all PR. The DEPLOYED bundle is independently kept fresh by docs.yml,
+#   which rebuilds it from main on every publish (rf2-ssxvg1 part 2) — so a brief
+#   committed lag does not ship a stale live guide. This gate keeps the COMMITTED
+#   snapshot honest so the lag is caught + corrected promptly.
+# - It does NOT auto-commit a rebuilt bundle back to main. A commit-back would
+#   add a noisy bundle commit on most runs (the :advanced bundle's symbol
+#   allocation churns per-build even on unchanged source — see the byte-stability
+#   note above) and risks a push loop; a fail-loud canary the operator resolves
+#   by rebuilding is the lower-risk shape.
+# - It is NOT a per-PR gate. Adding the heavy JVM+Node+Playwright SCI build to
+#   every core-touching PR is exactly the cost the PR-time surface gating scopes
+#   out; running it once post-merge on the relevant surfaces gives the coverage
+#   without the per-PR tax.
+
+name: post-merge playground freshness
+
+on:
+  push:
+    branches: [main]
+    # Fire only on the surfaces that are BAKED INTO the committed SCI bundle
+    # (so a change to one can staleness it) or on the playground build itself.
+    # Kept in lockstep with the sci/ bundle's require graph (re-frame2 core +
+    # reagent-slim + machines) and the docs/cljs committed artefacts.
+    paths:
+      - 'implementation/core/**'
+      - 'implementation/adapters/reagent-slim/**'
+      - 'implementation/machines/**'
+      - 'docs/tools/playground/**'
+      - 'docs/cljs/playground.js'
+      - 'docs/cljs/playground.css'
+      - 'docs/cljs/playground-rf2.js'
+      - '.github/workflows/post-merge-playground-freshness.yml'
+  workflow_dispatch:
+
+# A workflow-edit or impl push may land alongside a follow-up push; keep the
+# latest (which has the latest source + committed bundle) and cancel any
+# in-progress rebuild from an older SHA.
+concurrency:
+  group: post-merge-playground-freshness-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild-and-verify:
+    name: Rebuild SCI bundle + smoke + committed-drift gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # The re-frame2 SCI bundle (docs/tools/playground/sci/) is a shadow-cljs
+      # :advanced build over the re-frame2 core + reagent-slim :local/root
+      # artefacts — it needs a JVM + the Clojure CLI + Node, the same
+      # toolchain the tools-playground job in test.yml uses.
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs (playground SCI bundle deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-playground-${{ hashFiles('docs/tools/playground/sci/deps.edn', 'docs/tools/playground/sci/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent-slim/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-playground-
+            ${{ runner.os }}-cljs-
+
+      # SCI-bundle freshness guard against the COMMITTED bundle (deterministic
+      # source-marker check — no rebuild, cross-machine stable). Same gate the
+      # PR-time tools-playground job runs. Catches the machine-lifecycle-marker
+      # staleness class (the rf2-2h1yhk :rf.machine/bootstrap -> :rf.machine/start
+      # rename). Run BEFORE the rebuild overwrites the committed file.
+      - name: Verify committed SCI bundle is fresh (machine lifecycle marker)
+        run: sh scripts/check-playground-sci-freshness.sh
+
+      # `npm ci` installs from the committed lockfile (reproducible).
+      - name: npm ci (playground bootstrap deps)
+        working-directory: docs/tools/playground
+        run: npm ci
+
+      - name: Install Playwright (Chromium + system deps)
+        working-directory: docs/tools/playground
+        run: npx playwright install --with-deps chromium
+
+      # Rebuild BOTH committed bundles fresh from the merged main — the esbuild
+      # bootstrap (playground.js/.css) and the shadow-cljs SCI bundle
+      # (playground-rf2.js). `npm run build:rf2` runs `npm install` inside sci/
+      # for react/react-dom + shadow-cljs. This overwrites the working-tree
+      # docs/cljs/playground*.js with the fresh build.
+      - name: Rebuild both bundles fresh from main
+        working-directory: docs/tools/playground
+        run: npm run build
+
+      # Authoritative current-source check: render the FRESHLY-BUILT production
+      # bundles under headless Chromium (live re-frame2 counter + both machine
+      # cells). If current implementation source no longer composes with the
+      # playground's mount shape (the EP-0024 / rf2-qhu72t class), the fresh
+      # build throws at render and this FAILS — surfacing the drift immediately
+      # post-merge instead of at the next nightly / mark_all PR.
+      - name: Run playground smoke (freshly-built bundles)
+        working-directory: docs/tools/playground
+        run: npm run smoke
+
+      # Committed-drift gate (esbuild artefacts only). The deployed docs/cljs/
+      # playground.js + playground.css are committed, vendored prebuilts.
+      # esbuild's minifier is byte-deterministic across platforms (EOL-pinned
+      # via .gitattributes), so a strict byte-diff against the fresh rebuild is
+      # robust: it fails only when a bootstrap source edit was not re-bundled,
+      # or someone hand-edited a bundle. (The SCI bundle is byte-unstable across
+      # machines, so it is NOT byte-diffed here — it is covered by the smoke
+      # above + the marker freshness guard run earlier; see the header.)
+      - name: Verify committed esbuild bundles match fresh build (no drift)
+        run: |
+          if ! git diff --exit-code -- docs/cljs/playground.js docs/cljs/playground.css; then
+            echo "::error::Committed docs/cljs/playground.{js,css} are stale on main — run 'npm run build' in docs/tools/playground and commit the rebuilt bundles."
+            exit 1
+          fi
+          echo "Committed esbuild bundles match a fresh rebuild. SCI bundle freshness covered by the smoke + marker guard."

--- a/.github/workflows/post-merge-workflow-sanity.yml
+++ b/.github/workflows/post-merge-workflow-sanity.yml
@@ -120,6 +120,7 @@ jobs:
             "docs.yml"                        # already runs on push (paths-filtered)
             "lint.yml"                        # already runs on push (via PR-merge push)
             "portability.yml"                 # already runs on push to main
+            "post-merge-playground-freshness.yml"  # already runs on push (paths-filtered, incl. its own file)
           )
           is_excluded() {
             local f="$1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1400,23 +1400,6 @@ jobs:
       - name: npm install
         run: npm ci
 
-      # rf2-0vav5.1 + rf2-cn6kc.1 — compile-coverage gate over EVERY declared
-      # standalone :examples/* shadow-cljs build (the list is derived from
-      # shadow-cljs.edn, so a newly-declared example build is swept
-      # automatically). Several example builds (login-uix, dashboard-uix,
-      # login-helix, process-monitor-helix) were declared browser targets that
-      # NO gate compiled — a ns / init-fn / :require / form regression in any
-      # shipped GREEN until a human manually ran it. This `compile` (not
-      # release) step closes that gap and fails on any compile warning too
-      # (a typo'd init-fn surfaces as an :undeclared-var warning, and
-      # `compile` exits 0 on warnings). Lives in the cljs_browser surface
-      # because a generic examples/** source edit (the regression source) AND
-      # a shadow-cljs.edn build-decl change both fire cljs_browser. Runs
-      # BEFORE the Playwright install so a broken example fails fast without
-      # the ~120 MB Chromium download.
-      - name: Compile every declared standalone example build (coverage gate)
-        run: npm run test:examples-compile
-
       # rf2-f79t8 — cache the Playwright browser binary across runs/jobs.
       # Every PR-time Playwright job previously re-downloaded Chromium
       # (~120 MB) on each run. The binary is keyed on the locked
@@ -1437,6 +1420,94 @@ jobs:
 
       - name: Compile :browser-test, serve, and run Playwright runner
         run: npm run test:browser
+
+  # rf2-9cw850 — the standalone example-compile COVERAGE GATE, split out of
+  # the cljs-browser job into its own parallel job.
+  #
+  # WHY THIS IS A SEPARATE JOB. Live step-timing on PR #4631 showed the
+  # `npm run test:examples-compile` step (compile EVERY declared
+  # :examples/* shadow-cljs build — rf2-0vav5.1 + rf2-cn6kc.1) was the
+  # dominant cost in cljs-browser at ~10 min, while the actual
+  # `:browser-test` compile + Playwright runner was only ~1-2 min. The
+  # example-compile step was piggybacked into cljs-browser, BEFORE the
+  # Playwright install, only to fail fast before the ~120 MB Chromium
+  # download. But that serialised ~10 min of example compiles in front of
+  # every browser-test run, making cljs-browser the ~12 min long-pole on
+  # every core-touching PR. The example-compile gate needs NO browser
+  # (it is a pure `shadow-cljs compile` over the example builds — no
+  # Playwright, no Chromium), so it has no reason to share the cljs-browser
+  # runner. Splitting it into its own job lets the two run in PARALLEL,
+  # dropping the cljs-browser long-pole to ~2-3 min while keeping the full
+  # coverage guarantee (the example builds are still compiled + warning-
+  # checked in CI on the same surface).
+  #
+  # SURFACE GATING. Fires on the SAME `cljs_browser` surface the inline
+  # step did — report-changed-surfaces.sh sets cljs_browser=true for a
+  # generic examples/** source edit (the regression source) AND for a
+  # shadow-cljs.edn build-decl change (a newly-declared example build) AND
+  # for every implementation code surface. No new surface output is needed:
+  # the coverage condition is unchanged, only the host job moved.
+  cljs-examples-compile:
+    name: CLJS (compile every standalone example build, coverage gate)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.cljs_browser == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-examples-compile-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-examples-compile-
+            ${{ runner.os }}-cljs-browser-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      # rf2-0vav5.1 + rf2-cn6kc.1 — compile-coverage gate over EVERY declared
+      # standalone :examples/* shadow-cljs build (the list is derived from
+      # shadow-cljs.edn, so a newly-declared example build is swept
+      # automatically). Several example builds (login-uix, dashboard-uix,
+      # login-helix, process-monitor-helix) were declared browser targets that
+      # NO gate compiled — a ns / init-fn / :require / form regression in any
+      # shipped GREEN until a human manually ran it. This `compile` (not
+      # release) step closes that gap and fails on any compile warning too
+      # (a typo'd init-fn surfaces as an :undeclared-var warning, and
+      # `compile` exits 0 on warnings). No Playwright/Chromium needed — a
+      # pure `shadow-cljs compile`, which is exactly why it now runs in its
+      # own parallel job instead of serialising in front of cljs-browser
+      # (rf2-9cw850).
+      - name: Compile every declared standalone example build (coverage gate)
+        run: npm run test:examples-compile
 
   cljs-browser-schemas-boundary-prod:
     name: CLJS (shadow-cljs :browser-test-schemas-boundary-prod, :advanced + goog.DEBUG=false, rf2-84e9)
@@ -3140,6 +3211,7 @@ jobs:
       - cljs
       - js-harness-self-tests
       - cljs-browser
+      - cljs-examples-compile
       - cljs-browser-schemas-boundary-prod
       - cljs-browser-prod-elision
       - cljs-elision

--- a/implementation/scripts/_rigorous-local-inventory.test.cjs
+++ b/implementation/scripts/_rigorous-local-inventory.test.cjs
@@ -7,8 +7,9 @@
  * It had drifted behind that sweep: it ran `test:story-feature-load`,
  * `test:xray-feature-gate`, and `test:story-static` but omitted
  * `test:story-play-scripts` (a sweep command) and `test:examples-compile`
- * (the example-build compile gate that test.yml's cljs-browser job runs before
- * Playwright install). A developer running `scripts/test-rigorous-local.sh`
+ * (the example-build compile gate that test.yml runs in its own parallel
+ * cljs-examples-compile job — split out of cljs-browser per rf2-9cw850). A
+ * developer running `scripts/test-rigorous-local.sh`
  * before a release-sized change could get `PASS rigorous local suite` without
  * the example-compile coverage gate or the Story play-script browser gate —
  * exactly the wiring regressions those gates were added to catch.


### PR DESCRIPTION
Two CI-infra changes, both touching `.github/workflows`. Done in one PR to avoid a second workflow-touching PR on the hot-zone.

## rf2-9cw850 — cut the cljs-browser wall-clock long-pole

**Finding (PR #4631 live step-timing, run 27802443506):** the dominant cost in the ~12 min `cljs-browser` job is NOT the browser test — it is the `Compile every declared standalone example build (coverage gate)` step (`npm run test:examples-compile`) at ~10 min (02:55:16 to 03:05:16). The actual `:browser-test` compile + Playwright runner is only ~1-2 min. That example-compile gate was piggybacked into `cljs-browser`, BEFORE the Playwright install, only to fail fast before the ~120 MB Chromium download — but that serialised ~10 min of example compiles in front of every browser-test run.

**Fix:** split the example-compile coverage gate into its own parallel job, `cljs-examples-compile`. It needs no browser (pure `shadow-cljs compile` over the `:examples/*` builds — no Playwright, no Chromium), so it has no reason to share the `cljs-browser` runner.

**Verified before moving:**
- Exact command: `npm run test:examples-compile` runs `node scripts/check-examples-compile.cjs`.
- Build-ids: the script DERIVES the full `:examples/*` build list from `implementation/shadow-cljs.edn` (not hardcoded) and runs a single `shadow-cljs compile <all example builds>`, failing on any warning or hard error. A newly-declared example build is swept automatically.
- No Playwright/Chromium dependency — confirmed it is a JVM + Node + Clojure + `npm ci` job only.

**Surface gating unchanged.** The new job is `if: needs.detect_changed_surfaces.outputs.cljs_browser == 'true'` — the SAME surface the inline step ran under. `report-changed-surfaces.sh` was NOT changed: `cljs_browser` already fires for a generic `examples/**` source edit (the regression source), a `shadow-cljs.edn` build-decl change (a new example build), and every implementation code surface. No new surface output was needed; only the host job moved.

### Job graph: before to after

**Before** (on a `cljs_browser`-firing PR):

```
detect_changed_surfaces -> cljs-browser:  npm ci -> test:examples-compile (~10m) -> Playwright install -> test:browser (~1-2m)   [~12m long-pole]
                        -> cljs-browser-schemas-boundary-prod   (parallel)
                        -> cljs-browser-prod-elision            (parallel)
all-required-passed needs: ... cljs-browser, cljs-browser-schemas-boundary-prod, cljs-browser-prod-elision, ...
```

**After:**

```
detect_changed_surfaces -> cljs-browser:           npm ci -> Playwright install -> test:browser   [~2-3m]
                        -> cljs-examples-compile:   npm ci -> test:examples-compile (~10m)         (parallel, own runner)
                        -> cljs-browser-schemas-boundary-prod  (parallel)
                        -> cljs-browser-prod-elision           (parallel)
all-required-passed needs: ... cljs-browser, cljs-examples-compile, cljs-browser-schemas-boundary-prod, cljs-browser-prod-elision, ...
```

`cljs-examples-compile` is added to the `all-required-passed` aggregator `needs:`, so a broken example build still blocks the merge — the coverage guarantee is preserved, only the wall-clock serialisation is removed. The `cljs-browser` long-pole drops from ~12m to ~2-3m (the example compile now runs in parallel on its own runner).

## rf2-3yufij — prevent the recurring stale playground SCI bundle

**Chosen: option (a) — a post-merge gate on `main` that rebuilds the SCI bundle and fails on drift** (new workflow `post-merge-playground-freshness.yml`).

The committed `docs/cljs/playground-rf2.js` bakes in core + reagent-slim + machines, but the PR-time freshness gate (`tools-playground` in test.yml) only fires when `playground=true`, which for implementation surfaces is ONLY `implementation/machines/*` (a deliberate cost tradeoff). So a `core`/`reagent-slim` change silently staleness the committed bundle with no PR-time gate. It bit twice: **ssxvg1** (committed bundle ~36 impl commits behind, predating the EP-0003 wave) and again after **#4631** (EP-0024 frame-provider rename made the bundle mount shape invalid against current core — rf2-qhu72t).

**Why (a), not (b)/(c):**
- **(b) widen the PR surface** to fire on `core` + `reagent-slim`: adds a heavy JVM+Node+Playwright SCI build to most PRs — exactly the per-PR cost the surface gating scopes out.
- **(c) rebuild at deploy:** this is **already implemented** — `docs.yml` rebuilds the bundle fresh from main on every publish (rf2-ssxvg1 part 2), so the DEPLOYED bundle is never committed-stale. The residual harm is the COMMITTED snapshot drifting + breaking the next `mark_all` PR gate, which (c) does not address.
- **(a)** catches committed drift immediately post-merge, on the surfaces the PR gate skips, with zero per-PR cost.

**Implementation note (important nuance):** a naive "rebuild and `git diff --exit-code`" on the SCI bundle is **infeasible** — the `:advanced` Closure build minified-symbol allocation is per-machine deterministic but NOT cross-machine reproducible (documented at length in test.yml `tools-playground` job and in `scripts/check-playground-sci-freshness.sh`), so a byte-diff against a fresh CI rebuild would false-positive on essentially every run. So the gate uses the deterministic signals the codebase already trusts:
1. **Rebuild fresh + headless-Chromium smoke** against the freshly-built bundles. This is the authoritative current-source check — it renders the live re-frame2 counter + both machine cells. The EP-0024 class (source mount shape invalid against renamed core) throws at render, so the smoke FAILS here, immediately post-merge.
2. **esbuild byte-diff** (`playground.js`/`.css` only — these ARE byte-deterministic, EOL-pinned via `.gitattributes`).
3. **`scripts/check-playground-sci-freshness.sh`** against the committed SCI bundle (the deterministic machine-lifecycle-marker freshness guard, same as the PR-time job).

It does NOT block any merge (the merge already happened; this is a fast-feedback canary), does NOT auto-commit a rebuilt bundle (would add noisy bundle commits + risk a push loop), and is NOT a per-PR gate.

### Job graph (new workflow)

```
push to main touching {implementation/core/**, implementation/adapters/reagent-slim/**, implementation/machines/**,
                       docs/tools/playground/**, docs/cljs/playground.js, docs/cljs/playground.css,
                       docs/cljs/playground-rf2.js, this workflow}
  -> rebuild-and-verify:
       check-playground-sci-freshness.sh (committed) -> npm ci -> playwright install -> npm run build (fresh)
         -> npm run smoke (fresh) -> esbuild byte-diff
```

Existing PR-time playground gate (`tools-playground` in test.yml) is untouched. Added `post-merge-playground-freshness.yml` to the `post-merge-workflow-sanity.yml` EXCLUDE list (it already runs on push, including on edits to its own file, so the dispatcher should not double-fire it).

## Gates run
- `python -c "import yaml; safe_load(...)"` on test.yml, docs.yml, post-merge-workflow-sanity.yml, post-merge-playground-freshness.yml -> **yaml ok**.
- actionlint: not available in this environment.
- `bash -n` on the inline workflow shell + the dependent scripts (`report-changed-surfaces.sh`, `check-playground-sci-freshness.sh`) -> OK.
- `npm run test:script-policy` (incl. `_changed-surfaces.test.cjs` 110 passed, `_rigorous-local-inventory.test.cjs` 4 passed, `check-examples-compile.test.cjs`, `_lint-workflow-policy.test.cjs` 4 passed) -> all passed.
- Classifier spot-check: `cljs_browser=true` for `examples/foo/x.cljs`, `implementation/shadow-cljs.edn`, `implementation/core/src/x.cljc`; `false` for `spec/API.md`.

Do NOT merge — for review.
