### PR TITLE
fix(machines): depth-limit abort surfaces as failure + decl-path root default + raise-cofx replay determinism (rf2-y3jv8q +2)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -999,8 +999,20 @@
                              (catch :default e
                                {:re-frame.machines.result/snap nil
                                 :re-frame.machines.result/fx   [:error (ex-message e)]}))
-          snap-out      (:re-frame.machines.result/snap r)
-          fx-out        (:re-frame.machines.result/fx r)
+          ;; rf2-y3jv8q — a bounded-depth abort (:always / :raise depth limit
+          ;; tripped on a runaway cycle) now returns a result/fail carrying the
+          ;; ::depth-abort? sentinel, NOT an :ok rollback no-op (XState v5 throws
+          ;; on such a cycle). The fixture's :expect-next-snapshot /
+          ;; :expect-effects capture the atomic-rollback contract; project the
+          ;; depth-abort :fail onto the observable rollback shape (input
+          ;; snapshot, empty effects). Detected via the fully-qualified keyword
+          ;; literals so this fixture-runner keeps avoiding a require on the
+          ;; result ns.
+          depth-abort?  (and (= :fail (:re-frame.machines.result/tag r))
+                             (true? (get-in r [:re-frame.machines.result/info
+                                               :re-frame.machines.result/depth-abort?])))
+          snap-out      (if depth-abort? (:snapshot call) (:re-frame.machines.result/snap r))
+          fx-out        (if depth-abort? [] (:re-frame.machines.result/fx r))
           want-snap     (:expect-next-snapshot call)
           want-fx       (or (:expect-effects call) [])
           ok-snap?      (= want-snap snap-out)

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -1158,8 +1158,21 @@
                              (catch Throwable e
                                {:re-frame.machines.result/snap nil
                                 :re-frame.machines.result/fx   [:error (.getMessage e)]}))
-          snap-out      (:re-frame.machines.result/snap r)
-          fx-out        (:re-frame.machines.result/fx r)
+          ;; rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth
+          ;; limit tripped on a runaway cycle) now returns a `result/fail`
+          ;; carrying the `::depth-abort?` sentinel, NOT an `:ok` rollback
+          ;; no-op (XState v5 throws on such a cycle). The fixture's
+          ;; `:expect-next-snapshot` / `:expect-effects` capture the
+          ;; atomic-rollback contract (the macrostep does not commit), so
+          ;; project a depth-abort `:fail` onto the observable rollback shape:
+          ;; next-snapshot is the INPUT snapshot, effects empty. Detected via
+          ;; the fully-qualified keyword literals so this ns keeps avoiding a
+          ;; static require on the machines artefact.
+          depth-abort?  (and (= :fail (:re-frame.machines.result/tag r))
+                             (true? (get-in r [:re-frame.machines.result/info
+                                               :re-frame.machines.result/depth-abort?])))
+          snap-out      (if depth-abort? (:snapshot call) (:re-frame.machines.result/snap r))
+          fx-out        (if depth-abort? [] (:re-frame.machines.result/fx r))
           want-snap     (:expect-next-snapshot call)
           want-fx       (or (:expect-effects call) [])
           ok-snap?      (= want-snap snap-out)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -194,6 +194,29 @@
            :reason            reason})))
     {}))
 
+(defn- handle-step-failure!
+  "Route a `result/fail` macrostep to the handler's `{}` short-circuit
+  (atomic rollback — no snapshot write reaches runtime-db) per Spec 005
+  §Bounded depth / §Final states §`:on-error`.
+
+  rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth limit
+  tripped on a runaway cycle, the XState-v5-throws case) is a DISTINCT
+  failure from a thrown action: the engine already emitted the precise
+  `:rf.error/machine-{always,raise}-depth-exceeded` category at the abort
+  site (the single trace for the trip), so re-emitting the generic
+  `:rf.error/machine-action-exception` here would be a misleading second
+  signal. For a depth-abort we therefore SKIP `trace-action-failure!`
+  (which also routes the spawn-`:on-error` control flow — irrelevant to a
+  depth trip) and return `{}` directly. A thrown-action `:fail` keeps the
+  existing `trace-action-failure!` routing (the action-exception trace +
+  the spawn-`:on-error` dispatch). Both paths short-circuit the handler to
+  `{}`, so neither writes the post-event snapshot — the pre-event snapshot
+  stays committed in runtime-db (the atomic-rollback contract)."
+  [ctx event reason r]
+  (if (result/depth-abort? r)
+    {}
+    (trace-action-failure! ctx event reason (result/info r))))
+
 ;; ---- 4-step pipeline (rf2-2zzyg) ------------------------------------------
 ;;
 ;; The handler-fn returned by `make-machine-handler` decomposes into four
@@ -824,9 +847,14 @@
           (let [ctx         (ensure-bootstrap-cofx ctx)
                 boot-result (maybe-boot ctx)]
             (if (result/fail? boot-result)
-              (trace-action-failure! ctx [transition/start-marker]
-                                     "Machine initial-entry action threw."
-                                     (result/info boot-result))
+              ;; rf2-y3jv8q — route both a thrown initial-entry action AND a
+              ;; birth-time bounded-depth abort (a born-state `:always` / raise
+              ;; runaway) through the shared failure handler: a depth-abort
+              ;; skips the misleading action-exception re-emit (its precise
+              ;; category fired in-engine) while both atomically roll back.
+              (handle-step-failure! ctx [transition/start-marker]
+                                    "Machine initial-entry action threw."
+                                    boot-result)
               (result/with-ok [post-boot-snap boot-fx] boot-result
                 ;; Per rf2-gl588 — PURE init-kick (the Job-B cut-point,
                 ;; sub-decision (b)): when the routed inner event IS the
@@ -889,9 +917,16 @@
                   (let [ctx (ensure-ctx-cofx ctx post-boot-snap)
                         step-result (run-step ctx post-boot-snap)]
                     (if (result/fail? step-result)
-                      (trace-action-failure! ctx (:inner-event ctx)
-                                             "Machine action threw."
-                                             (result/info step-result))
+                      ;; rf2-y3jv8q — route both a thrown transition action AND
+                      ;; a bounded-depth abort (the runaway `:always` / `:raise`
+                      ;; cycle, XState-v5-throws case) through the shared
+                      ;; failure handler. A depth-abort surfaces as a FAILED
+                      ;; macrostep (atomic rollback, the precise depth-exceeded
+                      ;; category already emitted in-engine) rather than the
+                      ;; pre-fix silent no-op that swallowed the event.
+                      (handle-step-failure! ctx (:inner-event ctx)
+                                            "Machine action threw."
+                                            step-result)
                       ;; Per rf2-n9f4z: pass the full `boot-result` (fx +
                       ;; bootstrap-entry cascade), not just `boot-fx`, so a
                       ;; same-call bootstrap's entry cascade prepends the

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -942,17 +942,25 @@
               ;; survives (Spec 005 §Drain semantics: bounded depth halts
               ;; with the snapshot uncommitted, `:no-recovery`).
               (>= depth raise-limit)
-              (do (trace/emit-error! :rf.error/machine-raise-depth-exceeded
-                                     ;; rf2-yyvtk5 — the aborting actor is a
-                                     ;; LIVE INSTANCE; address it by `:actor-id`
-                                     ;; (mirrors the flat drain), not
-                                     ;; `:machine-id` (the registered TYPE).
-                                     {:actor-id   (or (:rf/parent-id machine)
-                                                      (:id machine))
-                                      :depth      depth
-                                      :frame      (:rf/frame machine)
-                                      :recovery   :no-recovery})
-                  (result/ok snapshot []))
+              ;; rf2-y3jv8q — a tripped re-broadcast `:raise` depth limit is a
+              ;; FAILED macrostep, not a benign no-op (parity with the flat
+              ;; drain in `transition/drain-to-fixed-point`). Emit the precise
+              ;; category, then return a `result/fail` carrying the
+              ;; `::depth-abort?` sentinel so the runaway region raise cycle
+              ;; routes through the handler's failure path (atomic rollback
+              ;; preserved — no snapshot write reaches runtime-db) instead of
+              ;; surfacing as a silent no-op that swallows the triggering event.
+              (let [info {;; rf2-yyvtk5 — the aborting actor is a LIVE INSTANCE;
+                          ;; address it by `:actor-id` (mirrors the flat drain),
+                          ;; not `:machine-id` (the registered TYPE).
+                          :error-id   :rf.error/machine-raise-depth-exceeded
+                          :actor-id   (or (:rf/parent-id machine)
+                                          (:id machine))
+                          :depth      depth
+                          :frame      (:rf/frame machine)
+                          :recovery   :no-recovery}]
+                (trace/emit-error! :rf.error/machine-raise-depth-exceeded info)
+                (result/depth-abort info))
 
               :else
               (let [ev   (first pending)

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -1329,7 +1329,6 @@
   (transition/drain-to-fixed-point
     region-spec
     (result/ok region-snap [])
-    region-snap                         ; atomic-rollback target = post-cascade
     0                                   ; raise-depth seed
     true))                              ; defer raises to the parent queue
 
@@ -1411,7 +1410,6 @@
         ;; drains FIFO inside the birth macrostep instead of escaping to the
         ;; outbound fx layer (bz0ox.1).
         (result/ok boot-snapshot (vec entry-fx))
-        boot-snapshot
         0
         false))))
 

--- a/implementation/machines/src/re_frame/machines/result.cljc
+++ b/implementation/machines/src/re_frame/machines/result.cljc
@@ -96,6 +96,45 @@
     (assoc r ::info (merge (::info r) extra))
     r))
 
