### PR TITLE
refactor(core+tools): canonical parse-view-id reader + migrate view-entity consumers (rf2-ztxnm8)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -176,6 +176,64 @@
              :line       (parse-coord-int line-part)
              :col        (parse-coord-int col-part)}))))))
 
+;; ---- data-rf-view attribute parser (rf2-ztxnm8 / rf2-16znzb) ---------------
+;;
+;; The inverse of `re-frame.adapter.context/format-view-id` (re-exported as
+;; `re-frame.views/format-view-id` / `re-frame.substrate.spine/format-view-id`).
+;; The formatter renders a registry id keyword into the `data-rf-view` DOM-
+;; attribute value via `(str id)` — `:rf.foo/bar` → `":rf.foo/bar"`; this parser
+;; recovers the id from that string. It lives HERE — beside `parse-source-coord`,
+;; in the source-coord contract owner (Spec 006 §View tagging contract /
+;; §Source-coord annotation) — because the read rule used to live ONLY in
+;; `format-view-id`'s docstring + Spec 006 prose and was re-implemented inline by
+;; every consumer (the Xray fallback view-walker and the re-frame2-pair preload
+;; runtime's `view-entity`). Co-locating format + parse keeps the round-trip a
+;; single source of truth (rf2-ztxnm8 collapses those re-derivations — the
+;; data-rf-view analogue of the `parse-source-coord` work in rf2-nr7vf2).
+;;
+;; Tool-Pair.md declares the attribute value opaque to consumers and warns
+;; downstream callers MUST NOT depend on the parsed shape's stability across
+;; re-frame2 versions. Canonicalising the parser in the contract owner ties the
+;; format and its inverse to the same version boundary.
+
+(defn parse-view-id
+  "Parse a `data-rf-view` attribute value back into the registry id. The
+  inverse of `re-frame.adapter.context/format-view-id` (re-exported as
+  `re-frame.views/format-view-id` / `re-frame.substrate.spine/format-view-id`),
+  which renders the id via `(str id)`.
+
+      \":rf.foo/bar\"  → :rf.foo/bar         ;; namespaced keyword id
+      \":bare\"        → :bare               ;; unqualified keyword id
+      \"raw-string\"   → \"raw-string\"      ;; non-keyword id (unusual)
+
+  A leading `:` marks a stringified keyword: the body is split on the first
+  `/` to recover namespace / name; a body with no `/` becomes an unqualified
+  keyword. Any other (non-colon-prefixed) string is a non-keyword id and is
+  returned verbatim. Returns nil for nil / non-string input; never throws.
+
+  Per Spec 006 §View tagging contract §Attribute value format and
+  Spec-Schemas §`:rf/view-id-attr`.
+
+  Tool-Pair.md declares the attribute value opaque to consumers; this parser
+  exists so tooling's DOM → registry-id bridge can be useful, but downstream
+  callers MUST NOT depend on the parsed shape's stability across re-frame2
+  versions."
+  [attr-val]
+  (cond
+    (or (nil? attr-val) (not (string? attr-val)))
+    nil
+
+    ;; Leading colon → keyword. Splits on the first `/` to recover ns/name.
+    (and (pos? (count attr-val)) (= ":" (subs attr-val 0 1)))
+    (let [body  (subs attr-val 1)
+          slash (str/index-of body "/")]
+      (if (nil? slash)
+        (keyword body)
+        (keyword (subs body 0 slash) (subs body (inc slash)))))
+
+    :else
+    attr-val))
+
 ;; ---- co-located per-element machine source (rf2-npvsx) -------------------
 ;;
 ;; The registered machine spec carries ONE cohesive map per guard / action /

--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -213,3 +213,44 @@
       ;; from an empty segment) so the round trip still recovers it
       (is (= {:ns "?" :handler-id "bare" :line 1 :col 2}
              (round-trip :bare {:line 1 :column 2}))))))
