### PR TITLE
refactor(tools/story): remove dead explain-state/selector-kind + dedupe runner/canvas/schemas (rf2-q6bdah +4)

### DIFF
--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -871,16 +871,3 @@
     (some (fn [r] (or (false? (:passed? r))
                       (some? (:exception r))))
           results)))
-
-;; ---- diagnostics --------------------------------------------------------
-
-(defn explain-state
-  "Render the run-state as a short multi-line string for diagnostics.
-  Pure data → data."
-  [{:keys [status step-idx total failures results name] :as state}]
-  (let [header (str (when name (str "[" name "] ")) (progress-str state))]
-    (str header
-         (when (pos? failures)
-           (str "\n  failures: " failures))
-         (when (seq results)
-           (str "\n  ran: " (count results) "/" total)))))

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -805,35 +805,6 @@
         :queue-empty {:kind :queue-empty}
         nil))))
 
-(defn step-assert-db
-  "Decompose an `:assert-db` step into `{:path <vec> :mode :equals|:pred
-  :expected <val> :pred-ref <fn-or-sym> :pred-fn? <bool>}`.
-
-  The `:pred` form is 4-arity (`[:assert-db path :pred ref]`) where
-  `ref` is EITHER a fn (preferred — works under advanced CLJS) OR a
-  symbol (resolved via `requiring-resolve` on JVM, best-effort
-  `goog.global` walk on CLJS — fragile under advanced). The
-  equality form is 3-arity (`[:assert-db path value]`).
-
-  `:pred-fn?` discriminates so the runner can skip resolution when the
-  caller already handed in a callable."
-  [step]
-  (when (= :assert-db (step-type step))
-    (let [path (nth step 1)]
-      (if (and (= 4 (count step)) (= :pred (nth step 2)))
-        (let [ref (nth step 3)]
-          {:path path :mode :pred :pred-ref ref :pred-fn? (fn? ref)})
-        {:path path :mode :equals :expected (nth step 2)}))))
-
-(defn step-assert-dom
-  "Decompose an `:assert-dom` step into `{:selector :mode :text}`."
-  [step]
-  (when (= :assert-dom (step-type step))
-    (let [selector (nth step 1)
-          mode     (nth step 2)]
-      (cond-> {:selector selector :mode mode}
-        (= :text mode) (assoc :text (nth step 3))))))
-
 (defn step-type-text
   "Return `[selector text]` from a `:type` step."
   [step]

--- a/tools/story/src/re_frame/story/recorder/dom_capture.cljs
+++ b/tools/story/src/re_frame/story/recorder/dom_capture.cljs
@@ -78,7 +78,8 @@
             [clojure.string                  :as str]
             [re-frame.story.config           :as config]
             [re-frame.story.recorder         :as recorder]
-            [re-frame.story.recorder.selector :as selector]))
+            [re-frame.story.recorder.selector :as selector]
+            [re-frame.story.ui.canvas-listeners :as canvas-listeners]))
 
 ;; ---- runtime knobs -----------------------------------------------------
 
@@ -386,18 +387,14 @@
         (record-dom-submit! sel)))))
 
 ;; ---- install / remove --------------------------------------------------
+;;
+;; The idempotent canvas-root install/remove scaffold is shared with the
+;; element inspector via `re-frame.story.ui.canvas-listeners`. This rail
+;; keeps only its own listener bodies + the recorder-specific pre/post
+;; hooks: the `config/enabled?` opt-in gate on install and the
+;; type-buffer drain on remove.
 
 (defonce ^:private installed-root (atom nil))
-
-(defn- canvas-root
-  "The current shell canvas root, looked up by the framework-stable
-  `[data-test=\"story-canvas-frame\"]` hook. Returns nil when the
-  shell isn't mounted (e.g. before `mount-shell!`)."
-  []
-  (when (and (exists? js/document) (.-querySelector js/document))
-    (try
-      (.querySelector js/document "[data-test=\"story-canvas-frame\"]")
-      (catch :default _ nil))))
 
 (defn- attach-listeners! [root]
   ;; Capture phase = false (bubble); we want the recorder to see what
@@ -418,6 +415,9 @@
   (.removeEventListener root "change" handle-change! false)
   (.removeEventListener root "submit" handle-submit! false))
 
