### PR TITLE
refactor(core): collapse consumer-dead realm threading in router/subs/live_frame (rf2-9w37t2, afdlyr stage-2)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -105,18 +105,6 @@
             ;; neutral. The alias is not referenced directly (the facade
             ;; re-exports are gone); the require is load-side-effect-only.
             [re-frame.app-value :as app-value]
-            ;; EP-0023 (rf2-10nggz): the realm machinery is RETAINED INTERNAL
-            ;; substrate (the registrar-backed installation/resolution spine);
-            ;; the public `:realm` registrar-query map arity has been REMOVED
-            ;; from the facade (a registrar-query map is now ALWAYS a
-            ;; frame-targeted read). The alias survives here only for
-            ;; `realm/default-realm-id` (the migration default-realm guard
-            ;; below); the realm-scoped readers `realm/realm-registrations` /
-            ;; `realm-handler-meta` / `realm-handler-ids` remain in
-            ;; `re-frame.realm` for INTERNAL/TOOLING callers (e.g. Xray's
-            ;; host-registry generation-bypass) that require the ns directly.
-            ;; A leaf on the registrar/late-bind spine; bundle-isolation neutral.
-            [re-frame.realm :as realm]
             ;; EP-0023 (rf2-32siq3.17): the public `rf/image` constructor —
             ;; an IMAGE value, the selected registration-set value a frame
             ;; resolves against (EP-0023 §Image, §Public API). PURE inert data
@@ -1217,40 +1205,22 @@
                           `trace/with-call-site` wrapper; subscriptions
                           carry no `:source` axis. DCEs in production."
   [frame {:keys [dispatch-opts subscribe-call-site]}]
-  ;; EP-0013 step 4 (rf2-a15n62): CAPTURE the realm half of the (realm, frame)
-  ;; address at handle-CREATION time, alongside the captured frame — the handle
-  ;; is the capture-at-creation affordance for crossing async boundaries, so it
-  ;; must pin BOTH dimensions of the address (a frame id alone is ambiguous once
-  ;; the same id is legal in two realms). The ambient realm is `*current-realm*`
-  ;; (set when the handle is created inside a realm-routed cascade / drain);
-  ;; nil ⇒ the default realm ⇒ the byte-identical handle (no realm carried, no
-  ;; `:realm` opt stamped). DERIVED from the carried address at creation, never
-  ;; ambient at op-call time (EP-0002 — the whole point of the handle is to NOT
-  ;; depend on op-time dynamic scope). The dispatch ops stamp `:realm` so the
-  ;; envelope routes; the subscribe op rebinds `*current-realm*` (subscribe has
-  ;; no `:realm` opt — it resolves the frame's realm from the carried var).
-  (let [realm (frame/frame-realm frame)
-        realm-opts (when (and realm
-                              (not (= realm realm/default-realm-id)))
-                     {:realm realm})]
-    {:frame frame
-     :dispatch
-     (fn dispatch-fn
-       ([event]      (dispatch* event (merge dispatch-opts realm-opts {:frame frame})))
-       ([event opts] (dispatch* event (merge dispatch-opts opts realm-opts {:frame frame}))))
-     :dispatch-sync
-     (fn dispatch-sync-fn
-       ([event]      (dispatch-sync* event (merge dispatch-opts realm-opts {:frame frame})))
-       ([event opts] (dispatch-sync* event (merge dispatch-opts opts realm-opts {:frame frame}))))
-     :subscribe
-     (fn subscribe-fn
-       [query-v]
-       (frame/call-with-realm realm
-         (fn []
-           (if (and subscribe-call-site interop/debug-enabled?)
-             (trace/with-call-site subscribe-call-site
-               (subs/subscribe frame query-v))
-             (subs/subscribe frame query-v)))))}))
+  {:frame frame
+   :dispatch
+   (fn dispatch-fn
+     ([event]      (dispatch* event (merge dispatch-opts {:frame frame})))
+     ([event opts] (dispatch* event (merge dispatch-opts opts {:frame frame}))))
+   :dispatch-sync
+   (fn dispatch-sync-fn
+     ([event]      (dispatch-sync* event (merge dispatch-opts {:frame frame})))
+     ([event opts] (dispatch-sync* event (merge dispatch-opts opts {:frame frame}))))
+   :subscribe
+   (fn subscribe-fn
+     [query-v]
+     (if (and subscribe-call-site interop/debug-enabled?)
+       (trace/with-call-site subscribe-call-site
+         (subs/subscribe frame query-v))
+       (subs/subscribe frame query-v)))})
 
 (defn frame-handle
   "Return a per-frame OPERATION BUNDLE — the keystone affordance for

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -338,16 +338,6 @@
   (if parent-envelope
     (cond-> (select-keys parent-envelope inheritable-envelope-keys)
       (:rf.machine/internal? parent-envelope)  (assoc :rf.machine/internal? true)
-      ;; EP-0013 step 4 (rf2-a15n62): a child dispatch STAYS in the parent's
-      ;; realm. The parent envelope carries `:rf.realm/id` only for a
-      ;; non-default realm, so inherit it as the child's `:realm` opt
-      ;; (`build-envelope` reads `:realm` → `:rf.realm/id`). Carried as an
-      ;; EXPLICIT opt — NOT left to the ambient `*current-realm*` — so the realm
-      ;; survives the ASYNC `:dispatch-later` timer boundary (the timer callback
-      ;; fires on a fresh stack where no dynamic binding survives), exactly as
-      ;; `:frame` is carried for the same reason. Absent ⇒ default realm.
-      (:rf.realm/id parent-envelope)
-      (assoc :realm (:rf.realm/id parent-envelope))
       ;; Cascade-exclusion (rf2-snsup5): never inherit a reject-tier reserved-fx
       ;; override into a child dispatch. No-op (identity, no churn) when the
       ;; inherited `:fx-overrides` carries no reject-tier key — the dominant path.

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -87,13 +87,13 @@
   ## Relationship to the EP-0013 `re-frame.frame` registry
 
   This is the EP-0023 public live-frame registry. It is DELIBERATELY SEPARATE
-  from `re-frame.frame`'s EP-0013 `(realm, frame)`-addressed `frames` registry
-  (the realm-routed substrate). EP-0023 partially supersedes EP-0013's public
-  app/realm surface while RETAINING the realm machinery as an internal
-  substrate; this slice introduces the image-loaded public frame object without
-  disturbing the existing `reg-frame` / `re-frame.frame/make-anon-frame-record!` callers. The
-  reload slice (.10) wires image replacement on the frame object this slice
-  returns.
+  from `re-frame.frame`'s `frames` registry. EP-0023's public model (image ->
+  frame -> event stream) supersedes EP-0013's app/realm surface; the realm
+  threading through the dispatch/subscribe spine was collapsed to the single
+  default realm (rf2-afdlyr). This slice introduces the image-loaded public
+  frame object without disturbing the existing `reg-frame` /
+  `re-frame.frame/make-anon-frame-record!` callers. The reload slice (.10) wires
+  image replacement on the frame object this slice returns.
 
   ## Frame-derived live resolution (rf2-32siq3.9 — LANDED here)
 
@@ -103,10 +103,9 @@
   inside it — dispatch / subscribe / fx / cofx / view / resource all funnel
   through `registrar/lookup` — resolves through the TARGET frame's OWN image
   generation, not the global/default registrar (EP-0023 §Frame-derived live
-  registration resolution). This is the same observable contract the a15n62
-  slice shipped for the EP-0013 realm substrate (`registrar/*registrar*` bound
-  to a realm's atom), restated for an EP-0023 frame OBJECT that carries its
-  generation directly. Two frames running DIFFERENT images resolve the same
+  registration resolution). The resolution-routing contract is carried by an
+  EP-0023 frame OBJECT that holds its generation directly. Two frames running
+  DIFFERENT images resolve the same
   `[kind id]` to their OWN image's descriptor; absence (a nil target / no
   generation) falls through to the registrar atom path, byte-identical for every
   existing caller (absence-is-default).
@@ -250,20 +249,17 @@
 ;; beside the target, progressive docs examples) all depend on ONE prerequisite:
 ;; live dispatch / subscribe / fx / cofx / view / resource lookups must resolve
 ;; through the TARGET frame's resolved image generation, not the global/default
-;; registrar. The a15n62 slice already shipped this for the EP-0013 realm
-;; substrate by binding `registrar/*registrar*` to a frame's REALM registrar
-;; atom; this slice ships the same observable contract for an EP-0023 frame
-;; OBJECT, which carries its generation directly under `:rf.frame/generation`.
+;; registrar. This is the EP-0023 frame OBJECT's resolution contract — a frame
+;; carries its generation directly under `:rf.frame/generation`.
 ;;
-;; The mechanism is a SINGLE binding seam, mirroring
-;; `re-frame.frame/call-with-frame-realm-registrar`: bind `registrar/*generation*`
+;; The mechanism is a SINGLE binding seam: bind `registrar/*generation*`
 ;; to the frame object's sealed generation around a thunk, and EVERY `(kind, id)`
 ;; lookup inside it (`registrar/lookup` is the universal chokepoint dispatch /
 ;; subscribe / fx / cofx / view / resource all funnel through) resolves through
 ;; the frame's OWN image's resolver. Two frames running DIFFERENT images thus
 ;; resolve the same `[:event :boot/init]` to their OWN image's descriptor.
 ;;
-;; ALL-OR-NOTHING (the a15n62 coherence rule, restated): the binding covers the
+;; ALL-OR-NOTHING (the coherence rule): the binding covers the
 ;; WHOLE cascade — event handler + every cofx injection + the whole fx walk +
 ;; view/resource lookup — so a frame-local handler's effects resolve in the same
 ;; image as the handler. Routing only some lookups would be an incoherent
@@ -272,10 +268,7 @@
 ;; ABSENCE-IS-DEFAULT (the load-bearing fall-through): a nil frame object, or a
 ;; frame object carrying no generation, binds NOTHING — `registrar/*generation*`
 ;; stays nil and resolution falls through to the registrar atom path (the
-;; single-realm default AND the a15n62 realm-routed path alike), byte-identical
-;; for every existing caller. This slice is purely ADDITIVE: it introduces a new
-;; resolution dimension for EP-0023 frame objects without disturbing any path
-;; that does not target one.
+;; single default), byte-identical for every existing caller.
 ;;
 ;; DERIVED from the carried frame object, never an ambient binding (EP-0002
 ;; carried-invariant): the generation is read off the frame the caller targets,