+(defn depth-abort
+  "Build a `:fail` Result for a bounded-depth abort (`:always-depth-limit`
+  / `:raise-depth-limit` tripped mid-macrostep) — per rf2-y3jv8q.
+
+  A runaway eventless / raise cycle (e.g. `a →:always b →:always a`) is NOT
+  a benign no-op: XState v5 THROWS on such a cycle. The pre-fix engine
+  returned `(ok rollback-snapshot [])` from the abort, which the lifecycle
+  boundary (`commit-or-finalize`) saw as `next == snapshot` ⇒ a no-op,
+  emitting NO `:rf.machine/transition` trace and routing NO error to the
+  handler return — the runaway was indistinguishable from a guard-blocked
+  no-op and the triggering user event was silently swallowed (only an
+  out-of-band `emit-error!` recorded it).
+
+  Returning a `:fail` instead routes the abort through the SAME failure
+  path an action exception takes (`trace-action-failure!` short-circuits the
+  handler to `{}`), so the macrostep surfaces as a FAILED macrostep — no
+  snapshot write reaches runtime-db, preserving the atomic rollback Spec
+  005 §Bounded depth requires (the pre-event snapshot stays committed),
+  while the event is no longer silently consumed.
+
+  The `::info` map carries `::depth-abort? true` so the handler routing
+  recognises this is a depth-abort — NOT a thrown action — and SKIPS the
+  generic `:rf.error/machine-action-exception` re-emit (the engine already
+  emitted the precise `:rf.error/machine-{always,raise}-depth-exceeded`
+  category at the abort site, the single trace for the trip). `info` carries
+  the diagnostic context (`:error-id`, `:actor-id`, `:depth`, `:path`,
+  `:frame`) for callers / tests that inspect the `::info`."
+  [info]
+  {::tag :fail ::info (assoc info ::depth-abort? true)})
+
+(defn depth-abort?
+  "True iff `r` is a `:fail` Result produced by a bounded-depth abort
+  (`depth-abort`) — distinguishes a `:always` / `:raise` depth-limit trip
+  from a thrown-action `:fail`, so the handler routing skips the generic
+  action-exception trace for the depth case (rf2-y3jv8q). A non-`:fail`
+  Result (or a thrown-action `:fail`) returns false."
+  [r]
+  (and (fail? r) (true? (get-in r [::info ::depth-abort?]))))
+
 (defn snap
   "Read the post-transition snapshot off an `:ok` Result. One-char-shorter
   spelling of `(::result/snap r)` — same semantics. For pair destructures

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -3818,27 +3818,39 @@
                 ;; ---- (1) PREFER `:always` — settle eventless first --------
                 (some? always-m)
                 (if (>= always-depth always-limit)
-                  (do (trace/emit-error! :rf.error/machine-always-depth-exceeded
-                                         {;; rf2-yyvtk5 — the aborting actor is
-                                          ;; a LIVE INSTANCE. Its address is
-                                          ;; `:rf/parent-id` (stamped by
-                                          ;; `prepare-machine-ctx`; the spec map
-                                          ;; forbids `:id`), or `:id` for a
-                                          ;; singleton (whose registration id IS
-                                          ;; its live address). It rides under
-                                          ;; `:actor-id`; `:machine-id` is the
-                                          ;; registered TYPE.
-                                          :actor-id   (or (:rf/parent-id m)
-                                                          (:id m))
-                                          :depth      always-depth
-                                          :path       visited
-                                          ;; Per rf2-ko8jb: epoch-capture
-                                          ;; admission requires `:frame`.
-                                          :frame      (:rf/frame m)
-                                          :recovery   :no-recovery})
-                      ;; Macrostep rolls back atomically — no cascade survives
-                      ;; the abort.
-                      (result/ok rollback-snapshot []))
+                  ;; rf2-y3jv8q — a tripped `:always` depth limit is a FAILED
+                  ;; macrostep, not a benign no-op. XState v5 THROWS on such a
+                  ;; runaway eventless cycle. Emit the precise error category
+                  ;; (the single trace for the trip) and return a `result/fail`
+                  ;; carrying the `::depth-abort?` sentinel so it routes through
+                  ;; the handler's failure path (`trace-action-failure!`
+                  ;; short-circuits to `{}` — no snapshot write reaches
+                  ;; runtime-db, so the rollback to the pre-event snapshot is
+                  ;; preserved). The pre-fix `(result/ok rollback-snapshot [])`
+                  ;; surfaced as `next == snapshot` ⇒ a no-op (no
+                  ;; `:rf.machine/transition`, no error to the return),
+                  ;; indistinguishable from a guard-blocked no-op and silently
+                  ;; swallowing the triggering event.
+                  (let [info {;; rf2-yyvtk5 — the aborting actor is a LIVE
+                              ;; INSTANCE. Its address is `:rf/parent-id`
+                              ;; (stamped by `prepare-machine-ctx`; the spec map
+                              ;; forbids `:id`), or `:id` for a singleton (whose
+                              ;; registration id IS its live address). It rides
+                              ;; under `:actor-id`; `:machine-id` is the
+                              ;; registered TYPE.
+                              :error-id   :rf.error/machine-always-depth-exceeded
+                              :actor-id   (or (:rf/parent-id m)
+                                              (:id m))
+                              :depth      always-depth
+                              :path       visited
+                              ;; Per rf2-ko8jb: epoch-capture admission requires
+                              ;; `:frame`.
+                              :frame      (:rf/frame m)
+                              :recovery   :no-recovery}]
+                    (trace/emit-error! :rf.error/machine-always-depth-exceeded info)
+                    ;; Macrostep rolls back atomically — no cascade survives the
+                    ;; abort; the `result/fail` carries no `::snap`/`::fx`.
+                    (result/depth-abort info))
                   ;; Per rf2-82a0u: `:always` microstep's transition `:action`
                   ;; `action-ran` emit carries `:phase :always` so the Handler
                   ;; section can group eventless cascades distinctly from
@@ -3921,26 +3933,32 @@
                       (result/with-microsteps always-depth)
                       (result/with-cascade cascade))
                   (if (>= raise-depth raise-limit)
-                    (do (trace/emit-error! :rf.error/machine-raise-depth-exceeded
-                                           {;; rf2-yyvtk5 — the aborting actor is
-                                            ;; a LIVE INSTANCE; its address is
-                                            ;; `:rf/parent-id` (stamped by
-                                            ;; `prepare-machine-ctx`; the spec
-                                            ;; map forbids `:id`), or `:id` for a
-                                            ;; singleton. It rides under
-                                            ;; `:actor-id`; `:machine-id` is the
-                                            ;; registered TYPE.
-                                            :actor-id   (or (:rf/parent-id m)
-                                                            (:id m))
-                                            :depth      raise-depth
-                                            ;; Per rf2-ko8jb: epoch-capture
-                                            ;; admission requires `:frame`.
-                                            :frame      (:rf/frame m)
-                                            :recovery   :no-recovery})
-                        ;; Macrostep rolls back atomically — neither the
-                        ;; partially-advanced snapshot nor the accumulated
-                        ;; effects survive the abort.
-                        (result/ok rollback-snapshot []))
+                    ;; rf2-y3jv8q — a tripped `:raise` depth limit is a FAILED
+                    ;; macrostep, not a benign no-op (mirrors the `:always`
+                    ;; abort above). Emit the precise category, then return a
+                    ;; `result/fail` carrying the `::depth-abort?` sentinel so
+                    ;; the runaway raise cycle routes through the handler's
+                    ;; failure path and the triggering event is no longer
+                    ;; silently swallowed.
+                    (let [info {;; rf2-yyvtk5 — the aborting actor is a LIVE
+                                ;; INSTANCE; its address is `:rf/parent-id`
+                                ;; (stamped by `prepare-machine-ctx`; the spec
+                                ;; map forbids `:id`), or `:id` for a singleton.
+                                ;; It rides under `:actor-id`; `:machine-id` is
+                                ;; the registered TYPE.
+                                :error-id   :rf.error/machine-raise-depth-exceeded
+                                :actor-id   (or (:rf/parent-id m)
+                                                (:id m))
+                                :depth      raise-depth
+                                ;; Per rf2-ko8jb: epoch-capture admission
+                                ;; requires `:frame`.
+                                :frame      (:rf/frame m)
+                                :recovery   :no-recovery}]
+                      (trace/emit-error! :rf.error/machine-raise-depth-exceeded info)
+                      ;; Macrostep rolls back atomically — neither the
+                      ;; partially-advanced snapshot nor the accumulated effects
+                      ;; survive the abort.
+                      (result/depth-abort info))
                     (let [[_ ev]       (first pending)
                           rest-pending (subvec pending 1)
                           ;; rf2-xsdn5h — re-run the consumer-attachment ensure

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -3774,12 +3774,15 @@
   becomes the base cascade and the `:always` loop appends one `:microstep`
   step per eventless iteration.
 
-  `rollback-snapshot` is the snapshot the macrostep atomically reverts to
-  if the loop trips `:always-depth-limit` or `:raise-depth-limit` — the
-  macrostep is atomic per Spec 005 §Bounded depth. The event-driven caller
-  passes the PRE-event snapshot (the whole macrostep unwinds); the birth
-  caller passes the POST-cascade snapshot (the initial state is already the
-  committed configuration — only the runaway settling is abandoned).
+  Atomic rollback on a tripped `:always-depth-limit` / `:raise-depth-limit`
+  (Spec 005 §Bounded depth) is enforced by the FAILURE SURFACE (rf2-y3jv8q):
+  the abort returns a `result/depth-abort` `:fail`, which threads NO snapshot
+  / fx, and the lifecycle handler short-circuits to `{}` — so neither a
+  partially-advanced snapshot nor accumulated fx reaches runtime-db, and the
+  last committed snapshot (the pre-event snapshot for the event-driven caller,
+  the post-cascade initial configuration for the birth caller) stays put. No
+  explicit rollback-target argument is threaded — the `:fail` carrying no
+  payload IS the rollback.
 
   `raise-depth` seeds the transitive `:raise` depth counter (rf2-b88nm);
   `defer?` is the effective region-defer flag. When `defer?` is true (a
@@ -3792,7 +3795,7 @@
 
   Returns a `result/ok` (snapshot + fx, with `::microsteps` / `::cascade`)
   or a `result/fail` if an `:always` action or a handled raise threw."
-  [machine start-result rollback-snapshot raise-depth defer?]
+  [machine start-result raise-depth defer?]
   (let [always-limit (get machine :always-depth-limit always-depth-limit-default)
         raise-limit  (get machine :raise-depth-limit  raise-depth-limit-default)]
     (if (result/fail? start-result)
@@ -4214,10 +4217,11 @@
     ;; Steps 3-5: hand the post-event seed Result to the shared
     ;; `drain-to-fixed-point` — raise-drain FIFO, `:always` fixed-point
     ;; loop, tag commit (rf2-505ic factored this out so machine birth
-    ;; reuses the identical settling tail). The atomic-rollback target is
-    ;; the PRE-event `snapshot` (the whole macrostep unwinds on
-    ;; `:always`-depth abort). `handled?` rides the Result for the
+    ;; reuses the identical settling tail). On a depth-abort the drain returns
+    ;; a `result/depth-abort` `:fail` (rf2-y3jv8q) — the whole macrostep
+    ;; unwinds via the failure surface (no snapshot threaded), leaving the
+    ;; PRE-event `snapshot` committed. `handled?` rides the Result for the
     ;; parallel parent's all-regions-declined no-op aggregation.
     (result/with-handled
-     (drain-to-fixed-point machine result-after-event snapshot raise-depth defer?)
+     (drain-to-fixed-point machine result-after-event raise-depth defer?)
      handled?))))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -2853,7 +2853,28 @@
                       `:rf.machine.history/restored` trace from it."
   [machine snapshot transition transition-phase]
   (let [src-path      (state-path (:state snapshot))
-        decl-path     (:decl-path transition (vec (take 1 src-path)))
+        ;; rf2-h16qii — the transition's DECLARATION path: the absolute path
+        ;; of the state node whose `:on` / `:always` / `:after` table this
+        ;; transition was declared in. It anchors the LCA geometry below —
+        ;; `target-path` resolves a keyword target as a SIBLING at this level
+        ;; (`(conj (drop-last decl-path) target)`), and `:same-state` resolves
+        ;; to `decl-path` itself. Every in-tree caller stamps `:decl-path`
+        ;; (`pick-transition` / the `:always` / `:after` pick sites, then
+        ;; `machine-transition-single` `(assoc :decl-path …)`), so the default
+        ;; is reached ONLY by a pure-fn / hand-built / future caller of the
+        ;; public `apply-transition-once`. The default is ROOT (`[]`): a
+        ;; transition with no declared owning node is, by definition, declared
+        ;; on the machine ROOT — `target-path` then resolves a keyword target
+        ;; to a top-level sibling (`[target]`) and `:same-state` to the root,
+        ;; which is the correct geometry for a root-declared targetless /
+        ;; self transition. The pre-fix default `(take 1 src-path)` GUESSED
+        ;; depth-1 (the first element of the active leaf's path) — wrong for a
+        ;; root-declared transition (its decl-path is `[]`, not `[<top>]`), so
+        ;; the LCA / exit / entry cascade diverged. (A transition declared
+        ;; DEEPER than root without a stamped `:decl-path` is not a reachable
+        ;; in-tree case; the root default is the principled, geometry-correct
+        ;; choice for the only caller that hits it.)
+        decl-path     (:decl-path transition [])
         raw-target    (:target transition)
         ;; `targetless?` is the structural "no `:target` declared" predicate.
         ;; It is NOT the same as the effective `internal?` flag computed

--- a/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
@@ -265,10 +265,13 @@
       (is (= :r-boot (:right state))
           "region :right's birth `:always` (guard false) stayed at its initial leaf"))))
 
-(deftest pure-birth-always-depth-limit-rolls-back-to-initial
-  (testing "a birth `:always` cycle trips `:always-depth-limit` and rolls
-            back atomically to the POST-cascade initial configuration — the
-            initial state survives, only the runaway settle is abandoned"
+(deftest pure-birth-always-depth-limit-surfaces-as-failed-macrostep
+  (testing "a birth `:always` cycle trips `:always-depth-limit` and surfaces
+            as a FAILED macrostep (rf2-y3jv8q — XState v5 throws on such a
+            runaway). The `:fail` carries the `::depth-abort?` sentinel and
+            threads NO snapshot; atomic rollback is enforced by the failure
+            surface (the lifecycle handler short-circuits to `{}`, leaving the
+            post-cascade initial configuration committed)"
     (let [m {:initial :a
              :data    {}
              :always-depth-limit 5
@@ -277,9 +280,11 @@
                        :b {:always [{:guard :p? :target :a}]}}}
           initial (parallel/build-initial-snapshot m {:bootstrap-pending? false})
           r       (parallel/apply-initial-entry-cascade m initial)]
-      (is (result/ok? r) "birth returns :ok (atomic rollback, not a :fail)")
-      (is (= :a (:state (result/snap r)))
-          "the birth `:always` cycle rolled back to the initial state :a"))))
+      (is (result/fail? r) "birth returns a :fail (failed macrostep), not an :ok no-op")
+      (is (result/depth-abort? r)
+          "the :fail carries the ::depth-abort? sentinel (a bounded-depth trip)")
+      (is (nil? (result/snap r))
+          "a :fail threads no snapshot — the runaway settle commits nothing"))))
 
 ;; ===========================================================================
 ;; LIVE — eager `[:rf.machine/start]` and lazy first-event birth

