### PR TITLE
fix(examples+skills): uix retry clears error + migration M-11 :rf/default claim + examples-asset css-url gate (rf2-qx9b1y, rf2-08n6p6, rf2-35lfqo)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -258,8 +258,14 @@
                                    :action :lock-account}]}}
 
     :error-shown
+    ;; Direct retry from :error-shown re-enters :submitting and must clear the
+    ;; prior `:error` first — otherwise the obsolete failure message stays
+    ;; visible (the view renders `:auth.login/error` whenever non-nil) as if it
+    ;; still applied to the request now in flight. Same `:clear-error` action as
+    ;; the :idle entry transition.
     {:on {:auth.login/dismiss {:target :idle}
-          :auth.login/submit  {:target :submitting}}}
+          :auth.login/submit  {:target :submitting
+                               :action :clear-error}}}
 
     :authed
     ;; :auth/authenticated tag — the banner swaps to "Welcome!" once

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -363,8 +363,14 @@
                                      :action :lock-account}]}}
 
       :error-shown
+      ;; Direct retry from :error-shown re-enters :submitting and must clear the
+      ;; prior `:error` first — otherwise the obsolete failure message stays
+      ;; visible (the view renders `:auth.login/error` whenever non-nil) as if it
+      ;; still applied to the request now in flight. Same `:clear-error` action
+      ;; as the :idle entry transition.
       {:on {:auth.login/dismiss {:target :idle}
-            :auth.login/submit  {:target :submitting}}}
+            :auth.login/submit  {:target :submitting
+                                 :action :clear-error}}}
 
       :authed
       ;; :auth/authenticated tag — the banner swaps to "Welcome!" once

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -692,11 +692,44 @@ function checkCssNetworkUrls(css, displayRef, errors, externalAllowlist = EXTERN
   }
 }
 
