### PR TITLE
refactor(core): shared error-emit helper + core-internals dedup (rf2-c4oycd, rf2-6zfzxy)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -83,23 +83,15 @@
   name collision (Spec 001 §Collisions)."
   #{:db :event})
 
-(defn- rf-prefixed-app-namespace?
-  "True when `id` is a qualified keyword whose namespace starts with `rf.`
-  but is NOT a framework-reserved root. Application ids MUST NOT use
-  `rf.`-prefixed namespaces (Spec 002 §Owner-qualified fact naming). The
-  framework's own facts (`:rf/time-ms`, `:rf.route/*`, `:rf.server/*`, …)
-  are owner-qualified and legitimate; this guard catches an APP registering
-  under an `rf.`-prefixed namespace, which the registration site cannot
-  distinguish from a framework fact. We only police the obviously-app shape
-  here (the lint surface in Spec 009 §9 is the deeper check); the structural
-  guard below rejects nothing that the framework itself registers."
-  [_id]
-  ;; Conservative: do not reject any `rf.`/`rf/` id at registration — the
-  ;; framework and its subsystems legitimately register many of them and the
-  ;; registration site cannot tell app from framework. The owner-qualified
-  ;; naming rule is enforced by the lint (Spec 009 §9), not a structural
-  ;; registration guard. Kept as a named seam for the future lint.
-  false)
+;; NOTE (rf2-6zfzxy): the registration site does NOT police `rf.`-prefixed
+;; APP namespaces — it cannot distinguish an app id from a legitimate
+;; framework/subsystem `rf.*` fact (`:rf/time-ms`, `:rf.route/*`, …), which
+;; the framework registers many of. The owner-qualified naming rule is the
+;; lint surface in Spec 009 §9, not a structural registration guard. The
+;; previously-present `rf-prefixed-app-namespace?` seam was a hardcoded `false`
+;; feeding an unreachable `emit-cofx-name-collision!` branch — removed as dead
+;; code (the future lint lives in Spec 009 §9, not a dormant always-false
+;; predicate here).
 
 (defn- emit-cofx-name-collision!
   "Emit `:rf.error/cofx-name-collision` (registration-time, diagnostic) and
@@ -221,12 +213,6 @@
              "and `:event` are the handler's own arguments — staged by the "
              "runtime, not registered coeffects, and not declarable via "
              "`:rf.cofx/requires`. Choose an owner-qualified fact name.")))
-    (when (rf-prefixed-app-namespace? id)
-      (emit-cofx-name-collision!
-        id
-        (str "`reg-cofx` id `" id "` uses an `rf.`-prefixed namespace reserved "
-             "for the framework. Application coeffects must be owner-qualified "
-             "under an application namespace.")))
     (let [recordable? (boolean (:recordable? meta))
           provided?   (boolean (:provided? meta))]
       ;; `:provided?` is meaningful ONLY alongside `:recordable? true` — a

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -441,15 +441,14 @@
                     "`:rf.cofx/requires`) so a supplier exists before the event "
                     "is dispatched."
                     (when frame-id (str " (frame `" frame-id "`)")))]
-    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! :rf.error/unregistered-cofx nil failing-id frame-id nil 0 (interop/now-ms)))
-    (trace/emit-error! :rf.error/unregistered-cofx
-                       (cond-> {:rf.cofx/id        cofx-id
-                                :failing-id        failing-id
-                                :rf.trace/event-id failing-id
-                                :reason            reason
-                                :recovery          :no-recovery}
-                         frame-id (assoc :frame frame-id)))
+    (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+      (emit-error-both! :rf.error/unregistered-cofx nil failing-id frame-id nil 0 (interop/now-ms)
+                        (cond-> {:rf.cofx/id        cofx-id
+                                 :failing-id        failing-id
+                                 :rf.trace/event-id failing-id
+                                 :reason            reason
+                                 :recovery          :no-recovery}
+                          frame-id (assoc :frame frame-id))))
     (error/throw-error! :rf.error/unregistered-cofx 'rf/reg-event reason
                         {:extra (cond-> {:rf.cofx/id cofx-id
                                          :failing-id failing-id}
@@ -470,15 +469,14 @@
                     "dispatch under `:live` so a generator-backed fact can mint "
                     "it."
                     (when frame-id (str " (frame `" frame-id "`)")))]
-    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! :rf.error/missing-required-cofx nil failing-id frame-id nil 0 (interop/now-ms)))
-    (trace/emit-error! :rf.error/missing-required-cofx
-                       (cond-> {:rf.cofx/id        cofx-id
-                                :failing-id        failing-id
-                                :rf.trace/event-id failing-id
-                                :reason            reason
-                                :recovery          :no-recovery}
-                         frame-id (assoc :frame frame-id)))
+    (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+      (emit-error-both! :rf.error/missing-required-cofx nil failing-id frame-id nil 0 (interop/now-ms)
+                        (cond-> {:rf.cofx/id        cofx-id
+                                 :failing-id        failing-id
+                                 :rf.trace/event-id failing-id
+                                 :reason            reason
+                                 :recovery          :no-recovery}
+                          frame-id (assoc :frame frame-id))))
     (error/throw-error! :rf.error/missing-required-cofx 'rf/reg-event reason
                         {:extra (cond-> {:rf.cofx/id cofx-id
                                          :failing-id failing-id}
@@ -498,18 +496,17 @@
   tools from double-recording a captured trace AND a propagated Throwable)."
   [cofx-id failing-id frame-id ^Throwable t]
   (let [msg #?(:clj (.getMessage t) :cljs (.-message t))]
-    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! :rf.error/coeffect-exception nil failing-id frame-id t 0 (interop/now-ms)))
-    (trace/emit-error! :rf.error/coeffect-exception
-                       (cond-> {:rf.cofx/id        cofx-id
-                                :failing-id        cofx-id
-                                :rf.trace/event-id failing-id
-                                :phase             :before
-                                :exception         t
-                                :reason            (str "Coeffect supplier for `" cofx-id "` threw"
-                                                        (when msg (str ": " msg)) ".")
-                                :recovery          :no-recovery}
-                         frame-id (assoc :frame frame-id)))))
+    (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+      (emit-error-both! :rf.error/coeffect-exception nil failing-id frame-id t 0 (interop/now-ms)
+                        (cond-> {:rf.cofx/id        cofx-id
+                                 :failing-id        cofx-id
+                                 :rf.trace/event-id failing-id
+                                 :phase             :before
+                                 :exception         t
+                                 :reason            (str "Coeffect supplier for `" cofx-id "` threw"
+                                                         (when msg (str ": " msg)) ".")
+                                 :recovery          :no-recovery}
+                          frame-id (assoc :frame frame-id))))))
 
 ;; ---- :schema validation of recordable values (EP-0017 §5 / slice B.7) -----
 ;;
@@ -566,18 +563,17 @@
                       "this is a hard error in dev AND production. Fix the value "
                       "to satisfy the declared `:schema` (or correct the schema). "
                       "See `:explain` for the validation detail.")]
