### PR TITLE
fix(tools/xray): reply_envelope frame read (rf2-l9vb09)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -402,6 +402,32 @@ machines / timers:
   `:rf.reply/*` spelling, so a row carrying only the additive vocabulary is
   still joined into the uniform work/reply rows by `:work/id` rather than
   losing its status / work-id / grouping.
+- **Frame attribution — two family spellings on a reply trace row
+  (rf2-l9vb09).** Two LEGITIMATE frame spellings ride a managed-async
+  reply TRACE ROW, by family:
+    - **resources / machines / mutations** stamp the canonical EP-0002
+      **carried-frame stamp `:rf.frame/id`** in `:tags` (the
+      reply-envelope facts the family emits its row FROM — Managed-Effects
+      §The reply map / §Tracing; e.g. `re-frame.resources.events`);
+    - **HTTP** stamps the **bare `:frame`** in `:tags` — the generic
+      raw-event carve-out read by the contract-owned canonical reader
+      `re-frame.trace/trace-event-frame` (`[:tags :frame]`, rf2-7737vq;
+      `re-frame.http.transport`'s `:rf.http/stale-suppressed`).
+
+  `work-event-row` therefore reads **`(or (:rf.frame/id tags)
+  (trace/trace-event-frame ev))`** — `:rf.frame/id` preferred, falling
+  back to the canonical raw-event reader for the bare `[:tags :frame]`. It
+  uses the canonical reader where it applies (HTTP) rather than
+  hand-reaching into `[:tags :frame]`. The historical defensive over-reads
+  (bare `:frame-id` in `:tags` — rf2-shaa1 dropped it, no emit site
+  produces it; a top-level `:frame` on the raw event — raw events carry
+  frame ONLY under `:tags`) are dead and not consulted.
+
+  The **reply MAP** layer is different: the dispatched reply map is
+  UNIFORM on `:rf.frame/id` across every family ("there is no second
+  frame spelling" — HTTP's reply BUILDER maps its internal `:frame` ctx
+  onto `:rf.frame/id` on the map), so `reply-row` reads `:rf.frame/id`
+  alone.
 - **`status->class`** gives the one cross-surface colour class so a
   `:stale` HTTP reply and a `:stale` resource reply render the **same
   badge** (Cross-Cutting [F.11](019-Cross-Cutting-Insight.md) — the

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -39,15 +39,20 @@
 
   ## Bundle isolation
 
-  Xray does NOT `:require` `re-frame.reply` (or any `implementation/`
-  namespace) — the closed vocabularies below are MIRRORED as literal
-  data, exactly as `resources-helpers` mirrors the reserved runtime-db
-  keys. The mirror is the bundle-isolation-safe price of not adding a
-  require edge from a tool into core; a drift would be caught by the
-  closed-vocabulary wiring test. (`re-frame.reply` is core, not an
-  optional artefact, but the no-tool-imports-core direction is the
-  bundle contract regardless — nothing in `implementation/` may require
-  `tools/`, and Xray consumes the WIRE FACTS, not the substrate fns.)
+  Xray does NOT `:require` `re-frame.reply` (the substrate ALGEBRA) — the
+  closed vocabularies below are MIRRORED as literal data, exactly as
+  `resources-helpers` mirrors the reserved runtime-db keys. The mirror is
+  the bundle-isolation-safe price of not adding a require edge into the
+  reply substrate; a drift would be caught by the closed-vocabulary
+  wiring test. It DOES `:require` `re-frame.trace` for the contract-owned
+  canonical RAW trace-event frame reader (`trace-event-frame`,
+  rf2-7737vq) — the same trace-CONTRACT reader the rest of Xray already
+  consumes (`self-noise`, `trace-collector`, `runtime`); that is a read of
+  the published trace contract, not the substrate fns. The bundle
+  contract is the no-tool-imports-CORE direction — nothing in
+  `implementation/` may require `tools/` — which neither edge violates;
+  Xray consumes the WIRE FACTS + the trace contract, never the substrate
+  algebra.
 
   ## PRIVACY
 
@@ -65,7 +70,15 @@
 
   Every fn here is pure data → data, JVM-runnable so the algebra runs
   under the unit-test target without a CLJS runtime."
-  (:require [day8.re-frame2-xray.panels.resources-helpers :as rh]))
+  (:require [day8.re-frame2-xray.panels.resources-helpers :as rh]
+            ;; the contract-owned canonical RAW trace-event frame reader
+            ;; (`[:tags :frame]` — Spec 009 §Frame identity on the raw event,
+            ;; rf2-7737vq). NOT the substrate algebra (`re-frame.reply`) the
+            ;; closed vocabularies below MIRROR: `re-frame.trace` is the trace
+            ;; CONTRACT reader xray already consumes (`self-noise`,
+            ;; `trace-collector`, `runtime`); the no-tool-imports-core bundle
+            ;; direction (core MUST NOT require tools) is unaffected.
+            [re-frame.trace :as trace]))
 
 ;; ---------------------------------------------------------------------------
 ;; The closed vocabularies (MIRRORED from re-frame.reply — Managed-Effects
@@ -249,7 +262,16 @@
      :status        status
      :work-status   (or (:work/status reply) (:work-status reply))
      :attempt       (:attempt reply)
-     :frame         (or (:rf.frame/id reply) (:frame-id reply) (:frame reply))
+     ;; The reply MAP's frame is the canonical EP-0002 carried-frame stamp
+     ;; `:rf.frame/id` — UNIFORM across every family on the reply map
+     ;; (Managed-Effects §The reply map — "there is no second frame spelling";
+     ;; HTTP's reply builder maps its internal `:frame` ctx ONTO `:rf.frame/id`
+     ;; on the dispatched map). This reply-map layer is distinct from the raw
+     ;; trace-event layer (where HTTP rows ride the bare `[:tags :frame]`
+     ;; carve-out — see `work-event-row`), so the canonical raw-event reader
+     ;; `trace-event-frame` does not apply to a reply map. The historical dead
+     ;; `:frame-id` / bare `:frame` reply-map aliases are gone (rf2-l9vb09).
+     :frame         (:rf.frame/id reply)
      :started-at    (:started-at reply)
      :completed-at  (:completed-at reply)
      :deadline-at   (:deadline-at reply)
@@ -544,7 +566,24 @@
                  :phase        phase
                  :work-kind    (or (work-kind-of tags) (infer-work-kind work-id))
                  :work-id      work-id
-                 :frame        (or (:rf.frame/id tags) (:frame-id tags) (:frame ev))
+                 ;; Frame attribution across families (rf2-l9vb09). Two
+                 ;; legitimate frame spellings ride a managed-async reply trace
+                 ;; row, by family:
+                 ;;   - resources / machines / mutations stamp the EP-0002
+                 ;;     carried-frame stamp `:rf.frame/id` in `:tags`
+                 ;;     (Managed-Effects §The reply map — the reply-envelope
+                 ;;     facts the family emits its row FROM);
+                 ;;   - HTTP stamps the bare `:frame` in `:tags` — the generic
+                 ;;     raw-event carve-out read by the contract-owned canonical
+                 ;;     reader `re-frame.trace/trace-event-frame` ([:tags :frame],
+                 ;;     rf2-7737vq).
+                 ;; Prefer `:rf.frame/id`, falling back to the canonical reader
+                 ;; for the bare `[:tags :frame]` slot. The historical dead
+                 ;; aliases — bare `:frame-id` in `:tags` (rf2-shaa1 dropped it;
+                 ;; no emit site produces it) and a top-level `:frame` on the
+                 ;; raw event (raw events carry frame ONLY under `:tags`) — are
+                 ;; gone.
+                 :frame        (or (:rf.frame/id tags) (trace/trace-event-frame ev))
                  ;; rf2-waawic — tolerate the additive `:rf.reply/work-status`
                  ;; production key so machine / resource / mutation rows do not
                  ;; lose their work status.

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -527,6 +527,78 @@
         (is (= expected-class (:status-class row)))))))
 
 ;; ---------------------------------------------------------------------------
