### PR TITLE
refactor(resources): fix owner-free :error GC leak + fresh-skip poll restart (rf2-ar9pcx, rf2-k9u4h3)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -335,7 +335,34 @@
                      ;; it) — treat the fresh entry as already-`:success` or
                      ;; the route hangs forever (Spec 016 §Route integration).
                      ;; No-op for a non-route-owned / non-blocking resource.
-                     (route/drain-blocking scoped-key hit :success))]
+                     (route/drain-blocking scoped-key hit :success))
+            ;; rf2-k9u4h3 — a fresh-skip that attaches a NEW owner to a
+            ;; previously OWNER-FREE entry must (re)arm polling. The original
+            ;; load may have settled while owner-free (`succeeded-handler` arms
+            ;; NO poll timer for an owner-free settle — a poll never pins an
+            ;; owner-free entry); the entry then sat `:loaded` with no poll
+            ;; armed. A later `ensure` from a live owner serves the cached value
+            ;; via this fresh-skip and — before this fix — emitted no
+            ;; `:rf.resource/schedule-timers`, so the SWR `refetchInterval`
+            ;; analogue silently never started. The entry now HAS an active
+            ;; owner, so polling MUST arm, mirroring the success-path arming
+            ;; (Spec 016 §Polling — a `:poll` timer is armed after a settle while
+            ;; the entry has at least one active owner). We also re-arm the
+            ;; advisory stale / GC timers (cancel-then-arm) so a fresh-skip that
+            ;; revives an owner-free entry re-establishes the full timer set the
+            ;; success path would have armed, never double-arming (the fx is
+            ;; cancel-then-arm by construction). Gated on a previously-owner-free
+            ;; entry: a fresh-skip onto an already-owned entry adds another lease
+            ;; but its timers are already live, so it re-arms nothing here.
+            was-owner-free? (empty? (:active-owners entry))
+            arm-timers?    (and owner-newly-attached? was-owner-free?)
+            spec           (registry/resource-meta (:resource/id entry))
+            poll-delay-ms  (when (and arm-timers? (seq (:active-owners hit)))
+                             (state/positive-or-nil (:poll-interval-ms spec)))
+            stale-delay-ms (when arm-timers?
+                             (state/positive-or-nil (:stale-after-ms spec)))
+            gc-delay-ms    (when arm-timers?
+                             (state/positive-or-nil (:gc-after-ms spec)))]
         (trace/emit! :rf.event :rf.resource/cache-hit
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation (:generation entry) :owner owner :cause cause})
@@ -346,7 +373,18 @@
                        {:rf.frame/id frame-id :resource/key scoped-key
                         :generation (:generation entry) :owner owner :cause cause
                         :work/id nil :joined-in-flight? false}))
