### PR TITLE
refactor(core+tools): canonical parse-source-coord, dedup the triplicated parser (rf2-nr7vf2)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -45,7 +45,8 @@
 
   The DOM-annotation hook (per Tool-Pair §Source-mapping) is the dev-only
   piece, gated separately."
-  (:require [re-frame.interop :as interop]
+  (:require [clojure.string :as str]
+            [re-frame.interop :as interop]
             [re-frame.source-coords.editor-uri :as editor-uri]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -109,6 +110,71 @@
       (if coords
         (merge coords (or user-meta {}))
         (or user-meta {})))))
+
+;; ---- DOM source-coord attribute parser (rf2-nr7vf2) -----------------------
+;;
+;; The inverse of `re-frame.adapter.context/format-source-coord` (re-exported
+;; as `re-frame.views/format-source-coord` / `re-frame.substrate.spine/
+;; format-source-coord`). The formatter renders a registry slot's id + coords
+;; into the `data-rf2-source-coord` DOM-attribute value `<ns>:<sym>:<line>:
+;; <col>`; this parser recovers `{:ns :handler-id :line :col}` from that
+;; string. It lives HERE — in the source-coord contract owner (Spec 006
+;; §Source-coord annotation / Tool-Pair §Source-mapping), not in the
+;; CLJS-only `adapter.context` ns — because consumers reading the attribute
+;; include JVM-side `.cljc` surfaces (Story's element-inspector pure helpers,
+;; the SSR round-trip parity test). Co-locating format + parse here keeps the
+;; round-trip a single source of truth (rf2-nr7vf2 collapses the parser that
+;; was reimplemented near-byte-for-byte in Story's element_inspector.cljc and
+;; the re-frame2-pair preload runtime).
+;;
+;; Tool-Pair.md declares the attribute value opaque to consumers and warns
+;; downstream callers MUST NOT depend on the parsed shape's stability across
+;; re-frame2 versions. Canonicalising the parser in the contract owner ties
+;; the format and its inverse to the same version boundary — the elegant
+;; single-source posture pre-alpha invites.
+
+(defn- parse-coord-int
+  "Parse a `data-rf2-source-coord` line/col segment to an integer, or nil.
+  Returns nil for the `?` placeholder (programmatic registrations that
+  bypassed the macro path) and any other non-numeric / non-string input.
+  Never throws."
+  [s]
+  (when (and (string? s) (re-matches #"\d+" s))
+    #?(:cljs (js/parseInt s 10)
+       :clj  (Long/parseLong s))))
+
+(defn parse-source-coord
+  "Parse a `data-rf2-source-coord` attribute value into
+  `{:ns :handler-id :line :col}`, or nil. The inverse of
+  `re-frame.adapter.context/format-source-coord` (re-exported as
+  `re-frame.views/format-source-coord`).
+
+  Per Spec 006 §Attribute value format the value is a four-segment colon-
+  separated string `<ns>:<sym>:<line>:<col>` where `<ns>` / `<sym>` derive
+  from the registry id keyword (`(namespace id)` / `(name id)`) and
+  `<line>` / `<col>` are the macro-captured source coords. Either coord
+  segment may be the literal `?` for programmatic registrations that
+  bypassed the macro path; `:line` / `:col` are nil in that case.
+
+  Returns nil for malformed input — blank / non-string input, fewer or
+  more than four segments, or an empty `<ns>` / `<sym>` segment. Never
+  throws. Pair-shaped consumers fall back to `(rf/handler-meta :view id)`
+  when this returns nil (Spec 006 §Documented exemption).
+
+  Tool-Pair.md declares the attribute value opaque to consumers; this
+  parser exists so tooling's DOM → source bridge can be useful, but
+  downstream callers MUST NOT depend on the parsed shape's stability
+  across re-frame2 versions."
+  [attr-val]
+  (when (and (string? attr-val) (seq attr-val))
+    (let [parts (str/split attr-val #":")]
+      (when (= 4 (count parts))
+        (let [[ns-part sym-part line-part col-part] parts]
+          (when (and (seq ns-part) (seq sym-part))
+            {:ns         ns-part
+             :handler-id sym-part
+             :line       (parse-coord-int line-part)
+             :col        (parse-coord-int col-part)}))))))
 
 ;; ---- co-located per-element machine source (rf2-npvsx) -------------------
 ;;

--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -25,6 +25,7 @@
   (when no form-meta `:file` is available and `*file*` is the sentinel)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.adapter.context :as adapter-context]
             [re-frame.source-coords :as source-coords]
             [re-frame.test-support :as test-support]))
 
