### PR TITLE
fix(machines): parallel error-final routes as error not success (rf2-encnvn)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -159,6 +159,32 @@
                           :recovery    :first-region-output-key-used}))
     (some (fn [[_ node]] (:output-key node)) declared)))
 
+(defn- parallel-error-leaf-node
+  "Per Spec 005 §Final states §`:on-error` + §Parallel regions (rf2-encnvn):
+  classify a finishing PARALLEL machine's terminal as ERROR by scanning
+  EVERY region's final leaf — not just the first region's. Returns the
+  first (state-map order) region final leaf that declares `:error? true`,
+  or nil when no region's terminal is an error final.
+
+  The pre-fix code read `:error?` from `(first state)` only — the SAME
+  first-region blind spot the `:output-key` scan (`parallel-output-key`)
+  already fixed for output. So a parallel child whose FIRST region reached
+  a plain final but a NON-FIRST region reached `{:final? true :error? true}`
+  was all-regions-final and torn down, yet classified as a SUCCESS finish:
+  the spawning parent's `:spawn :on-error` was skipped, `:on-done` could run
+  instead, and `:rf.machine/done` carried `:error? false` / `:status :ok`.
+
+  Spec 005 §3061 says a parallel machine finishes when EVERY region's active
+  leaf is `:final?` and never restricts the error terminal to the first
+  region; §3060 lets ANY `:final?` leaf declare `:error? true`. XState v5's
+  parallel `onDone`/error semantics treat the completion as an error when a
+  region ends in an error final. So a parallel finish routes as ERROR if ANY
+  region's reached final leaf declares `:error? true`; the error payload's
+  `:output-key` is sourced from that error region's leaf."
+  [machine state]
+  (some (fn [[_ node]] (when (true? (:error? node)) node))
+        (region-final-leaf-nodes machine state)))
+
 (defn- find-spawn-spec-at
   "Walk `parent-spec`'s state tree to the node at `invoke-id` (the
   absolute prefix-path stamped at spawn time) and return that node's
@@ -243,22 +269,29 @@
                           machine-id frame-id (result/info exit-result)))]
   (let [child-data (:data next-snapshot)
         parallel?  (parallel/parallel? machine)
-        ;; Resolve the FIRST region's final leaf (parallel) / the single
-        ;; final leaf (flat) — the representative node `:error?` is read
-        ;; from. Parallel error-terminal routing keeps its first-region
-        ;; convention; only `:output-key` scans every region (C2 below).
-        final-node (if parallel?
-                     (let [[region-name region-state] (first (:state next-snapshot))]
-                       (transition/node-at (get-in machine [:regions region-name])
-                                            (transition/state-path region-state)))
-                     (transition/node-at machine
+        ;; (rf2-encnvn) Resolve the ERROR-classifying leaf. For a PARALLEL
+        ;; machine, scan EVERY region's final leaf — a parallel finish is an
+        ;; ERROR when ANY region's reached final declares `:error? true`, not
+        ;; only the first region's (Spec 005 §3060-§3061; XState v5 parallel
+        ;; error-final semantics). The pre-fix code read `:error?` from
+        ;; `(first state)` only — the same first-region blind spot the
+        ;; `:output-key` scan (C2) already fixed for output. For a flat
+        ;; machine the single leaf IS the error-classifying leaf.
+        error-node  (if parallel?
+                      (parallel-error-leaf-node machine (:state next-snapshot))
+                      (transition/node-at machine
                                           (transition/state-path (:state next-snapshot))))
+        error-leaf? (true? (:error? error-node))
         ;; Per rf2-g13nm2 C2: a PARALLEL machine's `:output-key` may live on
         ;; ANY region's terminal leaf, not just the first. Scan all regions
-        ;; (error on conflict); a flat machine reads its single leaf.
-        output-key  (if parallel?
-                      (parallel-output-key machine (:state next-snapshot) frame-id machine-id)
-                      (:output-key final-node))
+        ;; (error on conflict); a flat machine reads its single leaf. When the
+        ;; finish is an ERROR, the error payload's `:output-key` is sourced
+        ;; from the ERROR region's leaf so the right error `:data` slot routes
+        ;; to `:on-error` (rf2-encnvn).
+        output-key  (cond
+                      (and parallel? error-leaf?) (:output-key error-node)
+                      parallel?                   (parallel-output-key machine (:state next-snapshot) frame-id machine-id)
+                      :else                       (:output-key error-node))
         result      (when output-key (get child-data output-key))
         ;; Per Spec 005 §Final states §`:on-error` (rf2-5hlsh; XState v5 invoke
         ;; `onError`): a `:final?` leaf MAY also declare `:error? true` — a
@@ -266,8 +299,8 @@
         ;; via an error leaf AND its spawning parent declares `:spawn :on-error`,
         ;; the runtime routes the failure to a PARENT TRANSITION (control flow,
         ;; not just observability) instead of the `:data`-only `:on-done`
-        ;; callback. A plain `:final?` leaf keeps firing `:on-done`.
-        error-leaf? (true? (:error? final-node))
+        ;; callback. A plain `:final?` leaf keeps firing `:on-done`. `error-leaf?`
+        ;; is computed above (cross-region scan for parallel — rf2-encnvn).
         parent-id   (:rf/parent-id child-data)
         invoke-id   (:rf/invoke-id child-data)
         ;; Per EP-0011 §Machine Completion / Managed-Effects §The uniform

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -411,6 +411,72 @@
         (is (seq (traces-for traces :rf.error/machine-parallel-output-key-conflict))
             "a :rf.error/machine-parallel-output-key-conflict trace was emitted")))))
 
