### PR TITLE
refactor(core): finish frame-teardown inventory migration + data-driven removed-API stubs (rf2-4n0hp9, rf2-8au0w6)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -1049,6 +1049,45 @@
 ;; not a dev diagnostic). The stub remains so a stale call site fails LOUDLY
 ;; with an actionable message rather than an opaque "no such var".
 
+;; ---- shared always-on removed-API thrower (rf2-8au0w6) --------------------
+;;
+;; The removed-public-API "throwing stub" pattern that ALSO fans out on the
+;; always-on observability channel (a catalogued Spec 009 §Error-event
+;; category — `:rf.error/inject-cofx-removed`, `:rf.error/reg-event-*-removed`)
+;; was hand-rolled per surface: the same three-step body (surface on the
+;; always-on `:error-emit/dispatch-on-error` listener → emit the dev
+;; `:rf.error/*` trace → throw the canonical `error/throw-error!` hard error).
+;; `raise-removed!` is the ONE shared fan-out thrower both surfaces delegate
+;; to (the EP-0017 `inject-cofx` stub here, and the EP-0018 reg-event removed
+;; names via `re-frame.events/raise-removed-reg-event!`, which requires this
+;; ns). Lives here rather than in `re-frame.error` because the fan-out needs
+;; `late-bind` + `trace`, both of which require `error` — pushing it into
+;; `error` would close a load cycle. Behaviour is byte-identical to the prior
+;; bespoke bodies: the caller passes its exact `error-kw` / `where` / `reason`
+;; / offending `id` and the `id-key` under which the id rides the trace tag +
+;; thrown ex-data (`:id` for reg-event, `:rf.cofx/id` for inject-cofx). The
+;; std-interceptor removed values (EP-0022) ride no catalogued 009 category, so
+;; they throw `error/throw-error!` directly (no fan-out) and do NOT use this.
+(defn raise-removed!
+  "Fan out + throw a removed-public-API hard error that rides the always-on
+  Spec 009 observability channel (rf2-8au0w6). Surfaces `error-kw` on the
+  always-on `:error-emit/dispatch-on-error` listener (production-survivable),
+  emits the dev `:rf.error/*` trace, then throws the canonical
+  `error/throw-error!` hard error attributed to `where` with `reason`. The
+  offending `id` (the removed registrar/cofx call's first arg, or nil) rides
+  the trace tag + thrown ex-data under `id-key` when present. Never returns
+  normally. The ONE place the fan-out throw mechanics live; every fan-out
+  removed stub delegates here so the next such removal is a data edit."
+  [error-kw where reason id id-key]
+  (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
+    (dispatch-on-error! error-kw nil id nil nil 0 (interop/now-ms)))
+  (trace/emit-error! error-kw
+                     (cond-> {:reason reason :recovery :no-recovery}
+                       (some? id) (assoc id-key id)))
+  (error/throw-error! error-kw where reason
+                      {:recovery :no-recovery
+                       :extra    (when (some? id) {id-key id})}))
+
 (defn inject-cofx
   "REMOVED in EP-0017 (no alias). Calling `inject-cofx` is the hard error
   `:rf.error/inject-cofx-removed`, naming `:rf.cofx/requires` as the
@@ -1064,13 +1103,8 @@
                      "under its id; the registration's grade decides replay "
                      "semantics. See spec/001-Registration.md §`inject-cofx` "
                      "is removed.")]
-    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! :rf.error/inject-cofx-removed nil cofx-id nil nil 0 (interop/now-ms)))
-    (trace/emit-error! :rf.error/inject-cofx-removed
-                       (cond-> {:reason reason :recovery :no-recovery}
-                         cofx-id (assoc :rf.cofx/id cofx-id)))
-    (error/throw-error! :rf.error/inject-cofx-removed 'rf/inject-cofx reason
-                        {:extra (when cofx-id {:rf.cofx/id cofx-id})})))
+    (raise-removed! :rf.error/inject-cofx-removed 'rf/inject-cofx reason
+                    cofx-id :rf.cofx/id)))
 
 ;; ---- standard registrations -----------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/error.cljc