+// Resolve every LOCAL `url(...)` reference inside a CSS source against the CSS
+// file's own directory and report any that does not resolve to a real file
+// (rf2-35lfqo). A broken local image / font / cursor / mask referenced from a
+// stylesheet (`background-image: url('missing-local.png')`,
+// `@font-face { src: url(fonts/gone.woff2) }`, `cursor: url(img/cursor.png)`)
+// would otherwise pass the asset gate silently: extractCssUrls already surfaces
+// these targets and the network-url policy SKIPS them (they fire no network
+// request), but nothing checked that the file is actually present. Network
+// refs (http(s)/protocol-relative) are the network-url policy's job and are
+// skipped here; `data:` URIs (inlined, no fetch) and `url(#fragment)`
+// same-document paint refs (SVG filter/gradient) are exempt. CSS urls resolve
+// relative to the stylesheet that declares them, NOT the page — so the base is
+// the CSS file's own directory.
+function checkCssLocalUrls(io, css, cssAbsPath, displayRef, errors) {
+  const cssDir = path.dirname(cssAbsPath);
+  for (const raw of extractCssUrls(css)) {
+    // isExternalRef is true for any scheme (data:, http:, …), protocol-relative
+    // `//`, and `#fragment` — every NON-local-file case. A local relative
+    // reference is the only thing left to resolve on disk.
+    if (isExternalRef(raw)) continue;
+    const cleaned = raw.split(/[?#]/)[0].trim(); // drop ?query / #frag suffixes
+    if (!cleaned) continue; // a bare `url(#frag)` normalised to empty — paint ref
+    const target = path.resolve(cssDir, cleaned);
+    if (!io.existsSync(target)) {
+      errors.push(
+        `${displayRef}: CSS url('${raw}') does not resolve to a file ` +
+          `(looked for ${path.relative(REPO_ROOT, target).split(path.sep).join('/')})`,
+      );
+    }
+  }
+}
+
 // Resolve + check a single local CSS file's @import targets, recursively.
 // Records an error for any local import that does not resolve to a real file,
 // for any EXTERNAL @import (http/https/protocol-relative) not present in the
-// external-import allowlist (rf2-vou5mm), and for any remote `url(...)` fetch
-// in the CSS body (rf2-o18ava).
+// external-import allowlist (rf2-vou5mm), for any remote `url(...)` fetch
+// in the CSS body (rf2-o18ava), and for any missing LOCAL `url(...)` asset
+// (rf2-35lfqo).
 function checkCssImports(io, cssAbsPath, displayRef, errors, seen, externalAllowlist = EXTERNAL_IMPORT_ALLOWLIST) {
   if (seen.has(cssAbsPath)) return;
   seen.add(cssAbsPath);
@@ -704,6 +737,8 @@ function checkCssImports(io, cssAbsPath, displayRef, errors, seen, externalAllow
   if (css == null) return; // a missing CSS file is reported by its referrer
   // Remote url() fetches (font-face/background/mask/cursor/…) — rf2-o18ava.
   checkCssNetworkUrls(css, displayRef, errors, externalAllowlist);
+  // Missing LOCAL url() assets (font-face/background/mask/cursor/…) — rf2-35lfqo.
+  checkCssLocalUrls(io, css, cssAbsPath, displayRef, errors);
   for (const imp of extractCssImports(css)) {
     if (isExternalRef(imp)) {
       // An external CSS @import pulls a third-party network dependency into

--- a/examples/scripts/serve-example.cjs
+++ b/examples/scripts/serve-example.cjs
@@ -80,6 +80,41 @@ const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
 const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
 const READY_TIMEOUT_MS = 30000;
 
+// Decide the dev-runner's process exit code from the observed child outcomes
+// (rf2-35lfqo). PURE — no I/O, no process state — so it is unit-testable in
+// isolation. The runner long-runs until the user interrupts it (Ctrl+C), so a
+// shutdown the USER asked for is success; an UNEXPECTED child crash is a
+// failure the runner must surface with a non-zero exit (the prior code always
+// returned 0, false-greening a `shadow-cljs watch` that died on a compile/JVM
+// error or an http-server that fell over). Each child outcome is a
+// `{ code, signal }` record (a process 'exit' event's args) or null if that
+// child was never started (e.g. no watch in --no-watch mode).
+//
+//   - `interrupted` true  => the user stopped the runner (SIGINT/SIGTERM). A
+//     child exiting via the SAME terminating signal is part of that teardown,
+//     not a crash — success.
+//   - a child that exited cleanly (code 0, or code null because it was killed
+//     by our own teardown signal) is not a failure.
+//   - any other child exit — a non-zero code, or a signal kill that was NOT our
+//     teardown — is an unexpected crash; the runner exits non-zero.
+//
+// Returns 0 on clean shutdown, 1 on any unexpected child failure.
+function decideRunnerExit({ server = null, watch = null, interrupted = false } = {}) {
+  const teardownSignals = new Set(['SIGINT', 'SIGTERM']);
+  const childFailed = (outcome) => {
+    if (!outcome) return false; // child never started — nothing to judge
+    const { code = null, signal = null } = outcome;
+    if (typeof code === 'number') return code !== 0; // explicit exit code wins
+    if (signal != null) {
+      // Killed by a signal. Our own teardown (or a user Ctrl+C that propagated)
+      // is expected; any other signal kill is a crash.
+      return !(interrupted && teardownSignals.has(signal));
+    }
+    return false; // code null + no signal => clean exit
+  };
+  return childFailed(server) || childFailed(watch) ? 1 : 0;
+}
+
 function parseArgs(argv) {
   let build = '';
   let watch = true;
@@ -189,13 +224,44 @@ async function main() {
   // so the page's assets are present from the start.
   stageExample(entry);
 
+  // Record the observed child outcomes so the runner's own exit code reflects
+  // an unexpected crash rather than always returning 0 (rf2-35lfqo). `interrupted`
+  // flips true once a teardown signal lands so a signal-killed child during
+  // Ctrl+C is read as an expected shutdown, not a crash.
+  let interrupted = false;
+  for (const sig of ['SIGINT', 'SIGTERM']) {
+    process.once(sig, () => { interrupted = true; });
+  }
+  let watchOutcome = null;
+  let serverOutcome = null;
+  // Tracks server reachability so a child crash aborts the readiness wait.
+  // Declared here (before the watch handler) so the watch-exit listener can
+  // flip it; the server-exit listener below also sets it.
+  let serverDown = false;
+
   if (watch) {
-    cleanup.trackProcess(
+    const watchProc = cleanup.trackProcess(
       spawnHarnessProcess(process.execPath, [shadowRunner, 'watch', entry.build], {
         cwd: IMPL_ROOT,
         stdio: 'inherit',
       }),
     );
+    // A `shadow-cljs watch` that dies unexpectedly (compile loop crash, JVM
+    // OOM, killed) must NOT leave the runner happily serving a now-frozen
+    // bundle and exiting 0. Record its outcome, abort the readiness wait, and
+    // tear the tree down (stopping http-server, which resolves the main wait)
+    // so the runner returns non-zero via decideRunnerExit.
+    watchProc.on('exit', (code, signal) => {
+      watchOutcome = { code, signal };
+      if (!interrupted && !(typeof code === 'number' && code === 0)) {
+        console.error(`shadow-cljs watch exited unexpectedly (code=${code}, signal=${signal}).`);
+        serverDown = true; // abort the readiness wait below if still pending
+        // Stop http-server too; the watch is the source of truth for a live
+        // build. cleanup() is idempotent and safe to call alongside the
+        // signal handlers.
+        cleanup.cleanup().catch(() => {});
+      }
+    });
   }
 
   // Serve the example's output dir on 127.0.0.1 (loopback-only — the dev
@@ -210,10 +276,10 @@ async function main() {
     ),
   );
 
-  let serverDown = false;
   server.on('exit', (code, signal) => {
     serverDown = true;
-    if (code !== 0 && code !== null) {
+    serverOutcome = { code, signal };
+    if (code !== 0 && code !== null && !interrupted) {
       console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
     }
   });
@@ -232,31 +298,37 @@ async function main() {
       '\n  Press Ctrl+C to stop.\n',
   );
 
-  // The watch + server run until interrupted; resolve only when the server
-  // exits (Ctrl+C is handled by the installed signal handlers, which tear the
-  // whole process tree down).
-  if (watch) {
-    await new Promise((resolve) => server.on('exit', resolve));
-    return 0;
-  }
+  // The watch + server run until interrupted; resolve when the server exits
+  // (Ctrl+C is handled by the installed signal handlers, which tear the whole
+  // process tree down). In watch mode an unexpected watch crash also tears the
+  // server down (see the watch 'exit' handler), so this resolves either way.
+  await new Promise((resolve) => {
+    if (serverDown) return resolve(); // already exited before we awaited
+    server.on('exit', resolve);
+  });
 
-  // --no-watch: keep serving until the server is stopped (Ctrl+C).
-  await new Promise((resolve) => server.on('exit', resolve));
-  return 0;
+  // Surface an unexpected child crash as a non-zero runner exit rather than the
+  // unconditional 0 the runner used to return (rf2-35lfqo).
+  return decideRunnerExit({ server: serverOutcome, watch: watchOutcome, interrupted });
 }
 
-main()
-  .then(async (code) => {
-    await cleanupAndExit(code);
-  })
-  .catch(async (err) => {
-    if (err && err.actionable) {
-      console.error(err.message);
-    } else {
-      console.error(err && err.stack ? err.stack : err);
-    }
-    await cleanupAndExit(1);
-  });
+// Only launch the runner when executed directly (`node serve-example.cjs …`).
+// When required as a module (the decideRunnerExit unit test), DON'T run main()
+// — just expose the pure helpers.
+if (require.main === module) {
+  main()
+    .then(async (code) => {
+      await cleanupAndExit(code);
+    })
+    .catch(async (err) => {
+      if (err && err.actionable) {
+        console.error(err.message);
+      } else {
+        console.error(err && err.stack ? err.stack : err);
+      }
+      await cleanupAndExit(1);
+    });
+}
 
 // The cleanup handle is created inside main(); for the top-level catch we
 // fall back to a plain exit (the in-main signal handlers already cover the
@@ -265,3 +337,5 @@ main()
 async function cleanupAndExit(code) {
   process.exit(code == null ? 1 : code);
 }
+
+module.exports = { decideRunnerExit, parseArgs };

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -230,8 +230,14 @@
                                    :action :lock-account}]}}
 
     :error-shown
+    ;; Direct retry from :error-shown re-enters :submitting and must clear the
+    ;; prior `:error` first — otherwise the obsolete failure message stays
+    ;; visible (the view renders `:auth.login/error` whenever non-nil) as if it
+    ;; still applied to the request now in flight. Same `:clear-error` action as
+    ;; the :idle entry transition.
     {:on {:auth.login/dismiss {:target :idle}
-          :auth.login/submit  {:target :submitting}}}
+          :auth.login/submit  {:target :submitting
+                               :action :clear-error}}}
 
     :authed
     ;; :auth/authenticated tag — the banner swaps to "Welcome!" once

--- a/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
@@ -49,6 +49,10 @@
   (get-in (rf/frame-state-value f)
           [:rf.db/runtime :rf.runtime/machines :snapshots :auth.login/flow :data]))
 
+(defn- machine-state [f]
+  (get-in (rf/frame-state-value f)
+          [:rf.db/runtime :rf.runtime/machines :snapshots :auth.login/flow :state]))
+
 (defn- collect-machine-data-traces!
   "Run `f` while collecting `:rf.error/schema-validation-failure` traces with
    `:where :machine-data`. Returns the captured (filtered) trace vector."
@@ -145,3 +149,39 @@
             "the string failure message committed into the machine's :data")
         (is (= 1 (:attempts (machine-data f)))
             "the attempt counter advanced (the transition committed)")))))