-      (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-        (dispatch-on-error! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)))
-      (trace/emit-error! :rf.error/cofx-value-invalid
-                         (cond-> {:rf.cofx/id        cofx-id
-                                  :failing-id        failing-id
-                                  :rf.trace/event-id failing-id
-                                  :value             (:value redacted)
-                                  :reason            reason
-                                  :recovery          :no-recovery}
-                           (contains? redacted :explain) (assoc :explain (:explain redacted))
-                           (:sensitive? redacted)        (assoc :sensitive? true)
-                           frame-id                      (assoc :frame frame-id)))
+      (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+        (emit-error-both! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)
+                          (cond-> {:rf.cofx/id        cofx-id
+                                   :failing-id        failing-id
+                                   :rf.trace/event-id failing-id
+                                   :value             (:value redacted)
+                                   :reason            reason
+                                   :recovery          :no-recovery}
+                            (contains? redacted :explain) (assoc :explain (:explain redacted))
+                            (:sensitive? redacted)        (assoc :sensitive? true)
+                            frame-id                      (assoc :frame frame-id))))
       (error/throw-error! :rf.error/cofx-value-invalid 'rf/reg-cofx reason
                           {:extra (cond-> {:rf.cofx/id cofx-id
                                            :failing-id failing-id
@@ -664,18 +660,17 @@
   [cofx-id bad value failing-id frame-id]
   (let [{:keys [path bad-type]} bad
         preview (recordable/safe-preview value)]
-    (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)))
-    (trace/emit-error! :rf.error/cofx-value-invalid
-                       (cond-> {:rf.cofx/id        cofx-id
-                                :failing-id        failing-id
-                                :rf.trace/event-id failing-id
-                                :reason            :non-edn-recordable-value
-                                :path              path
-                                :bad-type          bad-type
-                                :recovery          :no-recovery}
-                         (some? preview) (assoc :preview preview)
-                         frame-id        (assoc :frame frame-id)))
+    (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+      (emit-error-both! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)
+                        (cond-> {:rf.cofx/id        cofx-id
+                                 :failing-id        failing-id
+                                 :rf.trace/event-id failing-id
+                                 :reason            :non-edn-recordable-value
+                                 :path              path
+                                 :bad-type          bad-type
+                                 :recovery          :no-recovery}
+                          (some? preview) (assoc :preview preview)
+                          frame-id        (assoc :frame frame-id))))
     (error/throw-error!
       :rf.error/cofx-value-invalid 're-frame.cofx/run-generator
       (str "Generated `:rf.cofx` fact `" cofx-id
@@ -1079,11 +1074,14 @@
   normally. The ONE place the fan-out throw mechanics live; every fan-out
   removed stub delegates here so the next such removal is a data edit."
   [error-kw where reason id id-key]
-  (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-    (dispatch-on-error! error-kw nil id nil nil 0 (interop/now-ms)))
-  (trace/emit-error! error-kw
-                     (cond-> {:reason reason :recovery :no-recovery}
-                       (some? id) (assoc id-key id)))
+  ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the always-on
+  ;; listener (production-survivable), axis 2 the dev trace (DCEs in CLJS prod).
+  ;; Reached via the `:error-emit/emit-error-both` hook (cofx cannot
+  ;; static-require error-emit — load cycle). `elapsed-ms 0`.
+  (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+    (emit-error-both! error-kw nil id nil nil 0 (interop/now-ms)
+                      (cond-> {:reason reason :recovery :no-recovery}
+                        (some? id) (assoc id-key id))))
   (error/throw-error! error-kw where reason
                       {:recovery :no-recovery
                        :extra    (when (some? id) {id-key id})}))

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -30,9 +30,9 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.error :as error]
+            [re-frame.cofx.value-check :as value-check]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
-            [re-frame.recordable :as recordable]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
@@ -629,61 +629,6 @@
 ;; this structural always-EDN gate is the floor that fires even when no
 ;; `:schema` was declared.
 
-(defn- emit-cofx-generated-value-non-edn!
-  "Emit `:rf.error/cofx-value-invalid` for a GENERATED recordable value that is
-  not recordable EDN data (a host handle a generator minted) and throw. Reuses
-  the EP-0017 cofx error id with `reason :non-edn-recordable-value` — the
-  structural-EDN-always half (rf2-rmroo4 slice B, EP-0017:386: recordable
-  values must be EDN). The mirror of slice A's supplied-value emit
-  (router/diagnostics.cljc), at the GENERATOR write-back site.
-
-  The payload carries the failing fact id, the path WITHIN the generated value
-  to the bad leaf, the host `:bad-type`, and a `:preview` ONLY when the value
-  is itself recordable (so the preview round-trips) — NEVER the raw host
-  object. Fans out through the always-on `dispatch-on-error!` listener, then
-  throws (the throw propagates from inside the generator's HandlerScope, so the
-  failure carries the cofx's source-coord like every other cofx emit)."
-  [cofx-id bad value failing-id frame-id]
-  (let [{:keys [path bad-type]} bad
-        preview (recordable/safe-preview value)]
-    (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
-      (emit-error-both! :rf.error/cofx-value-invalid nil failing-id frame-id nil 0 (interop/now-ms)
-                        (cond-> {:rf.cofx/id        cofx-id
-                                 :failing-id        failing-id
-                                 :rf.trace/event-id failing-id
-                                 :reason            :non-edn-recordable-value
-                                 :path              path
-                                 :bad-type          bad-type
-                                 :recovery          :no-recovery}
-                          (some? preview) (assoc :preview preview)
-                          frame-id        (assoc :frame frame-id))))
-    (error/throw-error!
-      :rf.error/cofx-value-invalid 're-frame.cofx/run-generator
-      (str "Generated `:rf.cofx` fact `" cofx-id
-           "` is not recordable EDN data: the value "
-           "at path " (pr-str path) " is a `"
-           bad-type "` (a host object — DOM node, "
-           "Promise, function, atom, Date, or other "
-           "JS / Java handle). A generator-backed "
-           "recordable coeffect rides the durable "
-           "causal record (it is written back into "
-           "`:rf.cofx`, folded into the epoch ledger, "
-           "replayed, shipped in the SSR payload, read "
-           "by Xray) and MUST mint ordinary EDN data "
-           "that reads back unchanged (EP-0017:386). "
-           "Have the generator return the recordable "
-           "projection — the identifier / snapshot / "
-           "plain data you actually need on replay.")
-      ;; The structured sub-kind that distinguishes a structural-EDN failure
-      ;; from a declared-`:schema` miss now rides its own `:rf.cofx/value-error`
-      ;; slot — `:reason` is reserved for the human sentence per the central
-      ;; thrown-error builder (Spec 009 §The thrown-error shape, rf2-vvixub).
-      {:extra {:rf.cofx/value-error :non-edn-recordable-value
-               :rf.cofx/id          cofx-id
-               :failing-id          failing-id
-               :path                path
-               :bad-type            bad-type}})))
-
 (defn- validate-generated-recordable-value!
   "ALWAYS-ON structural-EDN check of a GENERATED recordable `value` for
   `cofx-id`, run at the generator write-back site BEFORE the value is folded
@@ -704,14 +649,15 @@
   check stays the complementary always-on production contract; this is the
   structural always-EDN floor that fires even with no `:schema` (closing the
   EP-0017 errata tail — a generator without a `:schema` minting a host handle
-  no longer escapes to a far-away replay / Xray / SSR failure). Reuses the
-  slice-A walker (`re-frame.recordable`); the reported path is rooted at the
-  fact id so it reads from the coeffect key, not the per-value walk root."
+  no longer escapes to a far-away replay / Xray / SSR failure).
+
+  The `:generated` arm of the shared `value-check/check-edn-value!` (rf2-6zfzxy)
+  — its supplied-value twin (slice A) lives at the dispatch boundary
+  (`router.diagnostics`). The throw propagates from inside the generator's
+  HandlerScope, so the failure carries the cofx's source-coord like every other
+  cofx emit."
   [cofx-id value failing-id frame-id]
-  (when-let [bad (recordable/explain-non-recordable value)]
-    (let [rooted (update bad :path #(into [cofx-id] %))]
-      (emit-cofx-generated-value-non-edn! cofx-id rooted value failing-id frame-id)))
-  value)
+  (value-check/check-edn-value! :generated cofx-id value failing-id nil frame-id))
 
 ;; ---- generation at processing-start (EP-0017 §5 step 3 / slice B.7) --------
 ;;

--- a/implementation/core/src/re_frame/cofx/value_check.cljc
+++ b/implementation/core/src/re_frame/cofx/value_check.cljc
@@ -1,0 +1,125 @@
+(ns re-frame.cofx.value-check
+  "Shared structural-EDN check for recordable `:rf.cofx` values (rf2-6zfzxy,
+  factoring the rf2-rmroo4 slice-A + slice-B clones).
+
+  EP-0017:386 — a recordable coeffect value rides the durable causal record
+  (epoch ledger, replay, SSR payload, Xray export) and so MUST be ordinary EDN
+  data that reads back unchanged. A host handle (DOM node, `Promise`, function,
+  atom, `Date`, any JS / Java object) folded in corrupts durable state SILENTLY:
+  the failure surfaces far away, at replay / Xray / SSR time, not at the bad
+  coeffect. The structural-EDN floor catches it at the source — ALWAYS-ON, a
+  hard error in production as well as dev (rf2-q34j26).
+
+  Two write sites fold recordable `:rf.cofx` values into the in-flight token:
+
+    - SUPPLIED — a caller-supplied `:rf.cofx` override at the dispatch boundary
+      (`re-frame.router.diagnostics/validate-supplied-cofx-values!`, slice A);
+    - GENERATED — a generator-backed recordable fact minted at processing-start
+      (`re-frame.cofx/validate-generated-recordable-value!`, slice B).
+
+  Both emitted the SAME `:rf.error/cofx-value-invalid` (reason
+  `:non-edn-recordable-value`) with the SAME path-rooting, the SAME `:preview`-
+  only-when-itself-recordable rule, the SAME two-channel fan-out, and the SAME
+  `:extra` discriminator shape — differing only by the `:supplied` / `:generated`
+  noun in the human message, the throw `where` symbol, and which always-on
+  listener positional slot (`event` vs `frame`) the source carries. [[check-edn-value!]]
+  is the ONE shared definition both delegate to; behaviour is byte-identical.
+
+  Requires `error` / `interop` / `late-bind` / `recordable` — exactly the four
+  both call sites already required; this leaf ns adds no load cycle (nothing
+  those four reach requires cofx or router.diagnostics)."
+  (:require [re-frame.error      :as error]
+            [re-frame.interop    :as interop]
+            [re-frame.late-bind  :as late-bind]
+            [re-frame.recordable :as recordable]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; The two write-site shapes, table-driven so the only thing that varies is
+;; DATA (rf2-6zfzxy). `:noun` opens the human message; `:durable-clause` is the
+;; trailing how-and-fix sentence pair (the only prose that genuinely differs);
+;; `:where` is the throw site symbol the canonical builder stamps.
+(def ^:private kind->shape
+  {:supplied  {:noun           "Supplied"
+               :where          're-frame.router/build-envelope
+               :durable-clause (str "Recordable coeffect "
+                                    "values ride the durable causal record "
+                                    "(epoch ledger, replay, SSR payload, Xray) "
+                                    "and MUST be ordinary EDN data that reads "
+                                    "back unchanged (EP-0017:386). Replace the "
+                                    "host handle with its recordable "
+                                    "projection — the identifier / snapshot / "
+                                    "plain data you actually need on replay.")}
+   :generated {:noun           "Generated"
+               :where          're-frame.cofx/run-generator
+               :durable-clause (str "A generator-backed "
+                                    "recordable coeffect rides the durable "
+                                    "causal record (it is written back into "
+                                    "`:rf.cofx`, folded into the epoch ledger, "
+                                    "replayed, shipped in the SSR payload, read "
+                                    "by Xray) and MUST mint ordinary EDN data "
+                                    "that reads back unchanged (EP-0017:386). "
+                                    "Have the generator return the recordable "
+                                    "projection — the identifier / snapshot / "
+                                    "plain data you actually need on replay.")}})
+
+(defn check-edn-value!
+  "ALWAYS-ON structural-EDN check of a recordable `:rf.cofx` `value` for
+  `cofx-id` (rf2-6zfzxy — the shared slice-A / slice-B floor). When `value`
+  carries a non-recordable leaf, fan `:rf.error/cofx-value-invalid` (reason
+  `:non-edn-recordable-value`) out through BOTH error channels and throw; an
+  all-EDN value passes and returns `value`.
+
+  `kind` is `:supplied` (a caller-supplied override at the dispatch boundary)
+  or `:generated` (a generator write-back) — it selects the human-message noun,
+  the throw `where` symbol, and the always-on listener's source slot (the
+  supplied path carries the triggering `event`; the generated path carries the
+  `frame-id`). `failing-id` is the always-on record's event-id (the supplied
+  path's triggering event-id, the generated path's failing fact id). `event`
+  and `frame-id` are mutually-exclusive source context — pass the one the kind
+  carries and `nil` for the other. The reported path is rooted at `cofx-id`
+  here, so both call sites hand the bare per-value walk result.
+
+  Byte-identical to the two clones it replaced: same emitted category + reason,
+  same `:preview`-only-when-itself-recordable rule, same `cond->` payload, same
+  `:extra` discriminator shape, same human-message bytes per kind."
+  [kind cofx-id value failing-id event frame-id]
+  (when-let [bad (recordable/explain-non-recordable value)]
+    (let [{:keys [path bad-type]} (update bad :path #(into [cofx-id] %))
+          preview                 (recordable/safe-preview value)
+          {:keys [noun where durable-clause]} (kind->shape kind)]
+      ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the always-on
+      ;; listener (survives prod elision), axis 2 the dev trace (DCEs under
+      ;; `:advanced` + `goog.DEBUG=false`). Reached via the
+      ;; `:error-emit/emit-error-both` hook (this ns cannot static-require
+      ;; error-emit — load cycle). `elapsed-ms 0`.
+      (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+        (emit-error-both! :rf.error/cofx-value-invalid
+                          event failing-id frame-id nil 0 (interop/now-ms)
+                          (cond-> {:rf.cofx/id        cofx-id
+                                   :failing-id        failing-id
+                                   :rf.trace/event-id failing-id
+                                   :reason            :non-edn-recordable-value
+                                   :path              path
+                                   :bad-type          bad-type
+                                   :recovery          :no-recovery}
+                            (some? preview) (assoc :preview preview)
+                            frame-id        (assoc :frame frame-id))))
+      (error/throw-error!
+        :rf.error/cofx-value-invalid where
+        (str noun " `:rf.cofx` fact `" cofx-id
+             "` is not recordable EDN data: the value "
+             "at path " (pr-str path) " is a `"
+             bad-type "` (a host object — DOM node, "
+             "Promise, function, atom, Date, or other "
+             "JS / Java handle). " durable-clause)
+        ;; The structured sub-kind that distinguishes a structural-EDN failure
+        ;; from a declared-`:schema` miss rides its own `:rf.cofx/value-error`
+        ;; slot — `:reason` is reserved for the human sentence per the central
+        ;; thrown-error builder (Spec 009 §The thrown-error shape, rf2-vvixub).
+        {:extra {:rf.cofx/value-error :non-edn-recordable-value
+                 :rf.cofx/id          cofx-id
+                 :failing-id          failing-id
+                 :path                path
+                 :bad-type            bad-type}})))
+  value)

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -55,7 +55,8 @@
   (:require [re-frame.elision        :as elision]
             [re-frame.emit-substrate :as emit]
             [re-frame.late-bind      :as late-bind]
-            [re-frame.source-coords  :as source-coords]))
+            [re-frame.source-coords  :as source-coords]
+            [re-frame.trace          :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -237,6 +238,54 @@
                     time nil)))
   nil)
 
