### PR TITLE
perf(resources): incremental index maintenance + work-ledger key-index + owner-index mismatch scan (rf2-2c2mkh, rf2-wyan7e, rf2-tluunj)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1663,7 +1663,9 @@
                                      [wid (:transport (work-ledger/get-record runtime-db wid))]))))
                          in-scope-ids)
         ;; remove the entries, settle their in-flight work rows :cancelled,
-        ;; then recompute the indexes from what remains
+        ;; then reconcile the indexes for the removed keys. rf2-2c2mkh — only
+        ;; the in-scope keys' index members change, so reconcile that bounded
+        ;; set incrementally rather than full-rebuilding from all entries.
         rdb'       (-> runtime-db
                        (update-in (state/entries-path)
                                   (fn [es] (reduce dissoc es in-scope-ids)))
@@ -1672,7 +1674,8 @@
                                             d wid work-ledger/mark-terminal
                                             :cancelled {:reason :clear-scope}))
                                         db in-flight))
-                       (update state/resources-key state/recompute-indexes))]
+                       (update state/resources-key state/reindex-keys
+                               entries in-scope-ids))]
     (trace/emit! :rf.event :rf.resource/removed
                  {:rf.frame/id frame-id :scope cscope :cause cause
                   :removed (vec in-scope) :reason :clear-scope
@@ -1783,6 +1786,9 @@
         entry      (get-in runtime-db (state/entry-path scoped-key))
         wid        (:current-work entry)
         transport  (when wid (:transport (work-ledger/get-record runtime-db wid)))
+        ;; rf2-2c2mkh — removing ONE entry touches ONE key's index members;
+        ;; reconcile incrementally rather than full-rebuilding both indexes.
+        old-entries (get-in runtime-db (state/entries-path))
         rdb'       (-> runtime-db
                        ;; rf2-9e0tyq — dissoc by the byte key-id (a dissoc by
                        ;; the scoped-key vector would no-op and leak the entry).
@@ -1790,7 +1796,8 @@
                        (cond-> wid (work-ledger/update-record
                                      wid work-ledger/mark-terminal
                                      :cancelled {:reason :remove}))
-                       (update state/resources-key state/recompute-indexes))]
+                       (update state/resources-key state/reindex-keys
+                               old-entries [(state/key-id scoped-key)]))]
     (trace/emit! :rf.event :rf.resource/removed
                  {:rf.frame/id frame-id :resource/key scoped-key :reason :remove
                   :aborted (when wid [wid])})
