### PR TITLE
refactor(ssr-ring): collapse per-frame realm routing to plain with-frame (rf2-sm214m, afdlyr stage-3)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -92,7 +92,6 @@
     - Async Ring handler (3-arity) — synchronous-only in v1;
       extension is additive."
   (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.cookie :as cookie]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
@@ -411,27 +410,14 @@
         (if short-circuit
           short-circuit
           (try
-            ;; rf2-nu5w48 / EP-0013 §Realm Conformance: bind the request
-            ;; frame's OWN realm around the accumulator read + the redirect
-            ;; short-circuit so the per-frame response side channel is
-            ;; addressed by the `(realm, frame)` slot (`frame/frame-address`),
-            ;; not the default realm's bare-id slot. `ssr/get-response` reads
-            ;; the realm's accumulated status/headers/cookies/redirect, and the
-            ;; redirect materialiser ships THAT realm's response. The non-error
-            ;; render branch (`build-full-response*`) re-establishes the realm
-            ;; binding around its own render walk (rf2-bzw8gd); the error path
-            ;; binds it inside `project-render-throw->ring-response`. Both
-            ;; no-op for a default-realm frame (byte-identical single-realm
-            ;; path). The redirect branch does no view resolution, so it only
-            ;; needs `call-with-realm` (the side-channel addressing dimension);
-            ;; the registrar is bound by the branches that resolve views.
-            (frame/call-with-realm (frame/frame-realm frame-id)
-              (fn []
-                (let [resp (ssr/get-response frame-id)]
-                  (if (some? (:redirect resp))
-                    ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
-                    (pipeline/ssr-response->ring-response resp nil)
-                    (pipeline/build-full-response frame-id resp opts)))))
+            ;; `ssr/get-response` reads the per-frame accumulated
+            ;; status/headers/cookies/redirect, and the redirect materialiser
+            ;; ships that response; both name the frame explicitly.
+            (let [resp (ssr/get-response frame-id)]
+              (if (some? (:redirect resp))
+                ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
+                (pipeline/ssr-response->ring-response resp nil)
+                (pipeline/build-full-response frame-id resp opts)))
             (catch Throwable t
               ;; rf2-ljjh0 — `safe-on-error` contains a throwing
               ;; caller `:on-error`: a bug in the caller's transport-

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -36,7 +36,6 @@
   (rf2-kzvwq)."
   (:require [re-frame.core :as rf]
             [re-frame.error :as error]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring.headers :as headers]
@@ -343,21 +342,13 @@
         ;; AND the hydration-payload build. One push/pop per request.
         explicit-head (:head opts)
         {:keys [head-html html-attrs body-attrs body-html rf-payload]}
-        ;; rf2-bzw8gd / rf2-tqjc7h / EP-0013 §Realm Conformance: route the render
-        ;; walk's registered-view + head/route registry lookups + operating frame
-        ;; through the request frame's OWN realm scope (`call-in-request-scope`),
-        ;; so a non-default-realm frame renders its realm's views/heads — not the
-        ;; process-global default's. The scope is established ONCE per request
-        ;; (covers resolve-root-view, render-to-string's `:view` lookups,
-        ;; resolve-head's `:head` / `:route` lookups, AND the payload's
-        ;; resource-runtime projection); a default-realm frame binds nothing (the
-        ;; byte-identical single-realm path). The non-streaming handler already
-        ;; bound the carried realm (ring.clj), so the helper's realm binding is
-        ;; an idempotent same-realm rebind; it additionally binds the realm
-        ;; registrar + `*current-frame*` (which the resource-runtime projection
-        ;; reads via `frame/resolve-current-frame`).
-        (frame/call-in-request-scope (frame/frame-realm frame-id) frame-id
-         (fn []
+        ;; rf2-bzw8gd / rf2-tqjc7h: pin `*current-frame*` to the request frame
+        ;; for the whole render walk (`rf/with-frame`), established ONCE per
+        ;; request. The scope covers resolve-root-view, render-to-string's
+        ;; `:view` lookups, resolve-head's `:head` / `:route` lookups, AND the
+        ;; payload's resource-runtime projection (which reads `*current-frame*`
+        ;; via `frame/resolve-current-frame`).
+        (rf/with-frame frame-id
           (let [hiccup    (lifecycle/resolve-root-view root-view)
                 ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's
                 ;; :head (or default-head fallback). The head fragment
@@ -396,10 +387,10 @@
                              :emit-hash?  emit-hash?
                              :render-hash (when emit-hash? hash-str)})
                 ;; rf2-p026f5 — build the hydration payload INSIDE the same
-                ;; `with-frame` + realm-registrar scope. app-db-value /
-                ;; runtime-db-value read the named frame explicitly, but the
-                ;; runtime-db PROJECTION is NOT frame-blind: the resources SSR
-                ;; hook (`:ssr/extend-runtime-db-projection` →
+                ;; `with-frame` scope. app-db-value / runtime-db-value read the
+                ;; named frame explicitly, but the runtime-db PROJECTION is NOT
+                ;; frame-blind: the resources SSR hook
+                ;; (`:ssr/extend-runtime-db-projection` →
                 ;; `re-frame.resources.ssr/project-resources-runtime-db`)
                 ;; resolves the CURRENT frame (`frame/resolve-current-frame`,
                 ;; the `*current-frame*` dynamic var) to apply frame-owned
@@ -413,7 +404,7 @@
                 ;; continuation drain may have mutated the frame-state) AND the
                 ;; frame scope the projection needs. This mirrors the streaming
                 ;; path, where `build-final-payload` runs inside the same
-                ;; `call-in-request-scope` rebinding (rf2-tbr67x / rf2-tqjc7h).
+                ;; `with-frame` rebinding (rf2-tbr67x / rf2-tqjc7h).
                 ;; EP-0001 (rf2-30kzz2): the runtime-db rides as the
                 ;; serializable `:rf/runtime-db` slice.
                 app-db     (rf/app-db-value frame-id)
@@ -424,7 +415,7 @@
                                                    :payload       payload})]
             (assoc head-bag
                    :body-html  body-html
-                   :rf-payload rf-payload))))
+                   :rf-payload rf-payload)))
         payload-edn (pr-str rf-payload)
         shell-opts  (assoc opts
                            :head        head-html
@@ -492,38 +483,24 @@
   generic-500 public-error is substituted so the wire still carries a
   well-formed fail-closed body.
 
-  rf2-nu5w48 / rf2-tqjc7h / EP-0013 §Realm Conformance: the WHOLE
-  error-projection + error-body render path runs inside the request frame's OWN
-  realm scope (`call-in-request-scope`), mirroring the happy-path
-  `build-full-response*` binding (rf2-bzw8gd):
-
-    - the realm binding makes the per-frame side channels this path touches
-      (`project-render-exception!` stamps the response accumulator,
-      `peek-response` reads it) address the `(realm, frame)` slot via
-      `frame/frame-address` — a non-default-realm frame's error status /
-      headers / cookies are read from ITS slot, not the default realm's
-      bare-id slot;
-    - the realm-registrar binding makes a caller `:error-view` REGISTERED IN
-      THE REALM resolve through the owning realm's registrar
-      (`resolve-error-body`'s `[error-view public-error]` view lookup), not the
-      process-global default's. (`resolve-error-body` re-pins `*current-frame*`
-      around its own render, so the helper's `*current-frame*` binding is inert
-      on this path — the realm + registrar dimensions are the load-bearing
-      ones.)
-
-  All no-op for a default-realm frame (byte-identical single-realm path)."
+  rf2-nu5w48 / rf2-tqjc7h: the WHOLE error-projection + error-body render path
+  runs inside the request frame's `with-frame` scope, mirroring the happy-path
+  `build-full-response*` binding (rf2-bzw8gd). `project-render-exception!`
+  stamps the per-frame response accumulator, `peek-response` reads it, and a
+  caller `:error-view` resolves through the registrar (`resolve-error-body`'s
+  `[error-view public-error]` view lookup); `resolve-error-body` re-pins
+  `*current-frame*` around its own render."
   [frame-id ^Throwable t opts]
-  (frame/call-in-request-scope (frame/frame-realm frame-id) frame-id
-    (fn []
-      (let [public-error  (ssr/project-render-exception! frame-id t)
-            resp*         (ssr/peek-response frame-id)
-            public-error* (or public-error
-                              {:status 500 :code :internal-error
-                               :message "Something went wrong"
-                               :retryable? false})
-            body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
-            content-type  (:content-type opts)]
-        (ssr-response->ring-response resp* body-html content-type)))))
+  (rf/with-frame frame-id
+    (let [public-error  (ssr/project-render-exception! frame-id t)
+          resp*         (ssr/peek-response frame-id)
+          public-error* (or public-error
+                            {:status 500 :code :internal-error
+                             :message "Something went wrong"
+                             :retryable? false})
+          body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
+          content-type  (:content-type opts)]
+      (ssr-response->ring-response resp* body-html content-type))))
 
 (defn build-full-response
   "Render the caller's `:root-view` against `frame-id`, build the

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -47,7 +47,6 @@
   (`:replace-frame-state`) when it lands."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.html-helpers :as html]
@@ -222,16 +221,11 @@
   ;; deferral is a separate axis — blocking ROUTE resources still settle before
   ;; the shell, exactly as in the non-streaming path.
   (ssr/drain-blocking-resources! frame-id opts)
-  ;; rf2-bzw8gd / rf2-tqjc7h / EP-0013 §Realm Conformance: route the shell
-  ;; render walk's registered-view + head/route lookups through the request
-  ;; frame's OWN realm scope (streaming counterpart of the non-streaming
-  ;; `build-full-response*` binding) via `call-in-request-scope`. We run on the
-  ;; REQUEST thread where the handler already bound the carried realm, so
-  ;; re-binding it from `frame-realm` is an idempotent same-realm rebind; the
-  ;; helper also binds the realm registrar + operating frame as one coherent
-  ;; nest. A default-realm frame binds nothing (byte-identical path).
-  (frame/call-in-request-scope (frame/frame-realm frame-id) frame-id
-   (fn []
+  ;; rf2-bzw8gd / rf2-tqjc7h: pin `*current-frame*` to the request frame for the
+  ;; shell render walk (`rf/with-frame`), the streaming counterpart of the
+  ;; non-streaming `build-full-response*` binding. Covers the registered-view +
+  ;; head/route lookups. Runs on the REQUEST thread.
+  (rf/with-frame frame-id
     (let [hiccup     (lifecycle/resolve-root-view root-view)
           head-bag   (if (:head opts)
                        {:head-html (:head opts) :html-attrs nil :body-attrs nil}
@@ -260,12 +254,7 @@
        :head-bag      head-bag
        :doc-hash      doc-hash
        :shell-html    shell-html
-       :continuations continuations
-       ;; rf2-bzw8gd: capture the frame's realm-id on the REQUEST thread (where
-       ;; `*current-realm*` is bound) so the daemon writer thread — which has no
-       ;; carried realm — can re-establish it around the continuation render
-       ;; walk. nil ⇒ default realm (byte-identical path).
-       :realm-id      (frame/frame-realm frame-id)}))))
+       :continuations continuations})))
 
 ;; ---- chunk writer (daemon thread, AFTER the head commits) ---------------
 ;;
