### PR TITLE
refactor(epoch): collapse 4-way replace-*! clones + inline vestigial delta split (rf2-c0rv4v)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -138,16 +138,11 @@
   []
   (state/current-config))
 
-(defn- reset-config!
-  "Restore the epoch-history config to the shipped default baseline.
-  Test-support seam only — published through the `:epoch/reset-config!`
-  late-bind hook so `re-frame.test-support`'s reset-hook table can
-  isolate epoch config between tests without test namespaces
-  dereferencing the private `re-frame.epoch.state/config` var
-  (rf2-yw1w1u). Delegates to `state/reset-config!`, whose docstring is
-  the canonical pin."
-  []
-  (state/reset-config!))
+;; The test-support config-isolation seam (`:epoch/reset-config!`,
+;; rf2-yw1w1u) points straight at `state/reset-config!` from the late-bind
+;; map below (rf2-c0rv4v — no facade wrapper; `state/reset-config!`'s
+;; docstring is the canonical pin and there is no distinct public docstring
+;; to keep here).
 
 ;; The record-assembly helpers — `current-schema-digest`, the
 ;; sensitive-rollup family, and `build-record` itself — live in
@@ -220,23 +215,10 @@
 ;; `notify-listeners!` (the fan-out + failure-isolation policy) and
 ;; `on-frame-destroyed!` (the four-step destroy contract that
 ;; straddles state, capture, and assembly) live in
-;; `re-frame.epoch.listeners` (Phase-2 seam C, rf2-0wi86).
-
-(defn- on-frame-destroyed!
-  "Frame-teardown epoch hook (the `:epoch/on-frame-destroyed` late-bind
-  slot `re-frame.frame/destroy-frame!` fires at step 8). Delegates the
-  full four-step destroy contract — mid-drain `:halted-destroy` commit
-  (carrying the real `:db-before` / `:db-after` snapshots `destroy-frame!`
-  threads, per rf2-9neiq), `:rf.epoch.cb/silenced-on-frame-destroy`
-  fan-out, ring-buffer drop, and capture-buffer drop — to
-  `re-frame.epoch.listeners/on-frame-destroyed!`, whose docstring is the
-  canonical pin. `db-before` / `db-after` are the pre-cascade and
-  destroy-time snapshots `destroy-frame!` captured before the frame was
-  removed (both nil for an out-of-cascade destroy). `committed-at`
-  (rf2-bh56rc) is the destroying event's causal `:rf/time-ms`, used for the
-  `:halted-destroy` record's replayable `:committed-at`."
-  [frame-id db-before db-after committed-at]
-  (listeners/on-frame-destroyed! frame-id db-before db-after committed-at))
+;; `re-frame.epoch.listeners` (Phase-2 seam C, rf2-0wi86). The
+;; `:epoch/on-frame-destroyed` late-bind slot points straight at
+;; `listeners/on-frame-destroyed!` (rf2-c0rv4v — no facade wrapper; that
+;; seam carries no public docstring distinct from the listeners pin).
 
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;
@@ -583,167 +565,100 @@
     (listeners/notify-listeners! record)
     record))
 
