### PR TITLE
fix(examples): _shared warning token + reagent-slim gate entry (rf2-ihruwa, rf2-pe4u0g)

### DIFF
--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -315,8 +315,10 @@ The exception is bounded by four conditions, all of which must hold:
    NOT be co-required into one runtime.** Stock builds as
    `:examples/counter` (`:init-fn counter.core/run`); slim builds as
    `:examples/counter-slim-and-fast`
-   (`:init-fn counter-slim-and-fast.core/run`) — two independent `:browser`
-   modules with distinct build-ids, init-fns, and namespaces. They never
+   (`:init-fn counter-slim-and-fast.bundle-isolation-entry/run`, the
+   gate-owned entry that delegates to the teaching `core/boot!`) — two
+   independent `:browser` modules with distinct build-ids, init-fns, and
+   namespaces. They never
    share a JS runtime, so the identical registry ids never collide. The
    collision is purely theoretical *and already prevented by the build
    split*; it is not a risk the convention needs to guard against here.

--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -65,7 +65,14 @@
   --ex-accent-deep: #9C4F0E;  /* AA-safe text / filled-button background */
   --ex-accent-soft: #E5A23D;  /* warm gold — secondary highlight */
   --ex-success:     #4A7340;  /* forest green for connected/ok states */
-  --ex-warn:        #C49419;  /* warm amber for warnings */
+  /* --ex-warn (#C49419) is a DECORATIVE/large-fill amber only: as normal-text
+     foreground on the shared light surfaces it is ≤2.76:1 (sub-AA — 2.50:1 on
+     paper, 2.24:1 on sunken). Use --ex-warn-deep (#7E5F10) for warning TEXT and
+     for warning UI-component borders — it clears AA at ≥4.82:1 on every shipped
+     surface (5.38:1 paper, 4.82:1 sunken, 5.95:1 white) and the 3:1 non-text bar
+     (rf2-ihruwa). */
+  --ex-warn:        #C49419;  /* warm amber — decorative fill / accent only */
+  --ex-warn-deep:   #7E5F10;  /* AA-safe warning text / border */
   --ex-error:       #B23A2E;  /* warm oxblood for errors */
   --ex-info:        #3A6BA0;  /* warm slate-blue for informational */
 
@@ -107,7 +114,8 @@
   --hx-rule:         var(--ex-rule);
   --hx-rule-strong:  var(--ex-rule-strong);
   --hx-green:        var(--ex-success);
-  --hx-amber:        var(--ex-warn);
+  --hx-amber:        var(--ex-warn);       /* decorative warning fill/accent */
+  --hx-amber-deep:   var(--ex-warn-deep);  /* AA-safe warning text/border */
   --hx-red:          var(--ex-error);
   --hx-cyan:         var(--ex-info);
   --hx-mono:         var(--ex-mono);

--- a/examples/helix/process_monitor_helix/index.html
+++ b/examples/helix/process_monitor_helix/index.html
@@ -61,7 +61,10 @@
     .pm-tile-good { border-left: 3px solid var(--hx-green); }
     .pm-tile-good .pm-tile-value { color: var(--hx-green); }
     .pm-tile-warn { border-left: 3px solid var(--hx-amber); }
-    .pm-tile-warn .pm-tile-value { color: var(--hx-amber); }
+    /* Warning value is TEXT on the light --hx-bg-surface tile — use the AA-safe
+       deep amber (--hx-amber-deep), not decorative --hx-amber (sub-AA as text).
+       The left border above stays decorative amber. (rf2-ihruwa) */
+    .pm-tile-warn .pm-tile-value { color: var(--hx-amber-deep); }
     .pm-tile-bad  { border-left: 3px solid var(--hx-red); }
     .pm-tile-bad  .pm-tile-value { color: var(--hx-red); }
 
