### PR TITLE
test(schemas): restore the malli-validate late-bind hook in finally (rf2-hydpaf)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
@@ -150,14 +150,19 @@
 (deftest warning-suppressed-when-malli-validate-hook-bound
   (testing "with the Malli adapter loaded (`:schemas/malli-validate`
             is bound) the validation hot path runs — no warning"
-    (let [recorded (record-traces! ::malli-loaded)]
+    (let [recorded (record-traces! ::malli-loaded)
+          prior    (late-bind/get-fn :schemas/malli-validate)]
       (late-bind/set-fn! :schemas/malli-validate (fn [_ _] true))
       (try
         (rf/reg-app-schema [:user] [:map])
         (finally
-          ;; Restore the slot for sibling tests (the fixture restores the
-          ;; validator-fn but not the late-bind hook table).
-          nil))
+          ;; Restore the slot for sibling tests — the fixture restores the
+          ;; validator-fn but NOT the process-global late-bind hook table.
+          ;; Mirrors `with-unbound-malli-validate`'s prior-capture/restore so
+          ;; this stub does not leak a trivially-true validator process-wide
+          ;; (rf2-hydpaf).
+          (when prior
+            (late-bind/set-fn! :schemas/malli-validate prior))))
       (is (empty? (warnings-of recorded
                                :rf.warning/schema-validator-unavailable))
           ":schemas/malli-validate bound -> warning suppressed"))))


### PR DESCRIPTION
## What

`warning-suppressed-when-malli-validate-hook-bound` in `schemas_validator_unavailable_warning_test.clj` stubbed `:schemas/malli-validate` via `late-bind/set-fn!` but its `finally` body was literally `nil` (self-acknowledged in the original comment). It never restored the prior hook.

`late-bind/hooks` is a process-global `defonce` atom, and the shared `reset-runtime` fixture restores the schemas validator-fn but NOT the late-bind hook table. So the trivially-true stub leaked process-wide: any later test relying on real Malli validation silently got a `(constantly true)` validator, which could mask a real validation regression.

## Fix

Capture the prior fn via `(late-bind/get-fn :schemas/malli-validate)` BEFORE the `set-fn!`, and restore it in the `finally` — mirroring the sibling `with-unbound-malli-validate` helper's prior-capture/restore pattern exactly.

## Verification

- Full schemas JVM suite: 311 tests / 18809 assertions, 0 failures/errors (runs in one process — any sibling depending on real Malli would have been polluted if the leak persisted).
- Direct late-bind probe: confirmed the `finally` restores the *exact same* hook object as before the stub (`identical?` true), and that the stub is trivially-true only during the body.
- CLJS suite (`npm run test:cljs`): 7930 tests / 33018 assertions, 0 failures/errors.
- Per-namespace isolation gate: all 15 namespaces pass standalone.
- clj-kondo on the changed file: 0 errors (the lone unused-`re-frame.trace` warning is pre-existing, not introduced here).

Closes rf2-hydpaf.