### PR TITLE
refactor(flows): dedupe runtime-partition-stripping into one shared helper (rf2-4vreu8)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -116,28 +116,20 @@
 ;; the cached row, forcing recompute — it cannot be hidden merely because the
 ;; app-db partition was value-identical.
 
-(def ^:private runtime-partition-key
-  "The reserved partition key that, as a leading `:inputs`-path element,
-  opts a flow input into the runtime-db partition (`:rf.db/runtime`). Bare
-  paths (any other leading element) resolve against app-db. Held as a const
-  so the resolver and the doc stay in lockstep."
-  :rf.db/runtime)
-
-(defn- runtime-input?
-  "True iff `path` is a partition-qualified runtime-db input — a vector whose
-  FIRST element is `:rf.db/runtime`. Everything else is a bare app-db path
-  (binary syntax — rf2-4eisfr refinement (i): there is no third
-  `[:rf.db/app …]` explicit-app form)."
-  [path]
-  (= runtime-partition-key (first path)))
+;; The partition-syntax primitives (`runtime-partition-key` / `runtime-input?`
+;; / the strip via `input-resolve-path`) live ONCE in `re-frame.flows.registry`
+;; (rf2-4vreu8): `registry` is required by both this facade and
+;; `re-frame.flows.tooling` and requires neither back (no cycle), so it is the
+;; natural shared home for the rule all three consumers key on.
 
 (defn- resolve-input
   "Resolve one flow `:inputs` path against the pending frame-state's two
   partitions. A `[:rf.db/runtime …rest]` path reads `runtime-db` at `…rest`
-  (the partition key stripped); a bare path reads `db` (app-db) verbatim."
+  (the partition key stripped via the shared `registry/input-resolve-path`);
+  a bare path reads `db` (app-db) verbatim."
   [db runtime-db path]
-  (if (runtime-input? path)
-    (get-in runtime-db (subvec path 1))
+  (if (registry/runtime-input? path)
+    (get-in runtime-db (registry/input-resolve-path path))
     (get-in db path)))
 
 (defn- read-inputs

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -615,6 +615,38 @@
     [(vec (concat whole-sens per-sens))
      (vec (concat whole-lg   per-large))]))
 
