### PR TITLE
fix(pair-mcp): invalidate stale get-operating-frame cache (rf2-flm0iz)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -286,9 +286,19 @@ session per the [persistent-socket principle](Principles.md#single-persistent-nr
 no cross-process leak, no manual invalidation.
 
 Action tools (`dispatch`, `eval-cljs`, `tail-build`) and
-streaming tools (`subscribe`, `unsubscribe`, `list-streams`) bypass
-the cache — their return value is the result of an action / a read of
-the volatile streaming-tap registry, not frame state.
+streaming tools (`subscribe`, `unsubscribe`, `list-streams`,
+`get-stream-controls`) bypass the cache — their return value is the
+result of an action / a read of the volatile streaming-tap registry,
+not frame state. `get-operating-frame` bypasses for the same reason:
+its resolved triple is a function of the live **frame registry** plus
+the per-session **pin**, both of which can move WITHOUT an app-db
+mutation and WITHOUT a `set-operating-frame` / `reset-operating-frame`
+call (a frame mount/unmount, or a runtime reload with a different live
+frame set). The cache key cannot fold the registry/pin in, and the
+result-hash cache only flushes on an explicit operating-frame mutation
+— so caching it could serve a stale `:rf.mcp/cache-hit` for byte-
+identical empty args, masking a newly ambiguous session or a newly
+available app frame. It is non-cacheable.
 (`list-subscriptions` opts IN — it reads the live reactive sub-cache,
 a pure function of frame state, just like `snapshot`; rf2-qicji.)
 `:isError` results bypass too; a transient failure must not

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -359,12 +359,22 @@ Post-Lock additions accumulated as follows:
   named session setting (the operating frame), and the spec-mandated
   name wins for cross-server mental-model transfer (re-frame-pair-improver
   / Xray / Story carry the same trio). See Lock #8 + NAMING.md §The verb
-  table for the catalogue addition. `set` / `reset` are `:cacheable? false`
-  (session-state writes); `get` is `:cacheable? true` (a read of the
-  frame registry + pin, caught by the post-eval result-hash cache — the
-  precheck path is single-frame app-db-only `snapshot`-only (rf2-ww877w
-  retired `get-path` from precheck eligibility), so a pin write between
-  two `get`s is never served stale).
+  table for the catalogue addition. All three are `:cacheable? false`: `set` /
+  `reset` are session-state writes; `get` is a read of VOLATILE runtime
+  state — the live frame registry plus the per-session pin — NOT a
+  function of an app-db hash. Both axes can move WITHOUT an app-db
+  mutation and WITHOUT a `set` / `reset` call (a frame mount/unmount, or
+  a runtime reload with a different live frame set), and the result-hash
+  cache only flushes on an explicit operating-frame mutation — so a
+  cacheable `get` could serve a stale `:rf.mcp/cache-hit` for byte-
+  identical empty args, masking a newly ambiguous session or a newly
+  available app frame. It is non-cacheable, same posture as
+  `get-stream-controls` (the recording/streaming volatile-state reads).
+  An earlier revision marked `get` `:cacheable? true` on the theory that
+  set/reset cache-flushes covered every pin change; that missed the
+  registry-mutation axis above. If caching is ever wanted here, add a
+  runtime frame-registry/session-pin generation token to the cache
+  identity — do NOT key it on tool/build/args alone.
 - **rf2-3bu3d.7 / rf2-3bu3d.8** added the **read-orientation pair** —
   `read-sub` and `orient`. `read-sub {sub-id}` is the validated single-
   subscription read: resolve the named subscription against the reactive

--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -923,7 +923,16 @@ var.
 `tail-build`) bypass — their return value is the result of an
 action, not a read. Streaming tools (`subscribe`,
 `unsubscribe`) bypass — they emit progress notifications, not
