### PR TITLE
docs(template): remove stray rf2- bead-id from generated README prose (rf2-1jdp88)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
@@ -110,7 +110,7 @@
   (rf/reg-frame :rf/default {})
   ;; The canonical Story vocabulary auto-installs on the first `reg-*`
   ;; call in `{{namespace}}.stories` (loaded via the :require above)
-  ;; per rf2-p1ydc — no explicit `(story/install-canonical-vocabulary!)`
+  ;; — no explicit `(story/install-canonical-vocabulary!)`
   ;; call needed. The hook is idempotent and survives a `clear-all!`
   ;; during dev experiments.
   ;; Seed app-db before the first render so the live-app branch sees a

--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -12,7 +12,7 @@
             ;; lives in `re-frame.trace.tooling`, NOT `re-frame.core` —
             ;; CLJS production bundles DCE the tooling namespace
             ;; wholesale, so the `rf/...` alias for these fns is
-            ;; deliberately JVM-only (per rf2-qwm0a).
+            ;; deliberately JVM-only.
             ;;
             ;; Production elision has two halves and BOTH matter:
             ;;   1. `trace/emit!` is gated on `interop/debug-enabled?`

--- a/tools/template/resources/day8/re_frame2_template/_shared/stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/stories.cljs
@@ -37,7 +37,7 @@
    (`:dev :docs :test :screenshot :experimental :internal :agent` tags,
    the lifecycle machine, the `:rf.assert/*` handlers, the layout-debug
    decorator set, and the v1 panel set) auto-installs on the first
-   `reg-*` call below per rf2-p1ydc — no explicit boot step required."
+   `reg-*` call below — no explicit boot step required."
   []
   ;; -- reg-tag — a project-scoped tag for the canonical screenshot ---------
   (story/reg-tag :{{main}}/canonical

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -366,8 +366,8 @@ The scaffold registers a default error sink at the top of `events.cljs`:
 
 (The listener API lives in `re-frame.trace.tooling`, not `re-frame.core`
 — CLJS production bundles DCE the tooling namespace wholesale, so the
-`rf/...` alias for these fns is JVM-only. Per Spec 009 §JVM-only
-aliases — rf2-qwm0a.)
+`rf/...` alias for these fns is JVM-only. See Spec 009 §JVM-only
+aliases.)
 
 The sink surfaces every error to the console — silent regressions are
 impossible to miss. Replace `js/console.error` with whatever your app


### PR DESCRIPTION
## What

The GENERATED app README (`tools/template/resources/day8/re_frame2_template/root/README.md`, 'Errors are events too' section, ~line 370) carried a literal `rf2-` bead-id in user-facing onboarding prose — `Per Spec 009 §JVM-only aliases — rf2-qwm0a.)`. This violates the no-rf2-ids-in-user-facing-prose rule (the BEAD-ID-LEAK gate); generated consumer prose is NOT exempt.

## Fix

- **README** — dropped the bead-id, kept the substantive citation: `See Spec 009 §JVM-only aliases.)`. Meaning preserved.
- **Swept the rest of the generated source tree** for the same leak class (these comments/docstrings ship into the consumer's codebase):
  - `_shared/events.cljs` — `(per rf2-qwm0a)` → removed
  - `_reagent/core_with_stories.cljs` — `per rf2-p1ydc` → removed
  - `_shared/stories.cljs` (docstring) — `per rf2-p1ydc` → removed

Edits are minimal (5 insertions / 5 deletions) and keep each sentence's meaning.

## Out of scope (correctly kept)

- `template.edn` deps-new config comment + `deps.edn` authoring header + test-file comments carry bead-ids — these are template-internal authoring metadata, NOT emitted into the consumer's generated app. (deps-new emits only `root/` + the substrate/`_shared` transform entries; `template.edn` is the config it reads, never copied.)
- `{{rf2-version}}` template var, `.rf2-app-shell` / `.rf2-xray-host` CSS classes, `data-rf-xray-host` attr, and `day8/re-frame2-*` package names are not bead-ids.

## Gates

- Template tests (`clojure -M:test` in `tools/template`): **39 tests, 525 assertions, 0 failures, 0 errors**.
- Leak gate: canonical bead-id pattern (`\brf2-[a-z0-9]+(\.[0-9]+)?\b`) over `tools/template/resources/` returns only the out-of-scope `template.edn` config comment; no leak in generated/emitted prose.
- No test pinned the removed id-bearing phrase (verified the README content tests and the elision-wording cross-check).

Closes rf2-1jdp88.