### PR TITLE
refactor(core/fx-cofx): share registration tail + supplier skeleton + reuse emit-fx-error! (rf2-a3pl56, rf2-snxp8i, rf2-xxlzfl)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -273,18 +273,15 @@
       ;; marks themselves are DERIVED from the registrar meta at `marks-for`
       ;; read time (emit-time projection redacts the delivered coeffect value's
       ;; slots in trace events that surface `:coeffects`), no imperative stash.
-      (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
-        (validate! :cofx meta))
-      (registrar/register! :cofx id
-                           (assoc (source-coords/merge-coords meta)
-                                  ;; The value-returning supplier rides the
-                                  ;; registrar's conventional `:handler-fn`
-                                  ;; slot (so `registrar/handler` + descriptor
-                                  ;; lifting resolve it like every other kind);
-                                  ;; nil for a provided fact with no generator.
-                                  :handler-fn  supplier
-                                  :recordable? recordable?
-                                  :provided?   provided?)))
+      ;; Shares the validate-marks + merge-coords + register tail with `reg-fx`
+      ;; via `fx/register-with-marks!` (rf2-a3pl56). The value-returning
+      ;; supplier rides the registrar's conventional `:handler-fn` slot (so
+      ;; `registrar/handler` + descriptor lifting resolve it like every other
+      ;; kind); nil for a provided fact with no generator. The cofx-specific
+      ;; `:recordable?` / `:provided?` grade flags ride the `extra-slots` map.
+      (fx/register-with-marks! :cofx id meta supplier
+                               {:recordable? recordable?
+                                :provided?   provided?}))
     id))
 
 ;; ---- EP-0023 inline-registration lowering (rf2-ffc6s0) --------------------
@@ -683,99 +680,34 @@
        (not (:provided? meta))
        (some? (:handler-fn meta))))
 
