### PR TITLE
refactor(tools/xray): remove dead edn-widget facade + dedupe edn-inspector + config deep-merge (rf2-b479nm, rf2-4436lx, rf2-8y568j)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1129,6 +1129,36 @@
    :diff      {:highlight-fn-ref-changes? false}
    :buffer    {:cascades-retained 50}})
 
+(defn- merge-known-sections
+  "Deep-merge `src` (a persisted / bulk-config settings map) over
+  `default-settings`, section by section, returning the reconstructed
+  settings map. Pure; CLJC; JVM-testable.
+
+  ONE source of truth for the known-section list. Both persistence
+  paths — `load-settings-from-storage!` (src = the localStorage
+  payload) and `configure!` (src = the bulk-config `:rf.xray/settings`
+  map) — reconstruct the SAME shape, so the merge lived here twice
+  verbatim. Folding it into one helper means a NEW section added to
+  `default-settings` (the docstring anticipates future theme / buffer /
+  placement keys) is honoured by both paths from a single edit — the
+  forgot-the-other-half bug family is structurally removed.
+
+  Per-section semantics preserved exactly:
+  - `:general` / `:diff` / `:buffer` — `merge` the src's nested map
+    over the default's, so unknown nested keys in `src` survive but
+    a section absent from `src` keeps its full default.
+  - `:theme` — a flat keyword, not a nested map; take the src's value
+    or fall back to the default (rf2-jh9ws).
+  Any unknown TOP-LEVEL section in `src` (e.g. a legacy `:telemetry`
+  key) falls on the floor — the reconstruction only knows the sections
+  enumerated here."
+  [src]
+  (-> default-settings
+      (update :general merge (:general src))
+      (assoc  :theme  (or (:theme src) (:theme default-settings)))
+      (update :diff    merge (:diff src))
+      (update :buffer  merge (:buffer src))))
+
 (defn clamp-panel-width-px
   "Pure helper: clamp `px` to the resize handle's [min, viewport×0.9]
   range (rf2-x8h9y). Pass `viewport-width-px` explicitly so the helper
@@ -1353,13 +1383,7 @@
        (when-let [raw (storage-get settings-storage-key)]
          (let [parsed (cljs.reader/read-string raw)]
            (when (map? parsed)
-             (reset! settings
-                     (-> default-settings
-                         (update :general merge (:general parsed))
-                         (assoc  :theme  (or (:theme parsed)
-                                             (:theme default-settings)))
-                         (update :diff      merge (:diff parsed))
-                         (update :buffer    merge (:buffer parsed)))))))
+             (reset! settings (merge-known-sections parsed)))))
        (catch :default _ nil))
      nil))
 
@@ -1625,12 +1649,7 @@
   (when (contains? opts :rf.xray/settings)
     (when (map? settings-opt)
       (reset! day8.re-frame2-xray.config/settings
-              (-> default-settings
-                  (update :general merge (:general settings-opt))
-                  (assoc  :theme  (or (:theme settings-opt)
-                                      (:theme default-settings)))
-                  (update :diff      merge (:diff settings-opt))
-                  (update :buffer    merge (:buffer settings-opt))))
+              (merge-known-sections settings-opt))
       #?(:cljs (write-storage!))))
   ;; Filter seed + storage key (rf2-ak4ms). Storage key sets BEFORE
   ;; seed so a host that overrides both in one call gets the seed

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -763,6 +763,30 @@
     (pr-str s)
     (catch :default _ (str "\"" s "\""))))
 