+(def ^:private lifecycle
+  (canvas-listeners/make-lifecycle installed-root attach-listeners! detach-listeners!))
+
 (defn install!
   "Install the DOM-capture listeners on `root` (or the canvas root
   when called with no arg). Idempotent — re-installing removes the
@@ -426,14 +426,10 @@
   No-op when production elision is active (`config/enabled?` false).
   Returns the root node on success, nil otherwise."
   ([]
-   (install! (canvas-root)))
+   (install! (canvas-listeners/canvas-root)))
   ([root]
-   (when (and config/enabled? root)
-     (when-let [prev @installed-root]
-       (detach-listeners! prev))
-     (attach-listeners! root)
-     (reset! installed-root root)
-     root)))
+   (when config/enabled?
+     ((:install! lifecycle) root))))
 
 (defn remove!
   "Tear down any previously installed listeners. Idempotent. Drains
@@ -441,13 +437,10 @@
   in-flight typed value (if any)."
   []
   (flush-type-buffer!)
-  (when-let [root @installed-root]
-    (detach-listeners! root)
-    (reset! installed-root nil))
-  nil)
+  ((:remove! lifecycle)))
 
 (defn installed?
   "True iff `install!` is currently attached to a root node. Public
   for tests and the toolbar's status display."
   []
-  (some? @installed-root))
+  ((:installed? lifecycle)))

--- a/tools/story/src/re_frame/story/recorder/selector.cljc
+++ b/tools/story/src/re_frame/story/recorder/selector.cljc
@@ -122,20 +122,6 @@
   (or (some (partial attribute-selector (or attrs {})) attribute-priority)
       (nth-of-type-fallback shape)))
 
-(defn selector-kind
-  "Diagnostic: tell the caller WHICH tier `pick-selector` picked.
-  Returns one of `:data-test` / `:id` / `:aria-label` / `:nth-of-type`
-  / `:none`. Used by the translator to attach a hint when the
-  brittle fallback fires."
-  [{:keys [attrs index-of-type]}]
-  (let [a (or attrs {})]
-    (cond
-      (not (blank? (get a "data-test")))  :data-test
-      (not (blank? (get a "id")))         :id
-      (not (blank? (get a "aria-label"))) :aria-label
-      (some? index-of-type)               :nth-of-type
-      :else                               :none)))
-
 ;; ---- impure (CLJS-only DOM shape extractor) -----------------------------
 
 #?(:cljs

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -228,16 +228,30 @@
 
 ;; ---- shared shapes --------------------------------------------------------
 
+(defn- kw-headed?
+  "Predicate: `v` is a non-empty vector whose first element is a
+  keyword. The leading-keyword shape every tagged Story vector shares
+  (event / decorator-ref / play-step / assertion / sub-query)."
+  [v]
+  (and (vector? v)
+       (pos? (count v))
+       (keyword? (first v))))
+
+(defn- keyword-headed-vector
+  "Build the `[:vector :any]` + leading-keyword `:fn` guard schema,
+  carrying `error-msg` as the per-surface diagnostic. The five tagged
+  Story vectors differ only by that message, not by shape — see
+  `EventVector` / `DecoratorRef` / `PlayStep` / `AssertionVector` /
+  `SubQueryVector`."
+  [error-msg]
+  [:and
+   [:vector :any]
+   [:fn {:error/message error-msg} kw-headed?]])
+
 (def EventVector
   "An event vector: `[<event-id> & args]`. Used in `:events`,
   `:loaders`, decorator `:init`, etc. No fn-valued slots."
-  [:and
-   [:vector :any]
-   [:fn {:error/message "event vector must start with a keyword"}
-    (fn [v]
-      (and (vector? v)
-           (pos? (count v))
-           (keyword? (first v))))]])
+  (keyword-headed-vector "event vector must start with a keyword"))
 
 (def TagSet
   "A `:tags` set on a story / variant / workspace. The `!`-prefix
@@ -248,13 +262,7 @@
 (def DecoratorRef
   "A vector `[<decorator-id> & args]` referencing a registered decorator
   by id. Closures live at the decorator's registration site, not here."
-  [:and
-   [:vector :any]
-   [:fn {:error/message "decorator vector must start with a keyword id"}
-    (fn [v]
-      (and (vector? v)
-           (pos? (count v))
-           (keyword? (first v))))]])
+  (keyword-headed-vector "decorator vector must start with a keyword id"))
 
 (def DecoratorRefs
   [:vector DecoratorRef])
