### PR TITLE
test(core): fix subs-override-seam fixture + guard frame-constructing ns in isolation gate (rf2-8966iy)

### DIFF
--- a/implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs
+++ b/implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs
@@ -22,14 +22,12 @@
        failure trace."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
-            [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas.malli]                ;; install the default Malli validator
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling])
-  (:require-macros [re-frame.core :refer [with-frame]]))
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---- fixtures + helpers ---------------------------------------------------
 
@@ -51,20 +49,33 @@
 
 ;; EP-0002 (rf2-jue6sp): the override-seam tests exercise the ambient
 ;; 1-arity subscribe read path, which now requires a carried frame stamp.
-;; A function fixture registers :rf/default explicitly and pins it as the
-;; established scope for the whole test body via with-frame (the map-shape
-;; :before hook cannot wrap the body).
+;;
+;; rf2-8966iy: use the canonical `make-reset-runtime-fixture` instead of a
+;; bespoke `(rf/init! …)`-in-a-try fixture. The bespoke shape swallowed
+;; `init!`'s `install-once` throw (`install-adapter!` raises on a second
+;; install), so in the consolidated `:node-test` bundle — where a sibling
+;; ns may have left a reagent/uix adapter installed — `init!` threw, the
+;; throw was swallowed, and these subs ran against the WRONG substrate,
+;; masked by suite ordering. The canonical fixture force-DISPOSES the
+;; currently-installed adapter before installing `plain-atom`, ensures
+;; `:rf/default`, and binds it as the ambient scope for the whole body
+;; (the carried-invariant equivalent of `(with-frame :rf/default …)`), so
+;; the seam always runs against plain-atom regardless of run order.
+;;
+;; `:init-fn` runs UNDER that ambient scope right before each test body —
+;; the place to reset the override stand-in and (re)publish the test
+;; resolver. The outer `finally` resets the override atom on the way out as
+;; a belt-and-suspenders symmetry with `with-overrides*`'s own cleanup.
 (use-fixtures :each
-  (fn [test-fn]
-    (registrar/clear-all!)
-    (reset! override-atom nil)
-    (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-    (frame/ensure-default-frame!)
-    (install-test-resolver!)
-    (try
-      (with-frame :rf/default
-        (test-fn))
-      (finally (reset! override-atom nil)))))
+  (let [reset-runtime (test-support/make-reset-runtime-fixture
+                        {:adapter plain-atom/adapter
+                         :init-fn (fn []
+                                    (reset! override-atom nil)
+                                    (install-test-resolver!))})]
+    (fn [test-fn]
+      (try
+        (reset-runtime test-fn)
+        (finally (reset! override-atom nil))))))
 
 (defn- with-overrides* [m thunk]
   (reset! override-atom m)

--- a/implementation/scripts/check-per-ns-isolation.cjs
+++ b/implementation/scripts/check-per-ns-isolation.cjs
@@ -77,9 +77,12 @@ const ISOLATION_NAMESPACES = [
   're-frame.live-frame-reload-cljs-test',
   're-frame.migration-cljs-test',
   're-frame.multi-frame-isolation-cljs-test',
+  're-frame.owned-frame-lifecycle-cljs-test',
   're-frame.projection-cljs-test',
   're-frame.realm-cljs-test',
   're-frame.router-carried-frame-cljs-test',
+  're-frame.subs-override-seam-cljs-test',
+  're-frame.views-current-component-cljs-test',
 ];
 
 const NODE_TEST_BUNDLE = 'out/node-test.js';


### PR DESCRIPTION
## What

Two fixes for the per-namespace test-isolation gate class (rf2-8966iy, from rf2-ke7h7u).

### 1. Fix the subs-override-seam fixture
`implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs` did:
```clj
(registrar/clear-all!)
(try (rf/init! plain-atom/adapter) (catch :default _ nil))   ;; NO preceding dispose
```
`install-adapter!` is **install-once** (throws on a second install). In the consolidated `:node-test` bundle, if a sibling ns left a reagent/uix adapter installed, `init!` threw, the throw was **swallowed**, and the override-seam subs ran against the **wrong substrate** — masked by suite ordering.

**Fix:** switch to the canonical `make-reset-runtime-fixture {:adapter plain-atom/adapter}`, which force-DISPOSES the currently-installed adapter before installing `plain-atom`, ensures `:rf/default`, and binds it as the ambient scope for the body (the carried-invariant equivalent of `(with-frame :rf/default …)`). The per-test override-atom reset + resolver install move to `:init-fn` (which runs under that ambient scope). Dropped now-unused requires (`re-frame.frame`, `re-frame.registrar`, the `with-frame` macro).

### 2. Guard frame-constructing namespaces in the gate
Added to `scripts/check-per-ns-isolation.cjs` `ISOLATION_NAMESPACES`:
- `re-frame.subs-override-seam-cljs-test`
- `re-frame.owned-frame-lifecycle-cljs-test`
- `re-frame.views-current-component-cljs-test`

They construct runnable frames — the class the gate guards — and pass standalone today via the canonical fixture, but were unguarded against a future fixture regression. (realm stage-2 #4705 removed no ns; these are pure additions.)

## Gates
- `node scripts/check-per-ns-isolation.cjs` — **all 18 namespaces pass standalone (0 RED)**, including the 3 additions.
- `npm run test:cljs` — green (7929 tests, 33015 assertions, 0 failures, 0 errors).
- clj-kondo on the changed test file — 0 errors, 0 warnings.

Do NOT merge — for review.