-(defn- perform-replace-app-db!
-  "Carry out the `app-db` replacement once preconditions have passed.
-  Records a synthetic `:rf/epoch-record` (so `restore-epoch!` can rewind
-  the prior state), emits `:rf.epoch/db-replaced`, replaces the
-  container, and fans the record out to registered listeners. Returns
-  `true` on a real write.
+(defn- perform-replace!
+  "Carry out a partition-replace once preconditions have passed — the
+  shared body behind `perform-replace-app-db!` / `perform-replace-runtime-db!`
+  / `perform-replace-frame-state!` (rf2-c0rv4v). `write-fn` is a 0-arg thunk
+  that performs the `frame/replace-*!` partition write (the wrapper binds the
+  frame-id + new value into it); `fs-after-fn` builds the coherent
+  post-replace frame-state from the pre-replace `fs-before` (so restore of the
+  synthetic epoch reinstalls the right two-partition value). Returns `true`
+  on a real write.
 
-  Per rf2-7i872 (validate-then-destroy race): re-resolves the container
-  at the write boundary via `tool-pair/live-container-or-fail`. If the
-  frame was destroyed between the precondition pass and now, the container
-  is nil and `replace-container!` would silently no-op — so instead of
-  recording a synthetic epoch for a destroyed frame, fanning it out to
-  listeners, emitting `:rf.epoch/db-replaced`, and returning `true` (a
-  FALSE success against a frame that no longer exists), this emits the
-  canonical `:rf.error/no-such-handler` (kind `:frame`) failure trace and
-  returns `false`, matching the destroyed-frame contract.
+  Per rf2-7i872 (validate-then-destroy race): re-resolves the container at
+  the write boundary via `tool-pair/live-container-or-fail`. If the frame was
+  destroyed between the precondition pass and now, the container is nil and
+  `replace-container!` would silently no-op — so instead of recording a
+  synthetic epoch for a destroyed frame, fanning it out to listeners,
+  emitting `:rf.epoch/db-replaced`, and returning `true` (a FALSE success
+  against a frame that no longer exists), this emits the canonical
+  `:rf.error/no-such-handler` (kind `:frame`) failure trace and returns
+  `false`, matching the destroyed-frame contract.
 
   Per rf2-s93722 (post-liveness teardown race): the liveness check closes
   only HALF the window — a frame destroyed AFTER `live-container-or-fail`
-  passes but BEFORE `replace-app-db!` actually writes still slips through.
-  `frame/replace-app-db!` returns `nil` for a destroyed frame (a non-nil —
-  possibly EMPTY — changed-key-set for a live frame, even a no-op write),
-  so we check that return: a `nil` return is the destroyed-frame signal,
-  surfaced as the same `:rf.error/no-such-handler` (kind `:frame`) failure /
-  `false` return BEFORE any synthetic epoch, listener fanout, or success
-  telemetry."
-  [frame-id new-db]
+  passes but BEFORE the `frame/replace-*!` write actually lands still slips
+  through. The partition writers return `nil` for a destroyed frame (a
+  non-nil — possibly EMPTY — changed-key-set for a live frame, even a no-op
+  write), so we check that return: a `nil` return is the destroyed-frame
+  signal, surfaced as the same `:rf.error/no-such-handler` (kind `:frame`)
+  failure / `false` return BEFORE any synthetic epoch, listener fanout, or
+  success telemetry. On a real write records a synthetic epoch via
+  `record-synthetic-replace-epoch!` (single lockstep-maintained site for the
+  synthetic-record / committed-at / redaction contract — see that fn's
+  docstring for the rf2-bh56rc / rf2-czwwf4 / qs6dl rationale).
+
+  EP-0001 (rf2-adwcv6): the partition writes go through the `frame/replace-*!`
+  writers because `frame/app-db-container` / `runtime-db-container` are now
+  READ-ONLY projections, so a direct `replace-container!` on them throws."
+  [frame-id fs-after-fn write-fn]
   (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
     (if (= :fail outcome)
       (do (tool-pair/emit-precondition-failure! op tags)
           false)
       (let [;; EP-0001 (rf2-3aizt1): the canonical snapshot unit is the whole
-            ;; frame-state. `replace-app-db!` replaces ONLY the app-db
-            ;; partition (Mike ruling #10 — a db-shaped name never silently
-            ;; touches runtime-db), so the after-frame-state carries the new
-            ;; app-db with the live runtime-db preserved unchanged. Restore of
-            ;; this synthetic epoch reinstalls that coherent frame-state.
-            fs-before (frame/frame-state-value frame-id)
-            fs-after  (assoc fs-before frame/app-partition-key new-db)
-            ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION of the one
-            ;; physical frame-state container — `frame/app-db-container` is now
-            ;; a READ-ONLY projection, so a direct `replace-container!` on it
-            ;; throws. `replace-app-db!` replaces the app-db partition only;
-            ;; runtime-db is untouched (Mike ruling #10 — a db-shaped name
-            ;; never silently replaces runtime-db).
-            ;; rf2-s93722: capture the return — `nil` means the frame was
+            ;; frame-state; `fs-after-fn` builds the coherent post-replace
+            ;; value (app-db-only / runtime-db-only / both-partition per the
+            ;; calling wrapper). Restore of the synthetic epoch reinstalls it.
+            ;; rf2-s93722: capture the write return — `nil` means the frame was
             ;; destroyed in the post-liveness window (no write happened); a
             ;; non-nil changed-key-set (even empty) means the write landed.
-            changed   (frame/replace-app-db! frame-id new-db)]
+            fs-before (frame/frame-state-value frame-id)
+            fs-after  (fs-after-fn fs-before)
+            changed   (write-fn)]
         (if (nil? changed)
           (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
                                                     {:kind :frame :frame frame-id})
               false)
-          (do
-            ;; Record a synthetic epoch so `restore-epoch!` can rewind the
-            ;; previous state, stamp it as last-settled, emit
-            ;; `:rf.epoch/db-replaced`, and fan it out — shared with the
-            ;; runtime-db / frame-state perform helpers via
-            ;; `record-synthetic-replace-epoch!` (single lockstep-maintained
-            ;; site for the synthetic-record / committed-at / redaction
-            ;; contract — see that fn's docstring for the rf2-bh56rc /
-            ;; rf2-czwwf4 / qs6dl rationale).
-            (record-synthetic-replace-epoch! frame-id fs-before fs-after)
-            true))))))
+          (do (record-synthetic-replace-epoch! frame-id fs-before fs-after)
+              true))))))
+
+(defn- perform-replace-app-db!
+  "Carry out the `app-db` replacement once preconditions have passed.
+  Replaces ONLY the app-db partition (Mike ruling #10 — a db-shaped name
+  never silently touches runtime-db); the after-frame-state carries the new
+  app-db with the live runtime-db preserved unchanged. Partition-binding
+  wrapper over `perform-replace!` (rf2-c0rv4v) — see that fn for the full
+  validate-then-destroy / post-liveness-teardown contract."
+  [frame-id new-db]
+  (perform-replace! frame-id
+                    #(assoc % frame/app-partition-key new-db)
+                    #(frame/replace-app-db! frame-id new-db)))
 
 (defn- perform-replace-runtime-db!
   "Carry out the runtime-db replacement once preconditions have passed —
   the runtime-db sibling of `perform-replace-app-db!`. Replaces ONLY the
-  runtime-db partition (app-db preserved unchanged), records a synthetic
-  `:rf/epoch-record` (so `restore-epoch!` can rewind the prior state),
-  emits `:rf.epoch/db-replaced`, and fans the record out to listeners.
-  Returns `true` on a real write.
-
-  Per rf2-7i872 (validate-then-destroy race): re-resolves the live
-  container at the write boundary via `live-container-or-fail`. If the
-  frame was destroyed between the precondition pass and now, this reports
-  the canonical `:rf.error/no-such-handler` (kind `:frame`) failure and
-  returns `false` rather than recording a synthetic epoch for a destroyed
-  frame, matching the destroyed-frame contract.
-
-  Per rf2-s93722 (post-liveness teardown race): the liveness check closes
-  only HALF the window — a frame destroyed AFTER `live-container-or-fail`
-  passes but BEFORE `replace-runtime-db!` actually writes still slips
-  through. `frame/replace-runtime-db!` returns `nil` for a destroyed frame
-  (a non-nil — possibly EMPTY — changed-key-set for a live frame, even a
-  no-op write), so a `nil` return is the destroyed-frame signal, surfaced
-  as the same `:rf.error/no-such-handler` (kind `:frame`) failure / `false`
-  return BEFORE any synthetic epoch, listener fanout, or success telemetry."
+  runtime-db partition (app-db preserved unchanged). Partition-binding
+  wrapper over `perform-replace!` (rf2-c0rv4v)."
   [frame-id new-runtime-db]
-  (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
-    (if (= :fail outcome)
-      (do (tool-pair/emit-precondition-failure! op tags)
-          false)
-      (let [;; The canonical snapshot unit is the whole frame-state.
-            ;; `replace-runtime-db!` replaces ONLY the runtime-db partition
-            ;; (app-db preserved), so the after-frame-state carries the live
-            ;; app-db with the new runtime-db. Restore of this synthetic
-            ;; epoch reinstalls that coherent frame-state.
-            fs-before (frame/frame-state-value frame-id)
-            fs-after  (assoc fs-before frame/runtime-partition-key new-runtime-db)
-            ;; Write the runtime-db PARTITION of the one physical frame-state
-            ;; container; `frame/runtime-db-container` is a READ-ONLY
-            ;; projection, so the write goes through `frame/replace-runtime-db!`.
-            ;; rf2-s93722: capture the return — `nil` means the frame was
-            ;; destroyed in the post-liveness window (no write happened); a
-            ;; non-nil changed-key-set (even empty) means the write landed.
-            changed   (frame/replace-runtime-db! frame-id new-runtime-db)]
-        (if (nil? changed)
-          (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
-                                                    {:kind :frame :frame frame-id})
-              false)
-          (do (record-synthetic-replace-epoch! frame-id fs-before fs-after)
-              true))))))
+  (perform-replace! frame-id
+                    #(assoc % frame/runtime-partition-key new-runtime-db)
+                    #(frame/replace-runtime-db! frame-id new-runtime-db)))
 
 (defn- perform-replace-frame-state!
   "Carry out the full-frame (both-partition) replacement once preconditions
   have passed — the whole-frame sibling of `perform-replace-app-db!`.
-  Replaces BOTH partitions atomically (`{:rf.db/app … :rf.db/runtime …}`),
-  records a synthetic `:rf/epoch-record` (so `restore-epoch!` can rewind the
-  prior state), emits `:rf.epoch/db-replaced`, and fans the record out to
-  listeners. Returns `true` on a real write.
-
-  Per rf2-7i872 (validate-then-destroy race): re-resolves the live
-  container at the write boundary via `live-container-or-fail`. If the
-  frame was destroyed between the precondition pass and now, this reports
-  the canonical `:rf.error/no-such-handler` (kind `:frame`) failure and
-  returns `false`, matching the destroyed-frame contract.
-
-  Per rf2-s93722 (post-liveness teardown race): the liveness check closes
-  only HALF the window — a frame destroyed AFTER `live-container-or-fail`
-  passes but BEFORE `replace-frame-state!` actually writes still slips
-  through. `frame/replace-frame-state!` returns `nil` for a destroyed frame
-  (a non-nil — possibly EMPTY — changed-key-set for a live frame, even a
-  no-op write), so a `nil` return is the destroyed-frame signal, surfaced
-  as the same `:rf.error/no-such-handler` (kind `:frame`) failure / `false`
-  return BEFORE any synthetic epoch, listener fanout, or success telemetry."
+  Replaces BOTH partitions atomically (`{:rf.db/app … :rf.db/runtime …}`).
+  A missing partition key installs `nil` for that partition (a full-frame
+  replace is whole-value by contract — see `frame/replace-frame-state!`);
+  the recorded after-state is normalised to the same coherent shape.
+  Partition-binding wrapper over `perform-replace!` (rf2-c0rv4v)."
   [frame-id new-frame-state]
-  (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
-    (if (= :fail outcome)
-      (do (tool-pair/emit-precondition-failure! op tags)
-          false)
-      (let [fs-before (frame/frame-state-value frame-id)
-            ;; The canonical after-frame-state is the coherent two-partition
-            ;; value the caller installs. A missing partition key installs
-            ;; `nil` for that partition (a full-frame replace is whole-value
-            ;; by contract — see `frame/replace-frame-state!`); normalise the
-            ;; recorded after-state to the same coherent shape.
-            fs-after  {frame/app-partition-key     (get new-frame-state frame/app-partition-key)
-                       frame/runtime-partition-key (get new-frame-state frame/runtime-partition-key)}
-            ;; Write BOTH partitions in ONE atomic install through the one
-            ;; physical frame-state container via `frame/replace-frame-state!`.
-            ;; rf2-s93722: capture the return — `nil` means the frame was
-            ;; destroyed in the post-liveness window (no write happened); a
-            ;; non-nil changed-key-set (even empty) means the write landed.
-            changed   (frame/replace-frame-state! frame-id new-frame-state)]
-        (if (nil? changed)
-          (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
-                                                    {:kind :frame :frame frame-id})
-              false)
-          (do (record-synthetic-replace-epoch! frame-id fs-before fs-after)
-              true))))))
+  (perform-replace! frame-id
+                    (fn [_fs-before]
+                      {frame/app-partition-key     (get new-frame-state frame/app-partition-key)
+                       frame/runtime-partition-key (get new-frame-state frame/runtime-partition-key)})
+                    #(frame/replace-frame-state! frame-id new-frame-state)))
 
 (defn replace-app-db!
   "Replace `frame-id`'s `app-db` partition with `new-db`, bypassing the
@@ -1043,8 +958,9 @@
    ;; rf2-yw1w1u: test-support config-isolation hook. `re-frame.test-
    ;; support`'s reset-hook table fires this to restore epoch config to
    ;; the shipped default between tests, so test namespaces no longer
-   ;; reset the private `state/config` var directly.
-   :epoch/reset-config!              reset-config!
+   ;; reset the private `state/config` var directly. rf2-c0rv4v: points
+   ;; straight at the `state/reset-config!` seam (no facade wrapper).
+   :epoch/reset-config!              state/reset-config!
    :epoch/clear-history!             clear-history!
    :epoch/clear-epoch-listeners!     clear-epoch-listeners!
 

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -630,95 +630,6 @@
 ;; does the ring mutation and the two public fns are thin wrappers
 ;; pinning the slot.
 
-(defn- compute-delta
-  "Inspect the newly-appended delta (the new `:trace-events` `event` and
-  the new `slot` `row`) and return a MAP describing what to splice:
-
-    {:append?       <bool — was there a :trace-events delta?>
-     :row?          <bool — was there a structured `slot` row delta?>
-     :event         <the RAW :trace-events delta value, when :append?>
-     :slot          <the structured slot keyword>
-     :row-value     <the RAW `slot` delta row, when :row?>
-     :sensitive?    <bool — did the back-filled event carry the
-                     `:sensitive?` stamp? (rf2-j1ec6.1 rollup OR-source)>}
-
-  Returns `nil` when there is no delta to append (an unmount on a record
-  whose `:trace-events` was already dropped by the keep-window cap).
-
-  Per EP-0015 §15 + open-issue 6 (RULED, hardened): the back-fill stores
-  the RAW delta. Storage-side redaction was REMOVED — the ring is causal
-  replay material; the `:redact-fn` advanced override runs projection-side
-  only (inside `projected-record`), so the off-box egress sees the
-  redacted shape while the ring keeps the exact raw delta. There is no
-  per-back-fill redact invocation and therefore no non-idempotent-fn /
-  redact-outside-swap hazard (the old rf2-82pcg / rf2-7i872 / rf2-qhxz6
-  storage-side dance) — those concerns are gone by construction.
-
-  Per rf2-j1ec6.1 (Security.md:109 §Sensitive rollup): the record-level
-  `:rf.epoch/sensitive?` rollup MUST consider `:trace-events` overlap, but
-  `build-record` computes it ONCE at settle time over the SETTLE-TIME
-  events — a post-settle back-fill that appends a `:sensitive?`-stamped
-  trace event would otherwise leave the rollup stale-false. We capture the
-  back-filled event's `:sensitive?` stamp HERE so the pure `splice-delta`
-  can OR it into the record's rollup inside the swap (fail-CLOSED —
-  mayor-ruled option a)."
-  [record slot event row]
-  (let [append? (contains? record :trace-events)
-        row?    (some? row)
-        delta?  (or append? row?)]
-    (when delta?
-      (cond-> {:append?    append?
-               :row?       row?
-               :slot       slot
-               :sensitive? (privacy/sensitive? event)}
-        append? (assoc :event event)
-        row?    (assoc :row-value row)))))
-
-(defn- splice-delta
-  "PURE splice of a precomputed RAW delta (from `compute-delta`) onto
-  `record`'s real slots. Returns the updated record.
-
-  This is the ONLY part of the back-fill that rides inside the ring
-  `swap!`. It invokes NO injected fn — a CAS retry re-runs this splice
-  (re-reading the retried record's real slots) with no side effects.
-  Conjes the raw delta element onto a vector (or absent) real slot; a
-  slot already collapsed to a non-vector scalar (an unusual shape) is
-  left untouched (the delta is subsumed).
-
-  Per rf2-j1ec6.1: the record-level `:rf.epoch/sensitive?` rollup is
-  OR'd with the back-filled event's RAW sensitivity (`:sensitive?` on the
-  precomputed `delta`). A post-settle back-fill of a `:sensitive?`-stamped
-  trace event flips the rollup `true`, keeping the Security.md:109
-  invariant (the rollup considers `:trace-events` overlap) literally true
-  post-back-fill — coarse drop-gate consumers that branch on the boolean
-  rollup now correctly drop a record whose only sensitive content arrived
-  via back-fill. The OR is monotonic/idempotent, so it rides safely inside
-  the CAS-retried swap (a retry re-ORs the same true with no corruption).
-
-  `delta` nil (no append) is a pass-through — return the record
-  untouched."
-  [record delta]
-  (if (nil? delta)
-    record
-    (let [{:keys [append? row? slot event row-value sensitive?]} delta
-          splice (fn [rec real-slot dv]
-                   (cond
-                     (vector? (get rec real-slot))
-                     (update rec real-slot conj dv)
-
-                     (not (contains? rec real-slot))
-                     (assoc rec real-slot [dv])
-
-                     :else               ; real slot already a scalar
-                     rec))]              ; delta subsumed
-      (cond-> record
-        append?    (splice :trace-events event)
-        row?       (splice slot row-value)
-        ;; rf2-j1ec6.1 fail-CLOSED rollup recompute: OR the back-filled
-        ;; event's sensitivity into the record-level rollup. Only flips
-        ;; false→true (never clears a settle-time true).
-        sensitive? (assoc :rf.epoch/sensitive? true)))))
-
 (defn- back-fill-event!
   "Append the RAW `event` and its projected `row` (into the `slot`
   projection) on the already-committed epoch record identified by
@@ -752,18 +663,66 @@
   the back-fill once needed to plug, the rf2-qhxz6 once-per-slot narrowing,
   the rf2-7i872 redact-outside-swap fix) is GONE: with no per-back-fill
   redact invocation there is no leak to close on the storage path and no
-  non-idempotent-fn hazard inside the swap. The record index is resolved
-  once up-front (within-frame drain is single-threaded — Spec 002
-  §Run-to-completion — so no append can shift it between this deref and the
-  swap), reused by the delta computation, the pure swap, and the post-swap
-  read. nil when the epoch is absent from the ring (evicted, or fired
-  before any cascade settled)."
+  non-idempotent-fn hazard inside the swap.
+
+  rf2-c0rv4v: the splice is a single PURE `swap!` update fn. It invokes no
+  injected fn — `privacy/sensitive?` is a pure predicate, and the only
+  remaining recompute is the rf2-j1ec6.1 sensitivity OR-rollup — so a CAS
+  retry re-runs it (re-reading the retried record's real slots) with no
+  side effects. (Post-EP-0015 §15 the prior two-phase `compute-delta` →
+  `splice-delta` split was vestigial: it existed to keep an injected
+  storage-side redact-fn OUT of the CAS-retried swap, and that redact
+  invocation is gone — the split was inlined here, rf2-c0rv4v.) Conjes the
+  raw delta element onto a vector (or absent) real slot; a slot already
+  collapsed to a non-vector scalar (an unusual shape) is left untouched
+  (the delta is subsumed). The record index is resolved once up-front
+  (within-frame drain is single-threaded — Spec 002 §Run-to-completion — so
+  no append can shift it between this deref and the swap). nil when the
+  epoch is absent from the ring (evicted, or fired before any cascade
+  settled)."
   [frame-id epoch-id slot event row]
   (let [idx (epoch-index (history-for frame-id) epoch-id)]
     (when idx
-      (let [record (get-in @histories [frame-id idx])
-            delta  (compute-delta record slot event row)
-            splice (fn [rec] (splice-delta rec delta))]
+      (let [record  (get-in @histories [frame-id idx])
+            ;; Was there anything to splice? `:trace-events` is appended only
+            ;; when the record retained its raw stream (keep-window); a
+            ;; non-nil `row` rides the structured `slot`. No delta → the swap
+            ;; is a pass-through (e.g. an unmount on a record whose trace
+            ;; stream was already dropped by the keep-window cap); the
+            ;; sensitivity rollup is NOT touched when there is no delta to
+            ;; carry it, matching the prior `compute-delta` nil short-circuit.
+            append? (contains? record :trace-events)
+            row?    (some? row)
+            delta?  (or append? row?)
+            ;; rf2-j1ec6.1 (Security.md:109 §Sensitive rollup): the record-
+            ;; level `:rf.epoch/sensitive?` rollup MUST consider :trace-events
+            ;; overlap, but `build-record` computes it ONCE at settle time over
+            ;; the SETTLE-TIME events; a post-settle back-fill of a
+            ;; `:sensitive?`-stamped trace event would otherwise leave the
+            ;; rollup stale-false. `privacy/sensitive?` is pure — read it once
+            ;; here (depends only on `event`) so the swap fn OR's it into the
+            ;; rollup fail-CLOSED (mayor-ruled option a). The OR is
+            ;; monotonic/idempotent (only flips false→true, never clears a
+            ;; settle-time true), so it rides safely inside the CAS-retried
+            ;; swap.
+            sens?   (privacy/sensitive? event)
+            splice-slot (fn [rec real-slot dv]
+                          (cond
+                            (vector? (get rec real-slot))
+                            (update rec real-slot conj dv)
+
+                            (not (contains? rec real-slot))
+                            (assoc rec real-slot [dv])
+
+                            :else            ; real slot already a scalar
+                            rec))            ; delta subsumed
+            splice (fn [rec]
+                     (if-not delta?
+                       rec                   ; no delta → pure pass-through
+                       (cond-> rec
+                         append? (splice-slot :trace-events event)
+                         row?    (splice-slot slot row)
+                         sens?   (assoc :rf.epoch/sensitive? true))))]
         (-> (swap! histories update-in [frame-id idx] splice)
             (get-in [frame-id idx]))))))
 

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -815,122 +815,87 @@
               (quiesce-orphaned-async-host-work! frame-id)
               true))))))
 
