### PR TITLE
docs(spec/002): enforce EP-0023 vocab — program members → image members (rf2-nva6pk)

### DIFF
--- a/docs/EP/EP-0022-registered-interceptors.md
+++ b/docs/EP/EP-0022-registered-interceptors.md
@@ -96,10 +96,10 @@ assembled chain. It works only when the inline value happens to carry a stable
 replacement does not serialize across stories, SSR artifacts, app values, or
 agent-visible tooling.
 
-The system is already behaving as if interceptors are named program members.
+The system is already behaving as if interceptors are named image members.
 This EP makes that true.
 
-### App-as-value needs named program members
+### App-as-value needs named image members
 
 EP-0013 turns applications into values that can be constructed, installed,
 queried, patched, tested, and explained. Events, subs, effects, coeffects,
@@ -473,7 +473,7 @@ frame :interceptor-overrides < dispatch opts :interceptor-overrides
 A replacement ref is resolved through the same registrar before execution. A
 `nil` replacement removes the matching ref from the chain.
 
-Framework dispatch-time interceptors that are not authored program members
+Framework dispatch-time interceptors that are not authored image members
 remain governed by their owning specs. For example, flow transformation can
 still wrap after the authored chain in the position required by Spec 013. This
 EP changes authored interceptor naming, not subsystem-owned dispatch

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -2127,7 +2127,7 @@ All three override types propagate transitively through any depth of `:fx [:disp
 
 ## Registered interceptors and the chain grammar
 
-[EP-0018](../docs/EP/EP-0018-one-event-registration.md) makes interceptors the public application full-context (`context -> context`) mechanism; [EP-0022](../docs/EP/EP-0022-registered-interceptors.md) makes them first-class **registered** program members and changes the event/frame `:interceptors` surfaces to carry interceptor **references**, not inline interceptor values. The registrar half — the `:interceptor` registry kind, `reg-interceptor`, descriptors, metadata, and `handler-meta :interceptor` — is owned by [001 §Interceptors](001-Registration.md#interceptors--reg-interceptor-the-interceptor-registrar). This section owns the runtime half: the reference shape, the event/frame chain grammar, dispatch-option restrictions, `:interceptor-overrides`, effective ordering, validation/resolution timing, the standard `:rf.interceptor/path` interceptor, and the no-standard-`unwrap` decision. The interceptor **execution model** (`:before` in order, handler, `:after` in reverse; the short-circuit / always-runs rules) is unchanged — see [§Interceptor chain execution](#interceptor-chain-execution--before-short-circuit-after-always-runs).
+[EP-0018](../docs/EP/EP-0018-one-event-registration.md) makes interceptors the public application full-context (`context -> context`) mechanism; [EP-0022](../docs/EP/EP-0022-registered-interceptors.md) makes them first-class **registered** image members and changes the event/frame `:interceptors` surfaces to carry interceptor **references**, not inline interceptor values. The registrar half — the `:interceptor` registry kind, `reg-interceptor`, descriptors, metadata, and `handler-meta :interceptor` — is owned by [001 §Interceptors](001-Registration.md#interceptors--reg-interceptor-the-interceptor-registrar). This section owns the runtime half: the reference shape, the event/frame chain grammar, dispatch-option restrictions, `:interceptor-overrides`, effective ordering, validation/resolution timing, the standard `:rf.interceptor/path` interceptor, and the no-standard-`unwrap` decision. The interceptor **execution model** (`:before` in order, handler, `:after` in reverse; the short-circuit / always-runs rules) is unchanged — see [§Interceptor chain execution](#interceptor-chain-execution--before-short-circuit-after-always-runs).
 
 ### Interceptor references
 
@@ -2210,7 +2210,7 @@ Groups 1 and 2 are **authored references** and resolve through the same registra
 
 After refs resolve, the runtime applies the merged override map (frame `:interceptor-overrides` < dispatch-opts `:interceptor-overrides`): a replacement ref is resolved through the same registrar before execution; a `nil` replacement removes the matching ref from the chain.
 
-Framework dispatch-time interceptors that are **not** authored program members remain governed by their owning specs — flow transformation, for instance, still wraps after the authored chain in the position [013](013-Flows.md) requires (the outermost `:after`, per [§Drain-loop pseudocode](#drain-loop-pseudocode)). EP-0022 changes authored interceptor naming, not subsystem-owned dispatch machinery.
+Framework dispatch-time interceptors that are **not** authored image members remain governed by their owning specs — flow transformation, for instance, still wraps after the authored chain in the position [013](013-Flows.md) requires (the outermost `:after`, per [§Drain-loop pseudocode](#drain-loop-pseudocode)). EP-0022 changes authored interceptor naming, not subsystem-owned dispatch machinery.
 
 ### Validation and resolution timing
 
@@ -2280,7 +2280,7 @@ An image's registration set may carry interceptor descriptors, so an image owns 
   cart-add)
 ```
 
-An image built over these namespaces (via `:include-ns`, or by listing them as inline `:registrations`) carries both members; the resolved image generation a frame runs validates the refs at assembly. This keeps the program-as-named-members rule intact: the registration set contains named members, not anonymous runtime objects embedded in other members.
+An image built over these namespaces (via `:include-ns`, or by listing them as inline `:registrations`) carries both members; the resolved image generation a frame runs validates the refs at assembly. This keeps the image-as-named-members rule intact: the registration set contains named members, not anonymous runtime objects embedded in other members.
 
 ### Tooling and metadata
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3838,7 +3838,7 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
         [:undo [:vector :any]] [:redo [:vector :any]]])
 (rf/reg-app-schema [:drawer] DrawerState)
 
-;; EP-0022: interceptors are registered program members. Author with
+;; EP-0022: interceptors are registered image members. Author with
 ;; `reg-interceptor` (the one public form) and reference by id in chains —
 ;; never an inline interceptor map/Var.
 (rf/reg-interceptor :drawer/undoable


### PR DESCRIPTION
Enforces EP-0023's own vocab table (line 1682: `program`→event-stream, "avoid for registration sets") by renaming the **registration-set sense** of "program members" to "image members". Bead **rf2-nva6pk** — ruled by Mike; bead notes authoritative.

## Edits

**spec/002-Frames.md** (Mike's 3 ruled sites):
- "registered program members" → "registered image members"
- "authored program members" → "authored image members"
- "the program-as-named-members rule" → "the image-as-named-members rule"

**docs/EP/EP-0022-registered-interceptors.md** (matching normative sites found via `git grep`, fixed per Mike's same-PR ruling):
- "interceptors are named program members" → "named image members"
- heading "App-as-value needs named program members" → "named image members" (no inbound anchor refs — slug change safe)
- "not authored program members" → "not authored image members"

**spec/005-StateMachines.md** (matching site):
- comment "interceptors are registered program members" → "registered image members"

## Left untouched (Mike explicit)
Sense-A "anonymous program **behaviour/behavior**" event-stream sites — EP-0023 endorses these:
- 002-Frames.md ~2013, ~2169
- EP-0022 ~107, ~900

No app_value.cljc / realm.cljc / Runtime-Subsystems Sense-B sites touched (those rode the realm collapse).

## Gates
- `mkdocs build --strict` — PASS (exit 0)
- `scripts/check_doc_slugs.py` (+ self-test) — PASS
- `scripts/check_ep_status_sync.py` — PASS (24 EPs in sync)
- `scripts/check_inject_cofx_residue.py` (+ self-test) — PASS
- `scripts/check_retired_composition_vocab.py` (+ self-test) — PASS

Spec-prose only; no code/test gates needed.