+
+;; ---- parse-view-id (rf2-ztxnm8 / rf2-16znzb) --------------------------------
+;;
+;; The canonical inverse of `format-view-id`, collapsing the reader that was
+;; reimplemented inline in Xray's fallback view-walker and the re-frame2-pair
+;; preload runtime's `view-entity`. These tests pin the read contract (Spec 006
+;; §View tagging contract §Attribute value format) and the round-trip against
+;; the REAL `re-frame.adapter.context/format-view-id` so the format + parse pair
+;; can never drift apart — the data-rf-view analogue of the parse-source-coord
+;; round-trip above.
+
+(deftest parse-view-id-namespaced-keyword
+  (testing "rf2-ztxnm8: a stringified namespaced keyword parses back to the keyword"
+    (is (= :rf.foo/bar (source-coords/parse-view-id ":rf.foo/bar")))))
+
+(deftest parse-view-id-bare-keyword
+  (testing "rf2-ztxnm8: a leading-colon body with no slash → unqualified keyword"
+    (is (= :bare (source-coords/parse-view-id ":bare")))))
+
+(deftest parse-view-id-raw-string
+  (testing "rf2-ztxnm8: a non-colon-prefixed value is a non-keyword id, returned verbatim"
+    (is (= "raw-string" (source-coords/parse-view-id "raw-string")))))
+
+(deftest parse-view-id-nil-and-non-string
+  (testing "rf2-ztxnm8: nil / non-string input returns nil and never throws"
+    (is (nil? (source-coords/parse-view-id nil)))
+    (is (nil? (source-coords/parse-view-id 42)))
+    (is (nil? (source-coords/parse-view-id :keyword)))))
+
+(deftest format-view-id-then-parse-round-trips
+  (testing "rf2-ztxnm8: (parse-view-id (format-view-id id)) recovers the registry id"
+    (let [round-trip (fn [id]
+                       (source-coords/parse-view-id
+                         (adapter-context/format-view-id id)))]
+      ;; namespaced keyword id
+      (is (= :rf.foo/bar (round-trip :rf.foo/bar)))
+      ;; unqualified keyword id (legal at the registrar)
+      (is (= :bare (round-trip :bare)))
+      ;; dotted ns + hyphenated name
+      (is (= :my-app.cart.view/apply-coupon-button
+             (round-trip :my-app.cart.view/apply-coupon-button))))))

--- a/skills/re-frame2-pair/docs/TESTING.md
+++ b/skills/re-frame2-pair/docs/TESTING.md
@@ -18,6 +18,7 @@ for run instructions.
 parser logic:
 
 - `parse_rf2_coord_test.clj` — `parse-rf2-coord`
+- `parse_view_id_test.clj` — `parse-view-id` (`data-rf-view` reader)
 - `app_db_reset_test.clj` — `app-db-reset!` failure-mode envelopes
 - `multi_frame_test.clj` — operating-frame resolution
 - `preload_sentinel_test.clj` — session-sentinel shape

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -3188,6 +3188,20 @@
    across re-frame2 versions)."
   source-coords/parse-source-coord)
 
