### PR TITLE
fix(story): run inline-plan teardown on failure path (rf2-7u3eja)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -313,14 +313,22 @@ rather than forking it:
    boundary), so an inline plan and a registered variant describing the
    same behaviour produce equivalent app-db + assertion records after
    `canonicalize` (the metamorphic relation);
-6. the anonymous frame is torn down when the run resolves; nothing is
-   registered.
+6. the anonymous frame is torn down when the run resolves — on BOTH the
+   success path AND the failure path. A run that fails AFTER the frame is
+   allocated (a `:db-seed` schema violation, a throw in loaders / setup /
+   the script) runs the SAME teardown a successful run does: the plan's
+   `[:world :loaders-teardown]` events then the `[:world :decorators]`
+   frame-setup `:teardown` events (§Loader teardown contract, 002-Runtime),
+   using the decorator stack that was set up at the point of failure. The
+   success and failure paths converge on identical cleanup — so a resource
+   an inline loader or frame-setup decorator opened is never leaked on the
+   failure path. Nothing is registered.
 
 A plan-construction failure for a map target (an unknown composed
 fragment, a missing `[:arg …]`, a misplaced `[:assert …]` in setup, …)
 surfaces as the SAME structured `:rf.error/story-*` error result a
 registered variant's malformed plan produces — the frame is never