+;; ---- the two-channel fan-out helper (rf2-c4oycd) --------------------------
+;;
+;; EVERY production-reachable runtime `:rf.error/*` site fans the SAME category
+;; out along BOTH error channels in lock-step: the always-on
+;; `dispatch-on-error!` listener registry (axis 1 — production-survivable; the
+;; off-box-shipper / SSR-projector source of truth) AND the dev-only
+;; `trace/emit-error!` surface (axis 2 — DCE'd under CLJS `:advanced` +
+;; `goog.DEBUG=false`). Before this helper that two-step was open-coded at ~12
+;; emit sites across `subs` / `subs.memo` / `cofx` / `router.diagnostics`
+;; (reaching `dispatch-on-error!` through the `:error-emit/dispatch-on-error`
+;; late-bind hook) plus 4 bespoke `router` wrappers (which static-require this
+;; ns and call `dispatch-on-error!` directly) and `fx`'s `emit-fx-error!`. The
+;; shape never varied — same positional record + the category-specific dev-trace
+;; `tags` map — so `emit-fx-error!` had already factored it locally (the proof
+;; the abstraction was wanted, just not shared). This is the ONE shared helper
+;; those sites collapse onto.
+
+(defn emit-error-both!
+  "Fan a runtime `:rf.error/*` `category` out through BOTH error channels in one
+  call (rf2-c4oycd): the always-on corpus-wide [[dispatch-on-error!]] listener
+  registry (axis 1 — production-survivable; survives CLJS `:advanced` +
+  `goog.DEBUG=false`, the off-box-shipper + SSR-error-projector source of truth)
+  AND the dev-only `re-frame.trace/emit-error!` surface (axis 2 — DCE'd in CLJS
+  production). The shared two-channel fan-out every catalogued production-
+  reachable runtime error site uses.
+
+  `category` is the `:rf.error/*` keyword (the SAME value flows to both
+  channels). `event` / `event-id` / `frame` / `exception` / `elapsed-ms` / `time`
+  are the always-on listener record's positional fields (see
+  [[dispatch-on-error!]] — `event` is elided by the wire-walker there, `time` is
+  the emit instant in millis, `elapsed-ms` is `0` at the non-timed invalid-op
+  sites and the measured duration at the router's timed pipeline/flow paths).
+  `trace-tags` is the category-specific dev-trace tag map — passed UNCHANGED to
+  `trace/emit-error!`, so dev-trace consumers see exactly the shape they did
+  before (the map is still built at the call site and threaded here).
+
+  Returns nil. Reached directly by `router.cljc` (static require) and via the
+  `:error-emit/emit-error-both` late-bind hook by `fx` / `subs` / `subs.memo` /
+  `cofx` / `router.diagnostics` (those layers cannot static-require this ns — a
+  load cycle through `elision` → `frame`)."
+  [category event event-id frame exception elapsed-ms time trace-tags]
+  ;; Axis 1 — always-on corpus-wide listener (+ EP-0015 frame-owned sink).
+  (dispatch-on-error! category event event-id frame exception elapsed-ms time)
+  ;; Axis 2 — dev-only trace surface; DCEs under `:advanced` + `goog.DEBUG=false`
+  ;; (the `interop/debug-enabled?` gate lives inside `trace/emit-error!`).
+  (trace/emit-error! category trace-tags)
+  nil)
+
 ;; ---- general non-event always-on record (EP-0008 union shape) -------------
 ;;
 ;; `dispatch-on-error!` (above) is the EVENT-centric always-on path: it takes
@@ -405,6 +454,12 @@
 ;; records without static-requiring this ns.
 
 (late-bind/set-fn! :error-emit/dispatch-on-error dispatch-on-error!)
+
+;; The shared two-channel fan-out (rf2-c4oycd). `fx` / `subs` / `subs.memo` /
+;; `cofx` / `router.diagnostics` reach it through this hook — they cannot
+;; static-require this ns (the `error-emit` → `elision` → `frame` load cycle),
+;; exactly as they reached `dispatch-on-error!` through its hook before.
+(late-bind/set-fn! :error-emit/emit-error-both emit-error-both!)
 
 ;; The frame-teardown report fires from `frame/destroy-frame!`'s finally-
 ;; shaped flush. `frame` MUST reach it via late-bind: a static

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -468,17 +468,21 @@
   substrate; this brings the three drift sites into line.
 
   `trace-payload` is the existing dev-trace map for the category
-  (unchanged shape, so dev consumers see exactly what they did before)."
+  (unchanged shape, so dev consumers see exactly what they did before).
+
+  Reaches the shared two-channel `emit-error-both!` (rf2-c4oycd) through the
+  `:error-emit/emit-error-both` late-bind hook — fx.cljc cannot static-require
+  `re-frame.error-emit` (a load cycle), exactly as it reached `dispatch-on-error!`
+  through its hook before. `elapsed-ms 0` (not a timed path); `(interop/now-ms)`
+  is the emit instant."
   [category event event-id frame-id exception trace-payload]
-  ;; Always-on substrate (the corpus-wide listener). The late-bind hook
-  ;; is how fx.cljc reaches error-emit without a static require (would
-  ;; form a load cycle); `nil` when the substrate ns hasn't loaded (it is
-  ;; a foundational always-on surface, so in practice it is present).
-  (when-let [dispatch-on-error! (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-    (dispatch-on-error! category event event-id frame-id exception 0
-                        (interop/now-ms)))
-  ;; Dev trace path; DCE'd in CLJS prod.
-  (trace/emit-error! category trace-payload))
+  ;; Both channels via the shared helper: axis 1 the always-on corpus-wide
+  ;; listener (survives prod elision), axis 2 the dev trace (DCE'd in CLJS prod).
+  ;; `nil` when the substrate ns hasn't loaded (it is a foundational always-on
+  ;; surface, so in practice it is present).
+  (when-let [emit-error-both! (late-bind/get-fn-cached :error-emit/emit-error-both)]
+    (emit-error-both! category event event-id frame-id exception 0
+                      (interop/now-ms) trace-payload)))
 
 (defn- emit-reserved-fx-override!
   "Emit `:rf.error/reserved-fx-override` (rf2-snsup5) when an `:fx-overrides`
@@ -842,29 +846,24 @@
               (let [msg     #?(:clj (.getMessage ^Throwable e)
                                :cljs (.-message e))
                     errored-at-ms (interop/now-ms)]
-                ;; Sticky hook (rf2-f72pd) — always-on per-error
-                ;; observability fan-out per rf2-bacs4; survives
-                ;; `:advanced` + `goog.DEBUG=false`.
-                (when-let [dispatch-on-error!
-                           (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-                  (dispatch-on-error!
-                    category
-                    origin-event
-                    origin-event-id
-                    frame-id
-                    e
-                    0
-                    errored-at-ms))
-                ;; Trace path for dev consumers; DCE'd in CLJS prod.
-                (trace/emit-error! category
-                                   (merge {:failing-id        fx-id
-                                           :rf.fx/id          fx-id
-                                           :rf.fx/args        args
-                                           :frame             frame-id
-                                           :exception         e
-                                           :exception-message msg
-                                           :recovery          :no-recovery}
-                                          (dissoc ex-data-map :rf.error/id))))
+                ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the
+                ;; always-on per-error observability fan-out (rf2-bacs4 / sticky
+                ;; hook rf2-f72pd; survives `:advanced` + `goog.DEBUG=false`),
+                ;; axis 2 the dev trace (DCE'd in CLJS prod). Reached via the
+                ;; `:error-emit/emit-error-both` hook (fx cannot static-require
+                ;; error-emit — load cycle).
+                (when-let [emit-error-both!
+                           (late-bind/get-fn-cached :error-emit/emit-error-both)]
+                  (emit-error-both!
+                    category origin-event origin-event-id frame-id e 0 errored-at-ms
+                    (merge {:failing-id        fx-id
+                            :rf.fx/id          fx-id
+                            :rf.fx/args        args
+                            :frame             frame-id
+                            :exception         e
+                            :exception-message msg
+                            :recovery          :no-recovery}
+                           (dissoc ex-data-map :rf.error/id)))))
               ;; Untyped reserved-fx throw — preserve crash-loud
               ;; contract by re-throwing.
               (throw e)))))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -798,6 +798,10 @@
     :producer-ns 're-frame.error-emit
     :design-bead "rf2-bacs4"
     :description "Always-on per-`:rf.error/*` fan-out: builds the tight error-record once (elided), then fans it out to the corpus-wide listener registry (rf2-bacs4 — Sentry / Honeybadger / Rollbar shippers), ALWAYS fired. Per-listener invocations try/catch wrapped (a buggy listener cannot block siblings). Recovery is framework-owned (the per-category typed defaults); the per-frame `:on-error` recovery policy was REMOVED (rf2-hiqtk8, superseding the rf2-2hvga axis-2 / recovery-policy-eligible column). Survives `:advanced` + `goog.DEBUG=false`. Invoked from EVERY production-reachable `:rf.error/*` site: router (handler-exception, flow-eval, frame-destroyed), fx (reserved-fx typed throws), subs/memo + subs (reactive + compute-sub exceptions), subs (frame-destroyed, no-such-sub on subscribe), router/diagnostics (no-such-handler)."}
