### PR TITLE
fix(machines-viz): light all active leaves for parallel region-map state (rf2-di7mda)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
@@ -106,18 +106,38 @@
   The walk-back + snapshot fallbacks are the case-B refinement per
   spec/021 §6.2 / §17.4.1 (rf2-dbi87) — even when the focused epoch
   has no transition, render the topology with the most-recent-known
-  state annotated as `:current`."
+  state annotated as `:current`.
+
+  The live-snapshot fallback preserves ALL THREE Spec 005 `:state`
+  arms so the chart's multi-active highlight (`chart.layout/highlight-ids`,
+  threaded via `machine-canvas/Chart`'s `:current-state`) can light EVERY
+  active leaf of a PARALLEL machine. A region-map (`{:data :loading
+  :form :neutral}`) is passed through UNCHANGED — narrowing it to
+  keyword/vector dropped the parallel snapshot before the chart could
+  render the N-active highlight (a live parallel machine showed no
+  active regions while the wrapper still claimed `data-current-state-source
+  = \"snapshot\"`). See machines-viz `API.md` §`:current-state`."
   [machine-id current-state-path trace-events epoch-history snapshot-state]
   (or current-state-path
       (trace-state/current-state-from-traces trace-events machine-id)
       (trace-state/current-state-from-epoch-history epoch-history machine-id)
-      ;; Live-snapshot fallback. The snapshot's `:state` slot is a
-      ;; bare keyword per Spec 005 §State; coerce to a path vector
-      ;; via `normalise-path` (vector / keyword / nil are all handled).
+      ;; Live-snapshot fallback. The snapshot's `:state` slot is one of
+      ;; the three Spec 005 `:state` arms: a flat keyword (`:authing`),
+      ;; a hierarchical path (`[:auth :authing]`), or — for a PARALLEL
+      ;; machine — a region-map (`{:data :loading :form :neutral}`) of N
+      ;; simultaneously-active leaves. All three forward through to
+      ;; `:current-state`; the chart resolves whichever arm via
+      ;; `chart.layout/highlight-ids` (which subsumes all three).
       (when (some? snapshot-state)
         (cond
           (keyword? snapshot-state) [snapshot-state]
           (vector? snapshot-state)  snapshot-state
+          ;; PARALLEL region-map — pass through unchanged so every active
+          ;; region leaf lights up (the multi-active highlight). Dropping
+          ;; it here is the rf2-di7mda bug: the chart CAN render N-active,
+          ;; but the caller blanked the topology for a live parallel
+          ;; machine.
+          (map? snapshot-state)     snapshot-state
           :else                     nil))))
 
 (defn Topology
@@ -138,12 +158,19 @@
                            recent-known transition for this machine
                            when the focused epoch has none (case B
                            per spec/021 §6.2).
-    :snapshot-state      — optional live snapshot state (a keyword or
-                           a path vector — per Spec 005 §State).
-                           Used as the final fallback for the
+    :snapshot-state      — optional live snapshot state — any of the
+                           three Spec 005 §State arms: a flat keyword
+                           (`:authing`), a hierarchical path
+                           (`[:auth :authing]`), or — for a PARALLEL
+                           machine — a region-map (`{:data :loading
+                           :form :neutral}`) of N simultaneously-active
+                           leaves. Used as the final fallback for the
                            current-state ● annotation when neither the
                            focused epoch nor the history buffer carries
-                           a transition for this machine.
+                           a transition for this machine. A region-map
+                           forwards through to `:current-state` so the
+                           chart lights EVERY active region leaf (the
+                           multi-active highlight — rf2-di7mda).
     :height              — outer wrapper height (default `'100%'` so the
                            chart fills its container — the topology is the
                            centrepiece and should not sit in a fixed box).

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_view_cljs_test.cljs
@@ -173,3 +173,78 @@
       (is (some? props))
       (is (= #{} (:fired-edge-ids props))
           "empty fired set → no fired highlight on the blank-epoch chart"))))
