### PR TITLE
refactor(http): inline form-encode-body + dedupe redacted-sentinel re-export (rf2-m00e7p)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -138,11 +138,6 @@
 
 ;; ---- body encoding --------------------------------------------------------
 
-(defn- form-encode-body
-  "URL-encoded form body from a Clojure map."
-  [form-map]
-  (params->query form-map))
-
 (defn encode-body
   "Per Spec 014 §Body encoding. Returns a tuple `[encoded-body content-type]`.
   `content-type` may be nil — the caller decides whether to set the header."
@@ -155,7 +150,7 @@
     [(util-json/json-stringify body) "application/json"]
 
     (= request-content-type :form)
-    [(form-encode-body body) "application/x-www-form-urlencoded"]
+    [(params->query body) "application/x-www-form-urlencoded"]
 
     (= request-content-type :text)
     [(str body) "text/plain"]

--- a/implementation/http/src/re_frame/http_privacy.cljc
+++ b/implementation/http/src/re_frame/http_privacy.cljc
@@ -79,17 +79,13 @@
             [re-frame.http-url :as url]
             [re-frame.late-bind :as late-bind]))
 
-(def redacted-sentinel
-  "The framework-reserved redaction sentinel per Spec 009 §Privacy. Sits
-  in the `:rf/` reserved-keyword namespace so apps cannot legitimately
-  produce it as a payload value. Consumers wanting \"was this redacted?\"
-  check `(= :rf/redacted v)`.
-
-  rf2-ee38b.7 — re-exported from the canonical `re-frame.http-url`
-  definition so the keyword + its string form (`redacted-url-token`)
-  cannot drift across the privacy cluster. This var preserves the
-  public `re-frame.http-privacy/redacted-sentinel` surface."
-  url/redacted-sentinel)
+;; rf2-m00e7p — internal alias for terse composer call sites below; the
+;; canonical home is the sibling leaf `re-frame.http-url` (carries no
+;; privacy deps, so no leaf→parent cycle). Private — `http-privacy` no
+;; longer carries a public re-export of the sentinel (the public surface
+;; is `re-frame.http-url/redacted-sentinel`, itself a re-export of the
+;; canonical `re-frame.privacy/redacted-sentinel` in core).
+(def ^:private redacted-sentinel url/redacted-sentinel)
 
 ;; ---- frame-local carrier resolution (EP-0015 §3, rf2-ppkh3v) ---------------
 

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -67,8 +67,9 @@
 (def redacted-sentinel
   "The framework-reserved redaction sentinel keyword per Spec 009 §Privacy.
   Re-exported from the canonical `re-frame.privacy/redacted-sentinel` in
-  core (rf2-qe237) — `http-privacy` re-exports it and `http-privacy-headers`
-  refers to it."
+  core (rf2-qe237). This is the http-side public anchor — `http-privacy`
+  and `http-privacy-headers` both refer to it privately (rf2-m00e7p), so
+  the keyword cannot drift across the http privacy cluster."
   privacy/redacted-sentinel)
 
 ;; ---- query-param denylist (rf2-2p8wr) -------------------------------------

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -24,9 +24,9 @@
             ;; trace fires (instead of an escaping `:rf.error/fx-handler-
             ;; exception`) when an invalid request header hits the managed
             ;; CLJS path. `re-frame.trace.tooling` owns the listener surface
-            ;; (rf2-qwm0a); `re-frame.http-privacy` carries the redaction
-            ;; sentinel for the denylist-scrub assertion.
-            [re-frame.http-privacy :as privacy]
+            ;; (rf2-qwm0a); `re-frame.http-url` carries the canonical redaction
+            ;; sentinel for the denylist-scrub assertion (rf2-m00e7p).
+            [re-frame.http-url :as http-url]
             [re-frame.test-support :as test-support]
             [re-frame.trace.tooling :as trace-tooling]))
 
@@ -593,7 +593,7 @@
 
 (deftest cljs-fetch-invalid-header-warning-redacts-denylisted-query-param
   (testing "rf2-f5pguu — the managed CLJS header-validation warning routes
-  its `:url` through `privacy/prepare-emit-tags` (same as the JVM path,
+  its `:url` through `re-frame.http-privacy/prepare-emit-tags` (same as the JVM path,
   rf2-1jcpm): a denylisted query param (`?api_key=…`) is scrubbed and
   `:sensitive?` is stamped at the top level of the trace event."
     (async done
@@ -619,7 +619,7 @@
                         "denylisted query-param value MUST be scrubbed in the trace URL")
                     (is (true? (:sensitive? w))
                         ":sensitive? stamped at top level — a denylisted param name is a signal")
-                    (is (= privacy/redacted-sentinel :rf/redacted)
+                    (is (= http-url/redacted-sentinel :rf/redacted)
                         "sanity: the redaction sentinel is the reserved keyword")))))
             (.then (fn [_] (done)))
             (.catch (fn [e]


### PR DESCRIPTION
Bead **rf2-m00e7p** — two tiny behaviour-PRESERVING http micro-leans.

## H1 — inline `form-encode-body`
`form-encode-body` (http_encoding.cljc) was a one-line wrapper around `params->query` with a single caller in `encode-body`'s `:form` branch. Inlined the call (`(params->query body)`) and deleted the helper.

## H2 — dedupe the `redacted-sentinel` re-export
The framework redaction sentinel has a single canonical home in core (`re-frame.privacy/redacted-sentinel`), re-exported on the http side as the public anchor `re-frame.http-url/redacted-sentinel`. `http-privacy` *also* publicly re-exported it, while `http-privacy-headers` already referred to it as `^:private`.

- Demoted `http-privacy`'s `redacted-sentinel` to `^:private` (matching `http-privacy-headers`) so it stays a terse internal alias for the redactor composer call sites (lines ~148–212) without duplicating the public surface. No leaf→parent cycle (`http-url` is already required).
- Repointed the single consumer of the now-removed public re-export — the http-cljs denylist-scrub test — at `http-url/redacted-sentinel`.
- Refreshed the now-stale "http-privacy re-exports it" docstring in `http-url`.

### Did H2's re-export have a consumer?
Yes, exactly one, and it was **internal to the http artefact**: `implementation/http/test/re_frame/http_cljs_test.cljs:622` (`privacy/redacted-sentinel`). No external consumer (swept tools/, all other implementation artefacts, tests, and `*.edn`/facade/manifest files — none reference `re-frame.http-privacy/redacted-sentinel`). All other http production files that alias `http-privacy :as privacy` consume only the composers, never the sentinel. Not a manifest/facade-tracked var, so no facade regen needed.

## Gates
- clj-kondo: 0 errors; 0 warnings on the four touched files (repo-wide http warnings are all pre-existing).
- http JVM suite (`clojure -M:test`): 448 tests / 2071 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 8022 tests / 33494 assertions, 0 failures, 0 errors.