### PR TITLE
fix(mcp-conformance): runTrusted timeout must SIGKILL hung setup children, not cancel the fallback (rf2-i4d5wr)

### DIFF
--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -680,6 +680,17 @@ function trustedExe(name) {
 const SETUP_COMMAND_TIMEOUT_MS =
   Number(process.env.HERMETIC_SETUP_TIMEOUT_MS) || 300_000;
 
+// Grace between the timeout SIGTERM and the SIGKILL escalation for a hung
+// setup child (rf2-i4d5wr). A well-behaved child reaps on SIGTERM within
+// this window; a SIGTERM-ignoring child gets SIGKILLed after it. This grace
+// is AWAITED (not a fire-and-forget `setTimeout` that the reject could
+// cancel), so a setup child that ignores SIGTERM is GUARANTEED to receive
+// SIGKILL before `runTrusted` rejects. `$HERMETIC_SETUP_SIGKILL_GRACE_MS`
+// shrinks it for the regression harness (`hermetic-setup-timeout.test.cjs`)
+// so the SIGTERM-ignoring arm runs fast; production CI never sets it.
+const SETUP_SIGKILL_GRACE_MS =
+  Number(process.env.HERMETIC_SETUP_SIGKILL_GRACE_MS) || 5_000;
+
 // Run a trusted setup command (resolved to an absolute path outside the
 // workspace via `trustedExe`) under an ASYNC spawn with an explicit
 // child-level timeout/kill.
@@ -697,9 +708,22 @@ const SETUP_COMMAND_TIMEOUT_MS =
 //
 // The async spawn keeps the event loop live, so both the per-command
 // timeout below AND the whole-run watchdog stay armed. On timeout we
-// SIGTERM the child, then SIGKILL after a short grace, and reject with an
-// orchestration error — surfacing as exit 2 (orchestration failure) within
+// SIGTERM the child, AWAIT its exit (bounded by `SETUP_SIGKILL_GRACE_MS`),
+// SIGKILL it if it ignored SIGTERM, then reject with an orchestration error
+// — surfacing as exit 2 (orchestration failure) shortly after
 // `SETUP_COMMAND_TIMEOUT_MS` rather than the multi-minute CI job timeout.
+//
+// rf2-i4d5wr: the pre-fix shape armed the SIGKILL as a fire-and-forget
+// `setTimeout` (`killTimer`) and then immediately `settle(reject, ...)`d.
+// But `settle` cleared `killTimer`, so the SIGKILL fallback was CANCELLED
+// on the very path that scheduled it. A setup child that ignored SIGTERM
+// would survive after the orchestrator reported "setup command hung —
+// killed", leaking npm/node children that hold locks/pipes. The fix makes
+// the SIGTERM→SIGKILL escalation an AWAITED sequence (the same shape the
+// teardown `makeCleanup` uses): the child is reaped (or has demonstrably
+// received SIGKILL) BEFORE the timeout promise rejects, and the reject no
+// longer cancels the kill. The happy path still settles promptly the moment
+// the child exits normally.
 function runTrusted(name, args, cwd) {
   const bin = trustedExe(name);
   // cross-spawn (async) handles the `.cmd` -> cmd.exe dispatch on Windows
@@ -717,36 +741,68 @@ function runTrusted(name, args, cwd) {
     let stdout = '';
     let stderr = '';
     let settled = false;
-    let killTimer = null;
+    let childExited = false;
+    let timedOut = false;
 
     const settle = (fn, arg) => {
       if (settled) return;
       settled = true;
-      if (killTimer) clearTimeout(killTimer);
       if (timer) clearTimeout(timer);
       fn(arg);
     };
 
     // Per-command hard cap, enforced by the live event loop (the whole
-    // point of the async spawn). On elapse: SIGTERM, then SIGKILL after a
-    // short grace, then reject as an orchestration failure.
+    // point of the async spawn). On elapse: SIGTERM, AWAIT the child's exit
+    // bounded by a grace, SIGKILL if it ignored SIGTERM, then reject as an
+    // orchestration failure.
+    //
+    // rf2-i4d5wr: the escalation is an AWAITED sequence, NOT a fire-and-
+    // forget `setTimeout` that `settle(reject)` could cancel. A child that
+    // ignores SIGTERM is therefore GUARANTEED to receive SIGKILL before the
+    // promise rejects; we never report "killed" while the child is still
+    // alive and un-SIGKILLed.
     const timer = setTimeout(() => {
       logErr(
         `${name} ${args.join(' ')} exceeded SETUP_COMMAND_TIMEOUT_MS ` +
           `(${SETUP_COMMAND_TIMEOUT_MS}ms) — killing the setup child`,
       );
-      try { child.kill('SIGTERM'); } catch {}
-      killTimer = setTimeout(() => {
-        try { child.kill('SIGKILL'); } catch {}
-      }, 5000);
-      killTimer.unref();
-      settle(
-        reject,
-        new Error(
-          `${name} ${args.join(' ')} in ${cwd} timed out after ` +
-            `${SETUP_COMMAND_TIMEOUT_MS}ms (setup command hung — killed)`,
-        ),
-      );
+      // The timeout owns the rejection attribution from here: the `exit`
+      // handler observes `timedOut` and defers, so the message is "timed
+      // out", not "killed by <signal>" from our own SIGKILL.
+      timedOut = true;
+      // `void`: the IIFE owns the kill/await; it ends by `settle(reject)`ing.
+      void (async () => {
+        try { child.kill('SIGTERM'); } catch {}
+        const exitedOnTerm = await settledWithin(
+          waitForChildExit(child, () => childExited),
+          SETUP_SIGKILL_GRACE_MS,
+        );
+        if (!exitedOnTerm && !childExited) {
+          logErr(
+            `${name} ${args.join(' ')} did not exit ${SETUP_SIGKILL_GRACE_MS}ms ` +
+              'after SIGTERM — escalating to SIGKILL',
+          );
+          try { child.kill('SIGKILL'); } catch {}
+          // Best-effort observe the post-SIGKILL exit so we don't reject
+          // while the OS reap is still in flight. Bounded so a truly
+          // unkillable child (PID-namespace edge) can't wedge the run.
+          await settledWithin(
+            waitForChildExit(child, () => childExited),
+            SETUP_SIGKILL_GRACE_MS,
+          );
+        }
+        // Reject with the timeout attribution. `settle` is first-wins, so if
+        // the `exit` handler already rejected with "killed by SIGKILL" this
+        // is a no-op; either way the child has been SIGTERM'd→SIGKILL'd, not
+        // left alive.
+        settle(
+          reject,
+          new Error(
+            `${name} ${args.join(' ')} in ${cwd} timed out after ` +
+              `${SETUP_COMMAND_TIMEOUT_MS}ms (setup command hung — killed)`,
+          ),
+        );
+      })();
     }, SETUP_COMMAND_TIMEOUT_MS);
     timer.unref();
 
@@ -760,9 +816,20 @@ function runTrusted(name, args, cwd) {
     });
     child.on('error', (err) => settle(reject, err));
     child.on('exit', (code, signal) => {
+      // Record the exit so the timeout path's awaited grace
+      // (`waitForChildExit(child, () => childExited)`) sees a child that
+      // exited before/while we waited and stops escalating. rf2-i4d5wr.
+      childExited = true;
+      if (timedOut) {
+        // Our own timeout SIGTERM/SIGKILL reaped it. Defer the rejection to
+        // the timeout IIFE so the attribution is the timeout message, and so
+        // the awaited escalation observes this exit (it `await`s
+        // `waitForChildExit`, which resolves on this event). rf2-i4d5wr.
+        return;
+      }
       if (signal) {
-        // Signal-terminated (incl. our own timeout SIGKILL, which the
-        // timeout branch has already rejected for). Treat as a failure so a
+        // Signal-terminated by something OTHER than our timeout path (an
+        // external SIGTERM/SIGKILL, an OOM kill). Treat as a failure so a
         // killed setup child never reads as success.
         settle(
           reject,
@@ -1254,10 +1321,13 @@ if (require.main === module) {
   clearTimeout(watchdog);
 }
 
-// Exported for the rf2-wqi4n4 finding-2 regression harness. `runTrusted` is
-// the async, timeout-bounded setup-command spawn; the test drives it
-// against a never-exiting child to prove a hung setup command is killed
-// within `SETUP_COMMAND_TIMEOUT_MS` instead of wedging the event loop.
+// Exported for the rf2-wqi4n4 finding-2 + rf2-i4d5wr regression harness.
+// `runTrusted` is the async, timeout-bounded setup-command spawn; the test
+// drives it against (a) a never-exiting child to prove a hung setup command
+// is killed within `SETUP_COMMAND_TIMEOUT_MS` instead of wedging the event
+// loop, and (b) a SIGTERM-IGNORING child to prove the timeout path AWAITS
+// the SIGTERM grace then SIGKILLs it (the reject no longer cancels the
+// fallback) so the child is actually reaped, not leaked.
 //
 // `readPortFile` + `isContainmentEscape` are exported for the rf2-khav7l
 // call-site regression harness (`port-file-escape.test.cjs`): it drives

--- a/tools/mcp-conformance/test/hermetic-setup-timeout.test.cjs
+++ b/tools/mcp-conformance/test/hermetic-setup-timeout.test.cjs
@@ -1,5 +1,12 @@
 // Regression test for the hermetic orchestrator's SETUP-command timeout
-// contract (rf2-wqi4n4 finding 2).
+// contract (rf2-wqi4n4 finding 2 + rf2-i4d5wr).
+//
+// Two arms:
+//   - rf2-wqi4n4: a hung setup command is killed within the per-command cap
+//     and the event loop stays live (proving the async-spawn shape).
+//   - rf2-i4d5wr: a SIGTERM-IGNORING setup child is actually SIGKILLed (the
+//     timeout reject must NOT cancel the SIGKILL fallback). See that test's
+//     own header for the leaked-child bug it pins.
 //
 // Uses Node's built-in `node:test` (same posture as
 // `runner-watchdog.test.cjs` / `exec-safety.test.cjs` — no extra
@@ -46,6 +53,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const os = require('node:os');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const ORCH = path.join(
@@ -55,9 +63,12 @@ const ORCH = path.join(
   'run-live-re-frame2-pair-overflow-hermetic.cjs',
 );
 
-// Shrink the per-command cap BEFORE requiring the orchestrator — it reads
-// `$HERMETIC_SETUP_TIMEOUT_MS` at module-load time.
+// Shrink the per-command cap AND the post-SIGTERM SIGKILL grace BEFORE
+// requiring the orchestrator — it reads both env vars at module-load time.
+// The grace shrink keeps the rf2-i4d5wr SIGTERM-ignoring arm fast (it must
+// wait the grace, then SIGKILL) without slowing the rf2-wqi4n4 arm.
 process.env.HERMETIC_SETUP_TIMEOUT_MS = '750';
+process.env.HERMETIC_SETUP_SIGKILL_GRACE_MS = '400';
 
 const { runTrusted, SETUP_COMMAND_TIMEOUT_MS } = require(ORCH);
 
@@ -130,5 +141,151 @@ test('runTrusted kills a hung setup command within its timeout, loop stays live 
       'liveness timer never fired. This is the synchronous-spawn signature ' +
       'finding 2 pins: a blocked loop starves both this timer AND the ' +
       'whole-run HERMETIC_TIMEOUT_MS watchdog.',
+  );
+});
+
+// ── rf2-i4d5wr ───────────────────────────────────────────────────────────
+//
+// Pins the SIGKILL-fallback bug: on the timeout path `runTrusted` armed the
+// SIGKILL as a fire-and-forget `setTimeout` (`killTimer`) and then
+// immediately `settle(reject, ...)`d. `settle` cleared `killTimer`, so the
+// SIGKILL fallback was CANCELLED on the very path that scheduled it. A setup
+// child that IGNORES SIGTERM survived after the orchestrator reported "setup
+// command hung — killed", leaking npm/node children that hold locks/pipes.
+//
+// The fix makes the SIGTERM→SIGKILL escalation an AWAITED sequence: the
+// child is reaped (SIGTERM grace, then SIGKILL, then a bounded final wait)
+// BEFORE the promise rejects, and the reject no longer cancels the kill.
+//
+// This arm spawns a child that installs a SIGTERM handler (and SIGINT, for
+// good measure) which logs but does NOT exit, holding itself alive with a
+// ref'd interval. Under POSIX signal semantics that child cannot be reaped
+// by SIGTERM — only SIGKILL ends it. We then assert the child PID is GONE
+// after `runTrusted` rejects, which can ONLY be true if the SIGKILL
+// escalation actually fired (the pre-fix code would leave it alive).
+//
+// Cross-platform note: Node on Windows maps BOTH `child.kill('SIGTERM')` and
+// `child.kill('SIGKILL')` to `TerminateProcess`, which is unconditional —
+// a Windows process cannot "ignore SIGTERM", so the SIGTERM handler is inert
+// there and the child dies on the first signal. The assertion ("child is
+// gone after reject") still holds on Windows; it just exercises the SIGTERM
+// leg rather than the SIGTERM→SIGKILL escalation. On Linux CI
+// (`ubuntu-latest`, the gate's runner) the SIGTERM handler is honoured, so
+// the escalation IS exercised — which is where the original bug bit.
+test('runTrusted SIGKILLs a SIGTERM-ignoring setup child — the reject does not cancel the fallback (rf2-i4d5wr)', async () => {
+  // PID handshake: the child writes its own PID to a temp file on startup so
+  // the parent can poll for the child's liveness directly (independent of
+  // the child handle, which `runTrusted` does not expose).
+  const pidFile = path.join(
+    os.tmpdir(),
+    `rf2-i4d5wr-sigterm-ignore-${process.pid}-${Date.now()}.pid`,
+  );
+  try { fs.rmSync(pidFile, { force: true }); } catch {}
+
+  // The child:
+  //   - installs SIGTERM/SIGINT handlers that LOG but never exit,
+  //   - writes its PID so the parent can watch it,
+  //   - stays alive with a ref'd interval (so it does not self-exit).
+  // Under POSIX this child outlives a SIGTERM; only SIGKILL ends it.
+  const IGNORE_SIGTERM = `
+    const fs = require('fs');
+    process.on('SIGTERM', () => { /* deliberately ignore */ });
+    process.on('SIGINT', () => { /* deliberately ignore */ });
+    fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+    setInterval(() => {}, 1000);
+  `;
+
+  // Read the child PID once it has written it (it does so synchronously at
+  // startup; poll briefly to cover spawn latency).
+  async function readChildPid(deadlineMs) {
+    const until = Date.now() + deadlineMs;
+    while (Date.now() < until) {
+      try {
+        const raw = fs.readFileSync(pidFile, 'utf8').trim();
+        const pid = Number(raw);
+        if (Number.isInteger(pid) && pid > 0) return pid;
+      } catch { /* not written yet */ }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    return null;
+  }
+
+  // `process.kill(pid, 0)` sends no signal; it throws ESRCH when the process
+  // is gone, succeeds (or throws EPERM) while it is alive. The
+  // platform-portable "is this PID still alive" probe.
+  function pidAlive(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (e) {
+      // ESRCH = gone. EPERM = alive but not ours to signal (treat as alive).
+      return e && e.code === 'EPERM';
+    }
+  }
+
+  let rejected = false;
+  let message = '';
+  let childPid = null;
+
+  // Start the child via runTrusted; grab its PID while runTrusted is awaiting
+  // its own timeout. We do NOT await runTrusted yet — we need the PID first.
+  const runPromise = runTrusted('node', ['-e', IGNORE_SIGTERM], os.tmpdir());
+  // Swallow the eventual rejection on the floating promise reference so an
+  // unhandled-rejection does not crash the test runner if our await races.
+  runPromise.catch(() => {});
+
+  childPid = await readChildPid(5000);
+  assert.ok(
+    childPid,
+    'the SIGTERM-ignoring child never wrote its PID file — could not spawn ' +
+      'the regression child; cannot prove the SIGKILL escalation.',
+  );
+
+  try {
+    await runPromise;
+  } catch (err) {
+    rejected = true;
+    message = (err && err.message) || String(err);
+  }
+
+  // 1. The timeout path rejected, attributed to the timeout (not "killed by
+  // <signal>" — the fix defers the exit-handler signal message to the
+  // timeout IIFE so attribution stays clear).
+  assert.ok(rejected, 'runTrusted did NOT reject on the SIGTERM-ignoring child.');
+  assert.ok(
+    /timed out after/.test(message),
+    'runTrusted rejected but NOT via the timeout path; got: ' + message,
+  );
+
+  // 2. THE LOAD-BEARING ASSERTION: the child is actually GONE after the
+  // reject. Pre-fix, `settle(reject)` cancelled the SIGKILL `killTimer`, so a
+  // SIGTERM-ignoring child stayed alive forever — this poll would never see
+  // ESRCH within the bound. Post-fix, the AWAITED SIGTERM→SIGKILL escalation
+  // reaps it before (or as) the promise rejects, so the PID is gone. Poll
+  // with a small bound to cover the OS reap latency after SIGKILL.
+  async function waitGone(pid, deadlineMs) {
+    const until = Date.now() + deadlineMs;
+    while (Date.now() < until) {
+      if (!pidAlive(pid)) return true;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    return !pidAlive(pid);
+  }
+  const gone = await waitGone(childPid, 5000);
+
+  // Defensive: if it somehow survived, kill it so the test does not leak the
+  // very child it is meant to prove was reaped.
+  if (!gone) {
+    try { process.kill(childPid, 'SIGKILL'); } catch {}
+  }
+  try { fs.rmSync(pidFile, { force: true }); } catch {}
+
+  assert.ok(
+    gone,
+    'the SIGTERM-ignoring child (pid ' + childPid + ') is STILL ALIVE after ' +
+      'runTrusted rejected — the SIGKILL fallback was cancelled by the ' +
+      'reject (the rf2-i4d5wr bug). The timeout path must AWAIT the ' +
+      'SIGTERM→SIGKILL escalation so a hung setup child is actually reaped, ' +
+      'not leaked.',
   );
 });


### PR DESCRIPTION
## What

`runTrusted` (the hermetic orchestrator's trusted setup-command spawn) had a SIGKILL-fallback that was cancelled on the very path that scheduled it.

On a setup-command timeout (`tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`), the pre-fix code:
1. `child.kill('SIGTERM')`,
2. armed `killTimer = setTimeout(() => child.kill('SIGKILL'), 5000)` (fire-and-forget),
3. immediately `settle(reject, ...)` — and **`settle` calls `clearTimeout(killTimer)`**.

So the SIGKILL fallback was cancelled the instant it was scheduled. A setup child that ignores SIGTERM (a wedged `npm install` with a signal handler, a package-manager subprocess) **survived** after the orchestrator logged `"setup command hung — killed"`, leaking npm/node children that hold locks/pipes — making the timeout contract weaker than the code/comments/tests claimed.

## Fix

The timeout path is now an **awaited** SIGTERM → grace → SIGKILL → final-wait escalation — the same shape `makeCleanup` already uses for the shadow-cljs child:

- SIGTERM, then `await settledWithin(waitForChildExit(child, () => childExited), SETUP_SIGKILL_GRACE_MS)`,
- if it ignored SIGTERM, SIGKILL and `await` a bounded final wait,
- only then `settle(reject, "timed out")`.

`settle` no longer touches any kill timer (the `killTimer` mechanism is gone). A new `timedOut` flag makes the `exit` handler defer to the timeout IIFE, keeping the rejection attributed to `"timed out after …"` rather than `"killed by SIGKILL"`. The child is reaped (or has demonstrably received SIGKILL) **before** the promise rejects, and the reject can no longer cancel the kill. Happy-path cleanup (settle on normal exit) is preserved.

New `SETUP_SIGKILL_GRACE_MS` constant (default 5s, overridable via `$HERMETIC_SETUP_SIGKILL_GRACE_MS` for the regression harness only).

## Test

New regression arm in `test/hermetic-setup-timeout.test.cjs`: spawns a child that installs SIGTERM/SIGINT handlers which never exit and holds itself alive with a ref'd interval, then asserts (a) `runTrusted` rejects via the timeout path and (b) **the child PID is gone** after the reject (`process.kill(pid, 0)` → ESRCH), proving SIGKILL actually fired.

- On Linux CI (`ubuntu-latest`, the gate's runner) the SIGTERM handler is honoured, so the SIGTERM→SIGKILL escalation is the path under test — exactly where the bug bit.
- On Windows, `child.kill('SIGTERM')` maps to unconditional `TerminateProcess`, so the SIGTERM leg reaps it; the "child is gone after reject" assertion still holds.

Verified the fix decisively via an isolated buggy-vs-fixed harness under simulated POSIX semantics (a fake child that ignores SIGTERM): pre-fix `sigkilled=false` (leak), post-fix `sigkilled=true` (reaped).

## Quality gates

- `node --test test/hermetic-setup-timeout.test.cjs` → 3/3 pass (incl. the new arm).
- All conformance unit-test arms (exec-safety, runner-watchdog, runner-cleanup, hermetic-setup-timeout, port-file-escape, dedup-envelope, call-coverage-ratchet, classification-ratchet) → 49 pass / 0 fail / 9 skipped.
- `node --check` on both files OK. No `.clj` changed (no clj-kondo). No ESLint config in repo.
- Only the two intended `.cjs` files changed; lockfile/node_modules untouched.