+   {:key         :error-emit/emit-error-both
+    :producer-ns 're-frame.error-emit
+    :design-bead "rf2-c4oycd"
+    :description "The shared two-channel `:rf.error/*` fan-out (rf2-c4oycd) — fires the always-on `dispatch-on-error!` listener record (axis 1, production-survivable) AND the dev-only `trace/emit-error!` surface (axis 2, DCE'd under `:advanced` + `goog.DEBUG=false`) in one call. Collapses the open-coded two-step that was duplicated at ~12 emit sites across `subs` / `subs.memo` / `cofx` / `router.diagnostics` (+ `fx`'s `emit-fx-error!` + the 4 bespoke `router` wrappers). Takes `[category event event-id frame exception elapsed-ms time trace-tags]` — `trace-tags` is the category-specific dev-trace map threaded unchanged. Reached via this hook by `fx` / `subs` / `subs.memo` / `cofx` / `router.diagnostics` (which cannot static-require `error-emit` — the `error-emit` → `elision` → `frame` load cycle); `router` static-requires `error-emit` and calls it directly. Survives `:advanced` + `goog.DEBUG=false`."}
    {:key         :error-emit/dispatch-frame-teardown-report
     :producer-ns 're-frame.error-emit
     :design-bead "rf2-ini4wr"

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -282,6 +282,25 @@
 ;; not inferred from process state. A plain fn (not a macro) so CLJS sibling-ns
 ;; callers use it with no `:require-macros` plumbing.
 
+(defn frame-resolution-target
+  "EP-0023 §Frame-derived live registration resolution (rf2-uejnt3): given the
+  CARRIED frame `target` a caller holds (a `subscribe` `frame-id` slot or a
+  dispatch envelope's `:frame`), return the EP-0023 frame OBJECT to derive the
+  resolution generation from — the object itself when the target IS one (the
+  direct-object form), or the live-frame registry's object for a frame-id
+  KEYWORD. nil for any target that names no live image-loaded frame — the
+  absence-is-default signal that [[call-with-frame-resolution]] binds NOTHING
+  and the build/dispatch resolves through the registrar atom path,
+  byte-identical for every existing caller. The shared resolution-target read
+  the subscribe-side (`subs`) and dispatch-side (`router`) twins collapsed onto
+  (rf2-6zfzxy) — both held a byte-identical copy. Pure read of the carried
+  target + the process-local live-frame registry."
+  [target]
+  (cond
+    (frame-object? target) target
+    (keyword? target)      (live-frame target)
+    :else                  nil))
+
 (defn frame-resolution-generation
   "Return the resolved image generation a `frame-target` resolves registrations
   through, or nil when the target names no image-loaded frame. EP-0024

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2253,23 +2253,6 @@
           (run-handler-cascade! envelope event-id event frame
                                 frame-record handler-meta))))))
 
-(defn- frame-resolution-target
-  "EP-0023 §Frame-derived live registration resolution (rf2-uejnt3): given the
-  CARRIED frame target an envelope holds in `:frame`, return the EP-0023 frame
-  OBJECT to derive the resolution generation from — the object itself when the
-  target IS one (the direct-object dispatch form), or the live-frame registry's
-  object for a frame-id KEYWORD (the `{:frame :counter/main}` form). nil for any
-  target that names no live image-loaded frame — the absence-is-default signal
-  that `call-with-frame-resolution` binds NOTHING and the cascade resolves
-  through the registrar atom path, byte-identical for every existing caller
-  (the EP-0013 realm-routed dispatch and the single-realm default alike).
-  Pure read of the carried target + the process-local live-frame registry."
-  [target]
-  (cond
-    (live-frame/frame-object? target) target
-    (keyword? target)                 (live-frame/live-frame target)
-    :else                             nil))
-
 (defn- process-event!
   "Wrap process-event* in four dynamic bindings:
 
@@ -2370,7 +2353,7 @@
           ;; cascade resolves through the registrar atom exactly as before
           ;; (absence-is-default). DERIVED from the carried target (EP-0002).
           (live-frame/call-with-frame-resolution
-            (frame-resolution-target (:frame envelope))
+            (live-frame/frame-resolution-target (:frame envelope))
             (fn [] (process-event* envelope))))))))
 
 (def ^:private drain-depth-default

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1023,40 +1023,45 @@
                      :rollback? false
                      :recovery  :no-recovery}
               event-id (assoc :failing-id event-id))))
-        app-ok?
+        run-partition-validator!
+        ;; The per-partition validator arm template (rf2-6zfzxy). Runs the
+        ;; late-bound `hook-key` validator against the partition's new value
+        ;; ONLY when `effect?` (that partition was written this commit) AND the
+        ;; hook is installed; otherwise → true (an absent validator / unwritten
+        ;; partition is a pass). Resolves the hook ONCE (the prior arms called
+        ;; `get-fn-cached` twice — in the `and` then re-fetched in the `let`).
+        ;; nil-coerce: a nil return is success (don't roll back) so a host
+        ;; returning nil on a clean validate keeps working. A host-thrown
+        ;; validator is caught, surfaced via `emit-swallow!`, and treated as
+        ;; `true` (the validator is failing on itself, not on a user schema; a
+        ;; hard abort here would mask the partition's state from the rest of the
+        ;; cascade — real schema failures route through the in-band false).
+        (fn [effect? hook-key partition-value where]
+          (if effect?
+            (if-let [validate (late-bind/get-fn-cached hook-key)]
+              (try
+                (let [result (validate partition-value event-id frame)]
+                  (if (nil? result) true result))
+                (catch #?(:clj Throwable :cljs :default) ex
+                  (emit-swallow! where ex)
+                  true))
+              true)
+            true))
         ;; App-db schema validation runs only when a `:db` effect produced a
         ;; new app-db (app schemas validate app-db only — Mike ruling #11).
         ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
-        (if (and app-effect?
-                 (late-bind/get-fn-cached :schemas/validate-app-schema!))
-          (let [validate (late-bind/get-fn-cached :schemas/validate-app-schema!)]
-            (try
-              ;; nil-coerce: treat a nil return as success (don't roll
-              ;; back) so a host that returns nil rather than true on a
-              ;; clean validate keeps working.
-              (let [result (validate db-after event-id frame)]
-                (if (nil? result) true result))
-              (catch #?(:clj Throwable :cljs :default) ex
-                (emit-swallow! :app-db ex)
-                true)))
-          true)
-        machines-ok?
+        app-ok?
+        (run-partition-validator! app-effect? :schemas/validate-app-schema!
+                                  db-after :app-db)
         ;; Per rf2-jbbp7 — the machine-data boundary (Spec 005 §Schema
         ;; validation). EP-0001 (rf2-vzld77): machine snapshots are durable
         ;; runtime-db state, so this validates the new RUNTIME-DB value and
         ;; runs only when a `:rf.db/runtime` effect landed this commit. The
         ;; hook is absent when the machines artefact isn't on the classpath;
         ;; absent → true (no machines means no machine-data to validate).
-        (if (and rt-effect?
-                 (late-bind/get-fn-cached :machines/validate-machine-data!))
-          (let [validate-md (late-bind/get-fn-cached :machines/validate-machine-data!)]
-            (try
-              (let [result (validate-md runtime-db-after event-id frame)]
-                (if (nil? result) true result))
-              (catch #?(:clj Throwable :cljs :default) ex
-                (emit-swallow! :machine-data ex)
-                true)))
-          true)]
+        machines-ok?
+        (run-partition-validator! rt-effect? :machines/validate-machine-data!
+                                  runtime-db-after :machine-data)]
     ;; Both must conform for the cascade to keep its commit; the per-
     ;; failure traces have already been emitted independently so the
     ;; operator sees every violation, not just the first.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -947,22 +947,14 @@
                      ;; (the pre-rf2-mszrz behaviour) mis-fed consumers.
                      handler-throw? (assoc :handler-id event-id)
                      icpt-coord     (assoc :source-coord icpt-coord))]
-    ;; Always-on per rf2-bacs4: every fn registered through
+    ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
+    ;; always-on corpus-wide listener (rf2-bacs4): every fn registered through
     ;; `rf/register-error-listener!` receives the tight error-record so
-    ;; production builds with the trace surface elided still observe the
-    ;; error. Trigger-handler / dispatch-id enrichment is dev-only and
-    ;; not present here — those ride the trace path below.
-    (error-emit/dispatch-on-error!
-      operation
-      emit-event
-      event-id
-      frame
-      exception
-      elapsed-ms
-      end-ms)
-    ;; Dev-side trace emission. Gated by `interop/debug-enabled?` inside
-    ;; `trace/emit-error!`; DCEs to a no-op in CLJS prod builds.
-    (trace/emit-error! operation tags)))
+    ;; production builds with the trace surface elided still observe the error.
+    ;; Trigger-handler / dispatch-id enrichment is dev-only and rides the trace
+    ;; path (`tags`). Axis 2 — the dev-only `trace/emit-error!` (DCE'd in prod).
+    (error-emit/emit-error-both!
+      operation emit-event event-id frame exception elapsed-ms end-ms tags)))
 
 (defn- run-post-commit-validation!
   "Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se): validate
@@ -1539,22 +1531,14 @@
         ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an integer.
         ;; Round once at the substrate boundary (JVM long / CLJS float).
         elapsed-ms (long (max 0 (- end-ms start-ms)))]
-    ;; Always-on per rf2-bacs4 — the corpus-wide listener registry fires
-    ;; in CLJS production where `trace/emit-error!` below is compile-time
-    ;; elided.
-    (error-emit/dispatch-on-error!
-      :rf.error/flow-eval-exception
-      event
-      event-id
-      frame
-      e
-      elapsed-ms
-      end-ms)
-    ;; Dev-side trace emission. Gated by `interop/debug-enabled?` inside
-    ;; `trace/emit-error!`; DCEs in CLJS prod. Same payload shape as
+    ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
+    ;; always-on corpus-wide listener (rf2-bacs4) fires in CLJS production where
+    ;; the trace surface (axis 2) is compile-time elided. Same payload shape as
     ;; before — existing trace consumers are unaffected.