+++ b/implementation/core/src/re_frame/error.cljc
@@ -132,6 +132,45 @@
   ([error-id where-sym reason opts]
    (throw (thrown-ex-info error-id where-sym reason opts))))
 
+;; ---- shared removed-API thrower: inline interceptor (rf2-8au0w6) -----------
+;;
+;; The retired-name "throwing stub" pattern (a removed public API survives as
+;; a `^:no-doc` var that throws a LOUD, actionable `:rf.error/<x>-removed`
+;; naming the replacement) was hand-rolled per surface. The per-surface DATA
+;; TABLES (`events/removed-reg-event-names`, `std-interceptors/removed-std-
+;; interceptor-values`, rf2-ne2uk8) already collapse each surface's rows to one
+;; literal vector — but the THROW MECHANICS were still re-rolled per file, and
+;; the `inline-interceptor-removed` thrower was LITERAL copy-paste across two
+;; namespaces (`events` + `interceptor-registry`). The helper below is the ONE
+;; shared definition both inline-interceptor rejection sites delegate to, so the
+;; throw mechanics live once. Behaviour is byte-identical: each caller passes
+;; its exact `where` / `reason` / `extra`, so the thrown ex-info shape is
+;; unchanged. (The always-on FAN-OUT removed-stub variant — the EP-0017
+;; `inject-cofx` + EP-0018 reg-event removals — shares `cofx/raise-removed!`
+;; instead, because that fan-out needs `late-bind` + `trace`, both of which
+;; require `error`; housing it here would close a load cycle.)
+
+(defn throw-inline-interceptor-removed!
+  "Throw the EP-0022 reference-only-flip hard error
+  `:rf.error/inline-interceptor-removed` (rf2-0adhqs.9) for an INLINE
+  interceptor value found where a chain expects a REFERENCE. The ONE
+  definition both rejection sites delegate to — the registration-time site
+  (`re-frame.events/validate-meta-interceptors!`, `:where 'rf/reg-event`) and
+  the chain-assembly site (`re-frame.interceptor-registry/resolve-chain`,
+  `:where 'rf/resolve-chain`). Each passes its own `where` symbol, fully
+  composed `reason` sentence, and `extra` ex-data map, so the thrown shape is
+  exactly what each site threw before the dedup; only the throw mechanics are
+  shared. The migration path the message names: register the interceptor with
+  `reg-interceptor` and reference it by id (a bare keyword or an `[id arg]`
+  2-vector). Never returns normally."
+  [where reason extra]
+  (throw-error!
+    :rf.error/inline-interceptor-removed
+    where
+    reason
+    {:recovery :fix-registration
+     :extra    extra}))
+
 (defn ex-info-from-data
   "Build a canonical thrown-error `ex-info` whose ex-data is the ALREADY-BUILT
   `data` map verbatim, deriving the human message from the map's own

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -102,10 +102,11 @@
   point for a stale inline value (an `->interceptor` result, a `(path …)` /
   `(redact-interceptor …)` value, a value-Var) — a typo dies at `reg-event`,
   not at first dispatch. Mirrors the dispatch-time
-  `interceptor-registry/resolve-chain` rejection with the same error id."
+  `interceptor-registry/resolve-chain` rejection with the same error id —
+  both delegate to the ONE shared `error/throw-inline-interceptor-removed!`
+  (rf2-8au0w6) passing this site's `:where 'rf/reg-event`, reason, and ex-data."
   [reg-fn-name id value offending]
-  (error/throw-error!
-    :rf.error/inline-interceptor-removed
+  (error/throw-inline-interceptor-removed!
     'rf/reg-event
     (str reg-fn-name " for `" id "` carried an INLINE interceptor value `"
          (pr-str offending) "` in its metadata `:interceptors` chain. "
@@ -113,12 +114,11 @@
          "interceptor with `rf/reg-interceptor` and reference it by id — "
          "a bare keyword `:my/ic` or an `[id arg]` 2-vector "
          "(e.g. `[:rf.interceptor/path [:cart]]`).")
