### PR TITLE
perf(core): cache sensitive-declarations hook + zero-decl skip + take-event swap-vals (rf2-ivr38u, rf2-tgea2z)

### DIFF
--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -50,9 +50,33 @@
 
 (defn- sensitive-declarations
   [frame-id]
-  (if-let [f (late-bind/get-fn :elision/sensitive-declarations)]
+  ;; rf2-ivr38u — HOT PATH (every dispatch, via `schema-redaction-paths`
+  ;; in the router's `prepare-handler-ctx`). The
+  ;; `:elision/sensitive-declarations` hook is published ONCE at boot
+  ;; (`re-frame.elision`, bottom of file) and never withdrawn in
+  ;; production — exactly the `get-fn-cached` sticky profile. Cached
+  ;; resolution avoids re-deref'ing the global `hooks` atom + re-walking
+  ;; its map on every dispatch; the cache invalidates on hook re-publish
+  ;; (`set-fn!`), so dev-time `(require 're-frame.elision :reload)` still
+  ;; swaps the resolved fn on the next dispatch.
+  (if-let [f (late-bind/get-fn-cached :elision/sensitive-declarations)]
     (f frame-id)
     {}))
+
+(defn- overlap-redaction-paths
+  "Given the handler chain's app-db `:path` slices and the frame's
+  declared sensitive app-db paths, return the distinct event-payload
+  paths whose path-scoped handler slice overlaps a sensitive path."
+  [db-paths sensitive-paths]
+  (vec
+    (distinct
+      (mapcat
+        (fn [db-path]
+          (keep (fn [sensitive-path]
+                  (when (path-prefix? db-path sensitive-path)
+                    (relative-path db-path sensitive-path)))
+                sensitive-paths))
+        db-paths))))
 
 (defn schema-redaction-paths
   "Return event-payload paths that should be redacted for a handler
@@ -61,18 +85,16 @@
   The overlap is computed against the frame's sensitive-declarations
   registry (frame-owned `:sensitive {:app-db …}` classification, EP-0015
   §3 / §8) — NOT against schema-attached `{:sensitive? true}` slot props,
-  which no longer feed this registry. The fn name is retained for callers."
+  which no longer feed this registry. The fn name is retained for callers.
+
+  rf2-ivr38u — DOMINANT-PATH SKIP: when the frame declares ZERO sensitive
+  app-db paths (the common case) there is no overlap to compute, so the
+  `handler-db-paths` chain walk + `mapcat` are bypassed entirely."
   [frame-id interceptors]
   (let [sensitive-paths (keys (sensitive-declarations frame-id))]
-    (vec
-      (distinct
-        (mapcat
-          (fn [db-path]
-            (keep (fn [sensitive-path]
-                    (when (path-prefix? db-path sensitive-path)
-                      (relative-path db-path sensitive-path)))
-                  sensitive-paths))
-          (handler-db-paths interceptors))))))
+    (if (seq sensitive-paths)
+      (overlap-redaction-paths (handler-db-paths interceptors) sensitive-paths)
+      [])))
 
 (defn- redact-path
   [payload path]
@@ -240,3 +262,40 @@
         (comp (filter redact-interceptor?)
               (mapcat :paths))
         interceptors))
