### PR TITLE
refactor(core/marks): collapse sensitive/large twins + dedup projector shapes (rf2-2s595w +6)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1028,6 +1028,23 @@
               (swap! frame->sub-id->large? dissoc frame-id)
               nil))
 
+(defn- frame-elision-decls?
+  "True when `frame-id`'s runtime-db elision registry carries any declaration
+  under `decl-key` (`:sensitive-declarations` or `:declarations`). The single
+  axis-parameterized read behind `resolve-sub-output-marks`'s layer-1 footgun
+  check (rf2-hkly6h) — the two near-identical container-read blocks differed
+  only in this sub-key.
+
+  EP-0001 (rf2-vzld77): the elision registry is durable framework state in the
+  frame's runtime-db partition at `[:rf.runtime/elision …]` (Conventions
+  §Reserved runtime-db keys), so the layer-1 footgun check reads the runtime-db
+  projection, not app-db."
+  [frame-id decl-key]
+  (let [container (frame/runtime-db-container frame-id)
+        rt        (when container (adapter/read-container container))
+        decls     (get-in rt [:rf.runtime/elision decl-key])]
+    (boolean (seq decls))))
+
 (defn resolve-sub-output-marks
   "Compute the sensitive/large flags that should be stamped onto a sub's
   output, given the sub's registered marks + input-signals' propagation
@@ -1066,21 +1083,13 @@
         ;; *actually* read; the conservative reading is "if there's
         ;; any sensitive path, the sub MAY have read it"). Spec 015
         ;; §Propagation rules acknowledges this is footgun prevention
-        ;; not security-grade taint.
-        ;; EP-0001 (rf2-vzld77): the elision registry is durable framework
-        ;; state in the frame's runtime-db partition at `[:rf.runtime/elision …]`
-        ;; (Conventions §Reserved runtime-db keys), so the layer-1 footgun
-        ;; check reads the runtime-db projection, not app-db.
+        ;; not security-grade taint. The two registry reads are the same
+        ;; axis-parameterized `frame-elision-decls?` differing only in the
+        ;; declaration sub-key (rf2-hkly6h).
         any-sens?   (when layer-1?
-                      (let [container (frame/runtime-db-container frame-id)
-                            rt        (when container (adapter/read-container container))
-                            decls     (get-in rt [:rf.runtime/elision :sensitive-declarations])]
-                        (boolean (seq decls))))
+                      (frame-elision-decls? frame-id :sensitive-declarations))
         any-large?  (when layer-1?
-                      (let [container (frame/runtime-db-container frame-id)
-                            rt        (when container (adapter/read-container container))
-                            decls     (get-in rt [:rf.runtime/elision :declarations])]
-                        (boolean (seq decls))))
+                      (frame-elision-decls? frame-id :declarations))
         sensitive?  (cond
                       (= :rf.egress/sensitive output-sens) true
                       (= :rf.egress/public output-sens)    false

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1109,42 +1109,26 @@
             redacted (redact-with-paths (:rf.fx/args tags) sens large)]
         (assoc tags :rf.fx/args redacted)))))
 
