### PR TITLE
fix(pair-mcp): unknown tool returns clean unknown-tool error before nREPL discovery (rf2-4mc6q1)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -404,6 +404,57 @@ runWithWatchdog(
       );
     }
 
+    // 3c-quater. Unknown tool name — pre-connection refusal (rf2-4mc6q1).
+    // Symmetric with the gated-write pre-connection guard above: a name
+    // absent from the registry (a typo or a removed alias) is rejected by
+    // `tools/refuse-unknown-tool` in `server.cljs/handle-call` BEFORE
+    // `ensure-connection!` runs discovery. So in degraded mode (no nREPL)
+    // an unknown tool returns the recovery-shaped `:unknown-tool` envelope,
+    // NOT `:nrepl-port-not-found`. Before this guard the discovery step
+    // rejected first and masked the unknown name behind a transport error,
+    // hiding the recovery affordances (`tools/list` hint + `:available-
+    // tools` catalogue) for exactly the fresh/misconfigured-session case
+    // they were built for — and the conformance harness, which drives the
+    // compiled server WITHOUT a live nREPL, would have shipped that drift
+    // green. A regression that drops the guard or re-orders it after
+    // discovery surfaces RED here.
+    {
+      const resp = await client.callTool({
+        name: 'no-such-tool-xyz',
+        arguments: {},
+      });
+      degradedResp['no-such-tool-xyz'] = resp;
+      if (!resp.isError) {
+        throw new Error(
+          'unknown tool MUST isError; got: ' + JSON.stringify(resp),
+        );
+      }
+      const text = resp.content?.[0]?.text || '';
+      if (!text.includes('unknown-tool')) {
+        throw new Error(
+          'unknown tool MUST diagnose as :unknown-tool even in degraded ' +
+            'mode (rf2-4mc6q1 — refused PRE-connection); got: ' + text.slice(0, 200),
+        );
+      }
+      if (text.includes('nrepl-port-not-found')) {
+        throw new Error(
+          'unknown tool refusal MUST NOT mention :nrepl-port-not-found — ' +
+            'registry membership is a pure function of the static catalogue, ' +
+            'refused before discovery (rf2-4mc6q1); got: ' + text.slice(0, 200),
+        );
+      }
+      if (!text.includes('tools/list')) {
+        throw new Error(
+          'unknown-tool envelope MUST carry the tools/list recovery hint ' +
+            '(rf2-tkmik); got: ' + text.slice(0, 200),
+        );
+      }
+      console.log(
+        'OK   tools/call no-such-tool-xyz (degraded) -> isError + ' +
+          ':unknown-tool (pre-connection refusal, recovery hint intact)',
+      );
+    }
+
     // 3c-ter. EP-0017 reproducible-dispatch `cofx` argument — degraded
     // accept (rf2-jyxmtq). The `dispatch` tool advertises a `cofx`
     // input-key (an EDN map of scripted recordable coeffects, e.g.

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -428,6 +428,16 @@ only when the bad name is within a small edit distance of a real tool.
 A model that typo'd a name self-corrects from the envelope without a
 `tools/list` round-trip.
 