@@ -767,27 +760,16 @@
 
   Returns `{frame-id reload-diff}` for every frame that MOVED (empty when none
   did). EP-0024 (rf2-tu2vr7): with the registries collapsed, an image-loaded
-  frame is simply a `frames` record carrying a generation.
-
-  rf2-vnduo9 — REALM-CORRECT enumeration. This flush runs on a `next-tick`
-  callback (`deferred-flush!`), by which point `*current-realm*` has unwound to
-  nil. The per-frame reads + the `set-generation!` swap inside
-  `reproject-live-frame!` all re-key the registry via `(frame-key *current-realm*
-  id)`, so a NON-default-realm image-loaded frame keyed by its `[realm-id
-  frame-id]` address would MISS a bare-id lookup → silent no-op → its generation
-  stays STALE. So enumerate `frame/image-loaded-frame-addresses` (each carrying the
-  frame's OWN `:realm`, read off the record, not the unwound dynamic var) and bind
-  `*current-realm*` to that realm per frame (via `frame/call-with-realm`) around
-  the reprojection, so every re-key resolves to the frame's own address. The
-  default-realm frame (every public `make-frame`, which is default-realm-only)
-  takes `call-with-realm`'s zero-binding fast path — byte-identical to before."
+  frame is simply a `frames` record carrying a generation. Every frame lives in
+  the single default realm, so a flat `frame/image-loaded-frame-ids` enumeration
+  re-keys the registry correctly with no per-frame realm binding."
   []
-  (reduce (fn [moved {:keys [realm id]}]
-            (if-let [diff (frame/call-with-realm realm #(reproject-live-frame! id))]
+  (reduce (fn [moved id]
+            (if-let [diff (reproject-live-frame! id)]
               (assoc moved id diff)
               moved))
           {}
-          (frame/image-loaded-frame-addresses)))
+          (frame/image-loaded-frame-ids)))
 
 ;; ===========================================================================
 ;; Auto-reprojection on `reg-*` source-store change (EP-0023 §Default Image

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -11,7 +11,6 @@
   (:require [re-frame.frame :as frame]
             [re-frame.elision :as elision]
             [re-frame.live-frame :as live-frame]
-            [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
@@ -308,21 +307,6 @@
                                    :dispatch
                                    {:where    're-frame.router/build-envelope
                                     :event-id (first event)})))
-        ;; EP-0013 step 4 (rf2-a15n62): resolve the REALM half of the carried
-        ;; (realm, frame) address — carried BESIDE `:frame`, never a
-        ;; realm-qualified frame tuple (EP-0013 OI-2). An explicit `:realm`
-        ;; dispatch opt (a realm map or id) wins; absence ⇒ the carried
-        ;; realm currently in scope (`frame/*current-realm*`, set by an
-        ;; outer realm-routed cascade so a child dispatch with no explicit
-        ;; realm STAYS in its parent's realm), which itself defaults to the
-        ;; default realm. `normalize-realm-id` collapses map/keyword/nil to a
-        ;; realm-id keyword. Stamped onto the envelope only when NON-default so
-        ;; the single-realm envelope is byte-identical (absent ⇒ default realm).
-        realm-id           (if (contains? opts :realm)
-                             (frame/normalize-realm-id (:realm opts))
-                             frame/*current-realm*)
-        non-default-realm? (and realm-id
-                                (not (= realm-id realm/default-realm-id)))
         ;; Per rf2-j20a7 / Spec 005 §Level 4: a dispatch emitted from a
         ;; machine's own processing (its `:action` / `:entry` / `:exit` /
         ;; transition handling, via `:fx [[:dispatch …]]` or an inter-
@@ -401,16 +385,7 @@
       ;; policy onto the envelope only when supplied, so `assemble-initial-ctx`
       ;; reads it (per-call wins over the frame config). Absent ⇒ the key is
       ;; omitted and the frame-config / `:live` fallback applies.
-      mint-policy        (assoc :rf.cofx/mint-policy mint-policy)
-      ;; EP-0013 step 4 (rf2-a15n62): carry the realm BESIDE the frame as a
-      ;; SEPARATE fact (`:rf.realm/id`), never a realm-qualified frame tuple
-      ;; (OI-2). Stamped ONLY for a non-default realm so the single-realm
-      ;; envelope is byte-identical (absence = default realm, the documented
-      ;; rule). The router reads it back to route the cascade's frame lookups +
-      ;; handler/fx/cofx/sub resolution through the owning realm. Carried
-      ;; UNCONDITIONALLY (a correctness fact that addresses the frame, not a
-      ;; dev diagnostic), like `:frame` itself.
-      non-default-realm? (assoc :rf.realm/id realm-id))))
+      mint-policy        (assoc :rf.cofx/mint-policy mint-policy))))
 
 (defn- resolve-handler [event-id]
   (registrar/lookup :event event-id))
@@ -1773,7 +1748,7 @@
         ;; framework's appended handler-wrapper (`:rf/default? true`) passes
         ;; through. Hot-path skip: when the chain is nothing but that framework
         ;; default (the common no-authored-chain shape) the walk is bypassed.
-        ;; Refs resolve through the active (realm-aware) registrar.
+        ;; Refs resolve through the active registrar.
         resolved-chain  (if (icpt-reg/chain-needs-resolution? prepended-chain)
                           (icpt-reg/resolve-chain prepended-chain)
                           prepended-chain)
@@ -2283,7 +2258,7 @@
                                 frame-record handler-meta))))))
 
 (defn- process-event!
-  "Wrap process-event* in four dynamic bindings:
+  "Wrap process-event* in three dynamic bindings:
 
    1. `trace/*handler-scope*` — set with the cascade's `:dispatch-id`
       and the envelope's `:call-site`, inheriting the rest from parent.
@@ -2315,46 +2290,22 @@
       threads the frame), or `:dispatch-later` (frame captured in
       closure) for those paths. Per rf2-l5q3.
 
-   3. `registrar/*registrar*` — bound to the owning frame's REALM
-      registrar for the WHOLE cascade WHEN the frame belongs to a
-      non-default realm (EP-0013 staging step 4, rf2-a15n62). This is
-      the realm-routed resolution seam: the event-handler lookup
-      (`resolve-handler`), every declared coeffect's supplier /
-      generator lookup (`:rf.cofx/requires` delivery runs at context
-      assembly via `re-frame.cofx/deliver-declared-cofx`, BEFORE the
-      interceptor chain — EP-0017 retired the `inject-cofx` interceptor),
-      and the whole fx walk (`do-fx` runs post-commit inside this same
-      call) all resolve through `registrar/active-registrar`, so binding
-      once here routes event + cofx + fx coherently to the realm that OWNS the
-      frame (ALL-OR-NOTHING — routing only some would be an incoherent
-      half-dispatch where a realm-local handler's effects resolve in the
-      default registrar). The realm is DERIVED from the carried frame
-      (the envelope's `:frame` → its realm), never an ambient binding
-      (EP-0002). Child dispatches emitted during the fx walk re-enter
-      `process-event!` for THEIR frame and re-derive the binding, so the
-      realm is preserved across the cascade automatically. The
-      default-realm frame (every single-realm app) takes the no-binding
-      fast path inside `call-with-frame-realm-registrar` — byte-identical
-      to the pre-realm hot path.
-
-   4. `registrar/*generation*` — bound to the target frame's resolved
+   3. `registrar/*generation*` — bound to the target frame's resolved
       IMAGE GENERATION for the WHOLE cascade WHEN the carried `:frame`
       names an EP-0023 image-loaded frame (rf2-uejnt3, operationalising
       the rf2-32siq3.9 seam). This is the EP-0023 restatement of the
-      a15n62 invariant in image/frame terms — `target frame -> resolved
-      image generation -> registration resolution`. The SAME chokepoint
-      (`registrar/lookup`) the realm binding above routes — event-handler
-      lookup, every cofx injection, the whole fx walk — resolves through
-      the frame's OWN image generation's resolver, so two frames running
-      DIFFERENT images resolve the same `[kind id]` to their own image's
-      descriptor (ALL-OR-NOTHING — `call-with-frame-resolution` covers the
-      whole thunk, exactly like the realm wrap it nests inside). The
-      generation is DERIVED from the carried frame target
+      `target frame -> resolved image generation -> registration
+      resolution` invariant in image/frame terms. The resolution
+      chokepoint (`registrar/lookup`) — event-handler lookup, every cofx
+      injection, the whole fx walk — resolves through the frame's OWN
+      image generation's resolver, so two frames running DIFFERENT images
+      resolve the same `[kind id]` to their own image's descriptor
+      (ALL-OR-NOTHING — `call-with-frame-resolution` covers the whole
+      thunk). The generation is DERIVED from the carried frame target
       (`frame-resolution-target` resolves a direct frame OBJECT verbatim,
       a frame-id keyword through the live-frame registry), never an
       ambient binding (EP-0002). A target that names no live image-loaded
-      frame — every EP-0013 realm-only frame and the single-realm default
-      alike — yields no generation, so `call-with-frame-resolution` binds
+      frame yields no generation, so `call-with-frame-resolution` binds
       NOTHING and resolution falls through to the registrar-atom path,
       byte-identical (absence-is-default). Child dispatches re-enter
       `process-event!` for their frame and re-derive the binding, so the
@@ -2362,28 +2313,17 @@
   [envelope]
   (trace/with-dispatch-id+call-site (:dispatch-id envelope) (:call-site envelope)
     (binding [frame/*current-frame* (:frame envelope)]
-      ;; EP-0013 step 4 (rf2-a15n62): route the cascade's resolution through
-      ;; the owning frame's realm registrar. Resolve the frame record ONCE
-      ;; here (the realm seam needs it; `process-event*` re-resolves cheaply
-      ;; from the same atom and tolerates a nil — the destroyed-frame branch).
-      ;; A nil record (frame destroyed before drain) yields no binding (the
-      ;; default-realm path), and `process-event*` then takes its
-      ;; `handle-frame-destroyed!` branch as before.
-      (frame/call-with-frame-realm-registrar
-        (frame/frame (:frame envelope))
-        (fn []
-          ;; EP-0023 (rf2-uejnt3): ALSO route the cascade through the target
-          ;; frame's resolved IMAGE generation when the carried `:frame` names
-          ;; an image-loaded frame, NESTED inside the realm binding so event +
-          ;; cofx + fx resolve coherently through the frame's own image
-          ;; (rf2-32siq3.9's seam, invoked at the live entry). A target that
-          ;; names no image-loaded frame (every realm-only / single-realm
-          ;; frame) derives no generation, so this binds nothing and the
-          ;; cascade resolves through the registrar atom exactly as before
-          ;; (absence-is-default). DERIVED from the carried target (EP-0002).
-          (live-frame/call-with-frame-resolution
-            (live-frame/frame-resolution-target (:frame envelope))
-            (fn [] (process-event* envelope))))))))
+      ;; EP-0023 (rf2-uejnt3): route the cascade through the target frame's
+      ;; resolved IMAGE generation when the carried `:frame` names an
+      ;; image-loaded frame, so event + cofx + fx resolve coherently through
+      ;; the frame's own image (rf2-32siq3.9's seam, invoked at the live
+      ;; entry). A target that names no image-loaded frame (a single-realm
+      ;; default frame) derives no generation, so this binds nothing and the
+      ;; cascade resolves through the registrar atom exactly as before
+      ;; (absence-is-default). DERIVED from the carried target (EP-0002).
+      (live-frame/call-with-frame-resolution
+        (live-frame/frame-resolution-target (:frame envelope))
+        (fn [] (process-event* envelope))))))
 
 (def ^:private drain-depth-default
   ;; Deep enough for typical cascade depths. When exceeded, the runtime
@@ -2745,28 +2685,19 @@
   for the queue (its release block re-checks under lock — see
   drain-loop!). On win, runs the drain body and releases.
 
-  Per rf2-ynk7 §single-drainer invariant.
-
-  EP-0013 step 4 (rf2-a15n62): bind the carried `realm-id` for the WHOLE drain
-  (`frame/call-with-realm`) so every bare-`frame-id` registry lookup inside —
-  the frame-record resolution here, plus `run-one-pass!`'s `frame-state-value` /
-  `frame-disposed-for-drain?` and `process-event!`'s frame + handler/fx/cofx/sub
-  resolution — targets the OWNING realm's frame. nil realm ⇒ no binding ⇒ the
-  byte-identical default-realm drain."
-  [realm-id frame-id]
-  (frame/call-with-realm realm-id
-    (fn []
-      (let [frame-record (frame/frame frame-id)]
-        (when frame-record
-          (let [drain-lock  (:drain-lock frame-record)
-                router      (:router frame-record)
-                drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
-            (when (compare-and-set! drain-lock false true)
-              (try
-                (drain-loop! frame-id router drain-lock drain-depth)
-                (catch #?(:clj Throwable :cljs :default) t
-                  (drain-emergency-release! router drain-lock)
-                  (throw t))))))))))
+  Per rf2-ynk7 §single-drainer invariant."
+  [frame-id]
+  (let [frame-record (frame/frame frame-id)]
+    (when frame-record
+      (let [drain-lock  (:drain-lock frame-record)
+            router      (:router frame-record)
+            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+        (when (compare-and-set! drain-lock false true)
+          (try
+            (drain-loop! frame-id router drain-lock drain-depth)
+            (catch #?(:clj Throwable :cljs :default) t
+              (drain-emergency-release! router drain-lock)
+              (throw t))))))))
 
 (defn- drain-block!
   "Synchronous drain entry point (called from `dispatch-sync!`). Unlike
@@ -2785,14 +2716,8 @@
 
   `under-lock-fn` runs once, immediately after CAS-acquire, before the
   drain loop. Exceptions inside it propagate through the same emergency-
-  release path as the drain loop body.
-
-  EP-0013 step 4 (rf2-a15n62): bind the carried `realm-id` for the whole
-  synchronous drain (`frame/call-with-realm`) so the bare-`frame-id` lookups
-  inside resolve to the owning realm (default realm ⇒ no binding)."
-  [realm-id frame-id under-lock-fn]
-  (frame/call-with-realm realm-id
-    (fn []
+  release path as the drain loop body."
+  [frame-id under-lock-fn]
   (let [frame-record (frame/frame frame-id)]
     (when frame-record
       (let [drain-lock  (:drain-lock frame-record)
@@ -2811,15 +2736,10 @@
           (drain-loop! frame-id router drain-lock drain-depth)
           (catch #?(:clj Throwable :cljs :default) t
             (drain-emergency-release! router drain-lock)
-            (throw t))))))))) ;; close fn + call-with-realm (rf2-a15n62)
+            (throw t)))))))
 
 (defn- ensure-drain-scheduled!
-  ;; EP-0013 step 4 (rf2-a15n62): `realm-id` is the carried realm half of the
-  ;; (realm, frame) address. The async drain fires on a fresh stack (no dynamic
-  ;; binding survives `next-tick`), so the realm is CLOSED OVER and rebound
-  ;; inside `drain-try!` — otherwise the drain's bare-`frame-id` lookups would
-  ;; resolve in the default realm. nil ⇒ default ⇒ no binding.
-  [realm-id frame-id router]
+  [frame-id router]
   (let [should-schedule?
         (locking router
           (let [{:keys [scheduled?]} @router]
@@ -2828,7 +2748,7 @@
               (do (swap! router assoc :scheduled? true)
                   true))))]
     (when should-schedule?
-      (interop/next-tick (fn [] (drain-try! realm-id frame-id))))))
+      (interop/next-tick (fn [] (drain-try! frame-id))))))
 
 (defn- emit-dispatched-trace!
   "Emit the :event :event/dispatched trace event for this envelope. Per
@@ -2863,23 +2783,10 @@
   [envelope sync?]
   (let [event        (:event envelope)
         event-id     (when (vector? event) (first event))
-        ;; EP-0013 step 4 (rf2-a15n62): the `:rf.trace/no-emit?` gate reads the
-        ;; TARGET handler's meta, which lives in the owning frame's realm
-        ;; registrar (not the default) for a non-default-realm dispatch. The
-        ;; realm is the envelope's CARRIED `:rf.realm/id` (already resolved by
-        ;; `build-envelope`) — NOT `*current-realm*`, which is unbound at this
-        ;; enqueue site (the drain binds it later). Route the lookup through the
-        ;; carried realm's registrar so a realm-installed tool handler's
-        ;; `:no-emit?` is honoured. Default-realm dispatch (no `:rf.realm/id`)
-        ;; takes the no-binding fast path. Dev-only (this whole emit DCEs under
-        ;; `goog.DEBUG=false`).
-        realm-id     (:rf.realm/id envelope)
+        ;; The `:rf.trace/no-emit?` gate reads the TARGET handler's meta from
+        ;; the registrar. Dev-only (this whole emit DCEs under `goog.DEBUG=false`).
         handler-meta (when event-id
-                       (if-let [reg (and realm-id
-                                         (some-> (realm/realm realm-id) realm/registrar))]
-                         (binding [registrar/*registrar* reg]
-                           (registrar/lookup :event event-id))
-                         (registrar/lookup :event event-id)))
+                       (registrar/lookup :event event-id))
         no-emit?     (trace/no-emit?-from-meta handler-meta)]
     (when-not no-emit?
       (trace/with-call-site (:call-site envelope)
@@ -2929,13 +2836,6 @@
                        (assoc :rf.trace/dispatch-id (:dispatch-id envelope))
                        (:parent-dispatch-id envelope)
                        (assoc :rf.trace/parent-dispatch-id (:parent-dispatch-id envelope))
-                       ;; EP-0013 step 4 (rf2-a15n62): preserve the realm on the
-                       ;; dispatch trace so tooling + the epoch buffer carry the
-                       ;; (realm, frame) address. Only stamped for a non-default
-                       ;; realm (the envelope carries `:rf.realm/id` only then),
-                       ;; so the single-realm trace is byte-identical.
-                       (:rf.realm/id envelope)
-                       (assoc :rf.realm/id (:rf.realm/id envelope))
                        ;; Per rf2-5qp4g: optional per-source-kind detail
                        ;; map (e.g. `{:ms 500}` for `:dispatch-later`)
                        ;; so the Epoch panel's DISPATCH source-kind
@@ -3020,12 +2920,7 @@
   ([event] (dispatch! event {}))
   ([event opts]
    (let [envelope     (build-envelope event opts)
-         ;; EP-0013 step 4 (rf2-a15n62): resolve the frame in the envelope's
-         ;; CARRIED realm (`:rf.realm/id`, absent ⇒ default). The frame record
-         ;; (and its router queue) for a non-default realm lives under the
-         ;; `[realm-id frame-id]` address, so a bare-id lookup would miss it.
-         realm-id     (:rf.realm/id envelope)
-         frame-record (frame/frame realm-id (:frame envelope))]
+         frame-record (frame/frame (:frame envelope))]
      (cond
        (nil? frame-record)
        ;; Per rf2-2hvga (= B + recover-but-emit): dispatch into a
@@ -3043,10 +2938,7 @@
        (let [router (:router frame-record)]
          (emit-dispatched-trace! envelope false)
          (enqueue-envelope! router envelope)
-         ;; Carry the realm into the (possibly async) drain so the drain's
-         ;; bare-`frame-id` registry lookups resolve to the owning realm's
-         ;; frame (default realm ⇒ no binding, byte-identical).
-         (ensure-drain-scheduled! realm-id (:frame envelope) router)))
+         (ensure-drain-scheduled! (:frame envelope) router)))
      nil)))
 
 (defn dispatch-sync!
@@ -3078,11 +2970,7 @@
   ([event] (dispatch-sync! event {}))
   ([event opts]
    (let [envelope     (build-envelope event opts)
-         ;; EP-0013 step 4 (rf2-a15n62): resolve the frame in the envelope's
-         ;; carried realm (absent ⇒ default) — a non-default-realm frame keys
-         ;; by `[realm-id frame-id]`.
-         realm-id     (:rf.realm/id envelope)
-         frame-record (frame/frame realm-id (:frame envelope))
+         frame-record (frame/frame (:frame envelope))
          ;; Read the call-site from the envelope (already gated in
          ;; build-envelope) so the synchronous error emits below can
          ;; carry it without referencing the keyword a second time.
@@ -3155,7 +3043,6 @@
            ;; :in-sync-drain? is cleared in the outer finally after
            ;; drain-block! returns.
            (drain-block!
-             realm-id
              (:frame envelope)
              (fn []
                (swap! router (fn [{:keys [queue] :as r}]

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -129,18 +129,10 @@
                             config's policy, else the router's `:live` default
                             (rf2-5spzo7)
     :rf.trace/call-site     macro-stamped invocation coord (dev-only)
-    :rf.machine/internal?   machine-internal continuation flag (front-queue)
-    :realm                  EP-0013 step 4 (rf2-a15n62) realm-routing opt —
-                            the REALM half of the carried (realm, frame)
-                            address (a realm map or id). `build-envelope`
-                            reads it to resolve `realm-id` and stamps the
-                            non-default result onto the envelope as the
-                            SEPARATE `:rf.realm/id` fact. `:realm` is the
-                            PUBLIC opts spelling; `:rf.realm/id` is the carried
-                            envelope key, never a caller-supplied opt."
+    :rf.machine/internal?   machine-internal continuation flag (front-queue)"
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
     :source-detail :origin :rf.cofx :rf.cofx/mint-policy :rf.trace/call-site
-    :rf.machine/internal? :realm})
+    :rf.machine/internal?})
 
 (defn reject-retired-dispatch-opts!
   "Throw `:rf.error/dispatched-at-retired` when a `dispatch` /

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -997,7 +997,7 @@
    ;; EP-0023 (rf2-32siq3.32): the 2-arity target may be a frame-id KEYWORD or a
    ;; live frame OBJECT (`(rf/subscribe frame query-v)` — `rf/make-frame`'s
    ;; return value). Normalize an object to its runnable-id ADDRESS so the
-   ;; sub-cache lookup (`(frame/frame frame-id)`), the realm-registrar binding,
+   ;; sub-cache lookup (`(frame/frame frame-id)`),
    ;; the override seam, and the error payloads all key the backing record
    ;; unchanged; a keyword passes through. The generation-resolution seam
    ;; (`frame-resolution-target`) then re-resolves the frame's image from this id
@@ -1056,34 +1056,17 @@
    ;; (CLJS, dev-only) returns the constant override reaction on a HIT, or
    ;; nil to fall through to the normal build-and-cache path. On the JVM
    ;; and in production it is always nil (the gate / reader DCE / no-op).
-   ;; EP-0013 step 4 (rf2-a15n62): route subscription resolution through the
-   ;; owning frame's realm registrar. `compute-and-cache!` resolves the sub
-   ;; handler via `registrar/lookup :sub` (and `resolve-sub-override` reads sub
-   ;; meta), so the realm-registrar binding must cover the BUILD path. The
-   ;; binding is established ONCE here and covers the recursive layer-2+ input
-   ;; `subscribe` calls inside `compute-and-cache!` (each re-derives the SAME
-   ;; realm registrar from the same frame-id — idempotent). The reaction's body
-   ;; is closed over the resolved handler at materialization, so a later
-   ;; reactive recompute needs no binding. A non-default-realm frame pays one
-   ;; binding per build (cache MISS); a cache HIT skips this entirely. The
-   ;; default-realm frame takes the no-binding fast path
-   ;; (`frame/realm-registrar-for-frame` returns nil) — byte-identical to the
-   ;; pre-realm subscribe path. DERIVED from the carried frame-id, never ambient
-   ;; (EP-0002).
    ;;
-   ;; EP-0023 (rf2-uejnt3): ALSO route the BUILD path through the target frame's
-   ;; resolved IMAGE generation when `frame-id` names an image-loaded frame —
-   ;; NESTED inside the realm binding so `registrar/lookup :sub` (and the layer-2+
-   ;; input `subscribe` calls inside `compute-and-cache!`) resolve the sub handler
-   ;; through the frame's OWN image (rf2-32siq3.9's seam, invoked at the live
-   ;; subscribe entry). Two frames running DIFFERENT images thus build the same
-   ;; sub-id against their own image's descriptor. A target naming no image-loaded
-   ;; frame (every realm-only / single-realm frame) derives no generation, so this
-   ;; binds nothing and the build resolves through the registrar atom exactly as
-   ;; before (absence-is-default). DERIVED from the carried target (EP-0002).
-   (frame/call-with-frame-realm-registrar
-     (frame/frame frame-id)
-     (fn []
+   ;; EP-0023 (rf2-uejnt3): route the BUILD path through the target frame's
+   ;; resolved IMAGE generation when `frame-id` names an image-loaded frame, so
+   ;; `registrar/lookup :sub` (and the layer-2+ input `subscribe` calls inside
+   ;; `compute-and-cache!`) resolve the sub handler through the frame's OWN
+   ;; image (rf2-32siq3.9's seam, invoked at the live subscribe entry). Two
+   ;; frames running DIFFERENT images thus build the same sub-id against their
+   ;; own image's descriptor. A target naming no image-loaded frame (a
+   ;; single-realm default frame) derives no generation, so this binds nothing
+   ;; and the build resolves through the registrar atom exactly as before
+   ;; (absence-is-default). DERIVED from the carried target (EP-0002).
    (live-frame/call-with-frame-resolution
      (live-frame/frame-resolution-target frame-id)
      (fn []
@@ -1156,7 +1139,7 @@
                (if (identical? reaction (get-in new [k :reaction]))
                  reaction
                  (compute-and-cache! frame-id query-v)))
-             (compute-and-cache! frame-id query-v))))))))))))) ;; close fn + call-with-frame-resolution (rf2-uejnt3) + fn + call-with-frame-realm-registrar (rf2-a15n62) + normalize-target let (rf2-32siq3.32)
+             (compute-and-cache! frame-id query-v))))))))))) ;; close fn + call-with-frame-resolution (rf2-uejnt3) + normalize-target let (rf2-32siq3.32)
 
 (defn subscribe-once
   "One-shot read of a sub's current value. Subscribes, derefs, then

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -487,76 +487,13 @@
         (finally
           (reset! source-store/kind->id->ns->descriptor snapshot))))))
 
-;; ---- the NON-DEFAULT-REALM leg (rf2-vnduo9) -------------------------------
-;;
-;; The reprojection flush runs on `interop/next-tick` (`deferred-flush!`), by
-;; which point the router's per-drain `*current-realm*` binding has UNWOUND to
-;; nil. `reproject-live-frame!`'s reads + `set-generation!` swap all re-key the
-;; registry via `(frame-key *current-realm* id)`. So a NON-default-realm
-;; image-loaded frame — keyed by its `[realm-id frame-id]` address — would be
-;; ENUMERATED by the old bare-`:id` `image-loaded-frame-ids`, but every
-;; subsequent per-frame re-key under nil `*current-realm*` would MISS its address
-;; → silent no-op → its generation stays STALE. The fix has
-;; `reproject-live-frames!` enumerate `image-loaded-frame-addresses` (carrying
-;; each frame's own `:realm`, read off the record) and bind `*current-realm*` per
-;; frame via `call-with-realm` so each re-key resolves the frame's OWN address.
-;;
-;; Not reachable via the public `make-frame` (default-realm-only per EP-0024);
-;; reachable via the internal substrate, which binds `*current-realm*` around a
-;; frame's creation when seating it into a realm (`seat-into-realm!`). This test
-;; mirrors that by binding `frame/*current-realm*` ONLY around creation + the
-;; read-backs, and running `reproject-live-frames!` with `*current-realm*` nil —
-;; exactly the next-tick-flush condition where the latent bug bites.
-
-(deftest reproject-swaps-a-non-default-realm-image-loaded-frame
-  (testing "reproject-live-frames! swaps a NON-default-realm image-loaded frame's
-            generation even though the flush runs with *current-realm* nil
-            (rf2-vnduo9): the frame is enumerated WITH its realm and re-keyed
-            under it, so the source-store change is actually picked up rather than
-            silently no-op'd against a bare-id miss."
-    (let [snapshot @source-store/kind->id->ns->descriptor
-          realm-id :rf.realm/vnduo9-test]
-      (try
-        (source-store/record-descriptor!
-          :event :nd/inc
-          {:rf.provenance/ns "nd.feature" :kind :event :id :nd/inc
-           :handler-fn ::nd-original})
-        (let [img (image/image {:id :nd/img :include-ns ["nd.feature"]})
-              ;; Create the image-loaded frame UNDER a non-default realm — the
-              ;; record is keyed `[realm-id :nd/main]` and stamped `:realm realm-id`
-              ;; (the internal seat-into-realm! shape). `make-frame` runs
-              ;; `reg-frame` which reads `*current-realm*` for the key + stamp.
-              _ (binding [frame/*current-realm* realm-id]
-                  (lf/make-frame {:id :nd/main :images [img]}))]
-          (testing "the frame is image-loaded under its non-default realm address"
-            (binding [frame/*current-realm* realm-id]
-              (is (= ::nd-original
-                     (:handler-fn (asm/resolve-descriptor
-                                    (frame/frame-generation :nd/main)
-                                    :event :nd/inc))))))
-          (testing "the bare-id (default-realm) lookup MISSES it — it is genuinely
-                    non-default-realm, so a realm-unaware flush would no-op"
-            (is (nil? (frame/frame-generation :nd/main))))
-          ;; Hot reload the selected source slot (new impl, same (kind,id,ns)).
-          (source-store/record-descriptor!
-            :event :nd/inc
-            {:rf.provenance/ns "nd.feature" :kind :event :id :nd/inc
-             :handler-fn ::nd-reloaded})
-          ;; THE FAILING PATH: reproject with *current-realm* nil (the next-tick
-          ;; flush condition). Pre-fix this returns {} (the non-default-realm frame
-          ;; is enumerated but its per-frame re-key misses → stale generation).
-          (let [moved (lf/reproject-live-frames!)]
-            (testing "reproject reports the non-default-realm frame as moved"
-              (is (contains? moved :nd/main))
-              (is (contains? (:changed (get moved :nd/main)) [:event :nd/inc])))
-            (testing "its generation actually swapped to the reloaded impl (not stale)"
-              (binding [frame/*current-realm* realm-id]
-                (is (= ::nd-reloaded
-                       (:handler-fn (asm/resolve-descriptor
-                                      (frame/frame-generation :nd/main)
-                                      :event :nd/inc))))))))
-        (finally
-          (reset! source-store/kind->id->ns->descriptor snapshot))))))
+;; The NON-DEFAULT-REALM reproject leg (rf2-vnduo9) was RETIRED under the
+;; realm-substrate collapse (rf2-9w37t2 / rf2-afdlyr): every frame lives in the
+;; single default realm, so `reproject-live-frames!` enumerates the realm-free
+;; `image-loaded-frame-ids` and no per-frame `*current-realm*` re-key is needed.
+;; The default-realm reproject behaviour is covered by the explicit/composed
+;; reproject tests above (source-store-change-reprojects-an-explicit-image-frame,
+;; reproject-composed-frame-on-one-member-ns-change, …).
 
 ;; ===========================================================================
 ;; 9. AUTO-reprojection: a `reg-*` change reprojects the affected explicit-image

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -107,22 +107,6 @@
       (is (empty? (unknown-opt-warnings recorded))
           ":frame is a recognised opt — no warning"))))
 
-(deftest no-warning-for-realm-opt
-  (testing "EP-0013 step 4 (rf2-a15n62): a realm-routed `{:realm r :frame f}`
-            dispatch — the shipped public envelope — emits no unknown-opt
-            warning; `:realm` is a recognised opt build-envelope honours"
-    (rf/reg-frame :game {:doc "non-default frame target"})
-    (rf/reg-event :game/tick {:frame :game} (fn [{:keys [db]} _] {:db db}))
-    (let [recorded (record-traces! ::realm)]
-      ;; `:rf.realm/default` keeps the dispatch on the default realm (so the
-      ;; default-seated `:game` frame resolves and the dispatch completes),
-      ;; while exercising the `:realm` opts key through build-envelope's
-      ;; known-opts check — the path the conformance test drives live with a
-      ;; constructed non-default realm (`{:realm :live/a :frame :live/f}`).
-      (rf/dispatch-sync [:game/tick] {:realm :rf.realm/default :frame :game})
-      (is (empty? (unknown-opt-warnings recorded))
-          ":realm + :frame are both recognised opts — no warning"))))
-
 (deftest no-warning-for-source-and-origin-opts
   (testing "the full known set is accepted without warning"
     (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
@@ -161,11 +145,10 @@
     ;; EP-0017 §6 / slice-B.8 per-call cofx mint policy (rf2-5spzo7) —
     ;; build-envelope reads it and threads it through to the satisfaction
     ;; step's mint-policy resolution, so it belongs in the honoured set.
-    ;; `:realm` is the EP-0013 step 4 (rf2-a15n62) realm-routing opt —
-    ;; build-envelope reads it off the opts map to resolve `realm-id` and
-    ;; stamps the non-default result onto the envelope as `:rf.realm/id`, so
-    ;; the PUBLIC opts spelling `:realm` belongs in the honoured set.
+    ;; (The `:realm` opt was removed under the realm-substrate collapse —
+    ;; rf2-9w37t2 / rf2-afdlyr — every dispatch is the single default realm,
+    ;; so build-envelope no longer reads a realm dimension.)
     (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
              :source-detail :origin :rf.cofx :rf.cofx/mint-policy
-             :rf.trace/call-site :rf.machine/internal? :realm}
+             :rf.trace/call-site :rf.machine/internal?}
            diag/known-dispatch-opts))))


### PR DESCRIPTION
## What

Stage 2 of the realm-substrate collapse (**rf2-9w37t2**, parent **rf2-afdlyr** — RULED by Mike: collapse the retained-internal realm substrate to the single default realm). Stage 1 (#4692) removed the multi-realm substrate and kept default-only threading shims. This PR removes the now consumer-dead realm THREADING in the dispatch/subscribe spine.

The non-default-realm branch was verified consumer-dead by the bead census: every `construct-realm`/non-default `make-realm` call site lives in tests, no example/tool/production path constructs a non-default realm, and `call-with-realm` / `call-with-frame-realm-registrar` both short-circuit to a no-binding thunk for the default realm. Every dispatch and subscribe takes the default-realm fast path in practice.

## Threading removed, per file

- **router/build-envelope** — dropped the realm-id resolution (`:realm` opt / `*current-realm*`) and the `:rf.realm/id` envelope stamp.
- **router/process-event!** — dropped the `call-with-frame-realm-registrar` wrap; the `call-with-frame-resolution` (EP-0023 image-generation) wrap is now the sole resolution wrap (one fewer nesting layer on the hot path).
- **router/drain-try! / drain-block! / ensure-drain-scheduled!** — dropped the threaded `realm-id` param and the per-drain `call-with-realm` wrappers.
- **router/emit-dispatched-trace!** — dropped the realm-registrar rebind for the `:no-emit?` lookup and the `:rf.realm/id` trace re-stamp.
- **router/dispatch! / dispatch-sync!** — dropped the `realm-id` read; collapsed `(frame/frame realm-id frame-id)` to the 1-arity `(frame/frame frame-id)`.
- **router/diagnostics** — removed `:realm` from `known-dispatch-opts` (build-envelope no longer reads a realm dimension; a stray `:realm` now warns like any unknown opt — the no-silent-swallow contract).
- **subs/subscribe** — dropped the `call-with-frame-realm-registrar` wrap.
- **live_frame/reproject-live-frames!** — enumerates the realm-free `image-loaded-frame-ids` instead of a per-frame `call-with-realm` reduce over `image-loaded-frame-addresses`.
- **core/make-frame-handle** — dropped the `frame-realm` capture, `realm-opts`, the merges into dispatch/dispatch-sync opts, and the `call-with-realm` wrap on `:subscribe`; dropped the now-unused `re-frame.realm` require.
- **fx/child-dispatch-opts** — dropped the now-dead `:rf.realm/id -> :realm` inheritance step (the parent envelope can no longer carry `:rf.realm/id`). This is the child-dispatch half of the same envelope realm axis removed from build-envelope.

## Kept (frame.cljc-owned primitives — untouched)

`with-frame`, `*current-realm*`, `call-with-realm`, `call-with-frame-realm-registrar`, `call-in-request-scope`, `frame-realm`, `frame`'s 2-arity, `normalize-realm-id`, `frame-key`'s realm dimension. These are the stable default primitive that other code depends on — confirmed live consumers in **ssr-ring** (stage-3, rf2-sm214m), the **adapters**, and the retained `with-frame` lexical API. The PR switched its callers to the realm-free siblings rather than removing the primitives. `image-loaded-frame-addresses` / `frame-realm` / the realm-registrar seam are now orphaned in frame.cljc and filed for the frame-side owners as **rf2-m6n7hx** (sequenced after ssr-ring stage-3).

## Tests

- Retired `reproject-swaps-a-non-default-realm-image-loaded-frame` (rf2-vnduo9) in `live_frame_reload_cljs_test` — it constructs a non-default realm via the internal substrate and asserts the per-frame realm re-key the collapse removes. Default-realm reproject stays covered by the explicit/composed reproject tests. No test namespace removed (deftest only), so the per-ns isolation gate's `ISOLATION_NAMESPACES` is unchanged.
- Dropped `no-warning-for-realm-opt` and updated the `known-set` drift guard in `unknown_dispatch_opts_warn_test`.

## Exec-line delta

Net **−276 lines** across 8 files (110 insertions, 386 deletions).

## Gates (all green)

- `npm run test:cljs` — 0 failures, 0 errors (7925 tests, 32992 assertions)
- `scripts/test-jvm-implementation.sh` — PASS, 0 failures/0 errors across all artefacts
- `npm run test:bundle-isolation` — PASS (both checks)
- per-ns isolation gate — all 15 namespaces pass standalone
- clj-kondo — no new warnings vs baseline
- splint — 8 warnings (down from 10 baseline, zero new; the 2 removed lived in the deleted realm threading)
- api-manifest drift-check — OK, 486 public vars in sync (no public var changed)

No `:rf.error/*` category was removed, so no Spec 009 catalogue row changes. Spec docs + Xray vocab are out of scope (rf2-pl97nd, closed; the EP-0023 addendum is a separate afdlyr deliverable); Xray panels already tolerate the absence of `:rf.realm/id`.