+(def ^:private parse-view-id
+  "Parse re-frame2's `data-rf-view` attribute into the registry id keyword
+   (or the raw string for a non-keyword id), or nil.
+
+   Alias of the canonical `re-frame.source-coords/parse-view-id` (the source-
+   coord contract owner) — the inverse of `format-view-id`. This reader used to
+   be reimplemented inline in `view-entity` here and in Xray's fallback view-
+   walker; rf2-ztxnm8 collapsed both onto the one canonical impl in core (the
+   data-rf-view analogue of rf2-nr7vf2's `parse-source-coord` work). See that fn
+   for the value format (Spec 006 §View tagging contract §Attribute value
+   format) and the Tool-Pair opacity caveat (downstream callers MUST NOT depend
+   on the parsed shape's stability across re-frame2 versions)."
+  source-coords/parse-view-id)
+
 (defn- parse-rc-src
   "Parse re-com's `data-rc-src` attribute into {:file :line :column}.
    Expected shapes: 'app/cart.cljs:42', 'app/cart.cljs:42:8'."
@@ -3656,17 +3670,11 @@
   (if (nil? view-root)
     {:view-id nil :reason :no-tagged-view-root}
     (let [attr     (.getAttribute view-root "data-rf-view")
-          ;; Reuse the same parse the fallback view-walker uses
-          ;; (Spec 006): leading-colon → keyword, else raw string.
-          view-id  (cond
-                     (or (nil? attr) (not (string? attr))) nil
-                     (and (pos? (count attr)) (= ":" (subs attr 0 1)))
-                     (let [body  (subs attr 1)
-                           slash (.indexOf body "/")]
-                       (if (neg? slash)
-                         (keyword body)
-                         (keyword (subs body 0 slash) (subs body (inc slash)))))
-                     :else attr)
+          ;; The canonical `data-rf-view` reader (the inverse of
+          ;; `format-view-id`): leading-colon → keyword, else raw string
+          ;; (Spec 006 §View tagging contract). Same parse the fallback
+          ;; view-walker uses — both now alias core's `parse-view-id`.
+          view-id  (parse-view-id attr)
           ;; Source-coord: the attribute carries <ns>:<sym>:<line>:<col>;
           ;; handler-meta augments with :file (the four-segment attr can't
           ;; carry an absolute path — Tool-Pair §Where the DOM-to-source

--- a/skills/re-frame2-pair/tests/runtime/parse_view_id_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/parse_view_id_test.clj
@@ -1,0 +1,116 @@
+;;;; tests/runtime/parse_view_id_test.clj
+;;;;
+;;;; Babashka-runnable verification of `parse-view-id` from
+;;;; `preload/re_frame2_pair/runtime.cljs`.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `preload/re_frame2_pair/runtime.cljs` is a CLJS-only file loaded
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It now
+;;;;   aliases the CANONICAL reader `re-frame.source-coords/parse-view-id`
+;;;;   (the source-coord contract owner; rf2-ztxnm8 collapsed the formerly-
+;;;;   inline `data-rf-view` parse in `view-entity` onto it — the inverse of
+;;;;   `format-view-id`, the data-rf-view analogue of the parse-source-coord
+;;;;   work in rf2-nr7vf2). Loading that core `.cljc` ns under bb would drag
+;;;;   in re-frame.interop + the editor-uri sibling, so this script keeps a
+;;;;   dependency-free mirror of the read rule (leading-colon -> keyword;
+;;;;   first `/` -> namespaced keyword; else raw string) and asserts the
+;;;;   round-trip against a mirror of `format-view-id` so format drift shows
+;;;;   up under `bb`. The canonical CLJS-side coverage lives next to the
+;;;;   reader in `implementation/core/test/re_frame/source_coords_cljs_test.cljs`.
+;;;;
+;;;; Run:    bb tests/runtime/parse_view_id_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns parse-view-id-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is run-tests testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of the canonical `re-frame.source-coords/parse-view-id`
+;; (which `preload/re_frame2_pair/runtime.cljs` aliases as `parse-view-id`).
+;;
+;; KEEP IN SYNC WITH implementation/core/src/re_frame/source_coords.cljc.
+;; Logic is identical (both use clojure.string/index-of, which is portable
+;; CLJ/CLJS). The leading-colon test, first-slash split, and raw-string
+;; fallthrough are the contract under test.
+;; ---------------------------------------------------------------------------
+
+(defn parse-view-id
+  "See re-frame.source-coords/parse-view-id for the canonical version.
+   Returns the registry id keyword, the raw string for a non-keyword id,
+   or nil for nil / non-string input."
+  [attr-val]
+  (cond
+    (or (nil? attr-val) (not (string? attr-val)))
+    nil
+
+    (and (pos? (count attr-val)) (= ":" (subs attr-val 0 1)))
+    (let [body  (subs attr-val 1)
+          slash (str/index-of body "/")]
+      (if (nil? slash)
+        (keyword body)
+        (keyword (subs body 0 slash) (subs body (inc slash)))))
+
+    :else
+    attr-val))
+
+;; ---------------------------------------------------------------------------
+;; Stringified keyword ids — the common case (`(str id)` formats them).
+;; ---------------------------------------------------------------------------
+
+(deftest namespaced-keyword
+  (testing "leading colon + slash → namespaced keyword (split at first /)"
+    (is (= :rf.foo/bar (parse-view-id ":rf.foo/bar")))))
+
+(deftest bare-keyword
+  (testing "leading colon, no slash → unqualified keyword (legal at registrar)"
+    (is (= :bare (parse-view-id ":bare")))))
+
+(deftest dotted-and-hyphenated
+  (testing "dotted ns + hyphenated name parse cleanly"
+    (is (= :my-app.cart.view/apply-coupon-button
+           (parse-view-id ":my-app.cart.view/apply-coupon-button")))))
+
+;; ---------------------------------------------------------------------------
+;; Non-keyword id — returned verbatim (unusual but legal).
+;; ---------------------------------------------------------------------------
+
+(deftest raw-string
+  (testing "no leading colon → non-keyword id, returned verbatim"
+    (is (= "raw-string" (parse-view-id "raw-string")))))
+
+;; ---------------------------------------------------------------------------
+;; Malformed / edge cases — must never throw; return nil.
+;; ---------------------------------------------------------------------------
+
+(deftest nil-and-non-string
+  (testing "nil / non-string input returns nil — never throws"
+    (is (nil? (parse-view-id nil)))
+    (is (nil? (parse-view-id 42)))
+    (is (nil? (parse-view-id :keyword)))
+    (is (nil? (parse-view-id ["v" "e" "c"])))))
+
+;; ---------------------------------------------------------------------------
+;; Round-trip — (parse-view-id (format-view-id id)) recovers the id.
+;; `format-view-id` is `(str id)`; mirror it here so format drift surfaces.
+;; ---------------------------------------------------------------------------
+
+(defn- format-view-id
+  "Mirror of re-frame.adapter.context/format-view-id: `(str id)`."
+  [id]
+  (str id))
+
+(deftest round-trip-keyword-ids
+  (testing "parse(format id) recovers the registry id keyword"
+    (doseq [id [:rf.foo/bar
+                :bare
+                :my-app.cart.view/apply-coupon-button]]
+      (is (= id (parse-view-id (format-view-id id)))))))
+
+;; ---------------------------------------------------------------------------
+;; Run.
+;; ---------------------------------------------------------------------------
+
+(let [{:keys [fail error]} (run-tests 'parse-view-id-test)]
+  (System/exit (if (and (zero? fail) (zero? error)) 0 1)))

--- a/tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs
@@ -64,34 +64,28 @@
   so consumer code is path-agnostic. `:node-key` substitutes for the
   Fiber-walker's `:fiber-key` — same role (stable React key for tree-row
   rendering across re-walks)."
-  (:require [re-frame.interop :as interop]))
+  (:require [re-frame.interop :as interop]
+            [re-frame.source-coords :as source-coords]))
 
 ;; ---- attribute parsing -----------------------------------------------------
 
-(defn parse-view-id
+(def parse-view-id
   "Parse a `data-rf-view` attribute value back into the registry id.
 
       \":rf.foo/bar\"  → :rf.foo/bar         ;; namespaced kw
       \":bare\"        → :bare               ;; unqualified kw (legal at registrar)
       \"raw-string\"   → \"raw-string\"      ;; non-kw id (unusual)
 
-  Per Spec 006 §View tagging contract §Attribute value format and
-  Spec-Schemas §`:rf/view-id-attr`."
-  [s]
-  (cond
-    (or (nil? s) (not (string? s)))
-    nil
-
-    ;; Leading colon → keyword. Splits on the first `/` to recover ns/name.
-    (and (pos? (count s)) (= ":" (subs s 0 1)))
-    (let [body (subs s 1)
-          slash (.indexOf body "/")]
-      (if (neg? slash)
-        (keyword body)
-        (keyword (subs body 0 slash) (subs body (inc slash)))))
-
-    :else
-    s))
+  Alias of the canonical `re-frame.source-coords/parse-view-id` (the source-
+  coord contract owner) — the inverse of `format-view-id`. This parser used to
+  be reimplemented inline here and in the re-frame2-pair preload runtime's
+  `view-entity`; rf2-ztxnm8 collapsed both onto the one canonical impl in core
+  (the data-rf-view analogue of rf2-nr7vf2's `parse-source-coord` work). See
+  that fn for the value format (Spec 006 §View tagging contract §Attribute
+  value format / Spec-Schemas §`:rf/view-id-attr`) and the Tool-Pair opacity
+  caveat (downstream callers MUST NOT depend on the parsed shape's stability
+  across re-frame2 versions)."
+  source-coords/parse-view-id)
 
 ;; ---- DOM walk --------------------------------------------------------------
 ;;


### PR DESCRIPTION
## What

The `data-rf-view` DOM attribute had a canonical **producer** (`re-frame.adapter.context/format-view-id` = `(str id)`) but **no canonical exported reader**. The read rule (leading-colon → keyword; first `/` → namespaced keyword; else raw string) lived only in `format-view-id`'s docstring + Spec 006 prose and was re-implemented inline by **both** consumers:

- `tools/xray/.../views/view_walker.cljs` (`parse-view-id`)
- `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs` (`view-entity`, whose comment even said *"Reuse the same parse the fallback view-walker uses"* — but it re-derived)

This is the `data-rf-view` analogue of rf2-nr7vf2's `parse-source-coord` work (Stage B handled the trace frame-of reader; this is the view-id dual — the primary rf2-16znzb finding).

## How

- Add `re-frame.source-coords/parse-view-id`, **co-located beside `parse-source-coord`** in the source-coord contract owner (same `.cljc` ns; uses portable `clojure.string/index-of`). **Internal visibility — not a `re-frame.core` facade export** (matches `parse-source-coord`; api-manifest unchanged).
- Migrate both consumers to alias the canonical reader; the hand-rolled parses are removed. The pair runtime adds a `parse-view-id` alias mirroring its existing `parse-rf2-coord` alias.
- **Behaviour-preserving** — the value format is unchanged; this is a reader-sourcing refactor.

## Confirmed real duplication (not forced)

A `git grep` of `data-rf-view` across the tree confirms exactly **two** value-parsing consumers (the rest are producers, CSS attribute *selectors* for finding tagged elements, elision sentinels, or prose). Both migrated.

## Tests

- CLJS round-trip against the **real** `format-view-id` in `source_coords_cljs_test.cljs` (parse(format id) == id), plus shape tests — mirrors the existing `parse-source-coord` round-trip.
- bb-runnable mirror `tests/runtime/parse_view_id_test.clj` in the pair skill (auto-globbed by CI) so format drift surfaces under bb.

## Gates

- `npm run test:cljs` — 7935 tests, 0 failures (includes the xray view-walker `parse-view-id` tests on the node-test build).
- `scripts/test-jvm-tools.sh` — xray / machines-viz / story / story-mcp / mcp-base / wire-vocab all green.
- pair-mcp node `:server-test` — 1114 tests, 0 failures.
- pair-mcp descriptor drift — in sync (30 tools). No tool surface changed → MCP-conformance + skill↔MCP drift not triggered.
- api-manifest `--check` — in sync (486 public vars; reader is internal).
- clj-kondo — 0 errors (6 warnings, all pre-existing and unrelated).
- bb `parse_view_id_test.clj` + `parse_rf2_coord_test.clj` — green.

tools/xray spec: unchanged — the two `data-rf-view` mentions in `tools/xray/spec/*` describe the attribute *contract* (adapter stamps it; matched via it), which is unchanged; this is an internal reader-sourcing refactor.

Closes rf2-ztxnm8.