### PR TITLE
refactor(tools): migrate trace-frame consumers to the canonical trace-event-frame reader (rf2-7737vq Stage B, rf2-16znzb)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -81,6 +81,12 @@
             ;; dev-only, so requiring the tooling ns directly here is
             ;; bundle-isolation-safe.
             [re-frame.trace.tooling :as trace-tooling]
+            ;; rf2-7737vq — the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`). Owned by the trace
+            ;; contract ns; `re-frame.trace` is already loaded via
+            ;; `re-frame.core` above, so this require adds no bundle weight
+            ;; (dev-tier preload — bundle-isolation-safe).
+            [re-frame.trace :as trace]
             ;; `flush-render!` (the SYNCHRONOUS render-commit contract fn,
             ;; Spec 006 §`flush-render!`, rf2-40a84) lives in
             ;; re-frame.substrate.adapter, not re-frame.core. It resolves
@@ -1923,9 +1929,7 @@
       (and (or (nil? operation)  (= operation (:operation ev)))
            (or (nil? op-type)    (= op-type   (:op-type ev)))
            (or (nil? severity)   (= severity  (:op-type ev)))
-           (or (nil? frame)      (= frame
-                                    (or (:frame ev)
-                                        (get-in ev [:tags :frame]))))
+           (or (nil? frame)      (= frame (trace/trace-event-frame ev)))
            (or (nil? event-id)   (= event-id
                                     (get-in ev [:tags :rf.trace/event-id])))
            (or (nil? handler-id) (= handler-id

--- a/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj
@@ -54,9 +54,12 @@
  (and (or (nil? operation) (= operation (:operation ev)))
  (or (nil? op-type) (= op-type (:op-type ev)))
  (or (nil? severity) (= severity (:op-type ev)))
- (or (nil? frame) (= frame
- (or (:frame ev)
- (get-in ev [:tags :frame]))))
+ ;; rf2-7737vq — mirror the runtime's canonical
+ ;; `re-frame.trace/trace-event-frame` read: a RAW trace event carries
+ ;; frame identity ONLY under `[:tags :frame]`. (Inlined as the
+ ;; `get-in` the canonical reader is implemented as, because this bb
+ ;; mirror can't `:require` the CLJS preload / the CLJC trace ns.)
+ (or (nil? frame) (= frame (get-in ev [:tags :frame])))
  (or (nil? event-id) (= event-id
  (get-in ev [:tags :rf.trace/event-id])))
  (or (nil? handler-id) (= handler-id
@@ -327,10 +330,14 @@
  (is (not (trace-matches? filter-map {:time 99})))
  (is (not (trace-matches? filter-map {:time 201})))))
 
-(deftest trace-filter-frame-falls-back-to-tags
+(deftest trace-filter-frame-reads-tags-frame
+ ;; rf2-7737vq — a RAW trace event carries frame identity ONLY under
+ ;; `[:tags :frame]`. The prior top-level-`:frame` fallback is gone, so a
+ ;; top-level-only `:frame` no longer matches the frame filter axis.
  (let [filter-map {:frame :stories}]
  (is (trace-matches? filter-map {:tags {:frame :stories}}))
- (is (trace-matches? filter-map {:frame :stories}))
+ (is (not (trace-matches? filter-map {:frame :stories}))
+ "a stray top-level :frame is not a raw-event shape — it does not match")
  (is (not (trace-matches? filter-map {:tags {:frame :rf/default}})))))
 
 (deftest epoch-filter-matches-by-event-id

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -346,11 +346,14 @@
   PROJECTED epoch records, because epoch projection tracks the sensitive
   axis, not the large-slot toggle.
 
-  rf2-1we9fa — the trace-walk arm resolves the elision `:frame` PER
-  ELEMENT inside the walk: a cascade record's own `:frame` slot (cascade
-  bundles are keyed by `[frame dispatch-id]`), else a frameless event's
-  `[:tags :frame]` / `:frame`. An all-frame stream — or a filter frame
-  that differs from the operating frame — carries cascades from several
+  rf2-1we9fa / rf2-7737vq — the trace-walk arm resolves the elision
+  `:frame` PER ELEMENT inside the walk by LAYER: a cascade record's own
+  top-level `:frame` slot (DERIVED records key frame at top level —
+  cascade bundles are keyed by `[frame dispatch-id]`), else a frameless
+  RAW event's frame via the canonical reader
+  `re-frame.trace/trace-event-frame` (its `[:tags :frame]` slot). An
+  all-frame stream — or a filter frame that differs from the operating
+  frame — carries cascades from several
   frames in one tick, and per EP-0015 sensitive/large declarations are
   per-frame; eliding a foreign-frame cascade against the operating
   frame's registry mis-redacts (under-redaction leaks across the off-box
@@ -456,8 +459,10 @@
       ;; frame's) registry mis-redacts — the sharp edge is UNDER-redaction
       ;; (frame-A values A marks sensitive but B does not would leak across
       ;; the off-box MCP→LLM boundary). Each element supplies its own
-      ;; frame: a cascade record's `:frame` slot, else a frameless event's
-      ;; `[:tags :frame]` / `:frame`.
+      ;; frame BY LAYER (rf2-7737vq): a DERIVED cascade record's top-level
+      ;; `:frame` slot, else a frameless RAW event's frame via the
+      ;; canonical `re-frame.trace/trace-event-frame` reader ([:tags
+      ;; :frame]).
       ;;
       ;; EP-0002 (rf2-bd4div): `current-frame` survives as the genuinely
       ;; frameless FALLBACK only. The nREPL eval thread carries no ambient
@@ -475,7 +480,7 @@
             (str "(let [walk (fn [xs]"
                  "             (mapv (fn [x]"
                  "                     (let [frame (or (:frame x)"
-                 "                                     (get-in x [:tags :frame])"
+                 "                                     (re-frame.trace/trace-event-frame x)"
                  "                                     cur-frame)]"
                  "                       (re-frame.core/elide-wire-value"
                  "                         x (assoc base-opts :frame frame))))"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -631,18 +631,19 @@
         "sensitive slots redact when the caller did NOT opt in")))
 
 (deftest drain-form-resolves-elision-frame-per-element
-  ;; rf2-1we9fa — the trace-walk arm resolves the elision `:frame` PER
-  ;; ELEMENT inside the walk, NOT once for the whole drain. Cascade
-  ;; bundles are keyed by `[frame dispatch-id]`, so an all-frame stream —
-  ;; or a filter frame that differs from the operating frame — carries
-  ;; cascades from several frames in one tick. Per EP-0015 sensitive/large
-  ;; declarations are per-frame, so each element MUST be elided against its
-  ;; OWN frame: a cascade record's `:frame` slot, else a frameless event's
-  ;; `[:tags :frame]` / `:frame`. The operating frame
-  ;; (`(re-frame2-pair.runtime/current-frame)`) survives as the GENUINELY
-  ;; FRAMELESS FALLBACK only (EP-0002 rf2-bd4div: the nREPL eval thread
-  ;; carries no ambient `with-frame` scope, so a truly frameless element
-  ;; would otherwise fail closed and redact away).
+  ;; rf2-1we9fa / rf2-7737vq — the trace-walk arm resolves the elision
+  ;; `:frame` PER ELEMENT inside the walk BY LAYER, NOT once for the whole
+  ;; drain. Cascade bundles are keyed by `[frame dispatch-id]`, so an
+  ;; all-frame stream — or a filter frame that differs from the operating
+  ;; frame — carries cascades from several frames in one tick. Per EP-0015
+  ;; sensitive/large declarations are per-frame, so each element MUST be
+  ;; elided against its OWN frame: a DERIVED cascade record's top-level
+  ;; `:frame` slot, else a frameless RAW event's frame via the canonical
+  ;; `re-frame.trace/trace-event-frame` reader ([:tags :frame]). The
+  ;; operating frame (`(re-frame2-pair.runtime/current-frame)`) survives
+  ;; as the GENUINELY FRAMELESS FALLBACK only (EP-0002 rf2-bd4div: the
+  ;; nREPL eval thread carries no ambient `with-frame` scope, so a truly
+  ;; frameless element would otherwise fail closed and redact away).
   ;;
   ;; This test REPLACES the prior `drain-form-threads-operating-frame`,
   ;; which PINNED the buggy "one operating frame for every cascade"
@@ -651,12 +652,13 @@
   (let [form (sub/drain-form "sub-frame" :trace true false)]
     (is (str/includes? form "(re-frame2-pair.runtime/current-frame)")
         "the operating frame is resolved app-side as the frameless fallback")
-    ;; The per-element resolution: cascade record `:frame`, then frameless
-    ;; `[:tags :frame]`, then the operating-frame fallback.
+    ;; The per-element resolution: DERIVED cascade record top-level
+    ;; `:frame`, then a RAW event's frame via the canonical reader, then
+    ;; the operating-frame fallback.
     (is (str/includes? form "(:frame x)")
-        "each element's own :frame slot is the first elision-frame source")
-    (is (str/includes? form "(get-in x [:tags :frame])")
-        "a frameless event's [:tags :frame] is the second source")
+        "each element's own top-level :frame slot is the first elision-frame source")
+    (is (str/includes? form "(re-frame.trace/trace-event-frame x)")
+        "a frameless RAW event's frame reads via the canonical reader (the second source)")
     (is (str/includes? form "(or (:frame x)")
         "the per-element frame falls through (or ...) to the fallback")
     (is (str/includes? form "(assoc base-opts :frame frame)")

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -30,6 +30,10 @@
   that accidentally requires a stories ns sees the namespace load but
   with no registrations, every Story query returns empty."
   (:require [re-frame.privacy    :as privacy]
+            ;; rf2-7737vq — the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`), replacing Story's
+            ;; hand-rolled `[:tags :frame]` read.
+            [re-frame.trace      :as trace]
             ;; EP-0015 (rf2-3t26eh): the on-box dev visibility choice is a
             ;; named `:rf.egress/*` profile resolved through the framework's
             ;; centralized projection table — NOT a process-global on/off
