### PR TITLE
fix(machines): empty-vector transition target aligns to XState v5 semantics (rf2-r6fuz2)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -940,6 +940,30 @@
   (cond
     (nil? target)          nil
     (= :same-state target) nil
+    ;; An EMPTY vector is a malformed target SHAPE, not an unresolved path:
+    ;; Spec 005 §error taxonomy (005:4250) + Spec-Schemas §TransitionTarget
+    ;; require a NON-EMPTY vector path. `[]` names no node, so it can never
+    ;; be a real (resolvable-or-not) absolute path — it is a caller
+    ;; typo/schema error in the same class as `{:target 42}`. Reject it via
+    ;; the `:rf.error/machine-bad-target` (malformed-shape) branch BEFORE the
+    ;; generic keyword/vector resolution branch, so tools/conformance
+    ;; consumers that branch on `:rf.error/id` classify it correctly.
+    ;; Aligned with XState v5, which rejects malformed targets at machine
+    ;; creation rather than degrading them to a missing-state reference.
+    (and (vector? target) (empty? target))
+    (throw (validation-error
+             :rf.error/machine-bad-target
+             (str "the " slot " :target " (pr-str target) " on state "
+                  state-key " is malformed — an EMPTY vector is not a valid "
+                  "transition :target. A :target must be a keyword (sibling "
+                  "of the declaring state), a NON-EMPTY vector path (absolute "
+                  "from the region/machine root), or the :same-state "
+                  "self-target sentinel. Per Spec-Schemas §TransitionTarget "
+                  "([:or :keyword [:vector :keyword]]) + Spec 005 §error "
+                  "taxonomy (non-empty vector).")
+             {:state  state-key
+              :slot   slot
+              :target target}))
     (or (keyword? target) (vector? target))
     ;; A keyword is a sibling of the declaring state — owning compound is the
     ;; declaring state's PARENT (`drop-last path`). A vector is absolute.

--- a/implementation/machines/test/re_frame/grammar_parity_test.clj
+++ b/implementation/machines/test/re_frame/grammar_parity_test.clj
@@ -197,7 +197,29 @@
              :states  {:idle {:on {:go {:target 42}}}}}]
       (is (= :rf.error/machine-bad-target
              (registration-error-id :bad/shape m))
-          "registration rejects the malformed :target shape (42) loudly"))))
+          "registration rejects the malformed :target shape (42) loudly")))
+
+  (testing "an EMPTY vector :target is malformed-shape, not unresolved (rf2-r6fuz2)"
+    ;; Spec 005 §error taxonomy (005:4250) + Spec-Schemas §TransitionTarget
+    ;; require a NON-EMPTY vector path. `[]` names no node — it is a caller
+    ;; typo/schema error in the same class as `{:target 42}`, NOT an
+    ;; unresolved absolute path. Tools/conformance consumers branch on
+    ;; `:rf.error/id`, so the taxonomy must be exact. Aligned with XState v5
+    ;; (malformed targets are rejected at machine creation, not degraded to a
+    ;; missing-state reference).
+    (let [m {:initial :idle
+             :states  {:idle {:on {:go {:target []}}}}}]
+      (is (= :rf.error/machine-bad-target
+             (registration-error-id :bad/empty-vec m))
+          "registration rejects an empty-vector :target as malformed-shape"))
+    ;; CONTRAST: a NON-empty vector that names no declared state stays
+    ;; `:rf.error/machine-unresolved-target` (a real-but-missing path), so the
+    ;; empty-vector branch must not over-reach into the resolution branch.
+    (let [m {:initial :idle
+             :states  {:idle {:on {:go {:target [:missing]}}}}}]
+      (is (= :rf.error/machine-unresolved-target
+             (registration-error-id :bad/missing-vec m))
+          "a non-empty vector naming no state stays unresolved-target"))))
 
 ;; ---- parallel-region scope -----------------------------------------------
 


### PR DESCRIPTION
## Summary

An empty-vector transition target (`{:target []}`) was mis-classified at registration as `:rf.error/machine-unresolved-target`, but the contract requires it be `:rf.error/machine-bad-target` (a malformed shape).

## Bug (verified on current origin/main, post-#4767)

`(rf/reg-machine :m {:initial :idle :states {:idle {:on {:go {:target []}}}}})` printed `:rf.error/machine-unresolved-target`.

`validate-target!` (`implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc`) tested `(or (keyword? target) (vector? target))` and let `[]` fall into the resolution branch, so an empty vector reached the unresolved-target arm instead of the malformed-shape arm.

This violates the documented taxonomy:
- **Spec 005 §error taxonomy (005:4250):** a malformed-shape target (not a keyword / **non-empty vector** / `:same-state`) raises `:rf.error/machine-bad-target`; only a keyword/vector that resolves to no declared state raises `:rf.error/machine-unresolved-target`.
- **Spec-Schemas §TransitionTarget** and the validator's own contract comment both state the vector path must be **non-empty**.

`[]` names no node, so it can never be a real (resolvable-or-not) absolute path — it's a caller typo / schema error in the same class as `{:target 42}`. Tools/conformance consumers branch on `:rf.error/id`, so the wrong category misclassifies a schema error as a missing-state reference.

## XState v5 reference

XState v5 rejects malformed / unresolvable targets at machine creation rather than degrading them to a missing-state reference (the validator already cites this alignment). The fix keeps that posture: an empty-vector target is rejected at registration as malformed-shape. (In re-frame2 a vector `:target` is an absolute path, not XState's array-of-targets; the spec author deliberately defines the empty-vector as malformed.)

## Fix

Add an explicit `(and (vector? target) (empty? target))` malformed branch in `validate-target!` **before** the generic keyword/vector resolution branch, raising `:rf.error/machine-bad-target`. The grammar layer is unchanged (it deliberately emits `[]` as a present `:vec-target`, shared with the runtime normaliser).

## Test (load-bearing — proved by revert)

Added to `grammar_parity_test.clj` next to the existing malformed-shape test:
- `{:target []}` ⇒ `:rf.error/machine-bad-target` (FAILS against pre-fix code — verified: returns `:rf.error/machine-unresolved-target`)
- contrast: `{:target [:missing]}` ⇒ `:rf.error/machine-unresolved-target` (a non-empty vector naming no state stays unresolved; the new branch must not over-reach)

## Gates

- `grammar-parity-test`: 10 tests, 0 failures
- Full JVM implementation (incl. machines artefact): 0 failures / 0 errors across all artefacts
- `npm run test:cljs`: 7960 tests, 0 failures / 0 errors
- clj-kondo: 0 errors, 0 warnings

## Scope note

Engine source + test only. `docs/api/04-machines.md` left to the sibling docs-cluster worker per the conflict note.