-    (trace/emit-error! :rf.error/flow-eval-exception
-                       {:frame frame :event event :exception e})))
+    (error-emit/emit-error-both!
+      :rf.error/flow-eval-exception
+      event event-id frame e elapsed-ms end-ms
+      {:frame frame :event event :exception e})))
 
 (defn- emit-legacy-runtime-root!
   "Surface `:rf.error/legacy-runtime-root` through BOTH the always-on
@@ -1581,19 +1565,14 @@
   (let [end-ms     (interop/now-ms)
         elapsed-ms (long (max 0 (- end-ms start-ms)))
         tags       (events/legacy-runtime-root-ex-data event)]
-    ;; Always-on listener (survives prod elision). No exception object:
-    ;; this is an invalid-write rejection, not a host throw.
-    (error-emit/dispatch-on-error!
+    ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
+    ;; always-on listener (survives prod elision); axis 2 — the dev trace (DCE'd
+    ;; under `:advanced` + `goog.DEBUG=false`). No exception object: this is an
+    ;; invalid-write rejection, not a host throw.
+    (error-emit/emit-error-both!
       :rf.error/legacy-runtime-root
-      event
-      event-id
-      frame
-      nil
-      elapsed-ms
-      end-ms)
-    ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-    (trace/emit-error! :rf.error/legacy-runtime-root
-                       (assoc tags :frame frame))))
+      event event-id frame nil elapsed-ms end-ms
+      (assoc tags :frame frame))))
 
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame
@@ -1705,18 +1684,14 @@
   router already static-requires `error-emit`, but routing all the
   non-recovery sites through one helper keeps the gating uniform."
   [event-id event frame-id]
-  ;; Always-on listener (survives prod elision).
-  (error-emit/dispatch-on-error!
+  ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
+  ;; always-on listener (survives prod elision); axis 2 — the dev trace (DCE'd
+  ;; under `:advanced` + `goog.DEBUG=false`). No exception — invalid op, not a
+  ;; throw; `elapsed-ms 0` (not a timed path).
+  (error-emit/emit-error-both!
     :rf.error/frame-destroyed
-    event
-    event-id
-    frame-id
-    nil                                   ;; no exception — invalid op, not a throw
-    0                                     ;; elapsed-ms
-    (interop/now-ms))                     ;; time
-  ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-  (trace/emit-error! :rf.error/frame-destroyed
-                     {:frame frame-id :event event :reason :frame-destroyed}))
+    event event-id frame-id nil 0 (interop/now-ms)
+    {:frame frame-id :event event :reason :frame-destroyed}))
 
 (defn- handle-frame-destroyed!
   "Per Spec 002 §Run-to-completion: a frame disposed between enqueue and

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -19,11 +19,11 @@
   The cross-ns indirection from the router facade is amortised: callers
   (`process-event*`, `dispatch!`, `dispatch-sync!`) all sit on the
   facade and reach into this ns only on the rare warning / error paths."
-  (:require [re-frame.error :as error]
+  (:require [re-frame.cofx.value-check :as value-check]
+            [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.recordable :as recordable]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 
@@ -216,56 +216,6 @@
                :retired-key :dispatched-at
                :replacement '(:rf/time-ms (:rf.cofx envelope))}})))
 
-(defn- emit-cofx-value-invalid!
-  "Emit `:rf.error/cofx-value-invalid` for a SUPPLIED `:rf.cofx` value that is
-  not recordable EDN data (a host handle — DOM node, Promise, function, atom,
-  Date, JS / Java object — reached the durable causal token). Reuses the
-  EP-0017 cofx error id (built in slice B.7 for the `:schema`-when-declared
-  half) with `reason :non-edn-recordable-value` — the structural-EDN-always
-  half (rf2-rmroo4 slice A, EP-0017:386: recordable values must be EDN).
-
-  The payload carries the failing fact id, the path WITHIN that value to the
-  bad leaf, the host `:bad-type`, and a `:preview` ONLY when the supplied
-  value is itself recordable (so the preview round-trips) — NEVER the raw host
-  object. Fans out through the always-on `dispatch-on-error!` listener (the
-  same axis `re-frame.cofx`'s satisfaction-step emit uses), then throws."
-  [event cofx-id supplied bad failing-id]
-  (let [{:keys [path bad-type]} bad
-        preview (recordable/safe-preview supplied)]
-    (when-let [emit-error-both!
-               (late-bind/get-fn-cached :error-emit/emit-error-both)]
-      (emit-error-both! :rf.error/cofx-value-invalid
-                        event failing-id nil nil 0 (interop/now-ms)
-                        (cond-> {:rf.cofx/id        cofx-id
-                                 :failing-id        failing-id
-                                 :rf.trace/event-id failing-id
-                                 :reason            :non-edn-recordable-value
-                                 :path              path
-                                 :bad-type          bad-type
-                                 :recovery          :no-recovery}
-                          (some? preview) (assoc :preview preview))))
-    (error/throw-error!
-      :rf.error/cofx-value-invalid 're-frame.router/build-envelope
-      (str "Supplied `:rf.cofx` fact `" cofx-id
-           "` is not recordable EDN data: the value "
-           "at path " (pr-str path) " is a `"
-           bad-type "` (a host object — DOM node, "
-           "Promise, function, atom, Date, or other "
-           "JS / Java handle). Recordable coeffect "
-           "values ride the durable causal record "
-           "(epoch ledger, replay, SSR payload, Xray) "
-           "and MUST be ordinary EDN data that reads "
-           "back unchanged (EP-0017:386). Replace the "
-           "host handle with its recordable "
-           "projection — the identifier / snapshot / "
-           "plain data you actually need on replay.")
-      ;; Sub-kind on its own slot; `:reason` is the human sentence (rf2-vvixub).
-      {:extra {:rf.cofx/value-error :non-edn-recordable-value
-               :rf.cofx/id          cofx-id
-               :failing-id          failing-id
-               :path                path
-               :bad-type            bad-type}})))
-
 (defn- validate-supplied-cofx-values!
   "ALWAYS-ON structural-EDN check of a SUPPLIED `:rf.cofx` map's values
   (rf2-rmroo4 slice A; production-hardened rf2-q34j26). Every value other than
@@ -283,18 +233,19 @@
   on the override-free hot path), and the recordable predicate short-circuits
   at the first non-EDN leaf. The declared-`:schema` check (cofx.cljc) is the
   complementary always-on per-supplier contract; this is the structural
-  always-EDN floor that fires even when no `:schema` was declared."
+  always-EDN floor that fires even when no `:schema` was declared.
+
+  The `:supplied` arm of the shared `value-check/check-edn-value!` (rf2-6zfzxy)
+  — its generated-value twin (slice B) lives at the generator write-back site
+  (`re-frame.cofx`). The always-on listener carries the triggering `event` (the
+  supplied path runs at the dispatch boundary, before any frame is owned)."
   [supplied event]
   (let [event-id (first event)]
     (reduce-kv
       (fn [_ cofx-id value]
         ;; `:rf/time-ms` is already shape-checked above (integer); skip it.
         (when-not (= cofx-id :rf/time-ms)
-          (when-let [bad (recordable/explain-non-recordable value)]
-            ;; Prepend the fact-id so the reported path is rooted at the
-            ;; coeffect key, not at the (per-value) walk root.
-            (let [rooted (update bad :path #(into [cofx-id] %))]
-              (emit-cofx-value-invalid! event cofx-id value rooted event-id))))
+          (value-check/check-edn-value! :supplied cofx-id value event-id event nil))
         nil)
       nil
       supplied)))

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -53,24 +53,26 @@
   The dev `trace/emit-error!` below stays dev-only (it DCEs under
   `goog.DEBUG=false`); the always-on listener fan-out is what survives."
   [event-id event frame]
-  ;; Always-on listener (survives prod elision).
-  (when-let [dispatch-on-error!
-             (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-    (dispatch-on-error!
+  ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the always-on
+  ;; listener (survives prod elision), axis 2 the dev trace (DCEs under
+  ;; `:advanced` + `goog.DEBUG=false`). No exception — invalid op; `elapsed-ms 0`.
+  ;; Reached via the `:error-emit/emit-error-both` hook (this diagnostics ns
+  ;; cannot static-require error-emit — load cycle).
+  (when-let [emit-error-both!
+             (late-bind/get-fn-cached :error-emit/emit-error-both)]
+    (emit-error-both!
       :rf.error/no-such-handler
       event
       event-id
       frame
       nil                                 ;; no exception — invalid op
       0                                   ;; elapsed-ms
-      (interop/now-ms)))                  ;; time
-  ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-  (trace/emit-error! :rf.error/no-such-handler
-                     {:rf.trace/event-id event-id
-                      :rf.event/v        event
-                      :frame             frame
-                      :kind              :event
-                      :recovery          :replaced-with-default}))
+      (interop/now-ms)                    ;; time
+      {:rf.trace/event-id event-id
+       :rf.event/v        event
+       :frame             frame
+       :kind              :event
+       :recovery          :replaced-with-default})))
 
 (defn other-frame-mid-drain
   "Per rf2-fp97 — Spec 002 §dispatch-sync cross-frame note. Return the
@@ -230,19 +232,18 @@
   [event cofx-id supplied bad failing-id]
   (let [{:keys [path bad-type]} bad
         preview (recordable/safe-preview supplied)]
-    (when-let [dispatch-on-error!
-               (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error! :rf.error/cofx-value-invalid
-                          event failing-id nil nil 0 (interop/now-ms)))
-    (trace/emit-error! :rf.error/cofx-value-invalid
-                       (cond-> {:rf.cofx/id        cofx-id
-                                :failing-id        failing-id
-                                :rf.trace/event-id failing-id
-                                :reason            :non-edn-recordable-value
-                                :path              path
-                                :bad-type          bad-type
-                                :recovery          :no-recovery}
-                         (some? preview) (assoc :preview preview)))
+    (when-let [emit-error-both!
+               (late-bind/get-fn-cached :error-emit/emit-error-both)]
+      (emit-error-both! :rf.error/cofx-value-invalid
+                        event failing-id nil nil 0 (interop/now-ms)
+                        (cond-> {:rf.cofx/id        cofx-id
+                                 :failing-id        failing-id
+                                 :rf.trace/event-id failing-id
+                                 :reason            :non-edn-recordable-value
+                                 :path              path
+                                 :bad-type          bad-type
+                                 :recovery          :no-recovery}
+                          (some? preview) (assoc :preview preview))))
     (error/throw-error!
       :rf.error/cofx-value-invalid 're-frame.router/build-envelope
       (str "Supplied `:rf.cofx` fact `" cofx-id

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -488,41 +488,42 @@
   (let [data        (ex-data e)
         bad-return? (= :rf.error/sub-input-fn-bad-return error-kw)
         msg         #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))]
-    ;; Always-on listener (survives prod elision). For the bad-return
-    ;; case there is no genuine exception to ship (the throw is just our
-    ;; tagged carrier), so pass nil; the exception is meaningful only for
-    ;; the input-fn-threw case.
-    (when-let [dispatch-on-error!
-               (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-      (dispatch-on-error!
+    ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the always-on
+    ;; listener (survives prod elision), axis 2 the dev trace (DCEs under
+    ;; `:advanced` + `goog.DEBUG=false`). For the bad-return case there is no
+    ;; genuine exception to ship (the throw is just our tagged carrier), so the
+    ;; listener gets nil; the exception is meaningful only for the input-fn-threw
+    ;; case. Reached via the `:error-emit/emit-error-both` hook (subs cannot
+    ;; static-require error-emit — load cycle). `elapsed-ms 0`.
+    (when-let [emit-error-both!
+               (late-bind/get-fn-cached :error-emit/emit-error-both)]
+      (emit-error-both!
         error-kw
         query-v                       ;; attempted query-vector (as :event)
         query-id                      ;; sub-id (as :event-id)
         frame-id
         (when-not bad-return? e)      ;; exception (only the input-fn-threw case)
         0                             ;; elapsed-ms
-        (interop/now-ms)))            ;; time
-    ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-    (trace/emit-error! error-kw
-                       (if bad-return?
-                         {:rf.sub/id      query-id
-                          :rf.sub/query-v query-v
-                          :where          where
-                          :returned       (:returned data)
-                          :reason         (:reason data)
-                          :frame          frame-id
-                          :recovery       :replaced-with-default}
-                         {:rf.sub/id         query-id
-                          :rf.sub/query-v    query-v
-                          :where             where
-                          :exception         e
-                          :exception-message msg
-                          :reason            (str "Subscription `" query-id
-                                                  "` input-fn threw while "
-                                                  "materializing: " msg
-                                                  ". Recovering to nil.")
-                          :frame             frame-id
-                          :recovery          :replaced-with-default}))))
+        (interop/now-ms)             ;; time
+        (if bad-return?
+          {:rf.sub/id      query-id
+           :rf.sub/query-v query-v
+           :where          where
+           :returned       (:returned data)
+           :reason         (:reason data)
+           :frame          frame-id
+           :recovery       :replaced-with-default}
+          {:rf.sub/id         query-id
+           :rf.sub/query-v    query-v
+           :where             where
+           :exception         e
+           :exception-message msg
+           :reason            (str "Subscription `" query-id
+                                   "` input-fn threw while "
+                                   "materializing: " msg
+                                   ". Recovering to nil.")
+           :frame             frame-id
+           :recovery          :replaced-with-default})))))
 
 (defn- compute-and-cache!
   "Build the reaction for query-v and cache it. Per Spec 006 §Lookup
@@ -574,30 +575,31 @@
                         ;; `:advanced` + `goog.DEBUG=false` and reaches off-box
                         ;; shippers — a production-meaningful runtime error.
                         ;; An invalid op whose recovery is the built-in
-                        ;; `:replaced-with-default`. Reached via the
-                        ;; `:error-emit/dispatch-on-error` late-bind hook (subs
-                        ;; cannot static-require `re-frame.error-emit` — load
-                        ;; cycle). The `:frame`-stampable record carries
-                        ;; `frame-id` + the attempted `query-v` for 7d30s +
-                        ;; shipper attribution.
-                        (do
-                          ;; Always-on listener (survives prod elision).
-                          (when-let [dispatch-on-error!
-                                     (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-                            (dispatch-on-error!
-                              :rf.error/no-such-sub
-                              query-v               ;; attempted query-vector (as :event)
-                              query-id              ;; sub-id (as :event-id)
-                              frame-id
-                              nil                   ;; no exception — invalid op
-                              0                     ;; elapsed-ms
-                              (interop/now-ms)))    ;; time
-                          ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-                          (trace/emit-error! :rf.error/no-such-sub
-                                             {:rf.sub/id        query-id
-                                              :unresolved-input query-v
-                                              :resolved-inputs  []
-                                              :frame            frame-id})))
+                        ;; `:replaced-with-default`. The `:frame`-stampable
+                        ;; record carries `frame-id` + the attempted `query-v`
+                        ;; for 7d30s + shipper attribution.
+                        ;;
+                        ;; Both channels via the shared helper (rf2-c4oycd):
+                        ;; axis 1 the always-on listener (survives prod elision),
+                        ;; axis 2 the dev trace (DCEs under `:advanced` +
+                        ;; `goog.DEBUG=false`). No exception — invalid op;
+                        ;; `elapsed-ms 0`. Reached via the
+                        ;; `:error-emit/emit-error-both` hook (subs cannot
+                        ;; static-require error-emit — load cycle).
+                        (when-let [emit-error-both!
+                                   (late-bind/get-fn-cached :error-emit/emit-error-both)]
+                          (emit-error-both!
+                            :rf.error/no-such-sub
+                            query-v               ;; attempted query-vector (as :event)
+                            query-id              ;; sub-id (as :event-id)
+                            frame-id
+                            nil                   ;; no exception — invalid op
+                            0                     ;; elapsed-ms
+                            (interop/now-ms)      ;; time
+                            {:rf.sub/id        query-id
+                             :unresolved-input query-v
+                             :resolved-inputs  []
+                             :frame            frame-id})))
         body-fn       (:handler-fn sub-meta)
         layer-1?      (= :db (:input-kind sub-meta))
         ;; EP-0001 (rf2-vzld77): a `:runtime-db` sub is a layer-1-shaped
@@ -1069,22 +1071,25 @@
          ;; `query-v` (as `:event`) for 7d30s + shipper attribution.
          (nil? frame-record)
          (do
-           ;; Always-on listener (survives prod elision).
-           (when-let [dispatch-on-error!
-                      (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-             (dispatch-on-error!
+           ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the
+           ;; always-on listener (survives prod elision), axis 2 the dev trace
+           ;; (DCEs under `:advanced` + `goog.DEBUG=false`). No exception —
+           ;; invalid op; `elapsed-ms 0`. Reached via the
+           ;; `:error-emit/emit-error-both` hook (subs cannot static-require
+           ;; error-emit — load cycle).
+           (when-let [emit-error-both!
+                      (late-bind/get-fn-cached :error-emit/emit-error-both)]
+             (emit-error-both!
                :rf.error/frame-destroyed
                query-v                       ;; attempted query-vector (as :event)
                (first query-v)               ;; sub-id (as :event-id)
                frame-id
                nil                           ;; no exception — invalid op
                0                             ;; elapsed-ms
-               (interop/now-ms)))            ;; time
-           ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-           (trace/emit-error! :rf.error/frame-destroyed
-                              {:frame    frame-id
-                               :query-v  query-v
-                               :recovery :replaced-with-default})
+               (interop/now-ms)             ;; time
+               {:frame    frame-id
+                :query-v  query-v
+                :recovery :replaced-with-default}))
            nil)
 
          :else
@@ -1393,18 +1398,24 @@
                               ;; (mirroring the sub-input-fn path) so the kind-aware
                               ;; error-emit lookup resolves the sub's `:source-coord`
                               ;; under `[:sub query-id]` for off-box shippers.
-                              (when-let [dispatch-on-error!
-                                         (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-                                (dispatch-on-error!
+                              ;; Both channels via the shared helper
+                              ;; (rf2-c4oycd): axis 1 the always-on listener
+                              ;; (survives prod elision), axis 2 the dev trace
+                              ;; (DCEs under `:advanced` + `goog.DEBUG=false`).
+                              ;; Reached via the `:error-emit/emit-error-both`
+                              ;; hook (subs cannot static-require error-emit —
+                              ;; load cycle). `elapsed-ms 0`.
+                              (when-let [emit-error-both!
+                                         (late-bind/get-fn-cached :error-emit/emit-error-both)]
+                                (emit-error-both!
                                   :rf.error/sub-exception
                                   query-v                   ;; failing query-vector (as :event)
                                   query-id                  ;; sub-id (as :event-id) — drives [:sub …] coord lookup
                                   nil                       ;; frame (pure compute — no reactive frame)
                                   e
                                   0                         ;; elapsed-ms
-                                  (interop/now-ms)))        ;; time
-                              ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
-                              (trace/emit-error! :rf.error/sub-exception tags))
+                                  (interop/now-ms)          ;; time
+                                  tags)))
                             nil)))]
             (swap! memo assoc query-v v)
             v))))))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -876,23 +876,6 @@
                v*       (maybe-validate-sub-override! v query-v sub-meta frame-id)]
            (adapter/make-derived-value [] (constantly v*)))))))
 
