### PR TITLE
fix(core/substrate): use-subscribe getSnapshot tracks the committed subscription not the disposed render-phase reaction (rf2-sqhjtu)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -283,6 +283,12 @@
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
 
+;; rf2-sqhjtu — getSnapshot must deref the durable COMMITTED reaction, not the
+;; disposed render-phase handle (the React useSyncExternalStore disposed-
+;; reaction hazard). Object-identity proof; reuses the refcount-probe surface.
+(deftest use-subscribe-getsnapshot-tracks-committed-reaction
+  (suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
+
 ;; rf2-40a84 — flush-render! synchronously commits a pending render (the
 ;; proof the pair-MCP headless dispatch→render loop depends on).
 (deftest flush-render-synchronously-commits

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -281,6 +281,12 @@
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
 
+;; rf2-sqhjtu — getSnapshot must deref the durable COMMITTED reaction, not the
+;; disposed render-phase handle (the React useSyncExternalStore disposed-
+;; reaction hazard). Object-identity proof; reuses the refcount-probe surface.
+(deftest use-subscribe-getsnapshot-tracks-committed-reaction
+  (suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
+
 ;; rf2-40a84 — flush-render! synchronously commits a pending render (the
 ;; proof the pair-MCP headless dispatch→render loop depends on).
 (deftest flush-render-synchronously-commits

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1599,6 +1599,27 @@
         use-subscribe-2
         (fn use-subscribe-2 [frame-kw query-v]
           (let [key-ref (React/useRef nil)
+                ;; Holds the DURABLE committed reaction (rf2-sqhjtu). The
+                ;; render-phase `reaction` handle below is a balanced,
+                ;; net-zero subscribe/unsubscribe round-trip whose value
+                ;; equals the committed one but whose IDENTITY can differ on
+                ;; first mount: with no prior cache entry the round-trip's
+                ;; 1 → 0 unsubscribe DISPOSES that handle (evicts it, removes
+                ;; its source watches), and `subscribe-fn` then rebuilds a
+                ;; fresh committed reaction post-commit. A disposed reaction
+                ;; still recomputes on `-deref` (pull-based), so reading it
+                ;; from `get-snap` LOOKS correct for ordinary app-db updates
+                ;; — but it no longer holds source watches and, crucially,
+                ;; still closes over the OLD sub body. On sub re-registration
+                ;; / hot-reload the cache rebuilds the committed reaction with
+                ;; the v2 body while a `get-snap` pinned to the disposed v1
+                ;; handle keeps rendering v1 output. React's
+                ;; `useSyncExternalStore` contract requires `getSnapshot` to
+                ;; read a stable, LIVE source — so `get-snap` reads the
+                ;; committed reaction stored here once `subscribe-fn` has run
+                ;; (post-commit), falling back to the render-phase handle only
+                ;; for the very first pre-commit snapshot.
+                committed-ref (React/useRef nil)
                 stable-key
                 (let [prev (.-current key-ref)
                       new-key #js [frame-kw query-v]]
@@ -1672,10 +1693,31 @@
                               r))
                           #js [stable-key])
                 ;; The store-snapshot fn React calls on every render to
-                ;; detect tearing. Pure deref of the reaction.
+                ;; detect tearing. Pure deref of the LIVE committed reaction.
+                ;;
+                ;; rf2-sqhjtu: prefer the durable committed reaction stored in
+                ;; `committed-ref` by `subscribe-fn` (set post-commit, cleared
+                ;; on teardown). The render-phase `reaction` handle is only the
+                ;; fallback for the FIRST pre-commit snapshot — before React has
+                ;; run `subscribe-fn`, `committed-ref` is still nil and the
+                ;; balanced render-phase handle is the only thing to read. Once
+                ;; committed, `get-snap` tracks the live cached reaction (the
+                ;; one carrying source watches and the current sub body), never
+                ;; a disposed first-render handle. The committed reaction's
+                ;; value `=` the render-phase one (rf2-cmfln), so the source
+                ;; swap is tear-free.
+                ;;
+                ;; Deps include `reaction` so the pre-commit fallback never
+                ;; closes over a stale (perf-discarded) render-phase handle;
+                ;; once `committed-ref` is populated post-commit, `get-snap`'s
+                ;; identity is irrelevant to correctness — React drives tear
+                ;; detection off the returned VALUE, and the committed source
+                ;; is read through the ref on every call.
                 get-snap
-                (use-callback (fn [] (when reaction @reaction))
-                              #js [reaction])
+                (use-callback (fn []
+                                (let [r (or (.-current committed-ref) reaction)]
+                                  (when r @r)))
+                              #js [stable-key reaction])
                 ;; The store-subscribe fn — React's COMMIT-OWNED acquire/release
                 ;; pair. React calls it (once) only AFTER a commit, passing a
                 ;; force-update callback; its returned cleanup runs on unmount,
@@ -1707,6 +1749,11 @@
                     ;; reaction is the live cached one and `=` (often identical)
                     ;; to the render-phase handle `reaction`.
                     (let [committed (subs/subscribe stable-frame-kw stable-query-v)]
+                      ;; rf2-sqhjtu: publish the durable committed reaction so
+                      ;; `get-snap` derefs THIS live handle (source watches +
+                      ;; current sub body) rather than the disposed render-phase
+                      ;; one. Set post-commit (here), cleared on teardown below.
+                      (set! (.-current committed-ref) committed)
                       ;; UNIQUE watch key per `subscribe-fn` INVOCATION,
                       ;; closed over by the returned cleanup. The key MUST
                       ;; NOT derive from `(hash reaction)`: subscriptions are
@@ -1728,6 +1775,15 @@
                           (add-watch committed k (fn [_ _ _ _] (on-change))))
                         (fn unsubscribe []
                           (when committed (remove-watch committed k))
+                          ;; rf2-sqhjtu: clear the published committed reaction,
+                          ;; but ONLY if it still points at THIS invocation's
+                          ;; handle. A later `subscribe-fn` re-acquire (e.g. a
+                          ;; subscribe-identity change) may have already
+                          ;; overwritten `committed-ref` with the NEW committed
+                          ;; reaction before this older cleanup runs; clobbering
+                          ;; it to nil would strand `get-snap` on the fallback.
+                          (when (identical? (.-current committed-ref) committed)
+                            (set! (.-current committed-ref) nil))
                           ;; Release the durable committed ref — symmetric with
                           ;; the `subs/subscribe` above. Runs on unmount /
                           ;; key change / teardown.

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -3946,6 +3946,162 @@
               (finally
                 (try (.unmount root2) (catch :default _ nil)))))))))))
 
+;; ---- getSnapshot tracks the committed reaction (rf2-sqhjtu) ---------------
+;;
+;; THE BUG. `use-subscribe` fetches a render-phase reaction HANDLE with a
+;; balanced `subs/subscribe` + immediate `subs/unsubscribe` round-trip
+;; (net-zero ref-count, so an abandoned render leaks nothing). On a FIRST
+;; mount with no prior cache entry, that round-trip drives the cache slot
+;; 1 → 0 and DISPOSES the render-phase reaction (its source watches are
+;; removed, it is evicted from the cache). The DURABLE committed reaction is
+;; then built post-commit inside the `useSyncExternalStore` subscribe
+;; callback — a DIFFERENT object that owns the live watch + the cache
+;; ref-count.
+;;
+;; The pre-fix `get-snap` (the `getSnapshot` React calls on every render to
+;; read the store value) closed over and dereferenced the RENDER-PHASE
+;; handle. Because a disposed reaction still recomputes pull-based on deref,
+;; the rendered VALUE stayed correct for ordinary app-db updates — which is
+;; exactly why the existing call-balance/DOM-value assertions pass while the
+;; snapshot reads a disposed first-render handle. The hazard React's
+;; `useSyncExternalStore` contract guards against (getSnapshot must read a
+;; stable, LIVE source) is real: the disposed handle has no source watches,
+;; duplicates the sub-body recompute on every snapshot read, and on sub
+;; re-registration / hot-reload still closes over the OLD reaction (and its
+;; old body) rather than the committed cached one.
+;;
+;; THE PROOF (object-identity, not value). A value assertion cannot fail
+;; deterministically here — both the disposed handle and the committed
+;; reaction recompute the same live value. So we prove the snapshot's SOURCE
+;; OBJECT: spy `subs/subscribe` to wrap every returned reaction in a thin
+;; deref-recording proxy that delegates IDeref/IWatchable to the real
+;; reaction and tags each deref with a per-real-reaction generation. After a
+;; first mount (render-phase handle disposed; committed reaction freshly
+;; built) we force a re-render (which does NOT re-run the `[stable-key]`-keyed
+;; memo or re-invoke the commit-owned subscribe-fn) and assert the
+;; `get-snap`-driven deref hits the generation of the reaction CURRENTLY IN
+;; THE CACHE (the committed one), never the disposed render-phase handle. On
+;; the pre-fix spine the deref hits the disposed-handle generation.
+
+(defn assert-use-subscribe-getsnapshot-tracks-committed-reaction
+  "rf2-sqhjtu: after a first mount, `get-snap` (React's `getSnapshot`) must
+  deref the DURABLE committed cached reaction, not the disposed render-phase
+  handle. Proven by object identity: a `subs/subscribe` spy wraps each
+  returned reaction in a deref-recording proxy tagged with a per-real-reaction
+  generation; the committed reaction is the one left in the cache after mount.
+  A forced re-render re-runs `get-snap` (without re-running the stable-key memo
+  or re-invoking subscribe-fn); the recorded deref generation MUST be the
+  committed/cached reaction's, not the disposed first-render handle's.
+
+  cfg keys: reuses the refcount-probe surface
+    :probe-refcount-element / :refcount-target / :rc-frame / :rc-query"
+  [{:keys [name probe-refcount-element refcount-target rc-frame rc-query]}]
+  (testing (str name " — use-subscribe getSnapshot tracks the committed reaction, not the disposed render-phase handle (rf2-sqhjtu)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! refcount-target rc-frame)
+      (rf/reg-frame rc-frame {:doc "rf2-sqhjtu getSnapshot-tracks-committed probe frame"})
+      (rf/reg-event ::gs-seed (fn [{:keys [db]} _] {:db {:m 0}}))
+      (rf/dispatch-sync [::gs-seed] {:frame rc-frame})
+      (rf/reg-event ::gs-inc (fn [{:keys [db]} _] {:db {:m (inc (:m db))}}))
+      (rf/reg-sub rc-query (fn [db _] (:m db)))
+      (let [cache-key-v      [rc-query]
+            cache            (:sub-cache (frame/frame rc-frame))
+            real-subscribe   subs/subscribe
+            ;; per-real-reaction generation + the deref log (generation of
+            ;; the reaction each `get-snap` deref hit, in order).
+            gen-counter      (atom 0)
+            real->gen        (atom {})           ;; real reaction -> gen int
+            deref-log        (atom [])           ;; gens, in deref order
+            gen-of           (fn [real]
+                               (or (get @real->gen real)
+                                   (let [g (swap! gen-counter inc)]
+                                     (swap! real->gen assoc real g)
+                                     g)))
+            ;; A deref-recording proxy delegating to the REAL reaction. The
+            ;; spine derefs THIS (records the gen) and add-watch/remove-watch
+            ;; THIS (delegated to the real reaction so on-change still fires).
+            ;; `subs/unsubscribe` is by (frame, query), not by object, so the
+            ;; proxy needs no IDisposable — disposal hits the real reaction via
+            ;; the cache.
+            wrap             (fn [real]
+                               (let [g (gen-of real)]
+                                 (reify
+                                   IDeref
+                                   (-deref [_]
+                                     (swap! deref-log conj g)
+                                     @real)
+                                   IWatchable
+                                   (-add-watch [this k f]
+                                     (add-watch real k (fn [_ _ old nu] (f k this old nu)))
+                                     this)
+                                   (-remove-watch [_ k]
+                                     (remove-watch real k)
+                                     nil)
+                                   ;; Never invoked by the spine (the real
+                                   ;; reaction owns notification through its own
+                                   ;; source watches); present only to satisfy
+                                   ;; the IWatchable protocol surface. No-op.
+                                   (-notify-watches [_ _old _nu] nil))))
+            mount-node       (make-mount-node!)
+            root             (react-dom-client/createRoot mount-node)]
+        ;; Preserve subs/subscribe's 1-/2-arity shape (the spine binds the
+        ;; arity-2 invoke slot); both bodies route to the canonical 2-arity
+        ;; REAL directly (no Var recur double-trip — same discipline as the
+        ;; rf2-mwft2 spy) and wrap the returned reaction.
+        (with-redefs [subs/subscribe
+                      (fn spy-subscribe
+                        ([query-v]
+                         (wrap (real-subscribe (frame/resolve-current-frame) query-v)))
+                        ([frame-id query-v]
+                         (wrap (real-subscribe frame-id query-v))))]
+          (try
+            (act-fn (fn [] (.render root (probe-refcount-element))))
+            ;; The committed reaction is the one the cache holds (ref-count 1).
+            ;; On a first mount the render-phase handle was disposed + evicted,
+            ;; so it is a DIFFERENT object — distinct generation.
+            (let [committed-real (get-in @cache [cache-key-v :reaction])
+                  committed-gen  (get @real->gen committed-real)]
+              (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                  "after mount exactly one durable committed ref is pinned")
+              (is (some? committed-gen)
+                  "the committed cached reaction was seen through the subscribe spy")
+              ;; Force a re-render of the SAME mounted component. React re-reads
+              ;; get-snap; the `[stable-key]`-keyed memo does NOT re-run and the
+              ;; commit-owned subscribe-fn is NOT re-invoked, so get-snap's
+              ;; source is whatever it captured at mount — the committed reaction
+              ;; (fix) or the disposed render-phase handle (bug).
+              (reset! deref-log [])
+              (act-fn (fn [] (.render root (probe-refcount-element))))
+              (is (seq @deref-log)
+                  "the forced re-render drove at least one get-snap deref")
+              ;; THE LOAD-BEARING ASSERTION. Every get-snap deref on the
+              ;; re-render hit the COMMITTED cached reaction's generation — NOT
+              ;; the disposed first-render handle's. Pre-fix this is the
+              ;; render-phase handle's (different) generation.
+              (is (every? #(= committed-gen %) @deref-log)
+                  (str "get-snap derefs ONLY the committed cached reaction "
+                       "(gen " committed-gen ") on re-render — not the disposed "
+                       "render-phase handle. Observed deref gens " @deref-log))
+              ;; A dispatch-driven update also reads the committed reaction:
+              ;; the watch fires on-change (from the committed reaction), React
+              ;; re-reads get-snap, and the snapshot tracks the live committed
+              ;; source. Value stays correct AND the source is the committed one.
+              (reset! deref-log [])
+              (act-fn (fn [] (rf/dispatch-sync [::gs-inc] {:frame rc-frame})))
+              (is (= "m=1" (.-textContent mount-node))
+                  "post-dispatch the committed snapshot reflects the new value")
+              (is (every? #(= committed-gen %) @deref-log)
+                  (str "post-dispatch get-snap still derefs ONLY the committed "
+                       "cached reaction (gen " committed-gen "). Observed "
+                       @deref-log)))
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache cache-key-v))
+                    (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                "post-unmount the committed ref is released (no leak from the proxy path)")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))
+
 ;; ---- unsubscribe arity contract (rf2-gizlj) -------------------------------
 ;;
 ;; The shared spine's `use-subscribe` useEffect cleanup calls


### PR DESCRIPTION
## What

The React-substrate `use-subscribe` (`make-react-spine` in `core/src/re_frame/substrate/spine.cljs`) fetches its render-phase reaction handle with a balanced `subs/subscribe` + immediate `subs/unsubscribe` round-trip (net-zero ref-count, so an abandoned render leaks nothing). On a **first mount with no prior cache entry**, that round-trip drives the cache slot `1 -> 0` and **disposes** the render-phase reaction (source watches removed, evicted from cache). The durable committed reaction is then built post-commit inside the `useSyncExternalStore` subscribe callback — a **different object** owning the live watch + ref-count.

`get-snap` (React's `getSnapshot`) closed over and dereferenced the **disposed render-phase handle**. Because a disposed reaction still recomputes pull-based on deref, the rendered value stays correct for ordinary app-db updates (masking the hazard) — but the snapshot reads a disposed source: no source watches, duplicated sub-body recompute per snapshot read, and on sub re-registration / hot-reload it still closes over the old reaction/body rather than the committed cached one. This violates React's `useSyncExternalStore` contract (getSnapshot must read a stable, live source).

## Fix

Store the commit-acquired reaction in a `committed-ref` `useRef`, set in `subscribe-fn` post-commit and cleared on teardown **only if it still points at the same handle** (so a later re-subscribe's overwrite isn't clobbered). `get-snap` derefs that ref once populated, falling back to the render-phase handle only for the first pre-commit snapshot. The committed reaction's value `=` the render-phase one (rf2-cmfln) so the source swap is tear-free. The abandoned-render / ref-count-leak protections (rf2-es09qq / rf2-879fe / rf2-8u8tx.2) are preserved.

## Test

Object-identity regression test in the shared suite, forwarded by both the UIx and Helix `use-subscribe` DOM test entries. A `subs/subscribe` spy wraps each returned reaction in a deref-recording proxy tagged with a per-real-reaction generation; after a first mount it forces a re-render and a dispatch and asserts `get-snap` derefs **only the committed cached reaction's generation**, never the disposed render-phase handle's. A value assertion can't fail deterministically here (both sources recompute the same live value), so the proof is on the snapshot's **source object**.

- **Without the fix:** 4 browser failures — observed deref gens `[1 1]` (re-render) and `[1 1 1 1]` (post-dispatch) vs committed gen `2`, on both UIx and Helix. The DOM value stays correct (`m=1`), confirming the value-only masking.
- **With the fix:** green.

## Gates

- `npm run test:cljs` — 7955 tests / 36557 assertions, 0 failures
- `npm run test:browser` — 224 tests / 715 assertions, 0 failures (the load-bearing gate; UIx/Helix adapter smokes + the new regression)
- `npm run test:bundle-isolation` — pass (no reagent / internal-sentinel leak)
- `npm run test:reagent-slim:bundle-isolation` — pass
- `npm run test:cljs-isolation` (per-ns) — 18 namespaces pass standalone
- clj-kondo — 0 errors on changed files (no new warnings)

rf2-sqhjtu. Reagent has no equivalent (it doesn't use `useSyncExternalStore`).