### PR TITLE
ci(mcp-conformance): run the full authoritative Node regression gate set on PR (rf2-md05gp)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2743,13 +2743,23 @@ jobs:
       - name: Install mcp-conformance deps
         run: npm ci
 
-      # exec-safety helpers (rf2-33vvc): unit-test the
-      # trusted-PATH-resolution + symlink-safe-unlink helpers that the
-      # hermetic orchestrator + story-mcp harness route through. The
-      # symlink-rejection branches need a runner that allows symlinkSync
-      # — Ubuntu GHA does; Windows would soft-skip them.
-      - name: Run mcp-conformance exec-safety unit tests
-        run: npm run test:exec-safety
+      # Node unit-regression cluster (rf2-md05gp). Runs the FULL pure-Node
+      # unit set from the authoritative inventory in `scripts/test-all.cjs`
+      # — every `node --test` row: exec-safety (rf2-33vvc, the
+      # trusted-PATH-resolution + symlink-safe-unlink helpers), the runner
+      # watchdog teardown, the awaited hermetic cleanup, the bounded
+      # setup-command timeout, the symlink-safe port-file read, the
+      # dedup-envelope decoder, and the call-coverage / classification
+      # ratchets. These are the harness's OWN regression nets; pre-rf2-md05gp
+      # only exec-safety ran in CI, so a regression in the other seven could
+      # ship green. `test:unit` DERIVES its set from `test-all.cjs` (the
+      # single source of truth), so a new `node --test` row is picked up
+      # automatically — no second list to drift. Boots no server / nREPL /
+      # clojure / Chromium; whole cluster is ~2-5s. The symlink-rejection
+      # branches need a runner that allows symlinkSync — Ubuntu GHA does;
+      # Windows would soft-skip them (so they run for real here).
+      - name: Run mcp-conformance Node unit-regression cluster
+        run: npm run test:unit
 
       - name: Run re-frame2-pair-mcp end-to-end MCP-client conformance
         run: npm run test:re-frame2-pair

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -520,8 +520,22 @@ its own `mcp-conformance-{re-frame2-pair,story}` job, parallel to the
 existing `node-test-tools-{re-frame2-pair,story}-mcp` jobs. Same
 Node 24 + JDK 21 setup as those jobs.
 
-The `mcp-conformance-re-frame2-pair` job runs three steps in sequence:
+The `mcp-conformance-re-frame2-pair` job runs four steps in sequence:
 
+0. **`test:unit`** (rf2-md05gp) — the FULL pure-Node unit-regression
+   cluster: every `node --test` row from the authoritative inventory in
+   `scripts/test-all.cjs` (exec-safety, runner-watchdog, runner-cleanup,
+   hermetic-setup-timeout, port-file-escape, dedup-envelope,
+   call-coverage-ratchet, classification-ratchet). These are the harness's
+   own regression nets — watchdog teardown of hung clients, awaited
+   hermetic cleanup, bounded setup commands, symlink-safe port-file reads,
+   dedup-envelope decoding, and the call/classification ratchets. It runs
+   FIRST so a cheap unit regression fails before the heavier server boots,
+   and is the natural home for the unit set (Node-only, no `clojure`).
+   `test:unit` DERIVES its set from `test-all.cjs` rather than re-listing,
+   so a new `node --test` row is picked up automatically. Pre-rf2-md05gp
+   only `exec-safety` ran in CI; the other seven gates were in the local
+   inventory but dead in CI, so a regression they guard could ship green.
 1. **`test:re-frame2-pair`** — degraded-mode conformance against the SDK's
    strict schemas.
 2. **`test:re-frame2-pair-live-overflow`** — the gated live variant. Runs
@@ -550,8 +564,11 @@ ratchet) and **`test:flag-gates`** (the cross-MCP CLI flag-vocabulary
 conformance — story-mcp `--allow-writes` default-OFF for all three gated
 write tools + the ungated snippet-only path + opt-in + hard-rename
 rejection). Both need `clojure`. The `callTool` coverage ratchet's own