@@ -487,13 +495,7 @@
   so authors get clear runner error messages rather than schema
   rejections on a typo. The runner's `step-arity-ok?` performs deeper
   shape checks at run time and surfaces an `:unknown-step` result."
-  [:and
-   [:vector :any]
-   [:fn {:error/message "play step must be a vector starting with a keyword"}
-    (fn [v]
-      (and (vector? v)
-           (pos? (count v))
-           (keyword? (first v))))]])
+  (keyword-headed-vector "play step must be a vector starting with a keyword"))
 
 (def PlayScript
   "A `:script` vector — sequence of `PlayStep`s."
@@ -556,13 +558,7 @@
   positions). Shape is left loose (vector starting with a keyword) so the
   assertion-id registry surfaces a clear runner error rather than a schema
   rejection on an unknown id."
-  [:and
-   [:vector :any]
-   [:fn {:error/message "assertion must be a vector starting with a keyword id"}
-    (fn [v]
-      (and (vector? v)
-           (pos? (count v))
-           (keyword? (first v))))]])
+  (keyword-headed-vector "assertion must be a vector starting with a keyword id"))
 
 (def ComposeRefs
   "Schema for the `:compose` slot on a variant / inline plan (rf2-5x1wt.15
@@ -623,14 +619,8 @@
   subscription-output-schema validation (a plan-compiler concern) carries
   the precise diagnostic rather than a structural schema rejection on an
   arg shape."
-  [:and
-   [:vector :any]
-   [:fn {:error/message
-         ":sub-overrides key must be a query vector starting with a sub-id keyword"}
-    (fn [v]
-      (and (vector? v)
-           (pos? (count v))
-           (keyword? (first v))))]])
+  (keyword-headed-vector
+    ":sub-overrides key must be a query vector starting with a sub-id keyword"))
 
 (def SubOverridesMap
   "Schema for the `:sub-overrides` slot on a variant / fragment body —

--- a/tools/story/src/re_frame/story/ui/canvas_listeners.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas_listeners.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.story.ui.canvas-listeners
+  "Shared canvas DOM-listener lifecycle scaffold for Story's canvas-side
+  observers (the recorder's `dom-capture` rail and the click-to-source
+  `element-inspector`).
+
+  Both observers attach event listeners to the *story canvas root* and
+  share the SAME idempotent install/remove lifecycle: look the root up
+  by its framework-stable hook, keep a process-local ref to the
+  currently-installed root, and on (re-)install detach the previous set
+  before attaching the new one. Only the listener BODIES differ (which
+  events, the handler logic, the debounce buffer, the rAF throttle, the
+  redaction) — those stay in each observer. This ns owns just the
+  scaffold so the canvas-root selector lives in ONE place.
+
+  ## Surface
+
+  - `canvas-root` — the current shell canvas root, or nil when the
+    shell isn't mounted.
+  - `make-lifecycle` — given a process-local `installed-root` atom plus
+    an `attach-fn`/`detach-fn` pair, returns an `{:install! :remove!
+    :installed?}` closure-set that implements the idempotent lifecycle.
+    Callers wrap these thinly for any per-observer pre/post hooks (the
+    recorder's `config/enabled?` gate + type-buffer flush, the
+    inspector's inspect-mode reset).
+
+  ## Bundle isolation
+
+  Story-side, CLJS-only. Production builds elide the whole Story UI
+  shell at the `mount-shell!` call site, so this ns is reachable only
+  when Story is enabled. No tools->tools cross-require.")
+
+(def ^:const canvas-selector
+  "The framework-stable hook the shell stamps on the canvas frame
+  (`shell/canvas`). The single source of truth for where the
+  canvas-side observers attach."
+  "[data-test=\"story-canvas-frame\"]")
+
+(defn canvas-root
+  "The current shell canvas root, looked up by the framework-stable
+  `[data-test=\"story-canvas-frame\"]` hook. Returns nil when the shell
+  isn't mounted (e.g. before `mount-shell!`)."
+  []
+  (when (and (exists? js/document) (.-querySelector js/document))
+    (try
+      (.querySelector js/document canvas-selector)
+      (catch :default _ nil))))
+
+(defn make-lifecycle
+  "Build the idempotent install/remove lifecycle over `installed-root`
+  (a process-local atom holding the currently-installed root, or nil)
+  and the observer's own `attach-fn`/`detach-fn` (each `(fn [root] …)`).
+
+  Returns `{:install! :remove! :installed?}`:
+
+  - `:install!` — `([] (install! (canvas-root)))` / `([root] …)`.
+    Idempotent: detaches the previous root first, then attaches `root`,
+    records it, and returns it. No-op (nil) when `root` is nil.
+  - `:remove!`  — detaches the installed root and clears the ref.
+    Idempotent. Returns nil.
+  - `:installed?` — true iff a root is currently attached.
+
+  The per-observer pre/post concerns (the recorder's `config/enabled?`
+  gate + type-buffer flush, the inspector's inspect-mode reset) are NOT
+  the scaffold's business — callers wrap the returned closures."
+  [installed-root attach-fn detach-fn]
+  {:install!
+   (fn install!
+     ([] (install! (canvas-root)))
+     ([root]
+      (when root
+        (when-let [prev @installed-root]
+          (detach-fn prev))
+        (attach-fn root)
+        (reset! installed-root root)
+        root)))
+   :remove!
+   (fn []
+     (when-let [root @installed-root]
+       (detach-fn root)
+       (reset! installed-root nil))
+     nil)
+   :installed?
+   (fn []
+     (some? @installed-root))})

--- a/tools/story/src/re_frame/story/ui/element_inspector.cljc
+++ b/tools/story/src/re_frame/story/ui/element_inspector.cljc
@@ -46,9 +46,10 @@
   ## Why not a re-frame fx
 
   The inspector's state is per-process transient UI hover state — not
-  app-db material. Keeping it in a defonce'd atom (mirrors
-  `recorder/dom-capture/installed-root`) avoids the latency + overhead
-  of routing every mousemove through dispatch. Click DOES route through
+  app-db material. Keeping it in a defonce'd atom (same shape the
+  shared `ui/canvas-listeners` lifecycle uses for its installed-root
+  ref) avoids the latency + overhead of routing every mousemove through
+  dispatch. Click DOES route through
   `open-in-editor/open-source-coord!` so the launcher + allowlist gate
   stay the single source of truth.
 
@@ -64,6 +65,7 @@
             #?@(:cljs [[reagent.core :as r]
                        [re-frame.core :as rf]
                        [re-frame.source-coords :as source-coords]
+                       [re-frame.story.ui.canvas-listeners :as canvas-listeners]
                        [re-frame.story.ui.open-in-editor :as open-in-editor]])
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
@@ -294,23 +296,14 @@
 
 ;; ---- install / remove ----------------------------------------------------
 ;;
