### PR TITLE
refactor(adapters): assemble ratom-ops/hook-ops in the spine from bare primitives (rf2-0u5em6)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -30,10 +30,17 @@
 ;; CRITICAL — bundle isolation (IMPL-SPEC §1.8 / the
 ;; `test:reagent-slim:bundle-isolation` gate). The spine MUST NOT
 ;; `:require` stock `reagent.*`; the reactive-atom ops are INJECTED here
-;; so this adapter's `reagent2.*` requires stay confined to this ns and
-;; the spine never names a reactive-atom ns. deps.edn carries zero direct
-;; `reagent.*` requires (the slim framing: a re-implementation, not a
-;; thin wrapper).
+;; as a flat set of bare fns so this adapter's `reagent2.*` requires stay
+;; confined to this ns and the spine never names a reactive-atom ns.
+;; deps.edn carries zero direct `reagent.*` requires (the slim framing: a
+;; re-implementation, not a thin wrapper).
+;;
+;; rf2-0u5em6: the spine assembles its internal ratom-ops map from these
+;; bare fns. This adapter passes ~7 bare fns (flat config keys, mirroring
+;; `make-react-spine`'s bare hook fns) instead of a hand-shaped keyword
+;; map — earlier this adapter and the bridge one each built a structurally-
+;; identical 7-key `:ratom-ops` map differing only by ns-alias, a "keep two
+;; maps in lockstep" hazard the flat-bare-fn shape removes.
 
 (def ^:private spine-fns
   (spine/make-ratom-spine
@@ -47,30 +54,30 @@
      ;; slim render / dispose-drain pins rely on (capturing the bare Var
      ;; value at load time would freeze the original impls past any
      ;; `with-redefs` rebind). Runtime behaviour is identical.
-     :ratom-ops         {:r/atom              (fn [v] (r/atom v))
-                         :ratom/make-reaction (fn [thunk] (ratom/make-reaction thunk))
-                         :rdc/create-root     (fn [mount-point] (rdc/create-root mount-point))
-                         :rdc/render          (fn [root tree] (rdc/render root tree))
-                         :rdc/hydrate-root    (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
-                         :rdc/unmount         (fn [root] (rdc/unmount root))
-                         ;; rf2-40a84 / rf2-0bz5ah — synchronous render-commit
-                         ;; op. Runs `f` (which may mutate a ratom / dispatch),
-                         ;; then drains the rea-queue + forceUpdates every dirty
-                         ;; component via `reagent2.impl.batching/flush!`, INSIDE
-                         ;; a `react-dom/flushSync` boundary so the forced
-                         ;; re-renders COMMIT TO THE DOM synchronously before the
-                         ;; op returns. Under React 19 `createRoot` a bare
-                         ;; `forceUpdate` from outside React's batching is
-                         ;; auto-batched (scheduled, not committed), so the
-                         ;; boundary is load-bearing — see
-                         ;; `reagent2.dom.client/flush-render!` for the full
-                         ;; rationale + the empirical proof
-                         ;; (`reagent_slim_flush_render_dom_cljs_test`). The
-                         ;; commit is NOT microtask/rAF-deferred and fires even
-                         ;; in a backgrounded / headless tab. (Distinct from
-                         ;; `reagent2.dom.client/flush-views!`, the goog.DEBUG-
-                         ;; gated act()-composing TEST primitive.)
-                         :rdc/flush-render!   rdc/flush-render!}}))
+     :r-atom        (fn [v] (r/atom v))
+     :make-reaction (fn [thunk] (ratom/make-reaction thunk))
+     :create-root   (fn [mount-point] (rdc/create-root mount-point))
+     :render-root   (fn [root tree] (rdc/render root tree))
+     :hydrate-root  (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
+     :unmount-root  (fn [root] (rdc/unmount root))
+     ;; rf2-40a84 / rf2-0bz5ah — synchronous render-commit
+     ;; op. Runs `f` (which may mutate a ratom / dispatch),
+     ;; then drains the rea-queue + forceUpdates every dirty
+     ;; component via `reagent2.impl.batching/flush!`, INSIDE
+     ;; a `react-dom/flushSync` boundary so the forced
+     ;; re-renders COMMIT TO THE DOM synchronously before the
+     ;; op returns. Under React 19 `createRoot` a bare
+     ;; `forceUpdate` from outside React's batching is
+     ;; auto-batched (scheduled, not committed), so the
+     ;; boundary is load-bearing — see
+     ;; `reagent2.dom.client/flush-render!` for the full
+     ;; rationale + the empirical proof
+     ;; (`reagent_slim_flush_render_dom_cljs_test`). The
+     ;; commit is NOT microtask/rAF-deferred and fires even
+     ;; in a backgrounded / headless tab. (Distinct from
+     ;; `reagent2.dom.client/flush-views!`, the goog.DEBUG-
+     ;; gated act()-composing TEST primitive.)
+     :flush-render! rdc/flush-render!}))
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.
@@ -110,18 +117,18 @@
 
   The container quartet, renderer, render-to-string and dispose body
   come from `spine/make-ratom-spine` (rf2-rzex9, shared with the bridge
-  Reagent adapter under an injected `reagent2.*` op set); the adapter
+  Reagent adapter under an injected `reagent2.*` bare-fn set); the adapter
   map + the nine-call ratom-family `route-hook!` table + the chained
   SSR-emitter install are assembled by `spine/make-ratom-adapter`
   (rf2-ee38b.1, also shared with the bridge adapter under an injected
-  `reagent2.*` hook-ops set). `register-context-provider` is passed in
+  `reagent2.*` bare-fn hook set). `register-context-provider` is passed in
   (NOT spine-built) because it is the Reagent-component-shaped frame-
   provider from `re-frame.views`, distinct from the React-hook spine's
   hook-shaped one — keeping the core spine free of a spine→views edge.