+
+;; ---------------------------------------------------------------------------
+;; (4) direct retry from :error-shown clears the prior :error (rf2-qx9b1y)
+;; ---------------------------------------------------------------------------
+
+(deftest retry-clears-prior-error
+  (testing "a direct retry from :error-shown clears the stale :error as the machine re-enters :submitting"
+    ;; First request: a synchronous failure lands the flow in :error-shown with
+    ;; a non-nil :error (the message the view renders).
+    (reg-sync-failure-override! :login.test/retry-failure
+                                {:status 401 :message "Invalid credentials."})
+    ;; Second request (the RETRY): a no-op managed-HTTP fx that issues NO reply,
+    ;; so the machine parks in :submitting and we can observe the :error slot
+    ;; while the request is still in flight.
+    (rf/reg-fx :login.test/retry-noop
+      {:platforms #{:client :server}}
+      (fn [_frame-ctx _args] nil))
+    (with-new-frame [f (frame/make-anon-frame-record! {})]
+      ;; Drive idle → submitting → error-shown (per-call override → failure).
+      (rf/dispatch-sync [:auth.login/flow [:auth.login/submit valid-creds]]
+                        {:frame        f
+                         :fx-overrides {:rf.http/managed :login.test/retry-failure}})
+      (is (= :error-shown (machine-state f))
+          "the failed login settled in :error-shown")
+      (is (= "Invalid credentials." (:error (machine-data f)))
+          "the prior failure message is visible in :error-shown")
+      ;; Resubmit directly from :error-shown with the no-op override so the
+      ;; machine parks in :submitting and the :error slot is observable
+      ;; mid-flight.
+      (rf/dispatch-sync [:auth.login/flow [:auth.login/submit valid-creds]]
+                        {:frame        f
+                         :fx-overrides {:rf.http/managed :login.test/retry-noop}})
+      (is (= :submitting (machine-state f))
+          "the retry re-entered :submitting (no reply issued by the no-op fx)")
+      (is (nil? (:error (machine-data f)))
+          "the :clear-error action cleared the stale error on the retry transition"))))

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -286,6 +286,84 @@ it('serve-example.cjs calls cleanStageDirs on the selected outDir BEFORE stageEx
   assert.ok(cleanAt < stageAt, 'the clean must precede the stage so no stale file survives into the served dir');
 });
 
