### PR TITLE
refactor(tools/xray-panels): remove dead diff-format/cache-key-of helpers + stale comment (rf2-dd103a, rf2-gc7px3, rf2-iw6fks)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs
@@ -1,16 +1,6 @@
 (ns day8.re-frame2-xray.panels.app-db-diff-format
   "Display-only formatting helpers for the App-DB Diff panel.")
 
-(def op->border
-  {:added    :green
-   :modified :yellow
-   :removed  :red})
-
-(def op->label
-  {:added    "(added)"
-   :modified "(modified)"
-   :removed  "(removed)"})
-
 (def display-large-string-threshold
   "Display-only ceiling for string values. Clipboard values still use
   the original value; this only keeps visible hiccup bounded."
@@ -128,16 +118,3 @@
             (.set display-value-cache v rewritten)
             rewritten))
       (rewrite v))))
-
-(defn format-display-edn
-  "Best-effort EDN-like format for visible values."
-  [v]
-  (format-edn (display-value v)))
-
-(defn truncate
-  "Truncate `s` to `n` chars, adding an ellipsis when needed."
-  [s n]
-  (let [s (str s)]
-    (if (<= (count s) n)
-      s
-      (str (subs s 0 (max 0 (dec n))) "…"))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -675,15 +675,3 @@
                  :before   (get-in db-before path)
                  :after    (get-in db-after  path)}))
             history))))
-
-;; ---- diff caching --------------------------------------------------------
-
-(defn cache-key-of
-  "Return the cache key for a diff between an epoch's `:db-before`
-  and `:db-after`. Per spec §Performance §Diff caching the cache is
-  keyed by `:epoch-id` and the same epoch never re-diffs.
-
-  Pure-data helper so the sub layer can build a `{epoch-id triples}`
-  lookup without duplicating the key shape."
-  [epoch-record]
-  (:epoch-id epoch-record))

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -429,40 +429,35 @@
 ;; triples to every `:rf.event/db-changed` row's `:db-diff` slot so the
 ;; view stays dumb-and-pure.
 ;;
-;; The row idiom mirrors the Event-panel APP-DB CHANGES section
-;; (`panels/event_detail.cljs` `db-change-row`, spec/021 §2.2 step 6
-;; mockup):
+;; The row idiom (spec/021 §2.2 step 6 mockup):
 ;;
 ;;     + [:path] new            (added — green)
 ;;     ~ [:path] old → new      (modified — amber)
 ;;     - [:path]                (removed — red — path alone)
 ;;
