### PR TITLE
fix(pair-mcp): write-tool soft failures return failure-shaped MCP results + structured markers (rf2-or8s29)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -1513,7 +1513,10 @@ on state-mutating tools for the shape. Returns
 the id is not in the ring or a drain is in flight (the documented
 `:rf.epoch/*` failure modes per
 [`Tool-Pair.md` §Restore failure modes](../../../spec/Tool-Pair.md#time-travel)).
-The `app-db` is unchanged on failure.
+The `app-db` is unchanged on failure. A rejected restore is **not** a
+terminal-empty outcome — the write did not land — so it rides with
+`isError: true` per the §"Every `:ok? false` response is `isError: true`"
+rule (rf2-or8s29); the host must not read it as a landed write.
 
 ## replace-app-db
 
@@ -1548,8 +1551,13 @@ on success. Per rf2-6yqdl the cascade-summary projects the synthetic
 bypasses the dispatch loop entirely. See §Universal: cascade summary
 on state-mutating tools for the full shape. Returns `{:ok? false
 :reason :reset-rejected ...}` on no-such-frame / drain-in-flight /
-app-schema mismatch (the documented `:rf.epoch/*` failure modes). The
-`app-db` is unchanged on failure.
+app-schema mismatch (the documented `:rf.epoch/*` failure modes), and
+`{:ok? false :reason :unexpected-shape ...}` for a degraded runtime
+that returns a non-envelope value. The `app-db` is unchanged on
+failure. A rejected replace is **not** a terminal-empty outcome — the
+injection did not land — so it rides with `isError: true` per the
+§"Every `:ok? false` response is `isError: true`" rule (rf2-or8s29);
+the host must not read it as a landed write.
 
 ## Universal: cursor pagination on epoch slices
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
@@ -99,7 +99,8 @@
   (rf2-obpa9), `:rf.mcp/summary` (rf2-tygdv), `:rf.size/large-elided`
   (rf2-urjnc). Agents that learned the family see one more slot."
   (:require [applied-science.js-interop :as j]
-            [re-frame2-pair-mcp.tools.registry :as registry]))
+            [re-frame2-pair-mcp.tools.registry :as registry]
+            [re-frame2-pair-mcp.tools.wire :as wire]))
 
 ;; ---------------------------------------------------------------------------
 ;; LRU state — module-level atom; one MCP server process = one session.
@@ -273,10 +274,11 @@
   short-circuit)."
   ([entry tool] (cache-hit-result entry tool :result-hash))
   ([entry tool via]
-   (let [payload (cache-hit-payload (assoc entry :tool tool) via)]
-     #js {:content          #js [#js {:type "text"
-                                      :text (pr-str payload)}]
-          :structuredContent (clj->js payload)})))
+   ;; rf2-or8s29 — route through `wire/result` so the cache-hit marker's
+   ;; structuredContent keeps its namespace: a raw `clj->js` truncated
+   ;; the `:rf.mcp/cache-hit` marker key to `"cache-hit"`, so SDK-friendly
+   ;; hosts reading structuredContent missed the marker entirely.
+   (wire/result (cache-hit-payload (assoc entry :tool tool) via) false)))
 
 ;; ---------------------------------------------------------------------------
 ;; The wire-boundary entry-point.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -59,6 +59,7 @@
             [re-frame2-pair-mcp.tools.eval-cljs :as eval-cljs]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.writes :as writes]
