### PR TITLE
test(resources): de-vacuous terminal-dispose + reset-resources timer-clear assertions (rf2-wt53h9)

### DIFF
--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -1005,10 +1005,13 @@
         ;; (the exact drift EP-0012 closes; the old `(when rec …)` made it pass
         ;; silently when the byte-keyed row was read through a dead address).
         (let [rec (work-ledger/get-record (runtime-db) inflight-wid)]
-          (when rec
-            (is (work-ledger/terminal? (:status rec))
-                "a present post-clear work record must be terminal, never in-flight")
-            (is (= :suppressed (:status rec))))))
+          (is (some? rec)
+              "the post-clear work record MUST be readable through the byte-keyed
+               address — a nil here means the contract is asserted against a dead
+               address, the exact vacuity EP-0012 closes")
+          (is (work-ledger/terminal? (:status rec))
+              "a present post-clear work record must be terminal, never in-flight")
+          (is (= :suppressed (:status rec)))))
       (testing "rf2-m9h5iq — a LATE reply for a cleared in-flight entry cannot
                 recreate it (its existence check finds the entry gone)"
         (rf/dispatch-sync [:rf.resource.internal/succeeded
@@ -1240,7 +1243,7 @@
           "generation high-water cache cleared")
       (is (nil? (work-ledger/get-handle :rf/default work-id))
           "work-ledger host handle table cleared")
-      (is (not (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+      (is (not (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
           "stale/GC timer table cleared (timer cancelled)")
       (is (not (contains? @revalidate-listeners/listener-table :rf/default))
           "revalidation-listener side table cleared"))))


### PR DESCRIPTION
Fixes the 2 vacuous/tautological test assertions found by the rf2-ke7h7u test-quality audit, both in `implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc`. Bead: **rf2-wt53h9**.

## The 2 fixes

**1. terminal-settle dispose (rf2-m9h5iq) — was conditionally vacuous.**
The `terminal?`/`:suppressed` checks were wrapped in `(when rec ...)`. The docstring claimed the assertion was NON-vacuous and disowned the old `(when rec …)` form, yet the wrap was still present: if `work-ledger/get-record` returns `nil` (the dead-address drift the comment warns of), the test passed silently and the suppressed-disposal contract was never asserted. Now asserts `(some? rec)` FIRST (a nil record fails the test), then the `terminal?`/`:suppressed` checks UNCONDITIONALLY.

**2. reset-resources! timer-clear (rf2-784223) — was true by construction.**
The precondition (line ~1229) keys the timer table with `(state/key-id k)`, but the post-condition (line ~1243) checked `[:rf/default k timers/gc-kind]` using the RAW vector `k`. Since `k != (state/key-id k)`, the `(not (contains? ...))` was true regardless of whether the GC timer was cancelled. Now uses `(state/key-id k)` to match the precondition, so it actually verifies the GC timer was cleared.

## Did either newly-strict assertion expose a real bug?

No. Both pass. Neither was hiding a real bug — the resource-lifecycle source fixes (#4696) genuinely settle the work record terminal/`:suppressed` and clear the byte-keyed GC timer entry. The fixes simply make the assertions actually verify the contracts they claim to.

## Gates

- `npm run test:cljs` — 7930 tests / 33019 assertions, 0 failures, 0 errors
- `scripts/test-jvm-implementation.sh` — PASS (resources artefact: 595 tests / 2583 assertions, 0 failures)
- `node scripts/check-per-ns-isolation.cjs` — all 15 namespaces pass standalone
- `clj-kondo` on the changed file — 0 errors, 0 warnings