+
+(defn collect-redaction-paths
+  "Single-pass fusion (rf2-ivr38u / rf2-tgea2z companion) of
+  `schema-redaction-paths` + `user-redaction-paths` over the SAME
+  resolved interceptor chain — read together by the router's
+  `prepare-handler-ctx` on every dispatch.
+
+  Walks `interceptors` ONCE, collecting in one reduce both:
+    * the handler chain's app-db `:path` slices (for the frame-declared
+      sensitive-path overlap), and
+    * the `redact-interceptor` `:paths` (user-declared payload paths).
+
+  Returns `{:schema-paths <vec> :user-paths <vec>}`, behaviour-identical
+  to calling `schema-redaction-paths` and `user-redaction-paths`
+  separately. The schema-path overlap is only computed when the frame
+  declares ≥1 sensitive app-db path (the dominant no-classification path
+  skips the overlap `mapcat` entirely); the single chain walk still
+  collects `:path` slices unconditionally so the overlap, when needed,
+  sees the same db-paths the two-walk form did."
+  [frame-id interceptors]
+  (let [sensitive-paths (keys (sensitive-declarations frame-id))
+        {:keys [db-paths user-paths]}
+        (reduce (fn [acc interceptor]
+                  (if (map? interceptor)
+                    (cond-> acc
+                      (some? (:path interceptor))
+                      (update :db-paths conj (:path interceptor))
+
+                      (= redact-interceptor-id (:id interceptor))
+                      (update :user-paths into (:paths interceptor)))
+                    acc))
+                {:db-paths [] :user-paths []}
+                interceptors)]
+    {:schema-paths (if (seq sensitive-paths)
+                     (overlap-redaction-paths db-paths sensitive-paths)
+                     [])
+     :user-paths   (vec user-paths)}))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2499,13 +2499,26 @@
   this peek+pop pair is atomic w.r.t. any other drain attempt. The
   pre-fix race (executor and main thread both peek the same envelope)
   cannot occur — the loser of the CAS in `drain-try!` / `drain-block!`
-  never reaches this code."
+  never reaches this code.
+
+  rf2-tgea2z: ONE `swap-vals!` per dequeue instead of a deref PLUS a
+  separate `swap!`, halving the atom traffic on the hottest per-event
+  step. The swap pops the head when non-empty (idempotent no-op when
+  empty, so the empty case never `pop`s a `PersistentQueue` it shouldn't);
+  the popped envelope is read from the PRE-swap value the `swap-vals!`
+  returns — i.e. the head at the instant of the pop, strictly more atomic
+  than the prior deref-then-swap peek. A concurrent submitter only ever
+  `conj`s the tail (sync seed-pushes are serialised under the drain-lock
+  per `drain-block!`), so the head this pops is unchanged by any enqueue."
   [router]
-  (let [{:keys [queue]} @router]
-    (when-not (empty? queue)
-      (let [envelope (peek queue)]
-        (swap! router update :queue pop)
-        envelope))))
+  (let [[{old-queue :queue} _]
+        (swap-vals! router
+                    (fn [{:keys [queue] :as r}]
+                      (if (empty? queue)
+                        r
+                        (assoc r :queue (pop queue)))))]
+    (when-not (empty? old-queue)
+      (peek old-queue))))
 
 (defn- handle-drain-interrupted!
   "Per rf2-68kok / Spec 002 §Edge cases worth pinning §Frame disposal

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1776,17 +1776,20 @@
                           (icpt-reg/resolve-chain prepended-chain)
                           prepended-chain)
         base-chain      (apply-icpt-overrides resolved-chain icpt-overrides)