-;; Mirrors `recorder/dom-capture/install!`'s shape: defonce'd ref to
-;; the currently-installed root, attach/detach via the same key. Caller
-;; (shell) drives install at mount-time, remove at unmount.
+;; The idempotent canvas-root install/remove scaffold is shared with the
+;; recorder's DOM-capture rail via `re-frame.story.ui.canvas-listeners`.
+;; This ns keeps only its own attach/detach bodies + the inspector's
+;; remove-time inspect-mode reset. Caller (shell) drives install at
+;; mount-time, remove at unmount.
 
 #?(:cljs (defonce ^:private installed-root (atom nil)))
 #?(:cljs (defonce ^:private bound-handlers (atom nil)))
-
-#?(:cljs
-   (defn- canvas-root
-     "The shell canvas root, looked up via the framework-stable
-     `[data-test=\"story-canvas-frame\"]` hook (same selector
-     `recorder/dom-capture` uses)."
-     []
-     (when (and (exists? js/document) (.-querySelector js/document))
-       (try
-         (.querySelector js/document "[data-test=\"story-canvas-frame\"]")
-         (catch :default _ nil)))))
 
 #?(:cljs
    (defn- attach-listeners! [root]
@@ -335,18 +328,16 @@
        (reset! bound-handlers nil))))
 
 #?(:cljs
