### PR TITLE
fix(flows): reg-flow path replacement in-drain no longer resurrects old output (rf2-z980k8)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1087,6 +1087,24 @@
     #?(:clj  (identical? in-drain (Thread/currentThread))
        :cljs (true? in-drain))))
 
+(defn in-drain?
+  "True when the calling thread is `frame-id`'s currently-active drainer —
+  i.e. THIS call is happening reentrantly inside the frame's single-drainer
+  window (e.g. a `reg-flow` / `clear-flow` issued from an event HANDLER or a
+  `:rf.fx/reg-flow` effect mid-cascade). Public wrapper over the same
+  `:in-drain?` thread marker `call-serialized-with-drain!` reads.
+
+  rf2-z980k8: `reg-flow`'s same-frame `:path`-change vacate must DEFER to the
+  drain's pending-`:db` transform when in-drain (a direct app-db write made
+  here is clobbered by the deferred commit that publishes the handler's
+  returned `:db`), but may vacate directly when OUT of a drain (no pending
+  commit to clobber it). Returns false for an absent frame (nothing can be
+  draining it)."
+  [frame-id]
+  (boolean
+    (when-let [frame-record (frame frame-id)]
+      (current-thread-is-drainer? frame-record))))
+
 (defn call-serialized-with-drain!
   "Run thunk `f` serialized against `frame-id`'s event drain, returning its
   value (rf2-2woz9). Used by per-frame registry mutations that must not

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -251,6 +251,14 @@
     :producer-ns 're-frame.flows
     :design-bead "rf2-4wqu6"
     :description "Restore a frame's dirty-check (`last-inputs`) rows to a previously-captured snapshot. Invoked by `commit-db-effect!` when post-commit validation rolls app-db back to its pre-handler value — without it the eagerly-advanced rows survive a rollback and the next clean drain skips the flow on `=`-equal inputs, never re-materialising the output. Frame-scoped (rf2-94ol5)."}
+   {:key         :flows/snapshot-abandoned-paths
+    :producer-ns 're-frame.flows
+    :design-bead "rf2-z980k8"
+    :description "Snapshot a frame's pending abandoned output paths (recorded by an in-drain same-frame `reg-flow` `:path` move). The router's flows-after-interceptor captures this BEFORE the flow transform drains/clears them so a post-commit schema/machine-data rollback can re-record them in lock-step with the discarded pending `:db` (paired with `:flows/restore-abandoned-paths!`). Frame-scoped (rf2-94ol5)."}
+   {:key         :flows/restore-abandoned-paths!
+    :producer-ns 're-frame.flows
+    :design-bead "rf2-z980k8"
+    :description "Re-record a frame's pending abandoned output paths from a previously-captured snapshot. Invoked by `commit-db-effect!` when post-commit validation rolls app-db back — the pending `:db` that carried the vacated state is discarded, so a drained-but-not-durably-vacated `:path` move must re-attempt next drain rather than be silently lost. Frame-scoped (rf2-94ol5)."}
    {:key         :flows/reset-flows!
     :producer-ns 're-frame.flows
     :description "Clear the per-frame flow registry (test isolation)."}

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1305,6 +1305,15 @@
               (when (contains? ctx :rf/flow-last-inputs-before)
                 (when-let [restore-li (late-bind/get-fn-cached :flows/restore-last-inputs!)]
                   (restore-li frame (:rf/flow-last-inputs-before ctx))))
+              ;; rf2-z980k8: re-record the IN-DRAIN abandoned output paths the
+              ;; flow transform drained-and-cleared. The pending `:db` (which
+              ;; carried the vacated state) was just discarded by the rollback,
+              ;; so the `:path` move must re-attempt next drain rather than be
+              ;; silently lost — the exact mirror of the `last-inputs` restore
+              ;; above, at the post-commit boundary `run-flows-on-db` can't see.
+              (when (contains? ctx :rf/flow-abandoned-paths-before)
+                (when-let [restore-ap (late-bind/get-fn-cached :flows/restore-abandoned-paths!)]
+                  (restore-ap frame (:rf/flow-abandoned-paths-before ctx))))
               (when (contains? rb-changed frame/app-partition-key)
                 (emit-db-event! :rf.event/db-changed event-id emit-event frame :rollback))
               (emit-frame-state-changed! event-id emit-event frame rb-changed :rollback))
