### PR TITLE
lean(core/marks): drop dead/test-only surface post-EP-0015 (rf2-gjp7t6)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -93,9 +93,8 @@
 
   Internal helper; exposed (with `^:no-doc`) so the sibling
   `re-frame.marks` ns — which writes through the SAME slot via
-  `add-marks` / `set-marks` / `clear-app-db-marks!` — can share a
-  single source of truth for the prune logic. Not part of the
-  public API.
+  `add-marks` / `set-marks` — can share a single source of truth
+  for the prune logic. Not part of the public API.
 
   EP-0001 (rf2-vzld77): operates on the runtime-db partition value (the
   elision registry is durable framework state — Conventions §Reserved
@@ -167,9 +166,9 @@
 
   Internal helper; exposed (with `^:no-doc`) so the sibling
   `re-frame.marks` ns — which mutates the SAME slot from its
-  `add-marks` / `set-marks` / `clear-app-db-marks!`
-  paths — can share a single source of truth for the read-transform-
-  write skeleton. Not part of the public API.
+  `add-marks` / `set-marks` paths — can share a single source of
+  truth for the read-transform-write skeleton. Not part of the
+  public API.
 
   EP-0001 (rf2-vzld77): writes through `frame/swap-runtime-db!` (the
   runtime-db partition of the one physical frame-state container) — the

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -157,14 +157,13 @@
     :description "Reset the once-per-(frame,path) :rf.warning/large-value-unschema'd cache."}
 
    ;; ---- re-frame.marks (rf2-vw7f5 Spec 015 data classification) -------------
-   {:key         :marks/add-marks
-    :producer-ns 're-frame.marks
-    :design-bead "rf2-vw7f5"
-    :description "Additively merge path-marks into a frame's app-db (Spec 015 §App-db marks). Hook retained for the directory contract; the `add-marks` façade export was removed (frame-marks are author-declared at reg-* time, not imperatively mutated), so the underlying `re-frame.marks/add-marks` survives only as an internal / test / generated-code surface, reached by direct require — not through this late-bind hook."}
-   {:key         :marks/set-marks
-    :producer-ns 're-frame.marks
-    :design-bead "rf2-vw7f5"
-    :description "Replace the frame's app-db mark-set wholesale (Spec 015 §App-db marks). Like `:marks/add-marks`, the `set-marks` façade export was removed; the underlying `re-frame.marks/set-marks` survives as an internal / test / generated-code surface reached by direct require, not through this hook."}
+   ;; NOTE (rf2-gjp7t6): the `:marks/add-marks` / `:marks/set-marks` hook rows
+   ;; are GONE. EP-0015 §3 (rf2-mngp4o) removed the public imperative façade
+   ;; exports; the hooks themselves had ZERO consumers and were kept only for
+   ;; directory-contract symmetry — dead weight. The underlying `add-marks` /
+   ;; `set-marks` fns survive as test / conformance-only helpers reached by
+   ;; DIRECT REQUIRE (the marks tests + the conformance corpus harness), never
+   ;; through a late-bind hook.
    {:key         :marks/validate-marks!
     :producer-ns 're-frame.marks
     :design-bead "rf2-ehexnw"

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -36,9 +36,10 @@
   `:source :marks`. The frame-owned (`:source :frame`, EP-0015 §3) and
   marks-sourced declarations union at lookup time — a path declared
   sensitive by EITHER source is sensitive. (`add-marks` / `set-marks`
-  are DEMOTED off the public façade — EP-0015 §3, rf2-mngp4o — and remain
-  as internal / test / generated-code helpers; durable app-db
-  classification is authored on the frame. The former
+  are DEMOTED off the public façade — EP-0015 §3, rf2-mngp4o — and their
+  `:marks/*` late-bind hooks are GONE (rf2-gjp7t6, they had zero consumers);
+  they survive ONLY as test / conformance helpers reached by direct require.
+  Durable app-db classification is authored on the frame. The former
   schema→app-db-egress route is gone post-EP-0015 §8.)"
   (:require [re-frame.elision :as elision]
             [re-frame.error :as error]
@@ -688,10 +689,7 @@
   resolved `new-s` (`:sensitive-declarations`) and `new-l` (`:declarations`)
   maps: assoc the slot when its map is non-empty, dissoc it when empty so an
   emptied slot vanishes rather than lingering as `{}`. The single helper behind
-  `add-marks` / `set-marks` / `clear-app-db-marks!`, which hand-inlined this
-  same cond-> three times (rf2-mo9ekx). `clear-app-db-marks!` passes `base {}`,
-  where the empty-slot dissoc is a harmless no-op on an absent key — the result
-  is byte-identical to its prior seq-only cond->."
+  `add-marks` / `set-marks`, which hand-inlined this same cond-> (rf2-mo9ekx)."
   [base new-s new-l]
   (cond-> base
     (seq new-s)    (assoc :sensitive-declarations new-s)
@@ -699,9 +697,9 @@
     (seq new-l)    (assoc :declarations new-l)
     (empty? new-l) (dissoc :declarations)))
 
-(defn add-marks
-  "Additively merge path-marks into the `app-db` mark-set of `frame-id`.
-  Per Spec 015 §App-db marks (per frame).
+(defn ^:no-doc add-marks
+  "TEST / CONFORMANCE-ONLY (rf2-gjp7t6). Additively merge path-marks into the
+  `app-db` mark-set of `frame-id`. Per Spec 015 §App-db marks (per frame).
 
   `path->mark` is a map from `get-in`-shaped path vectors to mark
   keywords (`:sensitive` or `:large`). Paths supplied here MERGE into
@@ -722,9 +720,12 @@
   observation surfaces (trace bus, Xray, MCP, third-party log sinks)
   consult at emission time.
 
-  NOTE: not a public façade fn (EP-0015 §3, rf2-mngp4o) — frame-owned
+  NOTE: NOT a public façade fn and NOT reachable through a late-bind hook
+  (EP-0015 §3, rf2-mngp4o removed the imperative façade export; rf2-gjp7t6
+  removed the `:marks/add-marks` hook — it had zero consumers). Frame-owned
   `:sensitive` / `:large` classification is the public authoring surface;
-  this is an internal / test / generated-code helper.
+  this fn survives ONLY as a test / conformance helper, reached by direct
+  require from the marks tests + the conformance corpus harness.
 
   Frame-owned declarations (`reg-frame` `:sensitive` / `:large {:app-db …}`,
   `:source :frame`) are preserved — the two declaration sources union at
@@ -741,9 +742,9 @@
           (write-elision-slots (or reg {}) new-s new-l)))))
   frame-id)
 
