### PR TITLE
refactor(core/views): hoist shared source-coord/children-normalization helpers (rf2-t9s6p6)

### DIFF
--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -77,6 +77,93 @@
          #js {:value frame-kw}
          children))
 
+(defn normalize-children
+  "Collapse a substrate element-macro's trailing-`$`-children value into a
+  flat positional arg list (rf2-7kii2). The native trailing-children idiom
+  hands a provider core whatever shape each substrate's element macro
+  stashes on `:children` — a JS ARRAY for multiple trailing children
+  (UIx's `(cljs.core/array …)`, Helix's `(into-array …)`), a SINGLE element
+  for one trailing child (Helix), a CLJS vector/seq, or `nil` (no
+  children). All four collapse here: a JS array is spread via `array-seq`,
+  an existing CLJS sequential is passed through, `nil` becomes no children,
+  and any lone non-collection child is wrapped. React keys multi-child
+  arrays correctly because the spread reaches `createElement` as distinct
+  positional args, not a single array child.
+
+  Shared by `re-frame.substrate.spine/build-frame-provider-element` (the
+  scope-only provider core) and `re-frame.views.owned-frame`'s
+  `owned-frame-fc` / `owned-frame-react-element` (the UI-owned provider
+  cores) so the three element builders normalise children one identical
+  way — `(apply provider-element frame-kw (normalize-children children))`."
+  [children]
+  (cond
+    (nil? children)        nil
+    (array? children)      (array-seq children)
+    (sequential? children) children
+    :else                  [children]))
+
+;; ---- source-coord annotation value formatters (Spec 006) ------------------
+;;
+;; The `data-rf2-source-coord` / `data-rf-view` DOM attribute VALUES are
+;; pure string projections of the registry slot's id + captured coords.
+;; The DOM output MUST be byte-identical across substrates (Reagent's
+;; hiccup walk in `re-frame.views.source-coord-annotation` and the
+;; React-element-clone walk in `re-frame.substrate.spine` produce the SAME
+;; attribute string for the same view), so the formatters live here once —
+;; a shared leaf both walks already require — rather than as drifting
+;; per-walk copies. The injection WALKS stay split (hiccup vs React-element
+;; are genuinely different); only these pure formatters are shared.
+
+(defn format-source-coord
+  "Render the registry slot's captured coords as the attribute value shape
+  `<ns>:<sym>:<line>:<col>`. The id keyword's namespace and name give us
+  `<ns>` and `<sym>`; `<line>` / `<col>` come from the captured coords
+  (CLJS reg-view macro at expansion time). `<col>` is `?` when the column
+  was not captured (the column-key is optional per Spec 001). Per Spec 006
+  §Source-coord annotation. Shared by the Reagent hiccup walk
+  (`re-frame.views.source-coord-annotation`) and the React-element-clone
+  walk (`re-frame.substrate.spine`) so the attribute value is identical
+  across substrates."
+  [id coords]
+  (let [ns-part  (or (namespace id) "?")
+        sym-part (name id)
+        line     (:line coords)
+        col      (:column coords)]
+    (str ns-part ":" sym-part ":"
+         (if line (str line) "?")
+         ":"
+         (if col (str col) "?"))))
+
+(defn format-view-id
+  "Render the registry id keyword as the `:data-rf-view` attribute value.
+  Returns `(str id)` so `:rf.foo/bar` → `\":rf.foo/bar\"`. The walker reads
+  it back via `(keyword (subs s 1))` when the leading `:` is present. Per
+  Spec 006 §View tagging contract (rf2-01il5). Shared by the Reagent and
+  React-element walks so the attribute value is identical across
+  substrates."
+  [id]
+  (str id))
+
+(defn non-dom-root-warning
+  "Build the one-shot `console.warn` text for a reg-view'd component whose
+  root element is a non-DOM root (a fn/class component or a React Fragment)
+  — the source-coord walk skips the annotation and pair tools fall back to
+  the registry's `:rf/id` (documented exemption per Spec 006 §Source-coord
+  annotation). `type-tag` is the offending root's head/type for the
+  diagnostic. `substrate-name` is an optional string identifying the host
+  substrate (\"UIx\", \"Helix\", …); it is omitted from the message when
+  nil — the Reagent hiccup-walk path passes nil (no substrate qualifier),
+  the React-element spine path passes its substrate name. Shared by
+  `re-frame.views.warn-once` and `re-frame.substrate.spine` so the message
+  text does not drift; each side keeps its OWN warn-once cache."
+  [id type-tag substrate-name]
+  (str "[re-frame] reg-view " id " — root element is "
+       (pr-str type-tag)
+       (when substrate-name (str " (" substrate-name ")"))
+       "; data-rf2-source-coord skipped "
+       "(Spec 006 §Source-coord annotation: pair tools fall back to "
+       ":rf/id for non-DOM roots)."))
+
 ;; ---- coercion helper for React-context reads ------------------------------
 ;;
 ;; Defensive cover for raw-hiccup Provider mounts. The canonical user-

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -899,11 +899,7 @@
     're-frame.substrate.spine/build-frame-provider-element)
   (apply adapter-context/provider-element
          frame-kw
-         (cond
-           (nil? children)              nil
-           (array? children)            (array-seq children)
-           (sequential? children)       children
-           :else                        [children])))
+         (adapter-context/normalize-children children)))
 
 ;; ---- render flush for tests ----------------------------------------------
 ;;
