### PR TITLE
test(ssr): wire ^:slow/^:stress gating — skip on PR gate, run in nightly/rigorous (rf2-bv2qqm)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -206,3 +206,59 @@ jobs:
 
       - name: Run re-frame2-pair live-overflow conformance
         run: npm run test:re-frame2-pair-live-overflow-hermetic
+
+  jvm-slow-tests:
+    # rf2-bv2qqm — the heavy `^:slow` / `^:stress` JVM tests (the SSR
+    # 2000-request teardown load test, the ssr-ring multi-thread Jetty
+    # burst tests, and the core/machines/routing/flows 5000-iter × 8-thread
+    # concurrency-stress suites) are EXCLUDED from the PR/local `:test`
+    # gate (`-e :slow -e :stress` in each artefact's deps.edn). This nightly
+    # job runs them via the per-artefact `:slow-test` alias
+    # (`-i :slow -i :stress`) so the coverage moved off the PR critical path
+    # is NOT lost. `:test` (PR) + `:slow-test` (here) partition the suite:
+    # every test runs exactly once across the two. Local mirror:
+    # `scripts/test-rigorous-local.sh`.
+    name: JVM slow/stress tests (clojure -M:slow-test)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artefact:
+          - core
+          - machines
+          - routing
+          - flows
+          - ssr
+          - ssr-ring
+    defaults:
+      run:
+        working-directory: implementation/${{ matrix.artefact }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-expensive-slow-${{ matrix.artefact }}-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-expensive-slow-${{ matrix.artefact }}-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM slow/stress tests
+        run: clojure -M:slow-test

--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -112,7 +112,34 @@
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+         ;; rf2-bv2qqm — the default PR/local gate (incl. the fast-PR
+         ;; spine `scripts/test-fast-pr.sh`, which runs this artefact)
+         ;; EXCLUDES the heavy `^:stress` namespace
+         ;; (`concurrency_stress_test`, three 5000-iter × 8-thread
+         ;; scenarios). The runner passes `-e` through to
+         ;; cognitect-test-runner verbatim. Coverage is NOT lost: the
+         ;; `:slow-test` alias below runs the excluded tests, invoked by
+         ;; the nightly `expensive-tests.yml` job +
+         ;; `scripts/test-rigorous-local.sh`.
+         :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
+
+  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; `^:slow` / `^:stress` tests (the union the default `:test` alias
+  ;; excludes), so `:test` + `:slow-test` together cover every test once.
+  :slow-test
+  {:extra-paths ["test"]
+   :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
+                 day8/re-frame2-machines   {:local/root "../machines"}
+                 day8/re-frame2-routing    {:local/root "../routing"}
+                 day8/re-frame2-flows      {:local/root "../flows"}
+                 day8/re-frame2-http       {:local/root "../http"}
+                 day8/re-frame2-ssr        {:local/root "../ssr"}
+                 day8/re-frame2-epoch      {:local/root "../epoch"}
+                 day8/re-frame2-resources  {:local/root "../resources"}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow:
   ;; the release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/core/test/re_frame/concurrency_stress_test.clj
+++ b/implementation/core/test/re_frame/concurrency_stress_test.clj
@@ -71,7 +71,7 @@
 
 ;; ---- 1. Nested cross-frame dispatch under executor jitter ----------------
 
-(deftest cross-frame-dispatch-under-executor-jitter-stress
+(deftest ^:stress cross-frame-dispatch-under-executor-jitter-stress
   ;; rf2-35rgj scenario 1.
   ;;
   ;; Setup: two frames `:rgj.exec/a` and `:rgj.exec/b`. A handler on A
@@ -162,7 +162,7 @@
 
 ;; ---- 2. Cross-frame :dispatch-sync during sibling drain ------------------
 
-(deftest cross-frame-dispatch-sync-during-sibling-drain-stress
+(deftest ^:stress cross-frame-dispatch-sync-during-sibling-drain-stress
   ;; rf2-35rgj scenario 2.
   ;;
   ;; rf2-fp97 added `:rf.warning/cross-frame-dispatch-sync-during-drain`
@@ -269,7 +269,7 @@
 
 ;; ---- 3. Hot-reload race during drain -------------------------------------
 
-(deftest hot-reload-race-during-drain-stress
+(deftest ^:stress hot-reload-race-during-drain-stress
   ;; rf2-35rgj scenario 3.
   ;;
   ;; Spec 001 §Hot-reload semantics rule 1: an event handler currently

--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -51,7 +51,27 @@
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; `^:stress` namespace (`flows_concurrency_stress_test`,
+         ;; 5000-iter × 8-thread reg/eval/clear churn). The runner passes
+         ;; `-e` through to cognitect-test-runner verbatim. Coverage is NOT
+         ;; lost: the `:slow-test` alias below runs the excluded tests,
+         ;; invoked by the nightly `expensive-tests.yml` job +
+         ;; `scripts/test-rigorous-local.sh`.
+         :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
+
+  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; `^:slow` / `^:stress` tests, so `:test` + `:slow-test` together cover
+  ;; every test once.
+  :slow-test
+  {:extra-paths ["test"]
+   :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
+                 day8/re-frame2-routing    {:local/root "../routing"}
+                 day8/re-frame2-ssr        {:local/root "../ssr"}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -147,7 +147,7 @@
 
 ;; ---- the stress test ------------------------------------------------------
 
-(deftest flow-reg-eval-clear-stress
+(deftest ^:stress flow-reg-eval-clear-stress
   ;; rf2-ztw5p — mirrors rf2-1gpx8's pattern for the flows surface.
   ;;
   ;; The two pinned counter invariants are the same as rf2-35rgj /

--- a/implementation/machines/deps.edn
+++ b/implementation/machines/deps.edn
@@ -41,7 +41,25 @@
                        day8/re-frame2-schemas    {:local/root "../schemas"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; `^:stress` namespace (`machine_actor_concurrency_stress_test`,
+         ;; 5000-iter × 8-thread actor-spawn churn). The runner passes
+         ;; `-e` through to cognitect-test-runner verbatim. Coverage is NOT
+         ;; lost: the `:slow-test` alias below runs the excluded tests,
+         ;; invoked by the nightly `expensive-tests.yml` job +
+         ;; `scripts/test-rigorous-local.sh`.
+         :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
+
+  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; `^:slow` / `^:stress` tests, so `:test` + `:slow-test` together cover
+  ;; every test once.
+  :slow-test
+  {:extra-paths ["test"]
+   :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 day8/re-frame2-schemas    {:local/root "../schemas"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
+++ b/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
@@ -149,7 +149,7 @@
 
 ;; ---- the stress test ------------------------------------------------------
 
-(deftest actor-spawn-dispatch-destroy-stress
+(deftest ^:stress actor-spawn-dispatch-destroy-stress
   ;; rf2-1gpx8 — mirrors rf2-35rgj's pattern for the machine actor surface.
   ;;
   ;; The two pinned invariants are the same as rf2-35rgj's: every

--- a/implementation/routing/deps.edn
+++ b/implementation/routing/deps.edn
@@ -59,7 +59,28 @@
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; `^:stress` tests in `routing_concurrency_stress_test`
+         ;; (5000-iter × 8-thread cross-frame nav). These were tagged
+         ;; `^:stress` per rf2-q4twq but the exclude was never wired, so
+         ;; they ran on every PR. The runner passes `-e` through to
+         ;; cognitect-test-runner verbatim. Coverage is NOT lost: the
+         ;; `:slow-test` alias below runs them, invoked by the nightly
+         ;; `expensive-tests.yml` job + `scripts/test-rigorous-local.sh`.
+         :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
+
+  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; `^:slow` / `^:stress` tests, so `:test` + `:slow-test` together cover
+  ;; every test once.
+  :slow-test
+  {:extra-paths ["test"]
+   :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
+                 day8/re-frame2-flows      {:local/root "../flows"}
+                 day8/re-frame2-ssr        {:local/root "../ssr"}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -48,9 +48,13 @@
   recently as part of rf2-wp0w4's PR #1176; this JVM stress is
   complementary, not redundant.
 
-  Tagged `^:stress` per the rf2-q4twq convention so the default test
-  runner can opt out via `:exclude :stress` when CI wall-clock budget
-  is tight."
+  Tagged `^:stress` per the rf2-q4twq convention. The default `:test`
+  alias in deps.edn passes `-e :slow -e :stress` to the runner, so
+  cognitect-test-runner drops these vars on the PR/local gate; the
+  `:slow-test` alias passes `-i :slow -i :stress` to run them, and the
+  nightly `.github/workflows/expensive-tests.yml` job +
+  `scripts/test-rigorous-local.sh` invoke that alias so coverage is kept
+  (rf2-bv2qqm wired the exclude — it was previously inert)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]

--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -86,7 +86,35 @@
                        ring/ring-jetty-adapter {:mvn/version "1.12.1"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"]}
+         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; `^:stress` namespace (here: `concurrency_stress_test`, three
+         ;; multi-thread Jetty + java.net.http burst tests). The runner
+         ;; passes `-e` through to cognitect-test-runner verbatim. Coverage
+         ;; is NOT lost: the `:slow-test` alias below runs the excluded
+         ;; tests, invoked by the nightly `expensive-tests.yml` job and
+         ;; `scripts/test-rigorous-local.sh`.
+         :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"
+                       "-e" ":slow" "-e" ":stress"]}
+
+  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; `^:slow` / `^:stress` tests (the union the default `:test` alias
+  ;; excludes), so the default `:test` run plus this `:slow-test` run
+  ;; together cover every test exactly once. Invoked by the nightly
+  ;; `.github/workflows/expensive-tests.yml` job and the local
+  ;; `scripts/test-rigorous-local.sh` sweep.
+  :slow-test
+  {:extra-paths ["test"]
+   :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
+                 day8/re-frame2-flows      {:local/root "../flows"}
+                 day8/re-frame2-routing    {:local/root "../routing"}
+                 day8/re-frame2-machines   {:local/root "../machines"}
+                 day8/re-frame2-resources  {:local/root "../resources"}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 ring/ring-jetty-adapter {:mvn/version "1.12.1"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner" "--dir" "test"
+                 "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on the per-feature artefacts.
   ;; The release workflow swaps :local/root → :mvn/version before

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -27,7 +27,12 @@
 
   ## Test scope
 
-  Three tests, all tagged `^:stress`:
+  Three tests, all tagged `^:stress` so the default test gate skips them
+  (rf2-bv2qqm). The `:test` alias in deps.edn passes `-e :slow -e :stress`
+  to the runner, so cognitect-test-runner drops these vars on the PR/local
+  gate; the `:slow-test` alias passes `-i :slow -i :stress` to run them,
+  and the nightly `.github/workflows/expensive-tests.yml` job +
+  `scripts/test-rigorous-local.sh` invoke that alias so coverage is kept.
 
     1. `concurrent-streaming-requests-isolate-state` — N=8 threads each
        fire M=20 requests against one Jetty-hosted `stream-handler`.

--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -64,7 +64,32 @@
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+         ;; rf2-bv2qqm — the default PR/local gate EXCLUDES the heavy
+         ;; `^:slow` / `^:stress` namespaces (here: the 2000-request
+         ;; `ssr_teardown_load_test`). `re-frame.test-quiet.runner` passes
+         ;; `-e` through verbatim to cognitect-test-runner, whose
+         ;; `var-filter` drops any var whose metadata carries an excluded
+         ;; keyword. Coverage is NOT lost: the `:slow-test` alias below
+         ;; runs the excluded tests, and the nightly `expensive-tests.yml`
+         ;; job + `scripts/test-rigorous-local.sh` invoke it.
+         :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
+
+  ;; rf2-bv2qqm — nightly/rigorous slow-test gate. INCLUDES ONLY the
+  ;; `^:slow` / `^:stress` tests (the `-i` union the default `:test`
+  ;; alias excludes), so the default `:test` run plus this `:slow-test`
+  ;; run together cover every test exactly once. Invoked by the nightly
+  ;; `.github/workflows/expensive-tests.yml` job and the local
+  ;; `scripts/test-rigorous-local.sh` sweep.
+  :slow-test
+  {:extra-paths ["test"]
+   :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
+                 day8/re-frame2-flows      {:local/root "../flows"}
+                 day8/re-frame2-routing    {:local/root "../routing"}
+                 day8/re-frame2-machines   {:local/root "../machines"}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -41,8 +41,12 @@
        the total bytes the test churned — proves no large object graph
        is retained past frame destruction.
 
-  Marked `^:slow` so the default test gate skips it; CI runs it via the
-  `:slow-test` alias (see `:test` alias filter in deps.edn).
+  Marked `^:slow` so the default test gate skips it (rf2-bv2qqm). The
+  `:test` alias in deps.edn passes `-e :slow -e :stress` to the runner, so
+  cognitect-test-runner drops these vars on the PR/local gate; the
+  `:slow-test` alias passes `-i :slow -i :stress` to run them, and the
+  nightly `.github/workflows/expensive-tests.yml` job +
+  `scripts/test-rigorous-local.sh` invoke that alias so coverage is kept.
 
   Iteration counts:
     - quick smoke (in this file): 2_000 requests.

--- a/scripts/test-rigorous-local.sh
+++ b/scripts/test-rigorous-local.sh
@@ -7,6 +7,30 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 "$repo_root/scripts/test-jvm-implementation.sh"
 "$repo_root/scripts/test-jvm-tools.sh"
 
+# rf2-bv2qqm — the heavy `^:slow` / `^:stress` JVM tests are EXCLUDED from
+# the default `:test` gate (`-e :slow -e :stress`) so the PR/local fast path
+# stays quick. They are NOT lost: this rigorous sweep runs them via each
+# artefact's `:slow-test` alias (`-i :slow -i :stress`), mirroring the nightly
+# `jvm-slow-tests` job in `.github/workflows/expensive-tests.yml`. `:test`
+# (fast) + `:slow-test` (here) partition the suite — every test runs once.
+printf '==> implementation JVM slow/stress tests (:slow-test alias)\n'
+slow_artefacts=(
+  implementation/core
+  implementation/machines
+  implementation/routing
+  implementation/flows
+  implementation/ssr
+  implementation/ssr-ring
+)
+for artefact in "${slow_artefacts[@]}"; do
+  printf '==> JVM slow %s\n' "$artefact"
+  if ! (cd "$repo_root/$artefact" && clojure -M:slow-test); then
+    printf '\nFAIL JVM slow %s\nrepro: cd %s && clojure -M:slow-test\n' \
+      "$artefact" "$artefact" >&2
+    exit 1
+  fi
+done
+
 printf '==> implementation rigorous browser/bundle gates\n'
 # Local mirror of the rigorous browser-bundle-and-story sweep in
 # `.github/workflows/expensive-tests.yml` (plus `test:examples-compile`, the


### PR DESCRIPTION
## Problem (rf2-bv2qqm)

The `^:slow`/`^:stress` test gating was **non-functional**. The ssr / ssr-ring / routing docstrings claimed a `:slow-test` alias + a test-alias filter made the default gate skip the heavy tests — but no such alias/filter existed. Both `:test` aliases ran `re-frame.test-quiet.runner` (pass-through to cognitect-test-runner) with **no `-e` exclude**, and CI (`test.yml`) + the fast-PR/local gate ran bare `clojure -M:test`. cognitect only skips metadata given an explicit `-e`, so the heavy tests ran **unconditionally on every PR + local gate**:

- ssr: the 2000-request `ssr_teardown_load_test` (`^:slow`)
- ssr-ring: three multi-thread Jetty + `java.net.http` burst tests (`^:stress`)
- core / machines / routing / flows: 5000-iter × 8-thread concurrency-stress suites (routing was tagged `^:stress` but the tag was inert; core/machines/flows were untagged). No CI passed any `RF2_*_STRESS_ITERS` smaller-iteration override.

## Fix

Wired the gating consistently across all six artefacts carrying `^:slow`/`^:stress` tests:

1. **Default `:test` alias** now passes `-e :slow -e :stress` → cognitect-test-runner's `var-filter` drops excluded vars. PR/local gate skips the heavy tests.
2. **New `:slow-test` alias** passes `-i :slow -i :stress` (include-only). `:test` + `:slow-test` **partition** the suite — every test runs exactly once across the two.
3. **Tagged** the previously-untagged core/machines/flows stress deftests `^:stress`.
4. **Nightly**: new `jvm-slow-tests` matrix job in `expensive-tests.yml` runs `clojure -M:slow-test` per artefact. **Local**: `scripts/test-rigorous-local.sh` runs the same. No coverage lost.
5. Fixed the ssr / ssr-ring / routing docstrings to describe the actual wiring.

## Verified splits (all green, default `:test` / `:slow-test`)

| Artefact | `:test` (PR) | `:slow-test` (nightly) |
|---|---|---|
| core | 1721 | 3 |
| machines | 787 | 1 |
| routing | 293 | 3 |
| flows | 210 | 1 |
| ssr | 358 | 2 |
| ssr-ring | 157 | 3 |

`:slow-test` counts match the tagged deftests exactly. Full `scripts/test-jvm-implementation.sh` (default gate) green across all 17 artefacts with the reduced counts. `test:script-policy` (incl. the rigorous-local-inventory lockstep guard) green. clj-kondo: 0 errors on changed files (7 pre-existing warnings untouched).

## Hot-zone note

Touches `.github/workflows/expensive-tests.yml` (hot-zone — adds the nightly `jvm-slow-tests` job). I was the only worker touching workflows. Per-artefact `deps.edn` are not hot-zone.