### PR TITLE
fix(core/derivation): make egress projection idempotent for realized inputs + lock it in conformance (rf2-g197ep)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -1051,6 +1051,20 @@
 
 ;; ---- the in-tree egress projection (mirrors the Xray call site) ----------
 
+(defn- already-projected-handle?
+  "True when `v` is ALREADY an egress-projected handle — an opaque
+  `[:rf.resource/opaque <digest>]` token or the `:rf/redacted` fail-closed
+  sentinel. Re-projecting such a value MUST be the identity (idempotence):
+  the conformance mirror models the SAME forwarder-pipeline contract the Xray
+  call site does — a value may egress more than once, and hashing an
+  already-projected handle would mint a NEW handle and silently change the
+  live node identity across the boundary."
+  [v]
+  (or (= v privacy/redacted-sentinel)
+      (and (vector? v)
+           (= 2 (count v))
+           (= :rf.resource/opaque (nth v 0)))))
+
 (defn- opaque-scoped-key-handle
   "A STABLE, ONE-WAY opaque handle for one secret-bearing scoped-key
   component — the `implementation/`-resident analogue of the Xray
@@ -1059,16 +1073,19 @@
   canonical token (`identity/canonical-bytes`), never the token itself.
   FAILS CLOSED to the `:rf/redacted` sentinel for any value outside the
   CEDN-1 identity domain or on any error — never host-stringify a secret
-  onto the wire. Idempotent: hashing an already-`[:rf.resource/opaque …]`
-  handle yields a stable handle-of-handle."
+  onto the wire. IDEMPOTENT: an already-projected `[:rf.resource/opaque …]`
+  handle / `:rf/redacted` sentinel is returned UNCHANGED (hashing it again
+  would mint a fresh, DIFFERENT handle on a second egress pass)."
   [v]
-  (try
-    (let [token  (identity/canonical-bytes v)
-          digest #?(:clj  (Integer/toHexString (hash token))
-                    :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
-      [:rf.resource/opaque digest])
-    (catch #?(:clj Throwable :cljs :default) _
-      privacy/redacted-sentinel)))
+  (if (already-projected-handle? v)
+    v
+    (try
+      (let [token  (identity/canonical-bytes v)
+            digest #?(:clj  (Integer/toHexString (hash token))
+                      :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
+        [:rf.resource/opaque digest])
+      (catch #?(:clj Throwable :cljs :default) _
+        privacy/redacted-sentinel))))
 
 (defn- scoped-resource-key?
   "True when `v` is a live resource SCOPED KEY — a 3-tuple
@@ -1111,7 +1128,12 @@
   "Project a live resource node's realized `:inputs`
   `[[:scope <scope>] [:param <params>]]` — opaque the `[:scope …]` /
   `[:param …]` payloads (the realized scope + params edges carry the same
-  sensitive identity). Other input shapes ride through untouched."
+  sensitive identity). Other input shapes ride through untouched. Idempotent:
+  the payload runs through `opaque-scoped-key-handle`, which returns an
+  already-projected handle / `:rf/redacted` UNCHANGED, so re-projecting an
+  already-projected inputs vector is the identity (rf2-g197ep — this is the
+  one input position projected unconditionally rather than gated by the
+  scoped-key shape, so its idempotence MUST come from the handle minter)."
   [inputs]
   (if (sequential? inputs)
     (mapv (fn [in]
@@ -1429,19 +1451,45 @@
         (is (not (contains-secret? redacted)))))))
 
 (deftest g-graph-egress-is-idempotent
-  ;; A forwarder pipeline that double-projects must not corrupt the graph: the
-  ;; opaque handle of a handle is stable, the :rf/redacted sentinel is a
-  ;; non-matchable scalar.
+  ;; A forwarder pipeline that double-projects must not corrupt the graph: a
+  ;; value may egress MORE THAN ONCE (re-egress on re-render / re-subscribe /
+  ;; cascade), so the projection MUST be the identity on an already-projected
+  ;; graph — `project(project(x)) == project(x)`. The opaque handle of an
+  ;; already-opaque handle is the SAME handle (not a fresh handle-of-handle),
+  ;; and the `:rf/redacted` sentinel re-projects to itself.
+  ;;
+  ;; rf2-g197ep: the prior assertion checked ONLY node-key set + `:id` + no-raw-
+  ;; secret. That MISSED the real non-idempotence: `:id`/node-keys are stable
+  ;; only because a projected scoped key (`[<handle> id <handle>]`) no longer
+  ;; matches `scoped-resource-key?` (its tail is an opaque VECTOR, not a map),
+  ;; so they are not re-projected — but the realized `:inputs`
+  ;; `[:scope …]`/`[:param …]` payloads were re-hashed UNCONDITIONALLY, minting
+  ;; fresh handles on the second pass. Full graph equality is the assertion
+  ;; that catches it; it FAILS against the pre-fix unconditional re-hash.
   (rf/reg-frame egress-frame {})
   (let [raw   (graph/live-derivation-graph egress-frame (egress-live-contributors))
         once  (egress-project-graph raw egress-frame)
-        twice (egress-project-graph once egress-frame)]
+        twice (egress-project-graph once egress-frame)
+        node1 (-> once :nodes vals first)
+        node2 (-> twice :nodes vals first)]
+    (is (not (contains-secret? twice)) "still no secret after double projection")
+    ;; The headline idempotence law: a second egress pass changes NOTHING.
+    (is (= once twice)
+        "egress is idempotent — re-projecting an already-projected graph is the
+         identity (project(project(x)) == project(x))")
+    ;; Spelled-out witnesses so a regression reports WHICH position drifted.
     (is (= (set (keys (:nodes once))) (set (keys (:nodes twice))))
         "node keys are stable under re-projection")
-    (is (not (contains-secret? twice)) "still no secret after double projection")
-    (is (= (-> once :nodes vals first :id)
-           (-> twice :nodes vals first :id))
-        "the projected scoped-key identity is stable under re-projection")))
+    (is (= (:id node1) (:id node2))
+        "the projected scoped-key :id is stable under re-projection")
+    (is (= (:inputs node1) (:inputs node2))
+        "the projected realized :inputs ([:scope …]/[:param …]) are stable — a
+         second pass must NOT re-hash the opaque handles into fresh handles")
+    (is (= (:output node1) (:output node2))
+        "the projected :output runtime path is stable under re-projection")
+    (is (= (get-in node1 [:work-ledger :record :resource/key])
+           (get-in node2 [:work-ledger :record :resource/key]))
+        "the projected work-ledger :resource/key is stable under re-projection")))
 
 ;; ===========================================================================
 ;; (h) DERIVED-OUTPUT SENSITIVITY INHERITANCE (rf2-iormgq; EP-0015 §Derived

--- a/tools/xray/spec/025-Derivation-Graph-Panel.md
+++ b/tools/xray/spec/025-Derivation-Graph-Panel.md
@@ -227,6 +227,19 @@ identity positions inside node bodies (`:id` / `:output` / `:inputs` /
 a redacted resource node is still a node, and the edges naming it still
 connect. Structure survives; the identity-embedded secret does not egress.
 
+The projection is **idempotent** (rf2-g197ep): a value may egress more than
+once (re-egress on re-render / re-subscribe / a forwarder cascade that ships
+an already-projected graph onward), so `redact-graph-for-egress` ∘
+`redact-graph-for-egress` **must equal** `redact-graph-for-egress` — a second
+pass changes nothing. This holds at the source: the opaque-handle minter
+returns an already-`[:rf.resource/opaque …]` handle (and the `:rf/redacted`
+sentinel) **unchanged** instead of re-hashing it into a fresh, different
+handle. Without that guard the realized `:inputs` `[:scope …]` / `[:param …]`
+payloads — the one position projected unconditionally rather than gated by the
+scoped-key shape test — would be re-hashed on every pass, silently changing
+the live node's input-edge identity across the boundary even though the node
+key and `:id` (gated by the 3-tuple-with-map-tail shape) stayed stable.
+
 ## `:rf.xray/*` registry surface
 
 All under the `:rf.xray/*` isolation prefix (the collision contract); all
@@ -275,7 +288,11 @@ the enclosing `[rf/frame-provider-existing {:frame :rf/xray}]` in `shell.cljs`.
   `:inputs`, `:output`, work-ledger, edges) while connectivity survives (the
   node is still classified, the edge still connects to the projected key),
   the projection is deterministic across all identity positions, and it is
-  idempotent under double-projection.
+  **idempotent** — `project(project(x)) == project(x)`, asserted as full graph
+  equality across two (and three) passes plus per-position witnesses (node
+  keys, `:id`, `:inputs`, `:output`, work-ledger `:resource/key`, edges), so a
+  forwarder pipeline that re-egresses an already-projected graph cannot drift
+  the realized `:inputs` handles (rf2-g197ep).
 - **`derivation_graph_consumer_cljs_test.cljs`** (node) — the **behavioral
   consumer** test (rf2-4wtllq): registers the panel handlers via
   `registry/register-xray-handlers!` + `test-support/install-test-overrides!`

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
@@ -291,6 +291,20 @@
        (keyword? (nth v 1))
        (map? (nth v 2))))
 