+// ---- serve-example dev-runner exit-code decision (rf2-35lfqo) ------------
+//
+// serve-example.cjs used to return 0 unconditionally once the http-server
+// exited — so a `shadow-cljs watch` that crashed (compile loop / JVM error)
+// or an http-server that fell over false-greened the dev runner. The pure
+// decideRunnerExit helper now maps the observed child outcomes to the runner's
+// exit code: clean/interrupted shutdown -> 0, any unexpected child crash -> 1.
+
+const { decideRunnerExit } = require('../../examples/scripts/serve-example.cjs');
+
+it('decideRunnerExit returns 0 on a clean interrupted shutdown (Ctrl+C)', () => {
+  // User hit Ctrl+C: both children killed by our teardown signal — expected.
+  assert.strictEqual(
+    decideRunnerExit({
+      server: { code: null, signal: 'SIGTERM' },
+      watch: { code: null, signal: 'SIGTERM' },
+      interrupted: true,
+    }),
+    0,
+  );
+  // A clean code-0 exit is also success, interrupted or not.
+  assert.strictEqual(decideRunnerExit({ server: { code: 0, signal: null } }), 0);
+  // No children recorded (e.g. nothing ran) is not a failure.
+  assert.strictEqual(decideRunnerExit({}), 0);
+});
+
+it('TEETH: decideRunnerExit returns 1 when shadow-cljs watch crashes unexpectedly', () => {
+  // The watch died with a non-zero code while the user did NOT interrupt —
+  // the exact false-green the prior unconditional `return 0` masked.
+  assert.strictEqual(
+    decideRunnerExit({
+      server: { code: 0, signal: null },
+      watch: { code: 1, signal: null },
+      interrupted: false,
+    }),
+    1,
+  );
+  // A signal kill that is NOT our teardown (not interrupted) is also a crash.
+  assert.strictEqual(
+    decideRunnerExit({
+      watch: { code: null, signal: 'SIGSEGV' },
+      interrupted: false,
+    }),
+    1,
+  );
+});
+
+it('TEETH: decideRunnerExit returns 1 when http-server exits non-zero unexpectedly', () => {
+  assert.strictEqual(
+    decideRunnerExit({
+      server: { code: 1, signal: null },
+      watch: { code: 0, signal: null },
+      interrupted: false,
+    }),
+    1,
+  );
+});
+
+it('decideRunnerExit treats a teardown-signal kill during interrupt as expected (not a crash)', () => {
+  // During an interrupt, a child killed by SIGINT/SIGTERM is part of teardown.
+  assert.strictEqual(
+    decideRunnerExit({
+      server: { code: null, signal: 'SIGINT' },
+      watch: { code: null, signal: 'SIGINT' },
+      interrupted: true,
+    }),
+    0,
+  );
+  // But a NON-teardown signal even during interrupt is still a crash.
+  assert.strictEqual(
+    decideRunnerExit({
+      watch: { code: null, signal: 'SIGSEGV' },
+      interrupted: true,
+    }),
+    1,
+  );
+});
+
 // ---- per-example static assets (rf2-cq6va5) ------------------------------
 //
 // The clean-stage boundary recreates the selected output dir EMPTY, so any

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -586,6 +586,61 @@ it('a data: url() and a url(#fragment) paint ref are NOT rejected (no network fe
   );
 });
 