-(defn- project-cofx-tags
-  "Walk cofx-relevant tag shapes: the cofx-injected value rides under a
-  cofx-id key (per `re-frame.cofx`'s injection convention). When a
-  trace event carries a `:rf.event/coeffects` slot (e.g.
-  `:rf.event/dispatched`, `:rf.event/run-end` — rf2-9dk9y), walk each
-  cofx-id key against the cofx's marks."
-  [tags]
-  (let [cofx-map (:rf.event/coeffects tags)]
-    (if-not (map? cofx-map)
-      tags
-      (let [walked (reduce-kv
-                     (fn [acc cofx-id v]
-                       (let [marks (marks-when :cofx cofx-id)]
-                         (if-not marks
-                           (assoc acc cofx-id v)
-                           (let [sens     (or (:sensitive marks) [])
-                                 large    (or (:large marks) [])
-                                 redacted (redact-with-paths v sens large)]
-                             (assoc acc cofx-id redacted)))))
-                     (empty cofx-map)
-                     cofx-map)]
-        (assoc tags :rf.event/coeffects walked)))))
+(defn- project-cofx-map-slot
+  "Walk a `{cofx-id value}` map carried under `slot` in `tags`, redacting each
+  value against its cofx-id's registered `:sensitive` / `:large` marks.
+  Pass-through (returns `tags` unchanged) when the slot is not a map, and a
+  cofx-id with no declared marks rides its value verbatim. Re-assocs the
+  walked map back under the SAME `slot`.
 
-(defn- project-cofx-token-tags
-  "Walk the post-generation flat `:rf.cofx` replay token the
-  `:rf.event/run-start` trace carries (rf2-1xdotm): a one-fact-per-owner-
-  qualified-key map (`:rf/time-ms`, generated recordable facts, supplied
-  facts). Redact each fact's value against the cofx-id's registered
-  `:sensitive` / `:large` marks — the SAME per-cofx-id rule
-  `project-cofx-tags` applies to the `:rf.event/coeffects` slot, so a
-  declared-sensitive recordable fact never surfaces raw on the run-start
-  trace (the epoch record's `:rf.cofx` replay slot reads off this redacted
-  shape). The framework `:rf/time-ms` fact carries no marks and rides
-  verbatim. Pass-through when the slot is not a map."
-  [tags]
-  (let [cofx-map (:rf.event/cofx tags)]
+  The one parameterized walk behind both cofx map-slot trace shapes
+  (rf2-ew7uy2) — they were byte-identical modulo the slot keyword:
+
+    - `:rf.event/coeffects` — the injected coeffects map (e.g.
+      `:rf.event/dispatched`, `:rf.event/run-end` — rf2-9dk9y).
+    - `:rf.event/cofx` — the post-generation flat `:rf.cofx` replay token the
+      `:rf.event/run-start` trace carries (rf2-1xdotm): a one-fact-per-owner-
+      qualified-key map (`:rf/time-ms`, generated recordable facts, supplied
+      facts). The framework `:rf/time-ms` fact carries no marks and rides
+      verbatim; a declared-sensitive recordable fact never surfaces raw (the
+      epoch record's `:rf.cofx` replay slot reads off this redacted shape)."
+  [tags slot]
+  (let [cofx-map (get tags slot)]
     (if-not (map? cofx-map)
       tags
       (let [walked (reduce-kv
@@ -1158,7 +1142,7 @@
                              (assoc acc cofx-id redacted)))))
                      (empty cofx-map)
                      cofx-map)]
-        (assoc tags :rf.event/cofx walked)))))
+        (assoc tags slot walked)))))
 
 (defn- project-cofx-run-tags
   "Walk the produced-value op shape shared by `:rf.cofx/run` (ambient
@@ -1739,7 +1723,7 @@
                       (project-fx-tags)
 
                       (and (map? tags) (contains? tags :rf.event/coeffects))
-                      (project-cofx-tags)
+                      (project-cofx-map-slot :rf.event/coeffects)
 
                       ;; rf2-1xdotm — the `:rf.event/run-start` trace carries
                       ;; the post-generation flat `:rf.cofx` replay token under
@@ -1749,7 +1733,7 @@
                       ;; recordable fact never egresses raw on the run-start
                       ;; trace / epoch record's replay slot.
                       (and (map? tags) (contains? tags :rf.event/cofx))
-                      (project-cofx-token-tags)
+                      (project-cofx-map-slot :rf.event/cofx)
 
                       ;; The t1 / t2 pending-`:db` emits stamp the full
                       ;; app-db under `:rf.event/db`; redact against the

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -683,6 +683,22 @@
           (or existing {})
           paths))
 
+(defn- write-elision-slots
+  "Rewrite the two app-db elision-registry declaration slots on `base` from the
+  resolved `new-s` (`:sensitive-declarations`) and `new-l` (`:declarations`)
+  maps: assoc the slot when its map is non-empty, dissoc it when empty so an
+  emptied slot vanishes rather than lingering as `{}`. The single helper behind
+  `add-marks` / `set-marks` / `clear-app-db-marks!`, which hand-inlined this
+  same cond-> three times (rf2-mo9ekx). `clear-app-db-marks!` passes `base {}`,
+  where the empty-slot dissoc is a harmless no-op on an absent key — the result
+  is byte-identical to its prior seq-only cond->."
+  [base new-s new-l]
+  (cond-> base
+    (seq new-s)    (assoc :sensitive-declarations new-s)
+    (empty? new-s) (dissoc :sensitive-declarations)
+    (seq new-l)    (assoc :declarations new-l)
+    (empty? new-l) (dissoc :declarations)))
+
 (defn add-marks
   "Additively merge path-marks into the `app-db` mark-set of `frame-id`.
   Per Spec 015 §App-db marks (per frame).
@@ -722,11 +738,7 @@
       (fn [reg]
         (let [new-s (assoc-paths (get reg :sensitive-declarations) sens-paths)
               new-l (assoc-paths (get reg :declarations) large-paths)]
-          (cond-> (or reg {})
-            (seq new-s)    (assoc :sensitive-declarations new-s)
-            (empty? new-s) (dissoc :sensitive-declarations)
-            (seq new-l)    (assoc :declarations new-l)
-            (empty? new-l) (dissoc :declarations))))))
+          (write-elision-slots (or reg {}) new-s new-l)))))
   frame-id)
 
 (defn set-marks
@@ -771,11 +783,7 @@
               carry-l (without-marks-sourced (get reg :declarations))
               new-s   (assoc-paths carry-s sens-paths)
               new-l   (assoc-paths carry-l large-paths)]