-        redaction-paths (privacy/schema-redaction-paths frame base-chain)
-        ;; Per rf2-461sp — user-installed `(rf/redact-interceptor paths)`
-        ;; interceptors expose their paths on the interceptor map so the
-        ;; pre-chain trace projection (`:run-start`, `emit-cascade-
-        ;; trailers`) honours them too. Each user `:before` ALSO runs
-        ;; during chain execution and extends `:rf/redacted-event`
-        ;; in-chain, which is what the schema-redaction interceptor
-        ;; (when also installed) composes with. The union here is the
-        ;; OUT-OF-CHAIN projection used by emit sites that fire BEFORE
-        ;; the chain.
-        user-paths      (privacy/user-redaction-paths base-chain)
+        ;; rf2-ivr38u — fused single-pass collection of the frame-declared
+        ;; sensitive-path overlap (`:schema-paths`) AND the user-installed
+        ;; `(rf/redact-interceptor paths)` paths (`:user-paths`) over the
+        ;; SAME `base-chain`, replacing the prior two independent chain
+        ;; walks. Per rf2-461sp — user-installed redact interceptors expose
+        ;; their paths on the interceptor map so the pre-chain trace
+        ;; projection (`:run-start`, `emit-cascade-trailers`) honours them
+        ;; too. Each user `:before` ALSO runs during chain execution and
+        ;; extends `:rf/redacted-event` in-chain, which is what the schema-
+        ;; redaction interceptor (when also installed) composes with. The
+        ;; union here is the OUT-OF-CHAIN projection used by emit sites that
+        ;; fire BEFORE the chain.
+        {redaction-paths :schema-paths
+         user-paths      :user-paths} (privacy/collect-redaction-paths frame base-chain)
         redacted-chain  (if (seq redaction-paths)
                           (into [(privacy/schema-redaction-interceptor
                                    redaction-paths)]


### PR DESCRIPTION
Behaviour-preserving perf fixes for two hot-path findings from the rf2-vr8op8 dispatch-path audit.

## rf2-ivr38u (P3) — privacy.cljc + router.cljc
`prepare-handler-ctx` fires on **every** dispatch and calls `privacy/schema-redaction-paths` → `sensitive-declarations`.

1. **Cache the hook resolution.** `sensitive-declarations` resolved `:elision/sensitive-declarations` via the UNCACHED `late-bind/get-fn` (re-deref + re-walk of the global `hooks` atom each dispatch — the V8 megamorphic-IC pressure the cache exists to avoid). The hook is published once at boot (`re-frame.elision`, bottom of file) and never withdrawn — exactly the documented `get-fn-cached` sticky profile. Switched to `get-fn-cached`. The cache invalidates on `set-fn!` re-publish, so dev-time `(require 're-frame.elision :reload)` still swaps the resolved fn on the next dispatch (the `sensitive-stamping` / `elision` tests reload elision and stay green).

2. **Zero-decl skip.** `schema-redaction-paths` now early-returns `[]` when the frame declares ZERO sensitive app-db paths (the dominant case), skipping the `handler-db-paths` chain walk + overlap `mapcat`.

3. **Fused chain walk.** The router previously walked `base-chain` twice (schema overlap db-paths via `schema-redaction-paths` + user `redact-interceptor` `:paths` via `user-redaction-paths`). Fused into one `collect-redaction-paths` reduce returning `{:schema-paths :user-paths}`. Behaviour-identical (same `:path`/`:id` classification, same overlap, same union).

## rf2-tgea2z (P4) — router.cljc
`take-event!` (drain inner loop) did a `@router` deref PLUS a separate `swap! ... pop` per event — two atom ops on the hottest per-event step. Under the single-drainer invariant (`drain-loop!` runs only behind the `:drain-lock` CAS in `drain-try!` / `drain-block!`, so `take-event!` has exclusive queue access — verified both entry points gate on the CAS, loser returns/spins), collapsed to ONE `swap-vals!`: pops the head when non-empty (no-op when empty), reads the popped envelope from the pre-swap value. Strictly more atomic than the prior deref-then-peek; concurrent submitters only `conj` the tail (sync seed-pushes serialise under the lock), so the popped head is unaffected by any enqueue.

## Gates (all green)
- `test:elision` — PASS (42/42 absent prod, 42/42 present control) — confirms the cache + zero-decl skip did NOT change elision/redaction behaviour
- `test:jvm-implementation.sh` — PASS, core 1729 tests / 7460 assertions, 0 failures (router/dispatch + privacy/elision JVM)
- `test:cljs` — PASS, 7947 tests / 36484 assertions, 0 failures
- `test:bundle-isolation` — PASS
- `test:cljs-isolation` (per-ns) — PASS, 18 namespaces
- clj-kondo / splint — no new warnings (pre-existing only, all outside edited regions); privacy.cljc fully clean

`schema-redaction-paths` + `user-redaction-paths` retained as public helpers (now unused by production; carry the zero-decl skip).