-        {:rf.db/runtime rdb'})
+        ;; arm the poll (+ re-arm stale / GC) for an owner-free entry just
+        ;; revived by a new lease, mirroring the success-path arming. Only
+        ;; emitted when the resource declares at least one of poll / stale / GC.
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms poll-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource/key   scoped-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :poll-delay-ms  poll-delay-ms
+                        :server?        (state/server-frame? frame-id)}]])))
       ;; ----- dedupe: join the in-flight request (ensure only) -------------
       ;; Attach any supplied owner to the existing entry + record the cause;
       ;; do NOT start a new generation. Join the SAME work-ledger record

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -2226,8 +2226,10 @@
 
       :else
       (let [entry' (state/entry-failed entry {:error error})
-            op     (if (= :error (:status entry'))
+            first-load-error? (= :error (:status entry'))
+            op     (if first-load-error?
                      :rf.resource/failed :rf.resource/refresh-failed)
+            spec   (registry/resource-meta (:resource/id entry'))
             ;; the work row settles :failed (terminal) with the error
             ;; envelope as its outcome summary (Xray gets the summary). The
             ;; host handle is cleared (the attempt settled).
@@ -2245,7 +2247,25 @@
                        ;; kept, status back to :loaded) settles the slot like
                        ;; a success. drain-blocking keys on entry' status.
                        ;; (Spec 016 §Route integration.)
-                       (route/drain-blocking resource-key entry' :failure))]
+                       (route/drain-blocking resource-key entry' :failure))
+            ;; rf2-ar9pcx — a FIRST-LOAD `:error` settle MUST arm the GC timer
+            ;; (and the stale timer, if declared). GC timers are otherwise armed
+            ;; only on a SUCCESSFUL settle (`succeeded-handler`); a first load
+            ;; that fails goes to `:error` with `:current-work nil` and, before
+            ;; this fix, emitted NO `:rf.resource/schedule-timers` — so an
+            ;; owner-free errored entry was never reaped (an unbounded cache leak
+            ;; for the frame's life). Arming GC here mirrors the success-path
+            ;; arming; an errored entry is GC fodder, never a poll target, so no
+            ;; poll timer (symmetric with the owner-free / no-owner gate the
+            ;; success + release-owner paths already enforce). A BACKGROUND-
+            ;; refresh failure (entry returns to `:loaded`, prior data kept) is
+            ;; NOT re-armed here — its stale/GC timers were armed on the prior
+            ;; success and `entry-failed` makes no freshness change; re-arming
+            ;; would double-arm. Per Spec 016 §Stale and GC scheduling.
+            stale-delay-ms (when first-load-error?
+                             (state/positive-or-nil (:stale-after-ms spec)))
+            gc-delay-ms    (when first-load-error?
+                             (state/positive-or-nil (:gc-after-ms spec)))]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
@@ -2254,7 +2274,19 @@
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
-        {:rf.db/runtime rdb'}))))
+        ;; arm the GC (+ stale) timer on a first-load `:error` settle so an
+        ;; owner-free errored entry is reaped (cancel-then-arm via the fx; the
+        ;; re-check derives freshness/idle/owner-free from the durable facts).
+        ;; Only emitted when the resource declares at least one of GC / stale.
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource/key   resource-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :poll-delay-ms  nil
+                        :server?        (state/server-frame? frame-id)}]]))))))
 
 (def ^:private aborted-event-failure
   "The synthetic `:rf.http/aborted` failure envelope the legacy

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -122,6 +122,20 @@
                        {:resource/key scoped-key :work/id (:current-work e)
                         :generation (:generation e) :data data}])))
 
+(defn- fail!
+  "Feed an internal FAILED reply (a non-abort transport error) for a scoped
+  key, reading the LIVE entry's current work-id + generation. On an entry with
+  no usable data this is a FIRST-LOAD failure → `:error`."
+  [scoped-key reason]
+  (let [e (entry scoped-key)]
+    (rf/dispatch-sync [:rf.resource.internal/failed
+                       {:resource/key scoped-key :work/id (:current-work e)
+                        :generation (:generation e)
+                        :error {:kind :rf.http/server-error :reason reason}}])))
+
+(defn- last-schedule-for [scoped-key]
+  (last (filter #(= scoped-key (:resource/key %)) @scheduled-timers)))
+
 ;; ===========================================================================
 ;; 1. Exact tag invalidation — scoped default + cross-scope opt-in
 ;; ===========================================================================
@@ -583,6 +597,62 @@
               an owner-free + idle entry is removed"
       (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key k}])
       (is (nil? (entry k)) "GC removed the inactive entry"))))
