### PR TITLE
fix(ssr-ring+security+scripts): cookie :name type-guard + fail-closed hydration corpus + waitForHttpReady path assertion (rf2-d95o1y, rf2-kzhcv3, rf2-p8xl35)

### DIFF
--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -444,12 +444,19 @@ test('probeTargetFromBaseUrl rejects a non-http(s) scheme (rf2-rcepku)', () => {
   );
 });
 
-test('waitForHttpReady probes the supplied host + path (rf2-rcepku)', async () => {
-  // Only answer 200 on the exact base path the caller advertised; every
-  // other path 404s. Proves the probe targets opts.path (not the old
-  // hard-coded `/`), so a base-path server is correctly seen as ready.
+test('waitForHttpReady probes the supplied host + path (rf2-rcepku, rf2-p8xl35)', async () => {
+  // rf2-p8xl35 — bind the PATH probe directly. probeHttp resolves ready on
+  // ANY HTTP status (liveness, not 2xx), so a regression that hard-coded
+  // `/` instead of forwarding opts.path would still receive a response
+  // (a 404) and still report ready — leaving the old assertion (`ready ===
+  // true` against a server that 404s every other path) green under the
+  // bug. Observe the requested URL path directly instead: record every
+  // req.url and assert the advertised basePath was the path probed (and a
+  // bare `/` was NOT). This makes the path-forwarding contract load-bearing.
   const basePath = '/app/base/';
+  const requestedPaths = [];
   const server = http.createServer((req, res) => {
+    requestedPaths.push(req.url);
     if (req.url === basePath) {
       res.writeHead(200);
       res.end('ok');
@@ -460,16 +467,24 @@ test('waitForHttpReady probes the supplied host + path (rf2-rcepku)', async () =
   });
   const port = await listenOnLoopback(server);
   try {
-    // probeHttp resolves true on ANY status code (liveness, not 2xx), so a
-    // bare `/` would also report ready here — assert instead that the
-    // host/path opts flow through without breaking readiness for the
-    // advertised endpoint. The shape coverage is the deepEqual tests above.
     const ready = await waitForHttpReady(port, Date.now() + 1000, {
       host: '127.0.0.1',
       path: basePath,
       pollMs: 10,
     });
-    assert.equal(ready, true);
+    assert.equal(ready, true, 'the advertised base-path server must be seen as ready');
+    // The probe must have requested the caller-supplied path verbatim — a
+    // regression that hard-codes `/` would record `/` here and trip this.
+    assert.ok(
+      requestedPaths.includes(basePath),
+      `waitForHttpReady must probe the supplied path ${JSON.stringify(basePath)}; ` +
+        `observed requests: ${JSON.stringify(requestedPaths)}`,
+    );
+    assert.ok(
+      !requestedPaths.includes('/'),
+      `waitForHttpReady must NOT fall back to the hard-coded root path "/"; ` +
+        `observed requests: ${JSON.stringify(requestedPaths)}`,
+    );
   } finally {
     server.close();
   }

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -35,11 +35,15 @@
       (w3qgc#2 + rf2-3bv8o.)
 
     - SSR HYDRATION payload (`ssr.hydrate/hydrate-event-handler`): a
-      deserialised, untrusted payload that is not a map — or whose app-db
-      slice is present-but-not-a-map — MUST be REJECTED (the existing
-      client app-db left unchanged + a `:rf.error/malformed-hydration-payload`
-      diagnostic), NEVER installed as the whole app-db under the locked
-      `:replace-app-db` policy. (rf2-gro94, the new boundary of the class.)
+      deserialised, untrusted payload that is not a map — or whose
+      `:rf/app-db` OR `:rf/runtime-db` slice is present-but-not-a-map —
+      MUST be REJECTED (the existing client frame-state left unchanged + a
+      `:rf.error/malformed-hydration-payload` diagnostic), NEVER installed
+      as the whole partition under the locked `:replace-frame-state`
+      policy. EP-0001 (rf2-vzld77 / rf2-g00l2t) made `:rf/runtime-db` an
+      equally load-bearing frame-state slice; the corpus exercises BOTH
+      partitions so a regression dropping either branch trips this gate
+      (rf2-gro94, rf2-kzhcv3).
 
   This namespace fails RED if ANY boundary coerces a malformed / untrusted
   input to success. A new boundary that forgets to fail closed (or an
@@ -314,7 +318,19 @@
 
 (def ^:private malformed-hydration-payloads
   "Untrusted hydration payloads that MUST be rejected. A non-map payload,
-  or a map whose app-db slice is present-but-not-a-map."
+  a map whose `:rf/app-db` slice is present-but-not-a-map, OR a map whose
+  `:rf/runtime-db` slice is present-but-not-a-map.
+
+  EP-0001 (rf2-vzld77 / rf2-g00l2t) made `:rf/runtime-db` an equally
+  load-bearing frame-state slice: the production guard
+  (`re-frame.ssr.hydrate/malformed-hydration-payload!`) fails closed when
+  EITHER partition slice is present-but-non-map. The cross-surface
+  security corpus must therefore exercise BOTH partitions, else a
+  regression that drops the `:rf/runtime-db` branch from the production
+  guard would slip past this fail-closed invariant (rf2-kzhcv3). The
+  malformed-runtime-db cases are paired with a VALID `:rf/app-db` so the
+  invariant proves the WHOLE payload is rejected (app-db left unchanged),
+  not partially installed."
   [nil
    "a string payload"
    42
@@ -322,10 +338,25 @@
    :keyword
    ["a" "vector"]
    #{:a :set}
+   ;; --- present-but-non-map :rf/app-db slice ---
    {:rf/app-db "not-a-map"}      ;; slice present but a string
    {:rf/app-db 42}               ;; slice present but a number
    {:rf/app-db [:not :a :map]}   ;; slice present but a vector
-   {:rf/app-db true}])           ;; slice present but a boolean
+   {:rf/app-db true}             ;; slice present but a boolean
+   ;; --- present-but-non-map :rf/runtime-db slice (rf2-kzhcv3) ---
+   ;;     each paired with a VALID app-db slice, so the only thing that
+   ;;     can fail the payload is the malformed runtime-db — proving the
+   ;;     whole payload is rejected rather than installing the good
+   ;;     app-db and dropping the bad runtime-db.
+   {:rf/app-db {:ok 1} :rf/runtime-db "not-a-map"}    ;; runtime-db a string
+   {:rf/app-db {:ok 1} :rf/runtime-db 42}             ;; runtime-db a number
+   {:rf/app-db {:ok 1} :rf/runtime-db [:not :a :map]} ;; runtime-db a vector
+   {:rf/app-db {:ok 1} :rf/runtime-db true}           ;; runtime-db a boolean
+   {:rf/app-db {:ok 1} :rf/runtime-db false}          ;; runtime-db false
+   ;; runtime-db malformed even with NO app-db slice (no-server-app-db
+   ;; fallback shape) must still reject — runtime-db alone is load-bearing.
+   {:rf/runtime-db "not-a-map"}
+   {:rf/runtime-db [:not :a :map]}])
 
 (deftest malformed-hydration-payload-never-installs
   (testing "rf2-gro94 — a malformed / untrusted hydration payload is
@@ -377,6 +408,58 @@
       (is (= existing-db (:db result)))
       (is (zero? (count (ops traces :rf.error/malformed-hydration-payload)))))))
 
+;; ---- coherent-frame-state: malformed runtime-db leaves BOTH partitions ----
+
+(def ^:private existing-runtime-db
+  {:rf.runtime/ssr {:hydration {:version 7}}
+   :client/runtime-seeded true})
+
+(defn- hydrate-with-runtime
+  "Like `hydrate-with`, but ALSO seeds an existing `:rf.db/runtime`
+  coeffect so a rejection's effect on the runtime-db partition is
+  observable. Returns `{:result <handler-return> :traces <vec>}`."
+  [payload]
+  (let [out (atom nil)
+        traces (capture
+                 #(reset! out (hydrate/hydrate-event-handler
+                                {:db            existing-db
+                                 :rf.db/runtime existing-runtime-db
+                                 :rf.frame/id   :rf/default}
+                                [:rf/hydrate payload])))]
+    {:result @out :traces traces}))
+
+(deftest malformed-runtime-db-leaves-both-partitions-unchanged
+  (testing "rf2-kzhcv3 — coherent-frame-state contract: a payload whose
+            :rf/runtime-db slice is present-but-non-map (even alongside a
+            VALID :rf/app-db slice) is rejected as a WHOLE — the existing
+            app-db (:db) AND the existing runtime-db (:rf.db/runtime) are
+            both left unchanged, the diagnostic fires, and the good app-db
+            slice is NOT partially installed. Mirrors the SSR-artefact
+            pin (re_frame/ssr_hydration_test.clj) at the cross-surface
+            security boundary."
+    (doseq [payload [{:rf/app-db {:would-install 1} :rf/runtime-db "not-a-map"}
+                     {:rf/app-db {:would-install 1} :rf/runtime-db [:bad]}
+                     {:rf/app-db {:would-install 1} :rf/runtime-db 42}
+                     {:rf/runtime-db "not-a-map"}]]
+      (let [{:keys [result traces]} (hydrate-with-runtime payload)]
+        (is (= existing-db (:db result))
+            (str "payload " (pr-str payload)
+                 " must leave app-db unchanged (the good app-db slice must"
+                 " NOT be partially installed), got " (pr-str (:db result))))
+        ;; A rejection returns {:db db} — no :rf.db/runtime effect — so the
+        ;; runtime-db partition rides through unchanged (the effect is
+        ;; absent, leaving the seeded runtime-db in place).
+        (is (nil? (:rf.db/runtime result))
+            (str "payload " (pr-str payload)
+                 " must emit NO :rf.db/runtime effect (runtime-db partition"
+                 " left unchanged), got " (pr-str (:rf.db/runtime result))))
+        (is (pos? (count (ops traces :rf.error/malformed-hydration-payload)))
+            (str "payload " (pr-str payload)
+                 " must emit :rf.error/malformed-hydration-payload"))
+        (is (or (nil? (:fx result)) (empty? (:fx result)))
+            (str "payload " (pr-str payload)
+                 " must fire no compatibility-check fxs"))))))
+
 ;; ---- property: non-map payloads + non-map slices always fail closed -------
 
 (def ^:private gen-non-map
@@ -385,25 +468,38 @@
     (gen/gen-int -100 100)))
 
 (deftest non-map-hydration-inputs-always-fail-closed
-  (testing "rf2-gro94 — property: a non-map payload, OR a map carrying a
-            non-map app-db slice, is ALWAYS rejected — app-db unchanged +
+  (testing "rf2-gro94 / rf2-kzhcv3 — property: a non-map payload, OR a map
+            carrying a non-map :rf/app-db slice, OR a map carrying a non-map
+            :rf/runtime-db slice, is ALWAYS rejected — app-db unchanged +
             the diagnostic fires. One installed-garbage case = one
-            fail-open."
+            fail-open. Both load-bearing partition slices (:rf/app-db AND
+            :rf/runtime-db, per EP-0001) are exercised."
     (let [result
           (gen/for-all
             gen-non-map 200 23
             (fn [bad]
               (let [;; (i) the whole payload is the non-map `bad`
                     p1 (hydrate-with bad)
-                    ;; (ii) a map payload whose app-db slice is `bad`
+                    ;; (ii) a map payload whose :rf/app-db slice is `bad`
                     ;;      (skip the maps — a map slice is the valid case)
                     p2 (when-not (map? bad)
-                         (hydrate-with {:rf/app-db bad}))]
+                         (hydrate-with {:rf/app-db bad}))
+                    ;; (iii) a map payload carrying a VALID :rf/app-db but a
+                    ;;       non-map :rf/runtime-db slice — must reject the
+                    ;;       WHOLE payload (app-db left unchanged), not
+                    ;;       partially install the good app-db (rf2-kzhcv3).
+                    p3 (when-not (map? bad)
+                         (hydrate-with {:rf/app-db {:ok 1} :rf/runtime-db bad}))
+                    failed-closed?
+                    (fn [p]
+                      (or (nil? p)
+                          (and (= existing-db (:db (:result p)))
+                               (pos? (count (ops (:traces p)
+                                                 :rf.error/malformed-hydration-payload))))))]
                 (and (= existing-db (:db (:result p1)))
                      (pos? (count (ops (:traces p1) :rf.error/malformed-hydration-payload)))
-                     (or (nil? p2)
-                         (and (= existing-db (:db (:result p2)))
-                              (pos? (count (ops (:traces p2) :rf.error/malformed-hydration-payload)))))))))]
+                     (failed-closed? p2)
+                     (failed-closed? p3)))))]
       (is (nil? result)
           (str "a malformed hydration input was not failed closed: "
                (pr-str (when result (dissoc result :threw))))))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -92,6 +92,25 @@
 
 (defn- validate-cookie-name!
   [n]
+  ;; rf2-d95o1y — type-guard BEFORE `(clojure.core/name n)`. A cookie
+  ;; `:name` is only a string or a `Named` (keyword / symbol); anything
+  ;; else (a Long `42`, a vector `[]`, a map `{}`, …) would make
+  ;; `clojure.core/name` throw a raw `ClassCastException` with nil
+  ;; ex-data, bypassing the documented `:rf.error/cookie-invalid-name`
+  ;; contract and reaching `:on-error` / adapter code as a generic host
+  ;; exception. Reject the unsupported type loudly through the same
+  ;; structured error id so the validation contract holds for every
+  ;; name shape, not just bad strings.
+  (when-not (or (string? n) (instance? clojure.lang.Named n))
+    (error/throw-error!
+      :rf.error/cookie-invalid-name
+      'rf.ssr/cookie->set-cookie-header
+      (str "cookie :name must be a string or a keyword/symbol; got a "
+           (.getName (class n)) " (" (pr-str n) "). Use a string or"
+           " keyword token-grammar cookie name.")
+      {:recovery :use-a-token-grammar-cookie-name
+       :extra    {:name n
+                  :type (.getName (class n))}}))
   (let [s (clojure.core/name n)]
     (if (http-validation/valid-token-name? s)
       s
@@ -145,56 +164,60 @@
       {:recovery :supply-a-cookie-name
        :extra    {:cookie cookie}}))
   ;; rf2-rpedl §P2.4 — RFC 6265 §4.1.1 cookie-name token grammar.
-  (validate-cookie-name! name)
-  ;; `Instant/ofEpochMilli` takes a primitive long; passing anything
-  ;; else (a string-shaped epoch from a misconfigured projector, a
-  ;; `java.util.Date`, …) would NPE deep inside the format path. Catch
-  ;; the type-mismatch up front with a clear
-  ;; `:rf.error/cookie-invalid-expires` so the misuse surfaces with the
-  ;; cookie's actual shape attached.
-  (when (and (some? expires) (not (integer? expires)))
-    (error/throw-error!
-      :rf.error/cookie-invalid-expires
-      'rf.ssr/cookie->set-cookie-header
-      (str ":expires must be an epoch-millis long; got "
-           (.getName (class expires))
-           ". Pass :expires as a long count of milliseconds since the epoch.")
-      {:recovery :supply-epoch-millis-long
-       :extra    {:expires expires
-                  :cookie  cookie}}))
-  ;; rf2-rpedl §P1.2 — gate every string-shaped attribute that gets
-  ;; concatenated into the Set-Cookie wire form. `:value` is URL-encoded
-  ;; (CR/LF/NUL come out as %0D/%0A/%00 — no injection path); `:expires`
-  ;; flows through `rfc1123-formatter` which only emits ASCII letters /
-  ;; digits / `, : SP`; `:secure` / `:http-only` are booleans. The
-  ;; remaining string-typed slots — `:domain`, `:path`, `:max-age`
-  ;; (callers sometimes pass strings), `:same-site` (string form
-  ;; tolerated by same-site-token) — are validated here.
-  (when (some? domain)    (validate-attribute-string! :domain    domain))
-  (when (some? path)      (validate-attribute-string! :path      path))
-  (when (some? max-age)   (validate-attribute-string! :max-age   max-age))
-  (when (some? same-site) (validate-attribute-string! :same-site same-site))
-  (let [parts (cond-> [(str (clojure.core/name name)
-                            "="
-                            (url-encode (or value "")))]
-                ;; Order doesn't matter to the RFC, but the canonical
-                ;; serving order in most libraries is:
-                ;;   Max-Age, Domain, Path, Expires, Secure, HttpOnly, SameSite
-                (some? max-age)  (conj (str "Max-Age=" max-age))
-                (some? domain)   (conj (str "Domain=" domain))
-                (some? path)     (conj (str "Path=" path))
-                (some? expires)
-                (conj (str "Expires="
-                           (.format rfc1123-formatter
-                                    (ZonedDateTime/ofInstant
-                                      ;; `expires` was type-checked above
-                                      ;; (`integer?`); coerce to a
-                                      ;; primitive long so the static-
-                                      ;; method dispatch picks the long
-                                      ;; arity without reflection.
-                                      (Instant/ofEpochMilli (long expires))
-                                      ZoneOffset/UTC))))
-                (true? secure)    (conj "Secure")
-                (true? http-only) (conj "HttpOnly")
-                (some? same-site) (conj (str "SameSite=" (same-site-token same-site))))]
-    (str/join "; " parts)))
+  ;; rf2-d95o1y — `validate-cookie-name!` returns the type-guarded,
+  ;; coerced name string; reuse it for the wire form so `(name …)` is
+  ;; not re-derived (and the type guard cannot be skipped on the wire
+  ;; path).
+  (let [name-str (validate-cookie-name! name)]
+    ;; `Instant/ofEpochMilli` takes a primitive long; passing anything
+    ;; else (a string-shaped epoch from a misconfigured projector, a
+    ;; `java.util.Date`, …) would NPE deep inside the format path. Catch
+    ;; the type-mismatch up front with a clear
+    ;; `:rf.error/cookie-invalid-expires` so the misuse surfaces with the
+    ;; cookie's actual shape attached.
+    (when (and (some? expires) (not (integer? expires)))
+      (error/throw-error!
+        :rf.error/cookie-invalid-expires
+        'rf.ssr/cookie->set-cookie-header
+        (str ":expires must be an epoch-millis long; got "
+             (.getName (class expires))
+             ". Pass :expires as a long count of milliseconds since the epoch.")
+        {:recovery :supply-epoch-millis-long
+         :extra    {:expires expires
+                    :cookie  cookie}}))
+    ;; rf2-rpedl §P1.2 — gate every string-shaped attribute that gets
+    ;; concatenated into the Set-Cookie wire form. `:value` is URL-encoded
+    ;; (CR/LF/NUL come out as %0D/%0A/%00 — no injection path); `:expires`
+    ;; flows through `rfc1123-formatter` which only emits ASCII letters /
+    ;; digits / `, : SP`; `:secure` / `:http-only` are booleans. The
+    ;; remaining string-typed slots — `:domain`, `:path`, `:max-age`
+    ;; (callers sometimes pass strings), `:same-site` (string form
+    ;; tolerated by same-site-token) — are validated here.
+    (when (some? domain)    (validate-attribute-string! :domain    domain))
+    (when (some? path)      (validate-attribute-string! :path      path))
+    (when (some? max-age)   (validate-attribute-string! :max-age   max-age))
+    (when (some? same-site) (validate-attribute-string! :same-site same-site))
+    (let [parts (cond-> [(str name-str
+                              "="
+                              (url-encode (or value "")))]
+                  ;; Order doesn't matter to the RFC, but the canonical
+                  ;; serving order in most libraries is:
+                  ;;   Max-Age, Domain, Path, Expires, Secure, HttpOnly, SameSite
+                  (some? max-age)  (conj (str "Max-Age=" max-age))
+                  (some? domain)   (conj (str "Domain=" domain))
+                  (some? path)     (conj (str "Path=" path))
+                  (some? expires)
+                  (conj (str "Expires="
+                             (.format rfc1123-formatter
+                                      (ZonedDateTime/ofInstant
+                                        ;; `expires` was type-checked above
+                                        ;; (`integer?`); coerce to a
+                                        ;; primitive long so the static-
+                                        ;; method dispatch picks the long
+                                        ;; arity without reflection.
+                                        (Instant/ofEpochMilli (long expires))
+                                        ZoneOffset/UTC))))
+                  (true? secure)    (conj "Secure")
+                  (true? http-only) (conj "HttpOnly")
+                  (some? same-site) (conj (str "SameSite=" (same-site-token same-site))))]
+      (str/join "; " parts))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -176,6 +176,12 @@
     (testing "rf2-d95o1y — non-string / non-Named :name throws a STRUCTURED
               :rf.error/cookie-invalid-name (not a raw ClassCastException)"
       (doseq [bad [42 3.14 [] [1 2 3] {} {:k 1} #{1 2} true]]
+        ;; The broad `catch Throwable` is DELIBERATE: the regression is the
+        ;; raw `ClassCastException` (a `Throwable`, NOT an `ExceptionInfo`)
+        ;; the pre-fix `(clojure.core/name n)` threw. We must catch the broad
+        ;; type to OBSERVE which throwable surfaces, then assert it is the
+        ;; structured ex-info — a narrow `catch ExceptionInfo` would let the
+        ;; bug's raw exception escape the test and obscure the failure.
         (let [t (try
                   (ssr-ring/cookie->set-cookie-header {:name bad :value "v"})
                   ::no-throw
@@ -191,7 +197,7 @@
                 (str "non-Named name " (pr-str bad)
                      " must surface :rf.error/cookie-invalid-name"))
             (is (= bad (:name (ex-data t)))
-                (str "ex-data must carry the offending :name value"))))))))
+                "ex-data must carry the offending :name value")))))))
 
 ;; ===========================================================================
 ;; ssr-handler — happy path (Ring-level smoke)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -164,7 +164,34 @@
         (is (str/starts-with?
               (ssr-ring/cookie->set-cookie-header {:name ok :value "v"})
               (str ok "="))
-            (str "valid name " (pr-str ok) " should serialise"))))))
+            (str "valid name " (pr-str ok) " should serialise"))))
+
+    (testing "keyword / symbol names are coerced via clojure.core/name"
+      (doseq [named [:session 'session :data-1.2.3]]
+        (is (str/starts-with?
+              (ssr-ring/cookie->set-cookie-header {:name named :value "v"})
+              (str (clojure.core/name named) "="))
+            (str "Named cookie name " (pr-str named) " should serialise"))))
+
+    (testing "rf2-d95o1y — non-string / non-Named :name throws a STRUCTURED
+              :rf.error/cookie-invalid-name (not a raw ClassCastException)"
+      (doseq [bad [42 3.14 [] [1 2 3] {} {:k 1} #{1 2} true]]
+        (let [t (try
+                  (ssr-ring/cookie->set-cookie-header {:name bad :value "v"})
+                  ::no-throw
+                  (catch clojure.lang.ExceptionInfo e e)
+                  (catch Throwable e e))]
+          (is (instance? clojure.lang.ExceptionInfo t)
+              (str "non-Named name " (pr-str bad)
+                   " must throw an ex-info, not a raw host exception; got "
+                   (if (instance? Throwable t) (class t) t)))
+          (when (instance? clojure.lang.ExceptionInfo t)
+            (is (= :rf.error/cookie-invalid-name
+                   (:rf.error/id (ex-data t)))
+                (str "non-Named name " (pr-str bad)
+                     " must surface :rf.error/cookie-invalid-name"))
+            (is (= bad (:name (ex-data t)))
+                (str "ex-data must carry the offending :name value"))))))))
 
 ;; ===========================================================================
 ;; ssr-handler — happy path (Ring-level smoke)


### PR DESCRIPTION
Three P3 correctness-review findings across three disjoint slices. Each was verified REAL against source before fixing; each fix carries a verify-by-revert proof.

## rf2-d95o1y (ssr-ring) — cookie :name leaked raw exceptions for non-Named values

`validate-cookie-name!` (`ssr-ring/.../cookie.clj`) called `(clojure.core/name n)` before any type guard, so a non-Named/non-string `:name` (e.g. `42`, `[]`, `{}`) threw a raw `ClassCastException` with nil ex-data instead of the documented `:rf.error/cookie-invalid-name`. A malformed name could reach `:on-error`/adapter code as a generic host exception.

Fix: type-guard `:name` (string or `clojure.lang.Named`) BEFORE coercion; reject unsupported types loudly through the same structured error id with `:name`/`:type` ex-data. Reuse the validated name string for the wire form so the guard cannot be skipped. Added regression coverage for numeric/float/collection/set/boolean names (asserting an ex-info with `:rf.error/cookie-invalid-name`, not a raw throwable) plus a keyword/symbol coercion guard.

## rf2-kzhcv3 (security) — fail-closed hydration corpus missed :rf/runtime-db

The cross-surface fail-closed hydration invariant (`security/.../fail_closed_invariant_security_cljs_test.cljc`) only exercised present-but-non-map `:rf/app-db` slices. EP-0001 (rf2-vzld77/rf2-g00l2t) made `:rf/runtime-db` an equally load-bearing frame-state slice that the production guard (`ssr.hydrate/malformed-hydration-payload!`) rejects, so a regression dropping the runtime-db branch slipped past this security gate.

Fix: extend the corpus + the property test with present-but-non-map `:rf/runtime-db` cases (paired with a VALID `:rf/app-db` to prove the WHOLE payload rejects, not partial-installs), and add a coherent-frame-state test that drives a seeded `:rf.db/runtime` coeffect and asserts a malformed runtime-db leaves BOTH `:db` and `:rf.db/runtime` unchanged. Verify-by-revert: removing the production runtime-db branch turns 20 assertions RED (previously stayed green). Test-only change; no production code touched.

## rf2-p8xl35 (scripts) — waitForHttpReady path assertion was non-binding

The `waitForHttpReady probes the supplied host + path` test (`scripts/_local-browser-harness.test.cjs`) only asserted `ready === true` against a server that 404s every non-base path. Because `probeHttp` resolves ready on ANY HTTP status (liveness, not 2xx), a regression hard-coding `/` instead of forwarding `opts.path` would still get a 404, still report ready, and the test would stay green — re-opening the XRAY_FEATURE_GATE_BASE_URL base-path regression class (rf2-rcepku) without coverage.

Fix: record every requested `req.url` in the local server and assert the caller-supplied `basePath` was probed and a bare `/` was not. Verify-by-revert: hard-coding `path = '/'` in `probeHttp` now turns this test RED (previously stayed green). Implementation unchanged (it already forwards `opts.path` correctly — the gap was test quality).

## Quality gates (all green)

- ssr-ring JVM: 157 tests / 724 assertions, 0 failures
- security JVM: 86 tests / 637 assertions, 0 failures
- ssr JVM (touched-and-restored hydrate.cljc): 358 tests / 1437 assertions, 0 failures
- Full JVM implementation sweep (`test-jvm-implementation.sh`): PASS (all artefacts)
- CLJS suite (`npm run test:cljs`): 7955 tests / 36600 assertions, 0 failures
- scripts harness (`node _local-browser-harness.test.cjs`): 24 passed; script-spawn-policy: 119 passed
- clj-kondo: 0 errors; splint: no errors (warnings only, matching established file style)
- `test:elision` skipped: the security change is test-only and does not touch redaction (per the bead's conditional)