+;; (6c) Frame attribution across families (rf2-l9vb09). Two LEGITIMATE frame
+;; spellings ride a managed-async reply TRACE ROW, by family:
+;;   - resources / machines / mutations stamp the EP-0002 carried-frame stamp
+;;     `:rf.frame/id` in `:tags` (the reply-envelope facts — Managed-Effects
+;;     §The reply map; e.g. `re-frame.resources.events`);
+;;   - HTTP stamps the bare `:frame` in `:tags` — the generic raw-event
+;;     carve-out read by the contract-owned canonical reader
+;;     `re-frame.trace/trace-event-frame` ([:tags :frame], rf2-7737vq; e.g.
+;;     `re-frame.http.transport`'s `:rf.http/stale-suppressed` emit).
+;; `work-event-row` prefers `:rf.frame/id`, falling back to the canonical
+;; reader for the bare `[:tags :frame]`. The historical dead over-reads — bare
+;; `:frame-id` in `:tags` (rf2-shaa1 dropped it; NO emit site produces it) and
+;; a top-level `:frame` on the raw event (raw events carry frame ONLY under
+;; `:tags`) — are gone, pinned-out here.
+;;
+;; The reply MAP layer (`reply-row`) is UNIFORM on `:rf.frame/id` across every
+;; family — even HTTP, whose reply BUILDER maps its internal `:frame` ctx onto
+;; `:rf.frame/id` on the dispatched map (`re-frame.http.reply`).
+;; ---------------------------------------------------------------------------
+
+(deftest reply-row-frame-attribution-across-families
+  (testing "work-event-row reads :frame off the canonical [:tags :rf.frame/id]
+            carried stamp — the resource / machine / mutation reply-row shape"
+    (let [row (re/work-event-row
+                {:id 60 :operation :rf.resource/work-started
+                 :time 400 :tags {:work/id [:rf.work/resource :k 1]
+                                  :rf.frame/id :app/main}})]
+      (is (= :app/main (:frame row))
+          "frame read off the EP-0002 carried-frame stamp :rf.frame/id")))
+  (testing "work-event-row resolves the HTTP family's bare [:tags :frame] slot
+            via the canonical raw-event reader trace-event-frame (rf2-7737vq) —
+            EXACTLY as re-frame.http.transport's :rf.http/stale-suppressed emits"
+    (let [row (re/work-event-row
+                {:id 61 :operation :rf.http/stale-suppressed
+                 :time 410 :tags {:work/id [:rf.work/http :search 1 1]
+                                  :work/kind :http
+                                  :rf.reply/status :stale
+                                  ;; HTTP's family frame spelling — the bare
+                                  ;; [:tags :frame] carve-out
+                                  :frame :app/main}})]
+      (is (= :app/main (:frame row))
+          "HTTP's bare [:tags :frame] resolved via the canonical reader")))
+  (testing ":rf.frame/id is preferred over the bare [:tags :frame] when a row
+            (defensively) carried both"
+    (let [row (re/work-event-row
+                {:id 62 :operation :rf.resource/work-started
+                 :time 420 :tags {:work/id [:rf.work/resource :k 1]
+                                  :rf.frame/id :canonical/win
+                                  :frame :raw/lose}})]
+      (is (= :canonical/win (:frame row)))))
+  (testing "the dead alias reads are gone — bare :frame-id in tags + a top-level
+            :frame on the event are NOT consulted (no production row emits them)"
+    (let [row (re/work-event-row
+                {:id 63 :operation :rf.resource/work-started
+                 :time 430
+                 :frame :top-level/dead              ;; dead top-level alias
+                 :tags {:work/id [:rf.work/resource :k 1]
+                        :frame-id :tags-bare/dead}})] ;; dead bare-:frame-id alias
+      (is (nil? (:frame row))
+          "neither the dead bare :frame-id nor the top-level :frame is read")))
+  (testing "reply-row (the reply-MAP projector) rides :rf.frame/id uniformly
+            (incl. HTTP) and ignores the dead :frame-id / :frame aliases"
+    (let [canonical (re/reply-row {:status :ok :work/id [:rf.work/http :req 1]
+                                   :rf.frame/id :app/main})
+          dead      (re/reply-row {:status :ok :work/id [:rf.work/http :req 1]
+                                   :frame-id :bare/dead :frame :top/dead})]
+      (is (= :app/main (:frame canonical))
+          "reply map frame read off the canonical :rf.frame/id")
+      (is (nil? (:frame dead))
+          "the dead :frame-id / :frame reply-map aliases are not read"))))
+
+;; ---------------------------------------------------------------------------
 ;; (7) stale-races — keyed on :work/id; cross-surface tally; attempt arcs.
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up from rf2-7737vq Stage B (rf2-l9vb09, P3). `work-event-row` in `tools/xray/.../panels/reply_envelope.cljc` read a managed-async reply trace row's frame via stale divergent keys:

```clojure
:frame (or (:rf.frame/id tags) (:frame-id tags) (:frame ev))
```

## Investigation finding

The reply_envelope projectors read TWO distinct layers, and `work-event-row` specifically projects a RAW managed-async reply **trace event** (not a generic raw trace event, not a reply-envelope *record* with a single key). Across families there are **two legitimate frame spellings on a reply trace row**:

- **resources / machines / mutations** stamp the canonical EP-0002 **carried-frame stamp `:rf.frame/id`** in `:tags` (the reply-envelope facts the family emits its row FROM — Managed-Effects §The reply map; e.g. `re-frame.resources.events`).
- **HTTP** stamps the **bare `:frame`** in `:tags` — the generic raw-event carve-out read by the contract-owned canonical reader `re-frame.trace/trace-event-frame` (`[:tags :frame]`, rf2-7737vq; e.g. `re-frame.http.transport`'s `:rf.http/stale-suppressed`).

So this was a **real divergence**, but NOT the straight `trace-event-frame` migration the bead hypothesised:
- migrating to `trace-event-frame` alone (`[:tags :frame]`) would have **dropped the resource/machine frame** (they ride `:rf.frame/id`, not `[:tags :frame]`);
- the prior reader's top-level `(:frame ev)` fallback **never matched HTTP** (HTTP rides `[:tags :frame]`, not a top-level `:frame` on the event — raw events carry frame only under `:tags`).

## Fix

`work-event-row` now reads `(or (:rf.frame/id tags) (trace/trace-event-frame ev))` — `:rf.frame/id` preferred (resources/machines/mutations), falling back to the canonical raw-event reader for HTTP's bare `[:tags :frame]`. Uses the canonical reader where it applies rather than hand-reaching into `[:tags :frame]`.

The genuinely-dead aliases are dropped: bare `:frame-id` in `:tags` (rf2-shaa1 dropped it; no emit site produces it) and the top-level `:frame` on the raw event.

`reply-row` (the reply-MAP projector) is uniform on `:rf.frame/id` across every family — HTTP's reply *builder* (`re-frame.http.reply`) maps its internal `:frame` ctx onto `:rf.frame/id` on the dispatched map — so it reads `:rf.frame/id` alone; dead `:frame-id` / `:frame` aliases dropped there too.

Adds a cross-family frame-attribution acceptance test; documents the two-spelling contract in xray spec 013. Xray now `:require`s `re-frame.trace` for the canonical reader (the trace CONTRACT, same as `self-noise` / `trace-collector` / `runtime` already do — not the `re-frame.reply` substrate algebra), so the bundle-isolation `no-tool-imports-core` direction is unaffected.

## Gates
- clj-kondo: 0 errors, 0 warnings
- xray JVM (`clojure -M:test`): 1240 tests / 5692 assertions, 0 failures
- CLJS node-test (`npm run test:cljs`): 7930 tests / 33021 assertions, 0 failures
- bundle-isolation: PASS (the `re-frame.trace` edge does not leak tools into production)
- mcp-conformance wire-vocab: 101 tests / 1062 assertions, 0 failures