+            [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.resource-controls :as resource]
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
@@ -451,13 +452,15 @@
                (-> (tools/invoke conn name args extra)
                    (.catch (fn [err]
                              (log! "handler threw for" name "—" (.-message err))
-                             (let [payload {:ok?     false
-                                            :reason  :handler-threw
-                                            :message (.-message err)}]
-                               #js {:isError          true
-                                    :content          #js [#js {:type "text"
-                                                                :text (pr-str payload)}]
-                                    :structuredContent (clj->js payload)}))))))
+                             ;; rf2-or8s29 — route the server-level error
+                             ;; envelope through `wire/result` so the
+                             ;; structuredContent projection preserves
+                             ;; keyword namespaces (a raw `clj->js` here
+                             ;; truncated `:rf.error/*` reason values).
+                             (wire/result {:ok?     false
+                                           :reason  :handler-threw
+                                           :message (.-message err)}
+                                          true))))))
       (.catch
         (fn [err]
           ;; Discovery failed — surface a structured tool-call error.
@@ -468,10 +471,10 @@
                 payload (if-let [cs (:candidates data)]
                           (assoc payload :candidates cs)
                           payload)]
-            #js {:isError          true
-                 :content          #js [#js {:type "text"
-                                             :text (pr-str payload)}]
-                 :structuredContent (clj->js payload)})))))
+            ;; rf2-or8s29 — same namespace-preserving projection as the
+            ;; handler-threw path; a raw `clj->js` dropped the namespace
+            ;; on `:rf.error/*` reason values.
+            (wire/result payload true))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Server boot.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
@@ -142,9 +142,11 @@
                (and (some? sc) (not (undefined? sc)))
                (conj! (js/JSON.stringify sc))))))))
     (build-overflow-result [_ marker _original]
-      #js {:content          #js [#js {:type "text"
-                                       :text (pr-str marker)}]
-           :structuredContent (clj->js marker)})))
+      ;; rf2-or8s29 — route through `wire/result` so the overflow marker's
+      ;; structuredContent keeps its namespace: a raw `clj->js` truncated
+      ;; the `:rf.mcp/overflow` marker key to `"overflow"`, so SDK-friendly
+      ;; hosts reading structuredContent missed the marker.
+      (wire/result marker false))))
 
 (defn sum-text-tokens
   "Sum `token-estimate` across every wire-bearing slot in the MCP

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
@@ -107,7 +107,18 @@
               ;; :reset-rejected ...}). Pass it through; default to a
               ;; generic shape if the runtime returned a non-map (degraded
               ;; / pre-rf2-c2dtu runtime).