-(defn- run-generator
-  "Run a generator-backed recordable supplier at processing-start, returning
-  `[outcome value]` where `outcome` is `:generated` (value produced + emitted
-  + schema-validated), `:skipped` (platform gate — the fact is not produced,
-  the caller treats it as missing-required), or `:threw` (the generator threw
-  — emits `:rf.error/coeffect-exception` and the caller skips the handler).
+(defn- run-supplier-under-scope
+  "Shared supplier-invocation lifecycle for the two cofx suppliers
+  (rf2-snxp8i): `run-generator` (generator-backed recordable facts) and
+  `run-ambient-supplier` (ambient facts) are the same skeleton modulo one
+  outcome keyword + the generator-only post-run validation step. This is the
+  single definition of that skeleton:
 
-  A successful run emits the dev-only `:rf.cofx/generated` trace op (fact-name
-  + supplier id) so traces are self-describing even though the record is flat,
-  then validates the produced value: against the registration's `:schema` (a
-  PRODUCTION hard error on mismatch — the validation throw propagates) AND
-  structurally against the recordable-EDN walker (rf2-rmroo4 slice B /
-  rf2-uqz2ir / production-hardened rf2-q34j26 — a generator that mints a non-EDN
-  host handle throws `:rf.error/cofx-value-invalid` reason
-  `:non-edn-recordable-value` in dev AND production, BEFORE the value is written
-  back into the durable record). The emit / scope shape
-  mirrors `run-ambient-supplier`; the op differs (`:rf.cofx/generated` vs
-  `:rf.cofx/run`) because generation produces a RECORDED fact, not an ambient
-  read."
-  [cofx-id meta supplier arg frame-id failing-id]
-  (let [active-platform (active-platform-for-frame frame-id)]
-    (if (cofx-runs-on-platform? meta active-platform)
-      (trace/with-handler-scope
-        (trace/handler-scope-from-meta :cofx cofx-id meta)
-        (let [valued? (not (identical? arg no-arg))
-              outcome (try
-                        [:generated (if valued? (supplier arg) (supplier))]
-                        (catch #?(:clj Throwable :cljs :default) t
-                          (emit-coeffect-exception! cofx-id failing-id frame-id t)
-                          [:threw nil]))]
-          (when (= :generated (first outcome))
-            ;; Validate the produced value against `:schema` (production hard
-            ;; error) BEFORE emitting the dev `:rf.cofx/generated` trace. A
-            ;; miss throws `:rf.error/cofx-value-invalid` from here, inside the
-            ;; scope binding, so the failure carries the cofx's source-coord
-            ;; like every other cofx emit.
-            ;;
-            ;; rf2-0mjgx6 — validation runs FIRST so a schema-invalid generated
-            ;; value never reaches the `:rf.cofx/generated` trace. The earlier
-            ;; order (emit THEN validate) leaked a schema-`{:sensitive? true}`
-            ;; produced value verbatim on `:rf.cofx/generated` before the
-            ;; (correctly-redacted) `:rf.error/cofx-value-invalid` fired —
-            ;; `:rf.cofx/generated`'s marks projection (`project-cofx-run-tags`)
-            ;; redacts only explicit `:sensitive` reg-marks, not schema-slot
-            ;; `:sensitive?`, so the failing value egressed to trace listeners /
-            ;; epoch `:trace-events` / MCP / log sinks unredacted. Validating
-            ;; first means the throw aborts before the emit, so the raw value
-            ;; never ships on ANY trace on the failure path. (The structural
-            ;; EDN-always check runs AFTER `:schema` so a declared `:schema`
-            ;; mismatch — the prod contract — is reported first; rf2-rmroo4
-            ;; slice B / rf2-uqz2ir.)
-            (validate-recordable-value! cofx-id (second outcome) meta failing-id frame-id)
-            ;; Structural EDN-always check of the GENERATED value (rf2-rmroo4
-            ;; slice B, rf2-uqz2ir; production-hardened rf2-q34j26): a generator
-            ;; that mints a host handle fails loudly HERE — at the source, before
-            ;; the write-back into the durable `:rf.cofx` record — not far away
-            ;; at replay / Xray / SSR. ALWAYS-ON (production hard error too);
-            ;; reuses the slice-A walker + error shape. Runs AFTER `:schema` so a
-            ;; declared `:schema` mismatch is reported first, and BEFORE the
-            ;; `:rf.cofx/generated` emit (rf2-0mjgx6) so a non-EDN host handle
-            ;; never ships on the dev trace either.
-            (validate-generated-recordable-value! cofx-id (second outcome) failing-id frame-id)
-            ;; Dev-only `:rf.cofx/generated` — fact-name + supplier id (the
-            ;; cofx id is both). Gated on `interop/debug-enabled?` so
-            ;; production DCEs the tag-map + emit, exactly like
-            ;; `:rf.cofx/run`. The generated value itself rides the durable
-            ;; `:rf.cofx` record (always-on), NOT this dev trace. Emitted ONLY
-            ;; after both validations pass — a VALID generated value's
-            ;; `:rf.cofx/value` is still projected through the marks chokepoint
-            ;; (`project-cofx-run-tags`) for any explicit `:sensitive` reg-mark.
-            (when interop/debug-enabled?
-              (trace/emit! :rf.cofx :rf.cofx/generated
-                           (cond-> {:rf.cofx/id    cofx-id
-                                    :frame         frame-id
-                                    :rf.cofx/value (second outcome)}
-                             valued? (assoc :rf.cofx/arg arg)))))
-          outcome))
-      (do
-        (trace/emit! :warning :rf.cofx/skipped-on-platform
-                     {:rf.cofx/id                   cofx-id
-                      :frame                        frame-id
-                      :rf.cofx/platform             active-platform
-                      :rf.cofx/registered-platforms (:platforms meta)
-                      :recovery                     :skipped})
-        [:skipped nil]))))
+    1. resolve the active platform for `frame-id`;
+    2. PLATFORM GATE — when the supplier may not run on the active platform,
+       emit the BYTE-IDENTICAL `:rf.cofx/skipped-on-platform` warning and
+       return `[:skipped nil]` (both callers shared this branch verbatim);
+    3. otherwise run under the cofx HandlerScope (`handler-scope-from-meta`)
+       so errors + the success emit carry the cofx's source-coord, invoking
+       the supplier inside a try/catch — a throw emits
+       `:rf.error/coeffect-exception` and yields `[:threw nil]`, a success
+       yields `[ok-keyword value]`;
+    4. hand the `outcome` to `post-run!` for the per-caller work (the
+       generator's validate-before-emit chain + `:rf.cofx/generated` emit; the
+       ambient's `:rf.cofx/run` emit). `post-run!` receives the supplier
+       invocation's dev-only `elapsed-ms` (the ambient stamps it onto
+       `:rf.cofx/run`; the generator ignores it — `:rf.cofx/generated` carries
+       no duration slot). The `interop/now-ms` brackets ride
+       `interop/debug-enabled?` so production DCEs them.
 