+   (def ^:private lifecycle
+     (canvas-listeners/make-lifecycle installed-root attach-listeners! detach-listeners!)))
+
+#?(:cljs
    (defn install!
      "Install the inspector listeners on `root` (or the canvas root when
      called with no arg). Idempotent. Returns the root on success, nil
      otherwise."
-     ([] (install! (canvas-root)))
-     ([root]
-      (when root
-        (when-let [prev @installed-root]
-          (detach-listeners! prev))
-        (attach-listeners! root)
-        (reset! installed-root root)
-        root))))
+     ([] ((:install! lifecycle)))
+     ([root] ((:install! lifecycle) root))))
 
 #?(:cljs
    (defn remove!
@@ -354,16 +345,14 @@
      mode off — a re-mount mid-pick would otherwise leave the cursor
      stuck on `crosshair`."
      []
-     (when-let [root @installed-root]
-       (detach-listeners! root)
-       (reset! installed-root nil))
+     ((:remove! lifecycle))
      (set-active! false)
      nil))
 
 (defn installed?
   "True iff `install!` has attached listeners. Public for tests."
   []
-  #?(:cljs (some? @installed-root)
+  #?(:cljs ((:installed? lifecycle))
      :clj  false))
 
 ;; ---- overlay component + chip --------------------------------------------

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -476,25 +476,6 @@
   (is (= [:foo]   (runner/step-event [:dispatch-sync [:foo]])))
   (is (nil?       (runner/step-event [:wait 10]))))
 