-allocated.
+allocated, so there is nothing to tear down.
 
 ### Run artifact
 

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1389,35 +1389,73 @@
                frame-id (mint-inline-frame-id)]
            (async/promise
              (fn [resolve]
-               (try
-                 (let [ctx          (-> (prepare-inline-context frame-id plan opts)
-                                        run-inline-phase-0!
-                                        run-db-seed!
-                                        run-phase-1!
-                                        run-phase-2!)
-                       [ctx' play-promise] (run-phase-4! ctx)]
-                   (-> play-promise
-                       (async/then
-                         (fn [_]
-                           (let [result (record-result-map ctx' start-ms)]
-                             (frames/destroy-inline!
-                               frame-id (:decorator-stack ctx')
-                               (get-in plan [:world :loaders-teardown]))
-                             (resolve result))
-                           nil))))
-                 (catch #?(:clj Throwable :cljs :default) e
-                   ;; rf2-blw1q — a `:db-seed` schema-validation failure
-                   ;; records as its own structured assertion; every other
-                   ;; throw stays the opaque `:rf.error/exception` shape.
-                   (if (db-seed-error? e)
-                     (record-seed-error! frame-id e)
-                     (record-error! frame-id :phase-0-setup nil e))
-                   (loaders/error! frame-id (ex-data e))
-                   (let [result (record-result-map
-                                  {:variant-id frame-id :plan plan} start-ms)]
-                     (try (frames/destroy-inline! frame-id nil nil)
-                       (catch #?(:clj Throwable :cljs :default) _ nil))
-                     (resolve result))))))))))))
+               ;; rf2-7u3eja — the SUCCESS path tears the inline frame down
+               ;; with the decorator stack used for allocation + the plan's
+               ;; `:loaders-teardown`; the FAILURE path MUST converge on the
+               ;; SAME teardown. Previously the catch ran
+               ;; `(destroy-inline! frame-id nil nil)` — the frame was removed
+               ;; but `:loaders-teardown` + frame-setup decorator `:teardown`
+               ;; were SKIPPED, so any resource opened by an inline-plan loader
+               ;; or `:frame-setup` decorator leaked on precisely the failure
+               ;; path (db-seed / phase 1 / phase 2 / phase 4 setup) where
+               ;; cleanup matters.
+               ;;
+               ;; The decorator stack is fixed at `prepare-inline-context`
+               ;; time (resolved once, constant across phases), so `teardown!`
+               ;; reads it off the captured context. `allocated?` flips true
+               ;; only AFTER `run-inline-phase-0!` (which calls
+               ;; `allocate-inline!`) succeeds: a throw BEFORE allocation
+               ;; (e.g. inside `prepare-inline-context`) tears down nothing —
+               ;; no frame exists and no frame-setup `:init` ran — while a
+               ;; throw AFTER allocation tears down exactly what was set up
+               ;; (partial-allocation safety). `destroy-inline!` already
+               ;; no-ops the loader-teardown walk when its third arg is empty.
+               (let [ctx*       (volatile! nil)
+                     allocated? (volatile! false)
+                     teardown!  (fn []
+                                  (when @allocated?
+                                    (try
+                                      (frames/destroy-inline!
+                                        frame-id (:decorator-stack @ctx*)
+                                        (get-in plan [:world :loaders-teardown]))
+                                      (catch #?(:clj Throwable :cljs :default) _ nil))))
+                     fail!      (fn [e]
+                                  ;; rf2-blw1q — a `:db-seed` schema-validation
+                                  ;; failure records as its own structured
+                                  ;; assertion; every other throw stays the
+                                  ;; opaque `:rf.error/exception` shape.
+                                  (if (db-seed-error? e)
+                                    (record-seed-error! frame-id e)
+                                    (record-error! frame-id :phase-0-setup nil e))
+                                  (loaders/error! frame-id (ex-data e))
+                                  (let [result (record-result-map
+                                                 {:variant-id frame-id :plan plan} start-ms)]
+                                    (teardown!)
+                                    (resolve result)))]
+                 (try
+                   (let [prepared     (prepare-inline-context frame-id plan opts)
+                         _            (vreset! ctx* prepared)
+                         ;; Phase 0 allocates the anonymous frame (+ runs
+                         ;; frame-setup `:init`); only past it does the
+                         ;; failure path owe a teardown.
+                         ctx0         (run-inline-phase-0! prepared)
+                         _            (vreset! allocated? true)
+                         ctx          (-> ctx0 run-db-seed! run-phase-1! run-phase-2!)
+                         _            (vreset! ctx* ctx)
+                         [ctx' play-promise] (run-phase-4! ctx)
+                         _            (vreset! ctx* ctx')]
+                     (-> play-promise
+                         (async/then
+                           (fn [_]
+                             (let [result (record-result-map ctx' start-ms)]
+                               (teardown!)
+                               (resolve result))
+                             nil))
+                         ;; A rejection INSIDE the play promise (phase 4) must
+                         ;; also converge on teardown, not leak the frame.
+                         (async/catch* (fn [e] (fail! e) nil))))
+                   (catch #?(:clj Throwable :cljs :default) e
+                     (fail! e))))))))))))
 
 ;; ---- reset-variant -------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -23,8 +23,10 @@
   async; its plan compilation + report projection are covered host-free by
   the plan / result suites."
   (:require [clojure.test :refer [deftest is testing use-fixtures] :as t]
+            [malli.core         :as m]
             [re-frame.core      :as rf]
             [re-frame.frame     :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
@@ -318,3 +320,124 @@
       (is (= [:inline/explained] (:source-chain ex)))
       (is (= [[:dispatch [:inline/inc]]] (:setup-order ex)))
       (is (empty? (story/ids :variant)) "explain registered nothing"))))
+
+;; ===========================================================================
+;; FAILURE-PATH TEARDOWN — an inline plan that fails mid-run still runs the
+;; SAME teardown the success path runs (rf2-7u3eja)
+;;
+;; The success path tears the anonymous inline frame down with the decorator
+;; stack used for allocation + the plan's `:loaders-teardown`; the FAILURE
+;; path previously ran `(destroy-inline! frame-id nil nil)` — the frame was
+;; removed but `:loaders-teardown` + frame-setup decorator `:teardown` were
+;; SKIPPED, leaking any resource an inline loader or `:frame-setup` decorator
+;; opened on precisely the failure path where cleanup matters. Both paths now
+;; converge on the SAME teardown.
+;;
+;; The forced post-allocation throw is a `:db-seed` schema violation: it
+;; throws in `run-db-seed!` (phase 0.5) AFTER `allocate-inline!` ran the
+;; frame-setup `:init`, so the failure-path teardown owes the symmetric
+;; cleanup. Validation rides the SAME schemas late-bind seam the runtime uses
+;; (no hard dep on the schemas artefact — Malli backs the host-free stand-in).
+;; ===========================================================================
+
+(defn- install-schema-seam!
+  "Install the schemas late-bind seam (the SAME seam the runtime's
+  `db-seed-violations` reaches) so an inline frame validates its `:db-seed`
+  against `schema-for-any-frame`. An inline frame-id is minted dynamically,
+  so the entries fn returns the schema for ANY frame-id (the inline run is
+  the only frame on the classpath under test). Malli backs the validator —
+  no hard dep on the schemas artefact."
+  [schema-for-any-frame]
+  (late-bind/set-fn! :schemas/frame-schema-entries
+                     (fn [_frame-id] schema-for-any-frame))
+  (late-bind/set-fn! :schemas/validate-with-registered-fn
+                     (fn [schema value] (m/validate schema value)))
+  (late-bind/set-fn! :schemas/explain-with-registered-fn
+                     (fn [schema value] (m/explain schema value))))
+
+(defn- uninstall-schema-seam! []
+  (swap! late-bind/hooks dissoc
+         :schemas/frame-schema-entries
+         :schemas/validate-with-registered-fn
+         :schemas/explain-with-registered-fn))
+
+(deftest inline-plan-failure-runs-decorator-and-loader-teardown
+  (testing "an inline plan that FAILS mid-run (a :db-seed schema violation,
+            thrown AFTER frame allocation) still runs the plan's
+            :loaders-teardown AND its frame-setup decorator :teardown — the
+            same convergent cleanup the success path runs, so no frame /
+            decorator / loader leaks on the failure path (rf2-7u3eja).
+
+            :init / :teardown / :loaders-teardown write to side-atoms (the
+            frame's app-db is gone after destroy, so observation lives
+            outside it). Validation rides the schemas late-bind seam."
+    ;; An app-db schema the seed violates → run-db-seed! throws AFTER
+    ;; allocation (frame-setup :init already ran).
+    (install-schema-seam! {[:cart] {:schema [:map [:items [:vector :map]]]}})
+    (try
+      (let [decorator-init     (atom 0)
+            decorator-teardown (atom 0)
+            loader-teardown    (atom 0)]
+        (rf/reg-event :inline/dec-init
+          (fn [{:keys [db]} _] (swap! decorator-init inc) {:db db}))
+        (rf/reg-event :inline/dec-teardown
+          (fn [{:keys [db]} _] (swap! decorator-teardown inc) {:db db}))
+        (rf/reg-event :inline/loader-teardown
+          (fn [{:keys [db]} _] (swap! loader-teardown inc) {:db db}))
+        (story/reg-decorator :inline/live-resource
+          {:kind     :frame-setup
+           :init     [[:inline/dec-init]]
+           :teardown [[:inline/dec-teardown]]})
+        (let [result (run-target
+                       {:decorators       [[:inline/live-resource]]
+                        :loaders-teardown [[:inline/loader-teardown]]
+                        ;; :items must be a vector of maps — a string violates it.
+                        :db-seed          {:cart {:items "not-a-vector"}}
+                        :script           [[:dispatch [:inline/set-status :loaded]]]})]
+          (testing "the run FAILED on the schema-violating seed (not a vacuous pass)"
+            (is (= :error (:status result)))
+            (is (= :rf.error/story-db-seed-invalid
+                   (:assertion (first (filter #(= :rf.error/story-db-seed-invalid
+                                                  (:assertion %))
+                                              (:assertions result)))))))
+          (testing "frame-setup :init ran during allocation (precondition)"
+            (is (= 1 @decorator-init)))
+          (testing "the FAILURE path ran the SAME teardown the success path runs"
+            (is (= 1 @decorator-teardown)
+                "frame-setup decorator :teardown fired on the failure path
+                 — not skipped (the rf2-7u3eja leak)")
+            (is (= 1 @loader-teardown)
+                "the plan's :loaders-teardown fired on the failure path"))
+          (testing "the inline frame did not leak"
+            (is (empty? (story/variant-frames))
+                "no lingering nav frame after the failed inline run")
+            (is (not-any? #(and (keyword? %)
+                                (= "rf.story.inline" (namespace %)))
+                          (rf/frame-ids))
+                "no inline frame survives in the runtime frame registry"))))
+      (finally (uninstall-schema-seam!)))))
+
+(deftest inline-plan-success-runs-decorator-and-loader-teardown
+  (testing "control: the SUCCESS path runs the SAME decorator :teardown +
+            :loaders-teardown the failure path now runs — proving the two
+            paths converge on identical cleanup (rf2-7u3eja)"
+    (let [decorator-teardown (atom 0)
+          loader-teardown    (atom 0)]
+      (rf/reg-event :inline/dec-init     (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :inline/dec-teardown
+        (fn [{:keys [db]} _] (swap! decorator-teardown inc) {:db db}))
+      (rf/reg-event :inline/loader-teardown
+        (fn [{:keys [db]} _] (swap! loader-teardown inc) {:db db}))
+      (story/reg-decorator :inline/live-resource
+        {:kind     :frame-setup
+         :init     [[:inline/dec-init]]
+         :teardown [[:inline/dec-teardown]]})
+      (let [result (run-target
+                     {:decorators       [[:inline/live-resource]]
+                      :loaders-teardown [[:inline/loader-teardown]]
+                      :script           [[:dispatch [:inline/set-status :loaded]]
+                                         [:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+        (is (= :pass (:status result)) "the control run passes")
+        (is (= 1 @decorator-teardown) "decorator :teardown fired on success")
+        (is (= 1 @loader-teardown) "loaders-teardown fired on success")
+        (is (empty? (story/variant-frames)) "no lingering frame")))))


### PR DESCRIPTION
## What

The `tools/story` inline-plan runtime ran convergent teardown only on the
**success** path. On **failure** it leaked the frame's decorator- and
loader-opened resources.

`run-inline-plan` success path (runtime.cljc):

```clojure
(frames/destroy-inline! frame-id (:decorator-stack ctx')
                        (get-in plan [:world :loaders-teardown]))
```

…tears the anonymous inline frame down with the decorator stack used for
allocation **and** the plan's `:loaders-teardown`. The exception catch ran:

```clojure
(frames/destroy-inline! frame-id nil nil)
```

`destroy-inline!` only runs `:loaders-teardown` when its third arg is
non-empty, and only runs frame-setup decorator `:teardown` from
`(:frame-setup decorator-stack)` — so `nil nil` **removes the frame but skips
both teardown walks**. Any resource an inline-plan loader or `:frame-setup`
decorator opened leaked on precisely the failure path (db-seed / phase 1 /
phase 2 / phase 4) where cleanup matters. Tests checking only frame absence
still passed while author-visible teardown never ran.

## Fix

Both paths now converge on one `teardown!` closure that carries the decorator
stack captured at the point of failure + the plan's `:loaders-teardown`. An
`allocated?` flag gates it:

- a throw **before** allocation (e.g. inside `prepare-inline-context`) tears
  down nothing — no frame exists, no frame-setup `:init` ran;
- a throw **after** allocation tears down exactly what was set up
  (partial-allocation safety).

A phase-4 play-promise rejection (`async/catch*`) also routes through the
convergent cleanup. The fix is CLJS-portable.

## Test

Added to `inline_plan_test.clj`:

- `inline-plan-failure-runs-decorator-and-loader-teardown` — an inline plan
  that fails mid-run (a `:db-seed` schema violation, thrown after allocation)
  still runs the plan's `:loaders-teardown` AND its frame-setup decorator
  `:teardown`; no frame/decorator/loader leak. **Verified load-bearing**:
  temporarily reverting to the pre-fix `(destroy-inline! frame-id nil nil)`
  fails both teardown assertions (counts observed `0`, expected `1`).
- `inline-plan-success-runs-decorator-and-loader-teardown` — control proving
  the success and failure paths converge on identical cleanup.

## Spec

`spec/017-Testing-Story.md` §Inline plan item 6 updated to state both the
success and failure paths run the same teardown (when the frame was
allocated).

## Gates

- `clojure -M:test` in `tools/story` — 1705 tests, 6322 assertions, 0 failures
- `npm run story:build` — build completed, 0 warnings
- `npm run test:cljs` — 7955 tests, 36622 assertions, 0 failures (story runtime is in the node-test build)
- `clj-kondo` on changed files — 0 errors, 0 warnings