-    {:recovery :fix-registration
-     :extra    {:reg-fn    reg-fn-name
-                :id        id
-                :got       value
-                :offending offending
-                :expected  "a vector of interceptor references (keyword ids / [id arg] vectors)"}}))
+    {:reg-fn    reg-fn-name
+     :id        id
+     :got       value
+     :offending offending
+     :expected  "a vector of interceptor references (keyword ids / [id arg] vectors)"}))
 
 (defn- validate-meta-interceptors!
   "Validate the metadata-map `:interceptors` value at registration. The value
@@ -1075,23 +1075,15 @@
   "Fan out + throw the EP-0018 retired-name hard error `error-kw` for a stale
   call to a removed public event registrar `reg-fn-name` (a string like
   \"reg-event-db\"), naming `replacement` and showing `fix` (the actionable
-  conversion). Mirrors the `inject-cofx` removed-stub shape: surface on the
-  always-on error-emit listener (production-survivable) AND the dev trace bus,
-  then throw the ex-info carrying the same `:rf.error/id`."
+  conversion). The `inject-cofx` removed-stub twin: composes the EP-0018
+  reason then delegates to the ONE shared `cofx/raise-removed!` (rf2-8au0w6),
+  which surfaces on the always-on error-emit listener (production-survivable)
+  AND the dev trace bus, then throws the ex-info carrying the same
+  `:rf.error/id` — the offending `id` rides the trace + ex-data under `:id`."
   [error-kw reg-fn-name where id replacement fix]
   (let [reason (str "`" reg-fn-name "` is REMOVED in EP-0018 (no alias). "
                     "Use `" replacement "` instead — " fix)]
-    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! error-kw nil id nil nil 0 (interop/now-ms)))
-    (trace/emit-error! error-kw
-                       (cond-> {:recovery :no-recovery :reason reason}
-                         (some? id) (assoc :id id)))
-    (error/throw-error!
-      error-kw
-      where
-      reason
-      {:recovery :no-recovery
-       :extra    (cond-> {} (some? id) (assoc :id id))})))
+    (cofx/raise-removed! error-kw where reason id :id)))
 
 ;; ---- data-driven removed event-registration names (rf2-ne2uk8) ------------
 ;;

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1836,16 +1836,41 @@
   table) and an opaque `:teardown` fn token the spec says 'runs on frame destroy'
   (Runtime-Subsystems §Host-transient subsystem state).
 
-  Before this step, `destroy-frame!` released host-transient state only through
-  the FIXED list of hard-coded `safe-call-hook!` hooks (`:routing/...`,
-  `:resources/...`, `:ssr/...`, `:machines/...`). A subsystem could correctly
-  register a frame-scoped host-transient descriptor with the realm AND still leak
-  on `destroy-frame!` unless it ALSO had a bespoke hook in that list — the
-  realm-owned inventory was the single source of truth for realm DISPOSAL
-  (`dispose-realm-host-transient!`) but had no frame-destroy counterpart. This
-  step is that counterpart: it walks the realm's inventory and tears down the
-  `:frame`-scoped descriptors for the frame being destroyed, so a subsystem that
-  declares its host-transient descriptor needs no second hard-coded hook.
+  This step COMPLEMENTS — it does not replace — the named ordered cleanup hooks
+  above (rf2-4n0hp9 ruling). The two mechanisms are deliberately distinct per
+  the spec (Runtime-Subsystems §The host-transient grading column + §Host-
+  transient subsystem state):
+
+    - The named hooks (`:ssr/on-frame-destroyed`, `:machines/on-frame-
+      destroyed!`, `:routing/on-frame-destroyed!`, `:schemas/on-frame-
+      destroyed!`, `:flows/teardown-on-frame-destroy!`, `:resources/on-frame-
+      destroyed!`, `:elision/clear-warning-cache!`) tear down the SHIPPED
+      subsystems' host-transient BYTES, in the DECLARATION ORDER 002 §Destroy
+      step 5 normatively pins. Their side-table atoms live in the producing
+      artefacts and are realm-AGNOSTIC (keyed by bare frame-id), so they fire
+      correctly for a frame in ANY realm, ordered. The spec is explicit that
+      \"the side-table atoms continue to live in their producing artefacts and
+      are reset/torn down through the existing late-bind reset + frame-destroy
+      hooks — moving the bytes is not what [the inventory] does\"
+      (Runtime-Subsystems §host-transient subsystem registry).
+
+    - The realm-owned inventory is the single QUERYABLE RECORD of which host-
+      transient subsystems exist and how each is scoped/torn-down. This walk
+      is its frame-destroy arm (the counterpart of `dispose-realm-host-
+      transient!`): it releases any ADDITIONAL `:frame`-scoped descriptor an
+      app, test, or future subsystem registers with the realm — without that
+      descriptor needing a second hard-coded hook here. In the shipped tree no
+      production subsystem registers one (they use the named hooks above), so
+      this walk is a no-op in production; it is exercised by the realm
+      conformance suite and is the seam apps/tools extend.
+
+  Folding the shipped named hooks INTO this walk was considered and REJECTED
+  (rf2-4n0hp9): the inventory is an UNORDERED map (`assoc`, no insertion
+  order in CLJS), which cannot honour the spec's declaration-order teardown
+  contract, and descriptors are realm-OWNED with no per-realm seeding seam on
+  `construct-realm`, so a descriptor registered once at ns-load would not
+  cover a frame in a constructed realm the way the realm-agnostic named hooks
+  do. The two-mechanism shape is the spec's, not incomplete-migration debt.
 
   Only `:scope :frame` descriptors are torn down here — `:realm`-scoped tables
   outlive an individual frame (they release on `dispose-realm!`). The teardown is
