### PR TITLE
fix(examples/reagent): seed settings draft on mount not render so field edits survive re-render (rf2-o5ok6a)

### DIFF
--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -115,11 +115,6 @@
             [:span.attribution "An interactive learning project from Thinkster."
              " Code & design licensed under MIT."]]])
 
-(reg-view settings-mount []
-  ;; The settings page seeds its draft on mount (the route is auth-guarded).
-  (let [_ (dispatch [:settings/load])]
-    [settings/settings-page]))
-
 (reg-view ^{:doc "Confirm dialog shown when a `:can-leave` guard blocks a
                    navigation (e.g. the editor with a dirty draft). Reads the
                    blocked navigation off the `:rf/pending-navigation` sub
@@ -154,7 +149,7 @@
      :realworld.editor/edit   [editor/editor-page]
      :realworld.profile/show      [views/profile-page]
      :realworld.profile/favorites [views/profile-page]
-     :realworld.user/settings [settings-mount]
+     :realworld.user/settings [settings/settings-page]
      [not-found-page])
    [footer]])
 

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -124,8 +124,14 @@
   {:doc "Register page." :path "/register"})
 
 (rf/reg-route :realworld.user/settings
-  {:doc  "User settings page (requires auth)."
+  {:doc  "User settings page (requires auth). `:on-match` seeds the settings
+          draft from the authenticated user ONCE on route entry — the same
+          route-entry seam the `:rf.http/managed` sibling uses (its settings
+          route also `:on-match [[:settings/load]]`). The settings view is then
+          a pure Form-1 that NEVER dispatches out of band, so a re-render can no
+          longer re-run the load and clobber in-progress field edits."
    :path "/settings"
+   :on-match [[:settings/load]]
    :tags #{:requires-auth}})
 
 (rf/reg-route :realworld.editor/new

--- a/examples/reagent/realworld_resources/settings.cljs
+++ b/examples/reagent/realworld_resources/settings.cljs
@@ -62,9 +62,11 @@
 ;; ============================================================================
 
 (rf/reg-event :settings/load
-  {:doc "Seed the settings draft from the authenticated user. Dispatched from
-         the settings view on mount (the page is auth-guarded, so a user is
-         always present here)."}
+  {:doc "Seed the settings draft from the authenticated user. Dispatched ONCE on
+         route entry via the settings route's `:on-match` (the page is
+         auth-guarded, so a user is always present here). Seeding on route entry
+         — not from the view's render — is what keeps the form a pure Form-1: a
+         re-render never re-runs the load, so in-progress field edits survive."}
   (fn [{:keys [db]} _]
     {:db (assoc-in db [:settings-form :draft] (draft-from-user (get-in db [:auth :user])))}))
 


### PR DESCRIPTION
## What

The `realworld_resources` settings page seeded its editable draft via a **render-time dispatch**: `core.cljs` wrapped the form in a `settings-mount` `reg-view` whose RENDER body did `(dispatch [:settings/load])`. `:settings/load` rebuilds `[:settings-form :draft]` from `[:auth :user]`.

Because `:settings/edit-field` writes the **same** `[:settings-form :draft]` and the form reads it through the `:settings/draft` sub, **every re-render re-ran the load and clobbered in-progress field edits** — a user typing in settings lost their input on any re-render (P1 correctness, rf2-o5ok6a).

It was also an anti-pattern: dispatching from a Form-1 render directly contradicts the view's own documented contract (`settings.cljs:112-122` — "a pure function of subs that never dispatches out of band"). Examples must be idiomatic re-frame2.

## Fix

Move the seed to **route entry** via the settings route's `:on-match [[:settings/load]]` — the exact route-entry seam the `:rf.http/managed` sibling (`examples/reagent/realworld/routing.cljs:77-81`) already uses for its settings route. Then render `settings/settings-page` directly in the route switch and delete the `settings-mount` render-dispatch wrapper.

- `routing.cljs` — add `:on-match [[:settings/load]]` to `:realworld.user/settings`.
- `core.cljs` — delete the `settings-mount` wrapper view; route switch now renders `[settings/settings-page]` directly.
- `settings.cljs` — `:settings/load` docstring updated to describe the route-entry seam (the event body is unchanged).

## Why field edits now survive re-render

`:settings/load` fires **once per navigation** (route entry), not per render. The view is now a genuine pure Form-1 with no `dispatch` in its body, so a re-render reads the latest `[:settings-form :draft]` (including edits) and never re-runs the load. Edits persist.

## Gates

- `node scripts/check-examples-compile.cjs` — all 44 example builds compile with **zero warnings**, including `:examples/realworld-resources` (re-confirmed after rebase onto latest `origin/main`).
- `clj-kondo` on the three changed files — **0 errors, 0 new warnings** (the one `realworld-resources.http unused-require` warning is pre-existing on `origin/main`; the `:require` list was not touched).
- Examples are test-free (rf2-8cevm) — no `*.spec.cjs` added under `examples/`.

Fixes rf2-o5ok6a.