-  CRITICAL: bundle isolation is preserved — the `:hook-ops` are injected
-  `reagent2.*` impls, so the spine names no reactive-atom ns (the
-  `test:reagent-slim:bundle-isolation` gate by construction). Per-hook
-  rationale lives at `spine/make-ratom-adapter`."
+  CRITICAL: bundle isolation is preserved — the hook ops are injected
+  `reagent2.*` impls (flat bare-fn config keys, rf2-0u5em6), so the spine
+  names no reactive-atom ns (the `test:reagent-slim:bundle-isolation` gate
+  by construction). Per-hook rationale lives at `spine/make-ratom-adapter`."
   (spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent-slim
@@ -130,24 +137,25 @@
      ;; at render time. Per IMPL-SPEC §9.4: views.cljs continues to back
      ;; the frame-provider; the rewrite doesn't replace it.
      :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
-     ;; Injected reagent2.* ops for the ratom-family late-bind hooks.
-     ;; Wiring reagent2.* impls is load-bearing (rf2-s36l): without this
-     ;; seam the first (interop/add-on-dispose! ...) under the slim
-     ;; adapter threw because reagent2.ratom/Reaction does NOT reify stock
-     ;; Reagent's IDisposable. rf2-jicu2: the dual-IDisposable dispatch
+     ;; Injected reagent2.* ops for the ratom-family late-bind hooks (flat
+     ;; bare-fn config keys, rf2-0u5em6 — the spine assembles the route-hook
+     ;; table from them). Wiring reagent2.* impls is load-bearing (rf2-s36l):
+     ;; without this seam the first (interop/add-on-dispose! ...) under the
+     ;; slim adapter threw because reagent2.ratom/Reaction does NOT reify
+     ;; stock Reagent's IDisposable. rf2-jicu2: the dual-IDisposable dispatch
      ;; (re-frame-owned first, then reagent2's) is handled inside
      ;; make-ratom-adapter — this adapter supplies the substrate-side
      ;; `disposable?` predicate + `add-on-dispose!` / `dispose!` impls.
-     :hook-ops {:current-frame     views/current-frame
-                :current-component r/current-component
-                :atom              r/atom
-                :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
-                :make-reaction     ratom/make-reaction
-                :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
-                :add-on-dispose!   ratom/add-on-dispose!
-                :dispose!          ratom/dispose!
-                :reactive?         ratom/reactive?
-                :after-render      r/after-render}}))
+     :current-frame     views/current-frame
+     :current-component r/current-component
+     :atom              r/atom
+     :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
+     :make-reaction     ratom/make-reaction
+     :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
+     :add-on-dispose!   ratom/add-on-dispose!
+     :dispose!          ratom/dispose!
+     :reactive?         ratom/reactive?
+     :after-render      r/after-render}))
 
 ;; ---- warn-once cache reset wiring (rf2-qy6cl) -----------------------------
 ;;

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -17,10 +17,18 @@
 ;; live in `re-frame.substrate.spine/make-ratom-spine` (rf2-rzex9) — one
 ;; implementation, two adapters, zero drift, mirroring the React-hook
 ;; `make-react-spine` that backs UIx/Helix. The reactive-atom ops are