+(defn- already-projected?
+  "True when `v` is ALREADY an egress-projected handle — an opaque
+  `[:rf.resource/opaque <digest>]` token or the `:rf/redacted` fail-closed
+  sentinel. Re-projecting such a value MUST be the identity (idempotence): a
+  forwarder pipeline may run egress more than once (re-egress on re-render /
+  re-subscribe / cascade), and hashing an already-projected handle would mint
+  a NEW, different handle — silently changing the live node's identity across
+  the boundary and breaking stable graph connectivity."
+  [v]
+  (or (= v :rf/redacted)
+      (and (vector? v)
+           (= 2 (count v))
+           (= :rf.resource/opaque (nth v 0)))))
+
 (defn- opaque-handle
   "A STABLE, ONE-WAY opaque handle for one secret-bearing scoped-key
   component. Deterministic from the value (same value ⇒ same handle, so
@@ -298,20 +312,24 @@
   CEDN-1 canonical token, NOT the token itself (the token PRESERVES the raw
   value, which would defeat redaction). FAILS CLOSED to the `:rf/redacted`
   sentinel for any value outside the CEDN-1 identity domain or on any error
-  (never host-stringify a secret onto the wire). Idempotent: hashing an
-  already-`[:rf.resource/opaque …]` handle yields a stable handle-of-handle."
+  (never host-stringify a secret onto the wire). IDEMPOTENT: an already-
+  projected `[:rf.resource/opaque …]` handle / `:rf/redacted` sentinel is
+  returned UNCHANGED (hashing it again would mint a fresh, DIFFERENT handle
+  and silently change the projected identity on a second egress pass)."
   [v]
-  (try
-    ;; `canonical-bytes` is the deterministic CEDN-1 token (stable for a given
-    ;; value, cross-spelling-invariant); `hash` makes it one-way so the raw
-    ;; scope/params cannot be read back off the wire. Render unsigned hex so
-    ;; the handle is a compact, non-reversible, value-stable token.
-    (let [token  (identity/canonical-bytes v)
-          digest #?(:clj  (Integer/toHexString (hash token))
-                    :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
-      [:rf.resource/opaque digest])
-    (catch #?(:clj Throwable :cljs :default) _
-      :rf/redacted)))
+  (if (already-projected? v)
+    v
+    (try
+      ;; `canonical-bytes` is the deterministic CEDN-1 token (stable for a
+      ;; given value, cross-spelling-invariant); `hash` makes it one-way so the
+      ;; raw scope/params cannot be read back off the wire. Render unsigned hex
+      ;; so the handle is a compact, non-reversible, value-stable token.
+      (let [token  (identity/canonical-bytes v)
+            digest #?(:clj  (Integer/toHexString (hash token))
+                      :cljs (.toString (bit-and (hash token) 0xffffffff) 16))]
+        [:rf.resource/opaque digest])
+      (catch #?(:clj Throwable :cljs :default) _
+        :rf/redacted))))
 
 (defn- project-scoped-key
   "Project a live resource scoped key `[scope resource-id params]` into its
@@ -468,10 +486,17 @@
   egressing under no reachable policy redacts, never ships raw.
 
   Returns the graph with redacted node value fields + projected live
-  resource identities; `:mode` / `:frame` unchanged. Idempotent over
-  `:rf/redacted` (re-walking an already-redacted value is a no-op — the
-  sentinel is a non-matchable scalar) and over the opaque resource handle
-  (re-projecting a `[:rf.resource/opaque …]` handle is stable)."
+  resource identities; `:mode` / `:frame` unchanged. IDEMPOTENT — a value may
+  egress more than once (re-egress on re-render / re-subscribe / a forwarder
+  cascade), and re-projecting an already-projected graph is the IDENTITY:
+  `redact-graph-for-egress` ∘ `redact-graph-for-egress` == `redact-graph-for-
+  egress` (rf2-g197ep). `rf/elide-wire-value` is a no-op over an already-
+  `:rf/redacted` value (the sentinel is a non-matchable scalar), and the
+  opaque resource handle is idempotent at the source: `opaque-handle` returns
+  an already-`[:rf.resource/opaque …]` handle / `:rf/redacted` sentinel
+  UNCHANGED rather than re-hash it into a fresh, different handle. (Pinned by
+  `live-resource-identity-projection-is-idempotent` here and the cross-family
+  `g-graph-egress-is-idempotent` in derivation-conformance.)"
   ([graph frame-id] (redact-graph-for-egress graph frame-id nil))
   ([graph frame-id opts]
    ;; A reachable (live) frame governs egress under its own policy; an

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
@@ -406,11 +406,45 @@
             "every identity position projects to the SAME opaque scoped key")))))
 
 (deftest live-resource-identity-projection-is-idempotent
-  (testing "re-projecting an already-egressed graph is stable (the opaque
-            handle of a handle is the handle) — a forwarder pipeline that
-            double-projects does not corrupt the graph"
-    (let [once  (h/redact-graph-for-egress live-resource-graph secure-frame)
-          twice (h/redact-graph-for-egress once secure-frame)]
+  ;; A value may egress MORE THAN ONCE (re-egress on re-render / re-subscribe /
+  ;; a forwarder cascade), so re-projecting an already-egressed graph MUST be
+  ;; the identity — `project(project(x)) == project(x)`. The opaque handle of
+  ;; an already-opaque handle is the SAME handle, and `:rf/redacted` re-projects
+  ;; to itself.
+  ;;
+  ;; rf2-g197ep: the prior assertion checked ONLY node-key set + no-raw-secret.
+  ;; That MISSED the real non-idempotence — node-keys/`:id` are stable only
+  ;; because a projected scoped key no longer matches `scoped-resource-key?`
+  ;; (opaque-vector tail, not a map), so they are not re-projected; but the
+  ;; realized `:inputs` `[:scope …]`/`[:param …]` payloads were re-hashed
+  ;; UNCONDITIONALLY, minting fresh handles on the second pass. Full graph
+  ;; equality catches it; it FAILS against the pre-fix unconditional re-hash.
+  (testing "re-projecting an already-egressed graph is the IDENTITY — a
+            forwarder pipeline that double-projects does not corrupt the graph"
+    (let [once   (h/redact-graph-for-egress live-resource-graph secure-frame)
+          twice  (h/redact-graph-for-egress once secure-frame)
+          thrice (h/redact-graph-for-egress twice secure-frame)
+          node1  (-> once :nodes vals first)
+          node2  (-> twice :nodes vals first)]
+      (is (not (contains-secret? twice)) "still no secret after double projection")
+      ;; The headline idempotence law: a second (and third) egress pass changes
+      ;; NOTHING.
+      (is (= once twice)
+          "egress is idempotent — project(project(x)) == project(x)")
+      (is (= twice thrice)
+          "and stays the identity on every further pass")
+      ;; Spelled-out witnesses so a regression names WHICH position drifted.
       (is (= (set (keys (:nodes once))) (set (keys (:nodes twice))))
           "node keys are stable under re-projection")
-      (is (not (contains-secret? twice)) "still no secret after double projection"))))
+      (is (= (:id node1) (:id node2))
+          "the projected scoped-key :id is stable under re-projection")
+      (is (= (:inputs node1) (:inputs node2))
+          "the projected realized :inputs ([:scope …]/[:param …]) are stable — a
+           second pass must NOT re-hash the opaque handles into fresh handles")
+      (is (= (:output node1) (:output node2))
+          "the projected :output runtime path is stable under re-projection")
+      (is (= (get-in node1 [:work-ledger :record :resource/key])
+             (get-in node2 [:work-ledger :record :resource/key]))
+          "the projected work-ledger :resource/key is stable under re-projection")
+      (is (= (:edges once) (:edges twice))
+          "the projected edge endpoints are stable under re-projection"))))