-(defn- run-ambient-supplier
-  "Run an ambient supplier under its HandlerScope + platform gate, returning
-  `[outcome value]` where `outcome` is `:delivered`, `:skipped` (platform
-  gate; the fact is not delivered), or `:threw` (the supplier threw — emits
-  `:rf.error/coeffect-exception` and the caller skips the handler). A run
-  emits the dev-only `:rf.cofx/run` success op."
-  [cofx-id meta supplier arg frame-id failing-id]
+  Returns the `[outcome value]` pair. `ok-keyword` is the success outcome head
+  (`:generated` vs `:delivered`); `post-run!` is `(fn [outcome valued? arg
+  elapsed-ms])`, run inside the scope binding after the try/catch."
+  [cofx-id meta supplier arg frame-id failing-id ok-keyword post-run!]
   (let [active-platform (active-platform-for-frame frame-id)]
     (if (cofx-runs-on-platform? meta active-platform)
       (trace/with-handler-scope
@@ -783,26 +715,12 @@
         (let [valued? (not (identical? arg no-arg))
               t0      (when interop/debug-enabled? (interop/now-ms))
               outcome (try
-                        [:delivered (if valued? (supplier arg) (supplier))]
+                        [ok-keyword (if valued? (supplier arg) (supplier))]
                         (catch #?(:clj Throwable :cljs :default) t
                           (emit-coeffect-exception! cofx-id failing-id frame-id t)
                           [:threw nil]))
               elapsed (when interop/debug-enabled? (- (interop/now-ms) t0))]
-          ;; `:rf.cofx/value` carries the supplier's PRODUCED value — the
-          ;; coeffect that actually egresses into `:coeffects` — so the
-          ;; marks chokepoint (`marks/project-cofx-run-tags`, wired to
-          ;; `:rf.cofx/value`) redacts a declared-`:sensitive` produced
-          ;; value before it surfaces in trace. The requirement-arg rides
-          ;; under the distinct `:rf.cofx/arg`, present only for a
-          ;; parameterized `[id arg]` requirement (rf2-sepqgg). Both ride
-          ;; under the `interop/debug-enabled?` gate so production DCEs them.
-          (when (and interop/debug-enabled? (= :delivered (first outcome)))
-            (trace/emit! :rf.cofx :rf.cofx/run
-                         (cond-> {:rf.cofx/id    cofx-id
-                                  :frame         frame-id
-                                  :rf.cofx/value (second outcome)}
-                           valued?           (assoc :rf.cofx/arg arg)
-                           (some? elapsed)   (assoc :rf.cofx/elapsed-ms elapsed))))
+          (post-run! outcome valued? arg elapsed)
           outcome))
       (do
         (trace/emit! :warning :rf.cofx/skipped-on-platform
@@ -812,6 +730,109 @@
                       :rf.cofx/registered-platforms (:platforms meta)
                       :recovery                     :skipped})
         [:skipped nil]))))