+;; ---- (rf2-encnvn) :error? final on a NON-FIRST region routes as ERROR ------
+;; A spawned PARALLEL child whose FIRST region (state-map order) reaches a
+;; plain final but a NON-FIRST region reaches `{:final? true :error? true}`
+;; must route to the spawning parent's `:spawn :on-error` (control flow) — NOT
+;; `:on-done` — and the `:rf.machine/done` trace must carry `:error? true`.
+;; The pre-fix finalize read `:error?` from `(first state)` only (the same
+;; first-region blind spot the C2 `:output-key` scan above already fixed), so
+;; a non-first-region error final was MIS-REPORTED as a successful finish.
+
+(deftest parallel-error-final-on-non-first-region-routes-as-error
+  (testing "rf2-encnvn: a spawned parallel child whose NON-FIRST region reaches an :error? final routes to :on-error, not :on-done"
+    (let [traces       (record-traces! ::par-err-non-first)
+          on-done-ran? (atom false)]
+      (rf/reg-machine :rf2-encnvn/par-err-child
+        {:type    :parallel
+         ;; :alpha is the FIRST region and reaches a PLAIN final (no :error?).
+         ;; :beta (a later region) is the one reaching the ERROR terminal.
+         ;; Pre-fix, finalize classified the finish off :alpha only → success.
+         :regions {:alpha {:initial :run
+                           :states  {:run  {:on {:fin :done}}
+                                     :done {:final? true}}}
+                   :beta  {:initial :run
+                           :states  {:run  {:on {:fin {:target :failed
+                                                       :action (fn [{data :data}]
+                                                                 {:data (assoc data :err :beta/boom)})}}}
+                                     :failed {:final?     true
+                                              :error?     true
+                                              :output-key :err}}}}})
+      (rf/reg-machine :rf2-encnvn/par-err-parent
+        {:initial :working
+         :data    {}
+         :states
+         {:working
+          {:spawn {:machine-id :rf2-encnvn/par-err-child
+                    ;; If finalize mis-classifies the finish as success, :on-done
+                    ;; fires (flipping the flag) and :on-error never runs.
+                    :on-done  (fn [{d :data}] (reset! on-done-ran? true) d)
+                    :on-error {:target :errored                  ;; ← sibling of :working
+                               :action (fn [{data :data ev :event}]
+                                         ;; ev = [:rf.machine.spawn/error <invoke-id> <error>]
+                                         {:data (assoc data :captured (nth ev 2))})}}}
+          :errored {}}})
+      (rf/dispatch-sync [:rf2-encnvn/par-err-parent [:rf.machine.spawn/spawned]])
+      (let [spawned-id (get-in (rf/runtime-db-value :rf/default)
+                               [:rf.runtime/machines :spawned :rf2-encnvn/par-err-parent [:working]])]
+        (is (some? spawned-id) "parallel child was spawned")
+        ;; :fin is broadcast to both regions; :alpha reaches its plain final and
+        ;; :beta reaches its :error? final → all-regions-final → the child
+        ;; finishes via an ERROR terminal in a NON-FIRST region.
+        (rf/dispatch-sync [spawned-id [:fin]])
+        (is (= :errored (:state (snapshot :rf2-encnvn/par-err-parent)))
+            "the parent moved to :errored — its :spawn :on-error fired (NOT :on-done)")
+        (is (= :beta/boom (get-in (snapshot :rf2-encnvn/par-err-parent) [:data :captured]))
+            "the error payload (the error region's :output-key slot) rode into the :on-error transition's :event")
+        (is (false? @on-done-ran?)
+            ":on-done was NOT called — error finish skips the success callback")
+        (is (nil? (snapshot spawned-id))
+            "the parallel child auto-destroyed on all-regions-final")
+        (let [dones (traces-for traces :rf.machine/done)]
+          (is (= 1 (count dones)) "exactly one :rf.machine/done trace fired")
+          (let [t (first dones)]
+            (is (true? (-> t :tags :error?))
+                "the :rf.machine/done trace classifies the completion as :error? true")
+            (is (= :error (-> t :tags :rf.reply/status))
+                "the reply-envelope status is :error, not :ok")))))))
+
 ;; ---- registration-time validation -----------------------------------------
 
 (deftest final-state-validations


### PR DESCRIPTION
## Summary

`finalize-machine` classified a finishing **parallel** machine's terminal by reading `:error?` from the **first region's** final leaf only (the old `final-node`, resolved from `(first (:state next-snapshot))`). A parallel child whose first region reached a plain `:final?` leaf but a **non-first** region reached `{:final? true :error? true}` was all-regions-final and torn down, yet classified as a **SUCCESS** finish:

- the spawning parent's `:spawn :on-error` was skipped,
- `:on-done` ran instead,
- `:rf.machine/done` carried `:error? false` / `:rf.reply/status :ok`.

This was the **same first-region blind spot** the C2 `:output-key` scan (`parallel-output-key`, rf2-g13nm2) already fixed for output — the error classification simply hadn't been brought along.

## Fix

Add `parallel-error-leaf-node`, which scans **every** region's final leaf (mirroring `parallel-output-key`) and returns the first region final declaring `:error? true`. A parallel finish now routes as **ERROR if ANY region's reached final is an error terminal**. When the finish is an error, the payload's `:output-key` is sourced from the error region's leaf so the right `:data` slot rides into the parent's `:on-error` transition. Flat-machine behaviour is unchanged.

## Spec alignment

Aligns the implementation to **Spec 005 §3060–§3061** (any `:final?` leaf may declare `:error? true`; a parallel machine finishes when *every* region is final — the spec never restricts the error terminal to the first region) and to **XState v5** parallel error-final semantics. No spec or error-catalogue change: the spec already described the correct behaviour; the bug was implementation-only.

## Test

Regression test `parallel-error-final-on-non-first-region-routes-as-error`: a spawned parallel child whose first region reaches a plain final and second (non-first) region reaches an `:error? true` final. Asserts the parent transitions through `:spawn :on-error` (not `:on-done`), receives the raw error payload, `:on-done` is not called, the child auto-destroys, and `:rf.machine/done` marks `:error? true` / `:rf.reply/status :error`. **Confirmed it fails on all five assertions without the fix.**

## Gates (all green)

- machines JVM: `clojure -M:test` — 798 tests / 2610 assertions, 0F/0E
- machines + scxml conformance — 69 / 118, 0F/0E
- reply-conformance — 28 / 397, 0F/0E
- `scripts/test-jvm-implementation.sh` — all artefacts, 0F/0E
- `npm run test:cljs` — 7952 / 36531, 0F/0E
- per-ns isolation gate — 18 ns pass standalone
- clj-kondo + splint — no new findings (pre-existing warnings only)

rf2-encnvn