### PR TITLE
refactor(tools/mcp): extract pair-mcp eval-prelude + mcp-conformance helpers (rf2-776qze, rf2-9hkwkp)

### DIFF
--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -72,6 +72,7 @@
 const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
 const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
 const { ErrorCode, McpError } = require('@modelcontextprotocol/sdk/types.js');
+const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
 
 const CLIENT_VERSION = '0.1.0';
 
@@ -790,6 +791,64 @@ function assertCallCoverageRatchet({ advertised, called, exclusions = {} }) {
   }
 }
 
+// ---------------------------------------------------------------------
+// Envelope readers / coverage tracker (rf2-9hkwkp dedup).
+//
+// Three SDK-envelope-shape helpers that every conformance body re-rolled
+// identically. None pins a per-test contract — they are pure mechanics
+// feeding the shared ratchets above, so they live here once.
+// ---------------------------------------------------------------------
+
+// Concatenate the `.text` of every content block from an SDK callTool
+// response into one newline-joined string. Tolerates a missing / non-
+// array `content` (returns '') so a malformed envelope reads as empty
+// rather than throwing — callers grep the whole string for sentinels /
+// EDN, so a no-text block must contribute nothing, not crash the search.
+function responseText(resp) {
+  if (!resp || !Array.isArray(resp.content)) return '';
+  return resp.content
+    .map((c) => (c && typeof c.text === 'string' ? c.text : ''))
+    .join('\n');
+}
+
+// SDK callTool() coverage tracker (rf2-ke5n56). Wrap the raw SDK client
+// in a Proxy that records the tool name on each `callTool({name,…})` into
+// a fresh `called` Set and transparently delegates every other client
+// member (listTools, getServerVersion, request, close, …) to the real
+// client — so existing call sites read unchanged. Returns
+// `{ client, called }`: drive the workflow through `client`, then feed
+// `called` to `assertCallCoverageRatchet`. A callTool that bypasses the
+// proxy can't quietly erode coverage — the tool simply goes unrecorded
+// and the ratchet catches it as uncovered.
+function track(rawClient) {
+  const called = new Set();
+  const client = new Proxy(rawClient, {
+    get(target, prop, receiver) {
+      if (prop === 'callTool') {
+        return (req, ...rest) => {
+          if (req && typeof req.name === 'string') called.add(req.name);
+          return target.callTool(req, ...rest);
+        };
+      }
+      const v = Reflect.get(target, prop, receiver);
+      return typeof v === 'function' ? v.bind(target) : v;
+    },
+  });
+  return { client, called };
+}
+
+// Read a callTool response's `structuredContent` through
+// `decodeDedupEnvelope`. A dedup-eligible tool ships its structured
+// payload wrapped in a `{:rf.mcp/dedup-table …}` envelope that a real MCP
+// client expands via `de-dupe.core/expand` before reading semantic slots;
+// this mirrors that. Idempotent on payloads without the marker, so it is
+// safe to route EVERY structuredContent read through it — a tool gaining
+// or losing dedup-eligibility doesn't break the suite (the slot is
+// reachable either way).
+function structured(resp) {
+  return decodeDedupEnvelope((resp && resp.structuredContent) || {});
+}
+
 module.exports = {
   runWithWatchdog,
   connectServer,
@@ -800,4 +859,7 @@ module.exports = {
   assertDescriptorShape,
   assertClassificationRatchet,
   assertCallCoverageRatchet,
+  responseText,
+  track,
+  structured,
 };

--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -82,20 +82,16 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { connectServer, closeQuietly } = require('./_runner.cjs');
+const { connectServer, closeQuietly, structured } = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
-const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
 
 // `record-as-variant` ships its structuredContent wrapped in the
 // `{:rf.mcp/dedup-table …}` envelope (recorder.cljc `:dedup-eligible?
 // true`); a real MCP client decodes it via `de-dupe.core/expand` before
-// reading semantic slots. `structured` mirrors that — idempotent on
-// payloads without the marker (register/unregister envelopes pass
-// through unchanged), so it is safe to route every structuredContent
-// read through it. Same adapter the sibling end-to-end-story.cjs uses.
-function structured(resp) {
-  return decodeDedupEnvelope((resp && resp.structuredContent) || {});
-}
+// reading semantic slots. The shared `structured` helper (_runner.cjs)
+// mirrors that — idempotent on payloads without the marker (register /
+// unregister envelopes pass through unchanged), so it is safe to route
+// every structuredContent read through it.
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -35,6 +35,7 @@ const {
   assertDescriptorShape,
   assertClassificationRatchet,
   assertCallCoverageRatchet,
+  track,
 } = require('./_runner.cjs');
 
 const RE_FRAME2_PAIR_MCP_DIR = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp');
@@ -70,29 +71,11 @@ const EXPECTED_TOOLS = JSON.parse(
 const env = { ...process.env };
 delete env.SHADOW_CLJS_NREPL_PORT;
 
-// SDK callTool() coverage tracking (rf2-ke5n56). Every tool driven through
-// `Client.callTool()` records its name here; the coverage ratchet at the
-// end of the body fails if any ADVERTISED tool is neither recorded nor in
-// the reviewed exclusion table. `track(rawClient)` returns a Proxy that
-// records the tool name on each `callTool({name,…})` and transparently
-// delegates every other client member (listTools, getServerVersion,
-// request, …) — so existing call sites read unchanged. Same shape as the
-// sibling end-to-end-story.cjs.
-const CALLED = new Set();
-function track(rawClient) {
-  return new Proxy(rawClient, {
-    get(target, prop, receiver) {
-      if (prop === 'callTool') {
-        return (req, ...rest) => {
-          if (req && typeof req.name === 'string') CALLED.add(req.name);
-          return target.callTool(req, ...rest);
-        };
-      }
-      const v = Reflect.get(target, prop, receiver);
-      return typeof v === 'function' ? v.bind(target) : v;
-    },
-  });
-}
+// SDK callTool() coverage tracking (rf2-ke5n56) via the shared `track`
+// helper (_runner.cjs): every tool driven through `Client.callTool()`
+// records its name into the returned `called` Set; the coverage ratchet at
+// the end of the body fails if any ADVERTISED tool is neither recorded nor
+// in the reviewed exclusion table.
 
 // Advertised pair-mcp tools intentionally NOT SDK-call-covered by THIS
 // degraded harness, each with a rationale naming WHERE its coverage lives
@@ -131,7 +114,7 @@ runWithWatchdog(
     // `client.callTool({name,…})` below records `name` for the callTool
     // coverage ratchet at the end of this body. All other client members
     // delegate transparently.
-    const client = track(rawClient);
+    const { client, called } = track(rawClient);
     // The SDK's `client.connect()` (invoked by the runner) already
     // validated the initialize envelope against `InitializeResultSchema`
     // — a missing / malformed `serverInfo` would have thrown there.
@@ -530,18 +513,18 @@ runWithWatchdog(
 
     // 4b. callTool() coverage ratchet (rf2-ke5n56). Every advertised
     // pair-mcp tool MUST have been driven through `Client.callTool()`
-    // above (recorded in `CALLED` by the `track` proxy) or carry a
+    // above (recorded in `called` by the `track` proxy) or carry a
     // reviewed exclusion in `PAIR_CALL_EXCLUSIONS`. A NEW advertised tool
     // the workflow forgets to probe trips RED here — closing the
     // descriptor-only false-green the senior review flagged.
     assertCallCoverageRatchet({
       advertised: names,
-      called: CALLED,
+      called,
       exclusions: PAIR_CALL_EXCLUSIONS,
     });
     console.log(
       'OK   callTool coverage ratchet -> every advertised tool SDK-called ' +
-        '(' + CALLED.size + '/' + names.length + ') or reviewed-excluded',
+        '(' + called.size + '/' + names.length + ') or reviewed-excluded',
     );
 
     // 5. The runner tears down the transport via client.close() on

--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -59,9 +59,10 @@ const {
   assertDescriptorShape,
   assertClassificationRatchet,
   assertCallCoverageRatchet,
+  track,
+  structured,
 } = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
-const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
@@ -99,48 +100,22 @@ const EXPECTED_CLASSIFICATIONS = JSON.parse(
 // the two test scripts could in principle run against the same JVM.
 const FIXTURE_VARIANT = 'story.mcp-conformance/probe.primary';
 
-// Wire → semantic adapter. Every assertion below reaches for slots
-// that the SEMANTIC contract guarantees (e.g. `:lifecycle` on
-// `preview-variant`'s structuredContent). Three of story-mcp's tools
-// (`preview-variant`, `run-variant`, `record-as-variant`) ship their
-// payloads wrapped in `{:rf.mcp/dedup-table <cache>}` at the wire
-// boundary (rf2-90eft) — a real MCP client decodes via
-// `de-dupe.core/expand` before user code sees it. The harness mirrors
-// that by routing every structuredContent read through
-// `decodeDedupEnvelope`, a no-op on payloads that don't carry the
-// marker. This keeps conformance assertions talking to the semantic
-// contract, not the wire shape — so a future tool gaining or losing
-// dedup-eligibility doesn't break this suite (the slot is reachable
-// either way).
-function structured(resp) {
-  return decodeDedupEnvelope(resp.structuredContent || {});
-}
-
-// SDK callTool() coverage tracking (rf2-ke5n56). Every tool the workflow
-// drives through `Client.callTool()` records its name here; the coverage
-// ratchet at the end of the body fails if any ADVERTISED tool is neither
-// recorded here nor in the reviewed exclusion table. `track(rawClient)`
-// returns a Proxy that records the tool name on each `callTool({name,…})`
-// and otherwise transparently delegates EVERY other member (listTools,
-// getServerVersion, request, close, …) to the real SDK client — so the
-// existing call sites read unchanged. A `callTool` that bypasses the
-// proxy can't quietly erode coverage: the tool would simply go unrecorded
-// and the ratchet would catch it as uncovered.
-const CALLED = new Set();
-function track(rawClient) {
-  return new Proxy(rawClient, {
-    get(target, prop, receiver) {
-      if (prop === 'callTool') {
-        return (req, ...rest) => {
-          if (req && typeof req.name === 'string') CALLED.add(req.name);
-          return target.callTool(req, ...rest);
-        };
-      }
-      const v = Reflect.get(target, prop, receiver);
-      return typeof v === 'function' ? v.bind(target) : v;
-    },
-  });
-}
+// Wire → semantic adapter (`structured`, _runner.cjs). Every assertion
+// below reaches for slots the SEMANTIC contract guarantees (e.g.
+// `:lifecycle` on `preview-variant`'s structuredContent). Three of
+// story-mcp's tools (`preview-variant`, `run-variant`,
+// `record-as-variant`) ship their payloads wrapped in
+// `{:rf.mcp/dedup-table <cache>}` at the wire boundary (rf2-90eft) — a
+// real MCP client decodes via `de-dupe.core/expand` before user code sees
+// it. Routing every structuredContent read through `structured` mirrors
+// that (a no-op on payloads without the marker), so a future tool gaining
+// or losing dedup-eligibility doesn't break this suite.
+//
+// SDK callTool() coverage tracking (rf2-ke5n56) via the shared `track`
+// helper (_runner.cjs): every tool the workflow drives through
+// `Client.callTool()` records its name into the returned `called` Set; the
+// coverage ratchet at the end of the body fails if any ADVERTISED tool is
+// neither recorded nor in the reviewed exclusion table.
 
 // Tools intentionally NOT SDK-call-covered by THIS harness, each with the
 // rationale + where its alternative coverage lives (rf2-ke5n56). Today the
@@ -171,7 +146,7 @@ runWithWatchdog(
     // `client.callTool({name,…})` below records `name` for the callTool
     // coverage ratchet at the end of this body. All other client members
     // delegate transparently.
-    const client = track(rawClient);
+    const { client, called } = track(rawClient);
     // The SDK's `client.connect()` (invoked by the runner) already
     // validated the initialize envelope against `InitializeResultSchema`
     // — a missing / malformed `serverInfo` would have thrown there.
@@ -693,18 +668,18 @@ runWithWatchdog(
 
     // 12. callTool() coverage ratchet (rf2-ke5n56). Every advertised
     // story-mcp tool MUST have been driven through `Client.callTool()`
-    // above (recorded in `CALLED` by the `track` proxy) or carry a
+    // above (recorded in `called` by the `track` proxy) or carry a
     // reviewed exclusion in `STORY_CALL_EXCLUSIONS`. A NEW advertised
     // tool that the workflow forgets to probe trips RED here — closing
     // the descriptor-only false-green the senior review flagged.
     assertCallCoverageRatchet({
       advertised: names,
-      called: CALLED,
+      called,
       exclusions: STORY_CALL_EXCLUSIONS,
     });
     console.log(
       'OK   callTool coverage ratchet -> every advertised tool SDK-called ' +
-        '(' + CALLED.size + '/' + names.length + ') or reviewed-excluded',
+        '(' + called.size + '/' + names.length + ') or reviewed-excluded',
     );
 
     // 13. Clean disconnect — runner handles client.close() on success.

--- a/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
@@ -86,7 +86,7 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { runWithWatchdog } = require('./_runner.cjs');
+const { runWithWatchdog, responseText } = require('./_runner.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -97,14 +97,6 @@ const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 
 // (2026-06-09 / 2025-01-01) so they are visibly NOT a live clock.
 const SCRIPTED_TIME_A = 1781078400123;
 const SCRIPTED_TIME_B = 1735689600000;
-
-// Concatenate every content block's text from an SDK callTool response.
-function responseText(resp) {
-  if (!resp || !Array.isArray(resp.content)) return '';
-  return resp.content
-    .map((c) => (c && typeof c.text === 'string' ? c.text : ''))
-    .join('\n');
-}
 
 // Read the fixture's `:stamped-at` app-db slot back through the runtime
 // snapshot — the slot `:counter/stamp` folds the recorded `:rf/time-ms`

--- a/tools/mcp-conformance/test/live-re-frame2-pair-event-meta.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-event-meta.cjs
@@ -66,7 +66,7 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { runWithWatchdog } = require('./_runner.cjs');
+const { runWithWatchdog, responseText } = require('./_runner.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -78,14 +78,6 @@ const FIXTURE_EVENT = ':counter/inc';
 // The retired per-kind handler-wrapper ids EP-0018 collapsed into the one
 // `:rf/event-handler`. None may appear on the live MCP response.
 const RETIRED_WRAPPER_IDS = [':rf/db-handler', ':rf/fx-handler', ':rf/ctx-handler'];
-
-// Concatenate every content block's text from an SDK callTool response.
-function responseText(resp) {
-  if (!resp || !Array.isArray(resp.content)) return '';
-  return resp.content
-    .map((c) => (c && typeof c.text === 'string' ? c.text : ''))
-    .join('\n');
-}
 
 // Pre-flight SKIP — same posture as the sibling live-* variants.
 if (!process.env.SHADOW_CLJS_NREPL_PORT) {

--- a/tools/mcp-conformance/test/live-re-frame2-pair-iserror.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-iserror.cjs
@@ -59,7 +59,7 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { runWithWatchdog } = require('./_runner.cjs');
+const { runWithWatchdog, responseText } = require('./_runner.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -69,14 +69,6 @@ const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 
 // selector that simply matches nothing returns `:ok? true :count 0`, so
 // we must use a selector the parser REJECTS, not one that merely misses.)
 const BAD_SELECTOR = '>>>';
-
-// Concatenate every content block's text from an SDK callTool response.
-function responseText(resp) {
-  if (!resp || !Array.isArray(resp.content)) return '';
-  return resp.content
-    .map((c) => (c && typeof c.text === 'string' ? c.text : ''))
-    .join('\n');
-}
 
 // The load-bearing assertion (rf2-87h71e / rf2-q7cavs): a GENUINE
 // `:ok? false` runtime failure MUST carry `isError === true`. Three

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -130,6 +130,7 @@ const {
   closeQuietly,
   registerAuxClient,
   unregisterAuxClient,
+  responseText,
 } = require('./_runner.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
@@ -384,16 +385,6 @@ const INNER_DECLARE_FORM = `
    (:rf.epoch/sensitive? (last (re-frame.core/epoch-history fid)))})`;
 
 // ---- helpers ---------------------------------------------------------------
-
-// Extract the concatenated text of every content block from an SDK
-// callTool response. The egress payload is EDN text inside
-// `content[].text`; we search the whole thing for the sentinel rather
-// than parsing — a leak ANYWHERE in the payload (a nested `:db-before`,
-// `:trace-events`, a stray `:trigger-event`) must trip the gate.
-function responseText(resp) {
-  if (!resp || !Array.isArray(resp.content)) return '';
-  return resp.content.map((c) => (c && typeof c.text === 'string' ? c.text : '')).join('\n');
-}
 
 function assertOk(resp, name) {
   if (resp.isError) {

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -128,7 +128,6 @@
   `dispatch-dry-run` (signal-runtime! + projected egress, same gate)."
   (:require [cljs.reader]
             [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.await-promise :as await-promise]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
@@ -484,25 +483,23 @@
           (let [settle-form (render-settle-form fn-sym event-vec opts-form)
                 mailbox-id  (await-promise/mailbox-key)
                 wrapped     (await-promise/wrap-form settle-form mailbox-id)]
-            (-> (probe/ensure-runtime! conn build-id)
-                ;; rf2-8fin7.3 — signal the boot-gate posture BEFORE the
-                ;; dispatch eval, exactly as `dispatch-dry-run` does. This
-                ;; flips the runtime's `raw-state-config` to the server's
-                ;; gate state (OFF by default) so the cascade-summary's
-                ;; `:event-vector` (the raw `:trigger-event`) redacts to
-                ;; `:rf/redacted` for a sensitive epoch — the path-3 leak
-                ;; (a first-in-session sensitive dispatch shipping its raw
-                ;; event vector under the default OFF gate). Without the
-                ;; signal the runtime stays at its permissive
-                ;; `{:allow-raw-state? true}` default and the redaction
-                ;; never fires. See raw-state/signal-runtime!.
-                (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-                (.then (fn [_] (nrepl/cljs-eval-value conn build-id wrapped)))
-                (.then (fn [sentinel]
-                         (await-promise/handle-sentinel
-                           conn build-id timeout-ms sentinel
-                           (await-render-callbacks mode))))
-                (.catch (fn [err] (probe/err->result :dispatch-failed err)))))
+            ;; rf2-8fin7.3 — the signalled prelude flips the boot-gate
+            ;; posture BEFORE the dispatch eval, exactly as
+            ;; `dispatch-dry-run` does. This sets the runtime's
+            ;; `raw-state-config` to the server's gate state (OFF by
+            ;; default) so the cascade-summary's `:event-vector` (the raw
+            ;; `:trigger-event`) redacts to `:rf/redacted` for a sensitive
+            ;; epoch — closing the path-3 leak (a first-in-session
+            ;; sensitive dispatch shipping its raw event vector under the
+            ;; default OFF gate). Without the signal the runtime stays at
+            ;; its permissive `{:allow-raw-state? true}` default and the
+            ;; redaction never fires. See raw-state/signal-runtime!.
+            (probe/eval-after-runtime-signalled!
+              conn build-id wrapped :dispatch-failed
+              (fn [sentinel]
+                (await-promise/handle-sentinel
+                  conn build-id timeout-ms sentinel
+                  (await-render-callbacks mode)))))
           (let [call-src (ef/emit (ef/rt-call fn-sym event-vec opts-form))
                 ;; rf2-olvr5 finding 1 — only the epoch-bearing modes
                 ;; (`:trace` / `:settle`) carry raw `:epoch` /
@@ -515,9 +512,9 @@
                 form     (if (contains? #{:trace :settle} mode)
                            (egress/project-dispatch-result-src call-src incl?)
                            call-src)]
-            ;; rf2-8fin7.3 — issue the boot-gate signal between the
-            ;; preload probe and the dispatch eval (the snapshot /
-            ;; get-path / subscribe / dispatch-dry-run prelude shape, NOT
+            ;; rf2-8fin7.3 — the signalled prelude issues the boot-gate
+            ;; signal between the preload probe and the dispatch eval (the
+            ;; snapshot / get-path / dispatch-dry-run prelude shape, NOT
             ;; the bare `eval-after-runtime!`). `signal-runtime!` flips the
             ;; runtime's `raw-state-config` to the server's gate state so
             ;; the DEFAULT cascade-summary's `:event-vector` (the raw
@@ -528,8 +525,6 @@
             ;; `:trace` / `:settle` epoch slots are ALSO projected
             ;; (egress/project-dispatch-result-src above, rf2-olvr5) — the
             ;; two protections compose, mirroring dispatch-dry-run.
-            (-> (probe/ensure-runtime! conn build-id)
-                (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-                (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-                (.then (fn [v] (runtime-envelope->result mode v)))
-                (.catch (fn [err] (probe/err->result :dispatch-failed err)))))))))))
+            (probe/eval-after-runtime-signalled!
+              conn build-id form :dispatch-failed
+              (fn [v] (runtime-envelope->result mode v))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -111,7 +111,6 @@
   the eval, the same `args/parse-cofx` gate `dispatch` carries."
   (:require [cljs.reader]
             [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.elision :as elision]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
@@ -372,10 +371,9 @@
                        ['env      (ef/rt-call 'dispatch-dry-run event-vec opts-form)
                         'redacted (ef/rt-raw (str "(" redact-src " env)"))]
                        (ef/rt-raw "{:value redacted :elided-count 0}"))))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [resp]
+        (probe/eval-after-runtime-signalled!
+          conn build-id form :dispatch-dry-run-failed
+          (fn [resp]
                      ;; Eval-form shape: `{:value <env> :elided-count N}`
                      ;; (matching snapshot / get-path, rf2-e35a5). The
                      ;; runtime fn ALWAYS returns a map, so an unwrapped
@@ -402,5 +400,4 @@
                        ;; verbatim so the caller still sees why.
                        (if (false? (:ok? result))
                          (wire/err-text result)
-                         (wire/ok-text result)))))
-            (.catch (fn [err] (probe/err->result :dispatch-dry-run-failed err))))))))
+                         (wire/ok-text result)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -32,8 +32,7 @@
   ran `re-frame.core/elide-wire-value` server-side already; the
   `:scalar-value` arm of `run-wire-pipeline` just counts the
   resulting `:rf.size/large-elided` markers."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.eval-form :as ef]
+  (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
             [re-frame2-pair-mcp.tools.probe :as probe]
@@ -184,37 +183,35 @@
         ;; `pluck` lifts the literal value the pipeline should count;
         ;; `rebuild` reassembles the envelope from the pipelined value.
         (fn [form pluck rebuild]
-          (-> (probe/ensure-runtime! conn build-id)
-              (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-              (.then (fn [envelope]
-                       (let [server-elided (when (:ok? envelope) (:elided-count envelope))
-                             {:keys [value indicators]}
-                             (wp/run-wire-pipeline
-                               (pluck envelope)
-                               {:kind :scalar-value
-                                :server-elided server-elided})
-                             {:keys [elided]} indicators
-                             rebuilt (wire/with-indicators
-                                       (rebuild (dissoc envelope :elided-count) value)
-                                       {:elided elided})]
-                         ;; rf2-wdxyx3 finding 2 — a known-tool runtime
-                         ;; failure (`:ok? false`, e.g. a singular
-                         ;; `:path-not-found` miss) MUST ride back as an
-                         ;; `isError` envelope, per the published wire
-                         ;; contract (spec/001-Wire-Protocol.md, API.md
-                         ;; §isError) and the dispatch/read-sub
-                         ;; no-silent-success parity model. An `ok-text`
-                         ;; wrapper let the failure cache as a normal success
-                         ;; (cache eligibility keys off `isError`, not
-                         ;; `:ok?`) and read as green by the MCP host. The
-                         ;; `:wholesale-read-of-reserved-frame` refusal is
-                         ;; built upstream as its own `err-text` and never
-                         ;; reaches this tail.)
-                         (if (false? (:ok? rebuilt))
-                           (wire/err-text rebuilt)
-                           (wire/ok-text rebuilt)))))
-              (.catch (fn [err] (probe/err->result :get-path-failed err)))))]
+          (probe/eval-after-runtime-signalled!
+            conn build-id form :get-path-failed
+            (fn [envelope]
+              (let [server-elided (when (:ok? envelope) (:elided-count envelope))
+                    {:keys [value indicators]}
+                    (wp/run-wire-pipeline
+                      (pluck envelope)
+                      {:kind :scalar-value
+                       :server-elided server-elided})
+                    {:keys [elided]} indicators
+                    rebuilt (wire/with-indicators
+                              (rebuild (dissoc envelope :elided-count) value)
+                              {:elided elided})]
+                ;; rf2-wdxyx3 finding 2 — a known-tool runtime
+                ;; failure (`:ok? false`, e.g. a singular
+                ;; `:path-not-found` miss) MUST ride back as an
+                ;; `isError` envelope, per the published wire
+                ;; contract (spec/001-Wire-Protocol.md, API.md
+                ;; §isError) and the dispatch/read-sub
+                ;; no-silent-success parity model. An `ok-text`
+                ;; wrapper let the failure cache as a normal success
+                ;; (cache eligibility keys off `isError`, not
+                ;; `:ok?`) and read as green by the MCP host. The
+                ;; `:wholesale-read-of-reserved-frame` refusal is
+                ;; built upstream as its own `err-text` and never
+                ;; reaches this tail.)
+                (if (false? (:ok? rebuilt))
+                  (wire/err-text rebuilt)
+                  (wire/ok-text rebuilt))))))]
     (cond
       ;; rf2-qef58 — server-side backstop: refuse a WHOLESALE root read
       ;; (`path: []`, or a `[]` element in a batch `paths`) of a reserved

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -58,6 +58,7 @@
   (:require [cljs.reader]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
 ;; ---------------------------------------------------------------------------
@@ -668,16 +669,22 @@
 ;; send, and how do I shape the response" — the prelude stops obscuring
 ;; the per-tool logic.
 ;;
-;; Tools that DON'T use this helper, and why:
-;;   - snapshot / get-path / subscribe — insert a `signal-runtime!` step
-;;     between `ensure-runtime!` and the eval (the raw-state tap gate,
-;;     rf2-c2dtu), so their prelude is a different shape.
+;; State-emitting tools wear the SAME chain plus ONE extra step: a
+;; `raw-state/signal-runtime!` reconfigure between `ensure-runtime!` and
+;; the eval (the raw-state tap gate, rf2-c2dtu) so the runtime is in its
+;; gated posture before the eval taps / egresses app-db.
+;; `eval-after-runtime-signalled!` is the sibling combinator for that
+;; shape — same prelude/postlude, the signal interposed.
+;;
+;; Tools that DON'T use either helper, and why:
 ;;   - eval-cljs — uses `resolve-and-preflight!` (fail-loud build
 ;;     resolution), not the plain `ensure-runtime!` probe.
 ;;   - watch-until / tail-build — poll a form on a cadence, not a single
-;;     eval.
-;;   - dispatch (`:await-render`) — threads the await-promise mailbox
-;;     between the eval and the result.
+;;     eval (the signal step lands, but the eval recurs inside a poll
+;;     loop, not as one terminal `.then`).
+;;   - subscribe — signals then opens a streaming controller whose
+;;     `.catch` must release the stream slot before `err->result`, so its
+;;     postlude is a different shape.
 ;;   - discover-app — chains a `runtime-health!` read after the probe.
 ;; ---------------------------------------------------------------------------
 
@@ -697,6 +704,32 @@
   call-sites."
   [conn build-id form fail-reason on-value]
   (-> (ensure-runtime! conn build-id)
+      (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+      (.then on-value)
+      (.catch (fn [err] (err->result fail-reason err)))))
+
+(defn eval-after-runtime-signalled!
+  "The shared single-eval prelude for STATE-EMITTING tools. Identical to
+  `eval-after-runtime!` except it interposes one extra step — a
+  `raw-state/signal-runtime!` reconfigure between `ensure-runtime!` and
+  the eval (the raw-state tap gate, rf2-c2dtu) — so the runtime is in its
+  gated (default-elided) posture before the eval taps / egresses app-db.
+
+  Confirm the runtime is preloaded for `(conn, build-id)`, signal the
+  raw-state posture, eval `form` over nREPL, pass the resolved value to
+  `on-value` (which returns the MCP envelope), and translate any
+  rejection via `err->result` keyed by `fail-reason`. Returns the Promise
+  of the MCP result.
+
+  `on-value` carries the part that genuinely differs per tool. The signal
+  re-runs on every call rather than caching a per-build flag — the
+  runtime's posture resets on reload (rf2-olvr5 finding 2). As with
+  `eval-after-runtime!`, `nrepl/cljs-eval-value` is resolved per-call (a
+  plain var reference) so the per-tool `set!`-based test seam keeps
+  working through this helper."
+  [conn build-id form fail-reason on-value]
+  (-> (ensure-runtime! conn build-id)
+      (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
       (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
       (.then on-value)
       (.catch (fn [err] (err->result fail-reason err)))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_sub.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_sub.cljs
@@ -40,7 +40,6 @@
   `:ambiguous-frame` / `:sub-error`)."
   (:require [cljs.reader]
             [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
@@ -153,27 +152,24 @@
       :ok
       (let [query-v payload
             form    (read-sub-form query-v frame walk? frame-edn elision-opts)]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then
-              (fn [envelope]
-                (if-not (and (map? envelope) (:ok? envelope))
-                  ;; Structured failure (unknown-id / ambiguous-frame /
-                  ;; sub-error / not-a-sub-vector) — surface verbatim as an
-                  ;; :isError envelope, never a silent nil success
-                  ;; (no-silent-swallow parity with dispatch).
-                  (wire/err-text (if (map? envelope)
-                                   envelope
-                                   {:ok? false :reason :unexpected-shape :value envelope}))
-                  ;; Hit — count the server-side elision markers over the
-                  ;; value and rebuild the envelope (the same `:scalar-value`
-                  ;; pipeline arm get-path uses).
-                  (let [{:keys [value indicators]}
-                        (wp/run-wire-pipeline (:value envelope) {:kind :scalar-value})
-                        {:keys [elided]} indicators]
-                    (wire/ok-text
-                      (wire/with-indicators
-                        (assoc envelope :value value :elision elision?)
-                        {:elided elided}))))))
-            (.catch (fn [err] (probe/err->result :read-sub-failed err))))))))
+        (probe/eval-after-runtime-signalled!
+          conn build-id form :read-sub-failed
+          (fn [envelope]
+            (if-not (and (map? envelope) (:ok? envelope))
+              ;; Structured failure (unknown-id / ambiguous-frame /
+              ;; sub-error / not-a-sub-vector) — surface verbatim as an
+              ;; :isError envelope, never a silent nil success
+              ;; (no-silent-swallow parity with dispatch).
+              (wire/err-text (if (map? envelope)
+                               envelope
+                               {:ok? false :reason :unexpected-shape :value envelope}))
+              ;; Hit — count the server-side elision markers over the
+              ;; value and rebuild the envelope (the same `:scalar-value`
+              ;; pipeline arm get-path uses).
+              (let [{:keys [value indicators]}
+                    (wp/run-wire-pipeline (:value envelope) {:kind :scalar-value})
+                    {:keys [elided]} indicators]
+                (wire/ok-text
+                  (wire/with-indicators
+                    (assoc envelope :value value :elision elision?)
+                    {:elided elided}))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
@@ -67,7 +67,6 @@
   the background sampler tick re-consults each frame)."
   (:require [cljs.reader]
             [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
@@ -317,17 +316,14 @@
 
       :else
       (let [form (start-recording-form signals stop frame max-entries elision-opts)]
-        ;; rf2-8fin7.2 — insert `signal-runtime!` between `ensure-runtime!`
-        ;; and the eval (the raw-state tap gate, rf2-c2dtu) so the runtime
-        ;; is in the OFF posture before the background sampler ticks —
-        ;; same prelude shape snapshot / get-path / subscribe use. The
-        ;; plain `eval-after-runtime!` skips this step, so the chain is
-        ;; spelled out here.
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [envelope] (wire/ok-text envelope)))
-            (.catch (fn [err] (probe/err->result :record-failed err))))))))
+        ;; rf2-8fin7.2 — the signalled prelude inserts `signal-runtime!`
+        ;; between `ensure-runtime!` and the eval (the raw-state tap gate,
+        ;; rf2-c2dtu) so the runtime is in the OFF posture before the
+        ;; background sampler ticks. The plain `eval-after-runtime!` skips
+        ;; the signal step, so this uses the `-signalled!` sibling.
+        (probe/eval-after-runtime-signalled!
+          conn build-id form :record-failed
+          (fn [envelope] (wire/ok-text envelope)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-recording — read back the change-log.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
@@ -56,12 +56,10 @@
   posture landing. This is why `replace-app-db` does NOT use the plain
   `probe/eval-after-runtime!` prelude (which skips the signal step) —
   it threads `signal-runtime!` between the probe and the eval."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
-            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.writes :as writes]))
 
 ;; The `db` arg has NO shape constraint — a frame's app-db is
@@ -95,23 +93,21 @@
                      (ef/rt-call 'app-db-reset! new-db frame)
                      (ef/rt-call 'app-db-reset! new-db))
               form (ef/emit call)]
-          ;; rf2-z7roa — `signal-runtime!` lands between `ensure-runtime!`
-          ;; and the `app-db-reset!` eval so the runtime's tap-emitting
-          ;; surface is in its gated (default-elided) posture BEFORE the
-          ;; reset taps the pre-/post-reset app-db. This mirrors the
-          ;; direct-read surfaces' prelude (rf2-c2dtu) rather than the
-          ;; plain `probe/eval-after-runtime!` (which has no signal step).
-          (-> (probe/ensure-runtime! conn build-id)
-              (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-              (.then (fn [v]
-                       ;; app-db-reset! returns a structured envelope
-                       ;; ({:ok? true :frame ...} / {:ok? false :reason
-                       ;; :reset-rejected ...}). Pass it through; default
-                       ;; to a generic shape if the runtime returned a
-                       ;; non-map (degraded / pre-rf2-c2dtu runtime).
-                       (wire/ok-text
-                         (if (map? v)
-                           v
-                           {:ok? false :reason :unexpected-shape :value v :frame frame}))))
-              (.catch (fn [err] (probe/err->result :replace-app-db-failed err)))))))))
+          ;; rf2-z7roa — the signalled prelude lands `signal-runtime!`
+          ;; between `ensure-runtime!` and the `app-db-reset!` eval so the
+          ;; runtime's tap-emitting surface is in its gated (default-elided)
+          ;; posture BEFORE the reset taps the pre-/post-reset app-db. This
+          ;; mirrors the direct-read surfaces' prelude (rf2-c2dtu) rather
+          ;; than the plain `probe/eval-after-runtime!` (no signal step).
+          (probe/eval-after-runtime-signalled!
+            conn build-id form :replace-app-db-failed
+            (fn [v]
+              ;; app-db-reset! returns a structured envelope
+              ;; ({:ok? true :frame ...} / {:ok? false :reason
+              ;; :reset-rejected ...}). Pass it through; default to a
+              ;; generic shape if the runtime returned a non-map (degraded
+              ;; / pre-rf2-c2dtu runtime).
+              (wire/ok-text
+                (if (map? v)
+                  v
+                  {:ok? false :reason :unexpected-shape :value v :frame frame})))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -48,12 +48,10 @@
   failure modes). The runtime primitive returns `false` on any failure
   (the frame's app-db is unchanged); we surface that as
   `{:ok? false :reason :restore-rejected}`."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
-            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.writes :as writes]))
 
 ;; The `epoch-id` arg is parsed as EDN with NO shape constraint — any
