### PR TITLE
fix(derivation): nil-frame graph egress fails closed instead of borrowing ambient frame (rf2-udkj69)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -1188,6 +1188,14 @@
   scoped-key projection, not this value walk."
   [:value :params :query :state])
 
+(def ^:private dead-egress-frame-sentinel
+  "A frame id that can NEVER resolve to a live frame — the conformance
+  mirror's fail-closed stamp for a nil / unreachable egress frame, matching
+  the Xray helper's `dead-frame-sentinel`. Stamped as the `:frame` opt so
+  `rf/elide-wire-value` takes its unresolvable-frame branch (whole value ⇒
+  `:rf/redacted`) instead of resolving the ambient bound frame."
+  ::no-egress-frame)
+
 (defn- egress-project-graph
   "Project a `DerivationGraph` through `frame-id`'s egress policy for the
   off-box wire boundary — the conformance surface's faithful mirror of the
@@ -1197,16 +1205,21 @@
     - value-bearing node fields → `rf/elide-wire-value` under the named
       frame's own policy (passed as the `:frame` opt so it applies THAT
       frame's classification regardless of any ambient scope);
-    - FAIL-CLOSED on an UNREACHABLE frame — a `:frame` opt naming no LIVE
-      frame is treated by `rf/elide-wire-value` exactly like the frameless
-      case (rf2-t55hxg.18: a frame-id alone is not policy-bearing — it must
+    - FAIL-CLOSED on a nil / UNREACHABLE frame — `rf/elide-wire-value`
+      resolves its governing frame as `(or (:frame opts)
+      (frame/resolve-current-frame))`, so a nil `:frame` opt falls through to
+      the AMBIENT dynamically-bound frame and would ship the value RAW under
+      its (here `:rf/default`, empty) policy. A NON-nil but unreachable
+      `:frame` opt instead takes the unresolvable-frame fail-closed branch
+      (rf2-t55hxg.18: a frame-id alone is not policy-bearing — it must
       resolve to a live frame via `frame/frame`, else the walker fails closed
-      to `:rf/redacted`). We pass the named frame id THROUGH even when it is
-      unreachable so the walker takes its own dead-frame fail-closed branch
+      to `:rf/redacted`). So when `frame-id` is nil or names no LIVE frame we
+      stamp a DEAD-FRAME SENTINEL as the `:frame` opt — a non-nil id that can
+      never resolve — so the walker takes its dead-frame fail-closed branch
       rather than resolving an AMBIENT frame (which, unlike Xray's
       `:ambient-frame nil` harness, this cross-family fixture binds to
-      `:rf/default`) — a nil opts map would let the frameless walk resolve to
-      that ambient frame and ship the value RAW under its empty policy;
+      `:rf/default`). A nil / absent `:frame` would let the frameless walk
+      resolve to that ambient frame and ship the value RAW (rf2-udkj69);
     - identity-embedded scoped keys (node KEY, `:id`, `:output`, `:inputs`,
       `:work-ledger :record :resource/key`, AND every edge endpoint) →
       stable opaque handles, the SAME projection applied consistently so the
@@ -1215,11 +1228,13 @@
   `:mode` / `:frame` unchanged; STRUCTURE preserved (a redacted value/param
   is still an edge; the node is still present + classified)."
   [graph frame-id]
