### PR TITLE
ci(examples): route shared examples-staging helper edits to the browser gates (rf2-eqjxya)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -228,6 +228,29 @@ else
         adapter_testbed_smokes=true
         story_xray_browser=true
         ;;
+      examples/scripts/examples-staging.cjs)
+        # rf2-eqjxya — false-green fix, mirroring port-resolver.cjs above.
+        # examples-staging.cjs is the SHARED staging/cleaning helper (it owns
+        # stageShared, cleanStageDirs, stageExample) require'd by BOTH browser
+        # gate families: the adapter-smoke orchestrator
+        # serve-and-run-examples-tests.cjs (`npm run test:examples`,
+        # adapter_testbed_smokes) imports stageShared + cleanStageDirs, AND the
+        # two Story launchers — serve-and-run-story-feature-load-tests.cjs
+        # (`npm run test:story-feature-load`) and
+        # serve-and-run-story-play-scripts.cjs (`npm run test:story-play-scripts`),
+        # both under story_xray_browser — import cleanStageDirs. A regression in
+        # the staging/cleaning code (e.g. cleanStageDirs or the _shared fan-out)
+        # can break the files those gates serve before they run, yet a PR
+        # touching only this helper used to fall through to the generic
+        # examples/* case below (cljs_browser only), skipping both Playwright
+        # gates it underpins — a CI false-green for this slice. Fire BOTH gates,
+        # exactly like the shared port-resolver.cjs case, so editing the shared
+        # helper runs the browser gates that depend on it. (The dev runner
+        # serve-example.cjs also imports it but is not a CI gate, so no extra
+        # fan-out is warranted.)
+        adapter_testbed_smokes=true
+        story_xray_browser=true
+        ;;
       implementation/epoch/*)
         # rf2-ribu5a — false-green fix. Epoch is the ONLY per-feature
         # artefact wired into a LIVE MCP conformance gate: the

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -694,6 +694,27 @@ test('examples/scripts/port-resolver.cjs (shared resolver) fires BOTH browser ga
   assert.equal(result.story_xray_browser, 'true');
 });
 
+// rf2-eqjxya — examples-staging.cjs is the SHARED staging/cleaning helper
+// (stageShared / cleanStageDirs / stageExample) require'd by the adapter-smoke
+// orchestrator (serve-and-run-examples-tests.cjs → adapter_testbed_smokes) AND
+// both Story launchers (serve-and-run-story-{feature-load-tests,play-scripts}.cjs
+// → story_xray_browser). Like the shared port-resolver.cjs above, it must fire
+// BOTH browser gates so a regression in the staging code can't ship green by
+// skipping the gates that serve its staged output.
+test('examples/scripts/examples-staging.cjs (shared staging helper) fires BOTH browser gates (rf2-eqjxya)', () => {
+  const result = classify('examples/scripts/examples-staging.cjs');
+  assert.equal(
+    result.adapter_testbed_smokes,
+    'true',
+    'examples-staging.cjs is imported by the adapter-smoke orchestrator; it must fire adapter_testbed_smokes',
+  );
+  assert.equal(
+    result.story_xray_browser,
+    'true',
+    'examples-staging.cjs is imported by both Story launchers; it must fire story_xray_browser',
+  );
+});
+
 test('examples/scripts static-only scanners stay on the always-on JS harness path, no browser gate (rf2-y9o5e3)', () => {
   for (const file of [
     'examples/scripts/check-examples-assets.cjs',


### PR DESCRIPTION
## Summary

`examples/scripts/examples-staging.cjs` is the **shared** staging/cleaning helper (`stageShared` / `cleanStageDirs` / `stageExample`) `require`'d by BOTH browser-gate families, but the changed-surface classifier had no dedicated routing case for it. A PR touching only this helper fell through to the generic `examples/*` fallback (`cljs_browser` only), skipping both Playwright gates it underpins — a CI **false-green** for this slice.

### The gap (verified against current source)

`./.github/scripts/report-changed-surfaces.sh examples/scripts/examples-staging.cjs` previously reported `cljs_browser=true` but `adapter_testbed_smokes=false` and `story_xray_browser=false`, despite:

- `serve-and-run-examples-tests.cjs:50` (the adapter-smoke orchestrator, `npm run test:examples` → `adapter_testbed_smokes`) imports `stageShared` + `cleanStageDirs`
- `serve-and-run-story-feature-load-tests.cjs:16` (`npm run test:story-feature-load` → `story_xray_browser`) imports `cleanStageDirs`
- `serve-and-run-story-play-scripts.cjs:58` (`npm run test:story-play-scripts` → `story_xray_browser`) imports `cleanStageDirs`

A regression in `cleanStageDirs` or the `_shared` staging fan-out could break the files those gates serve before they run, and still ship green.

### The fix

Add a dedicated classifier case for `examples/scripts/examples-staging.cjs` that fires **both** `adapter_testbed_smokes` and `story_xray_browser`, mirroring the existing shared `port-resolver.cjs` precedent (the other helper imported by both gate families).

- The dev runner `serve-example.cjs` also imports it but is **not** a CI gate (`dev:example`), so no extra fan-out.
- **No over-broadening**: a generic `examples/**` source change still fires only `cljs_browser`.

Pinned by a new `_changed-surfaces.test.cjs` assertion (analogous to the existing port-resolver both-gates test).

## Verification

```
# AFTER (fix target):
$ ./.github/scripts/report-changed-surfaces.sh examples/scripts/examples-staging.cjs
adapter_testbed_smokes=true
story_xray_browser=true

# Generic examples source (must NOT broaden):
$ ./.github/scripts/report-changed-surfaces.sh examples/reagent/some-example/core.cljs
cljs_browser=true   # (adapter_testbed_smokes=false, story_xray_browser=false)
```

## Gates run locally

- `node implementation/scripts/_changed-surfaces.test.cjs` → **111 passed** (incl. new assertion)
- `bash -n .github/scripts/report-changed-surfaces.sh` → ok (shellcheck not installed in env)
- Confirmed no over-broadening (generic examples touch still `cljs_browser` only)

Closes rf2-eqjxya.