@@ -995,29 +991,15 @@
 ;; confirms the `data-rf2-source-coord` literal is absent from
 ;; production builds.
 
-(defn format-source-coord
-  "Render captured registry coords as the attribute value shape
-  `<ns>:<sym>:<line>:<col>`. Mirrors re-frame.views/format-source-coord
-  so DOM output is identical across substrates."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
-
-(defn format-view-id
-  "Render the registry id keyword as the `:data-rf-view` attribute
-  value. Returns `(str id)` so `:rf.foo/bar` → `\":rf.foo/bar\"`. The
-  walker reads it back via `(keyword (subs s 1))` when the leading `:`
-  is present. Per Spec 006 §View tagging contract (rf2-01il5).
-  Mirrors re-frame.views.source-coord-annotation/format-view-id so
-  the attribute value is identical across substrates."
-  [id]
-  (str id))
+;; `format-source-coord` / `format-view-id` are the pure string projections
+;; of the annotation attribute VALUES — shared with the Reagent hiccup walk
+;; through the leaf `re-frame.adapter.context` so the React-element-clone
+;; path here and the hiccup path in `re-frame.views.source-coord-annotation`
+;; emit byte-identical `data-rf2-source-coord` / `data-rf-view` values
+;; across substrates (rf2-t9s6p6). Aliased to the spine's historical names
+;; so call sites in `make-wrap-view` are unchanged.
+(def format-source-coord adapter-context/format-source-coord)
+(def format-view-id       adapter-context/format-view-id)
 
 (defn make-warn-once-cache
   "Return an `(atom #{})` for tracking per-id warn-once emission. Each
@@ -1047,11 +1029,7 @@
     (when-not (contains? @cache-atom id)
       (swap! cache-atom conj id)
       (.warn js/console
-        (str "[re-frame] reg-view " id " — root element is "
-             (pr-str type-tag) " (" substrate-name "); "
-             "data-rf2-source-coord skipped "
-             "(Spec 006 §Source-coord annotation: pair tools fall back to "
-             ":rf/id for non-DOM roots).")))))
+        (adapter-context/non-dom-root-warning id type-tag substrate-name)))))
 
 (defn- dom-element?
   "True if the React element's `type` is a string (a DOM tag like

--- a/implementation/core/src/re_frame/views/owned_frame.cljs
+++ b/implementation/core/src/re_frame/views/owned_frame.cljs
@@ -326,11 +326,7 @@
       #js [])
     (apply adapter-context/provider-element
            frame-id
-           (cond
-             (nil? children)        nil
-             (array? children)      (array-seq children)
-             (sequential? children) children
-             :else                  [children]))))
+           (adapter-context/normalize-children children))))
 
 (defn ^:no-doc owned-frame-react-element
   "Build the raw React element for the UI-owned frame-provider, for the
@@ -352,8 +348,4 @@
   (apply React/createElement
          owned-frame-fc
          #js {:rfOpts (owned-frame-opts props)}
-         (cond
-           (nil? children)        nil
-           (array? children)      (array-seq children)
-           (sequential? children) children
-           :else                  [children])))
+         (adapter-context/normalize-children children)))

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -81,23 +81,19 @@
   `data-rf2-source-coord` + `data-rf-view` DOM attributes (which DO
   work and are read by re-frame-pair, the view-walker, IDE jump-to-
   source tooling) ride the same wrapper unchanged."
-  (:require [re-frame.views.warn-once :as warn-once]))
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.views.warn-once :as warn-once]))
 