-              (wire/ok-text
-                (if (map? v)
-                  v
-                  {:ok? false :reason :unexpected-shape :value v :frame frame})))))))))
+              (let [result (if (map? v)
+                             v
+                             {:ok? false :reason :unexpected-shape :value v :frame frame})]
+                ;; rf2-or8s29 — a soft failure (the runtime's
+                ;; `{:ok? false :reason :reset-rejected ...}` OR the
+                ;; non-map `:unexpected-shape` fallback) means the
+                ;; injection did NOT land; it is not a terminal-empty
+                ;; outcome. It MUST ride as an `isError: true` result so
+                ;; the MCP host sees the write failed + the reason
+                ;; (003-Tool-Catalogue §"Every :ok? false response is
+                ;; isError: true"). Only a genuine success returns
+                ;; `ok-text`.
+                (if (false? (:ok? result))
+                  (wire/err-text result)
+                  (wire/ok-text result))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -89,27 +89,38 @@
                 ;; :frame :cascade-summary :unreplayable-effects`. Failure
                 ;; remains the legacy `false` so older runtimes still
                 ;; surface as a clean reject envelope here.
-                (wire/ok-text
-                  (cond
-                    (map? v)
-                    v
+                (let [result
+                      (cond
+                        (map? v)
+                        v
 
-                    v
-                    {:ok?       true
-                     :restored? true
-                     :epoch-id  epoch-id
-                     :frame     frame}
+                        v
+                        {:ok?       true
+                         :restored? true
+                         :epoch-id  epoch-id
+                         :frame     frame}
 
-                    :else
-                    {:ok?       false
-                     :restored? false
-                     :reason    :restore-rejected
-                     :epoch-id  epoch-id
-                     :frame     frame
-                     :hint      (str "restore-epoch returned false — the epoch-id is not in the "
-                                     "ring, or a drain is in flight. Read the structured reason "
-                                     "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
-                                     "filtered to :rf.epoch/*.")})))]
+                        :else
+                        {:ok?       false
+                         :restored? false
+                         :reason    :restore-rejected
+                         :epoch-id  epoch-id
+                         :frame     frame
+                         :hint      (str "restore-epoch returned false — the epoch-id is not in the "
+                                         "ring, or a drain is in flight. Read the structured reason "
+                                         "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
+                                         "filtered to :rf.epoch/*.")})]
+                  ;; rf2-or8s29 — a soft failure (the legacy `false` reject
+                  ;; OR a structured `{:ok? false ...}` envelope from a newer
+                  ;; runtime) is NOT a terminal-empty outcome: the write did
+                  ;; not land. It MUST ride as an `isError: true` result so
+                  ;; the MCP host sees the failure + reason rather than a
+                  ;; success-shaped envelope (003-Tool-Catalogue §"Every
+                  ;; :ok? false response is isError: true"). Only a genuine
+                  ;; success returns `ok-text`.
+                  (if (false? (:ok? result))
+                    (wire/err-text result)
+                    (wire/ok-text result))))]
           ;; rf2-6nks4 (finding-2): the signalled prelude signals the
           ;; raw-state posture to the runtime BEFORE the restore eval, so
           ;; the cascade-summary it builds redacts a sensitive

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -171,6 +171,43 @@
       ;; payload keeps its namespace inside the envelope too.
       (if (object? sc) sc (clj->js {"rf.mcp/value" (qualify-keywords v)})))))
 
+(defn structured-content
+  "Public projection of `v` to the SDK-friendly `:structuredContent` JS
+  value — the SAME namespace-preserving, null-safe projection `ok-text`
+  / `err-text` use (rf2-t2n04, rf2-r5erl).
+
+  Exposed (rf2-or8s29) for the handful of result envelopes built OUTSIDE
+  the per-tool callbacks — server-level handler-threw / discovery
+  errors (server.cljs), the cache-hit marker (cache.cljs), and the
+  overflow marker (cap.cljs). Those sites previously built
+  `:structuredContent (clj->js payload)` directly, which is
+  namespace-LOSSY: `:rf.mcp/cache-hit` → `\"cache-hit\"`,
+  `:rf.mcp/overflow` → `\"overflow\"`, and `:rf.error/*` reason VALUES
+  lose their namespace. Routing them through this single helper keeps
+  the structured-content round-trip contract intact everywhere."
+  [v]
+  (structured-of v))
+
+(defn result
+  "Build an arbitrary MCP result envelope (rf2-or8s29) carrying both the
+  pr-str EDN `:content` text and the namespace-preserving
+  `:structuredContent` projection of the SAME `v`. Sets `:isError true`
+  when `error?` is truthy.
+
+  This is the single canonical envelope constructor; `ok-text` /
+  `err-text` are the `(result v false)` / `(result v true)` shorthands.
+  Result-envelope builders OUTSIDE the per-tool callbacks (server-level
+  errors, cache-hit + overflow markers) route through here so they get
+  the same namespace-faithful structured projection rather than a raw,
+  namespace-lossy `clj->js`."
+  [v error?]
+  (if error?
+    #js {:isError          true
+         :content          #js [#js {:type "text" :text (pr-str v)}]
+         :structuredContent (structured-of v)}
+    #js {:content          #js [#js {:type "text" :text (pr-str v)}]
+         :structuredContent (structured-of v)}))
+
 (defn ok-text
   "Success result envelope. Always emits both `:content` (the
   pr-str EDN text) and `:structuredContent` (the JS-coerced
@@ -183,8 +220,7 @@
   SDK's outputSchema validation never rejects the result for a `null`
   structuredContent."
   [v]
-  #js {:content          #js [#js {:type "text" :text (pr-str v)}]
-       :structuredContent (structured-of v)})
+  (result v false))
 
 (defn err-text
   "Error result envelope. Same dual-slot shape as `ok-text` plus
@@ -192,9 +228,7 @@
   LLM without aborting the conversation (per MCP §Error Handling).
   `:structuredContent` is non-null by construction (rf2-r5erl)."
   [v]
-  #js {:isError          true
-       :content          #js [#js {:type "text" :text (pr-str v)}]
-       :structuredContent (structured-of v)})
+  (result v true))
 
 (defn with-indicators
   "Splice the cross-MCP indicator-field slots (`:dropped-sensitive`,

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -939,6 +939,24 @@
     {:isError? true
      :reason :missing-epoch-id}}
 