-;; INJECTED here so the spine never `:require`s a reactive-atom ns: this
-;; adapter passes its stock `reagent.*` impls; the slim adapter passes
-;; `reagent2.*`. (Load-bearing for reagent-slim bundle isolation — the
-;; slim adapter's deps.edn carries zero direct `reagent.*` requires.)
+;; INJECTED here as a flat set of bare fns so the spine never `:require`s a
+;; reactive-atom ns: this adapter passes its stock `reagent.*` impls; the
+;; slim adapter passes `reagent2.*`. (Load-bearing for reagent-slim bundle
+;; isolation — the slim adapter's deps.edn carries zero direct `reagent.*`
+;; requires.)
+;;
+;; rf2-0u5em6: the spine assembles its internal ratom-ops map from these
+;; bare fns. Each adapter passes ~7 bare fns (flat config keys, mirroring
+;; `make-react-spine`'s bare hook fns) instead of a hand-shaped keyword
+;; map — earlier this adapter and the slim one each built a structurally-
+;; identical 7-key `:ratom-ops` map differing only by ns-alias, a "keep two
+;; maps in lockstep" hazard the flat-bare-fn shape removes.
 
 (def ^:private spine-fns
   (spine/make-ratom-spine
@@ -34,21 +42,21 @@
      ;; adapter-render / dispose-drain pins rely on (capturing the bare
      ;; Var value at load time would freeze the original impls past any
      ;; `with-redefs` rebind). Runtime behaviour is identical.
-     :ratom-ops         {:r/atom              (fn [v] (r/atom v))
-                         :ratom/make-reaction (fn [thunk] (ratom/make-reaction thunk))
-                         :rdc/create-root     (fn [mount-point] (rdc/create-root mount-point))
-                         :rdc/render          (fn [root tree] (rdc/render root tree))
-                         :rdc/hydrate-root    (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
-                         :rdc/unmount         (fn [root] (rdc/unmount root))
-                         ;; rf2-40a84 — synchronous render-flush op. Run `f`
-                         ;; (which may mutate a ratom / dispatch), then
-                         ;; `reagent.core/flush` drains Reagent's render queue
-                         ;; SYNCHRONOUSLY — bypassing the rAF-scheduled
-                         ;; `next-tick` drain — and (on React 19) commits the
-                         ;; forced component re-renders to the DOM via
-                         ;; react-dom/flushSync. NOT rAF-scheduled ⇒ fires even
-                         ;; in a backgrounded / headless tab.
-                         :rdc/flush-render!   (fn [f] (f) (r/flush))}}))
+     :r-atom        (fn [v] (r/atom v))
+     :make-reaction (fn [thunk] (ratom/make-reaction thunk))
+     :create-root   (fn [mount-point] (rdc/create-root mount-point))
+     :render-root   (fn [root tree] (rdc/render root tree))
+     :hydrate-root  (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
+     :unmount-root  (fn [root] (rdc/unmount root))
+     ;; rf2-40a84 — synchronous render-flush op. Run `f`
+     ;; (which may mutate a ratom / dispatch), then
+     ;; `reagent.core/flush` drains Reagent's render queue
+     ;; SYNCHRONOUSLY — bypassing the rAF-scheduled
+     ;; `next-tick` drain — and (on React 19) commits the
+     ;; forced component re-renders to the DOM via
+     ;; react-dom/flushSync. NOT rAF-scheduled ⇒ fires even
+     ;; in a backgrounded / headless tab.
+     :flush-render! (fn [f] (f) (r/flush))}))
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.
@@ -96,10 +104,10 @@
   which moved only those React-hook adapters; the Reagent shape is
   unchanged).
 