+;; ---- partition-qualified input primitives (EP-0001 §535-551, rf2-4eisfr) --
+;;
+;; The ONE home for the binary `:inputs`-path partition syntax shared across
+;; the flows artefact (rf2-4vreu8 dedupe): a bare leading path element resolves
+;; against app-db; a leading `:rf.db/runtime` opts the input into the runtime-db
+;; partition and is stripped before the path is used. Three consumers ride
+;; these primitives so the rule lives once:
+;;   - `re-frame.flows/resolve-input` — reads the input VALUE against the
+;;     pending app-db / runtime-db partitions (strips for the runtime read);
+;;   - `re-frame.flows/elide-inputs` + `input-overlaps-declaration?` below —
+;;     resolve the declaration-COORDINATE path (`input-resolve-path`);
+;;   - `re-frame.flows.tooling/declared-input` — lowers to the algebra
+;;     `[:db …]` / `[:runtime …rest]` declared-input form.
+;; `registry` is required by both `re-frame.flows` and `re-frame.flows.tooling`
+;; and requires neither back (no cycle), so it is the natural shared home.
+
+(def ^:no-doc runtime-partition-key
+  "The reserved partition key that, as a leading `:inputs`-path element, opts a
+  flow input into the runtime-db partition (`:rf.db/runtime`). Bare paths (any
+  other leading element) resolve against app-db. The single const all three
+  flow-artefact consumers (resolver / elision / algebra projection) key on so
+  the rule, the resolver, and the doc stay in lockstep (rf2-4vreu8)."
+  :rf.db/runtime)
+
+(defn ^:no-doc runtime-input?
+  "True iff `path` is a partition-qualified runtime-db input — a vector whose
+  FIRST element is `runtime-partition-key` (`:rf.db/runtime`). Everything else
+  is a bare app-db path (binary syntax — rf2-4eisfr refinement (i): there is no
+  third `[:rf.db/app …]` explicit-app form)."
+  [path]
+  (= runtime-partition-key (first path)))
+
 (defn ^:no-doc input-resolve-path
   "Resolve one flow `:inputs` path to the absolute declaration-coordinate
   path the elision registry is keyed by (plain path vectors, partition-
@@ -626,6 +658,13 @@
   `add-marks`). Partition-aware by construction — the SAME machinery, one
   pass, per the rf2-ihfz9o COMPOSE-WITH-rf2-4eisfr note.
 
+  This is the SHARED strip-partition primitive (rf2-4vreu8): a runtime input
+  drops its leading `runtime-partition-key`; a bare input is returned verbatim
+  (as a vector). `re-frame.flows/resolve-input` uses it for the runtime-db
+  value read and `re-frame.flows.tooling/declared-input` for the algebra
+  `[:runtime …rest]` / `[:db …]` lowering, so all partition stripping routes
+  through this one fn.
+
   NOT private (rf2-p44r3u): `re-frame.flows/elide-inputs` reuses this SAME
   normalization when seeding `elision/elide-wire-value`'s `:path` opt for a
   flow's per-input trace value, so the `:rf.flow/computed` `:input-values`
@@ -635,7 +674,7 @@
   but the trace seed carried the raw `[:rf.db/runtime …]` path and never
   matched it."
   [input-path]
-  (if (= :rf.db/runtime (first input-path))
+  (if (runtime-input? input-path)
     (subvec (vec input-path) 1)
     (vec input-path)))
 

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -69,15 +69,6 @@
 ;; or the `:rf/derivation-node` shape (those are owned by Spec-Schemas /
 ;; Derivations).
 
-(def ^:private runtime-partition-key
-  "The reserved partition key that, as a leading `:inputs`-path element,
-  marks a flow input as a runtime-db read (`:rf.db/runtime`). The binary
-  syntax (EP-0001 §535-551, rf2-4eisfr): a bare path reads app-db; a
-  `[:rf.db/runtime …rest]` path reads runtime-db at `…rest`. Held as the
-  same const `re-frame.flows` uses for input resolution so the projection
-  and the resolver stay in lockstep."
-  :rf.db/runtime)
-
 (defn- declared-input
   "Lower ONE flow `:inputs` path to its algebra declared-input form
   (Derivations §Declared input). A bare path is an app-db read `[:db path]`;
@@ -85,11 +76,16 @@
   `[:runtime …rest]` (the partition key stripped). Flow inputs are always
   concrete app-db / runtime-db paths — never `:sub` edges or the
   `:parametric` marker — because a flow declares its dependency graph
-  statically as paths (Spec 013 §Flow shape)."
+  statically as paths (Spec 013 §Flow shape).
+
+  Routes the partition test and the key strip through the SHARED
+  `registry/runtime-input?` / `registry/input-resolve-path` primitives
+  (rf2-4vreu8) so the projection, the value resolver, and the elision
+  declaration-path resolver all key on the one home for the rule."
   [path]
-  (if (= runtime-partition-key (first path))
-    [:runtime (subvec (vec path) 1)]
-    [:db (vec path)]))
+  (if (registry/runtime-input? path)
+    [:runtime (registry/input-resolve-path path)]
+    [:db (registry/input-resolve-path path)]))
 
 (defn- declared-inputs
   "Project a flow's `:inputs` vector into the algebra view's declared


### PR DESCRIPTION
## What

**rf2-4vreu8 — flows structural lean (F1; behaviour-PRESERVING).**

The binary partition-syntax rule — *`:rf.db/runtime` leading element → strip → runtime-db path; else app-db path* — was implemented **three times**:

- `re-frame.flows/resolve-input` (value read against the two pending partitions)
- `re-frame.flows.registry/input-resolve-path` (declaration-coordinate path)
- `re-frame.flows.tooling/declared-input` (algebra `[:db …]` / `[:runtime …rest]` lowering)

…and the `runtime-partition-key` const was **def'd twice** (flows + tooling) with mutual "stay in lockstep" docstrings.

## Change

Hoist `runtime-partition-key` + `runtime-input?` into **`re-frame.flows.registry`** — the namespace already `:require`d by both `re-frame.flows` and `re-frame.flows.tooling`, and which requires neither back (**no cycle**) — alongside the existing strip primitive `input-resolve-path` (which now also keys on `runtime-input?`). All three consumers route through the one home:

| Consumer | Now calls |
|---|---|
| `flows/resolve-input` | `registry/runtime-input?` + `registry/input-resolve-path` |
| `registry/input-resolve-path` | `registry/runtime-input?` |
| `flows.tooling/declared-input` | `registry/runtime-input?` + `registry/input-resolve-path` |

## Behaviour

**Byte-identical.** The runtime read resolves to `subvec(vec path, 1)` either way; the bare read is unchanged. `input-resolve-path` already returned exactly the stripped/verbatim vector each call site built inline. No facade or manifest change (all internals; `input-resolve-path` was already public `^:no-doc`; the two new vars are `^:no-doc`).

## F2 (audit-only — no code change)

The bead's F2 asked only whether the drain-time flow-output-mark-propagation refresh+rollback (rf2-ihfz9o `refresh-flow-output-declarations!` + rf2-gdzv6o snapshot/restore in `run-flows-on-db`) earns its weight. Per the brief this is an **audit question, not a refactor** — left untouched.

## Gates

- Flows JVM suite (`clojure -M:test`): **211 tests / 4871 assertions, 0 failures, 0 errors** (re-run green post-rebase)
- `npm run test:cljs`: **8022 tests / 33494 assertions, 0 failures, 0 errors**
- `clj-kondo`: 0 errors (1 pre-existing intentional `bundle-isolation-sentinel` unused-private-var warning, unrelated)