@@ -1478,6 +1487,14 @@
                   ;; which case there are no rows and nothing to restore.
                   snapshot-li (late-bind/get-fn-cached :flows/snapshot-last-inputs)
                   li-before   (when snapshot-li (snapshot-li frame))
+                  ;; rf2-z980k8: snapshot the frame's pending abandoned-output-
+                  ;; paths BEFORE the transform (it DRAINS/clears them and
+                  ;; dissocs them from the pending `:db`). On a POST-commit
+                  ;; rollback `commit-frame-effects!` re-records this snapshot —
+                  ;; the exact mirror of the `last-inputs` snapshot above, for
+                  ;; the boundary `run-flows-on-db`'s own throw arm cannot see.
+                  snapshot-ap (late-bind/get-fn-cached :flows/snapshot-abandoned-paths)
+                  ap-before   (when snapshot-ap (snapshot-ap frame))
                   ;; EP-0001 §535-551 (rf2-4eisfr): hand the flow transform
                   ;; BOTH partitions of the pending frame-state. Bare `:inputs`
                   ;; resolve against `pending-db` (app-db); `[:rf.db/runtime …]`
@@ -1515,7 +1532,12 @@
               ;; commit/rollback boundary, and needs no snapshot.
               (if (or has-db? (not (identical? new-db pending-db)))
                 (cond-> (interceptor/assoc-effect ctx :db new-db)
-                  snapshot-li (assoc :rf/flow-last-inputs-before li-before))
+                  snapshot-li (assoc :rf/flow-last-inputs-before li-before)
+                  ;; rf2-z980k8: stash the pre-drain abandoned-paths snapshot so
+                  ;; a post-commit rollback can re-record the drained-but-not-
+                  ;; durably-vacated path moves. Only when a `:db` is published
+                  ;; (a no-`:db` event hits no commit/rollback boundary).
+                  snapshot-ap (assoc :rf/flow-abandoned-paths-before ap-before))
                 ctx))
             (catch #?(:clj Throwable :cljs :default) e
               ;; Atomicity contract (Spec 013 §Failure semantics, Mike

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -571,7 +571,20 @@
             ;; violating the all-or-nothing two-partition contract (Spec
             ;; 013:284,288 — a pre-install flow throw leaves BOTH partitions
             ;; unchanged). Frame-scoped (rf2-94ol5); restored in the catch.
-            decls-before       (registry/flow-output-declarations-snapshot frame-id)]
+            decls-before       (registry/flow-output-declarations-snapshot frame-id)
+            ;; rf2-z980k8: DRAIN (read-and-clear) this frame's pending abandoned
+            ;; output paths — recorded by an IN-DRAIN same-frame `reg-flow`
+            ;; `:path` move (a direct app-db write would be clobbered by the
+            ;; deferred commit). `abandoned-before` is the snapshot the catch /
+            ;; post-commit rollback re-records (the move re-attempts next drain
+            ;; if the event aborts); `abandoned-paths` is the SAME set, consumed
+            ;; here exactly once. They are dissoc'd from the pending `:db` below,
+            ;; BEFORE the flow walk, so the vacate rides the value the deferred
+            ;; commit publishes (the handler's returned `:db` cannot resurrect
+            ;; the old path) and the new flow's recompute lands on a clean slot.
+            ;; Frame-scoped (rf2-94ol5).
+            abandoned-before   (registry/abandoned-output-paths-snapshot frame-id)
+            abandoned-paths    (registry/drain-abandoned-output-paths! frame-id)]
         ;; rf2-ihfz9o: refresh each flow's output data-classification
         ;; declarations BEFORE the flow walk so a propagated (input-
         ;; inherited) sensitive mark is in the frame's elision registry
