### PR TITLE
lean(implementation): structural sprawl/dead-code/stale-comment removal post-realm-collapse (rf2-1sfb14)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -927,53 +927,6 @@
           (assoc :rf.cofx/requires-parsed requires-parsed))))
     id))
 
-(defn normalize-relowered-meta
-  "Normalize a PROJECTED event's registration metadata back into the
-  AUTHORED metadata shape `reg-event` accepts, so a projected app-value event
-  descriptor can be re-lowered through the one `reg-event` form (EP-0018,
-  rf2-untip9).
-
-  An app value projected off the live registrar (`av/app-value`) carries each
-  event's EFFECTIVE registrar metadata under `:metadata` — including the slots
-  `register-event!` GENERATES rather than the author supplies:
-
-    * `:interceptors` — the EFFECTIVE chain `reg-event` assembled: the author's
-      interceptor REFERENCES at the head, the inline `:rf/event-handler`
-      framework wrapper (`:rf/default? true`) appended at the tail. Re-feeding
-      that effective chain to `reg-event` makes `validate-meta-interceptors!`
-      read the inline wrapper as an AUTHORED inline interceptor and reject it
-      `:rf.error/inline-interceptor-removed` (chains are reference-only since
-      EP-0022). The author's chain is the references with the framework wrapper
-      removed — the documented recovery `(remove :rf/default? interceptors)`
-      (`resolve-interceptors`).
-    * `:rf.cofx/requires-parsed` — the normalised cofx-requirement vector
-      `register-event!` derives from the authored `:rf.cofx/requires`. `reg-event`
-      regenerates it, so a stale projected copy is dropped (the author's
-      `:rf.cofx/requires` survives and is re-parsed).
-
-  Stripping the regenerated slots (and recovering the author's reference chain)
-  yields a metadata map structurally identical to what the author originally
-  passed `reg-event`, so re-lowering re-validates the references, re-parses the
-  cofx requirements, and re-appends a FRESH framework wrapper — a faithful
-  round-trip. A CONSTRUCTED descriptor (from `module`) never carries these
-  generated slots, so this is a no-op on it: an authored `:interceptors` chain
-  is references-only (no `:rf/default?` entry to strip) and carries no
-  `:rf.cofx/requires-parsed`. INTERNAL."
-  [meta]
-  (if-not (map? meta)
-    meta
-    (cond-> (dissoc meta :rf.cofx/requires-parsed)
-      ;; Recover the author's reference chain from the effective chain by
-      ;; dropping the framework-default wrapper(s). Done ONLY when the chain
-      ;; actually carries a `:rf/default?` entry, so an authored
-      ;; references-only chain is left byte-identical (and an empty residual
-      ;; chain is removed rather than passed as `[]`).
-      (some :rf/default? (:interceptors meta))
-      (as-> m (let [user-refs (filterv (complement :rf/default?) (:interceptors meta))]
-                (if (seq user-refs)
-                  (assoc m :interceptors user-refs)
-                  (dissoc m :interceptors)))))))
-
 (defn reg-event
   "Register a `(fn [coeffects event-vec] effect-map)` event handler under
   `id` — the ONE public event-registration form (EP-0018, ruled


### PR DESCRIPTION
## Summary

Bounded straggler lean pass for **rf2-1sfb14** (P2). The bead's deep-read census (6-worker pass, 2026-06-19) was already fully actioned — every per-file lean child bead (cmxiss error-emit dedup, snxp8i cofx runner, xxlzfl/a3pl56 fx+cofx, v6muda subs, ciwv6l router, 6esbis frame, w1g0d2/6id3el spine, and the marks/elision twin-dedup family) is CLOSED+merged. This PR sweeps the remaining straggler the census missed.

## What was removed

**core/events.cljc** — deleted orphaned `normalize-relowered-meta` (47 lines).

It was added under rf2-untip9 (commit b52f0992f) wired SOLELY into `core/install-descriptor!`'s `:event` case (normalizing a projected app-value event descriptor's effective registrar metadata back to authored shape before re-lowering through `reg-event`). The EP-0023 realm-substrate collapse (rf2-afdlyr) RETIRED the `install!`/`reinstall!` seating machinery in `re-frame.app-value`, removing `install-descriptor!` and its `app_value_install` regression tests — deleting the only caller and orphaning the helper.

Verified zero references across the whole `implementation/` tree (core + adapters + tools + examples + tests); not exported via the facade; not in the api-manifest. Behaviour-preserving.

## Verified NOT sprawl (left as-is)

- **realm.cljc / frame.cljc:2076 / core.cljc:2013-2031 collapse-history comments** — correctly past-tense ("REMOVED"/"RETIRED"/"is gone"); deliberate historical record, not stale. (Lean-pass guardrail: prose is a deliverable.)
- **reply families** (http/routing/resources/machines) — intentionally family-specific per the Managed-Effects contract.
- **all other in-scope private helpers** — referenced within their own ns (normal private-fn shape, not dead).

## Deferred to follow-up

- **rf2-h9902s** (P3) — two documented closed-set `def`s with ZERO readers (`mint-policies` in cofx.cljc:846, `mutation-statuses` in resources/mutation_runtime.cljc:106). Judgment item (wire-in-the-promised-validation vs remove), and prose-as-data — out of scope for a clean behaviour-preserving delete.

Excluded set (marks/schemas/machines/privacy/elision — owned by concurrent worker rf2-398kql): light dead-def scan found nothing to file.

## Gates (all green)

- `npm run test:cljs` — 7955 tests / 36622 assertions, 0 failures, 0 errors
- `test-jvm-implementation.sh` — all artefacts pass
- `npm run test:bundle-isolation` — PASS
- `npm run test:elision` — PASS (42/42 absent, control 42/42 present)
- `npm run test:cljs-isolation` — 18 ns pass standalone
- clj-kondo — 0 errors, 0 warnings
- splint — 1 style warning, PRE-EXISTING on origin/main (line 309, untouched by this PR)
- api-manifest — no drift (private fn, never in manifest)

Exec-line delta: **-47 lines** (one file).

Do NOT merge — for review.