+(defn- scalar->string
+  "The bare printed STRING for a single non-collection value — the text
+  each scalar leaf prints (`\"nil\"`, `\"#uuid \\\"…\\\"\"`, a
+  quote-padded string, etc.). Pure; JVM-portable.
+
+  ONE source of truth for the scalar literal forms so `render-scalar`
+  (which wraps the string in a colour-coded span) and `inline-scalar-str`
+  (which returns the bare string for collapsed previews) don't keep two
+  copies of the same literal table. Returns `nil` for shapes whose text
+  the caller renders specially — `:fn` (each caller prints a different
+  arity of detail) and the sentinels (chip chrome vs. a one-word label)
+  — so callers branch those cases themselves."
+  [v]
+  (case (collection-kind v)
+    :nil      "nil"
+    :boolean  (str v)
+    :keyword  (str v)
+    :symbol   (str v)
+    :string   (str-pad-quote v)
+    :number   (str v)
+    :uuid     (str "#uuid \"" v "\"")
+    :regex    (str v)
+    nil))
+
 (def ^:private token-style
   ;; Memoized — `tokens` is a static const map of CSS-variable strings
   ;; (e.g. `:syntax-keyword` resolves to `"var(--rf-xray-syntax-keyword)"`)
@@ -782,23 +806,27 @@
   "Render a single non-collection value as `[:span ...]` hiccup. Pure
   function — no expansion state, no rf reads."
   [v]
+  ;; The bare printed string for the simple scalar forms is shared with
+  ;; `inline-scalar-str` via `scalar->string`; here each case wraps it in
+  ;; its colour-coded `:data-rf-type` span. `:fn` + the sentinels render
+  ;; specially (chip chrome / arity-detail), so they branch below.
   (case (collection-kind v)
     :nil      [:span {:data-rf-type "nil"
-                      :style (token-style :syntax-nil)} "nil"]
+                      :style (token-style :syntax-nil)} (scalar->string v)]
     :boolean  [:span {:data-rf-type "boolean"
-                      :style (token-style :syntax-boolean)} (str v)]
+                      :style (token-style :syntax-boolean)} (scalar->string v)]
     :keyword  [:span {:data-rf-type "keyword"
-                      :style (token-style :syntax-keyword)} (str v)]
+                      :style (token-style :syntax-keyword)} (scalar->string v)]
     :symbol   [:span {:data-rf-type "symbol"
-                      :style (token-style :syntax-symbol)} (str v)]
+                      :style (token-style :syntax-symbol)} (scalar->string v)]
     :string   [:span {:data-rf-type "string"
-                      :style (token-style :syntax-string)} (str-pad-quote v)]
+                      :style (token-style :syntax-string)} (scalar->string v)]
     :number   [:span {:data-rf-type "number"
-                      :style (token-style :syntax-number)} (str v)]
+                      :style (token-style :syntax-number)} (scalar->string v)]
     :uuid     [:span {:data-rf-type "uuid"
-                      :style (token-style :info)} (str "#uuid \"" v "\"")]
+                      :style (token-style :info)} (scalar->string v)]
     :regex    [:span {:data-rf-type "regex"
-                      :style (token-style :info)} (str v)]
+                      :style (token-style :info)} (scalar->string v)]
     :fn       [:span {:data-rf-type "fn"
                       :style (merge (token-style :text-tertiary)
                                     {:font-style "italic"})}
@@ -915,6 +943,16 @@
   [kind]
   (if (#{:map :record} kind) ", " " "))
 
+(defn- inline-separator-span
+  "The inter-element separator rendered as a `:text-tertiary` hiccup span
+  for inline collection renders. Shared by the two inline-fit render
+  paths — `render-inline-recursive` (width-aware recursive) and
+  `render-container`'s legacy inline-fit branch — which previously built
+  this same span twice. The separator STRING comes from `inline-separator`
+  (canonical EDN spacing per kind)."
+  [kind]
+  [:span {:style (token-style :text-tertiary)} (inline-separator kind)])
+
 (defn- record-tag
   "Render `#user.MyRec` prefix for a defrecord instance. CLJS records
   expose the constructor's name via `(.-name (type v))`."
@@ -950,15 +988,13 @@
   (one-level only). That keeps a `:deeply {:nested {:secret 1}}`
   preview from leaking `:secret` into a collapsed-collection summary."
   [v]
-  (case (collection-kind v)
-    :nil        "nil"
-    :boolean    (str v)
-    :keyword    (str v)
-    :symbol     (str v)
-    :string     (str-pad-quote v)
-    :number     (str v)
-    :uuid       (str "#uuid \"" v "\"")
-    :regex      (str v)
+  ;; Simple scalar forms (nil / boolean / keyword / symbol / string /
+  ;; number / uuid / regex) share their bare printed string with
+  ;; `render-scalar` via `scalar->string`; the `:fn` + sentinel + container
+  ;; cases below are preview-specific (a one-word label, not chip chrome).
+  (or
+   (scalar->string v)
+   (case (collection-kind v)
     :fn         "#fn"
     :sentinel-redacted        "redacted"
     :sentinel-redacted-size   "redacted"
@@ -971,7 +1007,7 @@
                  :record " keys"
                  " items")]
       (str open "…" n noun close))
-    (try (pr-str v) (catch :default _ (str v)))))
+    (try (pr-str v) (catch :default _ (str v))))))
 
 (defn inline-preview-string
   "Build a one-line preview of a collection. Returns a string; not
@@ -1800,12 +1836,9 @@
                       :data-rf-bracket "1"}
                text])
             ;; rf2-7hqwe — inter-element separator follows canonical EDN
