### PR TITLE
docs(core): fix stale path See-also + reg-cofx :schema docstring (rf2-mnerx2)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -155,8 +155,9 @@
                     `:rf.error/missing-required-cofx` in every mode.
       :doc          one-sentence what-and-why; surfaces via
                     `(rf/handler-meta :cofx id)`.
-      :schema       Malli schema validating supplied / replayed values
-                    (the `:schema` validation step is slice-B-built).
+      :schema       Malli schema validating supplied / replayed / generated
+                    recordable values (a production hard error on mismatch —
+                    `:rf.error/cofx-value-invalid`).
       :platforms    set of `#{:client :server}`; default
                     `#{:client :server}`. The supplier is skipped on
                     platforms not in the set (`:rf.cofx/skipped-on-platform`

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -56,8 +56,9 @@
 
   See also: `->interceptor` (the macro form, `re-frame.core`),
   `get-coeffect`, `assoc-coeffect`, `get-effect`, `assoc-effect`,
-  `:rf.cofx/requires` (the declared-coeffect key), `path`
-  (the std interceptor v2 ships). An interceptor IS the public
+  `:rf.cofx/requires` (the declared-coeffect key), `:rf.interceptor/path`
+  (the standard path interceptor, a registered factory referenced as
+  `[:rf.interceptor/path <path-vector>]`). An interceptor IS the public
   `context -> context` primitive — full-context work that a
   `reg-event-ctx` handler once expressed lives here (EP-0018)."
   [& {:keys [id before after source-coord] :as opts}]
@@ -150,7 +151,7 @@
   `:rf.error/interceptor-exception` trace so the Xray Epoch INTERCEPTOR
   row renders a jump-to-source chip (parity with EVENT HANDLER /
   SUBSCRIPTIONS / VIEWS). Absent on the fn-path / framework interceptors
-  (`path`) — they have no user definition site to jump to; the
+  (`:rf.interceptor/path`) — they have no user definition site to jump to; the
   slot's absence preserves the singleton-vs-vector equality invariant
   (`:rf/interceptor-error` ≡ first of `:rf/interceptor-errors`) for the
   common case."


### PR DESCRIPTION
Fixes 2 stale docstrings flagged by the rf2-sh4s3e docstring audit (parent epic rf2-cheez6). Docstring-only; no behaviour change.

## Fix 1 — `interceptor.cljc` stale `path` See-also (2 sites)
- L57-61 (`->interceptor*` public docstring) See-also listed `` `path` (the std interceptor v2 ships) ``. Per EP-0022 there is no `path` interceptor value/var — the standard path interceptor is a registered factory referenced as `[:rf.interceptor/path <path-vector>]` (`re-frame.std-interceptors` only carries a `^:no-doc` throwing `path-removed!` stub). Corrected to the `:rf.interceptor/path` spelling + usage form.
- L151-154 (the `^:no-doc` `error-record` docstring) carried the same stale `` (`path`) `` example; fixed in the same touch.

## Fix 2 — `cofx.cljc` `reg-cofx` `:schema` doc (L158-159)
The `:schema` metadata-key doc said the validation step is `slice-B-built` (reads as not-yet-done) but it is fully live: `validate-recordable-value!` (L566) is invoked from `deliver-declared-cofx` (L950) for present-on-token (supplied / replayed) values AND from `run-generator` (L780) for GENERATED values, throwing the production hard error `:rf.error/cofx-value-invalid` on mismatch. Dropped the `slice-B-built` parenthetical and widened the wording to cover supplied / replayed / generated recordable values.

All three claims verified against the live code bodies before editing.

## Gates
- clj-kondo on both changed files: 0 errors (3 pre-existing warnings unrelated to the docstring edits, identical on origin/main).
- `npm run test:cljs`: 8019 tests / 33486 assertions / 0 failures, 0 errors.
- api-manifest: NOT affected — the generator projects existence + `:kind` + `:facade?` only and joins curated tier/owner/status; no docstring text is projected, so docstring-only edits cannot cause manifest drift.
- mkdocs: no autodoc/codox API page consumes these docstrings (no generated API page), so no docs build needed.

Closes rf2-mnerx2.