+// ---- TEETH: missing LOCAL CSS url() assets are REJECTED (rf2-35lfqo) -----
+//
+// rf2-35lfqo found the gate resolved local HTML asset refs and CSS @import
+// targets, but NEVER resolved local `url(...)` references in a CSS body — a
+// broken `background-image: url('missing-local.png')` / `cursor: url(...)` /
+// `@font-face { src: url(...) }` referencing an absent file passed silently
+// (the network-url policy skipped it because it fires no network request, and
+// nothing else checked it on disk). Local CSS url() targets are now resolved
+// against the declaring stylesheet's directory and a missing one fails the
+// gate, while data:/url(#fragment)/network refs stay handled by their own
+// policies.
+
+it('TEETH: a missing LOCAL background-image: url() is REJECTED', () => {
+  // url() resolves relative to the STYLESHEET (examples/_shared/css/), not the
+  // page — so a bare 'missing-local.png' is looked for next to style.css.
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('structure.css');",
+      ".hero { background-image: url('missing-local.png'); }",
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e.includes("CSS url('missing-local.png')") &&
+        e.includes('does not resolve to a file'),
+    ),
+    `expected a missing local CSS url() to be rejected, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('a present LOCAL CSS url() (font/cursor) resolves and scans clean', () => {
+  // Two local url() targets that DO exist next to style.css must pass: a
+  // @font-face src and a cursor image. Query/hash suffixes are stripped before
+  // on-disk resolution (a cache-busting ?v=2 must not break the lookup).
+  const FONT = path.join(EXAMPLES_ROOT, '_shared', 'css', 'inter.woff2');
+  const CURSOR = path.join(EXAMPLES_ROOT, '_shared', 'css', 'img', 'cursor.png');
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('structure.css');",
+      "@font-face { font-family: 'Inter'; src: url('inter.woff2?v=2') format('woff2'); }",
+      '.x { cursor: url("img/cursor.png"), auto; }',
+    ].join('\n'),
+    [FONT]: 'WOFF2',
+    [CURSOR]: 'PNGDATA',
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `present local CSS url() assets must scan clean, got: ${errors.join(' | ')}`,
+  );
+});
+
 it('a remote CSS url() whose exact URL is allowlisted (with reason) scans clean', () => {
   // The scanner strips ?query/#hash before the allowlist lookup, so the key is
   // the query-stripped URL — sharing EXTERNAL_IMPORT_ALLOWLIST with @import.

--- a/scripts/check_skill_migration_contract_drift.py
+++ b/scripts/check_skill_migration_contract_drift.py
@@ -36,7 +36,18 @@ Two contract facts, each pinned against the shipped spec:
     (dev-only). The stale claim this gate kills: "`reg-event-error-handler` moved
     / moves to a frame-level (per-frame) `:on-error` (recovery) policy".
 
-Both rules are written to fire ONLY on the stale ASSERTION shape, never on the
+  * **M-11 (Leave-as-is variant) — a component does NOT auto-pin to
+    `:rf/default`.** A frame-dependent plain fn left unchanged under a non-default
+    provider does NOT silently pin / fall through / route to `:rf/default` — under
+    EP-0002 there is no `:rf/default` floor, so a frame-scoped op raises
+    `:rf.error/no-frame-context`. To intentionally target `:rf/default` the
+    component must scope or pass that frame explicitly. The stale claim this gate
+    kills: a component "pins to `:rf/default` regardless of where it renders" /
+    "falls through to `:rf/default`". (The earlier M-11 rule above keyed on a
+    "plain fn" subject + an inherit-verb on one line and so missed this distinct
+    "pins to `:rf/default`" wording — hence the dedicated narrow rule.)
+
+All three rules are written to fire ONLY on the stale ASSERTION shape, never on the
 corrected wording that states the negation — and never on the unrelated,
 still-live `:on-error` *surfaces* (a machine `:spawn :on-error` transition, a
 route `:on-error` lifecycle event), which are NOT frame-level recovery policies.
@@ -136,6 +147,40 @@ M11_NEGATION_RE = re.compile(
     re.IGNORECASE,
 )
 
+# --- Rule 3: M-11 — a component "pins to" / "falls through to" `:rf/default`.
+#
+# A distinct stale shape from Rule 1: the false claim that a component (left
+# as-is under a provider) PINS / DEFAULTS / FALLS THROUGH to `:rf/default`
+# "regardless of where it renders". This is the M-11 "Leave as-is" footgun — a
+# frame-dependent plain fn left unchanged does NOT silently route to
+# `:rf/default`; under EP-0002 there is no `:rf/default` floor, so a
+# frame-scoped op raises `:rf.error/no-frame-context`. Rule 1 misses this shape
+# because it requires a "plain fn" subject + an inherit-verb on the same line,
+# and the stale "pins to :rf/default regardless" wording carries neither.
+#
+# Fires ONLY on the narrow IMPLICIT-RESOLUTION stale shape: a subject said to
+# PIN / FALL THROUGH / silently ROUTE to `:rf/default` automatically. The verb
+# set is intentionally tight — `pin(s/ned)`, `fall(s) through`, `(silently)
+# route` — so the rule never fires on the MANY legitimate `:rf/default` mentions
+# the corpus carries: scoping interceptors `to :rf/default`, naming `:rf/default`
+# as the like-for-like replacement for non-frame-addressed v1 code, the optional
+# `:frame` default, or the `:re-frame/default` -> `:rf/default` rewrite table.
+# UNLESS the line carries a negation cue — the corrected wording always denies
+# the floor or frames the target as EXPLICITLY scoped.
+M11_RFDEFAULT_PIN_RE = re.compile(
+    r"(?:pin(?:s|ned)?|fall(?:s)?\s+through|fall-through|silently\s+routes?)"
+    r"[^.\n]*?`?:rf/default`?",
+    re.IGNORECASE,
+)
+# Negation cues — the corrected wording. Any clears Rule 3: the line denies the
+# floor, or marks `:rf/default` as something you must scope/pass EXPLICITLY.
+M11_RFDEFAULT_NEGATION_RE = re.compile(
+    r"no\s+`?:rf/default`?\s+(?:floor|tier|fall-through|fall\s+through)"
+    r"|does not (?:silently )?(?:pin|route|fall)|do not describe"
+    r"|no-frame-context|scope or pass|pass that frame|intentionally target",
+    re.IGNORECASE,
+)
+
 # --- Rule 2: M-13 — reg-event-error-handler "moved to frame-level :on-error".
 #
 # Fires when a line asserts that reg-event-error-handler MOVED / MOVES to a
@@ -182,6 +227,20 @@ def line_problems(line: str) -> list[str]:
             "`:rf.error/no-frame-context` (EP-0002; spec/002-Frames.md, "
             "spec/004-Views.md). Only a `reg-view`-registered view reads the "
             "provider frame. State the limitation, not the (false) inheritance."
+        )
+
+    # Rule 3 — M-11 component "pins to" / "falls through to" `:rf/default`.
+    if (
+        M11_RFDEFAULT_PIN_RE.search(line)
+        and not M11_RFDEFAULT_NEGATION_RE.search(line)
+    ):
+        problems.append(
+            "M11-RFDEFAULT-PIN: a component left as-is under a frame-provider "
+            "does NOT pin / fall through / silently route to `:rf/default` "
+            "(EP-0002 — there is no `:rf/default` floor; a frame-scoped op "
+            "raises `:rf.error/no-frame-context`). To intentionally target "
+            "`:rf/default`, the component must scope or pass that frame "
+            "explicitly. State the limitation, not the (false) auto-default."
         )
 
     # Rule 2 — M-13 reg-event-error-handler-moved-to-frame-level-:on-error claim.