### PR DESCRIPTION
## What

The live resource-graph egress projection (`redact-graph-for-egress` in the Xray derivation-graph helper, plus its `implementation/`-primitives mirror in the derivation-conformance suite) was **not idempotent for a realized resource node's `:inputs`**. Re-egressing an already-projected graph silently changed the live node's input-edge identity handles, weakening the stable-connectivity contract across the wire boundary.

## Was the real bug in core or only the test?

**Both.** The bug was real in the production egress call site (`tools/xray/.../derivation_graph_helpers.cljc` `redact-graph-for-egress` — the named first consumer / the "real" graph egress projection), AND in the conformance test's `implementation/`-primitives mirror. Both re-hashed an already-`[:rf.resource/opaque …]` handle into a fresh, different handle.

## Root cause

- `opaque-handle` / `opaque-scoped-key-handle` re-hashed any value handed to them, including an already-projected `[:rf.resource/opaque …]` handle — `f(f(x)) != f(x)`.
- `redact-resource-inputs` / `project-resource-inputs` project the `[:scope …]` / `[:param …]` payloads **unconditionally** (unlike the node key / `:id` / work-ledger key, which are gated by `scoped-resource-key?` — a 3-tuple-with-map-tail test a projected key no longer matches, so those positions stayed stable by accident).
- The old idempotence tests checked **only** node-key set + `:id` + no-raw-secret — exactly the positions that were accidentally stable — so they **missed** the `:inputs` drift.