--- a/implementation/machines/test/re_frame/machine_decl_path_default_test.clj
+++ b/implementation/machines/test/re_frame/machine_decl_path_default_test.clj
@@ -1,0 +1,88 @@
+(ns re-frame.machine-decl-path-default-test
+  "Per rf2-h16qii — `compute-cascade-paths`' default `:decl-path` is ROOT
+  (`[]`), not a depth-1 guess.
+
+  `compute-cascade-paths` (reached via the public `apply-transition-once`)
+  reads `(:decl-path transition <default>)` — the absolute path of the state
+  node whose `:on` / `:always` / `:after` table the transition was declared
+  in. It anchors the LCA / exit / entry geometry: the `target-descendant-of-
+  decl?` rule (XState v5 — \"child nodes targeted by a compound transition are
+  re-entered\") is GATED on a NON-EMPTY decl-path (`(pos? (count decl-path))`),
+  which deliberately excludes the synthetic ROOT.
+
+  The pre-fix default was `(vec (take 1 src-path))` — the FIRST element of the
+  active leaf's path, i.e. it assumed the transition was declared at DEPTH 1.
+  Every in-tree caller stamps `:decl-path` (via `pick-transition` then
+  `machine-transition-single`'s `(assoc :decl-path …)`), so the default is
+  reached only by a pure-fn / hand-built / future caller of the public
+  `apply-transition-once`. For such a caller a ROOT-declared transition
+  (decl-path `[]`) on a deep machine was mis-located at `[<top>]` — a NON-empty
+  path that WRONGLY tripped `target-descendant-of-decl?`, diverging the LCA
+  geometry (the wrong exit / entry set).
+
+  This is a pure-engine geometry test — it calls `apply-transition-once`
+  directly with a transition map carrying NO `:decl-path`, so it exercises the
+  default. JVM-runnable from arguments alone."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.machines.result :as result]
+            [re-frame.machines.transition :as transition]))
+
+;; A deep compound machine. `:p` is a top-level compound (initial :q); `:q` and
+;; `:r` are its children; `:r` is itself compound (initial :s). Each state
+;; records its `:exit` / `:entry` firing into `:data :log` so the cascade is
+;; observable. The active configuration is the leaf [:p :q].
+(def ^:private deep-machine
+  {:initial :p
+   :data    {:log []}
+   :actions {:exit-q  (fn [{:keys [data]}] {:data (update data :log conj :exit-q)})
+             :exit-p  (fn [{:keys [data]}] {:data (update data :log conj :exit-p)})
+             :enter-r (fn [{:keys [data]}] {:data (update data :log conj :enter-r)})
+             :enter-s (fn [{:keys [data]}] {:data (update data :log conj :enter-s)})}
+   :states
+   {:p {:initial :q
+        :states  {:q {:exit :exit-q}
+                  :r {:initial :s
+                      :entry   :enter-r
+                      :states  {:s {:entry :enter-s}}}}}}})
+
+(deftest decl-path-default-is-root-not-depth-1
+  (testing "a ROOT-declared transition with NO `:decl-path` (a pure-fn /
+   hand-built caller) targeting a deep descendant of a DIFFERENT top-level
+   subtree resolves the LCA geometry from ROOT — NOT the depth-1 guess that
+   would mis-trip `target-descendant-of-decl?` and break the exit/entry set"
+    ;; Active leaf [:p :q]; transition (no :decl-path) targets [:p :r :s]
+    ;; (a deeper descendant of :p, NOT on the active branch). The LCCA of
+    ;; [:p :q] and [:p :r :s] is [:p] (common-prefix length 1), so the
+    ;; correct geometry exits :q (deepest-first) and enters :r then :s while
+    ;; :p survives.
+    ;;
+    ;; With the ROOT default (decl-path []): `target-descendant-of-decl?` is
+    ;; false (empty decl-path), so lca-len = common-prefix = 1 → exit :q,
+    ;; enter :r, :s. CORRECT.
+    ;;
+    ;; With the pre-fix depth-1 default (decl-path [:p]):
+    ;; `target-descendant-of-decl?` would be TRUE ([:p] is a prefix of both
+    ;; src and target), forcing lca-len = (dec (count [:p :r :s])) = 2 →
+    ;; exit set EMPTY (:q not exited) and only :s entered. BROKEN: :q would
+    ;; stay on the active path while the machine dives to :s.
+    (let [snapshot {:state [:p :q] :data {:log []}}
+          ;; NB: no :decl-path key — exercises the default.
+          r        (transition/apply-transition-once
+                     deep-machine snapshot [:go] {:target [:p :r :s]})]
+      (is (result/ok? r) "the transition applies cleanly")
+      (let [snap (result/snap r)]
+        (is (= [:p :r :s] (:state snap))
+            "the machine lands at the targeted deep leaf [:p :r :s]")
+        (is (= [:exit-q :enter-r :enter-s] (get-in snap [:data :log]))
+            "ROOT-anchored geometry: :q exits (deepest-first), then :r and :s
+             enter — :p survives. The depth-1 guess would skip :q's exit and
+             :r's entry (lca-len pulled to 2 by a mis-tripped descendant rule)."))))
+
+  (testing "control — the SAME transition WITH an explicit root `:decl-path []`
+   produces the identical cascade (the default and the explicit root agree)"
+    (let [snapshot {:state [:p :q] :data {:log []}}
+          r        (transition/apply-transition-once
+                     deep-machine snapshot [:go] {:target [:p :r :s] :decl-path []})]
+      (is (result/ok? r))
+      (is (= [:exit-q :enter-r :enter-s] (get-in (result/snap r) [:data :log]))
+          "explicit root decl-path matches the defaulted-root geometry"))))

--- a/implementation/machines/test/re_frame/machine_depth_abort_failure_test.clj
+++ b/implementation/machines/test/re_frame/machine_depth_abort_failure_test.clj
@@ -1,0 +1,161 @@
+(ns re-frame.machine-depth-abort-failure-test
+  "Per rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth limit
+  tripped on a runaway cycle) surfaces as a FAILED macrostep, NOT a silent
+  benign no-op.
+
+  Before this bead the depth-abort returned `(result/ok rollback-snapshot
+  [])` from the drain. `commit-or-finalize` then saw `next == snapshot` and
+  classified the macrostep a no-op: no `:rf.machine/transition` trace, NO
+  error routed through the handler return — only an out-of-band
+  `emit-error!`. A runaway `a →:always b →:always a` cycle was thus
+  INDISTINGUISHABLE from a guard-blocked no-op, and the triggering user
+  event was silently swallowed. XState v5 THROWS on such a cycle.
+
+  The fix returns a `result/fail` carrying the `::result/depth-abort?`
+  sentinel; it routes through the SAME failure path a thrown action takes
+  (the handler short-circuits to `{}` — no snapshot write reaches
+  runtime-db, so the atomic rollback Spec 005 §Bounded depth requires is
+  preserved). The precise `:rf.error/machine-{always,raise}-depth-exceeded`
+  category is emitted once at the abort site (the single trace for the
+  trip); the engine does NOT additionally emit the benign
+  `:rf.machine.event/unhandled-no-op` — so the runaway is now DISTINGUISHABLE
+  from a guard-blocked no-op.
+
+  JVM-only — the dynamic-var listener path is platform-agnostic."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Loading `re-frame.machines` installs the late-bind hooks +
+            ;; reserved fxs `reg-machine` relies on.
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- record-traces! [body-fn]
+  (mtest/with-trace-capture seen
+    (body-fn)
+    @seen))
+
+(defn- ops [evs op] (filterv #(= op (:operation %)) evs))
+
+;; ---------------------------------------------------------------------------
+;; 1. `:always` cycle — a →:always b →:always a with always-true guards trips
+;;    the depth limit. It surfaces as the depth-exceeded ERROR trace, NOT the
+;;    benign unhandled-no-op; the snapshot rolls back atomically.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-always-cycle! []
+  (rf/reg-machine :rf2-y3jv8q/always
+    {:initial            :start
+     :data               {}
+     :always-depth-limit 5
+     :guards             {:p? (fn [_] true)}
+     :states
+     {:start {:on {:go {:target :a}}}
+      :a     {:always [{:guard :p? :target :b}]}
+      :b     {:always [{:guard :p? :target :a}]}}}))
+
+(deftest always-cycle-surfaces-as-failed-macrostep-not-no-op
+  (testing "an `:always` runaway cycle trips the depth limit and surfaces as a
+   FAILED macrostep — the depth-exceeded error trace fires, NOT a benign
+   `:rf.machine.event/unhandled-no-op`, and the snapshot rolls back atomically"
+    (reg-always-cycle!)
+    (rf/dispatch-sync [:rf2-y3jv8q/always [:rf.machine/start]])
+    (let [evs       (record-traces!
+                      (fn [] (rf/dispatch-sync [:rf2-y3jv8q/always [:go]])))
+          depth-err (ops evs :rf.error/machine-always-depth-exceeded)
+          no-ops    (ops evs :rf.machine.event/unhandled-no-op)]
+      (is (= 1 (count depth-err))
+          "exactly one :rf.error/machine-always-depth-exceeded error trace")
+      (let [tr (first depth-err)]
+        (is (= :error (:op-type tr))
+            "the depth-exceeded trace is error-grade (a failed macrostep)")
+        (is (= :no-recovery (:recovery tr))
+            "the trip is :no-recovery"))
+      ;; The CORE of the bug: a runaway cycle must NOT masquerade as the
+      ;; benign no-op a guard-blocked / unhandled event emits. Before the fix
+      ;; the abort returned an OK rollback snapshot and the runaway was
+      ;; indistinguishable from a guard-blocked no-op.
+      (is (= 0 (count no-ops))
+          "a runaway cycle is NOT a benign no-op — no unhandled-no-op fires")
+      ;; Atomic rollback (Spec 005 §Bounded depth): the macrostep failed, so
+      ;; no post-event snapshot reaches runtime-db — the pre-event :start
+      ;; snapshot stays committed.
+      (is (= :start (mtest/machine-state :rf2-y3jv8q/always))
+          "macrostep is atomic; the cycle aborts; snapshot rolls back to :start"))))
+
+;; ---------------------------------------------------------------------------
+;; 2. `:raise` cycle — two states ping-pong by raising each other's resolving
+;;    event. The raise-drain trips the depth limit; same failed-macrostep
+;;    contract as the `:always` cycle.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-raise-cycle! []
+  (rf/reg-machine :rf2-y3jv8q/raise
+    {:initial           :start
+     :data              {}
+     :raise-depth-limit 5
+     ;; Each action re-raises an event the SAME hub state handles, so the
+     ;; internal-event queue never drains to quiescence — a never-converging
+     ;; raise cycle that trips :raise-depth-limit. Raises are emitted from
+     ;; actions (the proven seed for the internal queue) rather than a
+     ;; transition-level :fx key.
+     :actions
+     {:start (fn [{:keys [data]}] {:data data :fx [[:raise [:tick]]]})
+      :tick  (fn [{:keys [data]}] {:data data :fx [[:raise [:tick]]]})}
+     :states
+     {:start {:on {:go   {:action :start}
+                   :tick {:action :tick}}}}}))
+
+
+(deftest raise-cycle-surfaces-as-failed-macrostep-not-no-op
+  (testing "a `:raise` runaway cycle trips the raise-depth limit and surfaces
+   as a FAILED macrostep — the raise-depth-exceeded error trace fires, NOT a
+   benign no-op, and the snapshot rolls back atomically"
+    (reg-raise-cycle!)
+    (rf/dispatch-sync [:rf2-y3jv8q/raise [:rf.machine/start]])
+    (let [evs       (record-traces!
+                      (fn [] (rf/dispatch-sync [:rf2-y3jv8q/raise [:go]])))
+          depth-err (ops evs :rf.error/machine-raise-depth-exceeded)
+          no-ops    (ops evs :rf.machine.event/unhandled-no-op)]
+      (is (= 1 (count depth-err))
+          "exactly one :rf.error/machine-raise-depth-exceeded error trace")
+      (is (= :error (:op-type (first depth-err)))
+          "the depth-exceeded trace is error-grade (a failed macrostep)")
+      (is (= 0 (count no-ops))
+          "a runaway raise cycle is NOT a benign no-op — no unhandled-no-op")
+      (is (= :start (mtest/machine-state :rf2-y3jv8q/raise))
+          "macrostep is atomic; the cycle aborts; snapshot rolls back to :start"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Negative control — a genuine guard-blocked no-op still emits the BENIGN
+;;    `unhandled-no-op` and NO depth-exceeded error. The depth-abort failure
+;;    path must not bleed into the legitimate no-op classification.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-blocked! []
+  (rf/reg-machine :rf2-y3jv8q/blocked
+    {:initial :red
+     :data    {:locked? true}
+     :guards  {:unlocked? (fn [{:keys [data]}] (not (:locked? data)))}
+     :states  {:red {:on {:force {:target :green :guard :unlocked?}}}
+               :green {}}}))
+
+(deftest guard-blocked-no-op-is-not-a-depth-abort
+  (testing "a guard-blocked no-op still emits the benign unhandled-no-op and
+   NO depth-exceeded error — the legitimate no-op classification is intact"
+    (reg-blocked!)
+    (rf/dispatch-sync [:rf2-y3jv8q/blocked [:rf.machine/start]])
+    (let [evs        (record-traces!
+                       (fn [] (rf/dispatch-sync [:rf2-y3jv8q/blocked [:force]])))
+          no-ops     (ops evs :rf.machine.event/unhandled-no-op)
+          always-err (ops evs :rf.error/machine-always-depth-exceeded)
+          raise-err  (ops evs :rf.error/machine-raise-depth-exceeded)]
+      (is (= 1 (count no-ops))
+          "the guard-blocked no-op still emits exactly one unhandled-no-op")
+      (is (= 0 (+ (count always-err) (count raise-err)))
+          "a benign no-op emits NO depth-exceeded error")
+      (is (= :red (mtest/machine-state :rf2-y3jv8q/blocked))
+          "the guard-blocked event leaves the snapshot at :red"))))

--- a/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
@@ -565,18 +565,23 @@
                         :actions shared-actions
                         :states  {:loop {:on {:e0 {:action :a/raise}}}}}
           ;; Both calls MUST return (not hang / SOE). The harness running to
-          ;; completion is the settle proof; we additionally assert the
-          ;; returned snapshot is a well-formed leaf config.
+          ;; completion is the settle proof. Per rf2-y3jv8q an unbounded
+          ;; :always / :raise cycle now surfaces as a FAILED macrostep at the
+          ;; depth bound (XState v5 throws on such a runaway) — a `result/fail`
+          ;; carrying the `::depth-abort?` sentinel, NOT an :ok rollback no-op
+          ;; that masqueraded as a guard-blocked decline.
           r-always (machines/machine-transition
                      always-cycle (initial-snapshot always-cycle) [:noop])
           r-raise  (machines/machine-transition
                      raise-cycle (initial-snapshot raise-cycle) [:e0])]
-      (is (result/ok? r-always) "always-cycle returns an :ok Result (settled at depth bound)")
-      (is (state-is-leaf? always-cycle (:state (result/snap r-always)))
-          "settled always-cycle snapshot is a leaf config")
-      (is (result/ok? r-raise) "raise-cycle returns an :ok Result (settled at depth bound)")
-      (is (state-is-leaf? raise-cycle (:state (result/snap r-raise)))
-          "settled raise-cycle snapshot is a leaf config")
+      (is (result/depth-abort? r-always)
+          "always-cycle aborts at the depth bound as a depth-abort :fail (settled, not hung)")
+      (is (nil? (result/snap r-always))
+          "the depth-abort :fail threads no snapshot (atomic rollback — no partial leaf commits)")
+      (is (result/depth-abort? r-raise)
+          "raise-cycle aborts at the depth bound as a depth-abort :fail (settled, not hung)")
+      (is (nil? (result/snap r-raise))
+          "the depth-abort :fail threads no snapshot (atomic rollback — no partial leaf commits)")
       ;; And over the random corpus: every step of every drawn machine
       ;; returned (the loop below cannot complete if any macrostep hangs).
       (let [completed

--- a/implementation/machines/test/re_frame/machine_raise_cofx_replay_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_cofx_replay_test.clj
@@ -1,0 +1,111 @@
+(ns re-frame.machine-raise-cofx-replay-test
+  "Per rf2-08br0v — replay-determinism of a generator-backed cofx fact MINTED
+  by a same-macrostep RAISED event's guard/action.
+
+  ## The investigation (rf2-08br0v — confirmed REAL)
+
+  `drain-to-fixed-point` re-runs `ensure-raised-cofx` per dequeued raise
+  (rf2-xsdn5h). Under `:live` it MINTS a fresh generator-backed recordable
+  fact mid-macrostep when a raise-selected guard's `:rf.cofx/requires` was NOT
+  in the external event's ensure-set. The minted value is written onto the
+  engine-local machine def's `:rf/cofx` and threads forward IN the drain (so a
+  later raise / `:always` re-presents it — in-drain consistency).
+
+  But it does NOT flow back to the token the EPOCH captures. The epoch's
+  `:rf.cofx` replay token is captured at `:rf.event/run-start`
+  (`re-frame.epoch.capture/find-trigger-event` reads the run-start trace's
+  `:rf.event/cofx`), which the router emits from `assemble-initial-ctx`'s
+  coeffects BEFORE the handler runs. A state machine's outer event handler
+  declares no `:rf.cofx/requires` (they live on guards/actions), so
+  `assemble-initial-ctx` mints NOTHING for it — and the machine's own ensure
+  steps (`ensure-ctx-cofx` pre-drain, `ensure-raised-cofx` in-drain) run INSIDE
+  the handler, AFTER run-start. So the captured replay token contains only the
+  externally-supplied facts (e.g. `:rf/time-ms`), never the machine-minted ones.
+
+  Consequence (the divergence): a `:live` original run mints a fresh value and
+  a raise-selected guard decides on it; on `:strict` replay the epoch token
+  lacks that fact, so `ensure-raised-cofx` (now mint-policy-aware, rf2-n0myjq)
+  REFUSES to mint and surfaces `:rf.error/missing-required-cofx` — the replayed
+  macrostep fails where the original advanced. Replay is non-deterministic.
+
+  The structural fix (re-capturing the post-handler / post-mint cofx token into
+  the epoch's run-start replay slot) is a CORE router + epoch capture-timing
+  change, tracked as a follow-up. This namespace is the CHARACTERISATION test
+  that LOCKS the confirmed divergence at the machines surface so the follow-up
+  has a regression target: it asserts (1) the in-drain MINT happens and the
+  guard decides on it under `:live`, and (2) the captured run-start replay token
+  does NOT yet carry the minted fact — the precise gap. When the follow-up
+  lands, assertion (2) flips (the token carries the minted fact) and this test
+  is updated to assert replay determinism directly.
+
+  JVM — drives the real dispatch path (`rf/dispatch-sync` through the live
+  machine handler + transition engine + epoch capture)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest in-drain-minted-fact-is-not-yet-captured-in-the-replay-token
+  (testing "rf2-08br0v — a raise-selected guard fact MINTED mid-macrostep under
+   :live drives the machine decision, but is NOT (yet) captured in the epoch's
+   run-start :rf.cofx replay token — the confirmed replay-determinism gap"
+    ;; A generator-backed recordable cofx that mints a FRESH value each call.
+    ;; Stamp a deterministic-but-distinct value via an atom counter so the test
+    ;; can prove the minted value reached the guard.
+    (let [minted    (atom 0)
+          seen      (atom ::unset)]
+      (rf/reg-cofx :replay/gen {:recordable? true}
+                   (fn [] (swap! minted inc) (* 100 @minted)))
+      (let [m {:initial :a
+               :data    {}
+               :guards  {:check
+                         {:rf.cofx/requires [:replay/gen]
+                          :fn (fn [{cofx :rf.cofx}]
+                                (reset! seen (:replay/gen cofx))
+                                ;; always selects the transition — the point is
+                                ;; that it DECIDED on the minted value
+                                (some? (:replay/gen cofx)))}}
+               :actions {;; :go raises [:inner]; :inner's guard requires
+                         ;; :replay/gen — NOT in :go's ensure-set, so it is
+                         ;; minted mid-drain by ensure-raised-cofx under :live.
+                         :raise-inner (fn [_] {:fx [[:raise [:inner]]]})}
+               :states  {:a    {:on {:go {:target :b :action :raise-inner}}}
+                         :b    {:on {:inner {:target :done :guard :check}}}
+                         :done {}}}
+            run-start (atom nil)]
+        (rf/reg-machine :replay/mint m)
+        (trace/register-listener!
+          ::cap (fn [ev] (when (= :rf.event/run-start (:operation ev))
+                           (reset! run-start ev))))
+        ;; LIVE dispatch — only :rf/time-ms in the external token. :replay/gen is
+        ;; minted mid-drain by the raised :inner's guard ensure.
+        (rf/dispatch-sync [:replay/mint [:go]] {:rf.cofx {:rf/time-ms 111}})
+        (trace/unregister-listener! ::cap)
+
+        ;; (1) The mint DID happen and the guard decided on the fresh value.
+        (is (= 100 @seen)
+            "the raised guard read the MINTED generator-backed fact (mid-drain)")
+        (is (= :done (mtest/machine-state :replay/mint))
+            "the machine advanced on the minted value")
+
+        ;; (2) THE GAP — the captured run-start replay token does NOT carry the
+        ;; minted :replay/gen. It carries only the externally-supplied
+        ;; :rf/time-ms. A :strict replay of this epoch would therefore lack the
+        ;; fact and diverge (ensure-raised-cofx refuses to mint → missing-
+        ;; required → the macrostep that here reached :done would FAIL).
+        (let [captured-cofx (:rf.event/cofx (:tags @run-start) (:rf.event/cofx @run-start))]
+          (is (some? @run-start) "a run-start trace was captured")
+          (is (= {:rf/time-ms 111} captured-cofx)
+              "CONFIRMED GAP (rf2-08br0v): the run-start replay token carries
+               only the external :rf/time-ms — the in-drain minted :replay/gen
+               is absent, so a :strict replay cannot re-present it. When the
+               core capture-timing follow-up lands this assertion flips to
+               expect :replay/gen 100 in the token, and replay becomes
+               deterministic.")
+          (is (not (contains? captured-cofx :replay/gen))
+              "the minted fact is not (yet) in the captured replay token"))))))

--- a/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
@@ -149,15 +149,22 @@
                                         (get-in ev [:tags :rf/op-type-id]
                                                 (:op-type-id ev)))
                                 (swap! seen conj ev)))]
-        ;; Just assert the macrostep rolls back to the original snapshot
-        ;; (depth bound halts the cascade uncommitted) — the snapshot stays
-        ;; at :idle, fx empty.
+        ;; rf2-y3jv8q — a depth-bound abort is now a FAILED macrostep, not an
+        ;; :ok rollback no-op (XState v5 throws on such a runaway). The pure
+        ;; surface returns a `result/fail` carrying the `::depth-abort?`
+        ;; sentinel; atomic rollback is still guaranteed — a `:fail` threads
+        ;; NO snapshot / fx, so nothing intermediate escapes the abort. (The
+        ;; lifecycle handler short-circuits to `{}`, leaving the pre-event
+        ;; snapshot committed in runtime-db.)
         (let [r (machines/machine-transition spec {:state :idle :data {}} [:start])]
-          (is (result/ok? r) "depth-exceeded returns an :ok rollback, not a :fail")
-          (is (= :idle (:state (result/snap r)))
-              "macrostep rolled back atomically — snapshot uncommitted")
-          (is (= [] (result/fx r))
-              "no fx survive the depth-bound rollback"))))))
+          (is (result/fail? r)
+              "depth-exceeded returns a :fail (failed macrostep), not an :ok no-op")
+          (is (result/depth-abort? r)
+              "the :fail carries the ::depth-abort? sentinel (a bounded-depth trip)")
+          (is (nil? (result/snap r))
+              "a :fail threads no snapshot — nothing intermediate survives")
+          (is (nil? (result/fx r))
+              "a :fail threads no fx — no accumulated side-effect leaks the abort"))))))
 
 ;; ---- 6. depth-bound rollback is TRULY atomic (x4s9t.1) --------------------
 ;;