+The registry-membership check is a **pre-connection** guard (rf2-4mc6q1):
+the server rejects an unregistered name with this envelope BEFORE it runs
+nREPL port discovery — symmetric with the gated-write pre-connection
+refusal (rf2-wz66k7). "Does this tool exist?" is a pure function of the
+static registry, so a typo or removed alias is diagnosable on a fresh or
+misconfigured session with no live app. Without this guard the lazy
+discovery step rejects first (`:nrepl-port-not-found`) and masks the
+unknown name behind a transport error, hiding the recovery affordances
+above for exactly the case they were built for.
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -419,16 +419,28 @@
   (let [params (j/get req :params)
         name   (j/get params :name)
         args   (or (j/get params :arguments) #js {})]
-    (if-let [refusal (writes/refuse-pre-connection name)]
-      ;; rf2-wz66k7 — a gated write tool (restore-epoch / replace-app-db)
-      ;; with `--allow-writes` OFF is refused HERE, before `ensure-
-      ;; connection!`. Otherwise a stock install with no nREPL port returns
-      ;; a misleading `:nrepl-port-not-found` (or runs discovery /
-      ;; elicitation) for a request that should be refused locally — the
-      ;; default-safe write posture would be observably false at the real
-      ;; MCP boundary. The tool body's own gate stays as defence in depth.
-      (js/Promise.resolve refusal)
-      (handle-call* launch-flags name args extra))))
+    (if-let [unknown (tools/refuse-unknown-tool name)]
+      ;; rf2-4mc6q1 — a name absent from the registry (a typo or a removed
+      ;; alias such as `registry-list`) is rejected HERE, before `ensure-
+      ;; connection!`. Otherwise a stock install with no nREPL port runs
+      ;; discovery, REJECTS with `:nrepl-port-not-found`, and the request
+      ;; never reaches `dispatch-tool*` — so the `:unknown-tool` recovery
+      ;; affordances (`:hint` → tools/list, `:available-tools`,
+      ;; `:did-you-mean`) are masked behind a confusing transport error.
+      ;; "Does this tool exist?" must be diagnosable without a live app.
+      ;; The dispatcher's own `:unknown-tool` branch stays as defence in
+      ;; depth (direct `tools/invoke` callers + the conformance corpus).
+      (js/Promise.resolve unknown)
+      (if-let [refusal (writes/refuse-pre-connection name)]
+        ;; rf2-wz66k7 — a gated write tool (restore-epoch / replace-app-db)
+        ;; with `--allow-writes` OFF is refused HERE, before `ensure-
+        ;; connection!`. Otherwise a stock install with no nREPL port returns
+        ;; a misleading `:nrepl-port-not-found` (or runs discovery /
+        ;; elicitation) for a request that should be refused locally — the
+        ;; default-safe write posture would be observably false at the real
+        ;; MCP boundary. The tool body's own gate stays as defence in depth.
+        (js/Promise.resolve refusal)
+        (handle-call* launch-flags name args extra)))))
 
 (defn handle-call-for-tests
   "Test seam onto the private `handle-call` (rf2-wz66k7). Lets the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -167,6 +167,33 @@
     (js/Promise.resolve
       (wire/err-text (unknown-tool-envelope name)))))
 