-(deftest step-assert-db-decomposition
-  (is (= {:path [:k] :mode :equals :expected 1}
-         (runner/step-assert-db [:assert-db [:k] 1])))
-  (testing "symbol ref decomposes to :pred-ref + :pred-fn? false"
-    (is (= {:path [:a :b] :mode :pred :pred-ref 'my/pos? :pred-fn? false}
-           (runner/step-assert-db [:assert-db [:a :b] :pred 'my/pos?]))))
-  (testing "fn ref decomposes to :pred-ref + :pred-fn? true (rf2-inbad)"
-    (let [decomp (runner/step-assert-db [:assert-db [:a :b] :pred pos?])]
-      (is (= [:a :b] (:path decomp)))
-      (is (= :pred (:mode decomp)))
-      (is (true? (:pred-fn? decomp)))
-      (is (identical? pos? (:pred-ref decomp))))))
-
-(deftest step-assert-dom-decomposition
-  (is (= {:selector "x" :mode :visible}
-         (runner/step-assert-dom [:assert-dom "x" :visible])))
-  (is (= {:selector "x" :mode :text :text "hi"}
-         (runner/step-assert-dom [:assert-dom "x" :text "hi"]))))
-
 ;; ---- trace record builder ------------------------------------------------
 
 (deftest trace-record-shape

--- a/tools/story/test/re_frame/story/recorder/selector_test.cljc
+++ b/tools/story/test/re_frame/story/recorder/selector_test.cljc
@@ -4,8 +4,7 @@
   Covers:
   - Priority tiers (data-test > id > aria-label > nth-of-type).
   - Attribute-value escaping (backslash + double-quote).
-  - Nth-of-type fallback geometry.
-  - `selector-kind` diagnostic returns the right tier."
+  - Nth-of-type fallback geometry."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.recorder.selector :as sel]))
 
@@ -89,15 +88,6 @@
            (sel/pick-selector
              {:tag "div"
               :attrs {"id" "a\\b"}})))))
-
-;; ---- selector-kind diagnostic --------------------------------------------
-
-(deftest selector-kind-reports-tier
-  (is (= :data-test  (sel/selector-kind {:attrs {"data-test" "x"}})))
-  (is (= :id         (sel/selector-kind {:attrs {"id" "x"}})))
-  (is (= :aria-label (sel/selector-kind {:attrs {"aria-label" "x"}})))
-  (is (= :nth-of-type (sel/selector-kind {:attrs {} :index-of-type 2})))
-  (is (= :none       (sel/selector-kind {:attrs {} :index-of-type nil}))))
 
 ;; ---- attribute-priority is the documented data ---------------------------
 


### PR DESCRIPTION
Lean pass across `tools/story` (parent rf2-91oga2): behaviour-preserving dead-code removal + dedup. Each "dead" claim was re-verified with `git grep` across `tools/` + `examples/` + `implementation/` before removal.

## Dead-code removal (verified zero callers)

- **rf2-q6bdah** — `play.runner/explain-state` removed. Caller count: **0** (git grep found only its own defn). The live run-state diagnostics surface is `progress-str` + `fail-summary`; this was a vestigial parallel renderer.
- **rf2-s6i3sr** — `recorder.selector/selector-kind` + its dedicated test removed. Caller count: **0 production** (only its defn + the one unit test written to exercise it). Its docstring claimed the translator attaches a brittleness hint via it; the translator never called it — the intended consumer was never wired.
- **rf2-3dlqi2** — `play.runner/step-assert-db` / `step-assert-dom` decomposers + their two `deftest`s removed. Caller count: **0 production** (defn + their decomposition tests only). The canonical-atom fold (`assertions/fold-assert-step` then `assert-db->atom` / `assert-dom->atom`) superseded them; the executor consumes only the folded `[:assert atom]` via `step-assertion`. Neither is in the spec's documented live step vocabulary, and no story-mcp consumer reads the decomposition map.

## Dedup (behaviour-preserving)

- **rf2-b7uroi** — extracted `re-frame.story.ui.canvas-listeners` (Story-side, CLJS-only) exposing `canvas-root` (the `[data-test="story-canvas-frame"]` selector lives in one place now) plus `make-lifecycle` returning the `{:install! :remove! :installed?}` closure-set. The recorder's `dom-capture` rail and the `element-inspector` keep only their attach/detach bodies and wrap the closures for their own pre/post hooks (recorder's `config/enabled?` gate + type-buffer drain; inspector's inspect-mode reset). Public `install!`/`remove!`/`installed?` signatures and behaviour unchanged. Bundle isolation holds (no tools-to-tools cross-require).
- **rf2-u8w4v3** — factored the hand-copied (5x) keyword-headed-vector Malli guard into one `kw-headed?` predicate plus a `keyword-headed-vector` builder taking the per-surface `:error/message`. EventVector / DecoratorRef / PlayStep / AssertionVector / SubQueryVector each collapse to a one-liner; the five named defs + five distinct messages are preserved.

## Quality gates (all green)

- `tools/story` JVM (`clojure -M:test`): **1702 tests / 6303 assertions, 0 failures** (3 dead-code tests removed).
- `implementation` CLJS node (`npm run test:cljs`): **8024 tests / 33499 assertions, 0 failures**.
- `npm run test:bundle-isolation`: **PASS**.
- `npm run test:story-feature-load`: **0 failures**.
- `npm run test:story-play-scripts`: **29 rows, 0 unexpected** — exercises the live assert-db / assert-dom fold path (`initialise-three-and-assert-pass`, `pred-fn-direct`, `type-click-and-assert-dom`), confirming the deleted decomposers were not on the executor path.
- `npm run story:build`: **585 files, 0 warnings** (advanced compilation — validates the canvas-listeners closure-set + cross-ns require).
- clj-kondo + splint: **zero new warnings** vs origin/main baseline (the new `canvas_listeners.cljs` is lint-clean; remaining warnings are pre-existing).

## Spec

Spec unchanged — no `tools/story/spec/*` document references any removed symbol, the new shared ns, or `make-lifecycle`. `017-Testing-Story.md` lists only the live step vocabulary (`step-types` / `step-arity-ok?` / `coerce-script` / `step-assertion` / `step-wait-until`), which is untouched.