-;; The diff helper itself (`diff-paths`) is already extracted to
-;; `app_db_diff_helpers.cljc` (shared); the render-side `db-change-row`
-;; in `event_detail.cljs` is private (`defn-`) — v1 keeps a small
-;; trace-flavoured duplicate here (denser layout, slightly different
-;; padding to fit the arc's row rhythm) per the rf2-b3zw2 brief's
-;; safer-move guidance (event_detail.cljs is post-#2114 stabilised; the
-;; lens cluster + B+ section reorder just landed). Dedupe is filed as a
-;; follow-on bead.
+;; The diff helper itself (`diff-paths`) is extracted to
+;; `app_db_diff_helpers.cljc` (shared); the render-side helpers below
+;; are this trace arc's changed-path renderer and are the SOLE copy of
+;; this table-style idiom. The Epoch panel renders changed paths in a
+;; deliberately distinct shape — single-line inline chrome
+;; (`epoch/view.cljs`), not a table — so there is no cross-panel
+;; duplication to dedupe.
 
 (def ^:private diff-op->glyph
-  "Cascade diff glyph per op (spec/021 §10.3 / event_detail.cljs `op->glyph`)."
+  "Cascade diff glyph per op (spec/021 §10.3)."
   {:added    "+"
    :modified "~"
    :removed  "-"})
 
 (def ^:private diff-op->tone
-  "Glyph + path colour per op (spec/021 §10.3 / event_detail.cljs `op->tone`)."
+  "Glyph + path colour per op (spec/021 §10.3)."
   {:added    :green
    :modified :yellow
    :removed  :red})
 
 (defn- path-suffix
   "Stable testid suffix for a changed path — pr-str of the path vector
-  with characters that break a data-testid selector folded to `_`.
-  Mirrors event_detail.cljs's `path-suffix` so the testids read
-  consistently across the two panels."
+  with characters that break a data-testid selector folded to `_`."
   [path]
   (-> (str/join " " (map pr-str path))
       (str/replace #"\s+" "_")))
@@ -510,7 +505,7 @@
        [:span {:style db-diff-added-value-style}
         (edn/inspect-inline after)]
 
-       ;; :removed — path alone (spec/021 line 229 / event_detail `db-change-row`).
+       ;; :removed — path alone (spec/021 line 229).
        nil)]))
 
 (defn- db-diff-rows

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_format_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_format_cljs_test.cljs
@@ -1,9 +1,8 @@
 (ns day8.re-frame2-xray.panels.app-db-diff-format-cljs-test
   "Per-leaf smoke test for `app-db-diff-format` (rf2-nb8if).
 
-  The format leaf carries pure display-only formatters — `format-edn`,
-  `display-value`, `format-display-edn`, `truncate`, plus the
-  `op->border` / `op->label` lookup tables and the
+  The format leaf carries the pure display-only formatters used in
+  production — `format-edn` and `display-value` — plus the
   `display-large-string-threshold` ceiling. CLJS-only because the
   underlying leaf is `.cljs` (parent panel is CLJS-only)."
   (:require [cljs.test :refer-macros [deftest is]]
@@ -11,10 +10,6 @@
 
 (deftest format-leaf-smoke
   (is (= "[:cart :items]" (f/format-edn [:cart :items])))
-  (is (= "abc…" (f/truncate "abcdef" 4))
-      "truncate trims and appends an ellipsis at the cap")
-  (is (contains? f/op->border :added))
-  (is (contains? f/op->label :modified))
   (let [big (apply str (repeat (inc f/display-large-string-threshold) "x"))
         v   (f/display-value {:k big})]
     (is (map? (:rf.size/large-elided (:k v)))


### PR DESCRIPTION
Behaviour-PRESERVING dead-code + comment cleanup across three tools/xray panel leaves. Parent: tools lean pass.

## Changes

### rf2-dd103a (P2) — dead test-only diff-format helpers
`tools/xray/src/.../panels/app_db_diff_format.cljs`: removed four public defns with **zero production callers** — `truncate`, `op->border`, `op->label`, `format-display-edn`. Verified via `git grep -nw` across tracked `tools/` + `implementation/`: each appeared only at its own definition and in the panel's own unit test. The three production consumers (`app_db_diff_state`, `app_db_segment_inspector`, `trace` — all alias the ns `:as f`) use only `f/display-value` and `f/format-edn`, both KEPT. Removed the corresponding assertions from `app_db_diff_format_cljs_test.cljs`, keeping the live `display-value`/`format-edn`/threshold smoke coverage.

### rf2-gc7px3 (P3) — dead cache-key-of helper
`tools/xray/src/.../panels/app_db_diff_helpers.cljc`: removed `cache-key-of` (a one-line `:epoch-id` lookup) and its "diff caching" section banner. `git grep -nw cache-key-of` across the tracked repo returned only the definition — zero callers, no test, no spec reference.

### rf2-iw6fks (P3) — stale event_detail dedupe comment
`tools/xray/src/.../panels/trace.cljs`: the per-path db-changed diff-row comment described the helpers as a trace-flavoured DUPLICATE of `event_detail.cljs`'s `db-change-row` idiom, with dedupe "filed as a follow-on bead". `event_detail.cljs` no longer exists (folded into the Epoch panel); this trace arc carries the SOLE copy of the table-style changed-path renderer, and the Epoch panel's inline single-line variant is a deliberately distinct shape. Rewrote the comment to drop the deleted-file reference + dedupe claim, and cleaned the now-dangling `event_detail.cljs` references from the helper docstrings. No code-shape change.

## Spec
Spec unchanged — `git grep` over `tools/xray/spec/` found no references to any of the four dead symbols, `cache-key-of`, or the trace dedupe plan. (The `event_detail.cljs` mentions in spec already document the panel as *retired*, consistent with this fix; the spec `truncate` mentions describe UI label-truncation behaviour, not the removed `f/truncate` symbol.)

## Quality gates (all green)
- clj-kondo on the 4 touched files: 0 errors, 0 warnings
- `sh scripts/test-jvm-tools.sh`: all tool JVM artefacts pass (xray 1239 tests / 5687 assertions, 0 failures)
- `npm run test:cljs`: 8019 tests / 33486 assertions, 0 failures, 0 errors
- `npm run test:bundle-isolation`: PASS (+ uix-helix-reagent-free PASS)