-single payloads. `:isError` results bypass — a transient
+single payloads. Volatile runtime-state reads bypass too —
+`list-streams` / `get-stream-controls` (the streaming-tap registry)
+and `get-operating-frame`, whose resolved triple is a function of the
+live frame registry plus the per-session pin: both axes can move
+WITHOUT an app-db mutation and WITHOUT a `set-operating-frame` /
+`reset-operating-frame` call (a frame mount/unmount, or a runtime
+reload with a different live frame set), and the result-hash cache only
+flushes on an explicit operating-frame mutation — so caching it could
+serve a stale `:rf.mcp/cache-hit` masking a newly ambiguous session or
+a newly available app frame. `:isError` results bypass — a transient
 failure must not mask a future successful read.
 
 **Cross-MCP vocabulary**. `:rf.mcp/cache-hit` is the wire

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -300,14 +300,27 @@
     :descriptor data/reset-operating-frame}
    {:name       "get-operating-frame"
     :handler    (ignoring-extra #(operating-frame/get-operating-frame-tool %1 %2))
-    ;; Pure read of the resolved frame triple — a function of the frame
-    ;; registry + session pin. Cacheable like the other read tools; the
-    ;; precheck-hash short-circuit keys on app-db, but the triple is
-    ;; cheap to recompute and the cache opt-in is per-call, so a stale
-    ;; read after a set/reset is avoided by the :cache default-false
-    ;; posture (rf2-c4fmh). Treating it as cacheable keeps it in the
-    ;; read family for the cache opt-in knob.
-    :cacheable? true
+    ;; NOT cacheable — same posture as `get-stream-controls` / `list-streams`:
+    ;; a read of volatile process/runtime state, not a function of frame
+    ;; app-db. The resolved triple (`:frames` / `:app-frames` / `:selected`
+    ;; / `:operating`) depends on the live frame registry plus the per-
+    ;; session pin, and BOTH axes can move WITHOUT an app-db mutation and
+    ;; WITHOUT a `set-operating-frame` / `reset-operating-frame` call —
+    ;; e.g. a frame mounts/unmounts or a connected runtime reloads with a
+    ;; different live frame set. The cache key is only
+    ;; `[tool build (args->fingerprint args)]` (see `cache/cache-key`); it
+    ;; cannot fold in the registry/pin, and the result-hash cache only
+    ;; clears on an explicit operating-frame mutation (see
+    ;; `operating-frame-mutating?` in `tools.cljs`). So a repeated
+    ;; `get-operating-frame {cache true}` over byte-identical empty args
+    ;; could serve a `:rf.mcp/cache-hit` marker telling the agent to reuse
+    ;; stale frame-discovery data — hiding a newly ambiguous session or a
+    ;; newly available app frame. Marking it non-cacheable keeps the read
+    ;; always-fresh; the triple is cheap to recompute. If caching is ever
+    ;; wanted here, add a runtime frame-registry/session-pin generation
+    ;; token to the cache identity — do NOT key it on tool/build/args
+    ;; alone.
+    :cacheable? false
     :descriptor data/get-operating-frame}
    {:name       "get-re-frame2-pair-instructions"
     :handler    (ignoring-extra #(get-re-frame2-pair-instructions/get-re-frame2-pair-instructions-tool %1 %2))
@@ -355,9 +368,13 @@
   for the inline `get-re-frame2-pair-instructions` onboarding text
   (which is a pure-data function with no state whatsoever — once is
   forever). False for action tools (`dispatch`, `eval-cljs`,
-  `tail-build`) and streaming tools (`subscribe`, `unsubscribe`,
-  `list-streams`) — their return value is the result of an action /
-  a read of the volatile streaming registry, not frame state.
+  `tail-build`), streaming tools (`subscribe`, `unsubscribe`,
+  `list-streams`, `get-stream-controls`), and volatile runtime-state
+  reads whose value can move without an app-db mutation —
+  `get-operating-frame`, whose resolved triple is a function of the
+  live frame registry plus the per-session pin (rf2-flm0iz). Their
+  return value is the result of an action / a read of volatile
+  process/runtime state, not frame app-db.
 
   Unknown names return false."
   [tool]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
@@ -77,6 +77,23 @@
   (is (not (cache/cacheable? "unsubscribe")))
   (is (not (cache/cacheable? "unknown-tool"))))
 
+(deftest cacheable-excludes-get-operating-frame
+  ;; rf2-flm0iz — `get-operating-frame` is a read of VOLATILE runtime
+  ;; state (the live frame registry + the per-session pin), not a
+  ;; function of frame app-db. Both axes can move WITHOUT an app-db
+  ;; mutation and WITHOUT a `set-operating-frame` / `reset-operating-
+  ;; frame` call (a frame mount/unmount, or a runtime reload with a
+  ;; different live frame set). The cache key cannot fold the
+  ;; registry/pin in (see `cache/cache-key`), and the result-hash cache
+  ;; only flushes on an explicit operating-frame mutation — so caching
+  ;; it could serve a stale `:rf.mcp/cache-hit` for byte-identical empty
+  ;; args. It must be non-cacheable, same posture as `get-stream-
+  ;; controls` / `list-streams`.
+  (is (not (cache/cacheable? "get-operating-frame"))
+      "get-operating-frame must not consult the response cache")
+  (is (not (cache/cacheable? "get-stream-controls"))
+      "sibling volatile-state read stays non-cacheable too"))
+
 ;; ---------------------------------------------------------------------------
 ;; args->fingerprint — stable across JS-object key order.
 ;; ---------------------------------------------------------------------------
@@ -214,6 +231,31 @@
       (is (identical? r out)))
     (is (zero? (cache/size))
         "action tools never poison the cache")))