-(defn- frame-resolution-target
-  "EP-0023 §Frame-derived live registration resolution (rf2-uejnt3): given the
-  CARRIED frame target `subscribe` holds in `frame-id`, return the EP-0023 frame
-  OBJECT to derive the resolution generation from — the object itself when the
-  target IS one (the direct-object `(rf/subscribe frame query-v)` form), or the
-  live-frame registry's object for a frame-id KEYWORD. nil for any target that
-  names no live image-loaded frame — the absence-is-default signal that
-  `live-frame/call-with-frame-resolution` binds NOTHING and the build resolves
-  through the registrar atom path, byte-identical for every existing caller.
-  Mirrors `re-frame.router/frame-resolution-target` (the dispatch-side twin).
-  Pure read of the carried target + the process-local live-frame registry."
-  [target]
-  (cond
-    (live-frame/frame-object? target) target
-    (keyword? target)                 (live-frame/live-frame target)
-    :else                             nil))
-
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
   build-and-cache on miss; reuse on hit. The 1-arity ambient form
@@ -1049,7 +1032,7 @@
      (frame/frame frame-id)
      (fn []
    (live-frame/call-with-frame-resolution
-     (frame-resolution-target frame-id)
+     (live-frame/frame-resolution-target frame-id)
      (fn []
    (or
      #?(:cljs

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -439,6 +439,33 @@
     ;; behaviour). Defensive; all `reg-sub` paths now stamp `:input-kind`.
     (vec (:input-signals sub-meta))))
 
+;; ---- single-source (layer-1-shaped) input-kinds (rf2-6zfzxy) --------------
+;;
+;; `:db` / `:runtime-db` / `:frame-state` are the layer-1-SHAPED single-source
+;; reader kinds: each reads ONE frame-state container directly (no `:<-` /
+;; `input-fn` producer, so `produce-input-queries` returns `[]` for all three),
+;; and each runs the same fixed-arity-1 memoised body — only the container the
+;; reaction watches differs. That membership was re-derived three ways (the
+;; reactive `(or layer-1? runtime-db? frame-state?)` flag union + the
+;; `compute-sub` `#{:db :runtime-db :frame-state}` inline set + the reactive
+;; `inputs` cond's three explicit container branches). The set + container map
+;; below are the single source those collapse onto.
+
+(def ^:private single-source-input-kinds
+  "The layer-1-shaped single-source reader kinds (EP-0001 / EP-0016 D3): each
+  reads ONE frame-state container directly via the same fixed-arity-1 body."
+  #{:db :runtime-db :frame-state})
+
+(def ^:private single-source-container-for
+  "`input-kind → (fn [frame-id] container)` for the single-source reader kinds.
+  The reactive build watches the resolved container as the reaction's lone
+  signal source: `:db` the app-db projection, `:runtime-db` the runtime-db
+  projection, `:frame-state` the WHOLE frame-state value (both partitions, so
+  the body re-runs on a change to EITHER — EP-0016 D3 slice 3, rf2-616xa6)."
+  {:db          frame/app-db-container
+   :runtime-db  frame/runtime-db-container
+   :frame-state frame/frame-state-container})
+
 ;; ---- the cache ------------------------------------------------------------
 
 (defn- cache-key
@@ -525,6 +552,37 @@
            :frame             frame-id
            :recovery          :replaced-with-default})))))
 