@@ -193,9 +200,15 @@
                              :on {:to-a :a}}}}
           original {:state :idle :data {:n 0}}
           r        (machines/machine-transition spec original [:start])]
-      (is (result/ok? r) "depth-exceeded returns an :ok rollback, not a :fail")
-      (is (= original (result/snap r))
-          "snapshot rolled all the way back to the ORIGINAL — no intermediate
-           :a/:b state or bumped :n survived")
-      (is (= [] (result/fx r))
-          "EVERY accumulated :side-effect fx was discarded with the macrostep"))))
+      ;; rf2-y3jv8q — the abort is a FAILED macrostep. Atomic rollback is
+      ;; enforced by the `:fail` threading NO snapshot / fx: every intermediate
+      ;; :a/:b state, bumped :n, and accumulated :side-effect fx is discarded
+      ;; with the macrostep (there is nothing to commit on a `:fail`).
+      (is (result/fail? r)
+          "depth-exceeded returns a :fail (failed macrostep), not an :ok no-op")
+      (is (result/depth-abort? r)
+          "the :fail carries the ::depth-abort? sentinel (a bounded-depth trip)")
+      (is (nil? (result/snap r))
+          "a :fail threads no snapshot — no intermediate :a/:b state or bumped :n survives")
+      (is (nil? (result/fx r))
+          "a :fail threads no fx — EVERY accumulated :side-effect was discarded"))))