-unit tests (`test:call-coverage-ratchet`) run with the cheap Node unit
-tests via `npm test`.
+unit tests (`test:call-coverage-ratchet`) run in PR CI as part of the
+`test:unit` cluster in the `mcp-conformance-re-frame2-pair` job (above) —
+the Node unit set is server-agnostic, so it runs once there rather than
+being duplicated in this `clojure`-only job. Locally the full inventory
+(unit + e2e + live + story) runs via `npm test` (`scripts/test-all.cjs`).
 
 ## Why a separate artefact?
 

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -23,6 +23,7 @@
     "test:classification-ratchet": "node --test test/classification-ratchet.test.cjs",
     "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
     "test:port-file-escape": "node --test test/port-file-escape.test.cjs",
+    "test:unit": "node scripts/test-unit.cjs",
     "test": "node scripts/test-all.cjs"
   },
   "dependencies": {

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -42,6 +42,16 @@ const ROOT = path.resolve(HERE, '..');
 // server. SKIP-by-default tests (live-re-frame2-pair-overflow) live near
 // the end so a green run reads as "real conformance passed, one
 // gracefully skipped".
+//
+// This array is the SINGLE SOURCE OF TRUTH for the conformance
+// inventory. It is exported (see the bottom of this file) so derived
+// runners can select a subset without re-listing — notably
+// `scripts/test-unit.cjs`, which runs the pure-Node unit cluster
+// (every row whose `argv[0] === '--test'`) in one `node --test`
+// invocation for the PR CI Node-regression gate (rf2-md05gp). Because
+// that runner DERIVES its set from this array, a new `--test` row added
+// here is automatically picked up by PR CI — no second list to keep in
+// sync.
 const TESTS = [
   {
     name: 'exec-safety unit tests',
@@ -118,45 +128,59 @@ function banner(line) {
   process.stdout.write('\n' + sep + '\n' + line + '\n' + sep + '\n');
 }
 
-const results = [];
-let firstFailure = null;
+function main() {
+  const results = [];
+  let firstFailure = null;
 
-for (const test of TESTS) {
-  banner('▶ ' + test.name + '\n  ' + test.argv.join(' '));
-  // `process.execPath` is always absolute; `spawnSync` inherits stdio
-  // so the child's stdout/stderr stream through verbatim (matching
-  // every historical caller's posture). `shell: false` keeps the
-  // accident-gating from the lib/exec-safety.cjs preamble: no
-  // shell-interpolation of test names.
-  const child = spawnSync(process.execPath, test.argv, {
-    cwd: ROOT,
-    stdio: 'inherit',
-    env: process.env,
-  });
-  const status = child.status === null ? 'signal:' + child.signal : child.status;
-  results.push({ name: test.name, status });
-  if (child.status !== 0 && firstFailure === null) {
-    firstFailure = { test: test.name, status: child.status, signal: child.signal };
-    break;
+  for (const test of TESTS) {
+    banner('▶ ' + test.name + '\n  ' + test.argv.join(' '));
+    // `process.execPath` is always absolute; `spawnSync` inherits stdio
+    // so the child's stdout/stderr stream through verbatim (matching
+    // every historical caller's posture). `shell: false` keeps the
+    // accident-gating from the lib/exec-safety.cjs preamble: no
+    // shell-interpolation of test names.
+    const child = spawnSync(process.execPath, test.argv, {
+      cwd: ROOT,
+      stdio: 'inherit',
+      env: process.env,
+    });
+    const status = child.status === null ? 'signal:' + child.signal : child.status;
+    results.push({ name: test.name, status });
+    if (child.status !== 0 && firstFailure === null) {
+      firstFailure = { test: test.name, status: child.status, signal: child.signal };
+      break;
+    }
   }
+
+  banner('mcp-conformance summary');
+  for (const r of results) {
+    const tick = r.status === 0 ? 'OK  ' : 'FAIL';
+    process.stdout.write(`  [${tick}] ${r.name} (exit=${r.status})\n`);
+  }
+
+  if (firstFailure) {
+    process.stdout.write(
+      `\nFAIL: ${firstFailure.test} exited ${firstFailure.status}` +
+        (firstFailure.signal ? ' (signal ' + firstFailure.signal + ')' : '') +
+        '\n',
+    );
+    // Forward the inner exit code verbatim. `null` (signal-terminated)
+    // becomes 1 so the parent shell still sees a non-zero exit.
+    process.exit(firstFailure.status === null ? 1 : firstFailure.status);
+  }
+
+  process.stdout.write('\nALL CONFORMANCE TESTS GREEN\n');
+  process.exit(0);
 }
 
-banner('mcp-conformance summary');
-for (const r of results) {
-  const tick = r.status === 0 ? 'OK  ' : 'FAIL';
-  process.stdout.write(`  [${tick}] ${r.name} (exit=${r.status})\n`);
-}
+// Export the authoritative inventory so derived runners (e.g.
+// `scripts/test-unit.cjs`) can select a subset without re-listing.
+// `ROOT` rides along so a derived runner resolves test paths against the
+// same artefact root. The orchestrator only auto-runs when invoked
+// directly (`node scripts/test-all.cjs` / `npm test`), not when required
+// as a module — so importing this file has no side effects.
+module.exports = { TESTS, ROOT };
 
-if (firstFailure) {
-  process.stdout.write(
-    `\nFAIL: ${firstFailure.test} exited ${firstFailure.status}` +
-      (firstFailure.signal ? ' (signal ' + firstFailure.signal + ')' : '') +
-      '\n',
-  );
-  // Forward the inner exit code verbatim. `null` (signal-terminated)
-  // becomes 1 so the parent shell still sees a non-zero exit.
-  process.exit(firstFailure.status === null ? 1 : firstFailure.status);
+if (require.main === module) {
+  main();
 }
-
-process.stdout.write('\nALL CONFORMANCE TESTS GREEN\n');
-process.exit(0);

--- a/tools/mcp-conformance/scripts/test-unit.cjs
+++ b/tools/mcp-conformance/scripts/test-unit.cjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/*
+ * PR-CI Node-regression gate (rf2-md05gp).
+ *
+ * Runs the pure-Node UNIT cluster of the conformance inventory — every
+ * row in `scripts/test-all.cjs`'s authoritative `TESTS` array whose
+ * `argv[0] === '--test'` (i.e. invoked via `node --test`). These are the
+ * harness's own regression nets: the runner watchdog teardown, the
+ * awaited hermetic cleanup, the bounded setup-command timeout, the
+ * symlink-safe port-file read, the dedup-envelope decoder, and the
+ * call-coverage / classification ratchets. They boot no MCP server, need
+ * no nREPL / clojure / Chromium, and finish in a couple of seconds.
+ *
+ * ## Why this script exists
+ *
+ * `test-all.cjs` is the single source of truth for the conformance
+ * inventory, but it spawns EVERY test — including the end-to-end (server
+ * bundle), live (nREPL), story (JVM `clojure`), and hermetic
+ * (shadow-cljs + Chromium) gates. Those are run by dedicated CI jobs
+ * (`mcp-conformance-{re-frame2-pair,story}`) with their own toolchains
+ * and caches. Pre-rf2-md05gp the PR CI for those jobs ran ONLY
+ * `test:exec-safety` (+ the e2e / live / story steps); the other seven
+ * `node --test` unit gates were in the local inventory but NEVER ran in
+ * CI, so a regression they guard could ship green.
+ *
+ * This runner DERIVES its set from `test-all.cjs` rather than
+ * re-listing, so it cannot drift: add a new `node --test` row to the
+ * authoritative array and PR CI picks it up automatically. It runs the
+ * whole cluster in ONE `node --test` invocation (Node's test runner
+ * aggregates results across files and exits non-zero if any file fails),
+ * which is faster than spawning each file separately and gives one
+ * combined summary.
+ *
+ * Exit codes: 0 = every unit gate green; non-zero = at least one failed
+ * (forwarded from the `node --test` child).
+ */
+'use strict';
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { TESTS, ROOT } = require('./test-all.cjs');
+
+// The unit cluster is exactly the rows invoked through `node --test`.
+// The end-to-end / live / story / flag-gates rows are plain
+// `node <script>` (no `--test`) and are excluded — they belong to the
+// dedicated server jobs, not this Node-only unit gate.
+const UNIT_FILES = TESTS.filter((t) => t.argv[0] === '--test').map(
+  (t) => t.argv[t.argv.length - 1],
+);
+
+if (UNIT_FILES.length === 0) {
+  process.stderr.write(
+    'test-unit: no `node --test` rows found in the authoritative inventory — ' +
+      'refusing to report green with an empty gate set.\n',
+  );
+  process.exit(1);
+}
+
+const sep = '─'.repeat(72);
+process.stdout.write(
+  '\n' +
+    sep +
+    '\n▶ mcp-conformance Node unit cluster (rf2-md05gp)\n  node --test ' +
+    UNIT_FILES.join(' ') +
+    '\n' +
+    sep +
+    '\n',
+);
+
+// One `node --test` invocation across every unit file: the runner
+// aggregates and exits non-zero on any failure. `cwd: ROOT` so the
+// relative `test/...` paths resolve against the artefact root regardless
+// of the caller's cwd. `shell: false` (spawnSync default) — no
+// shell-interpolation of file paths.
+const child = spawnSync(process.execPath, ['--test', ...UNIT_FILES], {
+  cwd: ROOT,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (child.status === null) {
+  process.stderr.write(
+    `\ntest-unit: node --test terminated by signal ${child.signal}\n`,
+  );
+  process.exit(1);
+}
+
+if (child.status === 0) {
+  process.stdout.write('\nMCP-CONFORMANCE NODE UNIT CLUSTER GREEN\n');
+}
+process.exit(child.status);


### PR DESCRIPTION
## Problem (rf2-md05gp, P2 correctness-review-2)

`tools/mcp-conformance/scripts/test-all.cjs` is the authoritative local conformance inventory. It lists **eight** pure-Node `node --test` regression gates: `exec-safety`, `runner-watchdog`, `runner-cleanup`, `hermetic-setup-timeout`, `port-file-escape`, `dedup-envelope`, `call-coverage-ratchet`, `classification-ratchet`.

But PR CI (`.github/workflows/test.yml`) only ran **`test:exec-safety`** in the `mcp-conformance-re-frame2-pair` job. The other seven were **dead in CI** — a regression in the harness's own nets (watchdog teardown of hung clients, awaited hermetic cleanup, bounded setup commands, symlink-safe port-file reads, dedup-envelope decoding, the call/classification ratchets) would not fail a PR. The `mcp-conformance-story` job ran no Node unit gates either.

## Fix — derive the CI set from the single source of truth

- **`scripts/test-all.cjs`** refactored to export `{ TESTS, ROOT }` and only auto-run under `require.main === module` (requiring it has no side-effects).
- **`scripts/test-unit.cjs`** (new) selects every row whose `argv[0] === '--test'` from the exported `TESTS` and runs them in **one** `node --test` invocation (aggregates, fails non-zero on any). Because the set is **derived**, a new `node --test` row added to the inventory is picked up by CI automatically — no second list to drift. Refuses to report green on an empty set.
- **`package.json`** adds `test:unit`.
- **CI**: the `mcp-conformance-re-frame2-pair` job's exec-safety-only step is replaced by `npm run test:unit` — a strict superset (exec-safety is one of the eight). It runs first so a cheap unit regression fails before the heavier server boots.

## No nightly-only carve-outs

The whole cluster is server-agnostic pure-Node (no nREPL / `clojure` / shadow-cljs / Chromium) and runs in ~2-5s, so it belongs on the PR spine, not nightly. It runs **once** in the pair job (which already sets up Node + `npm ci`) rather than being duplicated in the `clojure`-only story job. No flake risk added — these gates spawn only short-lived `node` children.

## Local verification (Node v24.13.0, matching CI Node 24)

- `npm run test:unit` → **58 tests, 49 pass, 9 skipped, 0 fail, exit 0, ~1.8s**. (The 9 skips are the symlink-rejection branches that need a runner allowing `symlinkSync`; Windows soft-skips them, **Ubuntu GHA runs them for real**.)
- `node scripts/test-all.cjs` confirms the orchestrator refactor is intact: all 8 unit rows `[OK]`, then proceeds to the e2e step (fails only on the absent server bundle in this worktree — expected, unrelated).
- `require('./scripts/test-all.cjs')` produces no side-effects and exports `TESTS` (17) + `ROOT`; the unit filter yields 8.
- Workflow YAML parses clean (`yaml.safe_load`).

README CI section updated to reflect the new four-step pair job and correct the stale "ratchet runs via npm test" note.

Closes rf2-md05gp.