+(defn- produce-input-queries-or-emit!
+  "Run [[produce-input-queries]] inside the shared try/produce/catch/
+  discriminate-bad-return wrapper both the reactive cache path and the
+  `compute-sub` path used identically (rf2-6zfzxy). Returns `[input-qs
+  input-error?]`: `[(produce-input-queries sub-meta query-v) false]` on
+  success, or — when the parametric `input-fn` throws OR returns a bad shape
+  (the tagged `:rf.error/sub-input-fn-bad-return` ex-info from
+  `normalize-sub-inputs`) — emits LOUDLY via [[emit-sub-input-fn-error!]] and
+  returns `[recovery-qs true]`. The exception is discriminated into
+  `:rf.error/sub-input-fn-bad-return` vs `:rf.error/sub-input-fn-exception` by
+  its `:rf.error/id`, exactly as both call sites did.
+
+  `where` (`:reactive` / `:compute-sub`) tags the emission site; `frame-id` is
+  the reactive path's owning frame (nil on the pure `compute-sub` path).
+  `recovery-qs` is the input-qs the caller wants on failure (`[]` reactive / nil
+  compute-sub — both yield `(count …) 0`, and the `input-error?` flag
+  short-circuits every downstream use, so the choice is cosmetic; preserved per
+  call site to keep the collapse byte-identical). Layer-1 / `:static` never
+  throw here — only the parametric `input-fn` can."
+  [sub-meta query-v query-id frame-id where recovery-qs]
+  (try
+    [(produce-input-queries sub-meta query-v) false]
+    (catch #?(:clj Throwable :cljs :default) e
+      (let [bad-return? (= :rf.error/sub-input-fn-bad-return
+                           (:rf.error/id (ex-data e)))]
+        (emit-sub-input-fn-error! (if bad-return?
+                                    :rf.error/sub-input-fn-bad-return
+                                    :rf.error/sub-input-fn-exception)
+                                  query-id query-v frame-id e where)
+        [recovery-qs true]))))
+
 (defn- compute-and-cache!
   "Build the reaction for query-v and cache it. Per Spec 006 §Lookup
   algorithm: recursively resolve the input query-vectors (the literal
@@ -601,24 +659,18 @@
                              :resolved-inputs  []
                              :frame            frame-id})))
         body-fn       (:handler-fn sub-meta)
+        ;; A `:db` layer-1 sub specifically (the narrow single-source kind whose
+        ;; input is the app-db container) — used by the dev-only output-marks
+        ;; resolve + the not-cached symmetric-input-release guard below.
+        ;; `:runtime-db` / `:frame-state` are the OTHER single-source kinds (the
+        ;; `single-source-input-kinds` set drives the shared memoised-body +
+        ;; container-lookup decisions); EP-0001 (rf2-vzld77) made `:runtime-db`
+        ;; a layer-1-shaped framework reader over the frame's runtime-db
+        ;; projection, and EP-0016 D3 slice 3 (rf2-616xa6) made `:frame-state`
+        ;; a single-source reader over the WHOLE frame-state value (both
+        ;; partitions, so the body re-runs on EITHER an app-db or a runtime-db
+        ;; change).
         layer-1?      (= :db (:input-kind sub-meta))
-        ;; EP-0001 (rf2-vzld77): a `:runtime-db` sub is a layer-1-shaped
-        ;; framework sub whose single signal source is the frame's RUNTIME-DB
-        ;; projection (machine snapshots / route slice / etc. are durable
-        ;; runtime-db state). Same fixed-arity-1 memoised body as a `:db`
-        ;; layer-1 sub — only the signal source differs (Spec 002
-        ;; §Subscriptions read the partition they belong to).
-        runtime-db?   (= :runtime-db (:input-kind sub-meta))
-        ;; EP-0016 D3 slice 3: a `:frame-state` sub is a single-source
-        ;; reader whose signal is the WHOLE frame-state container (both
-        ;; partitions), so the body re-runs on EITHER an app-db or a
-        ;; runtime-db change — the reactivity a resource sub needs to
-        ;; re-key when a `{:from-db …}` resolver's app-db inputs change
-        ;; (rf2-616xa6) while still reacting to runtime-db cache writes.
-        ;; The body receives the full frame-state value and extracts the
-        ;; partitions it needs; output `=` memoisation keeps downstream
-        ;; quiet when neither relevant slice changed.
-        frame-state?  (= :frame-state (:input-kind sub-meta))
         ;; Produce the realized input query-vectors for THIS concrete
         ;; cache entry from the sub's input producer (Spec 006
         ;; §Subscription input producers): `[]` for layer-1, the literal
@@ -636,25 +688,19 @@
         ;; never throw here — only the parametric `input-fn` can.)
         [input-qs input-error?]
         (when sub-meta
-          (try
-            [(produce-input-queries sub-meta query-v) false]
-            (catch #?(:clj Throwable :cljs :default) e
-              (let [bad-return? (= :rf.error/sub-input-fn-bad-return
-                                   (:rf.error/id (ex-data e)))]
-                (emit-sub-input-fn-error! (if bad-return?
-                                            :rf.error/sub-input-fn-bad-return
-                                            :rf.error/sub-input-fn-exception)
-                                          query-id query-v frame-id e :reactive)
-                [[] true]))))
+          (produce-input-queries-or-emit! sub-meta query-v query-id frame-id :reactive []))
         ;; Resolve inputs: layer-1 → frame's app-db; layer-2+ → recursive
         ;; subs over the realized input query-vectors. A failed parametric
         ;; production yields an empty `input-qs` and a constant-nil body.
+        ;; Single-source readers (`:db` / `:runtime-db` / `:frame-state`) watch
+        ;; ONE resolved container; the `single-source-container-for` lookup
+        ;; (rf2-6zfzxy) picks the app-db / runtime-db / whole-frame-state
+        ;; container — the `:frame-state` container propagates on a change to
+        ;; EITHER partition (EP-0016 D3 slice 3). Layer-2+ subscribes each
+        ;; realized input.
         inputs        (cond
-                        layer-1?     [(frame/app-db-container frame-id)]
-                        runtime-db?  [(frame/runtime-db-container frame-id)]
-                        ;; EP-0016 D3 slice 3: the WHOLE frame-state container
-                        ;; — propagates on a change to EITHER partition.
-                        frame-state? [(frame/frame-state-container frame-id)]
+                        (single-source-container-for (:input-kind sub-meta))
+                        [((single-source-container-for (:input-kind sub-meta)) frame-id)]
                         input-error? []
                         :else       (mapv (fn [input-q] (subscribe frame-id input-q)) input-qs))
         parametric?   (= :parametric (:input-kind sub-meta))
@@ -672,7 +718,7 @@
                         ;; vs runtime-db projection vs the whole frame-state
                         ;; container). A `:frame-state` body receives the full
                         ;; frame-state value `{:rf.db/app … :rf.db/runtime …}`.
-                        (or layer-1? runtime-db? frame-state?)
+                        (single-source-input-kinds (:input-kind sub-meta))
                         (subs-memo/make-layer-1-memoised-body
                           body-fn query-id query-v frame-id sub-meta)
 
@@ -1229,7 +1275,7 @@
                 ;; sub the caller supplies the runtime-db value (or a
                 ;; frame-state value, from which `compute-sub` extracts the
                 ;; right partition — see below).
-                layer-1? (#{:db :runtime-db :frame-state} (:input-kind meta))
+                layer-1? (single-source-input-kinds (:input-kind meta))
                 ;; Produce the realized input query-vectors from the sub's
                 ;; input producer — the SAME three-mode model as the
                 ;; reactive cache path (Spec 006 §Subscription input
@@ -1243,16 +1289,7 @@
                 ;; with `:where :compute-sub` and recover this sub to nil
                 ;; (a bad return is NEVER silently treated as no inputs).
                 [input-qs input-error?]
-                (try
-                  [(produce-input-queries meta query-v) false]
-                  (catch #?(:clj Throwable :cljs :default) e
-                    (let [bad-return? (= :rf.error/sub-input-fn-bad-return
-                                         (:rf.error/id (ex-data e)))]
-                      (emit-sub-input-fn-error! (if bad-return?
-                                                  :rf.error/sub-input-fn-bad-return
-                                                  :rf.error/sub-input-fn-exception)
-                                                query-id query-v nil e :compute-sub)
-                      [nil true])))
+                (produce-input-queries-or-emit! meta query-v query-id nil :compute-sub nil)
                 ;; Bind n once — `(empty? input-qs)` then `(= 1 (count input-qs))`
                 ;; counted twice on the multi-input path (rf2-r1rma).
                 n       (count input-qs)

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -402,20 +402,24 @@
           ;; (rf2-hiqtk8). The SSR fail-closed posture (rf2-vvwmi) rides the
           ;; always-on listener record the `error-emit-projection-listener`
           ;; buffers — which preserves the SSR 500 projection.
-          (when-let [dispatch-on-error!
-                     (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
-            (dispatch-on-error!
+          ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the
+          ;; always-on listener (survives prod elision), axis 2 the dev trace —
+          ;; preserved for the trace surface + retain-N buffer + dev-side
+          ;; projection (carries the same rich internal detail; DCEs under
+          ;; `:advanced` + `goog.DEBUG=false`). Reached via the
+          ;; `:error-emit/emit-error-both` hook (this subs layer cannot
+          ;; static-require error-emit — load cycle). `elapsed-ms 0`.
+          (when-let [emit-error-both!
+                     (late-bind/get-fn-cached :error-emit/emit-error-both)]
+            (emit-error-both!
               :rf.error/sub-exception
               query-v                             ;; failing query-vector (as :event)
               query-id                            ;; sub-id (as :event-id) — drives [:sub …] coord lookup
               frame-id
               e
               0                                   ;; elapsed-ms
-              (interop/now-ms)))                  ;; time
-          ;; Dev-only trace path — preserved for the trace surface +
-          ;; retain-N buffer + dev-side projection (carries the same rich
-          ;; internal detail). DCEs under `:advanced` + `goog.DEBUG=false`.
-          (trace/emit-error! :rf.error/sub-exception tags))
+              (interop/now-ms)                    ;; time
+              tags)))
         nil))))
 
 ;; ---- memoisation wrappers ------------------------------------------------

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -422,6 +422,36 @@
               tags)))
         nil))))
 