-(defn set-marks
-  "Replace the `app-db` mark-set of `frame-id` with `path->mark`.
-  Per Spec 015 §App-db marks (per frame).
+(defn ^:no-doc set-marks
+  "TEST / CONFORMANCE-ONLY (rf2-gjp7t6). Replace the `app-db` mark-set of
+  `frame-id` with `path->mark`. Per Spec 015 §App-db marks (per frame).
 
   `path->mark` is a map from `get-in`-shaped path vectors to mark
   keywords (`:sensitive` or `:large`). Paths supplied here REPLACE the
@@ -763,9 +764,12 @@
   observation surfaces (trace bus, Xray, MCP, third-party log sinks)
   consult at emission time.
 
-  NOTE: not a public façade fn (EP-0015 §3, rf2-mngp4o) — frame-owned
+  NOTE: NOT a public façade fn and NOT reachable through a late-bind hook
+  (EP-0015 §3, rf2-mngp4o removed the imperative façade export; rf2-gjp7t6
+  removed the `:marks/set-marks` hook — it had zero consumers). Frame-owned
   `:sensitive` / `:large` classification is the public authoring surface;
-  this is an internal / test / generated-code helper.
+  this fn survives ONLY as a test / conformance helper, reached by direct
+  require from the marks tests + the conformance corpus harness.
 
   Frame-owned declarations (`reg-frame` `:sensitive` / `:large {:app-db …}`,
   `:source :frame`) are preserved — only the `:source :marks` entries are
@@ -785,18 +789,6 @@
               new-l   (assoc-paths carry-l large-paths)]
           (write-elision-slots (or reg {}) new-s new-l)))))
   frame-id)
-
-(defn clear-app-db-marks!
-  "Drop every `add-marks` / `set-marks`-sourced declaration for
-  `frame-id`. Frame-sourced (`:source :frame`) declarations are preserved.
-  Returns nil. Test-isolation only; production code rarely needs this."
-  [frame-id]
-  (elision/swap-elision-slot! frame-id
-    (fn [reg]
-      (let [new-s (without-marks-sourced (:sensitive-declarations reg))
-            new-l (without-marks-sourced (:declarations reg))]
-        (write-elision-slots {} new-s new-l))))
-  nil)
 
 ;; ---- emit-time projection ------------------------------------------------
 ;;