--- a/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
@@ -72,10 +72,16 @@
         (is (= 6 (get-in s [:data :correct-count]))
             "action ran; data updated; state unchanged"))))
 
-  (testing ":always cycle hits depth limit — snapshot rolls back atomically"
-    ;; Two states ping-pong via :always with always-true guards. The
-    ;; microstep loop trips the depth limit; per Spec 005 §Bounded depth
-    ;; the snapshot rolls back to the input.
+  (testing ":always cycle hits depth limit — macrostep fails atomically (rf2-y3jv8q)"
+    ;; Two states ping-pong via :always with always-true guards. The microstep
+    ;; loop trips the depth limit; per Spec 005 §Bounded depth the macrostep
+    ;; FAILS atomically — XState v5 throws on such a runaway (rf2-y3jv8q). The
+    ;; abort routes through the failure path (the handler short-circuits to
+    ;; `{}`), so no snapshot write reaches runtime-db and the already-committed
+    ;; pre-event :start snapshot stays put. (Boot the machine FIRST so :start is
+    ;; committed before the failing [:go] — otherwise a first-dispatch lazy
+    ;; boot + [:go] is ONE atomic macrostep that rolls back wholesale, leaving
+    ;; no snapshot installed at all.)
     (let [machine
           {:initial :start
            :data    {}
@@ -87,16 +93,23 @@
             :b     {:always [{:guard :p? :target :a}]}}}
           traces (atom [])]
       (rf/reg-machine :osc/flow machine)
+      (rf/dispatch-sync [:osc/flow [:rf.machine/start]])  ;; commit :start first
       (trace-tooling/register-listener! ::osc (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:osc/flow [:go]])
       (trace-tooling/unregister-listener! ::osc)
-      ;; Atomic rollback: external snapshot stays at :start.
+      ;; Atomic rollback: the committed snapshot stays at :start (the failing
+      ;; [:go] macrostep commits nothing).
       (is (= :start (:state (snapshot :osc/flow)))
-          "macrostep is atomic; cycle aborts; snapshot rolls back to input")
+          "macrostep fails atomically; the committed snapshot stays at :start")
+      ;; The runaway is a FAILED macrostep, NOT a benign no-op — the
+      ;; depth-exceeded error trace fires, and no unhandled-no-op masks it.
       (is (some (fn [ev]
                   (and (= :rf.error/machine-always-depth-exceeded
                           (:operation ev))
                        (= :error (:op-type ev))
                        (= :no-recovery (:recovery ev))))
                 @traces)
-          "expected :rf.error/machine-always-depth-exceeded trace"))))
+          "expected :rf.error/machine-always-depth-exceeded trace")
+      (is (not-any? (fn [ev] (= :rf.machine.event/unhandled-no-op (:operation ev)))
+                    @traces)
+          "a runaway cycle is NOT a benign no-op — no unhandled-no-op fires"))))

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -255,8 +255,21 @@
                         (catch Throwable e
                           {::result/snap nil
                            ::result/fx   [:error (.getMessage e)]}))