@@ -154,3 +155,61 @@
 (deftest resolve-file-omits-when-both-nil
   (testing "rf2-mdjp: resolve-file returns nil when neither source supplies a file"
     (is (nil? (source-coords/resolve-file {} nil)))))
+
+;; ---- parse-source-coord (rf2-nr7vf2) ----------------------------------------
+;;
+;; The canonical inverse of `format-source-coord`, collapsing the parser
+;; that was reimplemented near-byte-for-byte in Story's element_inspector
+;; and the re-frame2-pair preload runtime. These tests pin the four-segment
+;; parse contract (Spec 006 §Attribute value format) and the round-trip
+;; against the REAL `re-frame.adapter.context/format-source-coord` so the
+;; format + parse pair can never drift apart.
+
+(deftest parse-source-coord-canonical-shape
+  (testing "rf2-nr7vf2: a four-segment value parses to {:ns :handler-id :line :col}"
+    (is (= {:ns "counter.core" :handler-id "counter-buttons" :line 47 :col 11}
+           (source-coords/parse-source-coord "counter.core:counter-buttons:47:11")))))
+
+(deftest parse-source-coord-degraded-placeholders
+  (testing "rf2-nr7vf2: `?` placeholders parse the id portion; line/col are nil"
+    (is (= {:ns "rf.x" :handler-id "programmatic" :line nil :col nil}
+           (source-coords/parse-source-coord "rf.x:programmatic:?:?")))
+    (is (= {:ns "ns.x" :handler-id "view" :line 42 :col nil}
+           (source-coords/parse-source-coord "ns.x:view:42:?")))))
+
+(deftest parse-source-coord-dotted-and-hyphenated
+  (testing "rf2-nr7vf2: dotted ns + hyphenated handler-id parse cleanly"
+    (is (= {:ns "my-app.cart.view" :handler-id "apply-coupon-button" :line 125 :col 4}
+           (source-coords/parse-source-coord "my-app.cart.view:apply-coupon-button:125:4")))))
+
+(deftest parse-source-coord-malformed-returns-nil
+  (testing "rf2-nr7vf2: malformed input returns nil and never throws"
+    (is (nil? (source-coords/parse-source-coord "ns:view:42")))      ; too few
+    (is (nil? (source-coords/parse-source-coord "ns:view")))
+    (is (nil? (source-coords/parse-source-coord "a:b:1:2:3")))       ; too many
+    (is (nil? (source-coords/parse-source-coord ":handler:1:2")))    ; empty ns
+    (is (nil? (source-coords/parse-source-coord "ns::1:2")))         ; empty sym
+    (is (nil? (source-coords/parse-source-coord "")))
+    (is (nil? (source-coords/parse-source-coord nil)))
+    (is (nil? (source-coords/parse-source-coord 42)))
+    (is (nil? (source-coords/parse-source-coord :keyword)))))
+
+(deftest format-then-parse-round-trips
+  (testing "rf2-nr7vf2: (parse-source-coord (format-source-coord id coords)) recovers id + coords"
+    (let [round-trip (fn [id coords]
+                       (source-coords/parse-source-coord
+                         (adapter-context/format-source-coord id coords)))]
+      ;; numeric line + col
+      (is (= {:ns "counter.core" :handler-id "counter-buttons" :line 47 :col 11}
+             (round-trip :counter.core/counter-buttons {:line 47 :column 11})))
+      ;; line only (column not captured -> `?` -> nil)
+      (is (= {:ns "ns.x" :handler-id "view" :line 42 :col nil}
+             (round-trip :ns.x/view {:line 42})))
+      ;; no coords at all (programmatic) -> both `?` -> nil
+      (is (= {:ns "ns.x" :handler-id "view" :line nil :col nil}
+             (round-trip :ns.x/view {})))
+      ;; namespaceless id -> formatter emits `?` ns, which the parser
+      ;; treats as a non-empty segment (the `?` is a literal char, distinct
+      ;; from an empty segment) so the round trip still recovers it
+      (is (= {:ns "?" :handler-id "bare" :line 1 :col 2}
+             (round-trip :bare {:line 1 :column 2}))))))

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -109,6 +109,13 @@
             [re-frame.realm :as realm]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            ;; `parse-source-coord` (the canonical inverse of
+            ;; `format-source-coord`) is the source-coord contract owner's
+            ;; parser for the `data-rf2-source-coord` DOM attribute (rf2-nr7vf2).
+            ;; The pair preload used to carry a near-byte-for-byte copy of this
+            ;; parser; it now routes through the one canonical impl in core.
+            ;; Dev-tier preload, so the direct require is bundle-isolation-safe.
+            [re-frame.source-coords :as source-coords]
             [clojure.data :as data]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -3162,50 +3169,20 @@
 ;; re-com's carries <file>/<line>/<column>. The runtime returns
 ;; whichever map the first present attribute parses to.
 