@@ -675,13 +679,16 @@
   (privacy/sensitive? ev))
 
 (defn event-frame
-  "Return the frame a trace event targets — its `[:tags :frame]` slot — or
-  nil for a frameless emit (registration-time, outermost-dispatch lookup
-  failures). The frame Story's listeners resolve the per-frame egress
-  profile against (EP-0015 issue 7)."
+  "Return the frame a RAW trace event targets — its `[:tags :frame]` slot
+  — or nil for a frameless emit (registration-time, outermost-dispatch
+  lookup failures). The frame Story's listeners resolve the per-frame
+  egress profile against (EP-0015 issue 7). Reads via the canonical
+  `re-frame.trace/trace-event-frame` reader (rf2-7737vq); the `map?`
+  guard keeps the accessor total for the non-map inputs Story's
+  defensive call sites may pass."
   [ev]
   (when (map? ev)
-    (get-in ev [:tags :frame])))
+    (trace/trace-event-frame ev)))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by a Story-registered listener

--- a/tools/story/src/re_frame/story/error.cljc
+++ b/tools/story/src/re_frame/story/error.cljc
@@ -69,7 +69,12 @@
   is the ONE projection predicate every capture site now consults —
   any of the three operations targeting the frame is a captured
   failure (spec/009 §Error contract; rf2-294yq5)."