-  The `:hook-ops` are injected stock-`reagent.*` impls so the spine
-  never names a reactive-atom ns (bundle isolation, identical to
-  `make-ratom-spine`'s `:ratom-ops` contract). Per-hook rationale lives
-  at `spine/make-ratom-adapter`."
+  The hook ops are injected stock-`reagent.*` impls (flat bare-fn config
+  keys, rf2-0u5em6) so the spine never names a reactive-atom ns (bundle
+  isolation, identical to `make-ratom-spine`'s bare-fn contract). Per-hook
+  rationale lives at `spine/make-ratom-adapter`."
   (spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent
@@ -108,18 +116,20 @@
      ;; at render time. The arg stays in the substrate signature per
      ;; Spec 006 §Frame-provider via React context.
      :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
-     ;; Injected stock-Reagent ops for the ratom-family late-bind hooks.
-     ;; rf2-jicu2: the dual-IDisposable dispatch (re-frame-owned first,
-     ;; then the substrate's) is handled inside make-ratom-adapter — this
-     ;; adapter supplies only the substrate-side `disposable?` predicate +
-     ;; `add-on-dispose!` / `dispose!` impls.
-     :hook-ops {:current-frame     views/current-frame
-                :current-component r/current-component
-                :atom              r/atom
-                :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
-                :make-reaction     ratom/make-reaction
-                :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
-                :add-on-dispose!   ratom/add-on-dispose!
-                :dispose!          ratom/dispose!
-                :reactive?         ratom/reactive?
-                :after-render      r/after-render}}))
+     ;; Injected stock-Reagent ops for the ratom-family late-bind hooks
+     ;; (flat bare-fn config keys, rf2-0u5em6 — the spine assembles the
+     ;; route-hook table from them). rf2-jicu2: the dual-IDisposable
+     ;; dispatch (re-frame-owned first, then the substrate's) is handled
+     ;; inside make-ratom-adapter — this adapter supplies only the
+     ;; substrate-side `disposable?` predicate + `add-on-dispose!` /
+     ;; `dispose!` impls.
+     :current-frame     views/current-frame
+     :current-component r/current-component
+     :atom              r/atom
+     :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
+     :make-reaction     ratom/make-reaction
+     :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
+     :add-on-dispose!   ratom/add-on-dispose!
+     :dispose!          ratom/dispose!
+     :reactive?         ratom/reactive?
+     :after-render      r/after-render}))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1895,42 +1895,52 @@
 ;; core/substrate and MUST NOT `:require` stock `reagent.*` — the day8/
 ;; reagent-slim adapter would otherwise drag the stock-Reagent impl tree
 ;; into every slim release bundle. The reactive-atom ops are therefore