@@ -309,6 +368,17 @@ def _self_test() -> int:
         "reg-event-error-handler moves to a per-frame :on-error recovery policy.",
         dirty=True, label="A5 reg-event-error-handler moves to per-frame :on-error",
     )
+    # A6/A7 — the exact pre-fix M-11 "Leave as-is" stale claim (guided-handlers-
+    # state.md:90 shape) + the README fall-through variant.
+    expect(
+        "Leave as-is. The author accepts that the component pins to `:rf/default` "
+        "regardless of where it renders.",
+        dirty=True, label="A6 component pins to :rf/default regardless",
+    )
+    expect(
+        "A plain fn with no enclosing provider just falls through to :rf/default.",
+        dirty=True, label="A7 plain fn falls through to :rf/default",
+    )
 
     # PASS fixtures — the corrected wording must NOT flag.
     expect(
@@ -353,6 +423,26 @@ def _self_test() -> int:
         "A frame-provider scopes a frame to a subtree; reg-view descendants "
         "resolve to it at render time.",
         dirty=False, label="B8 reg-view descendants resolve (no plain-fn subject)",
+    )
+    # B9/B10/B11 — the corrected M-11 "Leave as-is" wording (guided-handlers-
+    # state.md:90 post-fix) and explicit-target phrasing must NOT flag.
+    expect(
+        "Do not describe this as pinning to `:rf/default`: there is no "
+        "`:rf/default` fall-through (EP-0002), so a frame-dependent plain fn "
+        "raises `:rf.error/no-frame-context` — it does not silently route to a "
+        "default. To intentionally target `:rf/default`, scope or pass that "
+        "frame explicitly.",
+        dirty=False, label="B9 corrected M-11 leave-as-is wording (no :rf/default pin)",
+    )
+    expect(
+        "There is no `:rf/default` floor; the read tier returns nil and the op "
+        "fails loudly.",
+        dirty=False, label="B10 no :rf/default floor (correct)",
+    )
+    expect(
+        "To target `:rf/default`, scope it explicitly with `with-frame` or an "
+        "explicit `{:frame :rf/default}` opt.",
+        dirty=False, label="B11 explicit :rf/default target (correct)",
     )
 
     if failures:

--- a/skills/re-frame-migration/references/guided-handlers-state.md
+++ b/skills/re-frame-migration/references/guided-handlers-state.md
@@ -87,7 +87,7 @@ Present every call site with its file:line and the four options; collect the aut
 
 1. **Convert to `reg-view`**. Replace `(defn my-view [args] ...)` with `(rf/reg-view ^{:doc "..."} my-view [args] ...)`. The view picks up the surrounding frame correctly. Recommended.
 2. **Hold a `(rf/frame-handle)`**. Inside the plain fn body, capture the frame's operation bundle once and route through it: `(let [{:keys [dispatch subscribe]} (rf/frame-handle)] ...)`, then call `(dispatch [...])` / `(subscribe [...])` instead of the bare `rf/dispatch` / `rf/subscribe`. The handle captures the surrounding frame at render time and (unlike the ambient binding) survives into any async callback the body sets up.
-3. **Leave as-is**. The author accepts that the component pins to `:rf/default` regardless of where it renders. Sometimes intentional (a "global" UI primitive); document why.
+3. **Leave as-is** — *only* when the component never calls `rf/subscribe` / `rf/dispatch` (a pure presentational fn with no frame-scoped reads), **or** when it establishes / carries a frame explicitly inside its own body (a `with-frame`, an explicit `{:frame <id>}` op opt, or a captured `(rf/frame-handle)`). Do **not** describe this as pinning to `:rf/default`: there is no `:rf/default` fall-through (EP-0002), so a frame-dependent plain fn left under a non-default provider raises `:rf.error/no-frame-context` at render — it does not silently route to a default. To *intentionally* target `:rf/default` (e.g. a "global" UI primitive), the component must scope or pass that frame explicitly like any other; document why.
 
 ---
 