-  (:require [re-frame.elision :as elision])
+  (:require [re-frame.elision :as elision]
+            ;; rf2-7737vq — the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`), replacing Story's
+            ;; hand-rolled `[:tags :frame]` read. Core framework leaf, so
+            ;; the require keeps this ns at the leaf of the cycle graph.
+            [re-frame.trace   :as trace])
   (:refer-clojure :exclude [error]))
 
 (def pipeline-exception-operations
@@ -90,11 +95,12 @@
   predicate every Story phase-capture site (runtime loaders/events,
   play, frame setup/teardown) consults so a cofx / user-interceptor
   failure is captured with the same fidelity as a handler throw
-  (rf2-294yq5.2). Reads the canonical `:frame` tag (spec/009
-  §Per-frame routing)."
+  (rf2-294yq5.2). Reads the raw event's frame via the canonical
+  `re-frame.trace/trace-event-frame` reader (`[:tags :frame]` — spec/009
+  §Frame identity on the raw event, rf2-7737vq)."
   [frame-id ev]
   (and (contains? pipeline-exception-operations (:operation ev))
-       (= frame-id (get-in ev [:tags :frame]))))
+       (= frame-id (trace/trace-event-frame ev))))
 
 (defn- elide-ex-data
   "Project an `ex-data` map through `re-frame.elision/elide-wire-value`

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -71,6 +71,10 @@
             ;; (`register-listener!` / `unregister-listener!`) lives in
             ;; `re-frame.trace.tooling` (production-DCE split).
             [re-frame.trace.tooling    :as trace-tooling]
+            ;; rf2-7737vq — the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/frame-of`), replacing Story's hand-rolled
+            ;; `[:tags :frame]` read.
+            [re-frame.trace            :as trace]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
@@ -93,11 +97,6 @@
 (defn- listener-id [frame-id]
   (keyword "re-frame.story.play"
            (str "trace-" (when frame-id (str frame-id)))))