@@ -2250,11 +2275,19 @@
                                       host-transient descriptor inventory and
                                       run each :frame-scoped descriptor's
                                       :teardown for THIS frame (rf2-c6armm.7
-                                      #2). The realm-owned counterpart of the
-                                      fixed hooks above: a subsystem that
-                                      registers a frame-scoped host-transient
-                                      descriptor with the realm is torn down
-                                      here without a second hard-coded hook.
+                                      #2). COMPLEMENTS the named hooks above —
+                                      it does not replace them (rf2-4n0hp9):
+                                      the named hooks tear down the SHIPPED
+                                      subsystems' bytes in the declaration
+                                      order this step list pins; this walk
+                                      releases any ADDITIONAL :frame-scoped
+                                      descriptor an app/test/future subsystem
+                                      registers with the realm, without a
+                                      second hard-coded hook here. No-op in the
+                                      shipped tree (no production subsystem
+                                      registers one). See the fn docstring for
+                                      why the named hooks are NOT folded into
+                                      this unordered, realm-owned walk.
     5. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER the
                                       machine cascade.
     6. dissoc-frame!                — remove from the `frames` atom.
@@ -2419,14 +2452,19 @@
         (safe-call-hook! :resources/on-frame-destroyed! id)
         ;; rf2-c6armm.7 #2: walk the frame's realm's host-transient descriptor
         ;; inventory and tear down its :frame-scoped descriptors for THIS frame.
-        ;; The hard-coded hooks above release the SHIPPED subsystems' host-transient
-        ;; state; this realm-inventory walk releases any descriptor a subsystem
-        ;; registered with the realm without a second bespoke hook (the realm is
-        ;; the single inventory of what must be torn down on frame/realm destroy —
-        ;; Runtime-Subsystems §Host-transient subsystem state). The realm id was
-        ;; captured at the top (frame-rid), before mark-frame-destroyed! flipped
-        ;; :destroyed? (after which frame-realm returns nil). Best-effort (failures
-        ;; accumulate + trace exactly like safe-call-hook!).
+        ;; The named hooks above release the SHIPPED subsystems' host-transient
+        ;; state IN DECLARATION ORDER (002 §Destroy step 5); this realm-inventory
+        ;; walk COMPLEMENTS them — it releases any ADDITIONAL descriptor an
+        ;; app/test/future subsystem registered with the realm, without a second
+        ;; bespoke hook (the realm is the single inventory RECORD of what host-
+        ;; transient state exists — Runtime-Subsystems §Host-transient subsystem
+        ;; state). The two coexist BY DESIGN, not as incomplete-migration debt:
+        ;; folding the ordered named hooks into this unordered, realm-owned walk
+        ;; was considered + rejected (rf2-4n0hp9 — see the fn docstring). No-op in
+        ;; the shipped tree (no production subsystem registers a descriptor). The
+        ;; realm id was captured at the top (frame-rid), before mark-frame-
+        ;; destroyed! flipped :destroyed? (after which frame-realm returns nil).
+        ;; Best-effort (failures accumulate + trace exactly like safe-call-hook!).
         (tear-down-frame-host-transient! id frame-rid)
         (emit-frame-destroyed-trace! id)
         ;; Per Spec 009 §Per-frame trace rings (rf2-g1b2m / rf2-8uwce):

--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -326,10 +326,13 @@
   `->interceptor` result, a `(path …)` value, a `(redact-interceptor …)`
   value, a locally-bound interceptor symbol) is no longer accepted; it must be
   registered with `reg-interceptor` and referenced by id. Loud-fail at chain