-            ;; spacing: `, ` between map/record entries, a single space
-            ;; between sequential (vector / list / set / seq / map-entry)
-            ;; elements. Pre-fix this was a hardcoded `, ` for ALL kinds,
-            ;; which printed sequentials as `[a, b, c]` rather than `[a b c]`.
-            sep
-            [:span {:style (token-style :text-tertiary)} (inline-separator kind)]
+            ;; spacing (`, ` between map/record entries, a single space
+            ;; between sequentials), via the shared `inline-separator-span`.
+            sep       (inline-separator-span kind)
             labelled? (#{:map :record :map-entry} kind)
             pairs     (children-of value)
             item-children
@@ -1966,13 +1999,11 @@
                       (apply concat
                              (map-indexed
                                (fn [i [k cv]]
-                                 (let [;; rf2-7hqwe — EDN-correct separator:
-                                       ;; `, ` between map/record entries,
-                                       ;; a single space between sequential
-                                       ;; elements (was hardcoded `, `).
+                                 (let [;; rf2-7hqwe — EDN-correct separator
+                                       ;; via the shared `inline-separator-span`
+                                       ;; (`, ` map/record · single space seq).
                                        sep (when (pos? i)
-                                             [:span {:style (token-style :text-tertiary)}
-                                              (inline-separator kind)])
+                                             (inline-separator-span kind))
                                        ks  (when labelled? (key-segment k))
                                        sp  (when labelled?
                                              [:span {:style (token-style :text-tertiary)} " "])]

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -12,10 +12,9 @@
 
   ## One engine, one facade (post-rf2-q3dzw)
 
-  After phase 5 (D5=a per rf2-sndui, rf2-q3dzw) the WHOLE contract —
-  browse + diff + mini — lives in `views.edn-inspector` as one
-  renderer. This facade is a thin delegate that the legacy `edn/*`
-  call sites still reach through; new call sites should use
+  The WHOLE value-rendering contract lives in `views.edn-inspector`
+  as one renderer. This facade is a thin delegate that the legacy
+  `edn/*` call sites still reach through; new call sites should use
   `[edn-inspector value opts]` directly.
 
   Previous shape (pre-rf2-oqa60) composed two engines:
@@ -28,20 +27,9 @@
 
   ## Public API
 
-      (browse {:value v
-               :panel-id  :app-db
-               :render-id \"epoch-42\"      ; accepted but ignored
-                                            ; (widget auto-generates
-                                            ; mount-id; D4=a)
-               :default-depth 3})
-
-      (diff   {:before before-v
-               :after  after-v
-               :panel-id  :event-db
-               :render-id \"epoch-42\"
-               :default-depth 3})
-
-      (mini   v)    ;; one-liner (no expansion, no diff)
+      (inspect v)               ;; canonical L4 detail-panel renderer
+      (inspect v node-key)      ;; with a stable per-mount qualifier
+      (inspect-inline v)        ;; compact one-liner (hover / list cells)
 
       (code-block {:source \"(reg-event :foo …)\"
                    :lang   :clojure})
@@ -68,11 +56,6 @@
 ;; `views.edn-inspector` owns its own `:rf.xray.edn-inspector/expansion`
 ;; slot + toggle/reset events; the facade delegates and the cljs-
 ;; devtools-render adapter is deleted.
-
-;; `inspect` / `inspect-inline` (the panel-facing current-state facade)
-;; delegate to `browse` / `mini`, which are defined further down — forward
-;; declare so the facade can sit at the top of the file where callers look.
-(declare browse mini)
 
 ;; ---- universal copy-to-clipboard affordance (rf2-f026h) ------------------
 ;;
@@ -167,8 +150,9 @@
   accepted but ignored — copy chrome is deferred to a follow-on bead
   (the popup phase, D6=a).
 
-  Diff rendering also routes through the new widget after phase 5
-  (rf2-q3dzw, D5=a per rf2-sndui) — see `diff` below."
+  Diff rendering also routes through the new widget (an opt-in
+  `:before` mode on `ei/edn-inspector`) after phase 5 (rf2-q3dzw,
+  D5=a per rf2-sndui)."
   ([v] (inspect v "root" nil))
   ([v node-key] (inspect v node-key nil))
   ([v node-key _opts]
@@ -183,77 +167,6 @@
   other values render as a colour-coded one-liner."
   [v]
   (ei/mini v))
-
-;; ---- variant: browse -----------------------------------------------------
-
-(defn browse
-  "Render `:value` as a current-state tree via the first-class
-  edn-inspector widget.
-
-  Each collection node renders a `▸` / `▾` triangle that dispatches
-  `:rf.xray.edn-inspector/toggle-node` against the per-mount path —
-  operator drill-downs persist across re-renders in the
-  `:rf.xray.edn-inspector/expansion` slot.
-
-  Diff semantics are an opt-in mode on the SAME widget — call `diff`
-  below (or pass `:before` to `ei/edn-inspector` directly).
-
-  Required: `:value`.
-  Optional: `:panel-id` (defaults `:rf.xray/browse`),
-            `:render-id` (passed through as a stable per-mount
-                          qualifier; ignored under the new widget
-                          which auto-generates mount-ids, but accepted
-                          for facade-call-site compatibility),
-            `:default-depth` (renamed to `:default-expanded-depth`
-                              under the new widget, defaults to 1),
-            `:max-depth` (hard recursion cap; defaults to 16),
-            `:copy?` (accepted but no-op under the new widget — copy
-                      chrome is deferred per the rf2-oqa60 phasing)."
-  [{:keys [value panel-id render-id default-depth max-depth]
-    :or   {default-depth 1
-           max-depth     16}}]
-  [ei/edn-inspector value
-   {:panel-id (or panel-id
-                  (keyword (str "rf.xray.browse/" (or render-id "anon"))))
-    :default-expanded-depth default-depth
-    :max-depth max-depth}])
-
-;; ---- variant: diff -------------------------------------------------------
-
-(defn diff
-  "Render a before -> after diff tree. Annotates changed branches with
-  the §10.3 gutter glyphs (+ added / - removed / ~ modified / ◴ has
-  changed descendant) and a `← was <prior>` chip on modified
-  leaves. Returns hiccup.
-
-  After phase 5 (rf2-q3dzw, D5=a per rf2-sndui) diff is an opt-in
-  MODE on the same `views.edn-inspector` widget — this facade just
-  threads the `:before` opt through to the widget.
-
-  Required: `:before :after :panel-id :render-id`.
-  Optional: `:default-depth` (defaults to 2 per §10.4)."
-  [{:keys [before after panel-id render-id default-depth]
-    :or   {default-depth 2}}]
-  [ei/edn-inspector after
-   {:panel-id (or (when (keyword? panel-id) panel-id)
-                  (keyword (str "rf.xray.diff/"
-                                (or (when panel-id (name panel-id))
-                                    render-id
-                                    "anon"))))
-    :default-expanded-depth default-depth
-    :before before}])
-
-;; ---- variant: mini -------------------------------------------------------
-
-(defn mini
-  "One-liner inline rendering of `value` via the first-class
-  edn-inspector widget (rf2-oqa60 phase 1). Returns hiccup
-  `[:span ...]` so callers embed inline. Sentinels (`:rf/redacted`,
-  `:rf.size/large-elided`) keep their chip chrome inline; other values
-  render as a colour-coded inline-preview."
-  ([value] (mini value 80))
-  ([value max-len]
-   (ei/mini value max-len)))
 
 ;; ---- code-block (handler / interceptor source rendering) ----------------
 ;;
@@ -538,15 +451,3 @@
                                                (:text-primary tokens))}}
                     literal])
                  {:key idx})))])))