-;; ---- replace-app-db! preconditions ----------------------------------------
+;; ---- replace-*! preconditions ---------------------------------------------
+;;
+;; rf2-c0rv4v: the four-mutator family (`replace-app-db!` /
+;; `replace-runtime-db!` / `replace-frame-state!`) shares one precondition
+;; skeleton — (1) frame registered? (2) in-flight drain? (3) schema mismatch?
+;; — differing ONLY in which schema walk step (3) runs. `check-replace-
+;; preconditions!` is that skeleton parameterised by a `schema-check-fn`
+;; (a 0-arity thunk yielding the failing-path vector for the candidate
+;; value, or [] for valid / soft-pass), and the three public-facing
+;; validators are one-line bindings of the matching walk. Per Tool-Pair
+;; §Pair-tool writes the mutators share the identical failure-mode shape —
+;; the same `:rf.epoch/replace-*` trace ops cover all (Spec 009 §Trace
+;; events explicitly lists `replace-runtime-db!` / `replace-frame-state!`
+;; under those ops).
+
+(defn- check-replace-preconditions!
+  "Shared skeleton for the four-mutator precondition family (rf2-c0rv4v).
+  `schema-check-fn` is a 0-arity thunk returning the failing schema-path
+  vector for the candidate value (or [] for the valid / soft-pass cases);
+  it runs only on the `:else` branch after the frame-registered + drain
+  checks pass, so a frame-miss / in-flight-drain failure short-circuits
+  before any schema walk. Returns `{:outcome :ok}` when all checks pass,
+  otherwise `{:outcome :fail :op <kw> :tags <map>}` matching the
+  precondition-failure shape of `check-restore-preconditions!`. Pure data —
+  no trace events emitted from here; emission is the caller's job."
+  [frame-id schema-check-fn]
+  (let [frame-result (frame-exists-or-fail frame-id)]
+    (cond
+      ;; (1) Frame registered?
+      (= :fail (:outcome frame-result))
+      frame-result
+
+      ;; (2) In-flight drain?
+      (drain-in-flight? (:frame-record frame-result))
+      {:outcome :fail
+       :op      :rf.epoch/replace-during-drain
+       :tags    {:frame frame-id}}
+
+      :else
+      ;; (3) Schema mismatch? The caller's schema walk yields the failing
+      ;; paths (or [] for the valid / soft-pass cases).
+      (let [failing (schema-check-fn)]
+        (if (seq failing)
+          {:outcome :fail
+           :op      :rf.epoch/replace-schema-mismatch
+           :tags    {:frame         frame-id
+                     :failing-paths failing}}
+          {:outcome :ok})))))
 
 (defn check-replace-app-db-preconditions!
   "Validate the three documented preconditions for `replace-app-db!`.
-  Returns `{:outcome :ok}` when all checks pass, otherwise
-  `{:outcome :fail :op <kw> :tags <map>}` matching the precondition-
-  failure shape of `check-restore-preconditions!`. Pure data — no
-  trace events emitted from here; emission is the caller's job."
+  Step (3) walks `new-db` against the frame's app-schema set
+  (`failing-schema-paths`). See `check-replace-preconditions!` for the
+  shared skeleton + return shape."
   [frame-id new-db]
-  (let [frame-result (frame-exists-or-fail frame-id)]
-    (cond
-      ;; (1) Frame registered?
-      (= :fail (:outcome frame-result))
-      frame-result
-
-      ;; (2) In-flight drain?
-      (drain-in-flight? (:frame-record frame-result))
-      {:outcome :fail
-       :op      :rf.epoch/replace-during-drain
-       :tags    {:frame frame-id}}
-
-      :else
-      ;; (3) Schema mismatch? Single walk — `failing-schema-paths`
-      ;; returns the failing paths (or [] for the valid / soft-pass
-      ;; cases), folding what was previously a two-helper / two-walk
-      ;; chain into one.
-      (let [failing (failing-schema-paths frame-id new-db)]
-        (if (seq failing)
-          {:outcome :fail
-           :op      :rf.epoch/replace-schema-mismatch
-           :tags    {:frame         frame-id
-                     :failing-paths failing}}
-          {:outcome :ok})))))
+  (check-replace-preconditions!
+    frame-id #(failing-schema-paths frame-id new-db)))
 
 (defn check-replace-runtime-db-preconditions!
   "Validate the three documented preconditions for `replace-runtime-db!`
-  (the runtime-db sibling of `check-replace-app-db-preconditions!`).
-  Returns `{:outcome :ok}` when all checks pass, otherwise
-  `{:outcome :fail :op <kw> :tags <map>}`. Pure data — no trace events
-  emitted from here; emission is the caller's job.
-
-  Per Tool-Pair §Pair-tool writes the four injection mutators share the
-  identical failure-mode shape — the same `:rf.epoch/replace-*`
-  trace ops cover all four (Spec 009 §Trace events explicitly lists
-  `replace-runtime-db!` / `replace-frame-state!` under those ops). The
-  only difference is the schema check targets the runtime-db partition
-  against the framework-owned runtime-db validator (`failing-runtime-
-  paths`), NOT the user app-schema set."
+  (the runtime-db sibling). Step (3) walks `new-runtime-db` against the
+  framework-owned runtime-db validator (`failing-runtime-paths`,
+  `reg-runtime-schema`), NOT the user app-schema set. See
+  `check-replace-preconditions!` for the shared skeleton + return shape."
   [frame-id new-runtime-db]
-  (let [frame-result (frame-exists-or-fail frame-id)]
-    (cond
-      ;; (1) Frame registered?
-      (= :fail (:outcome frame-result))
-      frame-result
-
-      ;; (2) In-flight drain?
-      (drain-in-flight? (:frame-record frame-result))
-      {:outcome :fail
-       :op      :rf.epoch/replace-during-drain
-       :tags    {:frame frame-id}}
-
-      :else
-      ;; (3) Runtime-db schema mismatch? Single walk against the
-      ;; framework-owned runtime-db validator (Tool-Pair §Pair-tool writes
-      ;; — the runtime-db side is checked against `reg-runtime-schema`, not
-      ;; the app-schema set).
-      (let [failing (failing-runtime-paths frame-id new-runtime-db)]
-        (if (seq failing)
-          {:outcome :fail
-           :op      :rf.epoch/replace-schema-mismatch
-           :tags    {:frame         frame-id
-                     :failing-paths failing}}
-          {:outcome :ok})))))
+  (check-replace-preconditions!
+    frame-id #(failing-runtime-paths frame-id new-runtime-db)))
 
 (defn check-replace-frame-state-preconditions!
   "Validate the three documented preconditions for `replace-frame-state!`
-  (the full-frame sibling of `check-replace-app-db-preconditions!`).
-  Returns `{:outcome :ok}` when all checks pass, otherwise
-  `{:outcome :fail :op <kw> :tags <map>}`. Pure data — no trace events
-  emitted from here; emission is the caller's job.
-
-  `frame-state` carries BOTH partitions (`{:rf.db/app … :rf.db/runtime …}`),
-  so the schema check validates the app-db partition against the frame's
-  app-schema set AND the runtime-db partition against the framework-owned
-  runtime-db validator, surfacing the union of failing paths (Tool-Pair
-  §Pair-tool writes — `replace-frame-state!` replaces both atomically, so
-  either partition's schema failure rejects the whole install)."
+  (the full-frame sibling). `frame-state` carries BOTH partitions
+  (`{:rf.db/app … :rf.db/runtime …}`); step (3) validates the app-db
+  partition against the frame's app-schema set AND the runtime-db partition
+  against the framework-owned runtime-db validator, surfacing the UNION of
+  failing paths — a failure on EITHER rejects the whole atomic install. See
+  `check-replace-preconditions!` for the shared skeleton + return shape."
   [frame-id frame-state]
-  (let [frame-result (frame-exists-or-fail frame-id)]
-    (cond
-      ;; (1) Frame registered?
-      (= :fail (:outcome frame-result))
-      frame-result
-
-      ;; (2) In-flight drain?
-      (drain-in-flight? (:frame-record frame-result))
-      {:outcome :fail
-       :op      :rf.epoch/replace-during-drain
-       :tags    {:frame frame-id}}
-
-      :else
-      ;; (3) Schema mismatch? Both partitions are validated — the app-db
-      ;; side against the app-schema set, the runtime-db side against the
-      ;; framework-owned runtime-db validator. A failure on EITHER rejects
-      ;; the whole atomic install; the trace carries the union of failing
-      ;; paths.
-      (let [app-db      (get frame-state frame/app-partition-key)
-            runtime-db  (get frame-state frame/runtime-partition-key)
-            failing     (into (vec (failing-schema-paths frame-id app-db))
-                              (failing-runtime-paths frame-id runtime-db))]
-        (if (seq failing)
-          {:outcome :fail
-           :op      :rf.epoch/replace-schema-mismatch
-           :tags    {:frame         frame-id
-                     :failing-paths failing}}
-          {:outcome :ok})))))
+  (check-replace-preconditions!
+    frame-id
+    #(into (vec (failing-schema-paths frame-id (get frame-state frame/app-partition-key)))
+           (failing-runtime-paths frame-id (get frame-state frame/runtime-partition-key)))))
 
 ;; ---- projected egress -----------------------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -338,8 +338,8 @@
 ;; only sensitive content arrived via back-fill.
 ;;
 ;; THE FIX (mayor-ruled option a, fail-CLOSED): the back-fill swap OR's the
-;; rollup with the appended event's RAW sensitivity (`state/compute-delta`
-;; → `splice-delta`), flipping false→true.
+;; rollup with the appended event's RAW sensitivity (the pure splice inside
+;; `state/back-fill-event!`), flipping false→true.
 
 (defn- emit-sensitive-sub-run!
   "Emit a reactive `:rf.sub/run` at React-DEREF timing carrying the

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -537,7 +537,8 @@
 ;; (RULED, hardened) the back-fill stores the RAW delta — storage-side
 ;; redaction was REMOVED (the ring is causal replay material; the
 ;; `:redact-fn` advanced override runs projection-side only). The swap
-;; update fn (`splice-delta`) is therefore PURE — it invokes no injected
+;; update fn (the pure splice inside `back-fill-event!`, rf2-c0rv4v) is
+;; therefore PURE — it invokes no injected
 ;; fn, so a JVM CAS retry re-runs only the pure splice. The pre-removal
 ;; redact-outside-swap dance (rf2-7i872) is gone by construction: there is
 ;; no per-back-fill redact invocation, hence no double-invoke / duplicate-


### PR DESCRIPTION
## What

Behaviour-PRESERVING structural lean of the epoch surface (rf2-c0rv4v). No semantic change — the epoch surface was verified correct; this only removes duplication. Guarded by the epoch JVM suite + CLJS suite, both 0 failures.

### E1 — collapse the near-identical `replace-*!` clone family
- **tool_pair**: the three `check-replace-{app-db,runtime-db,frame-state}-preconditions!` shared one skeleton (frame-registered? / in-flight-drain? / schema-mismatch?), differing only in step (3)'s schema walk. Extracted a private `check-replace-preconditions!` parameterised by a schema-check thunk; the three public validators are now one-line bindings of the matching walk.
- **epoch**: the three `perform-replace-{app-db,runtime-db,frame-state}!` helpers shared the identical `live-container-or-fail` + nil-return (rf2-s93722) + synthetic-epoch body, differing only in the `fs-after` builder and which `frame/replace-*!` they call. Extracted a private `perform-replace!` taking `{:fs-after-fn :write-fn}`; the three become one-line partition-binding wrappers. The rf2-s93722 post-liveness nil-guard / `:rf.error/no-such-handler` dance is now written once instead of copy-pasted 3x.

### E2 — drop two dead/vestigial non-public facade wrappers
- `on-frame-destroyed!` was already **dead code** — the `:epoch/on-frame-destroyed` late-bind slot points straight at `listeners/on-frame-destroyed!`, never at the wrapper. Deleted.
- `reset-config!` was a pure docstring-only pass-through to `state/reset-config!`; pointed `:epoch/reset-config!` straight at the seam fn and deleted the wrapper (`state/reset-config!`'s docstring is the canonical pin).

### E3 — inline the vestigial two-phase back-fill delta split
`state/compute-delta` → `splice-delta` existed to keep an injected storage-side `:redact-fn` OUT of the CAS-retried swap. Post-EP-0015 §15 storage-side redaction was removed (the ring is raw causal-replay material; redaction is projection-side only), leaving `compute-delta` calling only the **pure** `privacy/sensitive?` predicate. Inlined both into `back-fill-event!` as a single pure swap update fn. The rf2-j1ec6.1 `:sensitive?` OR-rollup is preserved byte-for-byte, **including the no-delta short-circuit** (no rollup touch when there is nothing to splice — matching the prior `compute-delta` nil return).

## Line delta
192 insertions / 356 deletions (net **-164**).

## Quality gates (all green)
- Epoch JVM suite (`clojure -M:test` from implementation/epoch): **362 tests / 1435 assertions, 0 failures, 0 errors**
- CLJS suite (`npm run test:cljs`): **8022 tests / 33494 assertions, 0 failures, 0 errors**
- Production elision probe (`npm run test:elision`): PASS (41/41 absent in production, dev-only gating intact)
- clj-kondo: 0 new warnings (the pre-existing `re-frame.substrate.adapter required but never used` warning is on origin/main, unrelated)

## Surface
No facade/manifest change — only private `(defn-)` helpers and one internal seam-ns (`tool_pair`) signature touched. The `re-frame.core` public epoch surface is untouched (no `(defn ` public-fn lines in the diff). Late-bind hook KEYS unchanged (only the producing fn each key points at, within the epoch artefact).