+
+(deftest first-load-error-arms-gc-and-is-collected-after-release
+  ;; rf2-ar9pcx — a FIRST load that FAILS settles `:error` with `:current-work
+  ;; nil`. BEFORE the fix, GC timers were armed only on a SUCCESSFUL settle, so
+  ;; an owner-free errored entry was never reaped (an unbounded cache leak for
+  ;; the frame's life). The `:error` settle MUST now arm a GC timer (mirroring
+  ;; the success-path arming), and once owner-free + idle the fired GC re-check
+  ;; collects it.
+  (rf/reg-resource :gce/article (article-spec {:gc-after-ms 5000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gce/article {:slug "w"})]
+    (reset! scheduled-timers [])
+    (ensure! :gce/article scope "w" [:lease :gce 1])
+    (fail! k :transient-500)   ;; first load fails → :error (no usable data)
+    (testing "rf2-ar9pcx / Spec 016 §Stale and GC scheduling — a first-load
+              `:error` settle arms the GC timer (so the errored entry can be
+              reaped) — it was never armed before this fix"
+      (let [e (entry k)]
+        (is (= :error (:status e)) "first-load failure settled :error")
+        (is (nil? (:current-work e)) "no in-flight work after the error settle"))
+      (let [args (last-schedule-for k)]
+        (is (some? args) "schedule-timers emitted on the :error settle")
+        (is (= 5000 (:gc-delay-ms args)) "GC timer armed at :gc-after-ms")
+        (is (nil? (:poll-delay-ms args)) "no poll timer for an errored entry")))
+    (testing "the owner releases → owner-free + idle + :error; the fired GC
+              re-check collects the errored entry (no longer leaked)"
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gce 1]}])
+      (is (empty? (:active-owners (entry k))) "entry now owner-free")
+      (is (= :error (:status (entry k))) "still :error, idle (no current-work)")
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key k}])
+      (is (nil? (entry k)) "GC reaped the owner-free errored entry"))))
+
+(deftest background-refresh-failure-does-not-rearm-gc
+  ;; rf2-ar9pcx guard — a BACKGROUND-refresh failure (the entry keeps prior data
+  ;; and returns to `:loaded`) is NOT a first-load error: its stale/GC timers
+  ;; were armed on the prior success, and `entry-failed` makes no freshness
+  ;; change, so the refresh-failure settle re-arms NOTHING (no double-arm).
+  (rf/reg-resource :gcb/article (article-spec {:gc-after-ms 5000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gcb/article {:slug "w"})]
+    (ensure! :gcb/article scope "w" [:route :r 1])
+    (succeed! k {:title "W"})        ;; first load succeeds → :loaded, GC armed
+    ;; a background refetch that fails (entry keeps data, returns to :loaded)
+    (rf/dispatch-sync [:rf.resource/refetch {:resource :gcb/article :scope scope
+                                             :params {:slug "w"}}])
+    (reset! scheduled-timers [])
+    (fail! k :transient-503)         ;; background refresh failure
+    (testing "rf2-ar9pcx — a background-refresh failure (status :loaded, data
+              kept, :refresh-error) re-arms NO timer (the GC was already armed on
+              the prior success — no double-arm from the failure path)"
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "background refresh failure kept :loaded")
+        (is (= {:title "W"} (:data e)) "prior data kept")
+        (is (some? (:refresh-error e)) ":refresh-error recorded"))
+      (is (empty? (filter #(= k (:resource/key %)) @scheduled-timers))
+          "no schedule-timers re-armed on the background-refresh failure"))))
 
 (deftest gc-fired-skips-when-owner-reattached
   (rf/reg-resource :gck/article (article-spec {:gc-after-ms 1000}))

--- a/implementation/resources/test/re_frame/resources_polling_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_polling_cljs_test.cljc
@@ -198,6 +198,59 @@
         (is (nil? (:poll-delay-ms args)) "no poll timer armed for an owner-free entry")
         (is (= 9000 (:gc-delay-ms args)) "GC timer armed as usual")))))
 
