### PR TITLE
refactor(tools/pair-mcp): remove dead runtime fns + dedupe test scaffold + bencode client (rf2-k1lgkn, rf2-yrpt90, rf2-qq7w2k)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -617,11 +617,6 @@
   (swap! raw-state-config merge (select-keys opts [:allow-raw-state?]))
   (assoc @raw-state-config :ok? true))
 
-(defn raw-state-config-snapshot
-  "Return the current raw-state config — diagnostic helper."
-  []
-  (assoc @raw-state-config :ok? true))
-
 (defn- maybe-elide-for-tap
   "Walk `v` through `re-frame.core/elide-wire-value` when the raw-state
   gate is OFF, otherwise pass through. The walker substitutes large
@@ -1820,11 +1815,6 @@
   (swap! privacy-config merge (select-keys opts [:include-sensitive?]))
   (assoc @privacy-config :ok? true))
 
-(defn privacy-config-snapshot
-  "Return the current privacy config — diagnostic helper."
-  []
-  (assoc @privacy-config :ok? true))
-
 (defn- streaming-drop?
   "True when the streaming surface should drop `ev` for privacy reasons.
    Today: any trace event stamped `:sensitive? true` at the top level
@@ -2797,21 +2787,6 @@
            ;; Frame-untargetable / no-epoch — pass the structured failure
            ;; through, still echoing the resolved value.
            (assoc result :resolved event-v)))))))