-  ;; Always carry the named frame id as the explicit `:frame` opt. A LIVE
-  ;; frame applies its own policy; an unreachable / nil frame is treated by
-  ;; `rf/elide-wire-value` as the dead-frame fail-closed case (it must resolve
-  ;; to a live frame, else redact whole) — NEVER resolving the ambient frame.
-  (let [walk-opts  {:frame frame-id}
+  ;; Carry a NON-nil `:frame` opt so `rf/elide-wire-value` never falls through
+  ;; to the ambient frame. A LIVE frame applies its own policy; a nil /
+  ;; unreachable frame stamps the dead-frame sentinel so the walker takes its
+  ;; unresolvable-frame fail-closed branch (redact whole) — NEVER resolving
+  ;; the ambient `:rf/default` this fixture binds (rf2-udkj69).
+  (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
+        walk-opts  {:frame (if reachable? frame-id dead-egress-frame-sentinel)}
         redact-node
         (fn [node]
           (-> (reduce
@@ -1441,6 +1456,23 @@
         (is (not (contains-secret? redacted))
             "no raw secret survives — value-path fail-closed + frame-independent
              identity projection cover both leak channels")))
+    (testing "egress under a NIL frame fails closed EVEN UNDER an AMBIENT bound
+              frame — it must NOT borrow the ambient frame's policy and ship the
+              value raw (rf2-udkj69). The fixture binds ambient :rf/default
+              (empty policy); we bind it explicitly here so the regression is
+              self-contained. A nil frame-id MUST redact the value-bearing field,
+              not resolve :rf/default and pass [:cart :items] through raw."
+      (rf/with-frame :rf/default
+        (is (some? (frame/resolve-current-frame))
+            "PRECONDITION — an ambient frame IS dynamically bound, so a frameless
+             walk WOULD resolve it (the borrow this arm forbids)")
+        (let [redacted (egress-project-graph raw nil)
+              sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
+          (is (= privacy/redacted-sentinel (:value sub))
+              "nil frame ⇒ the whole value-bearing field is redacted, NOT shipped
+               raw under the borrowed ambient :rf/default empty policy")
+          (is (not (contains-secret? redacted))
+              "no raw secret survives a nil-frame egress under an ambient binding"))))
     (testing "egress under the KNOWN frame redacts the frame-declared sensitive
               value path while keeping the structure"
       (let [redacted (egress-project-graph raw egress-frame)

--- a/tools/xray/spec/025-Derivation-Graph-Panel.md
+++ b/tools/xray/spec/025-Derivation-Graph-Panel.md
@@ -191,11 +191,18 @@ call site:
   `reg-frame`), passed as the explicit `:frame` opt so the named frame's
   policy applies, never a borrowed or ambient one;
 - **fail-closed** — when the named frame is **not** a live frame (nil id, a
-  destroyed / never-registered frame), the projection walks frameless so
-  `rf/elide-wire-value` takes its own fail-closed branch and redacts the
-  whole value to the `:rf/redacted` sentinel rather than ship it raw under
-  no policy. A sensitive-declared value → `:rf/redacted`; a large-declared
-  value → the `:rf.size/large-elided` marker.
+  destroyed / never-registered frame), the projection stamps a **dead-frame
+  sentinel** as the `:frame` opt — a non-nil id that can never resolve — so
+  `rf/elide-wire-value` takes its unresolvable-frame fail-closed branch and
+  redacts the whole value to the `:rf/redacted` sentinel rather than ship it
+  raw under no policy. It must **not** leave the `:frame` opt nil/absent:
+  `rf/elide-wire-value` resolves its frame as `(or (:frame opts)
+  (frame/resolve-current-frame))`, so a nil/absent `:frame` would fall
+  through to the **ambient** dynamically-bound frame and ship value-bearing
+  fields **raw** under that borrowed frame's (possibly empty) policy — the
+  ambient-borrow leak this contract abolishes (rf2-udkj69). A
+  sensitive-declared value → `:rf/redacted`; a large-declared value → the
+  `:rf.size/large-elided` marker.
 
 **Redaction MUST NOT lose graph structure** (the headline guarantee — a
 redacted param/value is still an edge): the node is still present and still
@@ -280,7 +287,10 @@ the enclosing `[rf/frame-provider-existing {:frame :rf/xray}]` in `shell.cljs`.
   + edge structure survives (the "redact value, keep edge" arm the EP-0014
   testing-coverage audit flagged as missing); large elision → marker keeping
   structure; per-frame policy (a non-classifying frame ships the same value
-  raw); frameless fail-closed. Plus the **adversarial** live resource
+  raw); frameless fail-closed — including the **nil-frame-under-an-ambient-
+  binding** arm (rf2-udkj69): a nil frame-id while an ambient frame is bound
+  must still redact, never borrow that ambient frame and ship raw. Plus the
+  **adversarial** live resource
   identity arm (rf2-k0meap.1): a live resource scoped key carrying a session
   token in BOTH its cache scope and its canonical params, with an in-flight
   work-ledger record and a route-owned `:param` edge naming it — asserting

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
@@ -372,6 +372,22 @@
           inputs)
     inputs))
 
+(def ^:private dead-frame-sentinel
+  "A frame id that can NEVER resolve to a live frame, used to FAIL CLOSED a
+  nil / unreachable egress frame WITHOUT borrowing the ambient scope.
+
+  `rf/elide-wire-value` resolves its governing frame as `(or (:frame opts)
+  (frame/resolve-current-frame))` — so a nil `:frame` opt (or no `:frame` at
+  all) falls through to the AMBIENT dynamically-bound frame, applying that
+  frame's (possibly empty) policy and shipping value-bearing fields RAW. An
+  unreachable but NON-nil `:frame` opt instead takes the unresolvable-frame
+  fail-closed branch (`frame/frame` returns nil ⇒ whole value redacted to
+  `:rf/redacted`). We therefore stamp this sentinel as the `:frame` opt when
+  no live governing frame is known, so the walker fails closed on its own
+  dead-frame branch rather than resolving an ambient frame. The keyword is
+  namespaced into this panel so it can never collide with a real frame id."
+  ::no-egress-frame)
+
 (defn- redact-resource-node-identity
   "Project ONE live resource node's secret-bearing identity fields:
   `:id` (the scoped key), `:output` (the scoped key embedded in the runtime
@@ -474,16 +490,20 @@
   overrides any caller-supplied one (egress redacts under the OBSERVED
   frame's policy, never a borrowed one).
 
-  FAIL-CLOSED on an UNREACHABLE frame: `rf/elide-wire-value` treats a
-  carried `:frame` opt as a KNOWN frame even when that id names no live
-  frame — applying an empty (identity) policy, which would ship the value
-  RAW under no policy. Egress must not do that. So this projection first
-  checks the named frame is LIVE (`rf/frame-ids`); when it is not (nil id,
-  a destroyed / never-registered frame), it walks WITHOUT a `:frame` opt so
-  `rf/elide-wire-value` takes its own frameless fail-closed branch and
-  redacts the whole value to `:rf/redacted` rather than borrow another
-  frame's marks. This is the silent-leak this contract abolishes — a graph
-  egressing under no reachable policy redacts, never ships raw.
+  FAIL-CLOSED on a nil / UNREACHABLE frame: `rf/elide-wire-value` resolves
+  its governing frame as `(or (:frame opts) (frame/resolve-current-frame))`,
+  so a nil `:frame` opt (or no `:frame` at all) falls through to the AMBIENT
+  dynamically-bound frame and would ship value-bearing fields RAW under that
+  borrowed frame's (possibly empty) policy. Egress must NOT borrow an ambient
+  frame. So this projection first checks the named frame is LIVE
+  (`rf/frame-ids`); when it is not (nil id, a destroyed / never-registered
+  frame), it stamps a DEAD-FRAME SENTINEL as the `:frame` opt — a non-nil id
+  that can never resolve to a live frame — so `rf/elide-wire-value` takes its
+  unresolvable-frame fail-closed branch (`frame/frame` returns nil for it)
+  and redacts the whole value to `:rf/redacted` rather than borrow the
+  ambient frame's marks. This is the silent-leak this contract abolishes — a
+  graph egressing under no reachable policy redacts, never ships raw, even
+  when an ambient frame is dynamically bound (rf2-udkj69).
 
   Returns the graph with redacted node value fields + projected live
   resource identities; `:mode` / `:frame` unchanged. IDEMPOTENT — a value may
@@ -499,10 +519,16 @@
   `g-graph-egress-is-idempotent` in derivation-conformance.)"
   ([graph frame-id] (redact-graph-for-egress graph frame-id nil))
   ([graph frame-id opts]
-   ;; A reachable (live) frame governs egress under its own policy; an
-   ;; unreachable / nil frame walks frameless so the walker fails closed.
+   ;; A reachable (live) frame governs egress under its own policy; a nil /
+   ;; unreachable frame stamps the dead-frame sentinel as the `:frame` opt so
+   ;; `rf/elide-wire-value` takes its unresolvable-frame FAIL-CLOSED branch
+   ;; (whole value ⇒ `:rf/redacted`). We must NOT leave the `:frame` opt
+   ;; absent / nil here: that frameless path lets the walker fall through to
+   ;; the AMBIENT dynamically-bound frame (`frame/resolve-current-frame`) and
+   ;; ship value-bearing fields RAW under that frame's policy — the exact
+   ;; ambient-borrow leak this contract abolishes (rf2-udkj69).
    (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
-         walk-opts  (if reachable? (assoc opts :frame frame-id) opts)
+         walk-opts  (assoc opts :frame (if reachable? frame-id dead-frame-sentinel))
          redact-node
          (fn [node]
            (-> (reduce

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
@@ -36,12 +36,15 @@
        edge that names it survives intact (structure preserved).
     2. **per-frame** — egress redacts under the OBSERVED frame's policy,
        not an ambient or borrowed one; a non-sensitive value rides through.
-    3. **fail-closed** — egress for an unknown / frameless target redacts
-       the whole value rather than ship it raw under no policy.
+    3. **fail-closed** — egress for an unknown / nil / frameless target
+       redacts the whole value rather than ship it raw under no policy — and
+       must NOT borrow an AMBIENT dynamically-bound frame (rf2-udkj69): a nil
+       frame-id under an ambient binding still redacts, never ships raw.
     4. **large elision** — a frame-declared `:large` value is replaced by
        the `:rf.size/large-elided` marker, again keeping structure."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.frame-classification :as frame-class]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -244,7 +247,31 @@
         (is (some? route))
         (is (= :process (h/superkind route)))
         (is (= (:edges live-graph) (:edges r)))
-        (is (= (set (keys (:nodes live-graph))) (set (keys (:nodes r)))))))))
+        (is (= (set (keys (:nodes live-graph))) (set (keys (:nodes r))))))))
+
+  (testing "egress against a NIL frame fails closed EVEN WHEN an AMBIENT frame
+            is bound — it must NOT borrow that ambient frame's policy and ship
+            the value raw (rf2-udkj69). We bind ambient :app/plain (no sensitive
+            decl, so a borrow WOULD ship the token raw); a nil frame-id MUST
+            redact the whole value-bearing field, not resolve :app/plain."
+    (rf/with-frame plain-frame
+      (is (some? (frame/resolve-current-frame))
+          "PRECONDITION — an ambient frame IS dynamically bound, so a frameless
+           walk WOULD resolve it (the borrow this arm forbids)")
+      (let [r     (h/redact-graph-for-egress live-graph nil)
+            route (get-in r [:nodes [:rf/route :route/article]])]
+        (is (= :rf/redacted (:params route))
+            "nil frame ⇒ the whole :params summary is redacted, NOT shipped raw
+             under the borrowed ambient :app/plain (empty) policy")
+        (is (= :rf/redacted (:query route)))
+        (is (not= "secret-session-jwt-abc123"
+                  (get-in route [:params :current :params :token]))
+            "the session token must NOT ride through under the borrowed frame")
+        (testing "structure STILL survives in the nil-frame fail-closed case"
+          (is (some? route))
+          (is (= :process (h/superkind route)))
+          (is (= (:edges live-graph) (:edges r)))
+          (is (= (set (keys (:nodes live-graph))) (set (keys (:nodes r))))))))))
 
 ;; ===========================================================================
 ;; 5. THE ADVERSARIAL ARM — live resource scoped-key identity egress


### PR DESCRIPTION
## Summary

PRIVACY-CRITICAL fail-open fix (rf2-udkj69) — the same class rf2-vkblw4 just fixed for `project-egress` (#4756), applied to the **graph egress** path.

The graph egress redaction path could ship **RAW** value fields off-box when the egress frame is **nil/unreachable** AND an **ambient frame is dynamically bound**. `rf/elide-wire-value` resolves its governing frame as `(or (:frame opts) (frame/resolve-current-frame))`, so a nil `:frame` opt (or no `:frame` at all) falls through to the **ambient** bound frame and applies that frame's (possibly empty) policy — shipping value-bearing node fields verbatim instead of failing closed.

## The leak (verified against current main)

Both egress sites left the `:frame` opt nil/absent for the nil case:

- **Xray helper** `redact-graph-for-egress` set `walk-opts = opts` (no `:frame`) when the frame was nil/unreachable; with a bound ambient frame this borrowed it and shipped raw.
- **Conformance mirror** `egress-project-graph` built `{:frame frame-id}`, which is `{:frame nil}` when `frame-id` is nil — same ambient borrow.

The existing conformance + Xray fail-closed arms covered only a **non-nil** unknown frame (`:app/does-not-exist`), which takes a different (already-safe) branch, so the nil case slipped through.

## The fix (fail closed)

Both sites now stamp a **dead-frame sentinel** (a non-nil id that can never resolve to a live frame) as the `:frame` opt whenever no live governing frame is known. `rf/elide-wire-value` then takes its unresolvable-frame fail-closed branch (`frame/frame` returns nil ⇒ whole value ⇒ `:rf/redacted`) rather than resolving the ambient frame.

## New conformance arms (load-bearing)

- conformance `g-graph-egress-for-unknown-frame-fails-closed`: nil frame-id under an explicitly bound ambient `:rf/default` redacts the value-bearing field; no raw secret survives.
- Xray `frameless-egress-fails-closed`: nil frame-id under an explicitly bound ambient `:app/plain` redacts `:params`/`:query`; the session token does not ride through.

Both arms **fail against the pre-fix code** (verified by temporary revert — they ship the raw secret under the borrowed ambient frame) and pass after the fix.

## Spec reconciliation

`tools/xray/spec/025-Derivation-Graph-Panel.md` §Off-box egress updated to document the dead-frame-sentinel mechanism + the ambient-borrow leak it abolishes, and the new nil-frame test arm.

## Quality gates

- `test:cljs` — 7960 tests, 0 failures
- `test:elision` — **42/42 absent in prod** (redaction still elides in production)
- `test:security` — 87 tests, 0 failures
- `test:xray-feature-gate` — 15 scenarios, 0 failures (exit 0)
- wire-vocab — 101 tests, 0 failures
- derivation-conformance JVM — 21 tests / 429 assertions / 0 failures
- Xray redaction JVM — 6 tests / 69 assertions / 0 failures
- clj-kondo — 0 errors, 0 new warnings

Rebased onto origin/main (clean — disjoint from rf2-wvh95f). Do NOT merge.