-
-(defn- frame-of [ev]
-  ;; Per Spec 009 §Per-frame routing: the canonical tag key is :frame
-  ;; (rf2-shaa1 dropped the :frame-id alias from impl emit sites).
-  (get-in ev [:tags :frame]))
 
 ;; Per-frame pending-exception accumulator. The listener captures
 ;; `:rf.error/handler-exception` synchronously (from inside the running
@@ -150,7 +149,7 @@
      projection."
   [frame-id]
   (fn [ev]
-    (when (= frame-id (frame-of ev))
+    (when (= frame-id (trace/frame-of ev))
       (cond
         ;; rf2-6z4znr — resolve the suppress decision against THIS frame's
         ;; egress profile (the listener is already frame-scoped). Revealing a

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -144,7 +144,7 @@
                       ;; rf2-6z4znr — resolve the suppress decision against
                       ;; the event's own frame (per-(tool,frame) visibility).
                       (config/suppress-sensitive? ev)
-                      (config/note-suppressed! (get-in ev [:tags :frame]))
+                      (config/note-suppressed! (trace/trace-event-frame ev))
 
                       (story-error/pipeline-exception-event? variant-id ev)
                       (swap! collected conj ev)))]

--- a/tools/story/src/re_frame/story/ui/trace_buffer.cljs
+++ b/tools/story/src/re_frame/story/ui/trace_buffer.cljs
@@ -32,6 +32,10 @@
             ;; rf2-qwm0a — listener API lives in
             ;; `re-frame.trace.tooling` (production-DCE split).
             [re-frame.trace.tooling :as trace-tooling]
+            ;; rf2-7737vq — the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`), replacing Story's
+            ;; hand-rolled `[:tags :frame]` read.
+            [re-frame.trace :as trace]
             [re-frame.story.config :as config]))
 
 ;; ---- the per-variant trace buffer ----------------------------------------
@@ -135,13 +139,13 @@
            (str "listener-" (when variant-id (str variant-id)))))
 
 (defn- variant-event?
-  "Filter predicate: true iff `ev` targets `variant-id`'s frame. The
-  trace events emit `:frame` under `:tags`; events that have no frame
-  scope (registry / global) match nothing. Per Spec 009 §Per-frame
-  routing — `:frame` is the canonical tag key (rf2-shaa1 dropped the
-  `:frame-id` alias from impl emit sites)."
+  "Filter predicate: true iff RAW trace event `ev` targets `variant-id`'s
+  frame. Reads via the canonical `re-frame.trace/trace-event-frame`
+  reader (its `[:tags :frame]` slot); events that have no frame scope
+  (registry / global) match nothing. Per Spec 009 §Frame identity on the
+  raw event (rf2-7737vq) — `:frame` rides under `:tags` on the raw layer."
   [variant-id ev]
-  (= variant-id (get-in ev [:tags :frame])))
+  (= variant-id (trace/trace-event-frame ev)))
 
 (defn register-listener!
   "Install a trace listener that appends every `variant-id`-scoped event

--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -598,6 +598,11 @@ Trace → "Show wall-clock axis."
   the `:sensitive?` semantics the collector gates on.
 - [Spec-Schemas §`:rf/trace-event`](../../../spec/Spec-Schemas.md#rftrace-event)
   — the event shape consumers project from.
+- [Spec 009 §Frame identity on the raw event](../../../spec/009-Instrumentation.md)
+  — a raw trace event carries frame identity ONLY at `[:tags :frame]`;
+  Xray's collector + trace-panel helpers read it via the contract-owned
+  canonical reader `re-frame.trace/trace-event-frame` rather than
+  hand-reaching into `[:tags :frame]` (rf2-7737vq).
 - [`Principles.md`](./Principles.md) §Observation only — no new
   runtime surfaces — the discipline that keeps Xray downstream.
 - [`007-UX-IA.md`](./007-UX-IA.md) §Bottom rail — the

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -57,7 +57,8 @@
             [day8.re-frame2-xray.panels.app-db-diff-helpers :as diff-h]
             [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panels.epoch.badge :as epoch-badge]
-            [day8.re-frame2-xray.theme.tokens :as tokens]))
+            [day8.re-frame2-xray.theme.tokens :as tokens]
+            [re-frame.trace :as trace]))
 
 ;; ---- area-badge classification (spec/023 §3 · §5) -----------------------
 ;;
@@ -694,12 +695,15 @@
 ;; substrate supplies no timing, §6).
 
 (defn frame-of
-  "Project the event's frame routing key. Per Spec 009 every trace event
-  that names a frame uses `:frame` under `:tags`; consumers also fall
-  back to a top-level `:frame` (defensive)."
+  "Project the event's frame routing key. Reads the RAW trace-event
+  frame via the canonical reader `re-frame.trace/trace-event-frame`
+  (its `[:tags :frame]` slot — Spec 009 §Frame identity on the raw
+  event, rf2-7737vq). The prior defensive top-level `:frame` fallback is
+  removed: per the ruling raw trace events carry frame identity ONLY
+  under `[:tags :frame]`; a top-level `:frame` belongs to derived /
+  projection records, not the raw rows this projection consumes."
   [ev]
-  (or (get-in ev [:tags :frame])
-      (:frame ev)))
+  (trace/trace-event-frame ev))
 
 (defn realm-of
   "Project the event's runtime realm id — the `:rf.realm/id` stamp

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -83,6 +83,12 @@
             ;; panel's :devtools/preloads), so requiring the tooling ns
             ;; directly here is bundle-isolation-safe.
             [re-frame.trace.tooling :as trace-tooling]
+            ;; rf2-7737vq: the canonical RAW trace-event frame reader
+            ;; (`re-frame.trace/trace-event-frame`). A plain public defn on
+            ;; the trace contract ns (NOT a facade export); requiring it
+            ;; here is the bundle-isolation-safe dev-tier dependency the
+            ;; trace tooling sibling above already establishes.
+            [re-frame.trace :as trace]
             [re-frame.interop :as interop]
             ;; rf2-uv2q2: the canonical Editscript-A* diff engine. Used by
             ;; get-app-db-diff to project the changed-paths slice diff its
@@ -529,35 +535,37 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; EP-0015 frame-owned egress: a trace event's VALUES must project under the
-;; classification of the FRAME THAT EMITTED IT. A trace event carries its
-;; frame on `[:tags :frame]` (the router stamps it on most in-cascade emits)
-;; or top-level `:frame` — the same precedence the framework's
-;; `trace.tooling`/`trace.projection` frame-routing reads. For a per-frame
-;; ring read (`get-trace-buffer`) every surviving event already belongs to
-;; the resolved frame, but `get-issues` MERGES rings across frames, so each
-;; event must project under its OWN frame, not one ambient/resolved frame.
-;; When an event carries no frame (a frameless emit), fall back to the
-;; accessor's resolved frame so the read and the projection stay aligned;
-;; a truly frameless value then fails closed in the walker.
+;; classification of the FRAME THAT EMITTED IT. These are RAW trace events
+;; (the `get-trace-buffer` / `get-issues` reads forward `{:flat true}`
+;; ring slices), so each event's frame rides under `[:tags :frame]` — read
+;; via the canonical reader `re-frame.trace/trace-event-frame` (rf2-7737vq).
+;; For a per-frame ring read (`get-trace-buffer`) every surviving event
+;; already belongs to the resolved frame, but `get-issues` MERGES rings
+;; across frames, so each event must project under its OWN frame, not one
+;; ambient/resolved frame. When an event carries no frame (a frameless
+;; emit), fall back to the accessor's resolved frame so the read and the
+;; projection stay aligned; a truly frameless value then fails closed in
+;; the walker. The prior divergent top-level `:frame` fallback is removed
+;; (raw events never carry top-level `:frame` per the ruling).
 
-(defn- trace-event-frame
-  "Resolve the frame-id a trace event belongs to for value egress
-  (EP-0015 frame-owned projection). Reads `[:tags :frame]` then top-level
-  `:frame` (the framework trace frame-routing precedence). `fallback` is
-  the accessor's resolved frame, used when the event carries none. rf2-5b2ct2."
+(defn- egress-event-frame
+  "Resolve the frame-id a RAW trace event belongs to for value egress
+  (EP-0015 frame-owned projection). Reads the event's `[:tags :frame]`
+  via the canonical `re-frame.trace/trace-event-frame` reader; `fallback`
+  is the accessor's resolved frame, used when the event carries none.
+  rf2-5b2ct2 · rf2-7737vq."
   [ev fallback]
-  (or (get-in ev [:tags :frame])
-      (:frame ev)
+  (or (trace/trace-event-frame ev)
       fallback))
 
 (defn- egress-trace-event
   "Egress one trace event's VALUES under its OWN frame's classification
   (EP-0015 frame-owned egress, rf2-5b2ct2). The event's frame resolves
-  from its `[:tags :frame]` / top-level `:frame`, falling back to the
+  from its `[:tags :frame]` (canonical reader), falling back to the
   accessor's resolved `fid`. `egress-opts` carries the caller's
   `:include-sensitive?` / `:include-large?` opt-ins."
   [ev fid egress-opts]
-  (egress-value ev (assoc egress-opts :frame (trace-event-frame ev fid))))
+  (egress-value ev (assoc egress-opts :frame (egress-event-frame ev fid))))
 
 ;; ---------------------------------------------------------------------------
 ;; Inspection band (9 accessors)

--- a/tools/xray/src/day8/re_frame2_xray/self_noise.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/self_noise.cljc
@@ -20,11 +20,11 @@
   framework's `emit!`. Two residual classes still need a Xray-side
   guard, both pure-data + JVM-runnable:
 
-  1. **`xray-internal-event?`** — any trace event whose `:frame`
-     (top-level or `:tags :frame`) resolves to `:rf/xray`. Belt-and-
-     braces against reactive sub-read / view-render emits that slipped
-     past the frame gate (e.g. an emit-site that hasn't been touched
-     by the `:rf.trace/frame-no-emit?` migration).
+  1. **`xray-internal-event?`** — any RAW trace event whose
+     `[:tags :frame]` resolves to `:rf/xray`. Belt-and-braces against
+     reactive sub-read / view-render emits that slipped past the frame
+     gate (e.g. an emit-site that hasn't been touched by the
+     `:rf.trace/frame-no-emit?` migration).
 
   2. **`xray-internal-cascade?` / `xray-internal-event-id?`** —
      cascades whose `:event` vector's head is a keyword in the
@@ -58,24 +58,26 @@
   pre-mount seed in `mount.cljs`). The CLJC shape keeps them JVM-
   runnable so the JVM test corpus can drive every axis."
   (:require [clojure.string :as str]
+            [re-frame.trace :as trace]
             [re-frame.trace.projection :as projection]))
 
 ;; ---- predicates ---------------------------------------------------------
 
 (defn xray-internal-event?
-  "True when `event`'s `:frame` slot is `:rf/xray` — i.e. the trace
-  event was emitted by Xray's own subscriptions, views, or any other
-  machinery running under `(rf/with-frame :rf/xray ...)`.
+  "True when `event`'s frame is `:rf/xray` — i.e. the trace event was
+  emitted by Xray's own subscriptions, views, or any other machinery
+  running under `(rf/with-frame :rf/xray ...)`.
 
-  Reads top-level `:frame` first, falling back to `(:tags :frame)`,
-  matching the resolution order the framework's filter axis already
-  uses. Both keys can carry the frame id depending on emit site (Spec
-  009 §Core fields hoists some, leaves others under `:tags`).
+  Reads the RAW trace-event frame via the canonical reader
+  `re-frame.trace/trace-event-frame` (its `[:tags :frame]` slot — Spec
+  009 §Frame identity on the raw event, rf2-7737vq). The prior divergent
+  top-level `:frame` fallback is removed: per the ruling a raw trace
+  event carries frame identity ONLY under `[:tags :frame]`.
 
   Pure-data + JVM-runnable so the predicate is testable without a CLJS
   runtime."
   [event]
-  (= :rf/xray (or (:frame event) (get-in event [:tags :frame]))))
+  (= :rf/xray (trace/trace-event-frame event)))
 
 (defn xray-internal-event-id?
   "True when `event-id` is a keyword in the `rf.xray` namespace OR any

--- a/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
@@ -47,6 +47,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.trace :as trace]
             [re-frame.trace.tooling :as trace-tooling]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.self-noise :as self-noise]))
@@ -135,13 +136,15 @@
   nil)
 
 (defn- frameless-event?
-  "True when `event` has neither a top-level `:frame` slot nor a
-  `:rf.trace/dispatch-id` under `:tags` — the framework's per-frame
-  rings would have skipped it (per the B3 ruling) and Xray's
-  secondary ring is the only place it can be retained."
+  "True when `event` carries neither a frame nor a `:rf.trace/dispatch-id`
+  under `:tags` — the framework's per-frame rings would have skipped it
+  (per the B3 ruling) and Xray's secondary ring is the only place it can
+  be retained. Reads the RAW trace-event frame via the canonical reader
+  `re-frame.trace/trace-event-frame` ([:tags :frame] — rf2-7737vq); the
+  prior divergent top-level `:frame` check is removed (raw events never
+  carry a top-level `:frame`)."
   [event]
-  (and (nil? (:frame event))
-       (nil? (get-in event [:tags :frame]))
+  (and (nil? (trace/trace-event-frame event))
        (nil? (get-in event [:tags :rf.trace/dispatch-id]))))
 
 ;; ---- microtask-coalesced mirror sync (D3=b ruling) ---------------------
@@ -316,7 +319,7 @@
       ;; bump the per-frame suppressed counter so the `[● REDACTED N]`
       ;; indicator surfaces. EP-0015 per-(tool,frame) reveal grain.
       (config/suppress-sensitive? event)
-      (config/note-suppressed! (get-in event [:tags :frame]))
+      (config/note-suppressed! (trace/trace-event-frame event))
 
       :else
       (do

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -1713,8 +1713,9 @@
           "non-sensitive sibling survives"))))
 
 (deftest trace-event-frame-resolves-event-own-frame
-  (testing "rf2-5b2ct2 — `egress-trace-event` resolves a trace event's OWN
-            frame (from [:tags :frame] / top-level :frame) and threads it to
+  (testing "rf2-5b2ct2 / rf2-7737vq — `egress-trace-event` resolves a trace
+            event's OWN frame (from [:tags :frame] via the canonical
+            `re-frame.trace/trace-event-frame` reader) and threads it to
             the egress walker, so per-event projection uses the emitting
             frame's classification — NOT one ambient/resolved frame. A
             sensitive path declared on :host redacts a :host event's value
@@ -1742,7 +1743,7 @@
       (is (= "ada"
              (get-in (#'runtime/egress-trace-event ev :rf/default {}) [:tags :public]))
           "the non-sensitive sibling survives")
-      ;; A frameless event (no [:tags :frame] / :frame), no fallback frame,
+      ;; A frameless event (no [:tags :frame]), no fallback frame,
       ;; AND no ambient scope ⇒ no frame is resolvable anywhere ⇒ fail closed
       ;; (whole-value redacted). This is the get-issues merged-ring case where
       ;; each event must carry its own frame; one that carries none, with the

--- a/tools/xray/test/day8/re_frame2_xray/self_noise_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/self_noise_cljs_test.cljc
@@ -41,29 +41,36 @@
 
 ;; ---- predicate ----------------------------------------------------------
 
-(deftest xray-internal-event?-top-level-frame
-  (testing ":frame at top level — true iff = :rf/xray"
-    (is (true?  (self-noise/xray-internal-event? {:frame :rf/xray})))
-    (is (false? (self-noise/xray-internal-event? {:frame :rf/default})))
-    (is (false? (self-noise/xray-internal-event? {:frame :rf/main})))
-    (is (false? (self-noise/xray-internal-event? {:frame nil})))
-    (is (false? (self-noise/xray-internal-event? {})))))
-
-(deftest xray-internal-event?-tags-frame-fallback
-  (testing ":frame absent at top, present under :tags — fall-back applies"
+(deftest xray-internal-event?-reads-tags-frame
+  ;; rf2-7737vq: the predicate now reads the RAW trace-event frame via the
+  ;; canonical reader `re-frame.trace/trace-event-frame` ([:tags :frame]).
+  ;; Per the ruling a raw trace event carries frame identity ONLY under
+  ;; [:tags :frame]; the prior top-level-`:frame` fallback is gone.
+  (testing ":frame under :tags — true iff = :rf/xray"
     (is (true?  (self-noise/xray-internal-event?
                   {:tags {:frame :rf/xray}})))
     (is (false? (self-noise/xray-internal-event?
                   {:tags {:frame :rf/default}})))
     (is (false? (self-noise/xray-internal-event?
+                  {:tags {:frame :rf/main}})))
+    (is (false? (self-noise/xray-internal-event?
                   {:tags {:frame nil}})))
     (is (false? (self-noise/xray-internal-event?
-                  {:tags {}}))))
-  (testing "top-level wins when both present"
+                  {:tags {}})))
+    (is (false? (self-noise/xray-internal-event? {})))))
+
+(deftest xray-internal-event?-ignores-stray-top-level-frame
+  ;; rf2-7737vq: a stray top-level `:frame` is NOT a public raw-event shape;
+  ;; the canonical reader ignores it. A raw event whose `[:tags :frame]` is
+  ;; absent reads as frameless regardless of a top-level `:frame`.
+  (testing "top-level-only :frame is ignored (raw events frame under :tags)"
+    (is (false? (self-noise/xray-internal-event? {:frame :rf/xray})))
+    (is (false? (self-noise/xray-internal-event? {:frame :rf/default}))))
+  (testing "[:tags :frame] is authoritative when both are present"
     (is (true?  (self-noise/xray-internal-event?
-                  {:frame :rf/xray :tags {:frame :rf/default}})))
+                  {:frame :rf/default :tags {:frame :rf/xray}})))
     (is (false? (self-noise/xray-internal-event?
-                  {:frame :rf/default :tags {:frame :rf/xray}})))))
+                  {:frame :rf/xray :tags {:frame :rf/default}})))))
 
 (deftest xray-internal-event?-realistic-shapes
   (testing "shapes mirroring real :rf.sub/run + :rf.view/render envelopes"
@@ -75,12 +82,12 @@
                    :tags {:rf.sub/id  :rf.xray/trace-buffer
                           :rf.sub/query-v [:rf.xray/trace-buffer]
                           :frame   :rf/xray}})))
-    ;; View re-render from a Xray panel — :frame at top level per
-    ;; re-frame.views/emit-render-trace!.
+    ;; View re-render from a Xray panel — :frame rides under :tags per
+    ;; re-frame.views/emit-view-render-trace! (the emit passes :frame in
+    ;; the tags map; build-event never hoists it top-level — rf2-7737vq).
     (is (true?  (self-noise/xray-internal-event?
                   {:operation :rf.view/render :op-type :rf.view
                    :id 18 :time 1001
-                   :frame :rf/xray
                    :tags  {:rf.view/render-key 42 :frame :rf/xray}})))
     ;; Host event — must not be filtered.
     (is (false? (self-noise/xray-internal-event?
@@ -119,10 +126,11 @@
 #?(:cljs
    (defn- xray-view-render-event []
      ;; Realistic `:rf.view/render` emit from a Xray panel re-rendering.
-     ;; `:frame` is hoisted top-level per re-frame.views/emit-render-trace!.
+     ;; `:frame` rides under `:tags` per re-frame.views/emit-view-render-trace!
+     ;; (the emit passes it in the tags map; build-event never hoists it
+     ;; top-level — rf2-7737vq).
      {:operation :rf.view/render :op-type :rf.view
       :id 3 :time 1002
-      :frame :rf/xray
       :tags  {:rf.view/render-key 42 :frame :rf/xray}}))
 
 #?(:cljs


### PR DESCRIPTION
## Summary

Stage B of rf2-7737vq (Stage A merged the canonical reader `re-frame.trace/trace-event-frame` / `frame-of`, implemented as `(get-in trace-event [:tags :frame])`, and ruled the wire shape). This migrates the production tool consumer sites that hand-re-derived the trace-event frame accessor onto that canonical reader, removing the divergent per-tool fallbacks. Behaviour-preserving.

**The ruling (Stage A):** RAW trace events carry frame identity ONLY at `[:tags :frame]`. DERIVED / projection records (cascade bundles, epoch records, dispatch consequences, cursor / summary records) carry frame identity at TOP-LEVEL `:frame`. One shape, one reader, no compatibility ambiguity.

## Consumer sites migrated (by layer)

**Xray** (all RAW-event readers — divergent top-level `(:frame ev)` fallbacks REMOVED):
- `panels/trace_helpers.cljc` `frame-of` — RAW row projection
- `runtime.cljs` `egress-event-frame` — RAW egress (renamed from the local `trace-event-frame` that shadowed the canonical name)
- `self_noise.cljc` `xray-internal-event?` — RAW predicate
- `trace_collector.cljs` `frameless-event?` + `note-suppressed!` — RAW

**Story** (RAW-event readers; Story already read only `[:tags :frame]` with no divergent fallback, so purely de-duplication onto the contract reader):
- `play.cljc` (removed the private `frame-of`; calls `trace/frame-of`)
- `config.cljc` `event-frame` (kept the `map?` guard)
- `error.cljc` `pipeline-exception-event?`
- `runtime.cljc` phase-capture listener
- `ui/trace_buffer.cljs` `variant-event?`

**pair-mcp** `subscribe.cljs` drain-form **generated code** (rf2-16znzb): the walk runs over a MIXED collection — `:cascades` (DERIVED records, frame at top-level `:frame`) and `:events` (RAW events, frame at `[:tags :frame]`). Per the ruling this is the correct dual-LAYER read, NOT a divergent fallback: kept the top-level `(:frame x)` for the derived layer; migrated the raw arm from the hand-rolled `(get-in x [:tags :frame])` to `(re-frame.trace/trace-event-frame x)`. `re-frame.trace` is loaded in any consumer app via `re-frame.core`, so the generated code resolves at eval time.

**skills pair preload** `runtime.cljs` `trace-matches?` — RAW reader; migrated from the divergent `(or (:frame ev) (get-in ev [:tags :frame]))` to the canonical reader (top-level fallback removed).

**No migration needed:** story-mcp and machines-viz carry zero `frame-of` / `[:tags :frame]` re-derivations (verified by grep). The pair runtime's `:rf.event/origin` reads (`cascade-of`, `epoch-matches?`) are out of scope — they read origin, not frame, and Stage A added no origin reader.

## Divergent fallbacks removed

The `(or (:frame ev) (get-in ev [:tags :frame]))` raw-event dual-read is gone from xray (`frame-of`, `self_noise`, `runtime`, `trace_collector` `frameless-event?`) and the skills pair runtime (`trace-matches?`). Tests that pinned the old dual-read (`self_noise_cljs_test` `xray-internal-event?-top-level-frame`; the bb mirror's frame-filter test) were updated to the new contract: a stray top-level `:frame` is ignored on the raw layer; `[:tags :frame]` is authoritative.

## Spec

- `tools/xray/spec/013-Trace-Consumer.md` — added a Spec 009 §Frame identity on the raw event cross-reference (standing rule: touched tools/xray → update tools/xray/spec).
- machines-viz spec unchanged — no machines-viz source touched.
- skill↔MCP drift: unaffected — the change is internal generated-code, not a tool catalogue / allowed-tools surface change. Drift check passes (exit 0).

## Gates (all green)

- `sh scripts/test-jvm-tools.sh` — xray (1239), machines-viz (550), story (1702), story-mcp (284), mcp-base (247), wire-vocab (101): 0 failures
- `npm run test:cljs` (implementation): 7930 tests / 33017 assertions, 0 failures
- pair-mcp `npm test` (node :server-test): 1114 tests / 3706 assertions, 0 failures
- MCP conformance: pair-mcp end-to-end GREEN, story-mcp end-to-end GREEN, 8 hermetic conformance unit tests pass
- skill↔MCP drift check: exit 0
- bb skills mirror: 29 tests / 102 assertions, 0 failures
- bundle-isolation + uix/helix-reagent-free: PASS (the new requires are tools→core `re-frame.trace`, not a tool leak)
- clj-kondo: 0 errors (3 pre-existing warnings, none introduced)

Closes the Stage-B slice rf2-16znzb. The parent rf2-7737vq is left for the mayor to close after merge (note: a non-enumerated additional divergent frame reader exists at `tools/xray/.../panels/reply_envelope.cljc:547` — reads `(or (:rf.frame/id tags) (:frame-id tags) (:frame ev))`, stale aliases, NOT the canonical `[:tags :frame]`; left untouched as out-of-scope + behaviour-risky, flagged for follow-up triage).