-(defn format-source-coord
-  "Render the registry slot's captured coords as the attribute value
-  shape `<ns>:<sym>:<line>:<col>`. The id keyword's namespace and name
-  give us `<ns>` and `<sym>`; `<line>` / `<col>` come from the captured
-  coords (CLJS reg-view macro at expansion time). Per Spec 006
-  §Source-coord annotation."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
+;; `format-source-coord` / `format-view-id` are the pure string projections
+;; of the annotation attribute VALUES. They live in the shared leaf
+;; `re-frame.adapter.context` so the Reagent hiccup walk here and the
+;; React-element-clone walk in `re-frame.substrate.spine` produce byte-
+;; identical `data-rf2-source-coord` / `data-rf-view` values across
+;; substrates (rf2-t9s6p6). Re-exported under their historical names here
+;; so `re-frame.views/format-source-coord` (and the parity test referencing
+;; `#'re-frame.views/format-source-coord`) keep resolving.
+(def format-source-coord adapter-context/format-source-coord)
+(def format-view-id       adapter-context/format-view-id)
 
 (defn- dom-tag?
   "True if `head` is a Hiccup DOM-tag keyword. Reagent's React-fragment
@@ -107,14 +103,6 @@
   (and (keyword? head)
        (not= :<> head)
        (not= :> head)))
-
-(defn format-view-id
-  "Render the registry id keyword as the `:data-rf-view` attribute
-  value. Returns `(str id)` so `:rf.foo/bar` → `\":rf.foo/bar\"`. The
-  walker reads it back via `(keyword (subs s 1))` when the leading `:`
-  is present. Per Spec 006 §View tagging contract (rf2-01il5)."
-  [id]
-  (str id))
 
 (defn inject-source-coord-attr
   "Walk the user's render-fn output and merge `:data-rf2-source-coord`

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -11,7 +11,8 @@
   per-process set; `make-reset-runtime-fixture` clears it via the chained
   `:adapter/clear-warn-once-caches!` hook (enrolled through the governance
   chokepoint `register-warn-once-clear-fn!`, rf2-z79p8)."
-  (:require [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.late-bind :as late-bind]))
 
 ;; ---- non-DOM-root warning ------------------------------------------------
 
@@ -38,11 +39,11 @@
   (when-not (contains? @warned-non-dom-roots id)
     (swap! warned-non-dom-roots conj id)
     (when (exists? js/console)
+      ;; Shared builder (rf2-t9s6p6); nil substrate-name = the Reagent
+      ;; hiccup-walk path carries no substrate qualifier, so the message
+      ;; text is byte-identical to the pre-extraction inline string.
       (.warn js/console
-        (str "[re-frame] reg-view " id " — root element is "
-             (pr-str head) "; data-rf2-source-coord skipped (Spec 006 "
-             "§Source-coord annotation: pair tools fall back to :rf/id "
-             "for non-DOM roots).")))))
+        (adapter-context/non-dom-root-warning id head nil)))))
 
 ;; Enrol the `warned-non-dom-roots` cache into the chained
 ;; `:adapter/clear-warn-once-caches!` hook, via the canonical governance


### PR DESCRIPTION
## Summary

Behaviour-PRESERVING structural lean of the views/spine annotation + provider spine (rf2-t9s6p6). The DOM output is byte-identical across substrates — `data-rf2-source-coord` / `data-rf-view` attribute values and the non-DOM-root warning text are unchanged. Only the duplication is removed; the new helpers are internal (no facade/manifest change).

All three hoists land in the shared leaf `re-frame.adapter.context` — a ns both the Reagent hiccup walk (`re-frame.views.*`) and the React-element-clone walk (`re-frame.substrate.spine`) already require, so no `core->views` / `views->spine` cycle is introduced (verified: shadow-cljs dev + release builds compiled with 0 warnings).

### V1 — shared annotation-value formatters
`format-source-coord` + `format-view-id` were character-identical in `re-frame.views.source-coord-annotation` and `re-frame.substrate.spine` (the spine copies carried the "Mirrors re-frame.views…" comments). Both pure string-format fns now live once in `adapter.context`; the two original sites alias the single definition. The `re-frame.views/format-source-coord` re-export and the `#'re-frame.views/format-source-coord` parity test still resolve.

### V2 — shared children normalization
The children-normalization `cond` (`nil`→nil / `array?`→array-seq / `sequential?`→children / `:else`→`[children]`) appeared 3× verbatim — `spine/build-frame-provider-element`, `owned_frame/owned-frame-fc`, and `owned_frame/owned-frame-react-element`. Extracted `normalize-children` into the same leaf; all 3 call sites are now `(apply … (normalize-children children))`.

### V3 — shared non-DOM-root warning builder
The `warn-non-dom-root!` message builder had drifted (`views/warn_once` vs `spine`, the latter adding a substrate-name qualifier). Extracted one `non-dom-root-warning [id type-tag substrate-name]` builder (`substrate-name` optional/nil for the views hiccup path; the spine passes its substrate name). The two **separate** warn-once caches are kept; only the message text is shared. The two emitted strings are byte-identical to the pre-extraction inline strings.

## Quality gates (all green)

- `npm run test:cljs` — 8024 tests / 33499 assertions, 0 failures, 0 errors
- `npm run test:browser` — **222 tests / 701 assertions, 0 failures, 0 errors** (the source-coord annotation + provider DOM-attr guard; mandatory)
- `sh scripts/test-jvm-implementation.sh` — all JVM artefacts pass
- `npm run test:bundle-isolation` — pass (40 internal sentinels absent; UIx/Helix bundles Reagent-free)
- `npm run test:elision` — 41/41 sentinels absent in prod, 41/41 present in control (source-coord literals still DCE)
- clj-kondo — 0 errors (2 pre-existing warnings outside the diff)

Net: -73 / +119 lines (the +119 is mostly docstrings on the shared leaf).

Do NOT merge — flagged for review.