-
-;; ---- dispatch by variant -------------------------------------------------
-
-(defn render
-  "Single-entry dispatch by `:variant`. Routes to `browse` / `diff` /
-  `mini`. Helpful for call sites that pick the variant at runtime."
-  [{:keys [variant] :or {variant :browse} :as opts}]
-  (case variant
-    :browse (browse opts)
-    :diff   (diff   opts)
-    :mini   (mini   (:value opts) (or (:max-len opts) 80))
-    (browse opts)))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget_cljs_test.cljs
@@ -17,9 +17,8 @@
      malformed input and round-trips well-formed Clojure.
   4. **highlight-clojure-token mapping** — every token-type resolves
      to its Figma-aligned syntax token; keyword + builtin distinct.
-  5. **Variant dispatcher** — `render` routes by `:variant`.
-  6. **Facade delegation** — `browse` / `inspect` / `mini` return
-     hiccup whose root data-attribute identifies the new widget."
+  5. **Facade delegation** — `inspect` returns a Reagent component
+     invocation of the new widget."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [day8.re-frame2-xray.views.edn-widget :as w]
@@ -51,30 +50,15 @@
 
 ;; ---- facade delegation --------------------------------------------------
 ;;
-;; Post-rf2-oqa60 the facade returns a Reagent component form 2:
-;; `[ei/edn-inspector value opts]` for browse / inspect, and a hiccup
-;; vector for mini. The dispatcher returns hiccup. The test surface
-;; that mattered (sentinel chrome, type colours, click-to-toggle)
-;; lives in `views/edn_inspector_cljs_test.cljs`.
-
-(deftest browse-returns-edn-inspector-mount-form
-  (let [out (w/browse {:value     {:a 1 :b 2}
-                       :panel-id  :test
-                       :render-id "b1"})]
-    (testing "browse returns a Reagent component invocation"
-      (is (vector? out))
-      ;; First element is the edn-inspector fn (a Var).
-      (is (fn? (first out)) "first element is a function ref"))))
+;; Post-rf2-oqa60 `inspect` returns a Reagent component form 2:
+;; `[ei/edn-inspector value opts]`. The test surface that mattered
+;; (sentinel chrome, type colours, click-to-toggle) lives in
+;; `views/edn_inspector_cljs_test.cljs`.
 
 (deftest inspect-returns-edn-inspector-mount-form
   (let [out (w/inspect :hello "node-key")]
     (is (vector? out))
     (is (fn? (first out)))))