### PR DESCRIPTION
Fixes three correctness-review findings across three disjoint slices. Each was verified against source before fixing.

## rf2-qx9b1y (P3, examples/uix) — login retry leaves stale error visible
**Verified real.** The `:error-shown -> :submitting` direct-retry transition had no action, so the prior failure message stayed visible during the in-flight resubmit (the view renders `:auth.login/error` whenever non-nil). The `:idle -> :submitting` entry transition cleared it via `:action :clear-error`; the retry did not.

- Added `:action :clear-error` to the retry transition across all three parity login examples (uix, reagent, helix) — the artefact layer is intentionally in cross-substrate parity and shares the machine shape.
- Added a focused regression in the reagent login test surface (`login_cljs_test.cljs`) driving failure -> retry and asserting `:error` is nil while the machine is back in `:submitting`. Examples stay test-free.

## rf2-08n6p6 (P2, skills/re-frame-migration) — M-11 stale `:rf/default` claim
**Verified real** against `spec/004-Views.md` and `spec/002-Frames.md`: under EP-0002 there is no `:rf/default` floor — a frame-dependent plain fn under a non-default provider raises `:rf.error/no-frame-context`, it does NOT silently route to `:rf/default`.

- Rewrote the M-11 "Leave as-is" option: leave as-is only when the component never calls `rf/subscribe`/`rf/dispatch`, or when it establishes/carries a frame explicitly; to intentionally target `:rf/default`, scope or pass that frame explicitly. No bead ids in the prose; generic to any consumer app.
- Added a narrow Rule 3 to `check_skill_migration_contract_drift.py` that catches the implicit "pins to / falls through to `:rf/default`" stale shape (the earlier M-11 rule keyed on a plain-fn subject + inherit-verb on one line and missed this wording). Self-test + full corpus pass; the rule catches the original stale line and passes the corrected wording.

## rf2-35lfqo (P3, examples/scripts) — two false-green gaps
**Both verified real.**

1. `check-examples-assets.cjs` resolved local HTML asset refs and CSS `@import` targets but never resolved local `url(...)` references in a CSS body — a broken `background-image`/`cursor`/`@font-face` url referencing an absent file passed silently. Added `checkCssLocalUrls`: resolve each non-data/non-fragment/non-network `url()` against the declaring stylesheet dir and report missing files. Tests cover a missing and a present local CSS url. Teeth proven against a deliberately-broken shipped css url (gate went RED, exit 1), then reverted (gate GREEN).
2. `serve-example.cjs` returned 0 unconditionally once http-server exited, false-greening a crashed `shadow-cljs watch` or a fallen-over http-server. Now tracks child exit codes/signals, tears the server down when the watch dies unexpectedly, and returns via a pure `decideRunnerExit` helper (clean/interrupted -> 0, unexpected child crash -> 1). Unit tests pin the exit-code decision.

## Gates
- `npm run test:examples` — 3 adapter smokes, 0 failures
- `npm run test:cljs` — 7964 tests / 36616 assertions, 0 failures (incl. the new login retry regression, confirmed compiled into cljs-runtime)
- `npm run test:script-policy` — all pass (incl. spawn-policy + teardown-policy over serve-example.cjs)
- migration-contract-drift (self-test + repo), migration-cites, mcp-drift — all pass
- BEAD-ID-LEAK: zero `rf2-` ids in the changed skill prose
- clj-kondo on changed cljs: 0 errors / 0 warnings
- mkdocs: the edited reference leaf is not in the docs nav (the docs wrapper links to GitHub), so the docs build is unaffected (mkdocs not installed in this worktree environment)