## Fix

The opaque-handle minter now returns an already-projected `[:rf.resource/opaque …]` handle (and the `:rf/redacted` sentinel) **unchanged** instead of re-hashing it. This makes the whole projection the identity on an already-projected graph: `project(project(x)) == project(x)`. (The SSR / trace-egress path in `implementation/resources/` already had this guard via `redacted-token?`; this brings the graph-egress path into line.)

## Lock-in

Both idempotence tests now assert **full graph equality** across two (and three) passes plus per-position witnesses (node keys, `:id`, `:inputs`, `:output`, work-ledger `:resource/key`, edges). **Verified these strengthened assertions FAIL against the pre-fix projection** (3 failures pinpointing the `:inputs` re-hash, e.g. `[:rf.resource/opaque "8eea45eb"]` → `"7f3d9e2e"`) and pass with the fix. `tools/xray/spec/025-Derivation-Graph-Panel.md` updated to state the idempotence law (rf2-g197ep).

## Gates (all green)

- derivation-conformance JVM — 21 tests / 426 assertions
- Xray JVM — 1240 tests / 5699 assertions
- CLJS conformance corpus (`test:cljs`) — 7951 tests / 36523 assertions
- `test:elision` (CRITICAL — `:rf/redacted` interaction) — 42/42 absent, 42/42 present
- `test:bundle-isolation`
- clj-kondo (0 errors), splint (0 parse errors) — only pre-existing warnings in untouched files