-
-(deftest mini-returns-span-shape
-  (let [out (w/mini :hello)]
-    (is (= :span (first out)))
-    (is (= "rf-xray-edn-inspector-mini" (get (second out) :data-testid)))))
 
 ;; ---- code-block tokenizer ------------------------------------------------
 
@@ -333,34 +317,3 @@
       (is (string? resolved))
       (is (and (string? resolved)
                (str/starts-with? resolved "var(--rf-xray-"))))))
-
-;; ---- render dispatcher ---------------------------------------------------
-
-(deftest render-defaults-to-browse
-  (let [out (w/render {:value     {:a 1}
-                       :panel-id  :test
-                       :render-id "dispatch-1"})]
-    ;; browse delegates to ei/edn-inspector; the dispatcher returns
-    ;; the same shape as `browse` — a [function opts] reagent form.
-    (is (vector? out))))
-
-(deftest render-routes-to-diff-when-variant-diff
-  (let [out (w/render {:variant   :diff
-                       :before    {:a 1}
-                       :after     {:a 2}
-                       :panel-id  :test
-                       :render-id "dispatch-2"})]
-    ;; Post-rf2-q3dzw: diff delegates to ei/edn-inspector with a
-    ;; `:before` opt. The dispatcher returns the same shape as
-    ;; `diff` — a [function value opts] Reagent form. Assert the
-    ;; threaded `:before` lands on the opts so we don't regress the
-    ;; diff-routing contract.
-    (is (vector? out))
-    (is (fn? (first out)))
-    (is (contains? (last out) :before))
-    (is (= {:a 1} (:before (last out))))))
-
-(deftest render-routes-to-mini-when-variant-mini
-  (let [out (w/render {:variant :mini
-                       :value   {:a 1}})]
-    (is (= :span (first out)))))