+
+(defn- run-generator
+  "Run a generator-backed recordable supplier at processing-start, returning
+  `[outcome value]` where `outcome` is `:generated` (value produced + emitted
+  + schema-validated), `:skipped` (platform gate — the fact is not produced,
+  the caller treats it as missing-required), or `:threw` (the generator threw
+  — emits `:rf.error/coeffect-exception` and the caller skips the handler).
+
+  A successful run validates the produced value, THEN emits the dev-only
+  `:rf.cofx/generated` trace op (fact-name + supplier id) so traces are
+  self-describing even though the record is flat. The platform-gate +
+  HandlerScope + try/catch skeleton is shared with `run-ambient-supplier` via
+  `run-supplier-under-scope` (rf2-snxp8i); the per-generator post-run step
+  below validates the produced value: against the registration's `:schema` (a
+  PRODUCTION hard error on mismatch — the validation throw propagates) AND
+  structurally against the recordable-EDN walker (rf2-rmroo4 slice B /
+  rf2-uqz2ir / production-hardened rf2-q34j26 — a generator that mints a non-EDN
+  host handle throws `:rf.error/cofx-value-invalid` reason
+  `:non-edn-recordable-value` in dev AND production, BEFORE the value is written
+  back into the durable record). The op differs from the ambient
+  (`:rf.cofx/generated` vs `:rf.cofx/run`) because generation produces a
+  RECORDED fact, not an ambient read; the generated op carries no
+  `:rf.cofx/elapsed-ms` (the ambient stamps duration, the generator does not)."
+  [cofx-id meta supplier arg frame-id failing-id]
+  (run-supplier-under-scope
+    cofx-id meta supplier arg frame-id failing-id :generated
+    (fn [outcome valued? arg _elapsed]
+      (when (= :generated (first outcome))
+        ;; Validate the produced value against `:schema` (production hard
+        ;; error) BEFORE emitting the dev `:rf.cofx/generated` trace. A
+        ;; miss throws `:rf.error/cofx-value-invalid` from here, inside the
+        ;; scope binding, so the failure carries the cofx's source-coord
+        ;; like every other cofx emit.
+        ;;
+        ;; rf2-0mjgx6 — validation runs FIRST so a schema-invalid generated
+        ;; value never reaches the `:rf.cofx/generated` trace. The earlier
+        ;; order (emit THEN validate) leaked a schema-`{:sensitive? true}`
+        ;; produced value verbatim on `:rf.cofx/generated` before the
+        ;; (correctly-redacted) `:rf.error/cofx-value-invalid` fired —
+        ;; `:rf.cofx/generated`'s marks projection (`project-cofx-run-tags`)
+        ;; redacts only explicit `:sensitive` reg-marks, not schema-slot
+        ;; `:sensitive?`, so the failing value egressed to trace listeners /
+        ;; epoch `:trace-events` / MCP / log sinks unredacted. Validating
+        ;; first means the throw aborts before the emit, so the raw value
+        ;; never ships on ANY trace on the failure path. (The structural
+        ;; EDN-always check runs AFTER `:schema` so a declared `:schema`
+        ;; mismatch — the prod contract — is reported first; rf2-rmroo4
+        ;; slice B / rf2-uqz2ir.)
+        (validate-recordable-value! cofx-id (second outcome) meta failing-id frame-id)
+        ;; Structural EDN-always check of the GENERATED value (rf2-rmroo4
+        ;; slice B, rf2-uqz2ir; production-hardened rf2-q34j26): a generator
+        ;; that mints a host handle fails loudly HERE — at the source, before
+        ;; the write-back into the durable `:rf.cofx` record — not far away
+        ;; at replay / Xray / SSR. ALWAYS-ON (production hard error too);
+        ;; reuses the slice-A walker + error shape. Runs AFTER `:schema` so a
+        ;; declared `:schema` mismatch is reported first, and BEFORE the
+        ;; `:rf.cofx/generated` emit (rf2-0mjgx6) so a non-EDN host handle
+        ;; never ships on the dev trace either.
+        (validate-generated-recordable-value! cofx-id (second outcome) failing-id frame-id)
+        ;; Dev-only `:rf.cofx/generated` — fact-name + supplier id (the
+        ;; cofx id is both). Gated on `interop/debug-enabled?` so
+        ;; production DCEs the tag-map + emit, exactly like
+        ;; `:rf.cofx/run`. The generated value itself rides the durable
+        ;; `:rf.cofx` record (always-on), NOT this dev trace. Emitted ONLY
+        ;; after both validations pass — a VALID generated value's
+        ;; `:rf.cofx/value` is still projected through the marks chokepoint
+        ;; (`project-cofx-run-tags`) for any explicit `:sensitive` reg-mark.
+        (when interop/debug-enabled?
+          (trace/emit! :rf.cofx :rf.cofx/generated
+                       (cond-> {:rf.cofx/id    cofx-id
+                                :frame         frame-id
+                                :rf.cofx/value (second outcome)}
+                         valued? (assoc :rf.cofx/arg arg))))))))
+
+(defn- run-ambient-supplier
+  "Run an ambient supplier under its HandlerScope + platform gate, returning
+  `[outcome value]` where `outcome` is `:delivered`, `:skipped` (platform
+  gate; the fact is not delivered), or `:threw` (the supplier threw — emits
+  `:rf.error/coeffect-exception` and the caller skips the handler). A run
+  emits the dev-only `:rf.cofx/run` success op. Shares the platform-gate +
+  HandlerScope + try/catch skeleton with `run-generator` via
+  `run-supplier-under-scope` (rf2-snxp8i); the per-ambient post-run step below
+  emits `:rf.cofx/run` carrying the supplier-invocation `:rf.cofx/elapsed-ms`
+  (the generator omits this slot)."
+  [cofx-id meta supplier arg frame-id failing-id]
+  (run-supplier-under-scope
+    cofx-id meta supplier arg frame-id failing-id :delivered
+    (fn [outcome valued? arg elapsed]
+      ;; `:rf.cofx/value` carries the supplier's PRODUCED value — the
+      ;; coeffect that actually egresses into `:coeffects` — so the
+      ;; marks chokepoint (`marks/project-cofx-run-tags`, wired to
+      ;; `:rf.cofx/value`) redacts a declared-`:sensitive` produced
+      ;; value before it surfaces in trace. The requirement-arg rides
+      ;; under the distinct `:rf.cofx/arg`, present only for a
+      ;; parameterized `[id arg]` requirement (rf2-sepqgg). Both ride
+      ;; under the `interop/debug-enabled?` gate so production DCEs them.
+      (when (and interop/debug-enabled? (= :delivered (first outcome)))
+        (trace/emit! :rf.cofx :rf.cofx/run
+                     (cond-> {:rf.cofx/id    cofx-id
+                              :frame         frame-id
+                              :rf.cofx/value (second outcome)}
+                       valued?           (assoc :rf.cofx/arg arg)
+                       (some? elapsed)   (assoc :rf.cofx/elapsed-ms elapsed)))))))
 
 (def default-mint-policy
   "The mint policy when no binding point selects one — the router's `:live`

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -33,7 +33,6 @@
             [re-frame.cofx.value-check :as value-check]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
-            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -843,27 +843,31 @@
           (let [ex-data-map (ex-data e)
                 category    (:rf.error/id ex-data-map)]
             (if (keyword? category)
-              (let [msg     #?(:clj (.getMessage ^Throwable e)
-                               :cljs (.-message e))
-                    errored-at-ms (interop/now-ms)]
-                ;; Both channels via the shared helper (rf2-c4oycd): axis 1 the
-                ;; always-on per-error observability fan-out (rf2-bacs4 / sticky
-                ;; hook rf2-f72pd; survives `:advanced` + `goog.DEBUG=false`),
-                ;; axis 2 the dev trace (DCE'd in CLJS prod). Reached via the
-                ;; `:error-emit/emit-error-both` hook (fx cannot static-require
-                ;; error-emit — load cycle).
-                (when-let [emit-error-both!
-                           (late-bind/get-fn-cached :error-emit/emit-error-both)]
-                  (emit-error-both!
-                    category origin-event origin-event-id frame-id e 0 errored-at-ms
-                    (merge {:failing-id        fx-id
-                            :rf.fx/id          fx-id
-                            :rf.fx/args        args
-                            :frame             frame-id
-                            :exception         e
-                            :exception-message msg
-                            :recovery          :no-recovery}
-                           (dissoc ex-data-map :rf.error/id)))))
+              (let [msg #?(:clj (.getMessage ^Throwable e)
+                           :cljs (.-message e))]
+                ;; Both channels via the shared `emit-fx-error!` helper
+                ;; (rf2-xxlzfl): axis 1 the always-on per-error observability
+                ;; fan-out (rf2-bacs4 / sticky hook rf2-f72pd; survives
+                ;; `:advanced` + `goog.DEBUG=false`), axis 2 the dev trace
+                ;; (DCE'd in CLJS prod). `emit-fx-error!` reaches the shared
+                ;; two-channel `emit-error-both!` through the
+                ;; `:error-emit/emit-error-both` late-bind hook (fx cannot
+                ;; static-require error-emit — load cycle), stamping
+                ;; `elapsed-ms 0` + `(interop/now-ms)` internally — the same
+                ;; two-step the three other fx error sites
+                ;; (`:rf.error/no-such-fx`, `:rf.error/fx-handler-exception`,
+                ;; `:rf.error/override-fallthrough`) route through. The typed
+                ;; category + reserved-fx-specific ex-data slots ride verbatim
+                ;; (e.g. flow-cycle's `:cycle`) via the merged trace-payload.
+                (emit-fx-error! category origin-event origin-event-id frame-id e
+                                (merge {:failing-id        fx-id
+                                        :rf.fx/id          fx-id
+                                        :rf.fx/args        args
+                                        :frame             frame-id
+                                        :exception         e
+                                        :exception-message msg
+                                        :recovery          :no-recovery}
+                                       (dissoc ex-data-map :rf.error/id))))
               ;; Untyped reserved-fx throw — preserve crash-loud
               ;; contract by re-throwing.
               (throw e)))))

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -32,6 +32,25 @@
 
 ;; ---- registration ---------------------------------------------------------
 