+
+(deftest get-operating-frame-never-serves-stale-cache-hit
+  ;; rf2-flm0iz — the load-bearing scenario. Two byte-identical
+  ;; `get-operating-frame` responses MUST NOT collapse into a
+  ;; `:rf.mcp/cache-hit` marker, because the resolved frame triple can
+  ;; have changed underneath identical bytes (a frame mounted/unmounted,
+  ;; the runtime reloaded with a different live frame set) without any
+  ;; app-db mutation and without an operating-frame set/reset call to
+  ;; flush the cache. With `get-operating-frame` non-cacheable, both
+  ;; calls pass through untouched and nothing is stored.
+  (let [args (args-js {})
+        text "{:ok? true :frames [:rf/default] :selected nil :operating :rf/default}"
+        r1   (mcp-result text)
+        r2   (mcp-result text)
+        opts {:tool "get-operating-frame" :args args :enabled? true}]
+    (let [out1 (cache/apply-cache r1 opts)]
+      (is (identical? r1 out1)
+          "first get-operating-frame read passes through untouched"))
+    (let [out2 (cache/apply-cache r2 opts)]
+      (is (identical? r2 out2)
+          "second byte-identical read still returns the fresh payload")
+      (is (not (cache-hit-result? out2))
+          "no :rf.mcp/cache-hit marker — could mask a changed frame/session"))
+    (is (zero? (cache/size))
+        "get-operating-frame never poisons the cache")))
 
 (deftest error-results-bypass-cache
   ;; An :isError result should not be cached — a transient error


### PR DESCRIPTION
## Problem

`get-operating-frame` opted into the per-session response cache (`:cacheable? true`), but its resolved frame triple — `:frames` / `:app-frames` / `:selected` / `:operating` — is a function of the **live frame registry** plus the **per-session pin**. Both axes can move WITHOUT an app-db mutation and WITHOUT a `set-operating-frame` / `reset-operating-frame` call:

- a frame mounts / unmounts, or
- a connected runtime reloads with a different live frame set.

The cache key is only `[tool build (args->fingerprint args)]` and cannot fold the registry/pin in (see `cache/cache-key`), and the result-hash cache only flushes on an **explicit** operating-frame mutation (see `operating-frame-mutating?` in `tools.cljs`). `get-operating-frame` is not precheck-eligible, so it falls back to the post-eval result-hash cache. Result: a repeated `get-operating-frame {cache true}` over byte-identical empty args could serve a `{:rf.mcp/cache-hit ...}` marker telling the agent to reuse **stale** frame-discovery data — masking a newly ambiguous session or a newly available app frame.

## Fix

Mark `get-operating-frame` `:cacheable? false`, matching `get-stream-controls` / `list-streams` as a volatile runtime-state read. The triple is cheap to recompute. If caching is wanted later, add a runtime frame-registry/session-pin generation token to the cache identity — do not key it on tool/build/args alone.

## Tests

- `cacheable-excludes-get-operating-frame` — pins `cache/cacheable? "get-operating-frame"` is false.
- `get-operating-frame-never-serves-stale-cache-hit` — apply-cache-level regression proving two byte-identical `get-operating-frame` responses never collapse into a `:rf.mcp/cache-hit` marker (both pass through fresh, nothing stored).

## Spec currency

Tool-Catalogue (§Universal: per-session response cache), DESIGN-RATIONALE (operating-frame triplet Lock note), and Principles (§Per-session response cache Bypass policy) updated to the non-cacheable posture; the prior "set/reset cache-flush covers every pin change" rationale corrected to account for the registry-mutation axis.

## Gates

- pair-mcp suite: `npm test` — 1121 tests / 3728 assertions, 0 failures.
- mcp-conformance: `test:re-frame2-pair` GREEN (30/30 tools SDK-called incl. get-operating-frame).
- clj-kondo: 0 errors on changed source (one pre-existing redundant-let warning, untouched).
- bundle-isolation: unaffected — change is a `:cacheable?` boolean flip inside an already bundle-isolated tool; adds no new requires and touches nothing in `implementation/`.