-          (cond-> (or reg {})
-            (seq new-s)    (assoc :sensitive-declarations new-s)
-            (empty? new-s) (dissoc :sensitive-declarations)
-            (seq new-l)    (assoc :declarations new-l)
-            (empty? new-l) (dissoc :declarations))))))
+          (write-elision-slots (or reg {}) new-s new-l)))))
   frame-id)
 
 (defn clear-app-db-marks!
@@ -787,9 +795,7 @@
     (fn [reg]
       (let [new-s (without-marks-sourced (:sensitive-declarations reg))
             new-l (without-marks-sourced (:declarations reg))]
-        (cond-> {}
-          (seq new-s) (assoc :sensitive-declarations new-s)
-          (seq new-l) (assoc :declarations new-l)))))
+        (write-elision-slots {} new-s new-l))))
   nil)
 
 ;; ---- emit-time projection ------------------------------------------------

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -901,13 +901,19 @@
           redacted-payload (redact-with-paths payload sensitive-paths large-paths)]
       (into [id redacted-payload] rest-args))))
 
-(defn- event-marks
-  "Resolve the marks declared by the event handler registered under
-  `event-id`. Returns `{:sensitive [paths] :large [paths]}` or nil
-  when no marks are declared."
-  [event-id]
-  (when event-id
-    (marks-for :event event-id)))
+(defn- marks-when
+  "Resolve the marks declared by the `kind` handler registered under `id`,
+  guarding a nil `id` (no lookup, no marks). Returns the canonical
+  `{:sensitive [paths] :large [paths] …}` shape, or nil when `id` is nil or
+  the handler declared no marks. The single per-(kind, id) lookup wrapper the
+  trace-tag projectors reach through — `(marks-when :event event-id)`,
+  `(marks-when :fx fx-id)`, `(marks-when :cofx cofx-id)`, `(marks-when :sub
+  sub-id)`, and `(marks-when :event machine-id)` (a machine IS an `:event`
+  handler) replaced the five byte-identical `<kind>-marks` wrappers that
+  differed only in the kind keyword (rf2-8mvd28)."
+  [kind id]
+  (when id
+    (marks-for kind id)))
 
 (defn redact-event-by-registration
   "Apply the REGISTRATION-OWNED `:sensitive` / `:large` marks declared by the
@@ -932,29 +938,9 @@
   `re-frame.projection` consumes it for the `:rf.observe/error` / handled-event
   `:event` slot."
   [event]
-  (if-let [marks (event-marks (when (vector? event) (first event)))]
+  (if-let [marks (marks-when :event (when (vector? event) (first event)))]
     (redact-event-vec event (or (:sensitive marks) []) (or (:large marks) []))
     event))
-
-(defn- fx-marks
-  [fx-id]
-  (when fx-id
-    (marks-for :fx fx-id)))
-
-(defn- cofx-marks
-  [cofx-id]
-  (when cofx-id
-    (marks-for :cofx cofx-id)))
-
-(defn- machine-marks
-  [machine-id]
-  (when machine-id
-    (marks-for :event machine-id)))
-
-(defn- sub-marks
-  [sub-id]
-  (when sub-id
-    (marks-for :sub sub-id)))
 
 ;; Flow output marks are NOT resolved through this per-(kind, id) table
 ;; (rf2-ouemt). Spec 013 lets the SAME flow-id carry different definitions —
@@ -1044,7 +1030,7 @@
   and any consumer of its result, MUST be dev-gated; in production the table is
   empty and propagation would silently fail open."
   [frame-id sub-id input-signals layer-1?]
-  (let [marks       (sub-marks sub-id)
+  (let [marks       (marks-when :sub sub-id)
         output-sens (:output-sensitivity marks)
         forced-l    (:large? marks)
         ;; Propagation from inputs
@@ -1101,7 +1087,7 @@
   [tags slot]
   (let [event    (get tags slot)
         event-id (when (vector? event) (first event))
-        marks    (event-marks event-id)]
+        marks    (marks-when :event event-id)]
     (if-not marks
       tags
       (let [sens   (or (:sensitive marks) [])
@@ -1115,7 +1101,7 @@
   registration."
   [tags]
   (let [fx-id (:rf.fx/id tags)
-        marks (fx-marks fx-id)]
+        marks (marks-when :fx fx-id)]
     (if-not marks
       tags
       (let [sens     (or (:sensitive marks) [])
@@ -1135,7 +1121,7 @@
       tags
       (let [walked (reduce-kv
                      (fn [acc cofx-id v]
-                       (let [marks (cofx-marks cofx-id)]
+                       (let [marks (marks-when :cofx cofx-id)]
                          (if-not marks
                            (assoc acc cofx-id v)
                            (let [sens     (or (:sensitive marks) [])
@@ -1163,7 +1149,7 @@
       tags
       (let [walked (reduce-kv
                      (fn [acc cofx-id v]
-                       (let [marks (cofx-marks cofx-id)]
+                       (let [marks (marks-when :cofx cofx-id)]
                          (if-not marks
                            (assoc acc cofx-id v)
                            (let [sens     (or (:sensitive marks) [])
@@ -1186,7 +1172,7 @@
   success / generation emit does not ride under `:rf.event/coeffects`)."
   [tags]
   (let [cofx-id (:rf.cofx/id tags)
-        marks   (cofx-marks cofx-id)]
+        marks   (marks-when :cofx cofx-id)]
     (if (or (not marks) (not (contains? tags :rf.cofx/value)))
       tags
       (let [sens     (or (:sensitive marks) [])
@@ -1253,7 +1239,7 @@
   state."
   [tags frame-id]
   (let [sub-id     (:rf.sub/id tags)
-        marks      (sub-marks sub-id)
+        marks      (marks-when :sub sub-id)
         has-prev?  (contains? tags :rf.sub/prev-value)]
     (if (nil? frame-id)
       (cond-> (assoc tags :rf.sub/value privacy/redacted-sentinel :sensitive? true)
@@ -1487,7 +1473,7 @@
   ;; child's `:start` args are unclassifiable here at all).
   (let [tags       (project-spawn-synthetic-payloads tags)
         machine-id (or (:actor-id tags) (:machine-id tags))
-        marks      (machine-marks machine-id)]
+        marks      (marks-when :event machine-id)]
     (if-not marks
       tags
       (let [sens       (or (:sensitive marks) [])
@@ -1566,7 +1552,7 @@
   still gate the exception payload."
   [tags]
   (let [machine-id (or (:actor-id tags) (:machine-id tags))
-        marks      (machine-marks machine-id)]
+        marks      (marks-when :event machine-id)]
     (if (and (contains? tags :exception-data)
              marks
              (seq (:sensitive marks)))

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1532,6 +1532,19 @@
           (contains? tags :input)    (assoc :input    (project-input (:input tags)))
           (contains? tags :cascade)  (assoc :cascade  (project-cascade (:cascade tags))))))))
 
+(defn- redact-exception-data-slot
+  "Fail-closed whole-slot redaction tail shared by the two exception-payload
+  projectors (rf2-za4853): replace the WHOLE `:exception-data` slot with the
+  `:rf/redacted` sentinel and stamp `:sensitive? true`. The author-keyed
+  `ex-data` of a thrown machine action / flow output is not path-walkable, so
+  when the projector's (own) guard decides the surrounding machine / frame
+  handles secrets, the whole slot is dropped rather than shipped raw. Only the
+  redact ACTION is shared — each projector keeps its own redact-or-not guard —
+  so this helper unconditionally applies the same two-key assoc and cannot
+  weaken either fail-closed decision."
+  [tags]
+  (assoc tags :exception-data privacy/redacted-sentinel :sensitive? true))
+
 (defn- project-machine-error-tags
   "Walk the `:rf.error/machine-action-exception` tag shape (rf2-zsm03).
   The trace carries `:exception-data` — the `ex-data` of a thrown machine
@@ -1577,7 +1590,7 @@
     (if (and (contains? tags :exception-data)
              marks
              (seq (:sensitive marks)))
-      (assoc tags :exception-data privacy/redacted-sentinel :sensitive? true)
+      (redact-exception-data-slot tags)
       tags)))
 
 (defn- project-flow-failed-tags
@@ -1619,7 +1632,7 @@
              (some? (:exception-data tags))
              (or (nil? frame-id)
                  (seq (elision/sensitive-declarations frame-id))))
-      (assoc tags :exception-data privacy/redacted-sentinel :sensitive? true)
+      (redact-exception-data-slot tags)
       tags)))
 
 (defn- project-machine-wrote-db-tags

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -989,11 +989,27 @@
 ;; the resolved "is this sub's most recent value sensitive?" answer for
 ;; emit-time consultation. Frame-scoped because subs are frame-scoped.
 
-(defonce ^:private frame->sub-id->sensitive?
+;; ONE axis-keyed propagation table (rf2-2s595w): `{<axis> {<frame-id>
+;; {<sub-id> true}}}` where `<axis>` is `:sensitive` or `:large`. The prior
+;; fully-parallel twin atoms (`frame->sub-id->sensitive?` /
+;; `frame->sub-id->large?`) carried byte-identical assoc-in / dissoc structure
+;; per axis; collapsing into one defonce atom keyed by axis removes the twin
+;; while preserving the `[frame-id sub-id]` nesting under each axis (so a
+;; per-frame clear still drops both axes' entries for the frame). Empty in
+;; production — only `mark-sub-output!` writes it, and the sub-cache invokes
+;; that only under `debug-enabled?`.
+(defonce ^:private frame->sub-id->marks
   (atom {}))
 
-(defonce ^:private frame->sub-id->large?
-  (atom {}))
+(defn- swap-axis-flag
+  "Fold a single `axis` (`:sensitive` / `:large`) flag for `[frame-id sub-id]`
+  into the propagation map `m`: set the leaf `true` when `flag?`, else dissoc
+  the sub-id from the axis's frame entry. The shared per-axis update the twin
+  atoms each hand-inlined."
+  [m axis frame-id sub-id flag?]
+  (if flag?
+    (assoc-in m [axis frame-id sub-id] true)
+    (update-in m [axis frame-id] dissoc sub-id)))
 
 (defn mark-sub-output!
   "Record the resolved sensitive/large state of a sub's most recent
@@ -1002,36 +1018,33 @@
   emit sites read via `sub-output-sensitive?` / `sub-output-large?`.
 
   INVARIANT: the sub-cache only invokes this under `debug-enabled?`, so the
-  propagation table (`frame->sub-id->sensitive?` / `…->large?`) is EMPTY in
-  production. Any consumer reading it MUST be dev-gated too — an always-on
-  egress consumer would read empty and fail open."
+  propagation table (`frame->sub-id->marks`) is EMPTY in production. Any
+  consumer reading it MUST be dev-gated too — an always-on egress consumer
+  would read empty and fail open."
   [frame-id sub-id sensitive? large?]
-  (swap! frame->sub-id->sensitive?
+  (swap! frame->sub-id->marks
          (fn [m]
-           (if sensitive?
-             (assoc-in m [frame-id sub-id] true)
-             (update m frame-id dissoc sub-id))))
-  (swap! frame->sub-id->large?
-         (fn [m]
-           (if large?
-             (assoc-in m [frame-id sub-id] true)
-             (update m frame-id dissoc sub-id))))
+           (-> m
+               (swap-axis-flag :sensitive frame-id sub-id sensitive?)
+               (swap-axis-flag :large     frame-id sub-id large?))))
   nil)
 
 (defn sub-output-sensitive?
   [frame-id sub-id]
-  (true? (get-in @frame->sub-id->sensitive? [frame-id sub-id])))
+  (true? (get-in @frame->sub-id->marks [:sensitive frame-id sub-id])))
 
 (defn sub-output-large?
   [frame-id sub-id]
-  (true? (get-in @frame->sub-id->large? [frame-id sub-id])))
+  (true? (get-in @frame->sub-id->marks [:large frame-id sub-id])))
 
 (defn clear-sub-output-marks!
-  ([] (reset! frame->sub-id->sensitive? {})
-      (reset! frame->sub-id->large? {})
+  ([] (reset! frame->sub-id->marks {})
       nil)
-  ([frame-id] (swap! frame->sub-id->sensitive? dissoc frame-id)
-              (swap! frame->sub-id->large? dissoc frame-id)
+  ([frame-id] (swap! frame->sub-id->marks
+                     (fn [m]
+                       (-> m
+                           (update :sensitive dissoc frame-id)
+                           (update :large dissoc frame-id))))
               nil))
 
 (defn- frame-elision-decls?

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -880,6 +880,26 @@
   [v sensitive-paths large-paths]
   (walk-with-marks v sensitive-paths large-paths))
 
+(defn- mark-paths
+  "Destructure a canonical marks map into its `[sensitive-paths large-paths]`
+  pair, each defaulting to `[]` when the slot is absent — the shared shape
+  every per-registration projector hand-inlined as `(or (:sensitive marks) [])`
+  / `(or (:large marks) [])` before passing the pair to `redact-with-paths` /
+  `redact-event-vec` (rf2-tqxqm7)."
+  [marks]
+  [(or (:sensitive marks) []) (or (:large marks) [])])
+
+(defn- redact-by-marks
+  "Redact `v` against the canonical `marks` map — `(redact-with-paths v sens
+  large)` with the `[]`-defaulted `[sens large]` pair from `mark-paths`. The
+  shared one-shot redact the single-value projectors reach through (fx args,
+  cofx map values, the standalone cofx produced value); callers that redact
+  more than one slot from the same marks (sub value + prev-value, the machine
+  multi-slot walk) destructure `mark-paths` directly."
+  [v marks]
+  (let [[sens large] (mark-paths marks)]
+    (redact-with-paths v sens large)))
+
 ;; ---- per-trace-event projection ------------------------------------------
 ;;
 ;; The chokepoint `re-frame.trace/build-event` consults on every emit
@@ -939,7 +959,8 @@
   `:event` slot."
   [event]
   (if-let [marks (marks-when :event (when (vector? event) (first event)))]
-    (redact-event-vec event (or (:sensitive marks) []) (or (:large marks) []))
+    (let [[sens large] (mark-paths marks)]
+      (redact-event-vec event sens large))
     event))
 
 ;; Flow output marks are NOT resolved through this per-(kind, id) table
@@ -1090,8 +1111,7 @@
         marks    (marks-when :event event-id)]
     (if-not marks
       tags
-      (let [sens   (or (:sensitive marks) [])
-            large  (or (:large marks) [])
+      (let [[sens large] (mark-paths marks)
             redacted (redact-event-vec event sens large)]
         (assoc tags slot redacted)))))
 
@@ -1104,10 +1124,7 @@
         marks (marks-when :fx fx-id)]
     (if-not marks
       tags
-      (let [sens     (or (:sensitive marks) [])
-            large    (or (:large marks) [])
-            redacted (redact-with-paths (:rf.fx/args tags) sens large)]
-        (assoc tags :rf.fx/args redacted)))))
+      (assoc tags :rf.fx/args (redact-by-marks (:rf.fx/args tags) marks)))))
 
 (defn- project-cofx-map-slot
   "Walk a `{cofx-id value}` map carried under `slot` in `tags`, redacting each
@@ -1136,10 +1153,7 @@
                        (let [marks (marks-when :cofx cofx-id)]
                          (if-not marks
                            (assoc acc cofx-id v)
-                           (let [sens     (or (:sensitive marks) [])
-                                 large    (or (:large marks) [])
-                                 redacted (redact-with-paths v sens large)]
-                             (assoc acc cofx-id redacted)))))
+                           (assoc acc cofx-id (redact-by-marks v marks)))))
                      (empty cofx-map)
                      cofx-map)]
         (assoc tags slot walked)))))
@@ -1159,10 +1173,7 @@
         marks   (marks-when :cofx cofx-id)]
     (if (or (not marks) (not (contains? tags :rf.cofx/value)))
       tags
-      (let [sens     (or (:sensitive marks) [])
-            large    (or (:large marks) [])
-            redacted (redact-with-paths (:rf.cofx/value tags) sens large)]
-        (assoc tags :rf.cofx/value redacted)))))
+      (assoc tags :rf.cofx/value (redact-by-marks (:rf.cofx/value tags) marks)))))
 
 (defn- project-sub-tags*
   "Inner projection for `project-sub-tags` against a KNOWN carried frame.
@@ -1192,8 +1203,7 @@
         has-prev? (assoc :rf.sub/prev-value privacy/redacted-sentinel))
 
       :else
-      (let [sens     (or (:sensitive marks) [])
-            large    (or (:large marks) [])
+      (let [[sens large] (mark-paths marks)
             redacted (redact-with-paths (:rf.sub/value tags) sens large)]
         (cond-> (assoc tags :rf.sub/value redacted)
           has-prev? (assoc :rf.sub/prev-value (redact-with-paths (:rf.sub/prev-value tags) sens large))
@@ -1460,8 +1470,7 @@
         marks      (marks-when :event machine-id)]
     (if-not marks
       tags
-      (let [sens       (or (:sensitive marks) [])
-            large      (or (:large marks) [])
+      (let [[sens large] (mark-paths marks)
             ;; `:data`-map-relative paths for the slots that carry the bare
             ;; `:data` map (not a full snapshot).
             data-sens  (strip-data-prefix sens)


### PR DESCRIPTION
Cluster of 7 dedup beads, all confined to `implementation/core/src/re_frame/marks.cljc` (the EP-0015 redaction/egress surface). Every dedup is behaviour-PRESERVING; the fail-closed redaction semantics are preserved byte-identically (a declared-sensitive slot is still dropped at the AI/log boundary; the `:sensitive? true` stamp still rides).

## Beads landed (all 7)

- **rf2-8mvd28** — collapsed the five private `marks-for` wrappers (`event-marks` / `fx-marks` / `cofx-marks` / `machine-marks` / `sub-marks`, each `(when id (marks-for :KIND id))`) into one `marks-when` taking the kind. `machine-marks` resolved `:event` (a machine IS an event handler), now `(marks-when :event machine-id)`.
- **rf2-ew7uy2** — `project-cofx-tags` (`:rf.event/coeffects`) and `project-cofx-token-tags` (`:rf.event/cofx`) were byte-identical modulo the slot keyword; collapsed into one `project-cofx-map-slot` taking the slot key.
- **rf2-tqxqm7** — the `(or (:sensitive marks) []) / (or (:large marks) [])` defaulting shape (6+ projectors) extracted into `mark-paths` (returns the pair) + `redact-by-marks` (one-shot redact for single-value projectors).
- **rf2-hkly6h** — `resolve-sub-output-marks`'s `any-sens?`/`any-large?` near-identical runtime-db reads (differing only in the decl sub-key) extracted into one axis-parameterized `frame-elision-decls?`; the `(when layer-1? …)` gating preserved per call site.
- **rf2-mo9ekx** — the "assoc slot when seq else dissoc" cond-> over the two elision slots (inlined 3x in `add-marks` / `set-marks` / `clear-app-db-marks!`) extracted into `write-elision-slots`. `clear-app-db-marks!` passes `base {}` where the empty-slot dissoc is a no-op on an absent key — byte-identical.
- **rf2-2s595w** — collapsed the fully-parallel twin defonce atoms (`frame->sub-id->sensitive?` / `frame->sub-id->large?`) into one axis-keyed `frame->sub-id->marks` (`{:sensitive … :large …}`); a shared `swap-axis-flag` does the per-axis leaf update. Toggle/independence/per-frame-clear verified.
- **rf2-za4853** (P4, borderline) — LANDED. The shared "redact whole `:exception-data` slot + stamp `:sensitive? true`" tail of `project-machine-error-tags` / `project-flow-failed-tags` extracted into `redact-exception-data-slot`. Only the redact ACTION is shared; each projector keeps its own (different) redact-or-not guard untouched, so neither fail-closed decision is weakened and the `:sensitive? true` stamp is preserved literally.

## Gates (0 failures)

- `implementation/core` JVM: 1822 tests / 7962 assertions — 0 failures, 0 errors.
- `implementation/security` JVM (egress/redaction conformance): 85 tests / 600 assertions — 0 failures, 0 errors.
- `npm run test:cljs` (node): 8024 tests / 33499 assertions — 0 failures, 0 errors.
- `npm run test:elision` (prod elision probe): PASS — production 41/41 markers absent, EP-0023 provenance + assembly-DCE pass, control 41/41 present.
- clj-kondo: 0 errors. One pre-existing `re-frame.interop is required but never used` warning (present on origin/main, unrelated to this work, `:warning` level — left as-is, out of scope).

No facade/manifest change. No edits outside `marks.cljc` (no dedup required touching `elision.cljc` or other files — a concurrent worker owns `elision.cljc`).