+(deftest fresh-skip-re-arms-polling-on-new-owner
+  ;; rf2-k9u4h3 — an entry that settled `:loaded` while OWNER-FREE armed no poll
+  ;; timer (a poll never pins an owner-free entry). A later `ensure` from a NEW
+  ;; live owner serves the cached value via the fresh-skip path (the entry is
+  ;; still fresh — no `:stale-after-ms`, never invalidated). BEFORE the fix that
+  ;; fresh-skip attached the owner but emitted NO schedule-timers, so the
+  ;; `refetchInterval` analogue never started. It MUST now (re)arm polling,
+  ;; mirroring the success-path arming.
+  (rf/reg-resource :fs/poll (article-spec {:poll-interval-ms 5000}))
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :fs/poll {:slug "w"})]
+    (ensure! :fs/poll scope "w" [:lease :x 1])
+    ;; release the owner BEFORE the reply lands → settles owner-free (no poll)
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :x 1]}])
+    (succeed! k {:title "W"})
+    (is (empty? (:active-owners (entry k))) "entry settled owner-free")
+    (is (nil? (:poll-delay-ms (last-schedule-for k)))
+        "no poll timer armed at the owner-free settle (precondition)")
+    (reset! scheduled-timers [])
+    ;; a fresh ensure from a NEW live owner — served from cache (fresh-skip)
+    (ensure! :fs/poll scope "w" [:route :r 2])
+    (testing "Spec 016 §Polling — a fresh-skip that attaches a new owner to a
+              previously owner-free entry serves the cache AND (re)arms the poll
+              timer (the entry now has an active owner)"
+      (let [e (entry k)]
+        (is (= :loaded (:status e)) "served from cache (no fetch — still :loaded)")
+        (is (nil? (:current-work e)) "no in-flight work (fresh-skip, not a load)")
+        (is (= #{[:route :r 2]} (:active-owners e)) "the new owner is leased"))
+      (let [args (last-schedule-for k)]
+        (is (some? args) "schedule-timers emitted for the revived entry")
+        (is (= 5000 (:poll-delay-ms args)) "poll re-armed at :poll-interval-ms")))))
+
+(deftest fresh-skip-onto-owned-entry-does-not-re-arm
+  ;; Guard against double-arm: a fresh-skip onto an entry that ALREADY has an
+  ;; active owner adds a second lease but its poll is already live, so the
+  ;; fresh-skip re-arms nothing (the success-path settle armed it).
+  (rf/reg-resource :fa/poll (article-spec {:poll-interval-ms 5000}))
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :fa/poll {:slug "w"})]
+    (ensure! :fa/poll scope "w" [:route :r 1])
+    (succeed! k {:title "W"})   ;; active-owner settle → poll already armed
+    (reset! scheduled-timers [])
+    ;; a SECOND owner ensures the SAME fresh entry — fresh-skip, but the entry
+    ;; was already owned, so no re-arm fires here.
+    (ensure! :fa/poll scope "w" [:lease :x 1])
+    (testing "rf2-k9u4h3 — a fresh-skip onto an already-OWNED entry adds the
+              lease but re-arms NO timer (avoids double-arm; the prior settle
+              already armed the poll)"
+      (is (= #{[:route :r 1] [:lease :x 1]} (:active-owners (entry k)))
+          "both leases attached")
+      (is (empty? (filter #(= k (:resource/key %)) @scheduled-timers))
+          "no schedule-timers re-armed on a fresh-skip onto an owned entry"))))
+
 ;; ===========================================================================
 ;; 2. Unconditional tick — refetch by interval (not :stale?-gated), re-arm
 ;; ===========================================================================


### PR DESCRIPTION
@
Fixes two resource-lifecycle bugs found by the rf2-go7f5o adversarial audit,
both in `implementation/resources/src/re_frame/resources/events.cljc`.
Behaviour-correcting, with new tests. One commit per bead.

## rf2-ar9pcx — owner-free `:error` first-load entry never GC-collected (unbounded cache leak)

GC timers were armed only on a SUCCESSFUL settle. A first load that FAILS
settles `:error` with `:current-work nil` and, before this fix, emitted no
`:rf.resource/schedule-timers` — so an owner-free errored entry was never
reaped (it lingered in `:entries` / owner-index / tag-index for the frame
life). The failed-handler first-load branch now arms the GC timer (and the
stale timer, when declared) on the `:error` settle, mirroring the success-path
arming. No poll timer (an errored entry is GC fodder, never a poll target). A
background-refresh failure (entry stays `:loaded`, data kept) re-arms nothing
(no double-arm).

## rf2-k9u4h3 — fresh-skip ensure branch never restarts polling

An entry that settled `:loaded` while owner-free armed no poll timer. A later
`ensure` from a new live owner served the cache via fresh-skip and attached
the owner, but returned a runtime-db effect with no `:fx` — so polling never
started (the SWR `refetchInterval` analogue silently stopped). The fresh-skip
branch now re-arms polling (and re-arms stale / GC, cancel-then-arm) when a new
owner is attached to a previously owner-free entry, mirroring the success-path
arming. Gated on a previously-owner-free entry, so a fresh-skip onto an
already-owned entry re-arms nothing.

## Spec

No spec change: both fixes close gaps where the implementation diverged from
Spec 016 §Stale and GC scheduling (an inactive entry GCs after `:gc-after-ms`)
and §Polling (a `:poll` timer is armed after a settle while the entry has an
active owner). The documented contracts already prescribe this behaviour.

## Tests / gates

- New tests:
  - `resources-invalidation-gc`: `first-load-error-arms-gc-and-is-collected-after-release`, `background-refresh-failure-does-not-rearm-gc`
  - `resources-polling`: `fresh-skip-re-arms-polling-on-new-owner`, `fresh-skip-onto-owned-entry-does-not-re-arm`
- `npm run test:cljs` — 8023 tests / 33507 assertions, 0 failures, 0 errors
- resources JVM tier (`clojure -M:test`) — 595 tests / 2582 assertions, 0 failures, 0 errors
- per-namespace isolation gate — all pass (new tests use the reset-runtime fixture, installing their own substrate)
- clj-kondo / splint — 0 errors (only pre-existing style warnings outside the edited regions)
@