-        snap-out   (::result/snap r)
-        fx-out     (::result/fx r)
+        ;; rf2-y3jv8q — a bounded-depth abort (`:always` / `:raise` depth
+        ;; limit tripped on a runaway cycle) now returns a `result/fail`
+        ;; carrying the `::depth-abort?` sentinel, NOT an `:ok` rollback no-op
+        ;; (XState v5 throws on such a cycle; the silent-no-op masking it as a
+        ;; guard-blocked decline was the bug). The fixture's
+        ;; `:expect-next-snapshot` / `:expect-effects` capture the
+        ;; ATOMIC-ROLLBACK contract: the macrostep does not commit, so the
+        ;; externally-observable next-snapshot is the INPUT snapshot and the
+        ;; effects are empty (the lifecycle handler short-circuits to `{}`,
+        ;; leaving the pre-event snapshot committed). Project a depth-abort
+        ;; `:fail` onto that observable shape so the fixture asserts the same
+        ;; rollback fact under the corrected failure surface.
+        depth-abort? (result/depth-abort? r)
+        snap-out   (if depth-abort? (:snapshot call) (::result/snap r))
+        fx-out     (if depth-abort? [] (::result/fx r))
         want-snap  (:expect-next-snapshot call)
         want-fx    (or (:expect-effects call) [])
         ok-snap?   (= want-snap snap-out)