### PR DESCRIPTION
Three lean-pass beads under parent rf2-91oga2 ("Tighten tools/"), all touching different files in `tools/xray`. Behaviour-PRESERVING.

## rf2-b479nm (P2) — remove dead edn-widget facade fns
`views/edn-widget.cljs` is always aliased `:as edn`. `git grep` across `tools/` + `examples/` confirmed zero production callers for four facade fns:
- `browse` — only doc-comment mentions
- `diff` — zero references anywhere
- `render` — runtime `:variant` dispatcher with no runtime-variant caller
- `mini` — zero callers (was a 1:1 passthrough to `ei/mini`)

Deleted those four + the now-unused `(declare browse mini)` + the Public-API docstring block listing them; dropped the corresponding dead tests (`browse`/`mini`/`render` deftests). Live facade fns retained: `inspect`, `inspect-inline`, `code-block`, `copy-affordance`.

## rf2-4436lx (P3) — dedupe edn-inspector internal idioms
- Extracted `scalar->string` — the scalar literal forms (nil/boolean/keyword/symbol/string/number/uuid/regex) were duplicated verbatim between `render-scalar` (hiccup) and `inline-scalar-str` (string). Both now delegate; `:fn` + sentinels genuinely differ so the helper returns `nil` and callers branch them.
- Extracted `inline-separator-span` — the `:text-tertiary` separator span was built twice (`render-inline-recursive` + `render-container`'s legacy inline-fit branch). The two paths still fork on wrapping/value-rendering; only the identical separator span is shared.

## rf2-8y568j (P3) — extract config settings deep-merge helper
The per-section settings deep-merge over `default-settings` was written verbatim in `load-settings-from-storage!` and `configure!`. Folded into one CLJC-pure `merge-known-sections` — single source of truth for the known-section list, removing the forgot-the-other-half hazard when a future section is added. Per-section semantics preserved exactly.

## Gates
- `sh scripts/test-jvm-tools.sh` — PASS (xray 1239 tests / 5687 assertions, all tool artefacts green)
- `npm run test:cljs` — PASS (8019 tests / 33489 assertions, 0 failures; covers edn_widget, edn_inspector, settings persistence)
- `npm run test:bundle-isolation` — PASS (xray does not leak into prod bundles)
- clj-kondo — clean, zero new warnings (the 2 remaining warnings pre-exist on origin/main)

## Spec
tools/xray/spec/* unchanged: the spec documents `views.edn-inspector`'s `[edn-inspector …]` API + the facade's retained-delegate role, not the removed `browse`/`diff`/`render`/`mini` facade fns; the config per-section-merge behaviour the spec describes is preserved exactly. All three changes are internal `defn-`/pure-helper refactors with no contract change.