### PR TITLE
refactor(machines): spec-from-registry helper + shared actor-teardown pipeline (rf2-q5lkoi)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -149,9 +149,7 @@
   coords) for `machine-id`, or nil if no machine is registered under
   that id. Per Spec 005 §Querying machines."
   [machine-id]
-  (let [m (registrar/lookup :event machine-id)]
-    (when (:rf/machine? m)
-      (:rf/machine m))))
+  (resolver/spec-from-registry machine-id))
 
 (defn machine-by-system-id
   "Look up the spawned-machine id currently bound to `system-id` in the

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -81,6 +81,68 @@
                 (contains? (get-in runtime-db (paths/snapshot-path)) actor-id))
            (some #(= actor-id %) (spawn-order/frame-order frame-id)))))
 
+(defn- teardown-live-actor!
+  "The shared ordered teardown pipeline for a LIVE actor (the caller has
+  already confirmed liveness). Both destroy entry-points — the per-actor
+  `destroy-single-actor!` and the keyword/tracked `destroy-single!` — run
+  this IDENTICAL ordered sequence; they differ only in actor-id resolution
+  (done in the caller) and whether they emit the `:rf.machine/destroyed`
+  trace (passed as `emit-destroyed!-fn`).
+
+  Ordered steps (Spec 005 §Declarative `:spawn` §Composition with explicit
+  `:entry` / `:exit`; §Cancellation cascade D6-D8):
+
+    1. (rf2-nahfm) run the active configuration's `:exit` cascade BEFORE
+       any teardown work — fires `:exit`-emitted fx via do-fx and writes
+       any `:data` updates back to the (about-to-be-dissoc'd) snapshot;
+    2. (rf2-wvkn) abort in-flight `:rf.http/managed` requests;
+    3. (rf2-egvm4t) drop the actor's per-instance `:data-schema` marks so
+       no marks-table residue survives (symmetric with the snapshot dissoc
+       + registrar unregister below);
+    4. (rf2-82a0u) cancel armed `:after` timers, one
+       `:rf.machine.timer/cancelled :reason :on-destroy` trace per timer;
+    5. apply the unified teardown projection (`teardown/teardown-actor`),
+       capturing the released `:system-id` via a side channel so we keep a
+       single runtime-db read + single write (machine snapshots are durable
+       runtime-db state, rf2-vzld77). `teardown-args` selects the slots the
+       projection prunes (`{:actor-id …}` for the per-actor form; the
+       tracked map adds `:parent-id` / `:invoke-id`);
+    6. emit `:rf.machine/destroyed` via the optional `emit-destroyed!-fn`
+       (called with the released sid) — `destroy-single!` emits here so the
+       trace lands after `:exit` (rf2-iilco); `destroy-single-actor!`'s
+       callers own the emit, so they pass nil;
+    7. (rf2-vsigt) forget the actor from the per-frame spawn-order channel
+       REGARDLESS of whether the runtime-db swap landed — by the time
+       frame-destroy runs the container may already be nil but the
+       spawn-order entry still needs clearing;
+    8. when the swap landed, emit `:rf.machine/system-id-released` and
+       unregister the live event handler (last, so an in-flight trace emit
+       against the actor still resolves before the slot disappears).
+
+  Returns the `db-swapped?` flag from the teardown projection."
+  [frame-id actor-id teardown-args emit-destroyed!-fn]
+  (exit-cascade/run-child-exit! frame-id actor-id)
+  (finalize/abort-actor-in-flight-http! actor-id)
+  (finalize/clear-actor-schema-marks! actor-id)
+  (timer/cancel-actor-timers! frame-id actor-id)
+  ;; `teardown-actor` returns [new-runtime-db released-sid]; `swap-runtime-db!`
+  ;; expects a fn returning the new runtime-db only, so capture the sid via a
+  ;; volatile side channel.
+  (let [sid         (volatile! nil)
+        db-swapped? (frame/swap-runtime-db! frame-id
+                                            (fn [runtime-db]
+                                              (let [[new-rt released-sid]
+                                                    (teardown/teardown-actor runtime-db teardown-args)]
+                                                (vreset! sid released-sid)
+                                                new-rt)))]
+    (when emit-destroyed!-fn
+      (emit-destroyed!-fn @sid))
+    (spawn-order/forget! frame-id actor-id)
+    (when db-swapped?
+      (traces/emit-system-id-released! frame-id @sid actor-id)
+      (registrar/unregister! :event actor-id))
+    db-swapped?))
+
 (defn destroy-single-actor!
   "Destroy a single spawned actor against the frame's container: run
   the active configuration's `:exit` cascade (rf2-nahfm), apply the
@@ -89,6 +151,8 @@
   `:rf.http/managed` requests (rf2-wvkn), emit the
   `:system-id-released` trace, unregister the live event handler, and
   forget the actor from the per-frame spawn-order channel (rf2-vsigt).
+  The ordered teardown pipeline is shared with `destroy-single!` via
+  `teardown-live-actor!`.
 
   Used by `destroy-machine-fx` for the keyword-form imperative
   destroy AND iterated for each child in a `:spawn-all` teardown, AND
@@ -110,42 +174,11 @@
   `destroy-single!` carries (rf2-lbjnz)."
   [frame-id actor-id]
   (when (actor-live? frame-id actor-id (frame/frame-runtime-db-value frame-id))
-    ;; (rf2-nahfm) Run the active configuration's `:exit` cascade
-    ;; BEFORE any teardown work. This fires `:exit`-emitted fx via
-    ;; do-fx and writes any `:data` updates back to the snapshot —
-    ;; both transient (the snapshot is dissoc'd two steps later).
-    (exit-cascade/run-child-exit! frame-id actor-id)
-    (finalize/abort-actor-in-flight-http! actor-id)
-    ;; (rf2-egvm4t) Drop the actor's per-instance :data-schema marks so the
-    ;; destroyed actor leaves no marks-table residue (symmetric with the
-    ;; snapshot dissoc + registrar unregister below).
-    (finalize/clear-actor-schema-marks! actor-id)
-    ;; (rf2-82a0u) Cancel any armed `:after` timers the destroyed
-    ;; actor owns, emitting one `:rf.machine.timer/cancelled :reason
-    ;; :on-destroy` trace per timer. The epoch invariant already
-    ;; backstops firing-correctness; the explicit sweep releases the
-    ;; host-clock handle promptly and stamps the destroy attribution
-    ;; the Xray Handler section consumes.
-    (timer/cancel-actor-timers! frame-id actor-id)
-    ;; `teardown-actor` returns [new-runtime-db released-sid];
-    ;; `swap-runtime-db!` expects a fn returning the new runtime-db only.
-    ;; Capture sid via a side channel so we keep a single read + single
-    ;; write. Machine snapshots are durable runtime-db state (rf2-vzld77).
-    (let [sid (volatile! nil)
-          db-swapped? (frame/swap-runtime-db! frame-id
-                                              (fn [runtime-db]
-                                                (let [[new-rt released-sid]
-                                                      (teardown/teardown-actor runtime-db {:actor-id actor-id})]
-                                                  (vreset! sid released-sid)
-                                                  new-rt)))]
-      ;; (rf2-vsigt) Forget the actor regardless of whether the runtime-db
-      ;; swap landed — by the time frame-destroy runs, the container
-      ;; may already be nil but the spawn-order entry still needs
-      ;; clearing.
-      (spawn-order/forget! frame-id actor-id)
-      (when db-swapped?
-        (traces/emit-system-id-released! frame-id @sid actor-id)
-        (registrar/unregister! :event actor-id)))
+    ;; This site does NOT emit `:rf.machine/destroyed` — its callers
+    ;; (`destroy-spawn-all-children!`, the frame-destroy walker) own that
+    ;; emit, gating it on this fn's truthy return so each actor's destroyed
+    ;; trace fires exactly once (rf2-ndfjo). So no emit-destroyed callback.
+    (teardown-live-actor! frame-id actor-id {:actor-id actor-id} nil)
     ;; rf2-ndfjo — signal to callers (`destroy-spawn-all-children!`) that
     ;; this actor was live and torn down this call, so they emit
     ;; `:rf.machine/destroyed` exactly once. The `when` returns nil for
@@ -266,50 +299,33 @@
         live?     (or (actor-live? frame-id actor-id old-db)
                       (and tracked? (some? slot-id)))]
     (when live?
-      (let [released-sid (teardown/find-system-id-for-actor old-db actor-id)]
-        ;; (rf2-nahfm) Run the active configuration's `:exit` cascade
-        ;; BEFORE the teardown projection clears the snapshot — and
-        ;; BEFORE the `:rf.machine/destroyed` trace (rf2-iilco). Per Spec
-        ;; 005 §Declarative `:spawn` §Composition with explicit `:entry` /
-        ;; `:exit` (005:2138) the `:exit` action gets to read the actor's
-        ;; final snapshot before the auto-destroy clears it, so a consumer
-        ;; observing the db between `:exit` and `:rf.machine/destroyed`
-        ;; sees the live snapshot. This mirrors `finalize-machine`'s order
-        ;; (exit cascade → teardown → destroyed) so both destroy entry-
-        ;; points share one ordering convention.
-        (exit-cascade/run-child-exit! frame-id actor-id)
-        (finalize/abort-actor-in-flight-http! actor-id)
-        ;; (rf2-egvm4t) Drop the actor's per-instance :data-schema marks so the
-        ;; destroyed actor leaves no marks-table residue.
-        (finalize/clear-actor-schema-marks! actor-id)
-        ;; (rf2-82a0u) Cancel any armed `:after` timers the destroyed
-        ;; actor owns — see `destroy-single-actor!` for the rationale.
-        (timer/cancel-actor-timers! frame-id actor-id)
-        (frame/swap-runtime-db! frame-id
-                                (fn [runtime-db]
-                                  (first (teardown/teardown-actor
-                                           runtime-db {:actor-id  actor-id
-                                                       :parent-id parent-id
-                                                       :invoke-id invoke-id}))))
+      ;; Shared ordered teardown pipeline (see `teardown-live-actor!`). The
+      ;; `:exit` cascade runs BEFORE the `:rf.machine/destroyed` trace
+      ;; (rf2-iilco): per Spec 005 §Declarative `:spawn` §Composition with
+      ;; explicit `:entry` / `:exit` (005:2138) the `:exit` action reads the
+      ;; actor's final snapshot before the auto-destroy clears it, so a
+      ;; consumer observing the db between `:exit` and `:rf.machine/destroyed`
+      ;; sees the live snapshot. This mirrors `finalize-machine`'s order
+      ;; (exit cascade → teardown → destroyed) so both destroy entry-points
+      ;; share one ordering convention.
+      (teardown-live-actor!
+        frame-id actor-id
+        {:actor-id actor-id :parent-id parent-id :invoke-id invoke-id}
         ;; rf2-gn80 D6 — `:reason :explicit` discriminates "an action / fx
         ;; tore the actor down" from `:rf.machine/finished` (the auto-destroy
         ;; on `:final?`). Always stamp `:system-id` (nil when not bound) per
         ;; the destroyed-trace-shape contract for the `destroy-single!` site.
-        ;; `released-sid` was resolved from `old-db` above, before teardown
-        ;; mutated the reverse index — symmetric with `finalize-machine`.
-        (traces/emit-destroyed! {:frame     frame-id
-                                 :actor-id  actor-id
-                                 :system-id released-sid
-                                 :parent-id parent-id
-                                 :invoke-id invoke-id})
-        (traces/emit-system-id-released! frame-id released-sid actor-id)
-        ;; Unregister the live handler. Last so any in-flight trace emit
-        ;; against the actor still resolves before the slot disappears.
-        (registrar/unregister! :event actor-id)
-        ;; (rf2-vsigt) Forget the actor from the per-frame spawn-order
-        ;; channel so frame destroy's reverse-creation walk doesn't trip
-        ;; over a stale entry.
-        (spawn-order/forget! frame-id actor-id)))
+        ;; `released-sid` is the binding the teardown projection released —
+        ;; resolved from the reverse index BEFORE the dissoc, symmetric with
+        ;; `finalize-machine` and with the pre-teardown `old-db` read it
+        ;; replaces (the `:system-ids` index is untouched by the exit cascade
+        ;; / abort / mark-clear / timer-cancel steps, so the value is equal).
+        (fn [released-sid]
+          (traces/emit-destroyed! {:frame     frame-id
+                                   :actor-id  actor-id
+                                   :system-id released-sid
+                                   :parent-id parent-id
+                                   :invoke-id invoke-id}))))
     nil))
 
 (defn destroy-machine-fx

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -46,8 +46,7 @@
             [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
-            [re-frame.machines.result :as result]
-            [re-frame.registrar :as registrar]))
+            [re-frame.machines.result :as result]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -60,11 +59,7 @@
   nil when neither resolves — the actor was already torn down, or the
   destroy targets a non-machine event id."
   [actor-id snapshot]