+
+;; ---- Topology → Chart parallel region-map snapshot boundary (rf2-di7mda) -
+;;
+;; A PARALLEL machine's live snapshot `:state` is a region-map (Spec 005 +
+;; machines-viz API §:current-state) of N simultaneously-active leaves. When
+;; the wrapper falls back to a live snapshot (no focused transition / history
+;; hit), the region-map MUST forward through to the chart's `:current-state`
+;; UNCHANGED so the multi-active highlight (`chart.layout/highlight-ids`)
+;; lights EVERY active region leaf. The bug narrowed the snapshot fallback to
+;; keyword/vector only, dropping the region-map before the chart could render
+;; the N-active highlight (a live parallel machine showed no active regions
+;; while the wrapper still claimed `data-current-state-source = "snapshot"`).
+
+(defn- parallel-ingest-definition
+  "Canonical Spec 005 parallel fixture (mirrors the machines-viz
+  `highlight-ids` region-map test): two regions, each with its OWN
+  same-named `:done` leaf — so the region-scoped highlight must
+  attribute each region's active leaf to its OWN node."
+  []
+  {:type    :parallel
+   :regions {:fetch    {:initial :loading
+                        :states  {:loading {:on {:loaded :done}}
+                                  :done    {:final? true}}}
+            :validate {:initial :checking
+                       :states  {:checking {:on {:ok :done}}
+                                 :done     {:final? true}}}}})
+
+(deftest topology-forwards-parallel-region-map-snapshot-to-chart
+  (testing "rf2-di7mda — a parallel `:snapshot-state` region-map reaches the
+            `machine-canvas/Chart` mount's `:current-state` UNCHANGED, so the
+            chart's multi-active highlight lights every active region leaf.
+            Before the fix the wrapper dropped the map (narrowed to
+            keyword/vector) and a live parallel machine rendered no active
+            regions."
+    (let [def          (parallel-ingest-definition)
+          ;; BOTH regions reached their (same-named) :done leaf — the
+          ;; multi-active live snapshot a running parallel machine carries.
+          region-map   {:fetch :done :validate :done}
+          props        (find-chart-props
+                         (tv/Topology {:machine-id     :ingest
+                                       :definition     def
+                                       :snapshot-state region-map}))]
+      (is (some? props)
+          "the :else branch mounts machine-canvas/Chart")
+      (is (= region-map (:current-state props))
+          "the parallel region-map forwards through UNCHANGED — not dropped,
+           not narrowed to a single path")
+      ;; End-to-end: the forwarded map drives the chart's multi-active
+      ;; highlight — every active region leaf lights up (one id per region,
+      ;; region-scoped so the two same-named :done leaves stay distinct).
+      (let [ids (chart-layout/highlight-ids (:current-state props))]
+        (is (= 2 (count ids))
+            "TWO active leaves light up (one per region), not zero (dropped)
+             and not one (narrowed)")
+        (is (= #{(chart-layout/region-scoped-id :fetch [:done])
+                 (chart-layout/region-scoped-id :validate [:done])}
+               ids)
+            "each region's active :done leaf is attributed to its OWN
+             region-scoped node-id — every active region leaf lit")))))
+
+(deftest topology-keyword-and-vector-snapshot-still-forward
+  (testing "rf2-di7mda — the single-active arms are unchanged: a flat-keyword
+            snapshot forwards as a 1-element path, a vector path forwards
+            verbatim (regression guard around the region-map arm addition)."
+    (let [def       (toy-definition)
+          kw-props  (find-chart-props
+                      (tv/Topology {:machine-id :cart :definition def
+                                    :snapshot-state :populated}))
+          vec-props (find-chart-props
+                      (tv/Topology {:machine-id :cart :definition def
+                                    :snapshot-state [:populated]}))]
+      (is (= [:populated] (:current-state kw-props))
+          "flat keyword snapshot → 1-element path forwarded")
+      (is (= [:populated] (:current-state vec-props))
+          "vector path snapshot → forwarded verbatim"))))


### PR DESCRIPTION
## Problem

The Xray Topology wrapper (`tools/xray/.../panels/machines/topology_view.cljs`) narrowed its live-snapshot fallback to keyword/vector only, returning `nil` for a parallel machine's region-map `:state`. That dropped the region-map before forwarding `:current-state` to the `MachineChart`, so a live parallel machine could render **no active regions** while the wrapper still reported `data-current-state-source="snapshot"`.

The MachineChart already supports the parallel multi-active highlight: `chart.cljs` calls `chart.layout/highlight-ids` on `:current-state`, which resolves all three Spec 005 `:state` arms (flat keyword / hierarchical path / parallel region-map) and lights **every** active region leaf, region-scoped. The bug was purely the caller dropping the map.

## Fix

`resolve-current-state-path` now preserves a parallel region-map snapshot-state and forwards it through to `:current-state` unchanged. The chart then lights every active region leaf per the documented `:current-state` contract. Docstrings (`resolve-current-state-path` + `Topology`'s `:snapshot-state`) updated to the three-arm contract.

With the map preserved, `cur-path` is non-nil for a parallel snapshot, so `data-current-state-source="snapshot"` is now accurate (no longer claiming snapshot while rendering blank).

## Spec sync

Spec unchanged because the spec already documents the correct contract; only the impl was wrong. The machines-viz `API.md` §`:current-state` (line 55) and the xray `003-Machine-Inspector.md` (host passes snapshot `:state` straight through; parallel → region-map → every active region leaf lit) both already describe the correct three-arm / multi-active-highlight behaviour.

## Test

Added `topology-forwards-parallel-region-map-snapshot-to-chart`: a parallel `:snapshot-state` region-map (both regions in their same-named `:done` leaf) forwards to the Chart mount's `:current-state` unchanged, and `highlight-ids` on it returns the set of all active region leaves (one region-scoped id per region — verifying every active leaf lights). Plus a regression guard that the keyword/vector single-active arms still forward.

## Gates

- machines-viz own tests (`clojure -M:test`): 557 tests, 0 failures
- `npm run test:cljs` (shared build incl. xray test ns): 7957 tests, 0 failures
- `npm run test:xray-feature-gate`: 15 scenarios pass (one initial flaky `static mode chrome and chord` browser-harness failure that passed clean on re-run; unrelated to this change — touches dynamic-panel topology, not static-mode chrome/chord)
- clj-kondo on touched files: 0 errors, 0 warnings

Closes rf2-di7mda.