@@ -615,7 +628,16 @@
           ;; (the per-flow `:rf.flow/skip` / `:rf.flow/computed` traces carry
           ;; the dirty/clean signal tools actually read).
           (loop [remaining ordered
-                 db        db]
+                 ;; rf2-z980k8: vacate the IN-DRAIN abandoned output paths from
+                 ;; the pending `:db` FIRST — before any flow computes — so the
+                 ;; old path is gone from the value the deferred commit
+                 ;; publishes (the handler's returned `:db` carried it, but this
+                 ;; transform is applied to that SAME value, so it cannot
+                 ;; resurrect it) and a flow newly owning the slot recomputes
+                 ;; onto a clean base. Each `vacate-path-in-db` is a pure
+                 ;; `db → db` LEAF dissoc (no-op-safe). No-op set ⇒ `db`
+                 ;; unchanged. (`abandoned-paths` was read-and-cleared above.)
+                 db        (reduce registry/vacate-path-in-db db abandoned-paths)]
             (if (empty? remaining)
               db
               (let [flow         (flow-map (first remaining))
@@ -637,6 +659,13 @@
             ;; unchanged for router attribution.
             (registry/reset-frame-last-inputs-to! frame-id last-inputs-before)
             (registry/restore-flow-output-declarations! frame-id decls-before)
+            ;; rf2-z980k8: re-record the IN-DRAIN abandoned output paths drained
+            ;; above. A flow throw aborts the event — the pending `:db` (which
+            ;; carried the vacated state) is discarded — so the path move must
+            ;; re-attempt next drain rather than be silently lost. Frame-scoped
+            ;; (rf2-94ol5). The post-COMMIT rollback mirror lives in
+            ;; `commit-frame-effects!` via `:flows/restore-abandoned-paths!`.
+            (registry/restore-abandoned-output-paths! frame-id abandoned-before)
             (throw e)))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
@@ -677,6 +706,19 @@
 ;; structurally incapable of touching a sibling frame's container.
 (late-bind/set-fn! :flows/snapshot-last-inputs registry/frame-last-inputs-snapshot)
 (late-bind/set-fn! :flows/restore-last-inputs!  registry/reset-frame-last-inputs-to!)
+;; rf2-z980k8 — the abandoned-output-paths rollback pair, the exact mirror of
+;; the `last-inputs` pair above but for the IN-DRAIN `reg-flow` `:path`-move
+;; vacate. `run-flows-on-db` DRAINS (read-and-clears) the pending abandoned
+;; paths and dissocs them from the pending `:db`; its OWN throw arm re-records
+;; them. But a POST-commit schema / machine-data rollback lands AFTER the
+;; chain, in `commit-frame-effects!`, OUTSIDE `run-flows-on-db` — and discards
+;; the pending `:db` (which carried the vacated state). Without these hooks the
+;; abandoned path would be drained-and-cleared yet never durably vacated, so
+;; the move is silently lost. The router snapshots the pending set BEFORE the
+;; flow transform and, on a rollback, re-records it — the same boundary the
+;; `last-inputs` mirror covers. Frame-scoped (rf2-94ol5).
+(late-bind/set-fn! :flows/snapshot-abandoned-paths registry/abandoned-output-paths-snapshot)
+(late-bind/set-fn! :flows/restore-abandoned-paths!  registry/restore-abandoned-output-paths!)
 ;; Per rf2-wbtjn — frame-destroy teardown hook (symmetric with the
 ;; machines `:machines/teardown-on-frame-destroy!` hook landed by
 ;; rf2-vsigt). `frame/destroy-frame!` invokes this hook so per-frame

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -202,6 +202,96 @@
   [frame-id prior]
   (reset! (ensure-frame-last-inputs-atom! frame-id) prior))
 