-  assembly rather than a silent no-op (Conventions §No silent swallow)."
+  assembly rather than a silent no-op (Conventions §No silent swallow).
+  Delegates to the ONE shared `error/throw-inline-interceptor-removed!`
+  (rf2-8au0w6) passing this site's `:where 'rf/resolve-chain`, reason, and
+  ex-data — the registration-time twin (`re-frame.events`) shares the same
+  thrower."
   [entry]
-  (error/throw-error!
-    :rf.error/inline-interceptor-removed
+  (error/throw-inline-interceptor-removed!
     'rf/resolve-chain
     (str "an event/frame `:interceptors` chain carried an INLINE "
          "interceptor value `" (pr-str entry) "`. Interceptor "
@@ -337,9 +340,8 @@
          "interceptor with `reg-interceptor` and reference it by id "
          "— a bare keyword `:my/ic` or an `[id arg]` 2-vector "
          "(e.g. `[:rf.interceptor/path [:cart]]`).")
-    {:recovery :fix-registration
-     :extra    {:entry    entry
-                :expected "a keyword id or an [id arg] vector reference"}}))
+    {:entry    entry
+     :expected "a keyword id or an [id arg] vector reference"}))
 
 (defn- resolve-factory
   "Resolve a parameterized `[id arg]` ref against its registered `:factory`


### PR DESCRIPTION
Lean pass (parent rf2-1sfb14). Two CORE internal-sprawl refactors, different files, same surface. **Do not merge** — flagged for Mike's ruling on rf2-4n0hp9 (see below).

## rf2-8au0w6 — data-driven removed-API stubs (mechanical, behaviour-preserving)

Collapsed the hand-rolled removed-API throwing-stub *mechanics* to ONE shared throw path per variant, preserving EXACT thrown-error shape (same `:rf.error/*` ids, message text, ex-data, fan-out):

- **Deduped the cross-namespace LITERAL copy-paste** `throw-inline-interceptor-removed!` (`events.cljc` + `interceptor_registry.cljc`) to ONE shared `error/throw-inline-interceptor-removed!`. The two were *not* byte-identical (different arglist / `:where` / message lead-in / `:extra`), so the shared fn takes `where` / `reason` / `extra`; each site composes its exact values and delegates. Thrown ex-info is byte-identical to before.
- **Collapsed the always-on FAN-OUT mechanics** (the EP-0017 `inject-cofx` stub + the EP-0018 reg-event removals via `raise-removed-reg-event!`) to ONE shared `cofx/raise-removed!` — surface on the always-on `:error-emit/dispatch-on-error` listener → emit dev trace → throw canonical `error/throw-error!`. Housed in `cofx` (not `error`) because the fan-out needs `late-bind` + `trace`, both of which `:require` `error` — housing it in `error` closes a load cycle.
- The per-surface DATA TABLES (`removed-reg-event-names`, `removed-std-interceptor-values`, rf2-ne2uk8) remain the data-driven name registries; the next removal stays a data edit. The std-interceptor removals (`path` / `unwrap-interceptor`) ride no always-on category and already use `error/throw-error!` directly — unchanged. `redact-interceptor` (bead-mentioned) is NOT a throwing stub (it's live internal router plumbing) — correctly out of scope.

**No public-surface change**: the helpers are internal (not facade-exported), so the API manifest + late-bind directory are unaffected. No `set-fn!` change.

## rf2-4n0hp9 — frame-teardown migration: KEPT BOTH mechanisms (doc-truthing only) — needs a ruling

The brief's escape hatch ("if finishing the migration is genuinely unsafe/ambiguous … do the ones that are safe + clearly document which remain on the fixed list and why") applies to **all 7 subsystems**. Finishing the migration as the bead describes conflicts with the spec on **three independent grounds** — it would be a regression, not a lean:

1. **Ordering** — spec/002 §Destroy step 5 normatively pins the auxiliary cleanup hooks **"in declaration order"** (and Runtime-Subsystems §clause-5: "in the strict order of 002 §Destroy"). The inventory walk is a `doseq` over an **unordered map** (`assoc`; no CLJS insertion order), which cannot honour it.
2. **Realm coverage** — the inventory is realm-OWNED state with **no per-realm seeding seam** on `construct-realm`. The named hooks are realm-AGNOSTIC (module-level atoms keyed by bare frame-id) so they fire for a frame in *any* realm; a descriptor registered once at ns-load into the default realm would NOT cover a frame in a constructed realm (SSR per-request-realm churn, multi-realm tests would leak).
3. **Spec framing** — Runtime-Subsystems §host-transient subsystem registry states the side-table bytes "are reset/torn down through the existing late-bind reset + frame-destroy hooks — **moving the bytes is not what [the inventory] does**"; the inventory is the realm-owned RECORD of *which* host-transient state exists, the named hooks do the work. The grading table names each subsystem's late-bind hook as its teardown mechanism. **The two mechanisms are complementary by design, not incomplete-migration debt.**

**Verified**: no production subsystem registers a host-transient descriptor — the only non-test refs are the `register-host-transient!` *definition* (realm.cljc) and the walk *itself* (frame.cljc). So `tear-down-frame-host-transient!` is a **production no-op**, exercised only by the realm conformance suite. The "two coexisting mechanisms" are really: (1) the named hooks that do the work, ordered, realm-agnostic; (2) an inventory walk that is the realm-owned extensibility seam (dormant in the shipped tree).

**What I did**: corrected the misleading "incomplete migration / fixed-list-is-debt" framing in the `tear-down-frame-host-transient!` docstring + the `destroy-frame!` step list + the call-site comment, to describe the two mechanisms as complementary and to record why folding the ordered named hooks into the unordered realm-owned walk was rejected. **No executable code changed in frame.cljc** — teardown order + completeness for all 7 subsystems (ssr, machines, schemas, flows, routing, resources, elision) plus the trace-ring + epoch hooks is byte-identical to origin/main.

**Subsystems migrated: 0 / 7. Left on the named hooks: all 7 (ssr, machines, schemas, flows, routing, resources, elision)** — for the spec-conflict reasons above. **Decision for Mike**: accept the keep-both + doc-truth outcome and close rf2-4n0hp9, OR rule that the named hooks should fold into the inventory anyway (which would require first adding an *ordered* inventory + a per-realm subsystem-registration seam on `construct-realm` — a substantial new mechanism, not a lean-pass change).

## Gates
- JVM implementation suite (`test-jvm-implementation.sh`): exit 0 — every artefact 0 failures / 0 errors (core 1822, schemas 311, machines 778, routing 296, flows 211, http 448, + ssr / ssr-ring / epoch / resources).
- CLJS suite (`npm run test:cljs`): 8022 tests / 33494 assertions / **0 failures, 0 errors**.
- `check_thrown_error_messages.py`: exit 0.
- clj-kondo: 0 errors, 0 new warnings (3 pre-existing in untouched `cofx` lines).
- splint: 0 new warnings (7 pre-existing in untouched lines).