-(defn- parse-rf2-coord
-  "Parse re-frame2's `data-rf2-source-coord` attribute.
+(def ^:private parse-rf2-coord
+  "Parse re-frame2's `data-rf2-source-coord` attribute into
+   {:ns :handler-id :line :col} or nil.
 
-   Per Spec 006 §Source-coord annotation and Tool-Pair
-   §Source-mapping the attribute value is a four-segment colon-
-   separated string:
-
-       <ns>:<handler-id>:<line>:<col>
-
-   where <ns> and <handler-id> derive from the registry id keyword
-   (`(namespace id)` and `(name id)`) and <line>/<col> are the
-   captured source coords from the reg-view macro. Either coord
-   segment may be the literal `?` for programmatic registrations
-   that bypassed the macro path (Spec 006 §Attribute value format).
-
-   Returns
-       {:ns          <string>
-        :handler-id  <string>
-        :line        <int|nil>
-        :col         <int|nil>}
-
-   - :line and :col are nil when the corresponding segment is `?`
-     or otherwise non-numeric.
-   - Returns nil for blank input, non-strings, or fewer than four
-     segments. Pair-shaped consumers fall back to (rf/handler-meta
-     :view id) for those cases (Spec 006 §Documented exemption).
-
-   Tool-Pair.md declares the value format opaque to consumers; this
-   parser exists so re-frame2-pair's DOM-to-source bridge can be useful, but
-   downstream callers MUST NOT depend on the parsed shape's
-   stability across re-frame2 versions."
-  [attr-val]
-  (when (and (string? attr-val) (seq attr-val))
-    (let [parts (str/split attr-val #":")]
-      (when (= 4 (count parts))
-        (let [[ns-part sym-part line-part col-part] parts
-              parse-int (fn [s]
-                          (when (and (string? s) (re-matches #"\d+" s))
-                            (js/parseInt s 10)))]
-          (when (and (seq ns-part) (seq sym-part))
-            {:ns         ns-part
-             :handler-id sym-part
-             :line       (parse-int line-part)
-             :col        (parse-int col-part)}))))))
+   Alias of the canonical `re-frame.source-coords/parse-source-coord`
+   (the source-coord contract owner) — the inverse of
+   `format-source-coord`. This parser used to be reimplemented near-
+   byte-for-byte here and in Story's element_inspector.cljc; rf2-nr7vf2
+   collapsed both onto the one canonical impl in core. See that fn for
+   the four-segment value format (Spec 006 §Attribute value format),
+   the `?`-placeholder degradation, and the Tool-Pair opacity caveat
+   (downstream callers MUST NOT depend on the parsed shape's stability
+   across re-frame2 versions)."
+  source-coords/parse-source-coord)
 
 (defn- parse-rc-src
   "Parse re-com's `data-rc-src` attribute into {:file :line :column}.

--- a/skills/re-frame2-pair/tests/runtime/parse_rf2_coord_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/parse_rf2_coord_test.clj
@@ -6,18 +6,19 @@
 ;;;; Why a parallel implementation lives here:
 ;;;;
 ;;;;   `preload/re_frame2_pair/runtime.cljs` is a CLJS-only file loaded
-;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It
-;;;;   uses `js/parseInt`, so it can't run under bb directly. The real shadow-cljs test build (planned per
-;;;;   `docs/TESTING.md` §1) will exercise the `.cljs` source in place
-;;;;   under Node — that's the canonical home for these tests once the
-;;;;   build is wired up.
-;;;;
-;;;;   Until then, this file mirrors the parser logic and asserts
-;;;;   behaviour against samples cribbed from re-frame2's own tests
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It now
+;;;;   aliases the CANONICAL parser `re-frame.source-coords/parse-source-coord`
+;;;;   (the source-coord contract owner; rf2-nr7vf2 collapsed the formerly-
+;;;;   triplicated parser onto it — the inverse of `format-source-coord`).
+;;;;   Loading that core `.cljc` ns under bb would drag in re-frame.interop +
+;;;;   the editor-uri sibling, so this script keeps a dependency-free mirror
+;;;;   of the four-segment parse and asserts behaviour against samples cribbed
+;;;;   from re-frame2's own tests
 ;;;;   (`implementation/reagent/test/re_frame/source_coord_dom_cljs_test.cljs`
 ;;;;   and `implementation/core/test/re_frame/ssr_source_coord_test.clj`)
-;;;;   so format drift in `runtime.cljs` shows up under `bb` until the
-;;;;   shadow-cljs harness lands.
+;;;;   so format drift shows up under `bb`. The canonical CLJS-side coverage
+;;;;   lives next to the parser in
+;;;;   `implementation/core/test/re_frame/source_coords_cljs_test.cljs`.
 ;;;;
 ;;;; Run:    bb tests/runtime/parse_rf2_coord_test.clj
 ;;;; Exit:   0 = pass, non-zero = fail.
@@ -27,11 +28,12 @@
             [clojure.test :refer [deftest is run-tests testing]]))
 
 ;; ---------------------------------------------------------------------------
-;; Mirror of preload/re_frame2_pair/runtime.cljs `parse-rf2-coord`.
+;; Mirror of the canonical `re-frame.source-coords/parse-source-coord`
+;; (which `preload/re_frame2_pair/runtime.cljs` aliases as `parse-rf2-coord`).
 ;;
-;; KEEP IN SYNC WITH preload/re_frame2_pair/runtime.cljs. Logic is identical except
-;; for `js/parseInt` -> `Long/parseLong` (bb runtime). The regex,
-;; segment count, and shape are the contract under test.
+;; KEEP IN SYNC WITH implementation/core/src/re_frame/source_coords.cljc.
+;; Logic is identical except for `js/parseInt` -> `Long/parseLong` (bb
+;; runtime). The regex, segment count, and shape are the contract under test.
 ;; ---------------------------------------------------------------------------
 
 (defn- parse-int-str [s]
@@ -39,7 +41,7 @@
     (Long/parseLong s)))
 
 (defn parse-rf2-coord
-  "See preload/re_frame2_pair/runtime.cljs for the canonical version.
+  "See re-frame.source-coords/parse-source-coord for the canonical version.
    Returns {:ns :handler-id :line :col} or nil."
   [attr-val]
   (when (and (string? attr-val) (seq attr-val))

--- a/tools/story/src/re_frame/story/ui/element_inspector.cljc
+++ b/tools/story/src/re_frame/story/ui/element_inspector.cljc
@@ -61,10 +61,9 @@
   attribute it reads is itself dev-only (elides via
   `interop/debug-enabled?`) — under prod the inspector would find no
   matches and click would no-op. Per Spec 009 §Production builds."
-  (:require [clojure.string :as str]
+  (:require [re-frame.source-coords :as source-coords]
             #?@(:cljs [[reagent.core :as r]
                        [re-frame.core :as rf]
-                       [re-frame.source-coords :as source-coords]
                        [re-frame.story.ui.canvas-listeners :as canvas-listeners]
                        [re-frame.story.ui.open-in-editor :as open-in-editor]])
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
@@ -95,29 +94,18 @@
 
 ;; ---- pure: parse + resolve coord ----------------------------------------
 
-(defn parse-coord
+(def parse-coord
   "Parse a `data-rf2-source-coord` attribute value into
   `{:ns :handler-id :line :col}` or nil. Per Spec 006 §Attribute value
   format — `<ns>:<sym>:<line>:<col>`, with `?` for missing coords.
 
-  Mirrors the parser in `skills/re-frame2-pair/.../runtime.cljs` (the
-  re-frame2-pair nREPL consumer that does the same DOM → id walk). Returns nil
-  for malformed input (too few / too many segments, empty ns or
-  handler-id, non-string input). Never throws."
-  [attr-val]
-  (when (and (string? attr-val) (seq attr-val))
-    (let [parts (str/split attr-val #":")]
-      (when (= 4 (count parts))
-        (let [[ns-part sym-part line-part col-part] parts
-              parse-int (fn [s]
-                          (when (and (string? s) (re-matches #"\d+" s))
-                            #?(:cljs (js/parseInt s 10)
-                               :clj  (Long/parseLong s))))]
-          (when (and (seq ns-part) (seq sym-part))
-            {:ns         ns-part
-             :handler-id sym-part
-             :line       (parse-int line-part)
-             :col        (parse-int col-part)}))))))
+  Alias of the canonical `re-frame.source-coords/parse-source-coord` (the
+  source-coord contract owner) — the inverse of `format-source-coord`. The
+  parser used to be reimplemented near-byte-for-byte here and in the
+  re-frame2-pair preload runtime; rf2-nr7vf2 collapsed both onto the one
+  canonical parser. Returns nil for malformed input (too few / too many
+  segments, empty ns or handler-id, non-string input). Never throws."
+  source-coords/parse-source-coord)
 
 (defn coord->handler-keyword
   "Build the registered view id keyword from a parsed coord. Returns nil


### PR DESCRIPTION
## Summary

The `data-rf2-source-coord` DOM-attribute parser — the inverse of `format-source-coord` — was reimplemented near-byte-for-byte in two live consumers plus a bb test mirror, with **no canonical home in core**. This bead (rf2-nr7vf2, parent rf2-91oga2 tools-lean) canonicalises one parser and routes consumers through it. Behaviour-preserving.

**Ruling applied:** option (a) from the bead — canonicalise in `re-frame.source-coords` (the contract owner), tools import it.

## What changed

- **Added** `re-frame.source-coords/parse-source-coord` (`.cljc`) — the canonical inverse of `re-frame.adapter.context/format-source-coord`. Lives in the source-coord contract owner (not the CLJS-only `adapter.context`) because `.cljc`/JVM consumers (Story's element-inspector pure helpers, the SSR parity test) need it. Plain public fn on an internal core ns — mirrors `format-source-coord`'s visibility exactly. **NOT** a `re-frame.core` facade export → **no api-manifest change**.
- **Story** `element_inspector.cljc`: `parse-coord` is now a thin `def` alias of the canonical fn; the duplicated local impl is deleted. `re-frame.source-coords` moved to the unconditional require (JVM-side needs it now).
- **re-frame2-pair preload** `runtime.cljs`: `parse-rf2-coord` is now a thin `^:private def` alias; duplicated impl deleted; canonical ns required (dev-tier preload, bundle-isolation-safe).
- **bb skill test** `parse_rf2_coord_test.clj`: kept as a dependency-free contract guard (bb can't easily load the core ns chain), header/docstrings refreshed to point at the canonical home.
- **Round-trip test** added next to the parser in `source_coords_cljs_test.cljs`: `(parse-source-coord (format-source-coord id coords))` against the **real** formatter, plus direct parse-contract coverage.

The re-com `data-rc-src` parser was deliberately **left in place** — it parses a third-party (re-com) format with no re-frame2 formatter and exists in exactly one location (not duplicated; nothing to dedup).

## Gates (all green)

- `npm run test:cljs` — 8024 tests / 33503 assertions, 0F/0E (incl. new parser + round-trip tests, Story element-inspector CLJS)
- `scripts/test-jvm-tools.sh` — Story 1702 tests, all tools 0F/0E
- `scripts/test-jvm-implementation.sh` — core + SSR parity 0F/0E
- `npm run test:bundle-isolation` — PASS
- pair MCP-drift + pair-authoring-drift gates — PASS
- bb `parse_rf2_coord_test.clj` — 12 tests 0F/0E
- clj-kondo — 0 new warnings (the editor-uri warning is pre-existing on main)

Closes rf2-nr7vf2.