-  (or (resolver/spec-from-snapshot snapshot)
-      (when actor-id
-        (let [m (registrar/lookup :event actor-id)]
-          (when (:rf/machine? m)
-            (:rf/machine m))))))
+  (resolver/spec-from-id-or-snapshot actor-id snapshot))
 
 (defn run-child-exit!
   "Run the destroy-time `:exit` cascade for the actor identified by

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
@@ -37,6 +37,22 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+(defn spec-from-registry
+  "Resolve a registered machine's SPEC from `machine-id` via the `:event`
+  registrar's `:rf/machine?` / `:rf/machine` stamp (Spec 005 §Querying
+  machines). Returns the spec map, or nil when `machine-id` does not name
+  a registered machine (a plain event handler, or no entry at all).
+
+  This is the canonical one-liner over the
+  `(let [m (registrar/lookup :event id)] (when (:rf/machine? m) (:rf/machine m)))`
+  idiom that several lifecycle-fx + querying call sites repeat — the
+  registered-TYPE leg of spawned-actor / parent / singleton spec
+  resolution."
+  [machine-id]
+  (let [m (registrar/lookup :event machine-id)]
+    (when (:rf/machine? m)
+      (:rf/machine m))))
+
 (defn spec-from-snapshot
   "Resolve the machine SPEC for a spawned actor from its `snapshot`'s
   `:rf/machine-type` reserved slot (per Spec 005 §Reserved
@@ -56,9 +72,25 @@
   (let [t (:rf/machine-type snapshot)]
     (cond
       (map? t)     t
-      (keyword? t) (let [m (registrar/lookup :event t)]
-                     (when (:rf/machine? m)
-                       (:rf/machine m))))))
+      (keyword? t) (spec-from-registry t))))
+
+(defn spec-from-id-or-snapshot
+  "Resolve a machine SPEC for `id` (a singleton's registered handler key,
+  a spawned actor's instance address, or a spawning parent's id) preferring
+  the registered TYPE, falling back to the `snapshot`'s `:rf/machine-type`:
+
+    (or (spec-from-registry id) (spec-from-snapshot snapshot)).
+
+  Per rf2-a2sn1 the two legs are mutually exclusive for any one id — a
+  registered singleton has a registrar entry but no `:rf/machine-type` on
+  its snapshot, while a spawned actor carries no per-instance registrar
+  entry but stamps `:rf/machine-type` on its snapshot — so the `or` order
+  is behaviourally irrelevant and either leg resolves at most one spec.
+  Returns nil when neither resolves (the actor was already torn down, or
+  the id names a non-machine event)."
+  [id snapshot]
+  (or (spec-from-registry id)
+      (spec-from-snapshot snapshot)))
 
 (defn resolvable?
   "True iff the actor identified by `actor-id` in `db` resolves to a live

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -28,10 +28,10 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.lifecycle-fx.registration :as registration]
+            [re-frame.machines.lifecycle-fx.resolver :as resolver]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -92,9 +92,7 @@
         defn       (:definition args)]
     (cond
       defn        defn
-      machine-id  (let [m (registrar/lookup :event machine-id)]
-                    (when (:rf/machine? m)
-                      (:rf/machine m))))))
+      machine-id  (resolver/spec-from-registry machine-id))))
 
 (defn- unregistered-spawn-type?
   "Per rf2-ywv74m (Mike ruling, 2026-06-15): a `:spawn` / `:spawn-all`

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
@@ -38,8 +38,7 @@
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
-            [re-frame.machines.transition :as transition]
-            [re-frame.registrar :as registrar]))
+            [re-frame.machines.transition :as transition]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -51,11 +50,9 @@
   `finalize-machine` does for `:on-done`."
   [db parent-id]
   (when parent-id
-    (let [m (registrar/lookup :event parent-id)]
-      (if (:rf/machine? m)
-        (:rf/machine m)
-        (resolver/spec-from-snapshot
-          (get-in db (paths/snapshot-path parent-id)))))))
+    (resolver/spec-from-id-or-snapshot
+      parent-id
+      (get-in db (paths/snapshot-path parent-id)))))
 
 (defn- find-spawn-spec-at
   "Walk `parent-spec`'s state tree to the `:spawn`-bearing node at `invoke-id`

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -108,14 +108,13 @@
 
 (defn- machine-spec
   "The registered machine SPEC for `machine-id` (the value at `:rf/machine`),
-  or nil when no machine is registered under that id. The same registrar read
-  `re-frame.machines/machine-meta` performs — inlined here so this sibling does
-  not require the `re-frame.machines` facade (which requires THIS sibling for
-  its JVM alias, so the dependency must point one way)."
+  or nil when no machine is registered under that id. Delegates to the leaf
+  `resolver/spec-from-registry` — the same registrar read
+  `re-frame.machines/machine-meta` performs (this sibling requires `resolver`
+  directly, NOT the `re-frame.machines` facade, which requires THIS sibling for
+  its JVM alias — the dependency must point one way)."
   [machine-id]
-  (let [m (registrar/lookup :event machine-id)]
-    (when (:rf/machine? m)
-      (:rf/machine m))))
+  (resolver/spec-from-registry machine-id))
 
 (defn- registered-machine-ids
   "Every registered machine-id — every `:event` registration whose metadata


### PR DESCRIPTION
## Summary

Behaviour-PRESERVING structural lean over the machines lifecycle-fx + querying surfaces (rf2-q5lkoi). Guarded by the machines destroy/spawn/spawn-all test suite. No facade/manifest change.

### M1 — collapse the registered-machine-spec idiom

The copy-pasted idiom `(let [m (registrar/lookup :event id)] (when (:rf/machine? m) (:rf/machine m)))` is collapsed into two leaf helpers on `lifecycle-fx.resolver` (the designated leaf — requires only `registrar` + `paths`):

- `spec-from-registry [machine-id]` — the registered-TYPE leg;
- `spec-from-id-or-snapshot [id snapshot]` — `(or (spec-from-registry id) (spec-from-snapshot snapshot))`.

The two legs are mutually exclusive for any one id (rf2-a2sn1: a registered singleton has a registrar entry but no `:rf/machine-type` on its snapshot; a spawned actor carries no per-instance registrar entry but stamps `:rf/machine-type` on its snapshot), so the `or` order is behaviourally irrelevant — either leg resolves at most one spec.

Sites pointed at the helpers (6):
- `resolver/spec-from-snapshot` (keyword leg → `spec-from-registry`)
- `exit-cascade/resolve-machine-spec` → `spec-from-id-or-snapshot`
- `spawn/resolve-spawn-machine` → `spec-from-registry`
- `spawn-error/resolve-parent-spec` → `spec-from-id-or-snapshot`
- `machines/machine-meta` → `spec-from-registry`
- `tooling/machine-spec` → `spec-from-registry`

`machines.cljc` and `tooling.cljc` already required `resolver` (no cycle introduced). `finalize/parent-meta` was **left as-is**: it reuses an already-bound `parent-reg` registrar lookup for its `parent-live?` sibling, so collapsing it would introduce a redundant second registrar lookup — not a verbatim copy of the idiom. Drops now-unused `registrar` requires from `exit-cascade`, `spawn`, `spawn-error`.

### M2 — shared actor-teardown pipeline

`destroy-single-actor!` and `destroy-single!` ran the same ordered teardown (run-child-exit / abort-in-flight-http / clear-schema-marks / cancel-timers / teardown projection / system-id-released / unregister / spawn-order forget). Extracted `teardown-live-actor!` capturing the full pipeline. The two entry-points differ only in:
- actor-id resolution (done in the caller, gated on `actor-live?` / `live?`);
- whether they emit `:rf.machine/destroyed` (passed as an optional callback invoked with the released sid — `destroy-single!` emits; `destroy-single-actor!`'s callers own the emit and pass nil).

The released-sid the destroyed-trace stamps is now the value the teardown projection released (equal to the prior pre-teardown `old-db` read — the `:system-ids` reverse index is untouched by the exit-cascade / abort / mark-clear / timer-cancel steps).

## Gates

- machines JVM suite (`clojure -M:test` from `implementation/machines`): **788 tests, 2602 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **8024 tests, 33499 assertions, 0 failures, 0 errors**
- clj-kondo: 0 errors (3 pre-existing warnings unrelated to this change)

Internal refactor only — no compiled-output change expected, so no playground SCI bundle drift.