### PR TITLE
lean(tools): structural sprawl/dup/dead-code removal across story/story-mcp/template/machines-viz/mcp-base/testbed-support (rf2-91oga2)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -43,6 +43,8 @@
   competes with Stately Studio."
   (:require ["@xyflow/react" :as xyflow]
             [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
+             :refer [chart-constants palette-of]]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
              :refer [chart-label-stack]]
@@ -221,30 +223,11 @@
 ;;
 ;; rf2-k647w — edge typography (label font-size + backplate opacity)
 ;; reads off the resolved density's `visual-constants` map, threaded
-;; onto the edge `:data` by the projector. xyflow `clj->js`-es the edge
-;; array, so `chart-constants` recovers the kebab-keyword CLJS map and
-;; falls back to `vc/chart-regular` when absent.
-
-(defn- chart-constants
-  "Recover the resolved visual-constants map off an edge's `:data`
-  (`(.-chart d)`); `vc/chart-regular` when absent so the regular
-  density stays pixel-identical to the pre-rf2-k647w hardcoded values."
-  [^js d]
-  (let [c (.-chart d)]
-    (if (some? c)
-      (js->clj c :keywordize-keys true)
-      vc/chart-regular)))
-
-(defn- palette-of
-  "rf2-az6e2 — recover the resolved chart-semantic token map off an
-  edge's `:data` (`(.-palette d)`); `(tokens/chart-tokens)` (the dark
-  surface) when absent so a theme-less edge still paints the dark
-  grammar. Mirrors `chart.nodes.xyflow-node/palette-of`."
-  [^js d]
-  (let [p (.-palette d)]
-    (if (some? p)
-      (js->clj p :keywordize-keys true)
-      (tokens/chart-tokens))))
+;; onto the edge `:data` by the projector. `chart-constants` (the
+;; kebab-keyword recovery off `(.-chart d)`, `vc/chart-regular` fallback)
+;; and `palette-of` (the chart-semantic token recovery off `(.-palette d)`)
+;; are shared with the node renderers — both are `:refer`-ed from
+;; `chart.nodes.xyflow-node` rather than re-implemented here (rf2-91oga2).
 
 (defn- edge-stroke
   "rf2-fzrzlw — `blocked?` (the edge's guard rejected the event this

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -902,14 +902,6 @@
   is resolved per id, with the variant owning any id it sets directly."
   [:fx-overrides :interceptor-overrides])
 
-(defn- fragment-append-keys
-  "Context keys a fragment APPENDS (vectors concatenated in declared
-  order) into the composing body. Setup + script are handled separately
-  (they coordinate with the parent-chain setup and the child script);
-  these are the remaining append-shaped world slots."
-  []
-  [:loaders :loaders-teardown :decorators])
-
 (defn- check-flat-fragment!
   "FAIL with `:rf.error/story-compose-nested-fragment` when a composed
   `fragment` body carries `:compose` or `:extends` — P1 fragments MUST be

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -81,8 +81,7 @@
   slots (data) out. It requires nothing from `re-frame.core` / the DOM, so
   the full projection runs under `clojure -M:test`. The runner reads the
   retained tape via `re-frame.core/epoch-history` and hands the vector
-  here; the projection itself never touches the runtime."
-  (:require [clojure.string :as str]))
+  here; the projection itself never touches the runtime.")
 
 ;; ===========================================================================
 ;; SCHEMA-VIOLATION PROJECTION  (spec/017 §Schema rule)
@@ -915,21 +914,3 @@
               :renders           render-rows
               :narrative         (narrative script narr-tape)}
        (some? rc) (assoc :reactive-counts rc)))))
-
-;; ===========================================================================
-;; DIAGNOSTICS
-;; ===========================================================================
-
-(defn explain-evidence
-  "Render a short multi-line summary of the projected evidence for
-  diagnostics / log output. Pure data → data; deterministic."
-  [{:keys [schema-violations warnings effects narrative] :as _evidence}]
-  (str/join
-    "\n"
-    (cond-> [(str "schema-violations: " (count schema-violations))
-             (str "warnings: "          (count warnings))
-             (str "effects: "           (count effects))
-             (str "narrative-spans: "   (count narrative))]
-      (seq schema-violations)
-      (conj (str "  schema selectors: "
-                 (str/join ", " (map (comp pr-str :selector) schema-violations)))))))

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -553,17 +553,6 @@
     (rf/app-db-value frame-id)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
-(defn- pred-label
-  "Human-readable label for a `:pred` ref — the symbol literal when
-  the author handed a symbol, the marker `<fn>` when they handed a
-  fn directly. Used in failure messages so authors can spot which
-  predicate failed without leaking compiler-munged identifiers."
-  [ref]
-  (cond
-    (symbol? ref) (str ref)
-    (fn? ref)     "<fn>"
-    :else         (pr-str ref)))
-
 ;; ---- DOM-family assertion atom executor (rf2-5x1wt.19) -------------------
 ;;
 ;; The DOM family (`:rf.assert/dom-visible` / `:rf.assert/dom-hidden` /


### PR DESCRIPTION
## What

Bounded straggler sweep over the non-xray/pair tool dirs for bead **rf2-91oga2** (tools lean pass). The rf2-91oga2 census already landed its main batch (#4677 and others); this PR removes the behaviour-preserving items the per-surface census missed. All changes are dead-code deletions + one byte-identical dedup — zero behaviour change.

## Changes

**Dead code** (verified zero call sites via `git grep` across `tools/` + `implementation/` + `examples/`; private fns are externally unreachable, the public one is NOT re-exported by the `re-frame.story` facade):

- `story/plan` — drop `fragment-append-keys` (private 0-arg literal-vector helper, no callers).
- `story/play/runner_events` — drop `pred-label` (private; the predicate failure-label path it was drafted for was never wired).
- `story/play/evidence` — drop `explain-evidence` (public diagnostics renderer, zero callers, not facade-re-exported — the exact parallel of the already-deleted `explain-state` from rf2-q6bdah). Also removes the now-orphaned `DIAGNOSTICS` banner and the then-unused `clojure.string` require.

**Dedup**:

- `machines-viz/chart/edges` — `chart-constants` + `palette-of` were a byte-identical private re-implementation of the public versions in `chart.nodes.xyflow-node` (which the per-kind node renderers already `:refer`). `edges` now `:refer`s them too instead of carrying its own copy. `xyflow-node` is a leaf util ns (requires nothing from `chart.nodes`), so no dependency cycle. Same class as the census's rf2-7jjcfc / rf2-4rzz4e / rf2-ukcy5n.

Net **-55 / +8 lines** across 4 files.

## Spec

`tools/machines-viz/spec/*` unchanged: this is a pure internal dedup (one require moved between two already-co-located renderer nss); no API/topology/contract surface changed.

## Gates

- story JVM — 1703 tests, 0 failures
- machines-viz JVM — 552 tests, 0 failures
- `npm run test:cljs` (node) — 7969 tests, 0 failures
- `machines-viz-viewer` CLJS browser build — 183 compiled, **0 warnings** (proves the edges dedup compiles end-to-end with the new `:refer`)
- clj-kondo — 0 errors; 2 pre-existing unrelated warnings (`variant-id` / `yield?`, not in the diff)

MCP-conformance / bundle-isolation not run: no story-mcp/mcp-base output shape touched, and machines-viz is already a dev-only tool jar (a require moved between two co-located tool nss — no production-bundle reachability change).

Do not merge — per dispatch brief.

Closes the straggler tail of rf2-91oga2.