@@ -355,7 +344,7 @@
           ;; destructured here. rf2-1kqvbx — `:head-bag` rides along so the
           ;; post-drain final-payload hash folds in the SAME head channel.
           {:keys [head-html html-attrs body-attrs
-                  doc-hash head-bag shell-html continuations realm-id]} rendered
+                  doc-hash head-bag shell-html continuations]} rendered
           shell-opts (merge opts
                             {:html-attrs  html-attrs
                              :body-attrs  body-attrs
@@ -411,17 +400,12 @@
       (loop [queue (into clojure.lang.PersistentQueue/EMPTY continuations)]
         (when-let [entry (peek queue)]
           (let [{:keys [id html delta failed? continuations]}
-                ;; rf2-bzw8gd / rf2-tqjc7h: re-establish the frame's full
-                ;; realm-aware request scope on this DAEMON thread (the request
-                ;; thread's `*current-realm*`/`*current-frame*` do not cross the
-                ;; thread boundary), so `render-continuation`'s frame lookups +
-                ;; registered-view resolution route through the owning realm.
-                ;; `call-in-request-scope` binds realm + realm-registrar +
-                ;; operating-frame as one coherent nest; nil/default realm-id is
-                ;; the byte-identical single-realm path.
-                (frame/call-in-request-scope realm-id frame-id
-                  (fn []
-                    (streaming/render-continuation frame-id entry)))
+                ;; rf2-bzw8gd / rf2-tqjc7h: pin `*current-frame*` on this DAEMON
+                ;; thread (the request thread's `*current-frame*` does not cross
+                ;; the thread boundary), so `render-continuation`'s frame lookups
+                ;; + registered-view resolution operate on the request frame.
+                (rf/with-frame frame-id
+                  (streaming/render-continuation frame-id entry))
                 tmpl-fn (if failed?
                           streaming/failed-template
                           streaming/resolved-template)]
@@ -449,16 +433,14 @@
             ;; redacts under `:rf.egress/ssr-hydration`. `project-delta` runs
             ;; the raw delta through `payload-policy/apply-policy` +
             ;; `project-app-db-egress` under the request frame on THIS daemon
-            ;; thread (inside the carried realm + `with-frame` scope re-bound
-            ;; above for the continuation render — so `project-app-db-egress`'s
-            ;; frame walk resolves the realm frame's elision registry). A delta
-            ;; that projects to empty (every changed key off-allowlist, or all
-            ;; redacted away to an empty map) emits NO script.
-            (let [projected (frame/call-with-realm realm-id
-                              (fn []
-                                (rf/with-frame frame-id
-                                  (streaming/project-delta delta frame-id
-                                                           {:payload payload}))))]
+            ;; thread (inside the `with-frame` scope — so
+            ;; `project-app-db-egress`'s frame walk resolves the frame's elision
+            ;; registry). A delta that projects to empty (every changed key
+            ;; off-allowlist, or all redacted away to an empty map) emits NO
+            ;; script.
+            (let [projected (rf/with-frame frame-id
+                              (streaming/project-delta delta frame-id
+                                                       {:payload payload}))]
               (when (and (not failed?) (map? projected) (seq projected))
                 (vreset! phase [:continuation-delta id])
                 (write-chunk! out (streaming/hydrate-delta-script id (pr-str projected)))))
@@ -478,7 +460,7 @@
       ;; hashes it, and fires a spurious `:rf.ssr/hydration-mismatch` against
       ;; the stale pre-drain hash (Spec 011 §Hydration equivalence rule). So we
       ;; RE-RESOLVE the root view here — on this daemon thread, inside the
-      ;; carried realm + frame binding, AFTER the drain loop — and recompute
+      ;; `rf/with-frame` binding, AFTER the drain loop — and recompute
       ;; the full-document hash over the post-drain tree via the SAME
       ;; `lifecycle/render-document-hash` mechanism (folding the carried
       ;; `head-bag`, drain-invariant in v1). The streamed-shell
@@ -530,40 +512,32 @@
       ;; as `:phase :final-payload` rather than leaking out as the prior
       ;; `:continuation-template`/`:shell-html` phase.
       (vreset! phase [:final-payload nil])
-      ;; rf2-tbr67x / rf2-nu5w48 / EP-0013 §Realm Conformance: re-establish the
-      ;; frame's FULL realm-aware request scope on THIS daemon thread around the
-      ;; post-drain hash recompute + `build-final-payload`, the SAME
-      ;; `call-in-request-scope` the continuation render uses above. The writer
-      ;; thread has NO ambient realm (the request thread's `*current-realm*`
-      ;; does not cross the thread boundary), so without the realm binding a
-      ;; non-default-realm frame stored at the `[realm frame-id]` slot is MISSED:
-      ;; `build-final-payload`'s `frame/frame-app-db-value` /
-      ;; `frame/frame-runtime-db-value` reads (and the root-view re-resolution's
-      ;; registered-view / head lookups) resolve `(frame frame-id)` through
-      ;; `frame/*current-realm*` + the realm registrar. nil `realm-id` ⇒ default
-      ;; realm ⇒ NO binding (byte-identical single-realm path), exactly like the
-      ;; continuation-render rebinding.
+      ;; rf2-tbr67x / rf2-nu5w48: pin `*current-frame*` on THIS daemon thread
+      ;; around the post-drain hash recompute + `build-final-payload` (the
+      ;; request thread's `*current-frame*` does not cross the thread boundary),
+      ;; the SAME `rf/with-frame` the continuation render uses above. The
+      ;; root-view re-resolution's registered-view / head lookups + the payload
+      ;; reads operate on the request frame.
       (let [final-payload
-            (frame/call-in-request-scope realm-id frame-id
-              (fn []
-                ;; rf2-1kqvbx — re-resolve the root view against the POST-drain
-                ;; frame state and recompute the full-document hash over it, so
-                ;; the payload's `:rf/render-hash` describes the SAME moment as
-                ;; its post-drain `:rf/app-db`. Falls back to the pre-drain
-                ;; `doc-hash` when no `:root-view` could be re-resolved
-                ;; (defensive — `validate-construction-opts!` requires
-                ;; `:root-view`, so this is belt-and-braces).
-                (let [post-drain-hash
-                      (if root-view
-                        (lifecycle/render-document-hash
-                          (lifecycle/resolve-root-view root-view)
-                          head-bag)
-                        doc-hash)]
-                  (streaming/build-final-payload
-                    frame-id post-drain-hash
-                    {:version       version
-                     :schema-digest schema-digest
-                     :payload       payload}))))]
+            (rf/with-frame frame-id
+              ;; rf2-1kqvbx — re-resolve the root view against the POST-drain
+              ;; frame state and recompute the full-document hash over it, so
+              ;; the payload's `:rf/render-hash` describes the SAME moment as
+              ;; its post-drain `:rf/app-db`. Falls back to the pre-drain
+              ;; `doc-hash` when no `:root-view` could be re-resolved
+              ;; (defensive — `validate-construction-opts!` requires
+              ;; `:root-view`, so this is belt-and-braces).
+              (let [post-drain-hash
+                    (if root-view
+                      (lifecycle/render-document-hash
+                        (lifecycle/resolve-root-view root-view)
+                        head-bag)
+                      doc-hash)]
+                (streaming/build-final-payload
+                  frame-id post-drain-hash
+                  {:version       version
+                   :schema-digest schema-digest
+                   :payload       payload})))]
         ;; Shared id-pinned, `</script>`-escaped payload <script>
         ;; (rf2-7ksyr) — same helper the non-streaming shell uses.
         (write-chunk! out (shell/payload-script-tag (pr-str final-payload))))
@@ -870,22 +844,6 @@
         (if short-circuit
           short-circuit
           (try
-            ;; rf2-nu5w48 / EP-0013 §Realm Conformance: bind the request
-            ;; frame's OWN realm around the request-thread body so every
-            ;; per-frame side channel it reads — the early `ssr/get-response`
-            ;; drain read, the post-shell `ssr/get-response` re-read, and the
-            ;; response materialisation on BOTH redirect short-circuits — is
-            ;; addressed by the `(realm, frame)` slot (`frame/frame-address`),
-            ;; not the default realm's bare-id slot. `render-streaming-shell!`
-            ;; re-establishes the realm registrar around its OWN render walk
-            ;; (rf2-bzw8gd) and captures `:realm-id` for the daemon writer to
-            ;; carry across the thread boundary; the shell-render error path
-            ;; binds it inside `project-render-throw->ring-response`
-            ;; (rf2-nu5w48). This request-thread binding closes the redirect +
-            ;; accumulator-read gaps the render-walk binding did not cover.
-            ;; No-op for a default-realm frame (byte-identical single-realm
-            ;; path); it does NOT cross into the spawned writer thread (which
-            ;; carries its realm via `:realm-id`).
             ;; rf2-r06pc — the request-thread body, top-down: read the response
             ;; accumulator; on a `:redirect` short-circuit BEFORE any chunked
             ;; head / writer; otherwise render the shell on THIS thread (failing
@@ -895,35 +853,33 @@
             ;; the chunked head ONLY once the shell is known-renderable. The
             ;; helpers (`render-shell-or-projected-error`, `stream-rendered-
             ;; response`, `redirect-response!`) carry the per-step rationale.
-            (frame/call-with-realm (frame/frame-realm frame-id)
-              (fn []
-                (let [resp (ssr/get-response frame-id)]
-                  (if (some? (:redirect resp))
-                    ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
-                    (redirect-response! resp frame-id)
-                    (let [rendered (render-shell-or-projected-error frame-id opts)]
-                      (if (reduced? rendered)
-                        ;; Shell render threw — return the projected error page
-                        ;; (frame already torn down inline).
-                        @rendered
-                        ;; Shell rendered cleanly. Re-read the accumulator to
-                        ;; surface any fail-closed status (rf2-vvwmi /
-                        ;; rf2-c0bq1) before materialising the chunked head.
-                        ;;
-                        ;; rf2-5knxf.1 — a `:redirect` here is defense-in-depth:
-                        ;; in v1 it cannot surface at the post-shell re-read
-                        ;; (only the `:on-create`-drain `:rf.server/redirect`
-                        ;; sets it, caught by the early branch above; the error
-                        ;; projector stamps `:status` only, never `:redirect`).
-                        ;; The branch aligns the streaming path with the
-                        ;; non-streaming handler's redirect-ignores-body parity
-                        ;; for a future render-phase fx / hand-built accumulator
-                        ;; that learns to redirect.
-                        (let [resp2 (ssr/get-response frame-id)]
-                          (if (some? (:redirect resp2))
-                            (redirect-response! resp2 frame-id)
-                            (stream-rendered-response
-                              frame-id rendered resp2 content-type opts)))))))))
+            (let [resp (ssr/get-response frame-id)]
+              (if (some? (:redirect resp))
+                ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
+                (redirect-response! resp frame-id)
+                (let [rendered (render-shell-or-projected-error frame-id opts)]
+                  (if (reduced? rendered)
+                    ;; Shell render threw — return the projected error page
+                    ;; (frame already torn down inline).
+                    @rendered
+                    ;; Shell rendered cleanly. Re-read the accumulator to
+                    ;; surface any fail-closed status (rf2-vvwmi /
+                    ;; rf2-c0bq1) before materialising the chunked head.
+                    ;;
+                    ;; rf2-5knxf.1 — a `:redirect` here is defense-in-depth:
+                    ;; in v1 it cannot surface at the post-shell re-read
+                    ;; (only the `:on-create`-drain `:rf.server/redirect`
+                    ;; sets it, caught by the early branch above; the error
+                    ;; projector stamps `:status` only, never `:redirect`).
+                    ;; The branch aligns the streaming path with the
+                    ;; non-streaming handler's redirect-ignores-body parity
+                    ;; for a future render-phase fx / hand-built accumulator
+                    ;; that learns to redirect.
+                    (let [resp2 (ssr/get-response frame-id)]
+                      (if (some? (:redirect resp2))
+                        (redirect-response! resp2 frame-id)
+                        (stream-rendered-response
+                          frame-id rendered resp2 content-type opts)))))))
             (catch Throwable t
               ;; get-response throw, redirect-materialise throw, OR (per
               ;; rf2-z5azc) a head-materialisation throw raised BEFORE the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
@@ -27,9 +27,9 @@
   end-to-end projection assertion (same `\"jake\"` viewer + `{:articles …}`
   data the bead's review eval reproduced) but drives it through the actual
   non-streaming Ring render path (`build-full-response*`), where the payload
-  build had escaped the frame scope. The realm sibling that fixed the
-  STREAMING path is `re-frame.ssr.ring.realm-routing-test`
-  (rf2-tbr67x — daemon-writer realm rebinding)."
+  build had escaped the frame scope. The streaming-path frame-scope coverage
+  (the daemon-writer `rf/with-frame` rebinding, rf2-tbr67x) lives in
+  `re-frame.ssr.ring-streaming-test`."
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]


### PR DESCRIPTION
## What

Stage 3 of the rf2-afdlyr realm-substrate collapse (parent RULED: collapse the retained-internal realm substrate). Collapses ssr-ring's per-frame realm routing to the retained public lexical primitive `rf/with-frame`.

Per the rf2-sm214m census (verified by code-trace, not comment-inferred): **SSR-ring realm routing is ALWAYS the default realm.** `pipeline/setup-request-frame!` is the sole per-request frame creator — it calls `reg-frame` with NO `:realm` and never binds `frame/*current-realm*`, so every realm-routing wrap resolved to the default and was a guaranteed no-op. Re-verified in this branch: the only `*current-realm*`/`call-with-realm` references in `ssr-ring/src` were the routing sites themselves; nothing in `ssr-ring` or `ssr` production src constructs or binds a non-default realm.

## Sites collapsed (per census)

- **ring.clj** — dropped the `call-with-realm` wrapper around the redirect / response read (it bound only the realm dimension; the body names the frame explicitly).
- **pipeline.clj** — `build-full-response*` happy path + `project-render-throw->ring-response` error path: `call-in-request-scope` → `rf/with-frame`.
- **streaming.clj** — `render-streaming-shell!` request-thread walk, continuation render, `project-delta`, and final-payload build: `call-in-request-scope` / `call-with-realm` → `rf/with-frame`; **deleted** the `:realm-id` cross-thread envelope key + its writer-side destructure; dropped the request-thread `call-with-realm` wrapper in `stream-handler`.

The daemon-writer cross-thread realm-rebind machinery (the `:realm-id` envelope carry + three daemon-thread realm wrappers) was pure overhead under a single default realm — frames are keyed by bare frame-id, so the writer thread resolves `(frame frame-id)` with no realm binding. Removed the now-unused `re-frame.frame` `:require` alias from all three nss.

## Kept (why)

- `rf/with-frame` itself — the stable public lexical primitive (`*current-frame*` pin); every collapsed site needs the operating-frame binding.
- `ssr/head/registry.cljc` `call-with-frame-realm-registrar` (lines 168, 236) — **out of scope** (it lives in the `ssr` artefact, not `ssr-ring`; the census flags it as a general framework helper, coordinate with the head-registry owner).

## Discovery rule (afdlyr)

Verified: no real ssr-ring path seats a non-default realm. The census holds — nothing collapsed that wasn't always-default.

## frame.cljc orphan status (for rf2-m6n7hx)

After this lands:
- `call-in-request-scope` — **fully orphaned** (zero source consumers repo-wide; ssr-ring was the last).
- `call-with-realm` — **fully orphaned** (zero source consumers; router/subs collapsed in 9w37t2, already merged).
- `call-with-frame-realm-registrar` — **NOT orphaned** (2 consumers in `ssr/head/registry.cljc`).
- `frame-realm` — **NOT orphaned** (`routing/link.cljc:151`, `ssr/head/registry.cljc`, `realm_cljs_test.cljc`).

So m6n7hx can remove `call-in-request-scope` + `call-with-realm` outright; the other two need their remaining `ssr`/`routing` consumers handled first.

## Exec-line delta

ring.clj -3, pipeline.clj -14, streaming.clj -9 = **-26 exec lines** (plus ~80 comment lines removed). Diff stat: 115 insertions / 196 deletions.

## Gates (all green)

- ssr-ring JVM: 157 tests / 697 assertions, 0 failures (post-rebase; #4708's `^:slow`/`^:stress` gating moved 3 out of the PR gate)
- ssr JVM head-registry cross-check: 360 tests / 1445 assertions, 0 failures
- CLJS node (`test:cljs`): 7929 tests / 33015 assertions, 0 failures
- bundle-isolation: PASS
- clj-kondo: 0 errors (1 pre-existing `unused binding resp` warning in `build-full-response*`, present at HEAD, unrelated to this change)

Rebased onto origin/main (picked up merged #4708, bv2qqm — disjoint test files). No `realm_routing_test.clj` to retire (already removed in stage 1); fixed a stale docstring reference to it in `resource_payload_projection_test.clj`.

Do not merge — review gate.