+;; ---- the shared memo-hit `:rf.sub/skip` emit (rf2-6zfzxy) -----------------
+;;
+;; All three memo wrappers below emit a byte-identical `:rf.sub/skip` trace on a
+;; memo hit (input value-equal to last-seen, the user body does NOT re-run,
+;; rf2-719e) so tools can show the "considered, no recompute" branch of the
+;; reactive cascade DAG (rf2-931pm). The ONLY thing that varied was
+;; `:rf.sub/input-paths-unchanged` (`[]` for layer-1 which has no upstream sub
+;; inputs; `(vec input-signals)` for the layer-n forms). The skip-emit BODY is
+;; deduped here; the three wrappers stay separate (their per-recompute hot
+;; closures are perf-justified — fixed-arity-1 vs single-input vs varargs — and
+;; only the cold skip-emit body was the clone).
+
+(defn- emit-sub-skip!
+  "Emit the memo-hit `:rf.sub/skip` trace for a sub that was reactively
+  considered but did NOT recompute (input value-equal, rf2-719e / rf2-931pm).
+  `input-paths-unchanged` is the inputs-stable set (`[]` for layer-1, the
+  realized `:<-` query-vectors for layer-n). Outer `interop/debug-enabled?`
+  gate elides the tag-map construction + emit in CLJS production (Closure DCE
+  under `:advanced` + `goog.DEBUG=false`)."
+  [query-id query-v frame-id sub-meta input-paths-unchanged]
+  (when interop/debug-enabled?
+    (trace/with-handler-scope
+      (trace/handler-scope-from-meta :sub query-id sub-meta)
+      (trace/emit! :rf.sub :rf.sub/skip
+                   {:frame                        frame-id
+                    :rf.sub/id                    query-id
+                    :rf.sub/query-v               query-v
+                    :rf.sub/reason                :input-value-equal
+                    :rf.sub/input-paths-unchanged input-paths-unchanged}))))
+
 ;; ---- memoisation wrappers ------------------------------------------------
 
 (defn make-layer-1-memoised-body
@@ -445,20 +475,10 @@
           ;; Memo hit — input value-equal to last-seen, the user body
           ;; does NOT re-run (rf2-719e). Emit `:rf.sub/skip` so tools
           ;; can show the "considered, no recompute" branch of the
-          ;; reactive cascade DAG (rf2-931pm). Outer
-          ;; `interop/debug-enabled?` gate elides the tag-map
-          ;; construction + emit in CLJS production (Closure DCE under
-          ;; `:advanced` + `goog.DEBUG=false`).
+          ;; reactive cascade DAG (rf2-931pm). Layer-1 has no upstream
+          ;; sub inputs, so `:input-paths-unchanged` is `[]`.
           (do
-            (when interop/debug-enabled?
-              (trace/with-handler-scope
-                (trace/handler-scope-from-meta :sub query-id sub-meta)
-                (trace/emit! :rf.sub :rf.sub/skip
-                             {:frame                        frame-id
-                              :rf.sub/id                    query-id
-                              :rf.sub/query-v               query-v
-                              :rf.sub/reason                :input-value-equal
-                              :rf.sub/input-paths-unchanged []})))
+            (emit-sub-skip! query-id query-v frame-id sub-meta [])
             @last-result)
           ;; Capture the prior cells BEFORE the recompute so the
           ;; `:sub/run` attribution (rf2-l1jz8) can report value-change
@@ -515,15 +535,7 @@
           ;; stable; layer-2+ subs name their inputs by `[query-id args]`
           ;; rather than db-paths.
           (do
-            (when interop/debug-enabled?
-              (trace/with-handler-scope
-                (trace/handler-scope-from-meta :sub query-id sub-meta)
-                (trace/emit! :rf.sub :rf.sub/skip
-                             {:frame                        frame-id
-                              :rf.sub/id                    query-id
-                              :rf.sub/query-v               query-v
-                              :rf.sub/reason                :input-value-equal
-                              :rf.sub/input-paths-unchanged (vec input-signals)})))
+            (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
             @last-result)
           ;; Capture prior cells BEFORE the recompute for the `:sub/run`
           ;; attribution (rf2-l1jz8). `prev-in-vals` is the last-seen
@@ -585,15 +597,7 @@
           ;; stable (the varargs path has ≥2 inputs and the memo
           ;; compare is whole-seq `=`, so every input was stable).
           (do
-            (when interop/debug-enabled?
-              (trace/with-handler-scope
-                (trace/handler-scope-from-meta :sub query-id sub-meta)
-                (trace/emit! :rf.sub :rf.sub/skip
-                             {:frame                        frame-id
-                              :rf.sub/id                    query-id
-                              :rf.sub/query-v               query-v
-                              :rf.sub/reason                :input-value-equal
-                              :rf.sub/input-paths-unchanged (vec input-signals)})))
+            (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
             @last-result)
           ;; Capture prior cells BEFORE the recompute for the `:sub/run`
           ;; attribution (rf2-l1jz8). `prev-in-vals` is the last-seen

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -272,11 +272,18 @@
 
 (def ^:private emit-error-re
   "`(… emit-error! :rf.<area>/<cat> …)` / `(… dispatch-on-error!
-  :rf.<area>/<cat> …)` / `(… emit-warning! :rf.<area>/<cat> …)` — the
-  category keyword is the token immediately after the fn symbol. The fn
-  may be ns-qualified (`trace/emit-error!`, `error-emit/dispatch-on-
-  error!`) or bare."
-  (re-pattern (str "(?:emit-error!|dispatch-on-error!|emit-warning!)\\s+"
+  :rf.<area>/<cat> …)` / `(… emit-warning! :rf.<area>/<cat> …)` /
+  `(… emit-error-both! :rf.<area>/<cat> …)` — the category keyword is the
+  token immediately after the fn symbol. The fn may be ns-qualified
+  (`trace/emit-error!`, `error-emit/dispatch-on-error!`,
+  `error-emit/emit-error-both!`) or bare.
+
+  `emit-error-both!` (rf2-c4oycd) is the shared two-channel fan-out the
+  open-coded `dispatch-on-error!` + `trace/emit-error!` two-step collapsed
+  onto: it takes the category as its FIRST arg exactly like the others, so
+  the scanner reaches the categories now routed through it (e.g.
+  `:rf.error/no-such-handler`, `:rf.error/frame-destroyed`)."
+  (re-pattern (str "(?:emit-error-both!|emit-error!|dispatch-on-error!|emit-warning!)\\s+"
                    "(:rf\\.[a-z][a-z0-9.]*/" category-kw-class ")")))
 
 (def ^:private emit-bang-warning-re


### PR DESCRIPTION
Behaviour-PRESERVING core-internals lean refactor. Continues the prior worker that died on an infra timeout. Five commits — the previously-COMMITTED `rf2-c4oycd` error-emit dedup (verified green here) plus the seven `rf2-6zfzxy` dedups landed on top.

## rf2-c4oycd (verified, pre-existing commit `0e8c30b65`)

One shared `re-frame.error-emit/emit-error-both!` collapses the open-coded `(dispatch-on-error! …)` + `(trace/emit-error! …)` two-step at ~12 emit sites (subs / subs.memo / cofx / router.diagnostics, via the `:error-emit/emit-error-both` late-bind hook) + the 4 bespoke router wrappers (static require) + fx's `emit-fx-error!`. Reviewed the diff (behaviour byte-identical — same categories, same trace tags, same elapsed-ms), then ran the full gate suite to confirm it is green standalone before adding 6zfzxy. No fix needed.

## rf2-6zfzxy (all 7 items)

1. **frame-resolution-target** — byte-identical copy in `subs.cljc` (subscribe-side) + `router.cljc` (dispatch-side) hoisted to one `live-frame/frame-resolution-target` (the natural home — already owns `frame-object?` / `live-frame` / `call-with-frame-resolution`).
2. **check-edn-value!** — the cloned EDN-recordable emit+validate pair (`cofx` generated-value slice B; `router.diagnostics` supplied-value slice A) collapsed onto one `re-frame.cofx.value-check/check-edn-value!` with a `:supplied` / `:generated` discriminator (a tiny `kind->shape` data table holds the noun + `where` + durable-clause that vary). Human-message strings reproduced verbatim per kind. New leaf ns requires only the four (error/interop/late-bind/recordable) both sites already required — no load cycle. `recordable` require dropped from both call sites.
3. **produce-input-queries-or-emit!** — the parametric input-fn try/produce/catch/discriminate block, cloned at the reactive cache path + the `compute-sub` path, hoisted to one helper returning `[input-qs input-error?]`.
4. **emit-sub-skip!** — the three memo wrappers' identical memo-hit `:rf.sub/skip` emit extracted (the 3 wrappers stay separate — perf-justified hot closures; only the cold skip-emit body was the clone).
5. **run-partition-validator!** — the two structurally-identical post-commit validator arms (app-db / machine-data) collapsed onto one closure that resolves the late-bind hook ONCE (the prior arms double-resolved via `get-fn-cached`).
6. **DEAD CODE** — `cofx/rf-prefixed-app-namespace?` (hardcoded `false`) + its unreachable `emit-cofx-name-collision!` branch deleted (the owner-qualified `rf.`-naming rule is the Spec 009 §9 lint, not a dormant predicate). `:rf.error/cofx-name-collision` still emitted by the live fold-argument-keys guard — catalogue unchanged.
7. **single-source-input-kinds** — the `#{:db :runtime-db :frame-state}` membership re-derived three ways (reactive flag union + compute-sub inline set + reactive container cond) unified to one set + a `single-source-container-for` lookup map.

## Gates (all green)

- `sh scripts/test-jvm-implementation.sh` — 0 failures (all artefacts)
- `cd implementation && npm run test:cljs` — 8024 tests, 0 failures
- `python scripts/check_thrown_error_messages.py` — exit 0 (NO thrown error id/message/shape change)
- error-catalogue channel conformance — 9 tests, 0 failures (same categories emitted; scanner taught the new file via file-seq)
- clj-kondo `--fail-level error` — 0 errors (no new warnings vs baseline)
- Splint `--fail-on-errors` — 0 errors

No facade/manifest change. Rebased onto origin/main (conflict-free — no intervening commit touched any of the six files).