+(defn register-with-marks!
+  "Shared registration tail for `reg-fx` and `reg-cofx` (rf2-a3pl56). Both
+  register sites validate any declared `:sensitive` / `:large` marks fail-loud
+  BEFORE the registrar write (rf2-ehexnw — the marks themselves are DERIVED
+  from the registrar meta at `marks-for` read time, no imperative stash), then
+  write the registrar entry as the merged source-coords + the `:handler-fn`
+  callable slot. `kind` is `:fx` / `:cofx` (drives both the marks-validation
+  kind and the registrar kind); `extra-slots` is an optional map of
+  kind-specific registrar slots merged on top — `nil` for `reg-fx`, the
+  `:recordable?` / `:provided?` grade flags for `reg-cofx`. `re-frame.cofx`
+  reaches this through its existing `fx/` alias (the same single-definition
+  pattern as `runs-on-platform?` / `platform-for-frame-record`, rf2-4ymm0)."
+  [kind id meta handler-fn extra-slots]
+  (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
+    (validate! kind meta))
+  (registrar/register! kind id (merge (assoc (source-coords/merge-coords meta)
+                                             :handler-fn handler-fn)
+                                      extra-slots)))
+
 (defn reg-fx
   "Register an effect handler under `id`. The handler runs when a
   `reg-event` handler returns an effect-map carrying `[id args]` inside its
@@ -91,15 +110,7 @@
         (if (map? metadata-or-handler)
           [metadata-or-handler (first maybe-handler)]
           [{} metadata-or-handler])]