-;; INJECTED by each adapter via the `:ratom-ops` map (the HOF
+;; INJECTED by each adapter as a flat set of BARE-FN config keys (the HOF
 ;; parameterisation): the Reagent adapter passes its stock `reagent.*`
 ;; impls, the slim adapter passes its `reagent2.*` impls. The spine never
 ;; names either ns. (The same isolation principle as `make-react-spine`,
 ;; which calls `react-dom/client` directly but never Reagent.)
+;;
+;; rf2-0u5em6: the per-substrate ops arrive as FLAT bare-fn config keys
+;; (`:r-atom`, `:make-reaction`, `:create-root`, …) — mirroring how
+;; `make-react-spine` takes its bare `:use-memo` / `:use-callback` /
+;; `:use-context` hook fns — rather than as a hand-shaped `:ratom-ops`
+;; keyword map literal. Earlier each adapter built a structurally-identical
+;; 7-key `:ratom-ops` map differing only by ns-alias (`reagent.*` vs
+;; `reagent2.*`), a "keep two maps in lockstep" hazard. The keyword-key
+;; shape now lives ONCE here; each adapter passes ~7 bare fns.
 
 (defn make-ratom-spine
   "Build the per-substrate ratom-family substrate surfaces given the
-  substrate's ratom ops and gensym prefix:
+  substrate's gensym prefix and a FLAT set of injected reactive-atom BARE
+  FNS (rf2-0u5em6 — mirroring how `make-react-spine` takes its bare
+  `:use-memo` / `:use-callback` / `:use-context` hook fns, not a hand-
+  shaped keyword map):
 
       :gensym-prefix-sub — gensym prefix for `subscribe-container` watch
                            keys (substrate-scoped per rf2-l4dmr so logs /
                            inspectors attribute a watch to its substrate)
-      :ratom-ops         — the injected reactive-atom impls, a map of:
-          :r/atom              — (fn [v]) → reactive atom container
-          :ratom/make-reaction — (fn [thunk]) → reaction over a thunk
-          :rdc/create-root     — (fn [mount-point]) → React root
-          :rdc/render          — (fn [root tree]) → render hiccup into
-                                 root (the substrate's hiccup→element
-                                 walk + `.render`, NOT a bare `.render`)
-          :rdc/hydrate-root    — (fn [mount-point tree]) → React root
-          :rdc/unmount         — (fn [root]) → unmount the root
-          :rdc/flush-render!   — (fn [f]) → run `f` then SYNCHRONOUSLY commit
-                                 the substrate's pending renders to the DOM
-                                 (rf2-40a84; stock Reagent passes
-                                 `reagent.core/flush`, slim passes its
-                                 `reagent2.*` synchronous flush). NOT rAF-
-                                 scheduled — immune to the backgrounded-tab
-                                 throttle, so headless tooling can drive a
-                                 `dispatch → flush-render! → observe-DOM` loop.
+      :r-atom        — (fn [v]) → reactive atom container
+      :make-reaction — (fn [thunk]) → reaction over a thunk
+      :create-root   — (fn [mount-point]) → React root
+      :render-root   — (fn [root tree]) → render hiccup into root (the
+                       substrate's hiccup→element walk + `.render`, NOT a
+                       bare `.render`)
+      :hydrate-root  — (fn [mount-point tree]) → React root
+      :unmount-root  — (fn [root]) → unmount the root
+      :flush-render! — (fn [f]) → run `f` then SYNCHRONOUSLY commit the
+                       substrate's pending renders to the DOM (rf2-40a84;
+                       stock Reagent passes `(fn [f] (f) (reagent.core/
+                       flush))`, slim passes its `reagent2.*` synchronous
+                       flush). NOT rAF-scheduled — immune to the
+                       backgrounded-tab throttle, so headless tooling can
+                       drive a `dispatch → flush-render! → observe-DOM` loop.
 
-  The spine MUST NOT `:require` stock `reagent.*`; the ops above are the
-  only path to the substrate's reactive primitive, so each adapter's own
-  `reagent.*` / `reagent2.*` requires stay confined to the adapter ns
-  (load-bearing for reagent-slim bundle isolation — see the section
-  comment above).
+  The spine assembles its internal ratom-ops shape from these bare fns; it
+  MUST NOT `:require` stock `reagent.*`; the fns above are the only path to
+  the substrate's reactive primitive, so each adapter's own `reagent.*` /
+  `reagent2.*` requires stay confined to the adapter ns (load-bearing for
+  reagent-slim bundle isolation — see the section comment above).
 
   Returns a map of the substrate-contract surfaces (minus
   `register-context-provider`) plus the SSR helpers each adapter
@@ -1960,15 +1970,10 @@
   thunk that drops itself from the set; and the four-MUST dispose body
   (`dispose-frame-sub-caches!` + active-roots drain w/ per-root throw-
   swallow + emitter clear)."
-  [{:keys [gensym-prefix-sub ratom-ops]}]
-  (let [{r-atom        :r/atom
-         make-reaction :ratom/make-reaction
-         create-root   :rdc/create-root
-         render-root   :rdc/render
-         hydrate-root  :rdc/hydrate-root
-         unmount-root  :rdc/unmount
-         flush-render-op :rdc/flush-render!} ratom-ops
-        active-roots-cell (make-active-roots-cell)
+  [{:keys [gensym-prefix-sub r-atom make-reaction create-root render-root
+           hydrate-root unmount-root]
+    flush-render-op :flush-render!}]
+  (let [active-roots-cell (make-active-roots-cell)
         emitter-cell      (make-hiccup-emitter-cell)
         make-state-container
         (fn make-state-container [initial-value]
@@ -2109,9 +2114,18 @@
 ;; reactive-atom-family ops the hook table needs — `current-component`,
 ;; `atom`, `after-render`, `make-reaction`, the `ratom?`/`disposable?`
 ;; predicates, and the `add-on-dispose!`/`dispose!`/`reactive?` fns — are
-;; INJECTED via the `:hook-ops` map (predicate/dispatch lambdas over the
-;; substrate's protocols), so the spine never names a reactive-atom ns.
-;; Each adapter passes its `reagent.*` / `reagent2.*` impls.
+;; INJECTED as a flat set of bare-fn config keys (predicate/dispatch
+;; lambdas over the substrate's protocols), so the spine never names a
+;; reactive-atom ns. Each adapter passes its `reagent.*` / `reagent2.*`
+;; impls.
+;;
+;; rf2-0u5em6: as with `make-ratom-spine`, the hook ops arrive as FLAT
+;; bare-fn config keys rather than a hand-shaped `:hook-ops` keyword map
+;; literal. Earlier each adapter built a structurally-identical 10-key
+;; `:hook-ops` map differing only by ns-alias (the two maps were byte-
+;; identical modulo `reagent.*` vs `reagent2.*`) — a "keep two maps in
+;; lockstep" hazard. The keyword-key shape now lives ONCE here; the spine
+;; assembles the route-hook table from the bare fns each adapter passes.
 
 (defn make-ratom-adapter
   "Assemble a ratom-family adapter (Reagent / reagent-slim) from a
@@ -2123,22 +2137,25 @@
                    `(fn [_frame-keyword] (views/build-frame-provider))`.
                    Passed in (NOT spine-built) so the core spine carries no
                    spine→views dependency edge.
-      :hook-ops  — the injected reactive-atom-family ops the late-bind
-                   hook table routes (bundle-isolation: lambdas only, the
-                   spine names no reactive-atom ns):
-          :current-frame      — (fn []) → React-context-tier current frame
-                                (`views/current-frame`)
-          :current-component  — (fn []) → the in-flight component
-          :atom               — (fn [v]) → reactive atom
-          :ratom?             — (fn [x]) → boolean (IReactiveAtom check)
-          :make-reaction      — (fn [thunk]) → reaction
-          :disposable?        — (fn [x]) → boolean (substrate IDisposable
-                                check), used by the dual-protocol dispatch
-          :add-on-dispose!    — (fn [a f]) → register a substrate-reaction
-                                dispose hook
-          :dispose!           — (fn [a]) → dispose a substrate reaction
-          :reactive?          — (fn []) → boolean
-          :after-render       — (fn [f]) → schedule post-render callback
+
+  …plus a FLAT set of the injected reactive-atom-family BARE FNS the
+  late-bind hook table routes (rf2-0u5em6 — bundle-isolation: lambdas only,
+  the spine names no reactive-atom ns; mirrors `make-react-spine`'s bare-
+  hook-fn config rather than a hand-shaped keyword map):
+
+      :current-frame      — (fn []) → React-context-tier current frame
+                            (`views/current-frame`)
+      :current-component  — (fn []) → the in-flight component
+      :atom               — (fn [v]) → reactive atom
+      :ratom?             — (fn [x]) → boolean (IReactiveAtom check)
+      :make-reaction      — (fn [thunk]) → reaction
+      :disposable?        — (fn [x]) → boolean (substrate IDisposable
+                            check), used by the dual-protocol dispatch
+      :add-on-dispose!    — (fn [a f]) → register a substrate-reaction
+                            dispose hook
+      :dispose!           — (fn [a]) → dispose a substrate reaction
+      :reactive?          — (fn []) → boolean
+      :after-render       — (fn [f]) → schedule post-render callback
 
   Builds the 9-key adapter map, wires the chained SSR emitter install, and
   routes the nine ratom-family late-bind hooks against the adapter. The two
@@ -2151,13 +2168,12 @@
   (chain-fn! / route-hook!), exactly as the hand-written wiring was.
 
   Single source of truth (rf2-ee38b.1): Reagent and reagent-slim call this
-  with the same shape — only their injected `:hook-ops` and `:kind` differ.
-  The former hand-copied route-hook block now lives once."
-  [spine-fns {:keys [kind register-context-provider hook-ops]}]
-  (let [{:keys [current-frame current-component atom ratom? make-reaction
-                disposable? add-on-dispose! dispose! reactive? after-render]}
-        hook-ops
-        adapter {:kind                      kind
+  with the same shape — only their injected bare hook fns and `:kind`
+  differ. The former hand-copied route-hook block now lives once."
+  [spine-fns {:keys [kind register-context-provider
+                     current-frame current-component atom ratom? make-reaction
+                     disposable? add-on-dispose! dispose! reactive? after-render]}]
+  (let [adapter {:kind                      kind
                  :make-state-container      (:make-state-container spine-fns)
                  :read-container            (:read-container       spine-fns)
                  :replace-container!        (:replace-container!   spine-fns)


### PR DESCRIPTION
## What

The Reagent and reagent-slim adapters each hand-built two structurally-identical keyword maps that differed only by ns-alias (`reagent.*` vs `reagent2.*`):

- **A1** — the 7-key `:ratom-ops` map (`reagent.cljs` vs `reagent_slim.cljs`)
- **A2** — the 10-key `:hook-ops` map (byte-identical between the two adapters modulo the alias)

Keeping those two maps in lockstep across the two adapters was a standing drift hazard.

`make-ratom-spine` / `make-ratom-adapter` (in `substrate/spine.cljs`) now take their per-substrate ops as a **flat set of injected bare fns** (flat config keys) — mirroring how `make-react-spine` already takes its bare `:use-memo` / `:use-callback` / `:use-context` hook fns — and assemble the route-hook / container wiring internally. The keyword-key shape lives **once** in the spine; each adapter now passes ~7 bare fns instead of a hand-shaped map.

A3 (the UIx/Helix native `defui`/`defnc` shells) was left untouched, per the bead.

## Bundle isolation (the load-bearing constraint)

Preserved by construction. The spine still names no reactive-atom ns; each adapter's `reagent.*` / `reagent2.*` references stay confined to the bare-fn lambdas in the adapter ns. The call-through-lambda wrapping (`(fn [mount-point] (rdc/create-root mount-point))`) is retained so the `with-redefs` test observability the render / dispose-drain pins rely on is unchanged. The `test:reagent-slim:bundle-isolation` gate stays green (4 contracts, 21 sentinel checks).

## Gates

- `npm run test:cljs` — 8024 tests / 33499 assertions, 0 failures
- `npm run test:browser` — 222 tests / 701 assertions, 0 failures
- **`npm run test:reagent-slim:bundle-isolation`** — PASS (4 contracts, 21 sentinel checks)
- `npm run test:bundle-isolation` — PASS (40 sentinels absent) + uix-helix-reagent-free PASS
- `sh scripts/test-jvm-implementation.sh` — all artefacts PASS
- clj-kondo — 0 errors; only the 2 pre-existing warnings (lines 395, 1661), unchanged

No facade/manifest change.