### PR TITLE
test(machines-viz): parity tests guarding the engine-grammar mirror against drift (rf2-ir5nah)

### DIFF
--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -56,7 +56,25 @@
                        day8/re-frame2-test-quiet
                        {:local/root "../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                       ;; rf2-ir5nah — TEST-ONLY engine dep for the
+                       ;; engine-grammar PARITY tests
+                       ;; (engine_grammar_parity_test.cljc). machines-viz
+                       ;; hand-MIRRORS the engine's machine-grammar walk +
+                       ;; target resolution (Mike-ruled rf2-ir5nah opt (b):
+                       ;; the mirror is by-design — bundle-isolation +
+                       ;; JVM-portability make a shared :require infeasible);
+                       ;; the parity tests feed representative machine-defs
+                       ;; through BOTH the viz copy and the engine fn and
+                       ;; assert equal output, so a silent drift becomes a
+                       ;; RED gate. This dep lives ONLY on the :test alias —
+                       ;; the shipped jar (:clein/build :src-dirs ["src"])
+                       ;; never carries it, so bundle isolation (which gates
+                       ;; the production BUNDLE, not the test classpath)
+                       ;; holds: nothing under implementation/ requires this
+                       ;; jar, and this jar's src never requires the engine.
+                       day8/re-frame2-machines
+                       {:local/root "../../implementation/machines"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy. Mirrors tools/xray/deps.edn — the release

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/engine_grammar_parity_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/engine_grammar_parity_test.cljc
@@ -1,0 +1,247 @@
+(ns day8.re-frame2-machines-viz.engine-grammar-parity-test
+  "ENGINE-GRAMMAR PARITY tests (rf2-ir5nah, Mike-ruled option (b)).
+
+  machines-viz HAND-MIRRORS the runtime engine's machine-definition
+  grammar walk + target resolution: `grammar/normalise-root-targets`,
+  `grammar/reenter?`, `grammar/transition-candidates`, and the chart's
+  `resolve-target-path` each re-implement, in plain JVM-portable data,
+  what `re-frame.machines.parallel` / `re-frame.machines.transition` /
+  `re-frame.machines.grammar` do at runtime. Mike ruled the mirror is
+  BY-DESIGN — the viz tool is bundle-isolated from production
+  (`check-bundle-isolation` pins that nothing under implementation/ may
+  `:require` this jar, and this jar's SRC never `:require`s the engine)
+  and `grammar.cljc` is deliberately dep-free (`clojure.string` only), so
+  a shared `:require` would punch a hole through the very isolation
+  boundary the sentinel exists to protect. A shared grammar-codec ns
+  (option (a)) was REJECTED.
+
+  Because the copies are kept in sync only by hand, a silent drift — the
+  viz tool re-wiring an edge the engine resolves differently — is the
+  risk. These tests make that drift LOUD: each feeds REPRESENTATIVE
+  machine-defs through BOTH the machines-viz copy AND the engine fn and
+  asserts EQUAL OUTPUT (structural / behavioural, NOT a source-text
+  compare). If one fails, the viz grammar drifted from the engine — re-
+  sync the copy, do NOT delete the test.
+
+  This is a TEST, not the shipped tool: it MAY `:require` the engine
+  (the `day8/re-frame2-machines` dep lives ONLY on the :test alias —
+  tools/machines-viz/deps.edn). The engine-require here does NOT trip
+  `check-bundle-isolation`: that gate greps the compiled
+  examples/counter PRODUCTION BUNDLE, never the test classpath, and the
+  shipped machines-viz jar (`:clein/build :src-dirs [\"src\"]`) carries
+  no test deps.
+
+  The engine targets `parallel/normalise-root-targets`,
+  `transition/normalise-candidates`, and `transition/target-path` are
+  PRIVATE (`defn-`); the tests reach them through their vars
+  (`#'ns/fn`), which is the standard, drift-honest way to pin a private
+  contract from outside its namespace."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.grammar :as g]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.transition :as transition]))
+
+;; ---------------------------------------------------------------------------
+;; Private-var accessors for the engine fns the viz copies mirror.
+;;
+;; `parallel/normalise-root-targets`, `transition/normalise-candidates`,
+;; and `transition/target-path` are `defn-` (engine-internal). Pinning a
+;; private contract from outside its ns via its var is intentional here —
+;; the whole point is to assert the public viz copy agrees with the
+;; engine's internal resolver.
+
+(def engine-normalise-root-targets @#'parallel/normalise-root-targets)
+(def engine-normalise-candidates   @#'transition/normalise-candidates)
+(def engine-target-path            @#'transition/target-path)
+
+;; ---------------------------------------------------------------------------
+;; PARITY 1 — normalise-root-targets
+;;
+;; PARITY: mirror of re-frame.machines.parallel/normalise-root-targets —
+;; if this fails, the viz grammar drifted from the engine; re-sync, do
+;; not delete.
+;;
+;; grammar/normalise-root-targets (grammar.cljc) is byte-identical-logic
+;; to the engine's parallel/normalise-root-targets: a parallel-ROOT
+;; `:on` / `:after` candidate's `:target` is normalised into a vector of
+;; region-qualified absolute targets `[[<region> & <in-region-path>] …]`.
+;; Both projected/exported edges (viz) and the regions the engine moves
+;; must address the SAME regions, so the two normalisers must agree on
+;; every shape of the grammar.
+
+(def ^:private root-target-fixtures
+  "Representative parallel-root `:target` shapes spanning every arm of
+  the shared `cond`."
+  [;; nil / absent → [] (targetless / action-only)
+   nil
+   ;; a vector of KEYWORDS → ONE region-qualified target, wrapped
+   [:a :two]
+   [:region :nested :leaf]
+   ;; a single region head with no in-region path
+   [:r]
+   ;; a vector of VECTORS → MULTIPLE region-qualified targets, as-is
+   [[:a :x] [:b :y]]
+   [[:r1 :s] [:r2 :t] [:r3 :u]]
+   ;; a non-vector (e.g. a keyword) → [] (the :else arm)
+   :not-a-vector
+   ;; the empty vector — degenerate, both treat it via the (every? ...)
+   ;; arm: (every? vector? []) is true, so → (vec [])
+   []])
+
+(deftest normalise-root-targets-parity
+  (testing "viz grammar/normalise-root-targets agrees with the engine resolver"
+    (doseq [target root-target-fixtures]
+      (is (= (engine-normalise-root-targets target)
+             (g/normalise-root-targets target))
+          (str "root-target normalisation drifted for " (pr-str target))))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 2 — reenter?
+;;
+;; PARITY: mirror of re-frame.machines.transition's
+;; `(true? (:reenter? transition))` read — if this fails, the viz grammar
+;; drifted from the engine; re-sync, do not delete.
+;;
+;; The engine classifies a transition candidate as an EXTERNAL self /
+;; ancestor / compound-declared-descendant restart iff the candidate map
+;; opts in with `:reenter? true`, read as `(true? (:reenter? transition))`
+;; (re-frame.machines.transition). grammar/reenter? mirrors this exactly
+;; for a candidate MAP, adding a `(map? candidate)` guard so it is total
+;; over non-map candidates (a bare keyword / vector-path target — which
+;; can never carry `:reenter?` — yields false). The viz edge renders a
+;; `:reenter? true` transition DISTINCTLY from its internal default, so it
+;; must agree with the engine on which candidates are external.
+
+(def ^:private reenter-candidate-fixtures
+  "Representative candidate MAPS — the only shape the engine's
+  `(true? (:reenter? transition))` read sees (it operates on a selected
+  candidate map)."
+  [{:target :a :reenter? true}
+   {:target :a :reenter? false}
+   {:target :a}                       ;; :reenter? absent → false
+   {:target :a :reenter? nil}         ;; explicit nil → false (true? nil)
+   {:target :a :reenter? :truthy}     ;; truthy-but-not-true → false (true? only)
+   {:action :log}                     ;; internal candidate, no :reenter?
+   {}])                               ;; empty candidate
+
+(deftest reenter?-parity
+  (testing "viz grammar/reenter? agrees with the engine's (true? (:reenter? transition)) read"
+    (doseq [candidate reenter-candidate-fixtures]
+      (is (= (true? (:reenter? candidate))
+             (g/reenter? candidate))
+          (str ":reenter? classification drifted for " (pr-str candidate)))))
+
+  (testing "the viz (map? candidate) guard makes reenter? total over non-map candidates"
+    ;; The engine only ever reads :reenter? off a selected candidate MAP;
+    ;; the viz copy is additionally total over the bare keyword / vector-
+    ;; path target forms a candidate can take before normalisation, which
+    ;; never carry :reenter?. So these must all be false — none is an
+    ;; external restart.
+    (is (false? (g/reenter? :a)))
+    (is (false? (g/reenter? [:a :b])))
+    (is (false? (g/reenter? nil)))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 3 — transition-candidates
+;;
+;; PARITY: mirror of re-frame.machines.transition/normalise-candidates
+;; (the engine's transition-grammar normalisation) — if this fails, the
+;; viz grammar drifted from the engine; re-sync, do not delete.
+;;
+;; Both normalise a transition spec into a vector of candidate MAPS. They
+;; agree across the REPRESENTATIVE grammar a machine-def actually carries:
+;; a keyword sibling target, an absolute keyword vector-path target, a
+;; vector of candidate maps (first-guard-pass wins), and a single
+;; transition map.
+;;
+;; SCOPE NOTE (deliberate, documented divergence — NOT drift): the two
+;; differ ONLY on degenerate / non-grammar shapes the viz walker handles
+;; more permissively than the runtime normaliser:
+;;   - nil VALUE: viz → [] (drop, nothing to project); engine → [{}] (the
+;;     forbidden-transition / internal no-op form, rf2-16gxd).
+;;   - a MIXED vector ([:a [:x :y]] — not all maps, not all keywords):
+;;     viz mapcat-explodes it into per-element candidates; the engine
+;;     treats any non-all-maps vector as a single absolute vec-target.
+;;   - a malformed value (e.g. 42): viz → [] (drop); engine → throws.
+;; These are out of scope for THIS pair (the engine surfaces them through
+;; registration validation, not the projector). The equality assertion is
+;; pinned to the shared grammar so a drift WITHIN that region stays loud;
+;; the divergent shapes are asserted separately below so a future change
+;; that accidentally ALIGNS or further DIVERGES them is also caught.
+
+(def ^:private shared-grammar-spec-fixtures
+  "Transition specs on which the viz walker and the engine normaliser
+  MUST agree — the representative grammar a machine-def carries."
+  [;; a keyword sibling target
+   :authenticated
+   ;; an absolute keyword vector-path target
+   [:outer :inner :leaf]
+   ;; a vector of candidate maps (first-guard-pass wins)
+   [{:guard :g1 :target :a} {:target :b :action :log}]
+   [{:target :a} {:target :b} {:target :c}]
+   ;; a single transition map (targeted)
+   {:target :a :guard :g}
+   ;; a single transition map (internal / action-only)
+   {:action :log}])
+
+(deftest transition-candidates-parity
+  (testing "viz grammar/transition-candidates agrees with the engine normaliser across the shared grammar"
+    (doseq [spec shared-grammar-spec-fixtures]
+      (is (= (engine-normalise-candidates spec :rf.error/test-bad-value)
+             (g/transition-candidates spec))
+          (str "candidate normalisation drifted for " (pr-str spec))))))
+
+(deftest transition-candidates-documented-divergence
+  (testing "the deliberate viz-vs-engine divergences on degenerate shapes are unchanged"
+    ;; If any of these EQUALITIES start failing, the divergence shifted —
+    ;; re-read the scope note above and confirm the change is intentional
+    ;; (a viz walker that newly drops/explodes a shape differently from
+    ;; the documented contract is itself a drift signal).
+    (testing "nil value: viz drops, engine yields the internal no-op form"
+      (is (= [] (g/transition-candidates nil)))
+      (is (= [{}] (engine-normalise-candidates nil :rf.error/test-bad-value))))
+    (testing "mixed vector: viz mapcat-explodes, engine treats as one vec-target"
+      (is (= [{:target :a} {:target [:x :y]}]
+             (g/transition-candidates [:a [:x :y]])))
+      (is (= [{:target [:a [:x :y]]}]
+             (engine-normalise-candidates [:a [:x :y]] :rf.error/test-bad-value))))))
+
+;; ---------------------------------------------------------------------------
+;; PARITY 4 — resolve-target-path (chart/layout) vs target-path
+;;
+;; PARITY: mirror of re-frame.machines.transition/target-path — if this
+;; fails, the viz grammar drifted from the engine; re-sync, do not delete.
+;;
+;; The chart's resolve-target-path computes the absolute target path of a
+;; transition relative to its declaring (source) path, exactly as the
+;; engine's target-path does at runtime: `:same-state` → the declaring
+;; state's own path; a keyword → sibling at the declaring level; a
+;; vector → absolute. The chart's edges must land on the SAME node the
+;; engine transitions to. resolve-target-path is `defn-` in chart/layout;
+;; the test reaches it through its var.
+
+(def viz-resolve-target-path @#'layout/resolve-target-path)
+
+(def ^:private target-path-fixtures
+  "[<decl/source-path> <target>] pairs spanning the shared arms:
+  `:same-state`, keyword sibling, absolute keyword vector-path, and nil
+  (internal — both return nil)."
+  [[[:idle]              :same-state]
+   [[:outer :inner]      :same-state]
+   [[:idle]              :running]            ;; keyword sibling at top level
+   [[:outer :inner]      :sibling]            ;; keyword sibling, nested
+   [[:outer :inner :a]   :b]                  ;; keyword sibling, deeper
+   [[:a]                 [:other :leaf]]      ;; absolute keyword vector-path
+   [[:outer :inner]      [:x :y :z]]          ;; absolute keyword vector-path
+   [[:idle]              nil]                 ;; internal (no :target) → nil
+   [[:outer :inner]      nil]])
+
+(deftest resolve-target-path-parity
+  (testing "viz chart resolve-target-path agrees with the engine target-path"
+    (doseq [[decl-path target] target-path-fixtures]
+      (is (= (engine-target-path decl-path target)
+             (viz-resolve-target-path decl-path target))
+          (str "target-path resolution drifted for decl-path "
+               (pr-str decl-path) " target " (pr-str target))))))


### PR DESCRIPTION
## What

Adds **4 PARITY tests** (one per verified mirror pair) in the machines-viz TEST surface, guarding the engine-grammar hand-mirror against silent drift. Mike-ruled `rf2-ir5nah` **option (b)**: accept the mirror as by-design (bundle-isolation + JVM-portability make a shared `:require` infeasible) and make drift LOUD with co-located parity tests. A shared grammar-codec ns (option a) was rejected.

machines-viz hand-mirrors the runtime engine's machine-definition grammar walk + target resolution. The copies are kept in sync only by hand, so a silent divergence (the viz re-wiring an edge the engine resolves differently) is the risk. Each test feeds **representative machine-defs through BOTH the viz copy AND the engine fn** and asserts **EQUAL OUTPUT** (structural/behavioural, not source-text):

| # | viz copy | engine fn |
|---|----------|-----------|
| 1 | `grammar/normalise-root-targets` | `parallel/normalise-root-targets` |
| 2 | `grammar/reenter?` | `(true? (:reenter? transition))` read |
| 3 | `grammar/transition-candidates` | `transition/normalise-candidates` |
| 4 | `chart/layout` `resolve-target-path` | `transition/target-path` |

All 4 pairings **verified to hold** against current source. Pairing 3 holds across the **shared grammar** (keyword / keyword-vec-path / candidate-vector / single-map); the deliberate divergences on degenerate shapes (nil value, mixed vector, malformed value — surfaced by the engine through registration validation, not the projector) are **documented + separately pinned** so a future accidental align/diverge is also caught.

Each test carries a `PARITY: mirror of <engine fn> — if this fails, the viz grammar drifted from the engine; re-sync, do not delete.` comment. Verified the harness goes RED on an injected drift (mutated a `cond` arm → clear failure naming the drifted fixture), then reverted.

## Bundle isolation

The test `:require`s the engine — that is fine (it is a test, not the shipped tool). The `day8/re-frame2-machines` dep is added to the `:test` alias **only**. It does **not** trip `check-bundle-isolation`:
- that gate greps the compiled `examples/counter` **production bundle**, never the test classpath;
- machines-viz **src** has zero `:require` on `re-frame.machines.*` (verified);
- the shipped jar (`:clein/build :src-dirs ["src"]`) carries no test deps;
- counter never requires machines-viz (already bundle-isolated), so neither machines-viz src nor its test deps ever reach a release classpath.

## Gates

- `cd tools/machines-viz && clojure -M:test` — **557 tests, 1981 assertions, 0 failures** (incl. the 5 new parity deftests / 37 assertions). Green post-rebase.
- clj-kondo — 0 errors, 0 warnings on the new test + `deps.edn`.
- bundle-isolation — engine-require does not leak (verified by classpath structure + static src grep; full release build not run as node_modules is absent in the fresh worktree and the result is determined by classpath, not compilation).

spec unchanged — the parity test is an internal drift guard; the mirror relationship is already documented in `grammar.cljc` and `001-Topology-Parity.md`, and no spec section describes a parity-test contract.

Disjoint from `rf2-398kql` (schema→marks bridge, not the transition/parallel grammar fns referenced here). Rebased onto `origin/main`.

Closes rf2-ir5nah.