@@ -118,7 +121,10 @@
     }
     .pm-chip:hover { color: var(--hx-ink); border-color: var(--hx-ink-muted); }
     .pm-chip-info.is-on  { color: var(--hx-cyan);    border-color: var(--hx-cyan); }
-    .pm-chip-warn.is-on  { color: var(--hx-amber);   border-color: var(--hx-amber); }
+    /* Active warn chip carries label TEXT + a state border on the light
+       --hx-bg-surface pane-head — use AA-safe --hx-amber-deep so both the text
+       (≥4.5:1) and the UI-component border (≥3:1) clear WCAG. (rf2-ihruwa) */
+    .pm-chip-warn.is-on  { color: var(--hx-amber-deep); border-color: var(--hx-amber-deep); }
     .pm-chip-error.is-on { color: var(--hx-red);     border-color: var(--hx-red); }
 
     .pm-list {
@@ -185,7 +191,7 @@
       letter-spacing: 0.06em;
     }
     .pm-log-level-info  { color: var(--hx-cyan); }
-    .pm-log-level-warn  { color: var(--hx-amber); }
+    .pm-log-level-warn  { color: var(--hx-amber-deep); }  /* warn log level is TEXT on paper — AA-safe deep amber (rf2-ihruwa) */
     .pm-log-level-error { color: var(--hx-red); }
     .pm-log-msg { color: var(--hx-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 

--- a/examples/reagent-slim/counter_slim_and_fast/README.md
+++ b/examples/reagent-slim/counter_slim_and_fast/README.md
@@ -30,11 +30,13 @@ the teaching source so it does not bleed into `core.cljs`:
   so the gate's non-vacuity contract has signal.
 - The build's `:init-fn` is the gate-owned entrypoint
   [`bundle_isolation_entry.cljs`](bundle_isolation_entry.cljs), **not**
-  `core/run`. It boots the same app as `core/run` and weaves the fixture
-  exercise in at the one point its ordering needs (under the frame scope,
-  before the client mount). This keeps `core.cljs` free of harness
+  `core/run`. It does not re-copy the boot: both `core/run` and the entry
+  call the single shared `core/boot!` helper, so the two paths cannot drift.
+  The entry passes `boot!` an `on-frame` pre-mount hook that weaves the
+  fixture exercise in at the one point its ordering needs (under the frame
+  scope, before the client mount). This keeps `core.cljs` free of harness
   mechanics: `core/run` is plain, idiomatic re-frame2 with nothing but
-  the example's own dataflow (rf2-vyl0vt).
+  the example's own dataflow (rf2-vyl0vt, rf2-pe4u0g).
 
 A reader studying the example can ignore both gate files and read
 `core.cljs`.
@@ -75,8 +77,8 @@ prefixed first.
 
 ```
 counter_slim_and_fast/
-  core.cljs                          the teaching example: events/subs/views + mount
-  bundle_isolation_entry.cljs        gate-owned :init-fn — boots core + the SSR exercise (not app practice)
+  core.cljs                          the teaching example: events/subs/views + the shared boot! + mount
+  bundle_isolation_entry.cljs        gate-owned :init-fn — calls core/boot! with the SSR-exercise hook (not app practice)
   bundle_isolation_fixture.cljs      SSR/sentinel proof for the gate (not app practice)
   index.html                         minimal host page
   README.md                          this file

--- a/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/bundle_isolation_entry.cljs
@@ -15,38 +15,29 @@
    `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` and the
    slim adapter's IMPL-SPEC §1.4 + §1.8 + §8 — deliberately not duplicated.
 
-   The boot mirrors `counter-slim-and-fast.core/run` exactly (same adapter,
-   frame, boot dispatch, lazy client mount), with the one fixture concern
-   woven in: the pure-CLJS `render-to-static-markup` exercise runs under the
-   frame scope, before the client mount, so the static render's orphaned SSR
-   subscription is torn down (fixture/prove-pure-cljs-ssr! clears the
-   sub-cache) and the browser mount below owns the only live
-   `[:counter/value]` reaction."
-  (:require [reagent2.dom.client                            :as rdc]
-            [re-frame.core                                  :as rf]
-            [re-frame.views]
-            [re-frame.adapter.reagent-slim                  :as reagent-slim-adapter]
+   The boot is NOT re-copied here: this entry calls the shared
+   `counter-slim-and-fast.core/boot!` (the single source of truth for the
+   boot — same adapter, frame, boot dispatch, lazy client mount), so the
+   gate-owned path cannot drift from the teaching `core/run`. The one fixture
+   concern is the `on-frame` pre-mount hook `boot!` accepts: the pure-CLJS
+   `render-to-static-markup` exercise runs under the frame scope, before the
+   client mount, so the static render's orphaned SSR subscription is torn down
+   (fixture/prove-pure-cljs-ssr! clears the sub-cache) and the browser mount
+   owns the only live `[:counter/value]` reaction."
+  (:require [re-frame.views]
             [counter-slim-and-fast.core                     :as core]
             [counter-slim-and-fast.bundle-isolation-fixture :as fixture]))
 
 (defn run []
-  ;; Same boot as core/run — init the slim adapter, register the app frame,
-  ;; dispatch the boot event under the frame scope — plus the fixture's
-  ;; pure-CLJS SSR exercise woven in at the one point its ordering requires.
-  (rf/init! reagent-slim-adapter/adapter)
-  (rf/reg-frame core/app-frame {})
-  (rf/with-frame core/app-frame
-    (rf/dispatch-sync [:counter/initialise])
-    ;; Bundle-isolation fixture, not app practice. The static render derefs
-    ;; `[:counter/value]`, so it runs inside the frame scope established above;
-    ;; it caches an orphaned reaction with no component to unmount it, so the
-    ;; fixture clears the sub-cache in a `finally`. Running it here — before the
-    ;; client mount — means the browser mount below starts from a clean
-    ;; sub-cache and owns the only live `[:counter/value]` reaction.
-    (fixture/prove-pure-cljs-ssr! [core/counter-app]))
-  (when (exists? js/document)
-    (when-not @core/react-root
-      (reset! core/react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @core/react-root
-                [rf/frame-provider-existing {:frame core/app-frame}
-                 [core/counter-app]])))
+  ;; Delegate to the ONE canonical boot in `core/boot!` (init the slim adapter,
+  ;; register the app frame, dispatch the boot event under the frame scope, then
+  ;; lazily mount). There is no copied boot sequence to drift from `core/run`.
+  ;; The only fixture concern is woven in via the `on-frame` pre-mount hook:
+  ;;
+  ;; Bundle-isolation fixture, not app practice. The static render derefs
+  ;; `[:counter/value]`, so it must run inside the frame scope `boot!` opens; it
+  ;; caches an orphaned reaction with no component to unmount it, so the fixture
+  ;; clears the sub-cache in a `finally`. `boot!` runs the hook before the client
+  ;; mount, so the browser mount starts from a clean sub-cache and owns the only
+  ;; live `[:counter/value]` reaction.
+  (core/boot! #(fixture/prove-pure-cljs-ssr! [core/counter-app])))

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -14,9 +14,11 @@
    of this teaching surface entirely, behind the gate-owned entrypoint
    `counter-slim-and-fast.bundle-isolation-entry` (which the
    `:examples/counter-slim-and-fast` build uses as its `:init-fn`). That
-   entry boots the SAME app from `run` below and additionally exercises
-   the pure-CLJS SSR path the gate inspects; nothing about that fixture
-   plumbing leaks into this namespace."
+   entry boots the SAME app through the shared `boot!` helper below — it
+   does not re-copy the boot sequence — and passes a pre-mount hook that
+   exercises the pure-CLJS SSR path the gate inspects; nothing about that
+   fixture plumbing leaks into this namespace, and the two boot paths
+   cannot drift because there is only one (rf2-pe4u0g)."
   (:require [reagent2.dom.client                :as rdc]
             [re-frame.core                      :as rf]
             [re-frame.views]
@@ -77,16 +79,37 @@
 ;; the canonical mount in examples/reagent/counter/core.cljs.
 (def app-frame :rf/default)
 
+(defn boot!
+  "The one canonical boot sequence for this example: install the slim
+   adapter, register the app frame, dispatch the boot event under the frame
+   scope, then lazily mount `counter-app` into `#app` under a frame-provider.
+
+   `boot!` is the single source of truth for the boot so the teaching path
+   (`run` below) and the gate-owned path
+   (`counter-slim-and-fast.bundle-isolation-entry/run`) cannot drift: both
+   call this fn, so a future EP/API boot change is made in one place.
+
+   `on-frame` is an optional thunk run inside the `with-frame` scope, after
+   the boot dispatch and before the client mount. The teaching `run` passes
+   nothing; only the bundle-isolation entry uses it, to weave its pure-CLJS
+   SSR exercise into the frame scope at the one point its ordering requires.
+   Keeping the seam here — rather than re-copying the boot in the entry — is
+   what keeps `core` free of fixture plumbing while preventing drift."
+  ([] (boot! nil))
+  ([on-frame]
+   ;; Slim adapter — the difference from `examples/reagent/counter` is
+   ;; right here. Same `rf/init!` signature; different adapter Var.
+   (rf/init! reagent-slim-adapter/adapter)
+   (rf/reg-frame app-frame {})
+   (rf/with-frame app-frame
+     (rf/dispatch-sync [:counter/initialise])
+     (when on-frame (on-frame)))
+   (when (exists? js/document)
+     (when-not @react-root
+       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+     (rdc/render @react-root
+                 [rf/frame-provider-existing {:frame app-frame}
+                  [counter-app]]))))
+
 (defn run []
-  ;; Slim adapter — the difference from `examples/reagent/counter` is
-  ;; right here. Same `rf/init!` signature; different adapter Var.
-  (rf/init! reagent-slim-adapter/adapter)
-  (rf/reg-frame app-frame {})
-  (rf/with-frame app-frame
-    (rf/dispatch-sync [:counter/initialise]))
-  (when (exists? js/document)
-    (when-not @react-root
-      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root
-                [rf/frame-provider-existing {:frame app-frame}
-                 [counter-app]])))
+  (boot!))

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -630,6 +630,15 @@ function sharedContrastContract(tokens) {
   return [
     // Normal text / link / muted / skeleton foregrounds on every paper surface.
     { fg: '--ex-accent-deep', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'link / value text' },
+    // Warning TEXT foreground. --ex-warn (#C49419) is decorative-fill only
+    // (≤2.76:1 as text); the AA-safe text/border token is --ex-warn-deep, and
+    // the process_monitor_helix example consumes it (via --hx-amber-deep) for
+    // warn tile-value / log-level / active-chip text. The decorative --ex-warn
+    // is intentionally NOT listed (it ships only as borders / meter / dot fill).
+    { fg: '--ex-warn-deep', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'warning text' },
+    // --ex-warn-deep also carries the active warn-chip UI-component border on a
+    // light pane-head surface — it must clear the 3:1 non-text bar there too.
+    { fg: '--ex-warn-deep', bgs: surfaces, min: WCAG_NON_TEXT, role: 'warning border' },
     { fg: '--ex-ink-faint', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'muted / skeleton text' },
     { fg: '--ex-ink-muted', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'secondary text' },
     { fg: '--ex-ink', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'body text' },

--- a/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
+++ b/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
@@ -356,8 +356,10 @@ function main() {
       console.error('Contract 4 failed: the slim SSR path is NOT present in the bundle, so');
       console.error('Contract 3 (react-dom/server absence) is a VACUOUS S3-005 proof — the');
       console.error('bundle no longer exercises SSR at all. Likely cause: the');
-      console.error('`(rds/render-to-static-markup [counter-app])` boot exercise in');
-      console.error('examples/reagent-slim/counter_slim_and_fast/core.cljs was removed or');
+      console.error('`(rds/render-to-static-markup ...)` SSR exercise in');
+      console.error('examples/reagent-slim/counter_slim_and_fast/bundle_isolation_fixture.cljs');
+      console.error('(prove-pure-cljs-ssr!, woven into boot via the bundle_isolation_entry');
+      console.error('on-frame hook) was removed or');
       console.error('let get DCE-eliminated (the host-global write is the DCE anchor — keep');
       console.error('it writing the prerender result, not a literal). If the SSR exercise IS');
       console.error('still present and intentional, a serializer sentinel string may have');


### PR DESCRIPTION
Fixes two correctness-review findings in the examples tree. Both verified against source before fixing.

## rf2-ihruwa (P2, examples/_shared) — verified real

The shared `--ex-warn` (#C49419) is a decorative-fill amber: as foreground **text** on the shipped light surfaces it is 2.24–2.76:1, well below WCAG AA 4.5:1. `process_monitor_helix` consumed it (via the `--hx-amber` alias) as warning text in three places — tile value, active warn chip, and log level — plus the active-chip state border. The asset gate could not see this because its contrast contract only covered the token roles `style.css` itself uses, not design-led inline CSS.

- Add `--ex-warn-deep` (#7E5F10) + `--hx-amber-deep` alias: an AA-safe warning text/border token clearing ≥4.82:1 on every shipped surface (5.38 paper, 4.82 sunken, 5.95 white) and the 3:1 non-text bar. `--ex-warn` stays for decorative fills (tile border, meter bar, dot glow).
- Switch the three Helix warn-text roles + the active-chip border to the deep token; decorative amber fills unchanged.
- Extend `sharedContrastContract` with `--ex-warn-deep` foreground (AA) + border (non-text) rows so a sub-AA warn token now turns the asset gate **RED** (verified: a simulated regression fires all six teeth).

## rf2-pe4u0g (P3, examples/reagent-slim) — verified real

The slim counter had two boot paths that had to stay behaviourally identical but were hand-maintained: `core/run` (teaching) and `bundle-isolation-entry/run` (the build's gate-owned `:init-fn`). The entry copied the boot sequence verbatim, so a future boot change could drift the two while the gate stayed green.

- Factor a single canonical `core/boot!` (adapter init, reg-frame, boot dispatch under `with-frame`, lazy frame-provider mount) with an optional `on-frame` pre-mount thunk. `core/run` is now `(boot!)`.
- `bundle-isolation-entry/run` calls `core/boot!` and passes the pure-CLJS SSR exercise as the `on-frame` hook — no copied boot, so the paths cannot drift.
- Stale-contract cleanup on the same surface: `examples/TESTING.md` `:init-fn` reference and the gate's Contract-4 diagnostic (pointed at `core.cljs`; the SSR exercise lives in `bundle_isolation_fixture.cljs`) corrected, README updated to describe the shared-`boot!` delegation.

## Quality gates (all green)
- `clj-kondo` on changed cljs: 0 errors (1 pre-existing unused-`db` warning, untouched by this change)
- asset gate + its test suite (`check-examples-assets` + `.test.cjs`): pass, including the new `--ex-warn-deep` LIVE contract rows
- `test:reagent-slim:bundle-isolation`: `:advanced` release build of the refactored slim entry — 0 warnings, all 4 contracts pass incl. Contract 4 non-vacuity (SSR path stays alive through `boot!`'s hook)
- `test:examples` (3 adapter smokes: Reagent/UIx/Helix): 0 failures
- `test:examples-compile`: all 44 declared example builds compile with 0 warnings — confirms every `_shared` consumer (incl. `process-monitor-helix`) still builds