@@ -2090,18 +2097,21 @@
             poll-delay-ms (when (seq (:active-owners entry'))
                             (state/positive-or-nil (:poll-interval-ms spec)))
             ;; on a successful load the tag index for this key is REPLACED
-            ;; with the new tags (old tags removed); recompute is the simple,
-            ;; correct way to keep both indexes consistent. The work row
-            ;; settles :completed; terminal rows for this key are then PRUNED
-            ;; (bounded per-key tail kept for Xray) — Spec 016 §Ledger row
-            ;; retention. The host handle is cleared (the attempt settled).
+            ;; with the new tags (old tags removed). This settle touches ONE
+            ;; entry, so reconcile only that key's index members incrementally
+            ;; (rf2-2c2mkh) rather than full-rebuilding both indexes. The work
+            ;; row settles :completed; terminal rows for this key are then
+            ;; PRUNED (bounded per-key tail kept for Xray) — Spec 016 §Ledger
+            ;; row retention. The host handle is cleared (the attempt settled).
+            old-entries (get-in runtime-db (state/entries-path))
             rdb'      (-> runtime-db
                           (assoc-in (state/entry-path resource-key) entry')
                           (work-ledger/update-record
                             work-id work-ledger/mark-terminal
                             :completed {:loaded-at loaded-at})
                           (work-ledger/prune-terminal-for-key resource-key)
-                          (update state/resources-key state/recompute-indexes)
+                          (update state/resources-key state/reindex-keys
+                                  old-entries [(state/key-id resource-key)])
                           ;; route blocking: a route-owned blocking resource
                           ;; settling drops it from the nav-token blocking
                           ;; slot + lands the route transition when the slot
@@ -2766,10 +2776,13 @@
     (if (and entry (empty? (:active-owners entry)) (nil? (:current-work entry)))
       ;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; dissoc by it
       ;; (a dissoc by the scoped-key VECTOR would be a no-op and the GC removal
-      ;; would silently leak the entry).
-      (let [rdb' (-> runtime-db
+      ;; would silently leak the entry). rf2-2c2mkh — GC removes ONE entry, so
+      ;; reconcile only that key's index members incrementally.
+      (let [old-entries (get-in runtime-db (state/entries-path))
+            rdb' (-> runtime-db
                      (update-in (state/entries-path) dissoc (state/key-id resource-key))
-                     (update state/resources-key state/recompute-indexes))]
+                     (update state/resources-key state/reindex-keys
+                             old-entries [(state/key-id resource-key)]))]
         (trace/emit! :rf.event :rf.resource/gc-fired
                      {:rf.frame/id frame-id :resource/key resource-key})
         {:rf.db/runtime rdb'

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -609,12 +609,21 @@
         ;; apply every :restore disposition to the cache (an :invalidate
         ;; disposition leaves the moved entry in place — the read path recovers).
         restored?    #(= :restore (:disposition %))
+        ;; rf2-2c2mkh — capture the pre-rollback entries so the index delta is
+        ;; reconciled against them. Only the recorded inverse's keys can change
+        ;; (a :restore re-creates / drops an entry; an :invalidate leaves the
+        ;; moved entry untouched here), so reconcile that bounded key set
+        ;; incrementally rather than full-rebuilding from all entries.
+        old-entries  (get-in runtime-db (state/entries-path))
+        changed-ids  (mapv (fn [{scoped-key :resource/key}] (state/key-id scoped-key))
+                           inverse)
         rdb'         (reduce (fn [rdb disp]
                                (if (restored? disp)
                                  (mstate/restore-before rdb disp)
                                  rdb))
                              runtime-db dispositions)
-        rdb''        (update rdb' state/resources-key state/recompute-indexes)
+        rdb''        (update rdb' state/resources-key state/reindex-keys
+                             old-entries changed-ids)
         ;; one scoped invalidation per :invalidate (conflicted, non-:force) key,
         ;; computed against the ROLLED-BACK runtime-db (`rdb''` — the restores are
         ;; in, so the invalidate reads the moved entries that stayed). Drops a key
@@ -1342,8 +1351,12 @@
                                     ;; the SETTLE slice fills these:
                                     :reconciliation-refetches nil})
                          ;; a seed / remove may have created / dropped entries +
-                         ;; tags — recompute the reverse indexes.
-                         (update state/resources-key state/recompute-indexes))
+                         ;; tags. rf2-2c2mkh — only the applied keys' index
+                         ;; members change, so reconcile that bounded set
+                         ;; incrementally (against the pre-apply `opt-entries`)
+                         ;; rather than full-rebuilding from all entries.
+                         (update state/resources-key state/reindex-keys
+                                 opt-entries (mapv state/key-id opt-ks)))
                      rdb1)]
     (when opt-applied?
       (trace/emit! :rf.event :rf.mutation/optimistic-applied
@@ -1780,14 +1793,23 @@
             inst'       (mstate/instance-succeeded
                           inst {:result result :settled-at clock-ms
                                 :affected-keys affected :patch-summary patch-summary})
+            ;; rf2-2c2mkh — the cache consequences (apply-patches /
+            ;; apply-populates / apply-removes above) touch ONLY the
+            ;; `authoritative-keys`; reconcile that bounded set's index members
+            ;; incrementally against the pre-mutation entries rather than
+            ;; full-rebuilding from all entries. (The success-time invalidation
+            ;; rides a separate dispatched `:rf.resource/invalidate-tags`, which
+            ;; marks entries stale without touching `:tags` / `:active-owners`,
+            ;; so it never perturbs the indexes.)
+            old-entries (get-in runtime-db (state/entries-path))
             rdb'        (-> rdb3
                             (assoc-in (mstate/instance-path instance-id) inst')
                             (work-ledger/update-record
                               work-id work-ledger/mark-terminal
                               :completed {:settled-at clock-ms})
-                            ;; recompute indexes — patch/populate may have
-                            ;; changed entries' tags / created entries.
-                            (update state/resources-key state/recompute-indexes))
+                            (update state/resources-key state/reindex-keys
+                                    old-entries
+                                    (mapv state/key-id authoritative-keys)))
             ;; arm the advisory stale / GC timers (host-side side table) for
             ;; every patched / populated key carrying a policy — one
             ;; `:rf.resource/schedule-timers` fx per key, mirroring the

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -1369,6 +1369,81 @@
       (assoc resources-subtree :tag-index {} :owner-index {})
       entries)))
 
