### PR TITLE
docs(template): correct generated README reg-* reload cleanup claim (rf2-n70mno)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -34,8 +34,17 @@ you a clean reload:
    `events.cljs` / `subs.cljs` / `views.cljs` re-evaluates the
    `reg-event` / `reg-sub` / `reg-view` forms at the top level, so
    each handler / sub / view re-registers in place against the new
-   code. Add a new `reg-*` form and it shows up live; rename or remove
-   a handler and the next reload drops the old registration.
+   code. Editing an existing `reg-*` form replaces that exact `id` live
+   (the registry swaps the slot for the same `id`), and adding a new
+   `reg-*` form registers it live. **Deleting or renaming a handler does
+   NOT prune the old `id`, though** — a reload only re-runs the forms
+   that still exist; it never sweeps a namespace to drop ids whose
+   `reg-*` form you removed, so the old registration lingers in the
+   running process. To clear it, refresh the browser tab (or restart the
+   dev process) — that rebuilds the registry from an empty slate, so only
+   the forms still in your source survive. (A rename is a delete plus an
+   add: the new `id` shows up live, but the old `id` stays registered
+   until that refresh.)
 
 2. **`rf/init!` is safe to re-call but does NOT reset anything by
    itself.** It is idempotent and installs the substrate adapter

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -273,6 +273,39 @@
             (is (.contains readme-text "spec/Conventions.md")
                 "README links to spec/Conventions.md for the normative catalogue"))
 
+          ;; -- README Hot reload — accurate reg-* cleanup claim (rf2-n70mno) --
+          ;; The runtime registry only adds / same-id-replaces on reload; a
+          ;; deleted or renamed reg-* form's old (kind, id) is NOT pruned by
+          ;; a plain shadow-cljs reload — it lingers until a browser/dev-
+          ;; process refresh. The README previously over-promised that a
+          ;; rename/remove "drops the old registration". Reject the stale
+          ;; phrase and positively require the explicit-refresh recovery.
+          ;; Scope the assertions to the Hot reload section.
+          (let [readme-text (slurp (io/file root "README.md"))
+                hr-start    (.indexOf readme-text "## Hot reload")
+                hr-end      (let [i (.indexOf readme-text "\n## " (inc hr-start))]
+                              (if (neg? i) (count readme-text) i))
+                hr-sec      (subs readme-text (max 0 hr-start) hr-end)]
+            (is (not (neg? hr-start))
+                "README has a Hot reload section")
+            (is (not (.contains hr-sec "drops the old registration"))
+                "README Hot reload section must NOT promise that a
+                 rename/remove drops the old registration — the registry
+                 does not prune deleted/renamed ids on plain reload
+                 (rf2-n70mno)")
+            ;; The wording wraps across lines in the rendered README, so
+            ;; normalise whitespace before the substring check.
+            (let [hr-norm (string/replace hr-sec #"\s+" " ")]
+              (is (.contains hr-norm "does NOT prune the old")
+                  "README Hot reload section states deleting/renaming a
+                   handler does NOT prune the old id on plain reload
+                   (rf2-n70mno)"))
+            (is (or (.contains hr-sec "refresh the browser")
+                    (.contains hr-sec "restart the dev process"))
+                "README Hot reload section documents the real recovery —
+                 browser/dev-process refresh rebuilds the registry from
+                 an empty slate (rf2-n70mno)"))
+
           ;; -- README EP-0015 privacy/egress classification (rf2-7i66d0) --
           ;; The README must carry a concise privacy/egress section that
           ;; distinguishes app-db schemas (shape) from frame-owned durable


### PR DESCRIPTION
## What

The generated app README's **Hot reload** section over-promised that renaming or removing a handler would drop the old registration on the next reload:

> Add a new `reg-*` form and it shows up live; rename or remove a handler and the next reload drops the old registration.

## Why this is wrong

Verified against current `main`:

- `register!` (`implementation/core/src/re_frame/registrar.cljc:518`) only `(swap! reg assoc-in [kind id] metadata)` — it adds a new `(kind, id)` slot or replaces an existing same-id slot when its `reg-*` form re-runs.
- Removal is **explicit**: `unregister!` / `clear-kind!` / `clear-all!` (registrar lines 660 / 686 / 719) — there is no namespace-level hot-reload sweep that compares the old namespace registrations against the new forms and drops ids whose `reg-*` form was deleted.
- The Spec 001 §Hot-reload semantics contract (`spec/001-Registration.md:267`) confirms this: *"Re-registering the same id replaces the previous handler."* Its five guarantees cover in-flight safety, cache invalidation, machine-spec capture, trace emission, and dispatch continuity — none describes pruning deleted/renamed ids.

So a generated-app user who removes or renames a handler during `shadow-cljs watch` still has the old id registered in the running process until a browser/dev-process refresh. The scaffold README taught the opposite.

## The fix

- **README** — rewrite the clause to describe the actual behaviour: editing an existing `reg-*` form replaces that exact id live, adding a new form registers it live, but **deleting or renaming a handler does NOT prune the old id** — the old registration lingers until you refresh the browser tab (or restart the dev process), which rebuilds the registry from an empty slate. (Deliberately does **not** point at `unregister!`/`clear-*`: those are internal registrar/test-fixture fns, not public `re-frame.core` facade exports — referencing them in consumer onboarding text would be inaccurate.)
- **Test** — add a scoped assertion block in `template_test.clj` that rejects the stale "drops the old registration" phrase and positively requires the corrected "does NOT prune the old" + browser/dev-process-refresh recovery wording.

## Gates

- `clojure -M:test` in `tools/template` — **39 tests, 526 assertions, 0 failures / 0 errors** (includes the new assertions + the existing emitted-app generation/lockstep checks).
- `clj-kondo --lint tools/template/test` — **0 errors** (1 pre-existing warning in `template_emission_test.clj`, untouched).
- No new `rf2-` id leaked into the generated README (the README's only `rf2-` reference, `rf2-qwm0a` at line 370, is pre-existing from #1796 and outside this finding's scope).

Doc-only in the template's GENERATED README + one test assertion. Disjoint from the in-flight reg-* grammar work (that changes the registrar call grammar, not the reload-drop semantics — verified the statement still holds on current main).