+(defn refuse-unknown-tool
+  "Server-boundary pre-dispatch guard for unknown tool names (rf2-4mc6q1).
+  Returns the recovery-shaped `:unknown-tool` `wire/err-text` envelope
+  when `name` is NOT a registered tool, so `server.cljs/handle-call` can
+  reject a typo or removed alias LOCALLY — BEFORE `ensure-connection!`
+  runs any nREPL discovery. Returns `nil` for a registered name (it must
+  proceed to normal dispatch).
+
+  Mirrors `writes/refuse-pre-connection` (rf2-wz66k7): the server runs
+  `ensure-connection!` for EVERY tool before the dispatcher is reached,
+  so on a stock / misconfigured install with no nREPL port the discovery
+  step REJECTS with `:nrepl-port-not-found` and an unknown name never
+  reaches `dispatch-tool*`'s `:unknown-tool` branch — the recovery
+  affordances (`:hint` → tools/list, `:available-tools`, `:did-you-mean`)
+  are masked behind a confusing transport error. A typo such as
+  `registry-list` should be diagnosable without a live app/nREPL.
+
+  The envelope is the SAME `unknown-tool-envelope` the dispatch path
+  emits, routed through `wire/err-text` so the dual-slot wire shape
+  (pr-str EDN text + namespace-preserving `:structuredContent`,
+  `isError: true`) is identical at either entry point. The
+  `dispatch-tool*` branch STAYS as defence in depth (direct
+  `tools/invoke` callers + the conformance corpus)."
+  [name]
+  (when-not (contains? registry/handler-for name)
+    (wire/err-text (unknown-tool-envelope name))))
+
 ;; ---------------------------------------------------------------------------
 ;; Wire-boundary pipeline (rf2-3z0zi).
 ;;

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/unknown_tool_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/unknown_tool_test.cljs
@@ -1,0 +1,151 @@
+(ns re-frame2-pair-mcp.unknown-tool-test
+  "Server-boundary unknown-tool guard tests (rf2-4mc6q1).
+
+  The dispatcher's own `:unknown-tool` branch (`tools/dispatch-tool*`)
+  resolves an unregistered name to the recovery-shaped `:unknown-tool`
+  envelope — but it is reached only AFTER `ensure-connection!`. The real
+  MCP server handler (`server.cljs/handle-call`) runs `ensure-connection!`
+  for EVERY tool BEFORE the dispatcher. On a stock / misconfigured install
+  with NO nREPL port, that connection step REJECTS with
+  `:nrepl-port-not-found` and the unknown name never reaches the
+  dispatcher — so a typo or removed alias (e.g. `registry-list`) returned a
+  misleading discovery error, MASKING the `:unknown-tool` recovery
+  affordances (`:hint` → tools/list, `:available-tools`, `:did-you-mean`).
+
+  These tests pin the missing OUTER ring: the pre-connection guard
+  (`tools/refuse-unknown-tool`) and the server `handle-call` ordering
+  that proves the refusal precedes `ensure-connection!` — discovery never
+  runs; the session-state stays pristine. Mirrors `writes_test.cljs`
+  (rf2-wz66k7), the symmetric pre-connection write-gate."
+  (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
+            [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.server :as server]
+            [re-frame2-pair-mcp.tools :as tools]
+            [re-frame2-pair-mcp.tools.writes :as writes]))
+
+(use-fixtures :each
+  {:before (fn []
+             (server/reset-session-state-for-tests!)
+             (writes/set-allow-writes! false))
+   :after  (fn []
+             (server/reset-session-state-for-tests!)
+             (writes/set-allow-writes! false))})
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+;; ---------------------------------------------------------------------------
+;; refuse-unknown-tool — the pure pre-dispatch predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest refuse-unknown-tool-rejects-an-absent-name
+  (let [result (tools/refuse-unknown-tool "no-such-tool")]
+    (is (some? result) "an unregistered name is refused at the boundary")
+    (is (err? result) "the refusal is an isError envelope")
+    (let [edn (read-edn result)]
+      (is (false? (:ok? edn)))
+      (is (= :unknown-tool (:reason edn)))
+      (is (= "no-such-tool" (:tool edn)) "the refusal names the requested tool")
+      ;; Recovery affordances — identical to the dispatcher's branch.
+      (is (string? (:hint edn)))
+      (is (re-find #"tools/list" (:hint edn))
+          "hint points the agent at tools/list to recover")
+      (is (vector? (:available-tools edn)))
+      (is (some #{"snapshot"} (:available-tools edn))
+          ":available-tools carries the real catalogue"))))
+
+(deftest refuse-unknown-tool-offers-nearest-match
+  ;; A near-miss typo of a real name surfaces a :did-you-mean pointer —
+  ;; the same recovery the dispatcher branch emits (rf2-tkmik).
+  (let [result (tools/refuse-unknown-tool "snapsho")
+        edn    (read-edn result)]
+    (is (= :unknown-tool (:reason edn)))
+    (is (= "snapshot" (:did-you-mean edn))
+        "near typo `snapsho` suggests `snapshot`")
+    (is (re-find #"did you mean" (:hint edn))
+        "hint inlines the nearest-match suggestion")))
+
+(deftest refuse-unknown-tool-passes-registered-names-through
+  (doseq [tool ["snapshot" "get-path" "dispatch" "eval-cljs" "subscribe"
+                "trace-window" "discover-app" "restore-epoch" "replace-app-db"
+                "list-handlers"]]
+    (is (nil? (tools/refuse-unknown-tool tool))
+        (str tool " is a registered tool — must proceed to dispatch"))))
+
+;; ---------------------------------------------------------------------------
+;; Server boundary — the refusal precedes ensure-connection! (no discovery).
+;;
+;; The session-state is reset (pristine, :discovered? false) by the
+;; fixture, and no --port-file / env is configured in the test harness, so
+;; the real discovery cascade would REJECT with :nrepl-port-not-found if
+;; `handle-call` reached `ensure-connection!`. Proving the result is
+;; :unknown-tool (NOT :nrepl-port-not-found) AND that the session stayed
+;; pristine shows the refusal ran FIRST.
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-tool-refused-before-connection
+  (async done
+    (-> (server/handle-call-for-tests {} "no-such-tool" #js {} nil)
+        (.then (fn [result]
+                 (is (err? result) "unknown tool rides as isError")
+                 (let [edn (read-edn result)]
+                   (is (= :unknown-tool (:reason edn))
+                       "unknown tool returns :unknown-tool, NOT :nrepl-port-not-found")
+                   (is (= "no-such-tool" (:tool edn)))
+                   (is (re-find #"tools/list" (:hint edn))
+                       "the recovery hint survives at the server boundary")
+                   (is (vector? (:available-tools edn))))
+                 (let [snap (server/session-state-snapshot)]
+                   (is (false? (:discovered? snap))
+                       "discovery was NOT run — the refusal short-circuited before ensure-connection!")
+                   (is (nil? (:discovery-error snap))
+                       "no discovery attempt recorded — connection step never reached"))
+                 (done)))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Server-boundary regression guard: a removed alias such as `registry-list`
+;; (renamed to `list-handlers` per rf2-4y595) must diagnose as :unknown-tool
+;; at the boundary — the exact masking the bead reported.
+;; ---------------------------------------------------------------------------
+
+(deftest removed-alias-diagnoses-as-unknown-tool-not-discovery-error
+  (async done
+    (-> (server/handle-call-for-tests {} "registry-list" #js {} nil)
+        (.then (fn [result]
+                 (is (err? result))
+                 (let [edn (read-edn result)]
+                   (is (= :unknown-tool (:reason edn))
+                       "a removed alias diagnoses as :unknown-tool, not :nrepl-port-not-found")
+                   (is (= "registry-list" (:tool edn)))
+                   ;; `registry-list` is too far in edit distance from the
+                   ;; renamed `list-handlers` to trip the :did-you-mean
+                   ;; near-match cutoff — but the live catalogue still
+                   ;; carries the replacement, so the agent recovers via
+                   ;; the :available-tools list + the tools/list hint.
+                   (is (some #{"list-handlers"} (:available-tools edn))
+                       "the renamed tool is enumerated in the live catalogue")
+                   (is (re-find #"tools/list" (:hint edn))))
+                 (done)))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+
+;; ---------------------------------------------------------------------------
+;; structuredContent on the boundary refusal preserves the keyword
+;; namespace (rf2-or8s29) — the envelope rides through `wire/err-text`, the
+;; same dual-slot constructor the dispatcher uses, so the SDK-friendly slot
+;; is namespace-faithful (not a raw, namespace-lossy clj->js).
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-tool-boundary-structured-content-is-faithful
+  (async done
+    (-> (server/handle-call-for-tests {} "no-such-tool" #js {} nil)
+        (.then (fn [result]
+                 (let [sc (j/get result :structuredContent)]
+                   (is (= "unknown-tool" (j/get sc "reason"))
+                       "structuredContent :reason keeps its token")
+                   (is (= false (j/get sc "ok?"))
+                       ":ok? false round-trips through the structured slot")
+                   (is (= "no-such-tool" (j/get sc "tool"))))
+                 (done)))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))

--- a/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
+++ b/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
@@ -287,17 +287,27 @@ function run() {
       }
       console.log('OK   tools/call unsubscribe (no nREPL) -> degraded isError');
 
-      // 4. tools/call unknown — expect isError with :unknown-tool
+      // 4. tools/call unknown — expect isError with :unknown-tool, even
+      // with NO nREPL port (rf2-4mc6q1). The server's pre-connection guard
+      // (`tools/refuse-unknown-tool`) rejects an unregistered name BEFORE
+      // `ensure-connection!`, so a typo / removed alias is diagnosed as
+      // :unknown-tool rather than masked behind :nrepl-port-not-found. The
+      // recovery affordances (tools/list hint + available-tools) must
+      // survive at the real stdio boundary, not just via direct invoke.
       const unk = await call('tools/call', { name: 'no-such-tool', arguments: {} });
       const t2 = unk.result?.content?.[0]?.text || '';
-      // Degraded mode currently swallows everything — that's the documented
-      // behaviour when nREPL port is missing. Both paths are acceptable here:
-      //  - degraded path: isError with :nrepl-port-not-found
-      //  - connected path: isError with :unknown-tool
       if (!unk.result?.isError) {
         throw new Error('unknown tool should isError, got: ' + JSON.stringify(unk));
       }
-      console.log('OK   tools/call unknown-tool -> isError');
+      if (!t2.includes('unknown-tool')) {
+        throw new Error(
+          'unknown tool must diagnose as :unknown-tool (NOT :nrepl-port-not-found) ' +
+          'even with no nREPL port, got: ' + JSON.stringify(unk));
+      }
+      if (!t2.includes('tools/list')) {
+        throw new Error('unknown-tool envelope must carry the tools/list recovery hint, got: ' + t2);
+      }
+      console.log('OK   tools/call unknown-tool -> :unknown-tool (no nREPL, recovery hint intact)');
 
       child.kill();
       console.log('\nSERVER STDIO ROUND-TRIP GREEN');


### PR DESCRIPTION
## Summary

`server.cljs/handle-call` only short-circuited gated **write** tools (`writes/refuse-pre-connection`) before `ensure-connection!`; every other name — **including names absent from the registry** — fell through to `handle-call*`, which runs `ensure-connection!` first. On a fresh / misconfigured session with no discoverable nREPL port, discovery rejects with `:nrepl-port-not-found` and the unknown name never reaches the dispatcher's `:unknown-tool` branch. So a typo or removed alias (e.g. `registry-list`) was **masked behind a confusing transport error**, hiding the recovery affordances (`tools/list` hint, `:available-tools`, `:did-you-mean`) that exist for exactly that case.

## Fix

A pre-connection registry-membership guard, symmetric with the gated-write guard (rf2-wz66k7):

- **`tools.cljs`** — new public `refuse-unknown-tool`: returns the same `unknown-tool-envelope` the dispatcher already emits, routed through `wire/err-text` (dual-slot, `isError: true`, namespace-preserving `structuredContent` per rf2-or8s29), or `nil` for a registered name. The `dispatch-tool*` branch stays as defence in depth.
- **`server.cljs/handle-call`** — reject an unregistered name with that envelope **before** `ensure-connection!`. Known-tool behaviour is unchanged (degraded known tools still return `:nrepl-port-not-found`).

## Tests

- **`unknown_tool_test.cljs`** (new): the pure predicate; the server-boundary guarantee via `handle-call-for-tests` (proves discovery never runs + session stays pristine); a removed-alias regression; structuredContent fidelity.
- **`stdio-roundtrip.js`**: step 4 now **requires** `:unknown-tool` (+ `tools/list` hint) for an absent name even with no nREPL port — the prior test explicitly permitted the degraded path, letting the drift ship green.
- **`end-to-end-re-frame2-pair.cjs`** (mcp-conformance): new degraded-mode assertion that an unknown tool returns `:unknown-tool` (not `:nrepl-port-not-found`) with the recovery hint — closes the conformance false-green at the real wire boundary.
- **`spec/003-Tool-Catalogue.md`**: documents the pre-connection guarantee.

## Gates

- pair-mcp `:server-test`: **1131 tests / 3796 assertions green**
- `stdio-roundtrip`: **green** (`unknown-tool -> :unknown-tool (no nREPL, recovery hint intact)`)
- pair-mcp MCP-client conformance: **green** (`no-such-tool-xyz (degraded) -> :unknown-tool (pre-connection refusal, recovery hint intact)`)
- clj-kondo: **clean** (0/0)
- production `:server` bundle: **compiles, 0 warnings**
- descriptor manifest: **in sync**

Closes rf2-4mc6q1.