--- a/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
+++ b/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
@@ -200,14 +200,21 @@
                    :states  {:z {:on {:go {:action :start}}}}}}}
           original {:state {:loop :run :idle :z} :data {:token :keep}}
           r        (machines/machine-transition spec original [:go])]
-      (is (result/ok? r)
-          "depth-exceeded yields an :ok rollback Result, not a :fail")
-      (is (= {:loop :run :idle :z} (:state (result/snap r)))
-          "macrostep rolled back atomically — both regions' states uncommitted")
-      (is (= {:token :keep} (:data (result/snap r)))
-          ":data rolled back to the original — no partial cascade survives")
-      (is (= [] (result/fx r))
-          "no fx survive the depth-bound rollback"))))
+      ;; rf2-y3jv8q — a parallel re-broadcast depth-bound abort is a FAILED
+      ;; macrostep, not an :ok rollback no-op (parity with the flat drain;
+      ;; XState v5 throws on the runaway). The `:fail` threads NO snapshot /
+      ;; fx, so the whole macrostep — both regions' states, the looping
+      ;; region's :data writes, and every accumulated fx — is discarded. The
+      ;; lifecycle handler short-circuits to `{}`, leaving the pre-event
+      ;; snapshot committed in runtime-db.
+      (is (result/fail? r)
+          "depth-exceeded yields a :fail (failed macrostep), not an :ok no-op")
+      (is (result/depth-abort? r)
+          "the :fail carries the ::depth-abort? sentinel (a bounded-depth trip)")
+      (is (nil? (result/snap r))
+          "a :fail threads no snapshot — both regions' states stay uncommitted")
+      (is (nil? (result/fx r))
+          "a :fail threads no fx — no partial cascade or fx survives the abort"))))
 
 ;; ---- 6. region :always still fires on a re-broadcast transition ----------
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -1863,6 +1863,8 @@ Default microstep depth limit: **16** (matching `:raise`-depth's default). User-
 - Halts the cascade with the snapshot **uncommitted** — external observers do not see the partial path.
 - Recovery: `:no-recovery` (the runtime cannot guess the author's intent for a non-converging cycle).
 
+**A tripped depth limit is a FAILED macrostep, not a benign no-op (XState v5 parity).** XState v5 **throws** on a non-converging eventless / `raise` cycle; re-frame2 surfaces it as a **failed** macrostep — the abort routes through the **same** failure path a thrown action takes (the handler short-circuits to `{}`; no snapshot write reaches runtime-db, which **is** the atomic rollback). It does **not** emit the benign `:rf.machine.event/unhandled-no-op` an unhandled / guard-blocked event emits, so a runaway cycle is **distinguishable** from a guard-blocked decline rather than silently swallowing the triggering event. The `:rf.error/machine-always-depth-exceeded` (or `:rf.error/machine-raise-depth-exceeded`) error trace is the single signal for the trip. (A prior engine returned an `:ok` rollback snapshot from the abort, which the lifecycle boundary classified as a no-op — no error to the handler return, indistinguishable from a guard-blocked no-op; that was an unblessed implementation shortcut, now aligned to the XState v5 gold standard.)
+
 The depth counter is **separate** from the `:raise` depth counter — a microstep that itself raises events does not double-count. The two limits compose: each microstep can raise up to 16 events, and the macrostep can include up to 16 microsteps.
 
 ### Hierarchy interaction

--- a/spec/conformance/fixtures/always-depth-exceeded.edn
+++ b/spec/conformance/fixtures/always-depth-exceeded.edn
@@ -45,8 +45,18 @@
    ;; :b's :always fires (microstep 2, → :a). And so on. After 5 microsteps the
    ;; cascade halts.
    ;;
-   ;; The snapshot does NOT commit — the externally-visible state remains :start.
-   ;; The runtime emits :rf.error/machine-always-depth-exceeded.
+   ;; Per rf2-y3jv8q this runaway is a FAILED macrostep, not a benign no-op:
+   ;; the engine returns a `result/fail` carrying the depth-abort sentinel
+   ;; (XState v5 THROWS on such an eventless cycle). The atomic-rollback
+   ;; contract (Spec 005 §Bounded depth) is preserved by the failure surface —
+   ;; a `:fail` threads NO snapshot / fx, and the lifecycle handler
+   ;; short-circuits to `{}`, leaving the pre-event :start snapshot committed.
+   ;; The conformance runner projects the depth-abort `:fail` onto the
+   ;; observable rollback shape below: the externally-visible next-snapshot is
+   ;; the INPUT snapshot (state stays :start) and no effects survive. The
+   ;; runtime emits :rf.error/machine-always-depth-exceeded (error-grade) — NOT
+   ;; the benign :rf.machine.event/unhandled-no-op a guard-blocked decline
+   ;; would, so the runaway is distinguishable.
    :expect-next-snapshot {:state :start :data {}}
    :expect-effects       []
    :expect-trace


### PR DESCRIPTION
Fixes three state-machine findings from the rf2-go7f5o adversarial audit (parent rf2-cheez6), in the machines artefact. Behaviour-correcting; aligned to the XState v5 gold standard.

## rf2-y3jv8q (P3 bug) — depth-limit abort surfaces as a FAILED macrostep, not a silent no-op

On a tripped `:always` / `:raise` depth limit the drain returned `(result/ok rollback-snapshot [])`. `commit-or-finalize` saw `next == snapshot` and classified the macrostep a no-op: no `:rf.machine/transition` trace, NO error to the handler return — only an out-of-band `emit-error!`. A runaway `a→b→a` `:always` (or raise) cycle was thus indistinguishable from a guard-blocked no-op and silently swallowed the triggering event. XState v5 **throws** on such a cycle.

**Fix:** the three abort sites (`transition/drain-to-fixed-point` `:always` + raise, `parallel/drain-parent-queue`) return `result/depth-abort` — a `:fail` carrying a `::depth-abort?` sentinel. It routes through the same failure path a thrown action takes; the lifecycle handler short-circuits to `{}` (no snapshot write reaches runtime-db), preserving the atomic rollback Spec 005 §Bounded depth requires, while the event is no longer silently consumed. The precise `:rf.error/machine-{always,raise}-depth-exceeded` category is still emitted once at the abort site; the engine no longer emits the benign `unhandled-no-op`, so the runaway is distinguishable. `handle-step-failure!` skips the misleading action-exception re-emit for a depth-abort.

Also dropped the now-dead `rollback-snapshot` parameter from `drain-to-fixed-point` (clj-kondo flagged it; the `:fail` carrying no payload IS the rollback).

No new `:rf.error/*` category (both depth-exceeded categories pre-exist in the Spec 009 catalogue; behaviour preserved). Spec 005 §Bounded depth documents the failed-macrostep / XState-v5 parity.

## rf2-h16qii (P3, latent) — compute-cascade-paths defaults :decl-path to root, not depth-1

The default was `(vec (take 1 src-path))` — the first element of the active leaf's path, assuming depth-1. Every in-tree caller stamps `:decl-path`, so no in-tree path hit it, but a pure-fn / hand-built caller of the public `apply-transition-once` got a ROOT-declared transition mis-located at `[<top>]` — a non-empty path that wrongly tripped `target-descendant-of-decl?`, diverging the LCA / exit / entry geometry. **Fix:** default to root (`[]`). New focused pure-engine test proves the divergence (correct: log `[:exit-q :enter-r :enter-s]`; bug: `[:enter-s]`).

## rf2-08br0v (P3) — raised-event cofx minting replay-determinism: CONFIRMED a real bug

**Investigation result:** epoch capture does NOT re-snapshot the augmented `:rf/cofx` after each in-drain mint. The epoch's `:rf.cofx` replay token is captured at `:rf.event/run-start` (before the handler); a machine's outer event handler declares no `:rf.cofx/requires` (they live on guards/actions), so the captured token never carries machine-minted facts. A `:live` run mints a fresh value mid-drain and a raise-selected guard decides on it; a `:strict` replay lacks the fact → `:rf.error/missing-required-cofx` → the macrostep that advanced under `:live` fails. Replay diverges.

The structural fix (re-capture the post-handler machine-minted cofx into the epoch run-start replay slot) is a cross-artefact **core router + epoch capture-timing** change (hot-zone), out of this machines-only worktree's scope — filed as **rf2-cheez6.1**. This PR lands the machines-side characterization / regression test (`machine_raise_cofx_replay_test`) that locks the confirmed divergence; when rf2-cheez6.1 lands, its assertion (2) flips to assert replay determinism directly.

## Gates
- machines JVM (`clojure -M:test`): 793 tests, 0 failures
- core JVM (exercises the core conformance runner): 1820 tests, 0 failures
- CLJS node-runtime (`npm run test:cljs`): 8019 tests, 0 failures
- clj-kondo: clean (no new warnings)

Rebased onto origin/main. Do not merge — review first.