-
-;; ---------------------------------------------------------------------------
-;; Effect stubs (per-call :fx-overrides)
-;; ---------------------------------------------------------------------------
-
-(defn pair-dispatch-with-fx-overrides!
-  "Dispatch with a Spec 002 §Per-frame and per-call overrides
-   `:fx-overrides` map. `overrides` is `{fx-id stub-id ...}` where
-   `stub-id` is a separately-registered `reg-fx`. Each stub redirects
-   for this dispatch only."
-  [event-v overrides & {:keys [sync? frame]}]
-  (let [opts {:origin :pair :fx-overrides overrides :frame frame}]
-    (if sync?
-      (pair-dispatch-sync! event-v opts)
-      (pair-dispatch! event-v opts))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dispatch dry-run (rf2-17hvp)

--- a/skills/re-frame2-pair/scripts/bencode.clj
+++ b/skills/re-frame2-pair/scripts/bencode.clj
@@ -1,0 +1,73 @@
+;;;; scripts/bencode.clj — minimal bencode codec for the nREPL wire.
+;;;;
+;;;; bb ships no nREPL client and we don't want a Maven dep just for this:
+;;;; bencode is a ~40-line protocol and nREPL speaks it directly over TCP,
+;;;; so inlining the codec is simpler than bolting on a dependency.
+;;;;
+;;;; Shared by BOTH halves of the bash-shim transport (rf2-qq7w2k):
+;;;;   - scripts/ops.clj           ENCODES requests + DECODES responses
+;;;;   - tests/shim/stub_nrepl.clj DECODES requests + ENCODES canned replies
+;;;; They are mirror halves of the same protocol, so the codec lives once.
+;;;;
+;;;; Dependency-free + bb-loadable: both consumers `load-file` this off
+;;;; their own `*file*` (so cwd doesn't matter) BEFORE their `ns` form,
+;;;; then `(:require [bencode :as bc])`. It pulls in nothing beyond JDK
+;;;; classes, keeping the no-Maven-dep posture intact.
+
+(ns bencode
+  (:import (java.io PushbackInputStream)))
+
+(defn encode ^String [v]
+  (cond
+    (integer? v)   (str "i" v "e")
+    (string? v)    (let [bs (.getBytes ^String v "UTF-8")]
+                     (str (alength bs) ":" v))
+    (keyword? v)   (encode (name v))
+    (map? v)       (str "d"
+                        (apply str (mapcat (fn [[k v]] [(encode k) (encode v)])
+                                           (sort-by (fn [[k _]] (if (keyword? k) (name k) (str k))) v)))
+                        "e")
+    (sequential? v) (str "l" (apply str (map encode v)) "e")
+    (nil? v)       (encode "")
+    :else          (encode (pr-str v))))
+
+(defn read-char ^Character [^PushbackInputStream in]
+  (let [b (.read in)]
+    (when (neg? b) (throw (ex-info "unexpected EOF" {})))
+    (char b)))
+
+(defn decode [^PushbackInputStream in]
+  (let [c (read-char in)]
+    (case c
+      \i (let [sb (StringBuilder.)]
+           (loop [ch (read-char in)]
+             (if (= ch \e)
+               (Long/parseLong (.toString sb))
+               (do (.append sb ch) (recur (read-char in))))))
+      \l (loop [acc []]
+           (let [b (.read in)]
+             (cond (neg? b)          (throw (ex-info "unexpected EOF in list" {}))
+                   (= b (int \e))    acc
+                   :else             (do (.unread in b) (recur (conj acc (decode in)))))))
+      \d (loop [acc {}]
+           (let [b (.read in)]
+             (cond (neg? b)          (throw (ex-info "unexpected EOF in dict" {}))
+                   (= b (int \e))    acc
+                   :else             (do (.unread in b)
+                                         (let [k (decode in)
+                                               v (decode in)]
+                                           (recur (assoc acc k v)))))))
+      ;; digit — byte string of length N
+      (let [sb (StringBuilder.)]
+        (.append sb c)
+        (loop [ch (read-char in)]
+          (if (= ch \:)
+            (let [len (Long/parseLong (.toString sb))
+                  buf (byte-array len)]
+              (loop [read 0]
+                (when (< read len)
+                  (let [n (.read in buf read (- len read))]
+                    (when-not (pos? n) (throw (ex-info "EOF in string body" {})))
+                    (recur (+ read n)))))
+              (String. buf "UTF-8"))
+            (do (.append sb ch) (recur (read-char in)))))))))

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -37,7 +37,8 @@
 ;;;;
 ;;;; File layout (top→bottom)
 ;;;; ------------------------
-;;;;   1. Bencode + nREPL socket client (inline, no Maven dep)
+;;;;   1. nREPL socket client (bencode codec shared from scripts/bencode.clj,
+;;;;      no Maven dep)
 ;;;;   2. Config / env (build-id, port-file discovery)
 ;;;;   3. Output helpers (`emit`, `die`)
 ;;;;   4. nREPL conveniences (`jvm-eval`, `cljs-eval`, `cljs-eval-value`)
@@ -67,75 +68,22 @@
 ;;;;
 ;;;; All ops return edn on stdout. Shells capture and forward.
 
+;; The minimal bencode codec is shared with the test stub
+;; (tests/shim/stub_nrepl.clj); it lives in scripts/bencode.clj and is
+;; loaded off this file's own location so cwd doesn't matter (rf2-qq7w2k).
+(load-file (str (.getParent (java.io.File. *file*)) "/bencode.clj"))
+
 (ns ops
-  (:require [clojure.edn :as edn]
+  (:require [bencode :as bc]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str])
   (:import (java.net Socket)
            (java.io PushbackInputStream)))
 
 ;; ---------------------------------------------------------------------------
-;; Minimal bencode + nREPL socket client
+;; nREPL socket client (bencode codec in scripts/bencode.clj)
 ;; ---------------------------------------------------------------------------
-;;
-;; bb doesn't ship a built-in nREPL client and we don't want a classpath
-;; dep just for this. Bencode is a 40-line protocol and nREPL speaks it
-;; directly over TCP; inline is simpler than bolting on Maven deps.
-
-(defn- bencode ^String [v]
-  (cond
-    (integer? v)   (str "i" v "e")
-    (string? v)    (let [bs (.getBytes ^String v "UTF-8")]
-                     (str (alength bs) ":" v))
-    (keyword? v)   (bencode (name v))
-    (map? v)       (str "d"
-                        (apply str (mapcat (fn [[k v]] [(bencode k) (bencode v)])
-                                           (sort-by (fn [[k _]] (if (keyword? k) (name k) (str k))) v)))
-                        "e")
-    (sequential? v) (str "l" (apply str (map bencode v)) "e")
-    (nil? v)       (bencode "")
-    :else          (bencode (pr-str v))))
-
-(defn- read-char [^PushbackInputStream in]
-  (let [b (.read in)]
-    (when (neg? b) (throw (ex-info "unexpected EOF" {})))
-    (char b)))
-
-(defn- bdecode [^PushbackInputStream in]
-  (let [c (read-char in)]
-    (case c
-      \i (let [sb (StringBuilder.)]
-           (loop [ch (read-char in)]
-             (if (= ch \e)
-               (Long/parseLong (.toString sb))
-               (do (.append sb ch) (recur (read-char in))))))
-      \l (loop [acc []]
-           (let [b (.read in)]
-             (cond (neg? b)          (throw (ex-info "unexpected EOF in list" {}))
-                   (= b (int \e))    acc
-                   :else             (do (.unread in b) (recur (conj acc (bdecode in)))))))
-      \d (loop [acc {}]
-           (let [b (.read in)]
-             (cond (neg? b)          (throw (ex-info "unexpected EOF in dict" {}))
-                   (= b (int \e))    acc
-                   :else             (do (.unread in b)
-                                         (let [k (bdecode in)
-                                               v (bdecode in)]
-                                           (recur (assoc acc k v)))))))
-      ;; digit — byte string of length N
-      (let [sb (StringBuilder.)]
-        (.append sb c)
-        (loop [ch (read-char in)]
-          (if (= ch \:)
-            (let [len (Long/parseLong (.toString sb))
-                  buf (byte-array len)]
-              (loop [read 0]
-                (when (< read len)
-                  (let [n (.read in buf read (- len read))]
-                    (when-not (pos? n) (throw (ex-info "EOF in string body" {})))
-                    (recur (+ read n)))))
-              (String. buf "UTF-8"))
-            (do (.append sb ch) (recur (read-char in)))))))))
 
 (defn- nrepl-eval-raw
   "Open a socket to nREPL at port, send an op eval of code-str, read
@@ -145,11 +93,11 @@
     (let [out (.getOutputStream sock)
           in  (PushbackInputStream. (.getInputStream sock))
           id  (str (random-uuid))
-          msg (bencode {"op" "eval" "code" code-str "id" id})]
+          msg (bc/encode {"op" "eval" "code" code-str "id" id})]
       (.write out (.getBytes ^String msg "UTF-8"))
       (.flush out)
       (loop [responses []]
-        (let [resp (bdecode in)
+        (let [resp (bc/decode in)
               responses' (conj responses resp)
               done? (and (= id (get resp "id"))
                          (some #{"done"} (get resp "status" [])))]

--- a/skills/re-frame2-pair/tests/runtime/_support.clj
+++ b/skills/re-frame2-pair/tests/runtime/_support.clj
@@ -1,0 +1,83 @@
+;;;; tests/runtime/_support.clj
+;;;;
+;;;; Shared babashka test scaffold for the `tests/runtime/*` structural
+;;;; pins (rf2-yrpt90). Every structural-pin test needs to locate, slurp
+;;;; and parse `preload/re_frame2_pair/runtime.cljs`, then walk the parsed
+;;;; forms looking for a named defn / a predicate hit. That harness was
+;;;; copy-pasted verbatim across ~12 tests; it lives here once.
+;;;;
+;;;; Per-test ASSERTIONS stay in each test file — only the mechanical
+;;;; locate+parse+walk harness collapses here.
+;;;;
+;;;; Load it from a sibling test with:
+;;;;
+;;;;   (load-file (str (.getParent (io/file *file*)) "/_support.clj"))
+;;;;
+;;;; then `(:require [runtime-support :as rt])` or refer the vars. The
+;;;; load-file path is resolved off the loading test's own `*file*`, so it
+;;;; works regardless of the cwd `bb` was launched from.
+
+(ns runtime-support
+  (:require [clojure.java.io :as io]
+            [clojure.walk :as walk]))
+
+(def ^:private this-file
+  ;; Absolute path to THIS support file, so we can resolve runtime.cljs
+  ;; relative to the skill tree rather than the (unknown) launch cwd.
+  (-> *file* io/file .getAbsoluteFile))
+
+(def runtime-cljs-path
+  "Absolute path to `preload/re_frame2_pair/runtime.cljs`. Resolved off
+   this file's location: tests/runtime/_support.clj → skill root →
+   preload/…. Exits 2 (matching the historical per-test guard) when the
+   source can't be found, so a moved/renamed runtime fails loud."
+  (let [skill-root (-> this-file
+                       .getParentFile   ;; tests/runtime/
+                       .getParentFile   ;; tests/
+                       .getParentFile)  ;; skills/re-frame2-pair/
+        f          (io/file skill-root "preload" "re_frame2_pair" "runtime.cljs")]
+    (if (.exists f)
+      (.getPath f)
+      (do (binding [*out* *err*]
+            (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
+                     (.getPath this-file)))
+          (System/exit 2)))))
+
+(defn read-all-forms
+  "Read every top-level form from `src`.
+
+   `:read-cond :allow :features #{:cljs}` keeps reader conditionals on the
+   `:cljs` branch. `*default-data-reader-fn*` swallows unknown tagged
+   literals — notably the `#js {...}` / `#js [...]` the CLJS preload
+   carries in its streaming section. Without it the bb reader (which has
+   no `js` tag) HALTS on the first `#js`, silently dropping every form
+   after it — including defns near the end of the file."
+  [^String src]
+  (binding [*default-data-reader-fn* (fn [_tag v] v)]
+    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
+      (loop [acc []]
+        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
+                        (catch Exception _ ::eof))]
+          (if (= ::eof form) acc (recur (conj acc form))))))))
+
+(def all-forms
+  "Every top-level form parsed from the live runtime source."
+  (read-all-forms (slurp runtime-cljs-path)))
+
+(defn form-contains?
+  "True when any node within `form` satisfies `pred` (postwalk)."
+  [pred form]
+  (let [hit? (atom false)]
+    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
+    @hit?))
+
+(defn defn-named
+  "The top-level `(defn sym ...)` or `(defn- sym ...)` form for `sym`, or
+   nil. Matches both public and private defns."
+  [sym]
+  (some (fn [form]
+          (when (and (seq? form)
+                     (#{'defn 'defn-} (first form))
+                     (= sym (second form)))
+            form))
+        all-forms))

--- a/skills/re-frame2-pair/tests/runtime/app_db_reset_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/app_db_reset_test.clj
@@ -52,69 +52,17 @@
 ;;;; Run: bb tests/runtime/app_db_reset_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns app-db-reset-test
- (:require [clojure.java.io :as io]
- [clojure.test :refer [deftest is run-tests testing]]
- [clojure.walk :as walk]))
+ (:require [clojure.test :refer [deftest is run-tests testing]]
+ [runtime-support :as rt]))
 
-;; ---------------------------------------------------------------------------
-;; Locate runtime.cljs relative to this test file. Test runs from the
-;; skill root, so the path is preload/re_frame2_pair/runtime.cljs. We try a couple of
-;; likely paths to stay robust to where bb is invoked from.
-;; ---------------------------------------------------------------------------
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private form-contains? rt/form-contains?)
 
-(def ^:private runtime-cljs-path
- (some (fn [p] (when (.exists (io/file p)) p))
- ["preload/re_frame2_pair/runtime.cljs"
- "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
- "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
- (binding [*out* *err*]
- (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
- (System/getProperty "user.dir")))
- (System/exit 2))
-
-;; ---------------------------------------------------------------------------
-;; Read & parse all top-level forms. Use a CLJS-tolerant reader: the file
-;; uses `js/Date.now`, `:default`, etc., which Clojure's reader tolerates
-;; as symbols / keywords; we never evaluate the forms.
-;; ---------------------------------------------------------------------------
-
-(defn- read-all-forms [^String src]
- (let [pbr (java.io.PushbackReader.
- (java.io.StringReader. src))]
- (loop [acc []]
- (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
- (catch Exception _ ::eof))]
- (if (= ::eof form)
- acc
- (recur (conj acc form)))))))
-
-(def ^:private all-forms
- (read-all-forms (slurp runtime-cljs-path)))
-
-(def ^:private app-db-reset-form
- (some (fn [form]
- (when (and (seq? form)
- (= 'defn (first form))
- (= 'app-db-reset! (second form)))
- form))
- all-forms))
-
-;; ---------------------------------------------------------------------------
-;; Tree-walk helpers — answer "does this form contain a sub-form
-;; matching pred?".
-;; ---------------------------------------------------------------------------
-
-(defn- form-contains? [pred form]
- (let [hit? (atom false)]
- (walk/postwalk
- (fn [node]
- (when (pred node) (reset! hit? true))
- node)
- form)
- @hit?))
+(def ^:private app-db-reset-form (rt/defn-named 'app-db-reset!))
 
 (defn- calls? [sym form]
  (form-contains?

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj
@@ -40,11 +40,12 @@
 ;;;; Run: bb tests/runtime/cascade_summary_outcome_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns cascade-summary-outcome-test
-  (:require [clojure.java.io :as io]
-            [clojure.set]
+  (:require [clojure.set]
             [clojure.test :refer [deftest is run-tests testing]]
-            [clojure.walk :as walk]))
+            [runtime-support :as rt]))
 
 ;; ---------------------------------------------------------------------------
 ;; Mirror of preload/re_frame2_pair/runtime.cljs §Cascade summary.
@@ -282,32 +283,16 @@
 ;; Structural pin — keep the bb mirror honest against the cljs source.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(defn- read-all-forms [^String src]
-  (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-    (loop [acc []]
-      (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                      (catch Exception _ ::eof))]
-        (if (= ::eof form) acc (recur (conj acc form)))))))
-
-(def ^:private all-forms
-  (when runtime-cljs-path (read-all-forms (slurp runtime-cljs-path))))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private runtime-cljs-path rt/runtime-cljs-path)
+(def ^:private form-contains? rt/form-contains?)
 
 (defn- top-level-named [kinds sym]
   (some (fn [form]
           (when (and (seq? form) (kinds (first form)) (= sym (second form)))
             form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
-    @hit?))
+        rt/all-forms))
 
 (deftest source-defines-cascade-error-ops
   (is (some? runtime-cljs-path) "runtime.cljs must be locatable")

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
@@ -43,11 +43,12 @@
 ;;;; Run: bb tests/runtime/cascade_summary_redaction_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns cascade-summary-redaction-test
-  (:require [clojure.java.io :as io]
-            [clojure.set]
+  (:require [clojure.set]
             [clojure.test :refer [deftest is run-tests testing]]
-            [clojure.walk :as walk]))
+            [runtime-support :as rt]))
 
 ;; ---------------------------------------------------------------------------
 ;; Mirror of preload/re_frame2_pair/runtime.cljs §Cascade summary
@@ -236,32 +237,16 @@
 ;; trips these.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(defn- read-all-forms [^String src]
-  (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-    (loop [acc []]
-      (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                      (catch Exception _ ::eof))]
-        (if (= ::eof form) acc (recur (conj acc form)))))))
-
-(def ^:private all-forms
-  (when runtime-cljs-path (read-all-forms (slurp runtime-cljs-path))))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private runtime-cljs-path rt/runtime-cljs-path)
+(def ^:private form-contains? rt/form-contains?)
 
 (defn- top-level-named [kinds sym]
   (some (fn [form]
           (when (and (seq? form) (kinds (first form)) (= sym (second form)))
             form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
-    @hit?))
+        rt/all-forms))
 
 (deftest source-defines-redact-sensitive-event-vector
   (is (some? runtime-cljs-path) "runtime.cljs must be locatable")

--- a/skills/re-frame2-pair/tests/runtime/dispatch_consequence_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/dispatch_consequence_test.clj
@@ -17,45 +17,16 @@
 ;;;; Run: bb tests/runtime/dispatch_consequence_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns dispatch-consequence-test
-  (:require [clojure.java.io :as io]
-            [clojure.test :refer [deftest is run-tests]]
-            [clojure.walk :as walk]))
+  (:require [clojure.test :refer [deftest is run-tests]]
+            [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
-  (binding [*out* *err*]
-    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
-             (System/getProperty "user.dir")))
-  (System/exit 2))
-
-(defn- read-all-forms [^String src]
-  (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-    (loop [acc []]
-      (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                      (catch Exception _ ::eof))]
-        (if (= ::eof form) acc (recur (conj acc form)))))))
-
-(def ^:private all-forms
-  (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- defn-named [sym]
-  (some (fn [form]
-          (when (and (seq? form)
-                     (#{'defn 'defn-} (first form))
-                     (= sym (second form)))
-            form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
-    @hit?))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private defn-named rt/defn-named)
+(def ^:private form-contains? rt/form-contains?)
 
 (deftest defines-dispatch-consequence
   (is (some? (defn-named 'dispatch-consequence!))

--- a/skills/re-frame2-pair/tests/runtime/dom_readback_redaction_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/dom_readback_redaction_test.clj
@@ -48,11 +48,13 @@
 ;;;; Run: bb tests/runtime/dom_readback_redaction_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns dom-readback-redaction-test
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer [deftest is run-tests testing]]
-            [clojure.walk :as walk]))
+            [clojure.walk :as walk]
+            [runtime-support :as rt]))
 
 ;; ---------------------------------------------------------------------------
 ;; Mirror of the runtime's value-based derived-tree redaction. KEEP IN SYNC
@@ -182,35 +184,9 @@
 ;; regression in the cljs trips RED.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
-  (binding [*out* *err*]
-    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
-             (System/getProperty "user.dir")))
-  (System/exit 2))
-
-(defn- read-all-forms [^String src]
-  (binding [*default-data-reader-fn* (fn [_tag v] v)]
-    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-      (loop [acc []]
-        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                        (catch Exception _ ::eof))]
-          (if (= ::eof form) acc (recur (conj acc form))))))))
-
-(def ^:private all-forms (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- defn-form [sym]
-  (some (fn [form]
-          (when (and (seq? form)
-                     (#{'defn 'defn-} (first form))
-                     (= sym (second form)))
-            form))
-        all-forms))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private defn-form rt/defn-named)
 
 (defn- mentions? [form needle]
   (let [hit? (atom false)]

--- a/skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/frame_registrar_test.clj
@@ -26,53 +26,16 @@
 ;;;; Run: bb tests/runtime/frame_registrar_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns frame-registrar-test
-  (:require [clojure.java.io :as io]
-            [clojure.test :refer [deftest is run-tests]]
-            [clojure.walk :as walk]))
+  (:require [clojure.test :refer [deftest is run-tests]]
+            [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
-  (binding [*out* *err*]
-    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
-             (System/getProperty "user.dir")))
-  (System/exit 2))
-
-(defn- read-all-forms
-  "Read every top-level form. `*default-data-reader-fn*` swallows unknown
-   tagged literals (notably the `#js {...}` / `#js [...]` the CLJS preload
-   carries) so the bb reader doesn't HALT on the first `#js` — which would
-   silently drop every form after it (orient + the frame fns near the end)."
-  [^String src]
-  (binding [*default-data-reader-fn* (fn [_tag v] v)]
-    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-      (loop [acc []]
-        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                        (catch Exception _ ::eof))]
-          (if (= ::eof form) acc (recur (conj acc form))))))))
-
-(def ^:private all-forms
-  (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- defn-form [sym]
-  (some (fn [form]
-          (when (and (seq? form)
-                     (contains? #{'defn 'defn-} (first form))
-                     (= sym (second form)))
-            form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk
-      (fn [node] (when (pred node) (reset! hit? true)) node)
-      form)
-    @hit?))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private defn-form rt/defn-named)
+(def ^:private form-contains? rt/form-contains?)
 
 (defn- calls? [form sym]
   ;; True when `form` invokes `sym` as the head of any sub-list.

--- a/skills/re-frame2-pair/tests/runtime/orient_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/orient_test.clj
@@ -32,51 +32,16 @@
 ;;;; Run:  bb tests/runtime/orient_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns orient-test
-  (:require [clojure.java.io :as io]
-            [clojure.test :refer [deftest is run-tests]]
-            [clojure.walk :as walk]))
+  (:require [clojure.test :refer [deftest is run-tests]]
+            [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
-  (binding [*out* *err*]
-    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
-             (System/getProperty "user.dir")))
-  (System/exit 2))
-
-(defn- read-all-forms
-  "Read every top-level form. `*default-data-reader-fn*` swallows unknown
-   tagged literals (notably the `#js {...}` / `#js [...]` the CLJS preload
-   carries) so the reader doesn't HALT on the first `#js` — which would
-   silently drop every form after it, including `orient` near the end of
-   the file (the bb reader has no `#js` reader fn)."
-  [^String src]
-  (binding [*default-data-reader-fn* (fn [_tag v] v)]
-    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-      (loop [acc []]
-        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                        (catch Exception _ ::eof))]
-          (if (= ::eof form) acc (recur (conj acc form))))))))
-
-(def ^:private all-forms (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- defn-named [sym]
-  (some (fn [form]
-          (when (and (seq? form)
-                     (#{'defn 'defn-} (first form))
-                     (= sym (second form)))
-            form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
-    @hit?))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private defn-named rt/defn-named)
+(def ^:private form-contains? rt/form-contains?)
 
 (deftest defines-orient
   (is (some? (defn-named 'orient))

--- a/skills/re-frame2-pair/tests/runtime/preload_sentinel_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/preload_sentinel_test.clj
@@ -27,39 +27,16 @@
 ;;;; Run: bb tests/runtime/preload_sentinel_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns preload-sentinel-test
- (:require [clojure.java.io :as io]
- [clojure.test :refer [deftest is run-tests]]
- [clojure.walk :as walk]))
+ (:require [clojure.test :refer [deftest is run-tests]]
+ [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
- (some (fn [p] (when (.exists (io/file p)) p))
- ["preload/re_frame2_pair/runtime.cljs"
- "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
- "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
- (binding [*out* *err*]
- (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
- (System/getProperty "user.dir")))
- (System/exit 2))
-
-(defn- read-all-forms [^String src]
- (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
- (loop [acc []]
- (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
- (catch Exception _ ::eof))]
- (if (= ::eof form) acc (recur (conj acc form)))))))
-
-(def ^:private all-forms
- (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- form-contains? [pred form]
- (let [hit? (atom false)]
- (walk/postwalk
- (fn [node] (when (pred node) (reset! hit? true)) node)
- form)
- @hit?))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private all-forms rt/all-forms)
+(def ^:private form-contains? rt/form-contains?)
 
 (def ^:private sentinel-form
  (some (fn [form]

--- a/skills/re-frame2-pair/tests/runtime/raw_state_tap_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/raw_state_tap_test.clj
@@ -21,46 +21,26 @@
 ;;;; Run: bb tests/runtime/raw_state_tap_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns raw-state-tap-test
- (:require [clojure.java.io :as io]
- [clojure.test :refer [deftest is run-tests testing]]
- [clojure.walk :as walk]))
+ (:require [clojure.test :refer [deftest is run-tests testing]]
+ [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
- (some (fn [p] (when (.exists (io/file p)) p))
- ["preload/re_frame2_pair/runtime.cljs"
- "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
- "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
- (binding [*out* *err*]
- (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
- (System/getProperty "user.dir")))
- (System/exit 2))
-
-(defn- read-all-forms [^String src]
- (let [pbr (java.io.PushbackReader.
- (java.io.StringReader. src))]
- (loop [acc []]
- (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
- (catch Exception _ ::eof))]
- (if (= ::eof form)
- acc
- (recur (conj acc form)))))))
-
-(def ^:private all-forms
- (read-all-forms (slurp runtime-cljs-path)))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
 
 (defn- find-top-form
  "Find the top-level form whose head matches `head-sym` and whose first
- symbol slot matches `name-sym`. Returns nil when absent."
+ symbol slot matches `name-sym`. Returns nil when absent. (Local to this
+ test because it also matches `defonce`, unlike the shared `defn-named`.)"
  [head-sym name-sym]
  (some (fn [form]
  (when (and (seq? form)
  (= head-sym (first form))
  (= name-sym (second form)))
  form))
- all-forms))
+ rt/all-forms))
 
 (def ^:private configure-raw-state-form
  (find-top-form 'defn 'configure-raw-state!))
@@ -75,18 +55,7 @@
  ;; `defn-` because the helper is private.
  (find-top-form 'defn- 'maybe-elide-for-tap))
 
-;; ---------------------------------------------------------------------------
-;; Tree-walk helpers.
-;; ---------------------------------------------------------------------------
-
-(defn- form-contains? [pred form]
- (let [hit? (atom false)]
- (walk/postwalk
- (fn [node]
- (when (pred node) (reset! hit? true))
- node)
- form)
- @hit?))
+(def ^:private form-contains? rt/form-contains?)
 
 (defn- calls? [sym form]
  (form-contains?

--- a/skills/re-frame2-pair/tests/runtime/read_sub_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/read_sub_test.clj
@@ -32,57 +32,22 @@
 ;;;; Run:  bb tests/runtime/read_sub_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns read-sub-test
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.test :refer [deftest is run-tests testing use-fixtures]]
-            [clojure.walk :as walk]))
+  (:require [clojure.test :refer [deftest is run-tests testing use-fixtures]]
+            [runtime-support :as rt]))
 
 ;; ---------------------------------------------------------------------------
 ;; PART 1 — Structural pins: the named fns exist in the real runtime source
 ;; and carry the no-silent-swallow slots. Mirrors the dispatch_consequence
 ;; structural-pin style so a refactor that drops the validation can't ship
-;; green.
+;; green. Shared locate+parse+walk scaffold lives in
+;; tests/runtime/_support.clj (rf2-yrpt90).
 ;; ---------------------------------------------------------------------------
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
-  (binding [*out* *err*]
-    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
-             (System/getProperty "user.dir")))
-  (System/exit 2))
-
-(defn- read-all-forms
-  "Read every top-level form. `*default-data-reader-fn*` swallows unknown
-   tagged literals (the `#js {...}` the CLJS preload carries) so the reader
-   doesn't HALT on the first `#js` and silently drop later forms."
-  [^String src]
-  (binding [*default-data-reader-fn* (fn [_tag v] v)]
-    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-      (loop [acc []]
-        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                        (catch Exception _ ::eof))]
-          (if (= ::eof form) acc (recur (conj acc form))))))))
-
-(def ^:private all-forms (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- defn-named [sym]
-  (some (fn [form]
-          (when (and (seq? form)
-                     (#{'defn 'defn-} (first form))
-                     (= sym (second form)))
-            form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
-    @hit?))
+(def ^:private defn-named rt/defn-named)
+(def ^:private form-contains? rt/form-contains?)
 
 (deftest defines-read-sub!
   (is (some? (defn-named 'read-sub!))

--- a/skills/re-frame2-pair/tests/runtime/recorder_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/recorder_test.clj
@@ -35,52 +35,17 @@
 ;;;; Run: bb tests/runtime/recorder_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns recorder-test
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer [deftest is run-tests testing]]
-            [clojure.walk :as walk]))
+            [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
-  (some (fn [p] (when (.exists (io/file p)) p))
-        ["preload/re_frame2_pair/runtime.cljs"
-         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
-         "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
-  (binding [*out* *err*]
-    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
-             (System/getProperty "user.dir")))
-  (System/exit 2))
-
-(defn- read-all-forms [^String src]
-  ;; CLJS-tolerant read: the recorder fns sit AFTER the streaming section,
-  ;; which uses `#js {...}` reader literals. Clojure's reader has no `js`
-  ;; tag, so without a default-data-reader the parse aborts mid-file and
-  ;; never reaches the recorder defns. A pass-through default reader keeps
-  ;; the parse going (we never evaluate the forms, only walk their shape).
-  (binding [*default-data-reader-fn* (fn [_tag v] v)]
-    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
-      (loop [acc []]
-        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
-                        (catch Exception _ ::eof))]
-          (if (= ::eof form) acc (recur (conj acc form))))))))
-
-(def ^:private src (slurp runtime-cljs-path))
-(def ^:private all-forms (read-all-forms src))
-
-(defn- defn-form [sym]
-  (some (fn [form]
-          (when (and (seq? form)
-                     (#{'defn 'defn-} (first form))
-                     (= sym (second form)))
-            form))
-        all-forms))
-
-(defn- form-contains? [pred form]
-  (let [hit? (atom false)]
-    (walk/postwalk (fn [x] (when (pred x) (reset! hit? true)) x) form)
-    @hit?))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private defn-form rt/defn-named)
+(def ^:private form-contains? rt/form-contains?)
 
 (defn- mentions-sym? [form needle]
   (form-contains? #(= % needle) form))

--- a/skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj
@@ -22,39 +22,16 @@
 ;;;; Run: bb tests/runtime/registrar_describe_test.clj
 ;;;; Exit: 0 = pass, non-zero = fail.
 
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
 (ns registrar-describe-test
- (:require [clojure.java.io :as io]
- [clojure.test :refer [deftest is run-tests]]
- [clojure.walk :as walk]))
+ (:require [clojure.test :refer [deftest is run-tests]]
+ [runtime-support :as rt]))
 
-(def ^:private runtime-cljs-path
- (some (fn [p] (when (.exists (io/file p)) p))
- ["preload/re_frame2_pair/runtime.cljs"
- "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
- "../preload/re_frame2_pair/runtime.cljs"]))
-
-(when-not runtime-cljs-path
- (binding [*out* *err*]
- (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
- (System/getProperty "user.dir")))
- (System/exit 2))
-
-(defn- read-all-forms [^String src]
- (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
- (loop [acc []]
- (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
- (catch Exception _ ::eof))]
- (if (= ::eof form) acc (recur (conj acc form)))))))
-
-(def ^:private all-forms
- (read-all-forms (slurp runtime-cljs-path)))
-
-(defn- form-contains? [pred form]
- (let [hit? (atom false)]
- (walk/postwalk
- (fn [node] (when (pred node) (reset! hit? true)) node)
- form)
- @hit?))
+;; Shared locate+parse+walk scaffold lives in tests/runtime/_support.clj
+;; (rf2-yrpt90). Alias the vars the assertions below use.
+(def ^:private all-forms rt/all-forms)
+(def ^:private form-contains? rt/form-contains?)
 
 (def ^:private registrar-describe-form
  (some (fn [form]

--- a/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
+++ b/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
@@ -20,69 +20,19 @@
 ;;;; surface, not the runtime semantics. tests/runtime/ already covers
 ;;;; the pure CLJS logic; tests/e2e/ covers live nREPL.
 
+;; The minimal bencode codec is shared with the production shim
+;; (scripts/ops.clj); it lives in scripts/bencode.clj and is loaded off
+;; this file's own location so cwd doesn't matter (rf2-qq7w2k). The stub
+;; DECODES requests + ENCODES canned replies — the mirror of ops.clj.
+(load-file (str (.getParent (.getParentFile (.getParentFile (java.io.File. *file*))))
+                "/scripts/bencode.clj"))
+
 (ns stub-nrepl
-  (:require [clojure.java.io :as io]
+  (:require [bencode :as bc]
+            [clojure.java.io :as io]
             [clojure.string :as str])
   (:import (java.net ServerSocket Socket)
            (java.io PushbackInputStream)))
-
-;; ---------------------------------------------------------------------------
-;; bencode
-;; ---------------------------------------------------------------------------
-
-(defn- bencode ^String [v]
-  (cond
-    (integer? v)   (str "i" v "e")
-    (string? v)    (let [bs (.getBytes ^String v "UTF-8")]
-                     (str (alength bs) ":" v))
-    (keyword? v)   (bencode (name v))
-    (map? v)       (str "d"
-                        (apply str (mapcat (fn [[k v]] [(bencode k) (bencode v)])
-                                           (sort-by (fn [[k _]] (if (keyword? k) (name k) (str k))) v)))
-                        "e")
-    (sequential? v) (str "l" (apply str (map bencode v)) "e")
-    (nil? v)       (bencode "")
-    :else          (bencode (pr-str v))))
-
-(defn- read-char [^PushbackInputStream in]
-  (let [b (.read in)]
-    (when (neg? b) (throw (ex-info "unexpected EOF" {})))
-    (char b)))
-
-(defn- bdecode [^PushbackInputStream in]
-  (let [c (read-char in)]
-    (case c
-      \i (let [sb (StringBuilder.)]
-           (loop [ch (read-char in)]
-             (if (= ch \e)
-               (Long/parseLong (.toString sb))
-               (do (.append sb ch) (recur (read-char in))))))
-      \l (loop [acc []]
-           (let [b (.read in)]
-             (cond (neg? b)          (throw (ex-info "unexpected EOF in list" {}))
-                   (= b (int \e))    acc
-                   :else             (do (.unread in b) (recur (conj acc (bdecode in)))))))
-      \d (loop [acc {}]
-           (let [b (.read in)]
-             (cond (neg? b)          (throw (ex-info "unexpected EOF in dict" {}))
-                   (= b (int \e))    acc
-                   :else             (do (.unread in b)
-                                         (let [k (bdecode in)
-                                               v (bdecode in)]
-                                           (recur (assoc acc k v)))))))
-      (let [sb (StringBuilder.)]
-        (.append sb c)
-        (loop [ch (read-char in)]
-          (if (= ch \:)
-            (let [len (Long/parseLong (.toString sb))
-                  buf (byte-array len)]
-              (loop [read 0]
-                (when (< read len)
-                  (let [n (.read in buf read (- len read))]
-                    (when-not (pos? n) (throw (ex-info "EOF in string body" {})))
-                    (recur (+ read n)))))
-              (String. buf "UTF-8"))
-            (do (.append sb ch) (recur (read-char in)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Canned response table
@@ -127,7 +77,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- send-response [^java.io.OutputStream out m]
-  (.write out (.getBytes (bencode m) "UTF-8"))
+  (.write out (.getBytes (bc/encode m) "UTF-8"))
   (.flush out))
 
 (defn- handle-eval [out req cases]
@@ -173,7 +123,7 @@
     (with-open [in  (PushbackInputStream. (.getInputStream sock))
                 out (.getOutputStream sock)]
       (loop []
-        (let [req (try (bdecode in) (catch Exception _ ::eof))]
+        (let [req (try (bc/decode in) (catch Exception _ ::eof))]
           (when-not (= req ::eof)
             (case (get req "op")
               "clone"    (handle-clone out req)


### PR DESCRIPTION
Three behaviour-preserving runtime/test lean beads for the re-frame2-pair surface (parent rf2-91oga2). Branched off current origin/main (post mcp-lean #4676) and re-grepped before each change. Net: 282 insertions, 607 deletions (~325 net lines removed).

## rf2-k1lgkn (P2) — remove 3 unreferenced public fns from the pair runtime

Deleted three dead public defns from `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`:
- `pair-dispatch-with-fx-overrides!` — superseded; `:fx-overrides` threads directly through `pair-dispatch!`/`pair-dispatch-sync!` (and the MCP dispatch tool + shim `--fx-override` flag)
- `raw-state-config-snapshot` — `configure-raw-state!` already returns the same merged map
- `privacy-config-snapshot` — `configure-privacy!` already returns the same merged map

**Caller-verified**: full-repo `git grep` (both `-w` and bare, with `site/` + `.beads/` excluded) returned ONLY each fn's own defn line — zero callers across `tools/`, `tests/`, `skills/`, `spec/`, `docs/`. The reagent e2e consumer of the preload (`pair_dispatch_and_settle_dom_cljs_test.cljs`) calls only `select-frame!`/`dispatch-and-settle!`/`epoch-by-id`, none of the deleted fns.

## rf2-yrpt90 (P3) — extract shared bb test scaffold

The 12 babashka structural-pin tests under `tests/runtime/` each carried an identical copy-pasted harness (locate + slurp + `#js`-tolerant parse `runtime.cljs`, walk the parsed forms). Collapsed into one bb-loadable `tests/runtime/_support.clj` (`ns runtime-support`) exposing `runtime-cljs-path` / `read-all-forms` / `all-forms` / `form-contains?` / `defn-named`. Each test `load-file`s it off its own `*file*` (cwd-independent) then `:require`s it, aliasing the names its assertions already used. Per-test assertions are unchanged. The `_support.clj` underscore keeps it out of the CI `tests/runtime/*_test.clj` glob.

## rf2-qq7w2k (P4) — dedupe the bencode codec

The ~53-line bencode encoder/decoder duplicated near-verbatim between `scripts/ops.clj` (production shim) and `tests/shim/stub_nrepl.clj` (test nREPL stub) — mirror halves of the same protocol — now lives once in `scripts/bencode.clj` (`ns bencode`, public `encode`/`decode`/`read-char`). Both consumers `load-file` it off their own `*file*` before their `ns` form. Dependency-free (JDK classes only), preserving the deliberate no-Maven-dep posture both files carry.

## Gates

- Full bb suite (CI shape): 19 `tests/runtime/*_test.clj` + `tests/shim/shim_test.clj` = **20/20 PASS** post-rebase. Each refactored test reports the SAME test + assertion counts as the pre-refactor baseline (verified file-by-file).
- `shim_test` exercises both bencode halves end-to-end over a real TCP socket (ops.clj encode → stub decode → stub encode → ops.clj decode): 11 tests / 43 assertions, unchanged.
- `implementation` `npm run test:cljs` (compiles + preloads `re-frame2-pair.runtime`): **8019 tests / 33486 assertions, 0 failures, 0 errors**.
- clj-kondo: 0 errors / 0 warnings on the bencode files; the bb test files carry only the pre-existing skill-tree ns/file-name pattern (not CI-gated — `skills/` is outside the kondo lint surface).

No tool descriptor / registry / catalogue change (skill↔MCP drift check not triggered). No hot-zone files touched.