### PR TITLE
test(reply-conformance): add :timer row to EP-0017 completion-time conformance (rf2-suwuqo)

### DIFF
--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -171,6 +171,15 @@
      :current-epoch   2
      :frame           :app/main}))
 
+;; The machine `:after` timer's FIRED (live) completion. A fired `:after`
+;; timer's transition can mutate machine snapshot `:data`, so per
+;; Managed-Effects §Causal completion metadata it threads the durable causal
+;; `:completed-at` when the firing dispatch supplied one (rf2-hawtjr —
+;; `m-reply/after-fired-reply` `(some? completed-at) (assoc …)`). The no-time
+;; variant (the `families` `:success` row, which is held only to
+;; status/work-id/value shape) omits it; the with-time variant feeds the
+;; EP-0017 `completion-time-families` tier (rf2-suwuqo — the timer family was
+;; the one success-producing family the completion-time tier never exercised).
 (defn- after-fired-reply []
   (m-reply/after-fired-reply
     {:machine-id :a/multi
@@ -179,6 +188,16 @@
      :decl-path  [:loading]
      :epoch      1
      :frame      :app/main}))
+
+(defn- after-fired-reply-with-time []
+  (m-reply/after-fired-reply
+    {:machine-id   :a/multi
+     :state        :loading
+     :delay        30000
+     :decl-path    [:loading]
+     :epoch        1
+     :frame        :app/main
+     :completed-at completion-time-ms}))
 
 (defn- route-stale-reply []
   (:reply (route-reply/suppress {:route-id  :route/article
@@ -403,10 +422,17 @@
 ;; shape (the umbrella regression the bead names — rf2-ear61v).
 ;;
 ;; The families whose SUCCESS fixture seeds a completion time: HTTP, resource,
-;; mutation, machine, and route (the route live-reply threads `:completed-at`
-;; uniformly — rf2-bphg8v / rf2-2avo53). (The timer's success builder shapes
-;; only the stale path here; its success row is N/A — but the absence half
-;; below holds EVERY success-producing family to the omit-when-absent rule.)
+;; mutation, machine, route, AND timer (rf2-suwuqo). The route live-reply
+;; threads `:completed-at` uniformly (rf2-bphg8v / rf2-2avo53); the machine
+;; `:after` timer's FIRED completion threads it too (rf2-hawtjr —
+;; `after-fired-reply` `(some? completed-at) (assoc …)`), because a fired
+;; timer's transition can mutate durable machine `:data`. The timer family was
+;; the one success-producing family the completion-time tier had never
+;; exercised (the `families` `:success` row used the NO-time `after-fired-reply`
+;; and `completion-time-families` omitted `:timer`), so a timer builder that
+;; dropped or nil-filled `:completed-at` while preserving status/work-id shape
+;; would have left this cross-family tier green — exactly the umbrella gap the
+;; bead names. The with-time / no-time timer pair below closes it.
 ;; ---------------------------------------------------------------------------
 
 ;; Parallel "no completion time supplied" success builders — the SAME family
@@ -442,7 +468,16 @@
    {:family :machine  :with-time #(m-reply/success-reply machine-ctx {:user-id "u-42"})
     :no-time machine-success-no-time}
    {:family :route    :with-time route-live-reply
-    :no-time route-success-no-time}])
+    :no-time route-success-no-time}
+   ;; rf2-suwuqo — the machine `:after` timer's FIRED completion. The with-time
+   ;; variant seeds the causal `:completed-at` (a fired timer's transition can
+   ;; mutate durable machine `:data`); the no-time variant is the plain
+   ;; `after-fired-reply` (an unscripted / no-cofx fire path), which OMITS the
+   ;; slot. This holds the timer family to BOTH halves of the EP-0017 tier:
+   ;; uniform propagation when supplied, omit-when-absent (no nil sentinel)
+   ;; when not — and feeds it into the completion-time adversarial control.
+   {:family :timer    :with-time after-fired-reply-with-time
+    :no-time after-fired-reply}])
 
 (deftest completion-time-propagates-uniformly-across-families
   (testing "EP-0017 — every family supplied a causal completion time threads


### PR DESCRIPTION
## What

Closes the residual EP-0017 completion-time coverage gap in the cross-family reply-conformance umbrella tier: the `:timer` family was the one success-producing family the `completion-time-families` table never exercised.

## Why

`rf2-ear61v` added EP-0017 `:completed-at` cross-family coverage for HTTP / resource / mutation / machine / route, but `completion-time-families` omitted `:timer` — even though the umbrella vocabulary table (`families`) already treats the machine `:after` timer's FIRED completion as a success-producing family (`after-fired-reply`, `:work-head :rf.work/timer`).

The production builder `re-frame.machines.reply/after-fired-reply` DOES thread `:completed-at` when the firing dispatch supplies one (`rf2-hawtjr` — `(some? completed-at) (assoc :completed-at completed-at)`), because a fired timer's transition can mutate durable machine `:data`. But the conformance fixtures never seeded that value, so a timer builder that dropped or nil-filled `:completed-at` while preserving status/work-id shape would have left this cross-family tier green — exactly the umbrella regression the suite exists to catch.

**This is a coverage gap, not a bug — the impl already satisfies the contract.**

## Change (test-only)

- Add `after-fired-reply-with-time` fixture (seeds `:completed-at completion-time-ms`); keep the existing no-time `after-fired-reply` (used by the `families` `:success` row, which is held only to status/work-id/value).
- Register the `:timer` row in `completion-time-families` (`:with-time` = with-time variant, `:no-time` = plain `after-fired-reply`).

This automatically extends all four completion-time tests to the timer family:
- `completion-time-propagates-uniformly-across-families` (asserts the fired timer carries the uniform `:completed-at`)
- `completion-time-is-omitted-not-nil-when-absent` (no-time fire path omits, never nil-fills)
- `completion-time-gate-fails-closed-on-a-non-conforming-family` (both drop + nil-fill adversarial halves)

## Gates

- `clojure -M:test` (reply-conformance JVM): **29 tests, 437 assertions, 0 failures, 0 errors** (was 427 — +10 from the timer rows)
- `npm run test:cljs` (node CLJS): **7960 tests, 36650 assertions, 0 failures, 0 errors**

No spec / EP-0017 text touched — mkdocs not required.

rf2-suwuqo