+   ;; rf2-or8s29 — a restore that the runtime REJECTS (legacy bare
+   ;; `false`: aged-out id, drain-in-flight) means the write did not land.
+   ;; It MUST ride as isError carrying :restore-rejected, NOT a
+   ;; success-shaped envelope the host reads as a landed write.
+   {:fixture/id    :restore-epoch/rejected-false
+    :fixture/doc   "restore-epoch with --allow-writes ON whose runtime returns false (rejected restore) rides as isError :restore-rejected (rf2-or8s29)."
+    :fixture/tool  "restore-epoch"
+    :fixture/allow-writes? true
+    :fixture/args  {:epoch-id "999"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["restore-epoch"             false]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :restored? false :reason :restore-rejected :epoch-id 999}}}
+
    ;; ---------- replace-app-db (rf2-ee38b.18 — gated write) ---------------
    {:fixture/id    :replace-app-db/disabled-default
     :fixture/doc   "replace-app-db with --allow-writes OFF returns :rf.error/writes-disabled without touching the runtime."
@@ -982,6 +1000,26 @@
     :fixture/expect
     {:isError? true
      :reason :missing-db}}
+
+   ;; rf2-or8s29 — a replace the runtime REJECTS
+   ;; ({:ok? false :reason :reset-rejected ...}: no-such-frame,
+   ;; replace-during-drain, schema-mismatch) means the injection did NOT
+   ;; land. It MUST ride as isError carrying the reason, NOT a
+   ;; success-shaped envelope.
+   {:fixture/id    :replace-app-db/reset-rejected
+    :fixture/doc   "replace-app-db with --allow-writes ON whose runtime returns {:ok? false :reason :reset-rejected} rides as isError (rf2-or8s29)."
+    :fixture/tool  "replace-app-db"
+    :fixture/allow-writes? true
+    :fixture/allow-raw-state? false
+    :fixture/args  {:db "{:bad :shape}"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["app-db-reset!"             {:ok? false :reason :reset-rejected :frame :rf/default}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :reset-rejected :frame :rf/default}}}
 
    ;; ---------- trace-window -----------------------------------------------
    {:fixture/id    :trace-window/happy

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/replace_app_db_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/replace_app_db_test.cljs
@@ -205,7 +205,12 @@
 ;; Runtime soft-failure passthrough.
 ;; ---------------------------------------------------------------------------
 
-(deftest passes-through-reset-rejected-envelope
+(deftest reset-rejected-envelope-rides-as-isError
+  ;; rf2-or8s29 — a `{:ok? false :reason :reset-rejected ...}` from the
+  ;; runtime means the injection did NOT land (no-such-frame,
+  ;; replace-during-drain, schema-mismatch). It is not a terminal-empty
+  ;; outcome, so it MUST ride as an isError result carrying the reason,
+  ;; not a success-shaped envelope the host reads as a landed write.
   (async done
     (let [captured (atom nil)]
       (-> (with-writes-on!
@@ -217,10 +222,31 @@
                   (replace-app-db/replace-app-db-tool (fresh-conn)
                                                       #js {:db "{:bad :shape}"})))))
           (.then (fn [r]
-                   (is (not (err? r)) "soft-failure rides as ok-text, not isError")
+                   (is (err? r) "soft-failure rides as an isError result (rf2-or8s29)")
                    (let [edn (read-result-text r)]
                      (is (= false (:ok? edn)))
                      (is (= :reset-rejected (:reason edn))))
+                   (done)))))))
+
+(deftest unexpected-shape-fallback-rides-as-isError
+  ;; rf2-or8s29 — a degraded / pre-rf2-c2dtu runtime can return a
+  ;; non-map value; the tool synthesises `{:ok? false :reason
+  ;; :unexpected-shape ...}`. That too means the write did not land in a
+  ;; known-good shape, so it MUST ride as an isError result.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-eval! captured "not-a-map"
+                (fn []
+                  (replace-app-db/replace-app-db-tool (fresh-conn)
+                                                      #js {:db "{:counter 0}"})))))
+          (.then (fn [r]
+                   (is (err? r) "unexpected-shape fallback rides as isError (rf2-or8s29)")
+                   (let [edn (read-result-text r)]
+                     (is (= false (:ok? edn)))
+                     (is (= :unexpected-shape (:reason edn)))
+                     (is (= "not-a-map" (:value edn))))
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/restore_epoch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/restore_epoch_test.cljs
@@ -167,8 +167,10 @@
 
 (deftest surfaces-restore-rejected-when-runtime-returns-false
   ;; restore-epoch returns false on any failure (aged-out id,
-  ;; drain-in-flight, …); the app-db is unchanged. We surface a
-  ;; structured :restore-rejected.
+  ;; drain-in-flight, …); the app-db is unchanged. rf2-or8s29: this
+  ;; soft failure is NOT a terminal-empty outcome — the write did not
+  ;; land — so it MUST ride as an isError result carrying the reason,
+  ;; not a success-shaped envelope the host reads as a landed write.
   (async done
     (let [captured (atom nil)]
       (-> (with-writes-on!
@@ -177,12 +179,34 @@
                 (fn []
                   (restore-epoch/restore-epoch-tool (fresh-conn) #js {:epoch-id "999"})))))
           (.then (fn [r]
-                   (is (not (err? r)) "soft-failure rides as an ok-text envelope, not isError")
+                   (is (err? r) "soft-failure rides as an isError result (rf2-or8s29)")
                    (let [edn (read-result-text r)]
                      (is (= false (:ok? edn)))
                      (is (= false (:restored? edn)))
                      (is (= :restore-rejected (:reason edn)))
                      (is (= 999 (:epoch-id edn))))
+                   (done)))))))
+
+(deftest surfaces-isError-when-runtime-returns-structured-failure-map
+  ;; rf2-or8s29 — a newer runtime can return a structured
+  ;; `{:ok? false :reason :restore-rejected ...}` map (not the legacy
+  ;; bare `false`). The tool MUST still route a `{:ok? false ...}` map
+  ;; to isError — passing the map through to `ok-text` would report a
+  ;; rejected restore as success.
+  (async done
+    (let [failure-envelope {:ok? false :restored? false
+                            :reason :restore-rejected
+                            :epoch-id 7 :frame :rf/default}]
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-eval! (atom nil) failure-envelope
+                (fn []
+                  (restore-epoch/restore-epoch-tool (fresh-conn) #js {:epoch-id "7"})))))
+          (.then (fn [r]
+                   (is (err? r) "structured runtime failure rides as isError (rf2-or8s29)")
+                   (let [edn (read-result-text r)]
+                     (is (= false (:ok? edn)))
+                     (is (= :restore-rejected (:reason edn))))
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
@@ -90,6 +90,20 @@
       ;; corpus elsewhere).
       (is (object? (j/get result :structuredContent))))))
 
+(deftest cache-hit-marker-key-keeps-namespace-in-structured-slot
+  ;; rf2-or8s29 — the cache-hit marker is built OUTSIDE the per-tool
+  ;; callbacks; before the fix it used a raw namespace-lossy `clj->js`,
+  ;; so SDK-friendly hosts reading structuredContent saw `"cache-hit"`
+  ;; (the marker key truncated) and missed the marker. Now it routes
+  ;; through `wire/result`, preserving the fully-qualified token.
+  (testing "the :rf.mcp/cache-hit marker KEY survives namespace-faithfully (rf2-or8s29)"
+    (let [entry  {:hash 12345 :unchanged-since 1700000000000}
+          result (cache/cache-hit-result entry "snapshot" :result-hash)]
+      (is (some? (j/get-in result [:structuredContent "rf.mcp/cache-hit"]))
+          "the marker serialises to the fully-qualified \"rf.mcp/cache-hit\" key")
+      (is (nil? (j/get-in result [:structuredContent "cache-hit"]))
+          "the namespace-truncated \"cache-hit\" key must NOT appear (the lossy old shape)"))))
+
 ;; ---------------------------------------------------------------------------
 ;; structuredContent is NEVER null (rf2-r5erl).
 ;;

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
@@ -144,6 +144,22 @@
       (is (string? (:hint marker)))
       (is (re-find #"Narrow scope" (:hint marker))))))
 
+(deftest apply-cap-overflow-marker-key-keeps-namespace-in-structured-slot
+  ;; rf2-or8s29 — the overflow marker is built OUTSIDE the per-tool
+  ;; callbacks (cap/result-io build-overflow-result); before the fix it
+  ;; used a raw namespace-lossy `clj->js`, so SDK-friendly hosts reading
+  ;; structuredContent saw `"overflow"` (the marker key truncated) and
+  ;; missed the marker. Now it routes through `wire/result`.
+  (let [big (apply str (repeat 4000 "x"))
+        r   (ok-text-result {:huge big})
+        out (cap/apply-cap r {:tool "snapshot" :cap 500})
+        sc  (j/get out :structuredContent)]
+    (is (some? sc) "the overflow marker carries a structuredContent slot")
+    (is (some? (j/get sc "rf.mcp/overflow"))
+        "the marker serialises to the fully-qualified \"rf.mcp/overflow\" key")
+    (is (nil? (j/get sc "overflow"))
+        "the namespace-truncated \"overflow\" key must NOT appear (the lossy old shape)")))
+
 (deftest apply-cap-overflow-payload-is-itself-under-cap
   ;; The replacement marker must fit; otherwise we recurse on overflow.
   (let [big (apply str (repeat 8000 "x"))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
@@ -18,6 +18,7 @@
   that proves the refusal precedes `ensure-connection!` (discovery never
   runs; the session-state stays pristine)."
   (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
+            [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.server :as server]
             [re-frame2-pair-mcp.tools.writes :as writes]))
@@ -95,3 +96,42 @@
   (async done
     (writes/set-allow-writes! false)
     (assert-refused-locally "replace-app-db" done)))
+
+;; ---------------------------------------------------------------------------
+;; Server-level error envelope — namespace-preserving structuredContent
+;; (rf2-or8s29).
+;;
+;; The discovery-error / handler-threw envelopes are built in server.cljs
+;; OUTSIDE the per-tool callbacks. Before rf2-or8s29 they used a raw
+;; `(clj->js payload)` for structuredContent, which truncates the
+;; namespace on `:rf.error/*` reason VALUES (`:rf.error/foo` →
+;; `"foo"`). Routing them through `wire/result` preserves the
+;; fully-qualified token in the SDK-friendly structured slot. Here we
+;; drive a NON-write tool through the pristine, no-port harness so
+;; `ensure-connection!` rejects and `handle-call*` builds the
+;; discovery-error envelope; we assert both the EDN text slot AND the
+;; structured slot agree on the reason, namespace intact.
+;; ---------------------------------------------------------------------------
+
+(deftest discovery-error-structured-content-preserves-reason-namespace
+  (async done
+    (writes/set-allow-writes! false)
+    (-> (server/handle-call-for-tests {} "snapshot" #js {} nil)
+        (.then (fn [result]
+                 (is (err? result) "discovery failure rides as isError")
+                 (let [edn          (read-edn result)
+                       reason       (:reason edn)
+                       reason-token (str (symbol reason))
+                       sc           (j/get result :structuredContent)]
+                   ;; The canonical EDN reason is a keyword.
+                   (is (keyword? reason) "the EDN reason is a keyword")
+                   ;; The structured slot must carry the reason under its
+                   ;; colon-less FULLY-QUALIFIED token — proving the
+                   ;; envelope went through wire/result, not a raw clj->js
+                   ;; (a namespaced reason would otherwise be truncated).
+                   (is (= reason-token (j/get sc "reason"))
+                       "structuredContent :reason keeps its fully-qualified token")
+                   (is (= false (j/get sc "ok?"))
+                       ":ok? false round-trips through the structured slot"))
+                 (done)))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))


### PR DESCRIPTION
## Bead
rf2-or8s29 (P1 correctness-review). Verified both contract breaks against source before changing.

## Contract break 1 — write-tool soft failures shipped success-shaped
`restore-epoch` and `replace-app-db` wrapped **every** runtime outcome in `wire/ok-text`, so a REJECTED write (aged-out epoch, drain-in-flight, schema-mismatch, no-such-frame, degraded runtime) returned a success-shaped MCP result with `isError:false`. The MCP host could not tell the write failed — a `{:ok? false ...}` envelope read as a landed write. These are NOT terminal-empty outcomes; spec/003-Tool-Catalogue.md requires "Every `:ok? false` response is `isError: true`".

**Fix:** both callbacks build the result map first, then route `{:ok? false}` (the legacy bare `false` reject, a structured `{:ok? false}` runtime envelope, AND the `:unexpected-shape` non-map fallback) through `wire/err-text`; only genuine success returns `ok-text`. This is the write-tool counterpart to the rf2-q7cavs read-dom/read-ui fix and is what the existing `live-re-frame2-pair-iserror` conformance gate pins for the read family.

## Contract break 2 — non-wire envelopes bypassed the namespace-preserving projection
Server-level error envelopes (`handler-threw`, `discovery-error` in server.cljs), the cache-hit marker (cache.cljs), and the overflow marker (cap.cljs) built `:structuredContent` via a raw `clj->js`, which is namespace-LOSSY: `:rf.mcp/cache-hit` -> `"cache-hit"`, `:rf.mcp/overflow` -> `"overflow"`, and `:rf.error/*` reason VALUES lost their namespace (confirmed: the discovery error reason `:rf.error/pair-mcp-nrepl-port-not-found` truncated to `"pair-mcp-nrepl-port-not-found"`). SDK-friendly hosts reading `structuredContent` missed the markers / lost reason namespaces.

**Fix:** added a public `wire/result` envelope constructor (+ `wire/structured-content`) carrying the same namespace-preserving, null-safe projection `ok-text`/`err-text` use, and routed all three sites through it. `ok-text`/`err-text` are now `(result v false/true)` shorthands — single canonical envelope constructor.

## Tests (all confirmed RED before the fix, GREEN after)
- Unit: `restore-rejected` (bare `false` + structured map), `reset-rejected`, `unexpected-shape` each assert `isError`.
- Conformance fixtures: `:restore-epoch/rejected-false`, `:replace-app-db/reset-rejected`.
- Structured-marker: cache-hit + overflow marker keys keep the fully-qualified token; server-error reason keeps its namespace.

## Spec
003-Tool-Catalogue.md restore-epoch/replace-app-db Returns clauses now state the rejected write rides `isError: true` (not a terminal-empty outcome). The structuredContent projection contract was already documented (colon dropped, namespace kept); the fix makes the three non-wire builders consistent with it — no projection-contract change.

## Gates
- pair-mcp `npm test` (shadow-cljs :server-test): 1119 tests / 3722 assertions, 0 failures, 0 warnings.
- MCP conformance pair-mcp end-to-end: GREEN incl. universal `:ok? false` <-> `isError:true` cross-check (rf2-87h71e) + `:structuredContent` carry check (rf2-hj3pi); dedup-envelope + classification ratchet green.
- tool-descriptor manifest drift-check: in sync (no descriptor change).
- `scripts/test-jvm-tools.sh`: all 6 artefacts pass.
- clj-kondo: 0 errors on pair-mcp src+test (warnings are pre-existing, none in changed files).
- Skill<->MCP drift: no tool descriptor/surface change; skill docs describe EDN bodies (unchanged) and are agnostic to the isError flag — no drift.