@@ -112,19 +110,16 @@
                                      "ring, or a drain is in flight. Read the structured reason "
                                      "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
                                      "filtered to :rf.epoch/*.")})))]
-          ;; rf2-6nks4 (finding-2): signal the raw-state posture to the
-          ;; runtime BEFORE the restore eval, so the cascade-summary it
-          ;; builds redacts a sensitive `:event-vector` under the default
-          ;; gate-OFF posture. Mirrors dispatch-dry-run's prelude shape
-          ;; (which restore-epoch's primitive internally drives) — we can
-          ;; not use the plain `eval-after-runtime!` prelude because that
-          ;; helper has no `signal-runtime!` step. The signal reconfigures
-          ;; the posture before every state-emitting eval (rf2-olvr5
-          ;; finding 2 — the runtime's posture resets on reload, so a
-          ;; cached-delivered flag would leave a post-reload restore tapping
-          ;; raw values); it is one tiny idempotent round-trip.
-          (-> (probe/ensure-runtime! conn build-id)
-              (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-              (.then on-value)
-              (.catch (fn [err] (probe/err->result :restore-epoch-failed err)))))))))
+          ;; rf2-6nks4 (finding-2): the signalled prelude signals the
+          ;; raw-state posture to the runtime BEFORE the restore eval, so
+          ;; the cascade-summary it builds redacts a sensitive
+          ;; `:event-vector` under the default gate-OFF posture. Mirrors
+          ;; dispatch-dry-run's prelude shape (which restore-epoch's
+          ;; primitive internally drives) — the plain `eval-after-runtime!`
+          ;; has no `signal-runtime!` step, so this uses the `-signalled!`
+          ;; sibling. The signal reconfigures the posture before every
+          ;; state-emitting eval (rf2-olvr5 finding 2 — the runtime's
+          ;; posture resets on reload, so a cached-delivered flag would
+          ;; leave a post-reload restore tapping raw values).
+          (probe/eval-after-runtime-signalled!
+            conn build-id form :restore-epoch-failed on-value))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -9,8 +9,7 @@
   `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
   builds the eval form, awaits the runtime response, and routes the
   result through `run-wire-pipeline` with `:kind :snapshot-map`."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.eval-form :as ef]
+  (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
             [re-frame2-pair-mcp.tools.probe :as probe]
@@ -218,10 +217,9 @@
     ;; `:app` scope (reserved frames already excluded) pass through.
     (if-let [refused (guard/snapshot-refusal frames path mode)]
       (js/Promise.resolve refused)
-      (-> (probe/ensure-runtime! conn build-id)
-          (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-          (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-          (.then (fn [resp]
+      (probe/eval-after-runtime-signalled!
+        conn build-id form :snapshot-failed
+        (fn [resp]
                  ;; New eval-form shape (rf2-e35a5): `{:value <snap>
                  ;; :elided-count N}`. Defensively fall back to the
                  ;; bare-snap shape — a degraded runtime / stubbed
@@ -287,5 +285,4 @@
                                                        "(e.g. frames [\":rf/xray\"])."))
                                      path              (assoc :path path)
                                      (seq path-status) (assoc :path-not-found path-status))
-                                   {:dropped dropped :elided elided})))))
-          (.catch (fn [err] (probe/err->result :snapshot-failed err)))))))
+                                   {:dropped dropped :elided elided}))))))))


### PR DESCRIPTION
Two behaviour-preserving dedup leans on the tools/mcp surface (parent rf2-91oga2). Disjoint artefacts (pair-mcp vs mcp-conformance), no internal conflict.

## rf2-776qze — pair-mcp signalled eval-prelude

The state-emitting single-eval read/write tools each hand-rolled the same five-step promise chain: `ensure-runtime! -> signal-runtime! -> cljs-eval-value -> per-tool reshape -> err->result`. Only the reshape `.then` and the fail-reason keyword differ. `probe.cljs` already factored the NON-signalled shape as `eval-after-runtime!`; this adds the signalled sibling `eval-after-runtime-signalled!` (same prelude/postlude plus the `raw-state/signal-runtime!` step) and collapses the nine matching call sites to it.

- Converted: snapshot, get-path, read-sub, record, replace-app-db, restore-epoch, dispatch-dry-run, dispatch (both the `:await-render` and the plain dispatch sites).
- Left inline (different shape): **subscribe** — its `.catch` releases the stream slot before `err->result`, and its on-value threads the streaming controller's progress plumbing; **watch-until** — polls the form on a cadence, so the eval recurs inside a poll loop rather than as one terminal eval.
- Behaviour-preserving: the helper resolves `nrepl/cljs-eval-value` per-call as a plain var reference, so the `set!`-based test seam is unchanged; `signal-runtime!` routes through the same stubbed var.
- Removed the now-unused `nrepl`/`raw-state` requires the collapse left behind in each converted file.

## rf2-9hkwkp — mcp-conformance shared helpers

Three SDK-envelope-shape helpers survived the `_runner.cjs` factoring as copy-pasted bodies. None pins a per-test contract — all are pure SDK-envelope mechanics. Hoisted into a shared "envelope readers / coverage tracker" section of `_runner.cjs` and deleted the local copies:

- `responseText` (4 copies) — concatenate the `.text` of every callTool content block.
- `track` (2 byte-identical copies) — the callTool coverage Proxy. The shared form owns its `CALLED` Set and returns `{ client, called }`; the two call sites destructure rather than reaching a module-scope Set.
- `structured` (2 copies) — `decodeDedupEnvelope` unwrap; the import moves into `_runner.cjs` and is dropped from story + flag-gates. The null-safe `((resp && …) || {})` form is kept (a strict superset of story's no-guard copy).

Left untouched per the bead: the per-schema validators (`assertOverflowBody` / `assertProgressParams` / `assertDropped` / `dispatchStamp` …) — genuinely-distinct per-wire-surface conformance assertions whose per-function attribution the JVM cross-encoding grep gate depends on.

## Gates

- `clj-kondo` on pair-mcp src: 0 errors; the 2 remaining warnings (`dispatch.cljs catch :default e`, `subscribe.cljs raw-args`) are pre-existing on origin/main.
- pair-mcp `:server-test` build: 220 files compiled, 0 warnings; **1114 tests / 3706 assertions, 0 failures, 0 errors** — directly exercises every converted tool through the new helper.
- mcp-conformance Node unit suites (dedup-envelope, call-coverage-ratchet, classification-ratchet, runner-watchdog, runner-cleanup): **31 tests, 0 failures** — confirms `_runner.cjs` loads with the new import + exports.
- mcp-conformance/wire-vocab JVM: 101 tests / 1062 assertions, 0 failures (the cross-encoding attribution gate — unaffected).
- mcp-base JVM: 247 tests / 825 assertions, 0 failures.
- `node --check` on all 8 touched conformance files: clean.

No tool descriptors, registry, spec, or skill catalogue touched — the externally-visible MCP surface is unchanged, so no skill↔MCP drift check is needed.