### PR TITLE
test(event-conformance): remove stale realm-routing residue + add/locate the frame-query lock (rf2-h2g6x0)

### DIFF
--- a/implementation/event-conformance/deps.edn
+++ b/implementation/event-conformance/deps.edn
@@ -31,8 +31,16 @@
 ;;   - ONE unified `:rf/event-handler` wrapper (`:rf/default? true`); the
 ;;     `:event/kind` sub-tag is GONE; `reg-event-ctx` is NOT a public
 ;;     (doc'd) facade var.
-;;   - realm-routing is PRESERVED for `reg-event` — the public registrar
-;;     resolves through the owning frame's realm registrar (a15n62).
+;;
+;; This tier carries NO realm-routing / frame-query section. The EP-0013
+;; multi-realm substrate was retired in the EP-0023/EP-0024 realm collapse
+;; (rf2-afdlyr / rf2-tu2vr7) — there is no public realm query coordinate;
+;; the public read grammar is FRAME-TARGETED over a live frame's sealed
+;; image generation. The frame/query read contract (`rf/handler-meta` /
+;; `rf/registrations` / `rf/handler-ids` `{:frame …}`) is locked in core's
+;; `re-frame.facade-frame-read-cljs-test`, and the live-dispatch isolation
+;; leg in the sibling `re-frame.event-frame-isolation-conformance-cljs-test`
+;; — not restated here.
 ;;
 ;; Where the in-core `re-frame.reg-event-cljs-test` carries the narrow
 ;; per-feature unit checks, this tier is the ADVERSARIAL umbrella LOCK:
@@ -41,7 +49,7 @@
 ;; re-appearing `:event/kind` sub-tag, or a `reg-event-ctx` promotion back
 ;; onto the public facade would turn it RED. It lives in its own
 ;; cross-artefact surface because the contract spans the events runtime,
-;; the public facade, the error-emit channel, and the realm registrar.
+;; the public facade, and the error-emit channel.
 ;;
 ;; ## Why this deps.edn exists
 ;;
@@ -61,7 +69,7 @@
 ;; This artefact ships nothing, so the top-level `:deps` is empty. The
 ;; cross-artefact source the test namespaces `:require`
 ;; (`re-frame.core` — the public facade; plus the internal
-;; `re-frame.events` / `re-frame.error-emit` / `re-frame.realm` /
+;; `re-frame.events` / `re-frame.error-emit` /
 ;; `re-frame.registrar` / `re-frame.frame` / `re-frame.test-support` /
 ;; `re-frame.substrate.plain-atom` from core) is pulled in under the
 ;; `:test` alias only. `:extra-paths` is JUST `["test"]` so the cognitect
@@ -84,9 +92,9 @@
    ;; core carries the WHOLE one-form event contract: the public facade
    ;; (`re-frame.core`), the events runtime + retired stubs
    ;; (`re-frame.events`), the always-on error channel
-   ;; (`re-frame.error-emit`), the realm registrar
-   ;; (`re-frame.realm` / `re-frame.registrar` / `re-frame.frame`), the
-   ;; default substrate, and the shared test harness.
+   ;; (`re-frame.error-emit`), the registrar + frame registry
+   ;; (`re-frame.registrar` / `re-frame.frame`), the default substrate,
+   ;; and the shared test harness.
    :extra-deps  {day8/re-frame2 {:local/root "../core"}
                  ;; rf2-try1x — silent-on-success reporter.
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}

--- a/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
@@ -9,19 +9,21 @@
 
   > image -> frame -> event stream
 
-  ## Why this tier, and why it is DISTINCT from the realm-routing case already
-  ## here
+  ## Why this tier, and why it is DISTINCT from the frame/query READ lock
 
-  `re-frame.event-model-conformance-cljs-test` §8 (the sibling ns) locks the
-  EP-0013 realm-routing contract for the ONE `reg-event` form — but it asserts
-  resolution ONLY through `handler-meta` / `registrar/lookup` QUERIES, never a
-  live dispatch. That leaves a gap the review wave (rf2-ks67un) named: a
-  regression where LIVE event dispatch falls back to the DEFAULT/GLOBAL
-  registrar — while `handler-meta` and the realm registrar QUERIES still resolve
-  the per-frame handler correctly — would pass that surface GREEN. The
-  generation-routing seam (`router/process-event!` wrapping the cascade in
-  `live-frame/call-with-frame-resolution`, rf2-uejnt3) is exactly what such a
-  query-only suite cannot see.
+  Core's `re-frame.facade-frame-read-cljs-test` (EP-0023, rf2-wkw8na) locks the
+  frame-targeted READ contract for the ONE `reg-event` form — `rf/handler-meta`
+  / `rf/registrations` / `rf/handler-ids` `{:frame …}` resolving each frame's
+  OWN sealed image generation — but it asserts resolution ONLY through those
+  QUERIES, never a live dispatch. (Post-EP-0023/EP-0024 there is no realm
+  routing: the multi-realm substrate collapsed, rf2-afdlyr / rf2-tu2vr7, and the
+  read grammar is frame-targeted over a live frame's image generation.) That
+  leaves a gap the review wave (rf2-ks67un) named: a regression where LIVE event
+  dispatch falls back to the DEFAULT/GLOBAL registrar — while the frame-targeted
+  QUERIES still resolve the per-frame handler correctly — would pass that surface
+  GREEN. The generation-routing seam (`router/process-event!` wrapping the
+  cascade in `live-frame/call-with-frame-resolution`, rf2-uejnt3) is exactly what
+  such a query-only suite cannot see.
 
   This suite closes that gap at the conformance tier: it drives a REAL
   `rf/dispatch-sync` through two EP-0023 image-loaded frames whose resolved image
@@ -296,9 +298,8 @@
 
 ;; ===========================================================================
 ;; (4) ABSENCE-IS-DEFAULT — a dispatch into a frame with NO image-loaded object
-;;     (every EP-0013 realm-only / single-realm frame) resolves through the
-;;     DEFAULT/GLOBAL registrar, byte-identical for every existing caller, and no
-;;     generation is ever bound.
+;;     resolves through the DEFAULT/GLOBAL registrar, byte-identical for every
+;;     existing caller, and no generation is ever bound.
 ;; ===========================================================================
 
 (deftest absence-is-default-no-image-frame-uses-the-global-registrar

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -9,7 +9,32 @@
   the three retired names survive ONLY as facade-exported `^:no-doc`
   throwing stubs raising their exact hard errors; ONE `:rf/event-handler`
   wrapper (`:rf/default? true`); `:event/kind` gone; `reg-event-ctx` is
-  not a public facade var; realm-routing preserved (a15n62).
+  not a public facade var.
+
+  ## The frame/query contract is NOT locked here — it lives in core
+
+  This tier carries NO realm-routing / frame-query section. The EP-0013
+  multi-realm substrate was RETIRED under EP-0023/EP-0024 (the realm
+  collapse, rf2-afdlyr / rf2-tu2vr7): there is no public realm query
+  coordinate, and the public read grammar is FRAME-TARGETED over a live
+  frame's sealed image generation (spec/API.md §The public registrar
+  query API). The two halves of that post-collapse contract are locked
+  elsewhere, NOT duplicated as an adversarial umbrella here:
+
+    - the QUERY-shaped read contract (`rf/handler-meta` /
+      `rf/registrations` / `rf/handler-ids` `{:frame …}` resolving each
+      frame's own sealed image descriptors with provenance, `frame-
+      generation`, both fail-loud cases, and the byte-identical default
+      keyword path) is comprehensively locked in core's
+      `re-frame.facade-frame-read-cljs-test` (EP-0023, rf2-wkw8na);
+    - the LIVE-DISPATCH isolation leg (a real `rf/dispatch-sync` through
+      two image-loaded frames runs + commits ONLY that frame's handler /
+      app-db) is locked in the SIBLING ns
+      `re-frame.event-frame-isolation-conformance-cljs-test` (EP-0023,
+      rf2-slvzn3).
+
+  So a regression in the frame/query contract goes RED in those suites;
+  this tier deliberately does not restate it.
 
   ## Why a cross-artefact tier and not just the in-core unit suite
 
@@ -29,7 +54,8 @@
       `^:no-doc`, and `reg-event` FAILS if it ever GAINS one);
     - a removed-name error that THROWS but no longer fans out on the
       always-on error channel (the advanced/corpus integration listener —
-      NOT the normal off-box sink path; see the EP-0015 lock §9 below).
+      NOT the normal off-box sink path; see the EP-0015 lock in section
+      (8) below).
 
   The always-on `register-error-listener!` / `register-event-listener!`
   registries this tier asserts against are the LOW-LEVEL advanced /
@@ -38,17 +64,17 @@
   they are NOT the normal production off-box (Datadog / Sentry) story —
   the normal story is a frame `:observability` sink fed an already-
   PROJECTED record by the runtime (centralized `project-egress` runs
-  before any sink sees a record). Section (9) below locks the EP-0015
+  before any sink sees a record). Section (8) below locks the EP-0015
   event-registration intersection: registration-owned `:sensitive` /
   `:large` event-arg classification, and a frame-owned off-box sink that
   receives a projected handled-event (raw `:event` args omitted) / error
   record (a classified secret in the event payload redacted).
 
   The contract spans the events runtime, the public facade, the
-  always-on error-emit channel, the frame-owned observability sink
-  routing, and the realm registrar — wider than any single artefact's
-  test tree — so it lives in its own cross-artefact `event-conformance/`
-  surface (the precedent is `reply-conformance/` + `derivation-conformance/`).
+  always-on error-emit channel, and the frame-owned observability sink
+  routing — wider than any single artefact's test tree — so it lives in
+  its own cross-artefact `event-conformance/` surface (the precedent is
+  `reply-conformance/` + `derivation-conformance/`).
 
   `.cljc`, dual-runtime: the shadow-cljs `:node-test` build
   (`npm run test:cljs`, ns matches `cljs-test$`) AND the JVM
@@ -57,7 +83,7 @@
   `test-support/make-reset-runtime-fixture` wraps every body in
   `(with-frame :rf/default …)` so ambient `dispatch-sync` resolves; an
   outer fixture clears the always-on error-listener registry (a `defonce`
-  that survives re-runs) + drops constructed realms.
+  that survives re-runs) + the frame-owned observability sink registry.
 
   Canonical contract: EP-0018 §1/§2/§3/§4/§5/§6/§7 + spec/002-Frames.md
   §Event handlers + spec/001-Registration.md §The retired
@@ -72,7 +98,6 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.observability :as observability]
             [re-frame.privacy :as privacy]
-            [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -81,14 +106,9 @@
 ;; Harness. The runtime-reset fixture snapshot/restores the registrar and
 ;; wraps each body in `(with-frame :rf/default …)`. The second fixture clears
 ;; the always-on error-listener registry (a `defonce` atom that survives test
-;; re-runs — rf2-bacs4) before AND after each test so a listener never leaks
-;; between cases, and drops any constructed realm so the realm-routing case
-;; leaves no residue.
+;; re-runs — rf2-bacs4) AND the frame-owned observability sink registry before
+;; AND after each test so neither a listener nor a sink leaks between cases.
 ;; ---------------------------------------------------------------------------
-
-(defn- drop-non-default-realms! []
-  (swap! realm/realms select-keys [realm/default-realm-id])
-  (swap! realm/realms update realm/default-realm-id dissoc :app :capabilities))
 
 (defn- clear-observation-state! []
   ;; Clear the always-on listener registries (advanced/corpus APIs) AND the
@@ -102,10 +122,8 @@
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
   (fn [test-fn]
     (clear-observation-state!)
-    (drop-non-default-realms!)
     (test-fn)
-    (clear-observation-state!)
-    (drop-non-default-realms!)))
+    (clear-observation-state!)))
 
 ;; ---------------------------------------------------------------------------
 ;; Shared helpers.
@@ -1357,9 +1375,14 @@
           "the interceptor's directly-installed effect ran (no reg-event-ctx needed)"))))
 
 ;; ===========================================================================
-;; (9) EP-0015 event-registration intersection — the frame-owned OFF-BOX
+;; (8) EP-0015 event-registration intersection — the frame-owned OFF-BOX
 ;;     observability path is the normal production story (NOT the always-on
 ;;     low-level listener), and event-arg classification is REGISTRATION-owned.
+;;     (NB §8 follows §7 directly: the realm-routing section the EP-0013
+;;     multi-realm substrate once justified was removed in the EP-0023/EP-0024
+;;     realm collapse — the frame/query read contract is now locked in core's
+;;     `re-frame.facade-frame-read-cljs-test` and the sibling live-dispatch
+;;     `re-frame.event-frame-isolation-conformance-cljs-test`, not restated here.)
 ;;
 ;;     This tier's other sections assert the always-on `register-error-
 ;;     listener!` / `register-event-listener!` fan-out (the advanced/corpus

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -193,14 +193,17 @@
                 ;; (production-survivable — fan out on the always-on error
                 ;; channel THEN throw); ONE :rf/event-handler wrapper
                 ;; (:rf/default? true), :event/kind gone, reg-event-ctx NOT a
-                ;; public facade var; realm-routing preserved (a15n62). Every
-                ;; assertion is ADVERSARIAL — a re-introduced old form, a second
-                ;; wrapper id, a returning :event/kind, or a reg-event-ctx
-                ;; facade promotion goes RED. The contract spans the events
-                ;; runtime + the public facade + the error-emit channel + the
-                ;; realm registrar — wider than any single artefact's test tree
-                ;; — so (like reply-conformance/ + derivation-conformance/) it
-                ;; lives in its own top-level event-conformance/ surface.
+                ;; public facade var. Every assertion is ADVERSARIAL — a
+                ;; re-introduced old form, a second wrapper id, a returning
+                ;; :event/kind, or a reg-event-ctx facade promotion goes RED.
+                ;; The contract spans the events runtime + the public facade +
+                ;; the error-emit channel — wider than any single artefact's
+                ;; test tree — so (like reply-conformance/ +
+                ;; derivation-conformance/) it lives in its own top-level
+                ;; event-conformance/ surface. (No realm-routing/frame-query
+                ;; section: the realm substrate collapsed in EP-0023/EP-0024;
+                ;; that contract is locked in core's facade-frame-read + the
+                ;; sibling event-frame-isolation conformance ns.)
                 ;; Namespaces end in `-cljs-test`, so they run under the
                 ;; always-on :node-test gate (`cljs-test$` matches); the JVM
                 ;; counterpart is event-conformance/deps.edn `:test`.


### PR DESCRIPTION
## Summary

Correctness-review finding rf2-h2g6x0: the event-model conformance suite advertised an umbrella **realm-routing / frame-query lock** that has no executable body. The EP-0023/EP-0024 realm collapse (rf2-afdlyr / rf2-tu2vr7) removed the §8 realm-routing section but left its prose, helpers, and coverage claims behind — the section numbering jumps from `(7)` straight to `(9)`, and the sibling ns + deps.edn + shadow-cljs.edn all still reference a "§8 realm-routing lock" / "realm registrar" that no longer exists.

**Verified against source:** the frame-query read contract is **not missing**. It is comprehensively locked in core's `re-frame.facade-frame-read-cljs-test` (EP-0023, rf2-wkw8na) — two image-loaded frames with the same `[kind id]`, `rf/handler-meta` / `rf/registrations` / `rf/handler-ids` `{:frame …}` each resolving the frame's own sealed image descriptors with provenance, `frame-generation`, both fail-loud cases (`:rf.error/frame-no-generation`, `:rf.error/registrar-query-needs-frame`), and the byte-identical default keyword path. The live-dispatch isolation leg is locked in the sibling `event-frame-isolation-conformance-cljs-test`. So this is the **cleanup + cross-reference** path (the bead's alternative fix), not a new duplicate umbrella.

## Changes

- **event_model_conformance_cljs_test.cljc**: removed the `[re-frame.realm]` require, the dead `drop-non-default-realms!` helper + its two fixture call sites; rewrote the ns docstring to state where the frame/query contract is locked (core + sibling) rather than claiming it lives here; renumbered suite section `(9)` → `(8)` (no §8 to add — note explains it follows §7 directly post-collapse); scrubbed the "realm registrar" / "drops constructed realms" prose.
- **event_frame_isolation_conformance_cljs_test.cljc**: fixed the docstring's stale "`...-model-conformance §8` realm-routing lock" reference to point at core's `facade-frame-read` query lock; reframed the "Why this tier is distinct" rationale around the live-dispatch-vs-query gap; dropped the "EP-0013 realm-only" phrasing in the §4 comment.
- **event-conformance/deps.edn** + **implementation/shadow-cljs.edn**: removed the "realm-routing preserved (a15n62)" / "realm registrar" coverage claims; added a note that the frame/query contract is locked in core + the sibling ns.

## Gates

- event-conformance JVM (`clojure -M:test`): 57 tests / 199 assertions, 0 failures
- `npm run test:cljs`: 7953 tests / 36555 assertions, 0 failures
- per-ns isolation gate: 18 ns pass (no test ns removed — no gate-list edit)
- clj-kondo on changed test files: model-conformance clean; the one remaining `sub-desc` unused-private-var warning in the isolation test pre-exists on origin/main (untouched)

Closes rf2-h2g6x0.