-    ;; Per Spec 015 §4. Effects — VALIDATE any declared `:sensitive` / `:large`
-    ;; marks fail-loud BEFORE the registrar write (rf2-ehexnw); the marks
-    ;; themselves are DERIVED from the registrar meta at `marks-for` read time
-    ;; (emit-time projection redacts `:fx-args` slots on `:rf.fx/handled`
-    ;; traces), no imperative stash.
-    (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
-      (validate! :fx meta))
-    (registrar/register! :fx id (assoc (source-coords/merge-coords meta)
-                                       :handler-fn handler-fn))
+    (register-with-marks! :fx id meta handler-fn nil)
     id))
 
 (defn clear-fx


### PR DESCRIPTION
Three behaviour-preserving internal-sprawl dedup beads under parent rf2-1sfb14 (lean pass), all in `implementation/core/src/re_frame/{fx,cofx}.cljc`.

## rf2-a3pl56 — shared registration tail
`reg-fx` and `reg-cofx` shared the same validate-marks + merge-coords + register tail, written twice. Extracted one `fx/register-with-marks!` helper `[kind id meta handler-fn extra-slots]`; the kind drives both marks-validation and the registrar kind, and `extra-slots` carries the kind-specific registrar slots (`nil` for fx, the `:recordable?` / `:provided?` grade flags for cofx). `re-frame.cofx` reaches it through its existing `fx/` alias — the same single-definition pattern as `runs-on-platform?` / `platform-for-frame-record` (rf2-4ymm0). The per-kind metadata-or-handler arg split stays inline in each reg fn (a 3-line idiom that reads fine local). The now-orphaned `re-frame.source-coords` require was dropped from cofx.cljc.

## rf2-snxp8i — shared supplier-run skeleton
`run-generator` and `run-ambient-supplier` were the same supplier-invocation lifecycle (platform resolution + gate, HandlerScope binding, the `valued?`/`outcome` try-catch routing throws through `emit-coeffect-exception!`, and a byte-identical `:rf.cofx/skipped-on-platform` skip branch). Extracted one `run-supplier-under-scope` helper parameterized by the success outcome keyword (`:generated` vs `:delivered`) and a `post-run!` callback. The genuine per-fn differences stay: the generator's validate-before-emit chain (rf2-0mjgx6 ordering) + `:rf.cofx/generated` emit; the ambient's `:rf.cofx/run` emit carrying `:rf.cofx/elapsed-ms` (the generator omits the duration slot).

## rf2-xxlzfl — reuse emit-fx-error!
The reserved-fx typed-throw catch in `handle-one-fx` hand-inlined the same two-step (resolve `:error-emit/emit-error-both` hook + invoke) that fx.cljc's `emit-fx-error!` already defines and the three other fx error sites route through. Collapsed the last hand-inlined copy to the helper — `emit-fx-error!` stamps `elapsed-ms 0` + `(interop/now-ms)` internally (the inline hoisted `errored-at-ms` to the same effect); the typed category + reserved-fx ex-data slots ride verbatim via the merged trace-payload. The untyped re-throw branch is unchanged.

## Gates (all green)
- JVM implementation (`scripts/test-jvm-implementation.sh`): PASS, all artefacts, 0 failures/errors
- CLJS node (`npm run test:cljs`): 8024 tests / 33499 assertions, 0 failures, 0 errors
- `python scripts/check_thrown_error_messages.py`: exit 0 (xxlzfl throw path preserves the exact error)
- clj-kondo: 0 errors, no new warnings
- splint `--fail-on-errors`: 0 errors

No facade/manifest change.