+;; ---- pending abandoned output paths (rf2-z980k8) -------------------------
+;;
+;; A same-frame `reg-flow` REPLACEMENT that MOVES the output to a new `:path`
+;; must vacate the OLD path from the frame's app-db (Spec 013
+;; §Re-registration — otherwise the previous definition's last write lingers
+;; at the abandoned slot as stale derived state). `vacate-output-path!`
+;; (below) does that with a DIRECT app-db write, which is correct for an
+;; OUT-of-drain call.
+;;
+;; But when `reg-flow` runs IN-drain — reentrantly from inside an event
+;; handler or a `:rf.fx/reg-flow` effect — the direct write is CLOBBERED. The
+;; drain runs flows over the PENDING `:db` (the handler's returned value,
+;; which still carries the old path) and the router's single deferred commit
+;; PUBLISHES that pending value AFTER the reentrant `reg-flow` returned —
+;; overwriting the direct vacate and RESURRECTING the old output (rf2-z980k8).
+;;
+;; The fix: when in-drain, record the abandoned path here instead of writing
+;; app-db directly. `re-frame.flows/run-flows-on-db` drains this set at the
+;; START of the pending-`:db` transform (before the flow walk) and dissocs
+;; each path from the PENDING db — so the vacate participates in the SAME
+;; value the deferred commit publishes and the handler's returned `:db`
+;; cannot resurrect the old path. Per-frame (rf2-94ol5 idiom): each frame
+;; owns its own inner atom; a sibling frame draining concurrently on another
+;; thread holds a different atom and is structurally untouched.
+
+(defonce
+  ^{:doc     "frame-id → (atom #{abandoned-output-path ...}). Per-frame set
+              of OLD output paths recorded by an IN-DRAIN same-frame
+              `reg-flow` `:path` move, pending vacate by the current drain's
+              `run-flows-on-db` pending-`:db` transform (rf2-z980k8)."
+    :private true}
+  frame-abandoned-output-paths
+  (atom {}))
+
+(defn- ensure-frame-abandoned-paths-atom!
+  "Return `frame-id`'s inner abandoned-output-paths atom, creating (and
+  registering) it on first touch under a single `swap!` so concurrent
+  first-touches converge on ONE atom (mirrors
+  `ensure-frame-last-inputs-atom!`)."
+  [frame-id]
+  (or (get @frame-abandoned-output-paths frame-id)
+      (get (swap! frame-abandoned-output-paths
+                  (fn [m]
+                    (if (contains? m frame-id)
+                      m
+                      (assoc m frame-id (atom #{})))))
+           frame-id)))
+
+(defn ^:no-doc record-abandoned-output-path!
+  "Record `path` as a pending abandoned output path for `frame-id` — to be
+  vacated from the pending `:db` by the current drain's `run-flows-on-db`
+  (rf2-z980k8). Called by `reg-flow`'s in-drain `:path`-move branch instead
+  of the direct app-db write the OUT-of-drain branch uses. Frame-local."
+  [frame-id path]
+  (swap! (ensure-frame-abandoned-paths-atom! frame-id) conj path))
+
+(defn ^:no-doc abandoned-output-paths-snapshot
+  "Return `frame-id`'s pending abandoned output paths as a plain set (the
+  drain-start snapshot for the failed-flow / post-commit rollback). Empty set
+  when the frame has no container yet. Frame-local."
+  [frame-id]
+  (if-let [a (get @frame-abandoned-output-paths frame-id)]
+    @a
+    #{}))
+
+(defn ^:no-doc drain-abandoned-output-paths!
+  "Atomically read-and-clear `frame-id`'s pending abandoned output paths,
+  returning the set that was pending (rf2-z980k8). The current drain's
+  `run-flows-on-db` consumes these once — dissocing each from the pending
+  `:db` BEFORE the flow walk — and a throw / post-commit rollback re-records
+  them via `restore-abandoned-output-paths!` so the move re-attempts cleanly
+  next drain. Frame-local: returns an empty set when the frame has no
+  container."
+  [frame-id]
+  (when-let [a (get @frame-abandoned-output-paths frame-id)]
+    (let [drained (volatile! #{})]
+      (swap! a (fn [s] (vreset! drained s) #{}))
+      @drained)))
+
+(defn ^:no-doc restore-abandoned-output-paths!
+  "Restore `frame-id`'s pending abandoned output paths to `prior` (its
+  drain-start snapshot). Called when a flow throws mid-cascade
+  (`run-flows-on-db`'s catch arm) or a POST-commit schema / machine-data
+  validation rolls the event back — the pending `:db` (carrying the vacated
+  state) was discarded, so the abandoned paths must re-attempt next drain.
+  Frame-local (rf2-94ol5): a concurrently-draining sibling's container is a
+  different atom and is untouched."
+  [frame-id prior]
+  (reset! (ensure-frame-abandoned-paths-atom! frame-id) (set prior)))
+
 ;; ---- last-inputs row maintenance (rf2-94ol5) -----------------------------
 ;;
 ;; With per-frame `last-inputs` containers, dropping one flow's dirty-check
@@ -1099,10 +1189,28 @@
            ;; commit above already installed the new definition, so the new
            ;; path recomputes on the next drain. First-time registration and
            ;; same-path hot-reload leave app-db untouched.
+           ;;
+           ;; rf2-z980k8: the vacate is routed by call shape.
+           ;;  - OUT of a drain (a top-level / `:rf.fx`-post-commit lifecycle
+           ;;    call): write app-db DIRECTLY — there is no pending commit to
+           ;;    clobber it and the change is durable immediately.
+           ;;  - IN a drain (reentrant from an event handler / `:rf.fx/reg-flow`
+           ;;    mid-cascade): a direct write would be OVERWRITTEN by the single
+           ;;    deferred commit that later publishes the handler's returned
+           ;;    `:db` (which still carries the old path) — resurrecting the old
+           ;;    output. So RECORD the abandoned path instead; the current
+           ;;    drain's `run-flows-on-db` dissocs it from the PENDING `:db`
+           ;;    before the flow walk, so the vacate rides the SAME value the
+           ;;    deferred commit publishes and the handler's `:db` cannot
+           ;;    resurrect it. (`call-serialized-with-drain!` already ran this
+           ;;    thunk reentrantly when in-drain, so `frame/in-drain?` here is
+           ;;    the matching discriminator.)
            (when-let [prior @prior-on-frame]
              (let [old-path (:path prior)]
                (when (not= old-path (:path flow))
-                 (vacate-output-path! frame-id old-path))))
+                 (if (frame/in-drain? frame-id)
+                   (record-abandoned-output-path! frame-id old-path)
+                   (vacate-output-path! frame-id old-path)))))
            ;; Spec 015 §7 / rf2-ouemt + rf2-ihfz9o: install this flow's output
            ;; data-classification marks (EXPLICIT ∪ PROPAGATED-from-inputs)
            ;; into the frame's app-db elision registry, rooted at `(:path
@@ -1234,6 +1342,26 @@
       (not (map? parent)) db
       :else (update-in db parent-path dissoc leaf))))
 
+(defn ^:no-doc vacate-path-in-db
+  "Pure `db → db` removal of a flow output `:path`'s LEAF — the value
+  transform shared by `vacate-output-path!` (which writes the result to the
+  live app-db) and `run-flows-on-db`'s in-drain pending-`:db` vacate
+  (rf2-z980k8, which dissocs abandoned paths from the PENDING value the
+  deferred commit publishes). Returns `db` unchanged (often `identical?`)
+  when the dissoc is a no-op (missing key, unmaterialised parent, non-map
+  intermediate).
+
+  `validate-flow` guarantees `:path` is a non-empty vector at registration,
+  so a `:path` read back out of the registry always carries one. rf2-aqt7:
+  a single-element vector `[:k]` is dissoc'd directly (`(update-in db []
+  dissoc :k)` would write `{... nil nil}`); a `(>= 2)` path routes through
+  `dissoc-in-safe` (unmaterialised-parent / non-map-intermediate safe, per
+  audit rf2-q25os)."
+  [db path]
+  (if (= 1 (count path))
+    (dissoc db (first path))
+    (dissoc-in-safe db path)))
+
 (defn- vacate-output-path!
   "Dissoc a flow's output `:path` from `frame-id`'s app-db (only that
   frame's container). Shared by `clear-flow` (full deregistration) and
@@ -1269,9 +1397,7 @@
   preserved by computing `new-db` first and only swapping when it changed."
   [frame-id path]
   (when-let [db (frame/frame-app-db-value frame-id)]
-    (let [new-db (if (= 1 (count path))
-                   (dissoc db (first path))
-                   (dissoc-in-safe db path))]
+    (let [new-db (vacate-path-in-db db path)]
       (when-not (identical? new-db db)
         (frame/swap-frame-db! frame-id (constantly new-db))))))
 
@@ -1500,6 +1626,10 @@
       ;; rows ARE its inner atom, so removing the frame-keyed slot drops
       ;; every row at once and cannot touch any sibling frame's container.
       (swap! frame-last-inputs dissoc frame-id)
+      ;; rf2-z980k8: drop the destroyed frame's pending abandoned-output-paths
+      ;; container too (same per-frame storage idiom). The frame is gone, so
+      ;; any recorded-but-undrained path move is moot.
+      (swap! frame-abandoned-output-paths dissoc frame-id)
       ;; Registrar realignment (rf2-73pi1): for each flow-id the destroyed
       ;; frame owned, either unregister the `:flow` slot (no surviving
       ;; owner) or re-point it to a surviving owner when the destroyed
@@ -1572,8 +1702,14 @@
   single sound invariant — anything calling `reset-flows!` wants flow
   state cleared, and `last-inputs` is downstream cache for the same
   registry. Per rf2-94ol5 the dirty-check reset now drops every
-  per-frame `last-inputs` container (the `frame-last-inputs` registry)."
+  per-frame `last-inputs` container (the `frame-last-inputs` registry).
+
+  rf2-z980k8: ALSO drops every per-frame pending abandoned-output-paths
+  container — a `reset-flows!` caller wants ALL flow-derived per-frame state
+  cleared, and a leftover undrained path move from a sibling test must not
+  leak into the next."
   []
   (reset! flows {})
   (reset! frame-last-inputs {})
+  (reset! frame-abandoned-output-paths {})
   nil)

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -326,12 +326,17 @@
       ;; flow still live), then on resume re-register :scaled to :out-b. The
       ;; reg-flow runs reentrantly inside the single-drainer window; the
       ;; drain's flow transform then materialises :out-b = 100 × :n = 500.
-      ;; The handler dissocs the OLD output (:out-a) from its returned db so
-      ;; the deferred `:db` commit reflects the path change (the abandoned
-      ;; old-path value does not survive the move — mirrors what the path-
-      ;; change vacate intends; the reentrant vacate writes the container
-      ;; directly, but the drain's deferred commit installs THIS db, so the
-      ;; dissoc here is what makes the move durable through the drain).
+      ;;
+      ;; rf2-z980k8: the handler returns its db UNCHANGED — a PLAIN
+      ;; replacement, NO `(dissoc db :out-a)` workaround. The IN-DRAIN
+      ;; `reg-flow` `:path` move now records :out-a as a pending abandoned
+      ;; path; the drain's flow transform dissocs it from the pending `:db`
+      ;; BEFORE the deferred commit publishes that value, so the old-path
+      ;; value cannot be resurrected by the handler's returned db. The fact
+      ;; that the `:out-a absent` assertion below still holds with a plain
+      ;; handler is the load-bearing regression proof for the bug. (Pre-fix
+      ;; the only way to keep :out-a gone was the manual dissoc — the
+      ;; reentrant DIRECT vacate write was clobbered by this deferred commit.)
       (rf/reg-event :replace-scaled
                        (fn [{:keys [db]} _]
                          (.countDown in-handler)
@@ -341,7 +346,7 @@
                                        :output (fn [n] (* 100 (or n 0)))
                                        :path   [:out-b]}
                                       {:frame :rf/default})
-                         {:db (dissoc db :out-a)}))
+                         {:db db}))
 
       (let [;; Thread A: the replacement drain. Parks in the handler holding
             ;; the drain-lock with the OLD flow still live.
@@ -383,3 +388,91 @@
                (:out-b (rf/app-db-value :rf/default)) " in app-db."))
       (is (not (contains? (rf/app-db-value :rf/default) :out-a))
           ":out-a also absent (the replacement vacated it on the path change)"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-z980k8 — an IN-DRAIN same-frame `reg-flow` `:path` move must NOT
+;; resurrect the OLD output through the deferred `:db` commit.
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-path-move-in-drain-does-not-resurrect-old-output
+  ;; THE behavioral bug (rf2-z980k8). A same-frame `reg-flow` REPLACEMENT
+  ;; that MOVES the output `:path` from [:out-a] to [:out-b], issued from
+  ;; INSIDE an event handler (reentrantly, mid-drain), must vacate [:out-a].
+  ;;
+  ;; Pre-fix the `:path`-move vacate was a DIRECT app-db write made during the
+  ;; reentrant `reg-flow`. But the router runs flows over the PENDING `:db`
+  ;; (the handler's returned value, which still carries :out-a) and PUBLISHES
+  ;; that pending value via its single DEFERRED commit AFTER the handler
+  ;; returned — overwriting the direct vacate and RESURRECTING :out-a. The
+  ;; handler here returns its db UNCHANGED (no manual `(dissoc db :out-a)`),
+  ;; so the only thing that can keep :out-a gone is the framework making the
+  ;; vacate participate in the pending-`:db` transform the commit publishes.
+  ;;
+  ;; Single-threaded — no race, no latch: the resurrection is deterministic on
+  ;; the drain thread (the reentrant write then the deferred commit on the
+  ;; same thread). This is the load-bearing regression: PRE-FIX :out-a = 10
+  ;; survives; POST-FIX :out-a is absent and :out-b = 500 is present.
+  (testing "in-drain reg-flow :path move vacates the old path through the deferred commit"
+    (rf/reg-event :seed (fn [_ _] {:db {:n 5}}))
+    ;; OLD flow: :out-a = 2 × :n.
+    (rf/reg-flow {:id     :scaled
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:out-a]})
+    (rf/dispatch-sync [:seed])
+    (is (= 10 (:out-a (rf/app-db-value :rf/default)))
+        "precondition: the OLD flow materialised :out-a = 2 × :n = 10")
+
+    ;; A handler that, mid-drain, re-registers :scaled to move its output to
+    ;; [:out-b] (100 × :n) and returns its db UNCHANGED — a PLAIN replacement.
+    (rf/reg-event :move-scaled
+                  (fn [{:keys [db]} _]
+                    (rf/reg-flow {:id     :scaled
+                                  :inputs [[:n]]
+                                  :output (fn [n] (* 100 (or n 0)))
+                                  :path   [:out-b]}
+                                 {:frame :rf/default})
+                    {:db db}))
+    (rf/dispatch-sync [:move-scaled] {:frame :rf/default})
+
+    (let [db (rf/app-db-value :rf/default)]
+      (is (not (contains? db :out-a))
+          (str ":out-a ABSENT — the in-drain :path move vacated the old path "
+               "through the deferred commit. Pre-fix the direct vacate was "
+               "clobbered by the handler's returned :db and :out-a resurrected "
+               "as " (:out-a db) "."))
+      (is (= 500 (:out-b db))
+          ":out-b = 100 × :n = 500 — the moved flow materialised on its new path")
+      (is (= [:out-b] (:path (get-in (flows/flows-snapshot) [:rf/default :scaled])))
+          "the live registry points :scaled at its new path [:out-b]"))))
+
+(deftest reg-flow-path-move-out-of-drain-vacates-directly
+  ;; The OUT-of-drain branch is unchanged by rf2-z980k8: a top-level (not
+  ;; reentrant) `reg-flow` `:path` move vacates the old path with a DIRECT
+  ;; app-db write — there is no pending deferred commit to clobber it. Pins
+  ;; that the call-shape split (`frame/in-drain?`) did not regress the
+  ;; existing direct-vacate path (rf2-73pi1).
+  (testing "out-of-drain reg-flow :path move vacates the old path immediately"
+    (rf/reg-event :seed (fn [_ _] {:db {:n 5}}))
+    (rf/reg-flow {:id     :scaled
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:out-a]})
+    (rf/dispatch-sync [:seed])
+    (is (= 10 (:out-a (rf/app-db-value :rf/default)))
+        "precondition: :out-a = 10")
+
+    ;; Top-level re-registration (NOT inside a drain) that moves the path.
+    (rf/reg-flow {:id     :scaled
+                  :inputs [[:n]]
+                  :output (fn [n] (* 100 (or n 0)))
+                  :path   [:out-b]}
+                 {:frame :rf/default})
+    (is (not (contains? (rf/app-db-value :rf/default) :out-a))
+        ":out-a vacated immediately by the direct out-of-drain write")
+
+    ;; The new path materialises on the next drain.
+    (rf/reg-event :touch (fn [{:keys [db]} _] {:db db}))
+    (rf/dispatch-sync [:touch] {:frame :rf/default})
+    (is (= 500 (:out-b (rf/app-db-value :rf/default)))
+        ":out-b materialised on the next drain after the move")))


### PR DESCRIPTION
## Summary

A same-frame `reg-flow` replacement that **moves** the output `:path`, when issued from inside an event handler (reentrantly, mid-drain), could **resurrect the old output**. The path-move vacate (`registry.cljc`) wrote the old slot out of app-db **directly**, but `router.cljc` runs flows over the **pending** `:db` (the handler's returned value, still carrying the old path) and publishes it via the single **deferred commit** *after* the reentrant `reg-flow` returned — clobbering the direct vacate. Violated Spec 013 §Re-registration (line 461).

## Verified resurrect (drain/commit ordering)

1. Handler dispatched, drain holds `:drain-lock`.
2. Handler calls `reg-flow` to move `:scaled` `[:out-a] → [:out-b]` (reentrant, in single-drainer window).
3. `reg-flow` path-move branch directly dissocs `:out-a` from live app-db.
4. Handler returns its `:db` (still has `:out-a`).
5. `flows-after-interceptor` runs flows over the pending `:db` (with `:out-a`).
6. `commit-frame-effects!` installs that pending value → **`:out-a` resurrected**, the direct write dead.

## The fix (commit-pipeline vacate)

Route the vacate by call shape via a new public `frame/in-drain?`:
- **Out-of-drain**: keep the direct app-db write (no pending commit to clobber it).
- **In-drain**: record the abandoned path into a new per-frame store; `run-flows-on-db` drains it at the **start** of the pending-`:db` transform and dissocs each path **before** the flow walk — so the vacate rides the same value the deferred commit publishes and the handler's `:db` cannot resurrect it.

The vacate survives both rollback boundaries (in-`run-flows-on-db` flow throw + post-commit schema/machine-data rollback) via snapshot/restore mirroring the existing `last-inputs` pair (new `:flows/snapshot-abandoned-paths` / `:flows/restore-abandoned-paths!` hooks, documented in the late-bind directory). Shared pure `db → db` `vacate-path-in-db` helper keeps the dissoc semantics in one place. Per-frame storage (rf2-94ol5 idiom) keeps it structurally sibling-frame-safe.

No Spec 013 contract text changed — the fix brings the implementation into compliance with the existing line-461 contract (which does not qualify by call shape).

## Load-bearing regression proof

- The drain-race `clear-flow` path-move test **dropped its `(dissoc db :out-a)` workaround** — it now passes with a plain replacement handler.
- New focused single-thread regression `reg-flow-path-move-in-drain-does-not-resurrect-old-output` (bead acceptance: `[:out-a]` absent, `[:out-b]` = 500 present) + an out-of-drain direct-vacate guard.
- Confirmed both **fail pre-fix** (`:out-a` resurrected as 10) by temporarily disabling the in-drain branch.

## Gates

- flows JVM: 214 tests / 4837 assertions ✓
- core JVM: 1724 / 7465 ✓ (router.cljc is core)
- drain-race + new regression (de-workaround'd): 5 / 36 ✓
- ssr JVM (incl. flows_integration_test): 358 / 1437 ✓
- routing 296 ✓ · machines 779 ✓ · http 448 ✓ · epoch 371 ✓ · resources 608 ✓
- CLJS node (test:cljs): 7960 / 36640 ✓
- late-bind drift: 6 / 632 ✓
- clj-kondo: 0 errors · splint (--fail-on-errors): exit 0

Closes rf2-z980k8.