@@ -1887,5 +1879,10 @@
 (late-bind/set-fn! :marks/mark-sub-output!    mark-sub-output!)
 (late-bind/set-fn! :marks/clear-marks!        clear-marks!)
 (late-bind/set-fn! :marks/clear-sub-output-marks! clear-sub-output-marks!)
-(late-bind/set-fn! :marks/add-marks           add-marks)
-(late-bind/set-fn! :marks/set-marks           set-marks)
+;; NOTE: the `:marks/add-marks` / `:marks/set-marks` hooks are GONE (rf2-gjp7t6).
+;; EP-0015 §3 (rf2-mngp4o) removed the public imperative façade exports, and the
+;; hooks themselves had ZERO consumers — they were kept only for directory-
+;; contract symmetry. The underlying `add-marks` / `set-marks` fns survive as
+;; test / conformance-only helpers (^:no-doc), reached by DIRECT REQUIRE from
+;; the marks tests + the conformance corpus harness — never through a late-bind
+;; hook. With no consumer the publications were dead weight.


### PR DESCRIPTION
## What

Removes the dead/test-only surface `re-frame.marks` carried after EP-0015 §3 (rf2-mngp4o) removed the public imperative `add-marks`/`set-marks` façade. Behaviour-PRESERVING — no production code path touched.

## Items removed (each verified caller-count = zero production)

1. **`:marks/add-marks` + `:marks/set-marks` late-bind hooks** — DELETED both `(late-bind/set-fn! ...)` publications (`marks.cljc`) and their two `directory.cljc` manifest rows. Verified ZERO consumers: `git grep "get-fn.*:marks/add-marks|set-marks"` = 0 (the manifest itself documented them as kept only for "directory-contract symmetry"). The `late_bind_drift_test` enforces a bidirectional publication↔manifest contract, so both sides are removed together — drift-test stays green.

2. **`clear-app-db-marks!`** — DELETED. Orphan: zero references repo-wide (only doc-comment mentions in `elision.cljc`, now trimmed). No test called it.

3. **`add-marks` / `set-marks` fns** — KEPT but demoted to `^:no-doc` **TEST/CONFORMANCE-only**. Reached by DIRECT REQUIRE from the marks tests + conformance corpus harness (`conformance_test.clj` / `conformance_corpus_cljs_test.cljs` drive `:add-marks`/`:set-marks` EDN fixture ops), never through a late-bind hook now. Docstrings updated to drop the stale "generated-code / hook-reachable" framing.

## Suspects verified as LIVE (NOT removed)

- `:marks/mark-sub-output!` — consumed via late-bind by `subs.cljc:778`. LIVE.
- `:marks/clear-marks!` + `:marks/clear-sub-output-marks!` — consumed via the test-isolation runtime fixture reset-hook-table (`test_support.cljc:314-315`). LIVE wiring.

Live engine fns untouched: `project-trace-event`, `redact-event-by-registration`, `marks-for`, `validate-marks!`, `resolve-sub-output-marks`, `public-declassification-claims`, the machine-schema-marks cross-artefact hooks (legitimate machines decouple, excluded per the bead + rf2-eq7m0x).

## Quality gates (all green)

- `npm run test:cljs` — 7969 tests / 36675 assertions, 0 failures
- JVM: late-bind-drift-test + marks-test (787 assertions), conformance-test, frame-classification-test, flows-output-marks-test (132 assertions), security public-profile-projection-test — all green
- `test:elision` — PASS (production 42/42 absent; the marks→elision sensitivity path stays intact)
- `test:bundle-isolation` — PASS
- `test:cljs-isolation` (per-ns) — PASS
- api-manifest drift-check — in sync (488 public vars; no facade var touched)
- wire-vocab conformance — 1062 assertions, 0 failures
- clj-kondo/splint — net-neutral (the 2 warnings flagged are pre-existing on origin/main; my edits add zero new ones)

## Notes

The marks LATE-BIND architecture question (inlining intra-core phantom late-binds) is the separate held decision rf2-eq7m0x — out of scope here. This PR is the dead-CODE half only.