+;; ---- incremental reverse-index delta (rf2-2c2mkh) -------------------------
+;;
+;; The hot mutation paths (a load/mutation settle, a release, a remove, a GC,
+;; a clear-scope, an optimistic apply/rollback) each touch a SMALL, KNOWN set
+;; of key-ids — never the whole cache. Rebuilding both indexes from scratch via
+;; `recompute-indexes` on every such settle is O(E·(T+O)) per op even though a
+;; settle changes ONE entry's `:tags` / `:active-owners`. `reindex-keys`
+;; instead reconciles ONLY the touched key-ids: for each, it removes that key's
+;; members under its OLD `:tags` / `:active-owners` (read from the pre-mutation
+;; entries) and re-adds them under its NEW values (read from the post-mutation
+;; subtree). The result is EXACTLY what a full `recompute-indexes` would yield
+;; (the indexes are a pure projection of `:entries`, and a key's members depend
+;; only on that key's own entry), but at O(touched·(T+O)). `recompute-indexes`
+;; is retained for the restore / SSR-hydration / registrar-teardown trust-
+;; rebuild paths, where the whole `:entries` map is installed at once and there
+;; is no incremental old→new delta to apply.
+
+(defn- index-without-key
+  "Remove every membership of `k-id` from a reverse `index`
+  (`{<member-key> #{<key-id> …}}`) under the given `member-keys` (the entry's
+  OLD `:tags` or `:active-owners`). A member-key whose set empties is dropped
+  entirely, matching the shape `recompute-indexes` produces (it never leaves an
+  empty membership set behind). Pure."
+  [index member-keys k-id]
+  (reduce (fn [idx mk]
+            (let [s (disj (get idx mk #{}) k-id)]
+              (if (seq s)
+                (assoc idx mk s)
+                (dissoc idx mk))))
+          index
+          member-keys))
+
+(defn- index-with-key
+  "Add a membership of `k-id` to a reverse `index` under each of `member-keys`
+  (the entry's NEW `:tags` or `:active-owners`). Pure."
+  [index member-keys k-id]
+  (reduce (fn [idx mk] (update idx mk (fnil conj #{}) k-id))
+          index
+          member-keys))
+
+(defn reindex-keys
+  "INCREMENTALLY reconcile `:tag-index` + `:owner-index` for just the
+  `changed-key-ids` (a coll of byte `key-id`s) on the post-mutation
+  `resources-subtree`, given `old-entries` — the `:entries` map as it was
+  BEFORE the mutation. For each changed key-id, removes its OLD index members
+  (from `old-entries`) and adds its NEW members (from the subtree's current
+  `:entries`); a key absent on one side simply has no members to remove / add
+  (a create has no old members, a removal has no new ones). Returns the subtree
+  with both indexes updated.
+
+  EQUIVALENCE INVARIANT (rf2-2c2mkh — pinned by a round-trip test): provided
+  EVERY key whose `:tags` / `:active-owners` differ between `old-entries` and
+  the subtree's `:entries` is in `changed-key-ids`, the result is `=` to
+  `(recompute-indexes resources-subtree)`. Use `recompute-indexes` (not this)
+  for the restore / SSR-hydration / teardown trust-rebuild paths."
+  [resources-subtree old-entries changed-key-ids]
+  (let [new-entries (:entries resources-subtree)]
+    (reduce
+      (fn [subtree k-id]
+        (let [old-entry (get old-entries k-id)
+              new-entry (get new-entries k-id)]
+          (-> subtree
+              (update :tag-index
+                      (fn [ti]
+                        (-> ti
+                            (index-without-key (:tags old-entry) k-id)
+                            (index-with-key (:tags new-entry) k-id))))
+              (update :owner-index
+                      (fn [oi]
+                        (-> oi
+                            (index-without-key (:active-owners old-entry) k-id)
+                            (index-with-key (:active-owners new-entry) k-id)))))))
+      resources-subtree
+      changed-key-ids)))
+
 ;; ---- host-side transient generation allocator -----------------------------
 ;;
 ;; Per Spec 016 §Restore and replay part 1: the generation allocator is a

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -181,22 +181,35 @@
 
 (defn- active-mismatch-scope
   "The scope of a DIFFERENT active entry for `resource-id` — the heuristic's
-  evidence that the subscribed `sub-key` is a LIKELY scope mismatch. Scans
-  the cache `entries` for a key `[scope resource-id _params]` whose
-  `resource-id` matches `sub-key`'s but whose SCOPE differs, and whose entry
-  is active (`entry-active?`). Returns the first such scope, or nil when no
-  other scope for this resource is active. Pure."
-  [entries sub-key]
-  (let [[sub-scope rid _params] sub-key]
-    (some (fn [[_k-id entry]]
-            ;; rf2-9e0tyq — read the scope/rid from the entry's stored
-            ;; `:resource/key` VECTOR (the map key is now the opaque byte id).
-            (let [[scope r _p] (:resource/key entry)]
+  evidence that the subscribed `sub-key` is a LIKELY scope mismatch. Returns
+  the first such scope, or nil when no other scope for this resource is active.
+
+  rf2-tluunj — visits ONLY entries that currently hold an active owner, via the
+  `owner-index` (`{<owner> #{<key-id> …}}`), instead of scanning the WHOLE
+  `:entries` map on every `:rf.resource/state` sub recompute. The heuristic
+  only ever fires on an ACTIVE entry (`entry-active?`), and an entry is active
+  IFF it is a member of some owner-index bucket, so the owner-index members are
+  exactly the candidate set — every entry the old full scan would have passed
+  the `entry-active?` test for, and no more. Resolving each member to its entry
+  via `entry-path-by-id` keeps the rest of the predicate identical. Pure."
+  [resources-subtree sub-key]
+  (let [[sub-scope rid _params] sub-key
+        entries     (:entries resources-subtree)
+        owner-index (:owner-index resources-subtree)
+        ;; the byte key-ids of every entry holding ≥1 active owner — the union
+        ;; of the owner-index buckets (deduped). A non-from-caller-heavy cache
+        ;; with few active leases visits a handful of keys, not the whole cache.
+        active-ids  (reduce-kv (fn [acc _owner ids] (into acc ids)) #{} owner-index)]
+    (some (fn [k-id]
+            ;; rf2-9e0tyq — the index member IS the byte key-id; read the
+            ;; scope/rid off the entry's stored `:resource/key` VECTOR.
+            (let [entry        (get entries k-id)
+                  [scope r _p] (:resource/key entry)]
               (when (and (= r rid)
                          (not= scope sub-scope)
                          (entry-active? entry))
                 scope)))
-          entries)))
+          active-ids)))
 
 (defn maybe-warn-scope-mismatch!
   "Emit the dev-only likely-scope-mismatch warning (rf2-rsmiru) when a
@@ -224,9 +237,12 @@
       (when (and (= :rf.scope/from-caller (:scope spec))
                  ;; the subscribed entry has no active owner (or no entry) …
                  (not (entry-active? sub-entry)))
-        (let [entries       (get-in runtime-db (state/entries-path))
+        ;; rf2-tluunj — pass the whole resources subtree so the mismatch scan
+        ;; can use the `:owner-index` (visit only active entries) rather than
+        ;; scanning the entire `:entries` map on every reactive sub recompute.
+        (let [resources-subtree (get runtime-db state/resources-key)
               [sub-scope]   sub-key
-              active-scope  (active-mismatch-scope entries sub-key)]
+              active-scope  (active-mismatch-scope resources-subtree sub-key)]
           ;; … while a DIFFERENT scope for the same resource IS active.
           (when (some? active-scope)
             (let [dedupe-key [resource-id sub-scope active-scope]]

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -361,11 +361,83 @@
   [work-id]
   [:rf.runtime/work-ledger (work-id-id work-id)])
 
+;; ---- resource-key → work-id inverse index (rf2-wyan7e) --------------------
+;;
+;; `prune-terminal-for-key` runs after EVERY resource settle to trim terminal
+;; rows for the settling key. Filtering the WHOLE ledger to find that key's
+;; rows is O(W) over all in-flight + terminal work across all resources, per
+;; settle. This inverse index `{<rk-id> #{<work-id-id> …}}` (mirroring the
+;; resource `:tag-index`) lets the prune visit ONLY the settling key's rows.
+;;
+;; It is a PURE derived projection of the ledger (a row contributes its
+;; `work-id-id` to its `(:resource/key row)`'s bucket), so it is rebuilt — never
+;; trusted — wherever the ledger is installed wholesale (hydration / restore):
+;; `prune-terminal-for-key` self-heals by rebuilding the whole index when it
+;; finds the ledger populated but the index absent (the post-hydration shape),
+;; so no SSR / restore install site has to thread it. Maintained incrementally
+;; on the live path by `put-record` (add) / `prune-record` + the prune (remove).
+
+(def work-ledger-by-key-key
+  "Reserved runtime-db key for the work-ledger's resource-key → work-id-id
+  inverse index `{<rk-id> #{<work-id-id> …}}`. Recomputable-from-the-ledger
+  (rebuilt on hydration / restore, never trusted from a snapshot — mirrors the
+  resource `:tag-index`). Per Spec 016 §Ledger row retention (rf2-wyan7e)."
+  :rf.runtime/work-ledger-by-key)
+
+(defn recompute-ledger-index
+  "Rebuild the `:rf.runtime/work-ledger-by-key` inverse index
+  `{<rk-id> #{<work-id-id> …}}` from the ledger map in `runtime-db`. The single
+  authoritative full rebuild the hydration / restore self-heal uses (a pure
+  projection of the ledger). Returns the updated runtime-db."
+  [runtime-db]
+  (let [ledger (:rf.runtime/work-ledger runtime-db)
+        idx    (reduce-kv
+                 (fn [acc wid-id record]
+                   (let [rk-id (state/key-id (:resource/key record))]
+                     (update acc rk-id (fnil conj #{}) wid-id)))
+                 {}
+                 ledger)]
+    (assoc runtime-db work-ledger-by-key-key idx)))
+
+;; The incremental maintainers act ONLY when the index already EXISTS in the
+;; runtime-db. A wholesale ledger install (epoch restore / SSR hydrate /
+;; replace-frame-state! / router rollback / test fixtures) does NOT carry the
+;; index (a derived projection never trusted from a snapshot), so leaving it
+;; absent is the signal `prune-terminal-for-key` rebuilds it from ground truth
+;; ONCE — a `put-record` that ran first must NOT half-build it and mask that
+;; rebuild. Once present, every put/prune keeps it complete and in step.
+
+(defn- index-present? [runtime-db] (contains? runtime-db work-ledger-by-key-key))
+
+(defn- index-add
+  "Add `work-id-id` to its `rk-id` bucket in the inverse index — ONLY when the
+  index already exists (see the comment above). Pure."
+  [runtime-db rk-id work-id-id*]
+  (if (index-present? runtime-db)
+    (update-in runtime-db [work-ledger-by-key-key rk-id] (fnil conj #{}) work-id-id*)
+    runtime-db))
+
+(defn- index-remove
+  "Remove `work-id-id` from its `rk-id` bucket in the inverse index, dropping an
+  emptied bucket entirely (the recompute shape never leaves empty buckets) —
+  ONLY when the index already exists. Pure."
+  [runtime-db rk-id work-id-id*]
+  (if (index-present? runtime-db)
+    (let [s (disj (get-in runtime-db [work-ledger-by-key-key rk-id] #{}) work-id-id*)]
+      (if (seq s)
+        (assoc-in runtime-db [work-ledger-by-key-key rk-id] s)
+        (update runtime-db work-ledger-by-key-key dissoc rk-id)))
+    runtime-db))
+
 (defn put-record
   "Write `record` at the work-ledger byte-keyed slot for `work-id` in
-  `runtime-db`. Returns the updated runtime-db."
+  `runtime-db`, and register it in the resource-key inverse index when that
+  index is live (rf2-wyan7e — the index member is idempotent, so re-putting an
+  updated record is a no-op for the index). Returns the updated runtime-db."
   [runtime-db work-id record]
-  (assoc-in runtime-db (record-path work-id) record))
+  (-> runtime-db
+      (assoc-in (record-path work-id) record)
+      (index-add (state/key-id (:resource/key record)) (work-id-id work-id))))
 
 (defn get-record
   "Read the work record under `work-id` from `runtime-db`, or nil."
@@ -382,12 +454,16 @@
     runtime-db))
 
 (defn prune-record
-  "Remove the work record under `work-id` from `runtime-db`. Used when a
-  terminal row is pruned on the linked entry's next successful transition
-  (Spec 016 §Ledger row retention and identity). Returns the updated
-  runtime-db."
+  "Remove the work record under `work-id` from `runtime-db`, and drop it from
+  the resource-key inverse index (rf2-wyan7e). Used when a terminal row is
+  pruned on the linked entry's next successful transition (Spec 016 §Ledger row
+  retention and identity). No-op for the index when no record exists. Returns
+  the updated runtime-db."
   [runtime-db work-id]
-  (update runtime-db :rf.runtime/work-ledger dissoc (work-id-id work-id)))
+  (let [wid-id (work-id-id work-id)
+        record (get-in runtime-db [:rf.runtime/work-ledger wid-id])]
+    (cond-> (update runtime-db :rf.runtime/work-ledger dissoc wid-id)
+      record (index-remove (state/key-id (:resource/key record)) wid-id))))
 
 (defn update-record-by-id
   "Apply `f` (and `args`) to the work record under an ALREADY-COMPUTED byte
@@ -420,21 +496,46 @@
   `keep-tail` defaults to `default-terminal-tail`."
   ([runtime-db resource-key] (prune-terminal-for-key runtime-db resource-key default-terminal-tail))
   ([runtime-db resource-key keep-tail]
+   ;; rf2-wyan7e — self-heal: a wholesale-installed ledger (hydration /
+   ;; restore) arrives with NO inverse index (it is a derived projection, never
+   ;; trusted from the wire). Rebuild it ONCE here so the per-key visit below is
+   ;; bounded; live operation keeps it in step via put-record / prune-record.
+   ;; A ledger present but index absent is exactly the post-install shape.
    (let [ledger (:rf.runtime/work-ledger runtime-db)
+         runtime-db (if (and (seq ledger)
+                             (not (contains? runtime-db work-ledger-by-key-key)))
+                      (recompute-ledger-index runtime-db)
+                      runtime-db)
          ;; rf2-9e0tyq — match by CEDN-1 byte identity, not `=` over the
          ;; `:resource/key` vector (which would `=`-collapse a list- and a
          ;; vector-params key and prune both resources' rows).
          rk-id  (state/key-id resource-key)
+         ;; rf2-wyan7e — visit ONLY this key's rows (via the inverse index)
+         ;; instead of scanning the WHOLE ledger per settle (O(rows-for-key)
+         ;; rather than O(all-work)). The index members ARE this key's row ids.
+         ledger (:rf.runtime/work-ledger runtime-db)
+         this-key-ids (get-in runtime-db [work-ledger-by-key-key rk-id])
          ;; terminal rows for this key, newest-first by :started-at
          terminal-for-key
-         (->> ledger
-              (filter (fn [[_ r]] (and (= rk-id (state/key-id (:resource/key r)))
-                                       (terminal? (:status r)))))
+         (->> this-key-ids
+              (keep (fn [wid-id]
+                      (let [r (get ledger wid-id)]
+                        (when (and r (terminal? (:status r)))
+                          [wid-id r]))))
               (sort-by (fn [[_ r]] (or (:started-at r) 0)) >))
-         drop-ids (->> terminal-for-key (drop keep-tail) (map key))]
+         drop-ids (->> terminal-for-key (drop keep-tail) (map first))]
      (if (seq drop-ids)
-       (update runtime-db :rf.runtime/work-ledger
-               (fn [l] (reduce dissoc l drop-ids)))
+       (-> runtime-db
+           (update :rf.runtime/work-ledger
+                   (fn [l] (reduce dissoc l drop-ids)))
+           ;; keep the inverse index in step with the dropped rows
+           (update-in [work-ledger-by-key-key rk-id]
+                      (fn [s] (let [s' (reduce disj (or s #{}) drop-ids)]
+                                (when (seq s') s'))))
+           ;; drop an emptied bucket entirely (recompute shape: no empty sets)
+           (as-> rdb (if (nil? (get-in rdb [work-ledger-by-key-key rk-id]))
+                       (update rdb work-ledger-by-key-key dissoc rk-id)
+                       rdb)))
        runtime-db))))
 
 ;; ---- host-side handle side table (Spec 016 §Frame work ledger) ------------

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -888,6 +888,107 @@
       (is (= #{k1}    (get-in rebuilt [:tag-index :t1])))
       (is (= #{k1 k2} (get-in rebuilt [:owner-index [:lease 1]]))))))
 
+;; ---- rf2-2c2mkh: incremental reindex == full rebuild (the safety net) ------
+;;
+;; `reindex-keys` maintains :tag-index / :owner-index INCREMENTALLY at the hot
+;; mutation sites (a settle / release / remove / GC / clear / optimistic
+;; apply-rollback touches a small known key set) instead of full-rebuilding via
+;; `recompute-indexes` on every op. The indexes are a PURE projection of
+;; :entries, so the incremental result MUST equal the full rebuild after every
+;; op — these tests are the round-trip pin that stops incremental drift creeping
+;; in (the audit's CORRECTNESS GUARD).
+
+(deftest reindex-keys-equals-full-rebuild-on-crafted-transitions
+  (testing "rf2-2c2mkh — reindex-keys over the touched keys yields EXACTLY what
+            recompute-indexes would produce, across create / tag-change /
+            owner-change / multi-key / remove transitions"
+    (let [ka "id-a" kb "id-b" kc "id-c"
+          ;; helper: assert reindex(touched) == full-rebuild for an old→new
+          ;; entries transition (subtree carries the OLD indexes built by a
+          ;; prior full rebuild — the realistic pre-mutation shape).
+          check (fn [old-entries new-entries touched]
+                  (let [old-subtree (state/recompute-indexes {:entries old-entries})
+                        new-subtree (assoc old-subtree :entries new-entries)
+                        incremental (state/reindex-keys new-subtree old-entries touched)
+                        full        (state/recompute-indexes new-subtree)]
+                    (is (= (:tag-index full)   (:tag-index incremental))
+                        (str "tag-index drift on touched " (vec touched)))
+                    (is (= (:owner-index full) (:owner-index incremental))
+                        (str "owner-index drift on touched " (vec touched)))))]
+      (testing "create one entry from empty"
+        (check {} {ka {:tags #{:t1 :shared} :active-owners #{[:lease 1]}}} [ka]))
+      (testing "tag replacement on a settle (owners unchanged)"
+        (check {ka {:tags #{:t1 :shared} :active-owners #{[:lease 1]}}}
+               {ka {:tags #{:t2 :shared} :active-owners #{[:lease 1]}}}
+               [ka]))
+      (testing "owner attach + release on one key"
+        (check {ka {:tags #{:t1} :active-owners #{[:lease 1]}}}
+               {ka {:tags #{:t1} :active-owners #{[:lease 1] [:route :r 7]}}}
+               [ka])
+        (check {ka {:tags #{:t1} :active-owners #{[:lease 1] [:route :r 7]}}}
+               {ka {:tags #{:t1} :active-owners #{[:lease 1]}}}
+               [ka]))
+      (testing "removal (entry vanishes) drops its members + empties the bucket"
+        (check {ka {:tags #{:only} :active-owners #{[:lease 9]}}
+                kb {:tags #{:shared} :active-owners #{}}}
+               {kb {:tags #{:shared} :active-owners #{}}}
+               [ka]))
+      (testing "multi-key clear-scope (two keys removed at once)"
+        (check {ka {:tags #{:a :shared} :active-owners #{[:lease 1]}}
+                kb {:tags #{:b :shared} :active-owners #{[:lease 1]}}
+                kc {:tags #{:c} :active-owners #{}}}
+               {kc {:tags #{:c} :active-owners #{}}}
+               [ka kb]))
+      (testing "reindexing an UNCHANGED key in the touched set is a no-op"
+        (check {ka {:tags #{:t1} :active-owners #{[:lease 1]}}
+                kb {:tags #{:t1} :active-owners #{[:lease 1]}}}
+               {ka {:tags #{:t1} :active-owners #{[:lease 1]}}
+                kb {:tags #{:t2} :active-owners #{[:lease 1]}}}
+               ;; ka did not change but is in the touched set anyway
+               [ka kb])))))
+
+(deftest reindex-keys-equals-full-rebuild-under-random-mutation-sequence
+  (testing "rf2-2c2mkh — across a long randomised sequence of single-key
+            mutations (create / retag / re-own / remove), the incrementally
+            maintained indexes equal the full rebuild after EVERY step"
+    (let [;; small deterministic LCG so the property runs identically on every
+          ;; platform / CI machine (no test.check dependency in the PR gate).
+          seed     (atom 2463534242)
+          nextint  (fn [n]
+                     (let [x (-> (* @seed 1103515245) (+ 12345) (bit-and 0x7fffffff))]
+                       (reset! seed x)
+                       (mod x n)))
+          key-ids  (mapv #(str "k" %) (range 8))
+          tags     [:t0 :t1 :t2 :shared]
+          owners   [[:lease 1] [:lease 2] [:route :r 1] [:route :r 2]]
+          rand-set (fn [pool]
+                     (set (keep (fn [x] (when (zero? (nextint 2)) x)) pool)))]
+      (loop [step 0
+             entries {}
+             ;; the incrementally maintained subtree (indexes derived from the
+             ;; SAME entries via reindex-keys after each step).
+             subtree (state/recompute-indexes {:entries {}})]
+        (if (= step 600)
+          (is true "600 randomised mutations stayed in lock-step with the rebuild")
+          (let [k        (nth key-ids (nextint (count key-ids)))
+                remove?  (and (contains? entries k) (zero? (nextint 4)))
+                new-entries (if remove?
+                              (dissoc entries k)
+                              (assoc entries k {:tags          (rand-set tags)
+                                                :active-owners (rand-set owners)}))
+                incremental (state/reindex-keys (assoc subtree :entries new-entries)
+                                                entries [k])
+                full        (state/recompute-indexes {:entries new-entries})]
+            (is (= (:tag-index full) (:tag-index incremental))
+                (str "tag-index drift at step " step " key " k))
+            (is (= (:owner-index full) (:owner-index incremental))
+                (str "owner-index drift at step " step " key " k))
+            ;; also pin: no empty membership buckets survive (matches the
+            ;; recompute-indexes shape — an emptied set is dropped entirely).
+            (is (every? seq (vals (:tag-index incremental)))   "no empty tag buckets")
+            (is (every? seq (vals (:owner-index incremental))) "no empty owner buckets")
+            (recur (inc step) new-entries incremental)))))))
+
 ;; ===========================================================================
 ;; 12. resource registrar sanity (re-affirm the registrar kind is closed)
 ;; ===========================================================================

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -658,3 +658,151 @@
               "frame B's attempt still in flight — untouched by frame A's reply")
           (is (not= :loaded (:status (entry fb scoped-key)))
               "frame B's entry not settled by frame A"))))))
+
+;; ===========================================================================
+;; rf2-wyan7e — resource-key → work-id inverse index: prune visits only the
+;; settling key's rows (O(rows-for-key)) instead of scanning the whole ledger
+;; (O(all-work)). These pure tests pin the index-driven prune against a
+;; reference FULL-SCAN prune (the prior semantics) so the optimisation is
+;; behaviour-preserving, and pin the index as a derived projection of the
+;; ledger (== a full rebuild, self-healing on a wholesale-installed ledger).
+;; ===========================================================================
+
+(defn- reference-prune-full-scan
+  "The PRIOR `prune-terminal-for-key` semantics, kept here as the behaviour
+  oracle: a FULL ledger scan for the key's terminal rows, retaining `keep-tail`
+  newest-by-:started-at. Index-free — the result the new index-driven prune
+  must reproduce exactly (modulo the inverse-index sidecar key)."
+  [runtime-db resource-key keep-tail]
+  (let [ledger (:rf.runtime/work-ledger runtime-db)
+        rk-id  (state/key-id resource-key)
+        terminal-for-key
+        (->> ledger
+             (filter (fn [[_ r]] (and (= rk-id (state/key-id (:resource/key r)))
+                                      (work-ledger/terminal? (:status r)))))
+             (sort-by (fn [[_ r]] (or (:started-at r) 0)) >))
+        drop-ids (->> terminal-for-key (drop keep-tail) (map key))]
+    (if (seq drop-ids)
+      (update runtime-db :rf.runtime/work-ledger
+              (fn [l] (reduce dissoc l drop-ids)))
+      runtime-db)))
+
+(defn- record-for
+  [scoped-key generation status started-at]
+  {:work/id      [:rf.work/resource scoped-key generation]
+   :work/kind    :resource
+   :resource/key scoped-key
+   :generation   generation
+   :status       status
+   :started-at   started-at})
+
+(defn- build-ledger
+  "Build a `:rf.runtime/work-ledger` map (byte-keyed) from a seq of records, AND
+  maintain the inverse index via `put-record` (so the index is live, the
+  realistic in-session shape)."
+  [records]
+  (reduce (fn [rdb r] (work-ledger/put-record rdb (:work/id r) r))
+          {}
+          records))
+
+(deftest prune-terminal-for-key-matches-full-scan-reference
+  (testing "rf2-wyan7e — the index-driven prune drops EXACTLY the rows the
+            prior full-scan prune dropped, across mixed keys / statuses / tails"
+    (let [ka (state/scoped-resource-key :rf.scope/global :wl/a {:id 1})
+          kb (state/scoped-resource-key :rf.scope/global :wl/b {:id 2})
+          ;; ka: 5 terminal (varied started-at) + 1 running; kb: 2 terminal
+          records [(record-for ka 1 :completed 100)
+                   (record-for ka 2 :failed    300)
+                   (record-for ka 3 :completed 200)
+                   (record-for ka 4 :cancelled 500)
+                   (record-for ka 5 :suppressed 400)
+                   (record-for ka 6 :running   600)
+                   (record-for kb 1 :completed 50)
+                   (record-for kb 2 :failed    70)]
+          rdb (build-ledger records)]
+      (doseq [keep-tail [0 1 3 10]]
+        (let [new-rdb (work-ledger/prune-terminal-for-key rdb ka keep-tail)
+              ref-rdb (reference-prune-full-scan rdb ka keep-tail)]
+          (is (= (:rf.runtime/work-ledger ref-rdb)
+                 (:rf.runtime/work-ledger new-rdb))
+              (str "ledger after prune differs from full-scan reference at tail "
+                   keep-tail))
+          (testing "the running (non-terminal) row + the other key's rows are
+                    NEVER pruned"
+            (is (some? (get-in new-rdb (work-ledger/record-path
+                                         [:rf.work/resource ka 6]))))
+            (is (some? (get-in new-rdb (work-ledger/record-path
+                                         [:rf.work/resource kb 1]))))
+            (is (some? (get-in new-rdb (work-ledger/record-path
+                                         [:rf.work/resource kb 2])))))
+          (testing "the inverse index stays == a full rebuild from the ledger"
+            (is (= (-> new-rdb work-ledger/recompute-ledger-index
+                       :rf.runtime/work-ledger-by-key)
+                   (:rf.runtime/work-ledger-by-key new-rdb))
+                "inverse index drift vs full rebuild")))))))
+
+(deftest prune-self-heals-on-wholesale-installed-ledger
+  (testing "rf2-wyan7e — a ledger installed wholesale (hydration / restore /
+            replace-frame-state!) carries NO inverse index; the first prune
+            rebuilds it from ground truth and still matches the full scan"
+    (let [ka (state/scoped-resource-key :rf.scope/global :wl/h {:id 1})
+          ;; install the ledger DIRECTLY (no put-record), so no index sidecar
+          records [(record-for ka 1 :completed 100)
+                   (record-for ka 2 :completed 200)
+                   (record-for ka 3 :failed    300)
+                   (record-for ka 4 :running   400)]
+          installed (reduce (fn [rdb r]
+                              (assoc-in rdb (work-ledger/record-path (:work/id r)) r))
+                            {} records)]
+      (is (not (contains? installed :rf.runtime/work-ledger-by-key))
+          "precondition: installed ledger has no inverse index")
+      (let [new-rdb (work-ledger/prune-terminal-for-key installed ka 1)
+            ref-rdb (reference-prune-full-scan installed ka 1)]
+        (is (= (:rf.runtime/work-ledger ref-rdb)
+               (:rf.runtime/work-ledger new-rdb))
+            "self-healed prune matches the full-scan reference")
+        (is (contains? new-rdb :rf.runtime/work-ledger-by-key)
+            "the inverse index was rebuilt")
+        (is (= (-> new-rdb work-ledger/recompute-ledger-index
+                   :rf.runtime/work-ledger-by-key)
+               (:rf.runtime/work-ledger-by-key new-rdb))
+            "rebuilt index == full rebuild")))))
+
+(deftest ledger-inverse-index-equals-full-rebuild-under-random-mutation
+  (testing "rf2-wyan7e — across a randomised sequence of put-record /
+            prune-record / prune-terminal-for-key ops, the incrementally
+            maintained inverse index equals a full rebuild after EVERY op"
+    (let [seed    (atom 88172645)
+          nextint (fn [n]
+                    (let [x (-> (* @seed 1103515245) (+ 12345) (bit-and 0x7fffffff))]
+                      (reset! seed x)
+                      (mod x n)))
+          keys'   (mapv #(state/scoped-resource-key :rf.scope/global :wl/r {:id %})
+                        (range 5))
+          ;; seed the index live so put/prune keep it in step from step 0
+          start   (work-ledger/recompute-ledger-index {:rf.runtime/work-ledger {}})]
+      (loop [step 0, rdb start, gen 0]
+        (if (= step 500)
+          (is true "500 randomised ledger ops stayed in lock-step with the rebuild")
+          (let [op  (nextint 3)
+                k   (nth keys' (nextint (count keys')))
+                rdb' (case op
+                       ;; put a fresh record
+                       0 (let [g (inc gen)
+                               r (record-for k g
+                                             (nth [:running :completed :failed :cancelled]
+                                                  (nextint 4))
+                                             (nextint 1000))]
+                           (work-ledger/put-record rdb [:rf.work/resource k g] r))
+                       ;; prune one terminal tail for the key
+                       1 (work-ledger/prune-terminal-for-key rdb k (nextint 3))
+                       ;; prune a specific record (if any exist for the key)
+                       2 (let [g (inc (nextint (inc gen)))]
+                           (work-ledger/prune-record rdb [:rf.work/resource k g])))
+                full (-> rdb' work-ledger/recompute-ledger-index
+                         :rf.runtime/work-ledger-by-key)]
+            (is (= full (:rf.runtime/work-ledger-by-key rdb'))
+                (str "inverse-index drift at step " step " op " op))
+            (is (every? seq (vals (:rf.runtime/work-ledger-by-key rdb')))
+                "no empty inverse-index buckets")
+            (recur (inc step) rdb' (if (zero? op) (inc gen) gen))))))))


### PR DESCRIPTION
Fixes 3 resources hot-path perf findings from the rf2-vr8op8 audit. **Behaviour-preserving** (perf only; no observable resource state / timer / trace / egress change). The indexes touched are pure projections of their durable source, so the safety net is a test asserting *incremental == full-rebuild* after every mutation.

## rf2-2c2mkh (P2) — incremental reverse-index maintenance
`state/recompute-indexes` full-rebuilt both `:tag-index` and `:owner-index` from scratch (`reduce-kv` over every entry x tag x owner) on EVERY settle / release / remove / GC / clear-scope / optimistic apply+rollback — `O(E*(T+O))` per op, even though each op touches a small known key set.

New `state/reindex-keys` reconciles ONLY the touched key-ids (remove old members from the pre-mutation entries, add new members) — `O(touched*(T+O))`. Converted the six hot mutation sites. `recompute-indexes` is **retained** for the restore / SSR-hydration / registrar-teardown trust-rebuild paths (whole `:entries` installed at once; no incremental old->new delta).

## rf2-wyan7e (P3) — work-ledger resource-key inverse index
`work-ledger/prune-terminal-for-key` filtered the ENTIRE ledger per settle (`O(W)`). Added a `resource-key -> #{work-id-id}` inverse index (`:rf.runtime/work-ledger-by-key`, mirroring `:tag-index`) so the prune visits only the settling key's rows. Maintained incrementally by `put-record` / `prune-record` + the prune; a pure derived projection never trusted from a snapshot, so a wholesale-installed ledger (hydration / restore / `replace-frame-state!` / router rollback) self-heals by rebuilding the index once on the first prune.

## rf2-tluunj (P4) — owner-index-bounded scope-mismatch scan
`subs/active-mismatch-scope` did a `some` over the whole `:entries` map on every `:rf.resource/state` sub recompute for a `:rf.scope/from-caller` resource (dev-only, DCE'd in prod, but the scan repeated even after the one-shot warning fired). Now visits only the `:owner-index` members (entries with an active owner) — exactly the candidate set the old scan passed `entry-active?` for.

## Correctness guard (the safety net)
- `state` tests: a crafted-transition `reindex-keys == recompute-indexes` test + a **600-step randomised property** asserting equality (and no empty buckets) after every mutation.
- `work-ledger` tests: index-driven-prune `==` full-scan-reference across mixed keys/statuses/tails, a self-heal-on-wholesale-install test, and a **500-step randomised property** asserting the inverse index `==` a full rebuild after every put/prune.

## Gates
- `npm run test:cljs` — 7935 tests / 36461 assertions, 0 failures.
- resources JVM (`clojure -M:test`) — 600 tests / 6023 assertions, 0 failures.
- `npm run test:cljs-isolation` — pass.
- `npm run test:elision` — pass (production 42/42 absent; the dev-only mismatch-scan body still DCE-elides).
- clj-kondo — 0 errors, no new warnings.

Per-bead commits. Do not merge.