### PR TITLE
fix(xray): frame-strict spine step keys current row by frame-qualified id (rf2-xj3kbn)

### DIFF
--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1515,10 +1515,41 @@ requires frame agreement when both the cascade and focus carry a
 frame). The spine's own step path resolves the stepped row as a whole
 cascade record (`spine/step-cascade`) so its `:frame` comes from the
 exact row stepped to rather than an id-only re-resolution that could
-land on a foreign frame's same-id cascade. Test gate:
-`routing_helpers_cljs_test.cljc` pins two same-id cross-frame cascades
-selecting the focused frame; the trace / managed-fx / spine suites carry
-the same cross-frame fixture shape.
+land on a foreign frame's same-id cascade.
+
+The CURRENT-position end of the step is frame-strict too (rf2-xj3kbn).
+Two coupled lookups must agree on `[frame dispatch-id]`, not the bare
+id, or the walk starts from the wrong row when the focused id also
+occurs in an earlier frame:
+
+1. **`compose-focus` head-frame resolution.** When focus auto-tracks
+   the head (LIVE, or a snap-to-head fallback) with no picker frame
+   stored, the effective `:frame` is taken from the actual head cascade
+   RECORD (`spine/head-cascade` — the last focusable row), not from an
+   id-only `cascade-by-id` that returns the FIRST same-id row's frame.
+   So `:rf.xray/focus` reports `[head-id, head-frame]` in lockstep even
+   when `head-id` collides with an earlier frame's id.
+2. **`spine/step-cascade` current index.** The 4-arity
+   `[cascades current-frame current-id delta]` matches the current
+   position by `[current-frame current-id]` when a frame is known
+   (falling back to id-only for genuinely frameless focus, or when no
+   frame-matching current row exists). `focus-step-reducer` threads the
+   composed focus's `:frame` in, so `prev`/`next` from a colliding-id
+   head step from the RIGHT row instead of an earlier frame's same-id
+   row — which previously produced a false boundary no-op (the L2
+   `[◀ ▶]` controls skipping/failing) or a step from a foreign
+   neighbour. The boundary no-op test is likewise frame-strict: a
+   genuine edge means the same `[frame dispatch-id]` coordinate, so
+   stepping onto a same-id cascade in another frame is a real move.
+
+Test gates: `routing_helpers_cljs_test.cljc` pins two same-id
+cross-frame cascades selecting the focused frame; the trace / managed-fx
+/ spine suites carry the same cross-frame fixture shape;
+`spine_cljs_test.cljs` adds the rf2-xj3kbn current-position cases
+(`step-cascade` 4-arity frame-strict lookup +
+`focus-step-reducer` prev from a colliding-id LIVE head landing on the
+immediate previous row in the head's frame, with the stepped row's
+epoch resolved).
 
 ---
 

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -209,13 +209,13 @@
         (some #(when (= dispatch-id (:dispatch-id %)) %) cascades)))))
 
 (defn step-cascade
-  "Step by `delta` (-1 for prev, +1 for next) from `current-id`
-  through `cascades` and return the whole stepped cascade RECORD
-  (carrying `:frame`).
+  "Step by `delta` (-1 for prev, +1 for next) from the current
+  position through `cascades` and return the whole stepped cascade
+  RECORD (carrying `:frame`).
 
   - nil `current-id` (no focus yet) starts from the head.
-  - When `current-id` is not in `cascades` (was evicted), step from
-    head.
+  - When the current position is not in `cascades` (was evicted), step
+    from head.
   - Bounds-clamped — stepping past either edge stays at the edge.
   - Returns nil only when `cascades` is empty.
 
@@ -225,18 +225,47 @@
   (the previous `(cascade-by-id focusable (step-dispatch-id …))`
   shape) could land on a foreign frame's same-id cascade at a
   different index. Walking by index keeps frame + id in lockstep with
-  the row the user actually stepped to."
-  [cascades current-id delta]
-  (let [n (count cascades)]
-    (when (pos? n)
-      (let [current-idx (some (fn [[idx c]]
-                                (when (= current-id (:dispatch-id c)) idx))
-                              (map-indexed vector cascades))
-            base-idx    (or current-idx (dec n))
-            new-idx     (-> (+ base-idx delta)
-                            (max 0)
-                            (min (dec n)))]
-        (nth cascades new-idx)))))
+  the row the user actually stepped to.
+
+  rf2-xj3kbn — the CURRENT-position lookup must be frame-strict too.
+  Dispatch ids are unique only WITHIN a frame (Spec 002 §Frame
+  isolation + rf2-g6ih4); the framework projection emits a separate
+  cascade record per `[frame dispatch-id]`, so the same id can occur
+  in two frames at two indices. When the focus carries a `:frame`
+  (the live/composed head's frame, or a retro pin's frame), the
+  current index MUST match BOTH `[frame dispatch-id]` — otherwise a
+  same-id cascade in an EARLIER frame is found first and the walk
+  steps from the wrong row (a false boundary no-op, or a step into a
+  foreign neighbour). Frameless focus (single-frame / pre-frame-set)
+  degrades to the id-only match.
+
+  Two arities:
+  - `[cascades current-id delta]` — id-only current lookup (frameless
+    callers / `step-dispatch-id`'s thin projection).
+  - `[cascades current-frame current-id delta]` — frame-strict: when
+    `current-frame` is non-nil the current index matches
+    `[current-frame current-id]`, falling back to id-only when no
+    frame-matching row exists (a stale stored frame must not hide an
+    otherwise-valid current row)."
+  ([cascades current-id delta]
+   (step-cascade cascades nil current-id delta))
+  ([cascades current-frame current-id delta]
+   (let [n (count cascades)]
+     (when (pos? n)
+       (let [current-idx (or (when current-frame
+                               (some (fn [[idx c]]
+                                       (when (and (= current-id (:dispatch-id c))
+                                                  (= current-frame (:frame c)))
+                                         idx))
+                                     (map-indexed vector cascades)))
+                             (some (fn [[idx c]]
+                                     (when (= current-id (:dispatch-id c)) idx))
+                                   (map-indexed vector cascades)))
+             base-idx    (or current-idx (dec n))
+             new-idx     (-> (+ base-idx delta)
+                             (max 0)
+                             (min (dec n)))]
+         (nth cascades new-idx))))))
 
 (defn step-dispatch-id
   "Compute the new `:dispatch-id` when stepping by `delta` (-1 for
@@ -341,6 +370,21 @@
   apps drifts focus off the picker's frame on every cross-frame
   dispatch.
 
+  ## Frame-strict head-frame resolution (rf2-xj3kbn)
+
+  The effective cascade is resolved as a whole RECORD per branch — the
+  head-tracking / snap-to-head branches use `head-cascade` directly
+  (the last focusable row) rather than re-resolving `eff-id` through
+  the id-only `cascade-by-id`. With no `slot-frame` stored, an id-only
+  lookup would return the FIRST same-id cascade's `:frame`, so when the
+  head's `:dispatch-id` also occurs in an earlier frame the composed
+  focus would report `[head-id, earlier-frame]` — a mismatched pair
+  that mis-steers `focus-step-reducer`'s current-position lookup (the
+  L2 `[◀ ▶]` controls then false-no-op or step from a foreign row).
+  Taking the frame from the head record keeps `:dispatch-id` + `:frame`
+  in lockstep. RETRO / LIVE-paused branches still resolve by id (the
+  user pinned a specific id, possibly in a stored `slot-frame`).
+
   ## rf2-r9lyy — `:show-ungrouped?` opt-in
 
   Pass `show-ungrouped? true` via the 3-arity to include the
@@ -399,7 +443,28 @@
                        (if (or (nil? slot-id) (= slot-id head-id))
                          :live
                          :retro))
-        eff-id  (cond
+        ;; rf2-xj3kbn — resolve the effective CASCADE RECORD per branch,
+        ;; not a bare id that's then re-resolved by `cascade-by-id`
+        ;; (which is id-only when `slot-frame` is nil and so can pick a
+        ;; foreign frame's same-id row for the `:frame`). The head-track
+        ;; / snap-to-head branches use `head-cascade` directly so the
+        ;; composed focus's `:frame` is the ACTUAL head row's frame
+        ;; (the last focusable cascade), keeping `:dispatch-id` + `:frame`
+        ;; in lockstep even when the head id also occurs in an earlier
+        ;; frame. The paused / retro branches still resolve by id (the
+        ;; user pinned a specific id, possibly in a stored frame).
+        head-cascade* (head-cascade focusable)
+        ;; A RETRO pin (or a LIVE-paused pin) is the one case where the
+        ;; effective id is the STORED slot-id even if its cascade has
+        ;; been evicted (nil record) — those branches preserve the id
+        ;; so the downstream "epoch evicted" placeholder renders. The
+        ;; head-tracking branches never fall back to slot-id (an empty
+        ;; buffer yields a nil head, which downstream treats as cold
+        ;; start, NOT as the stale slot).
+        retro-pin? (or (and (= :live mode) paused?)
+                       (and (not (and (some? head-id) (not slot-pinnable?)))
+                            (not (and (= :live mode) (not paused?)))))
+        eff-cascade (cond
                   ;; rf2-fzbrw — slot is nil / :ungrouped while a
                   ;; focusable buffer exists. Snap to head regardless
                   ;; of mode so the unreachable "focus nil + buffer
@@ -407,7 +472,7 @@
                   ;; ids flow through to the :else branch so the
                   ;; orphaned-state UX survives.)
                   (and (some? head-id) (not slot-pinnable?))
-                  head-id
+                  head-cascade*
                   ;; Live + unpaused — track head, regardless of
                   ;; slot-id (rf2-s0s5x Phase A). Previously the
                   ;; stored slot-id won here, so once
@@ -416,20 +481,30 @@
                   ;; as newer cascades arrived. The LIVE pill's
                   ;; contract is unambiguous — head IS the focus.
                   (and (= :live mode) (not paused?))
-                  head-id
+                  head-cascade*
                   ;; Live + paused — slot-id wins (frozen inspection);
                   ;; if the stored id has been evicted from the
                   ;; buffer, snap to head so the inspector doesn't
                   ;; dangle on a nonexistent cascade.
                   (and (= :live mode) paused?)
-                  (if (cascade-by-id focusable slot-id slot-frame)
-                    slot-id
-                    head-id)
-                  ;; Retro — slot-id wins. Evicted ids preserve the
-                  ;; "epoch evicted" placeholder downstream panels render.
+                  (or (cascade-by-id focusable slot-id slot-frame)
+                      head-cascade*)
+                  ;; Retro — slot-id wins. Evicted ids resolve to a nil
+                  ;; cascade record here; `eff-id` falls back to the
+                  ;; stored slot-id below so the orphaned-state UX
+                  ;; survives.
                   :else
-                  slot-id)
-        cascade (cascade-by-id focusable eff-id slot-frame)
+                  (cascade-by-id focusable slot-id slot-frame))
+        ;; rf2-xj3kbn — `eff-id` + the `:frame` both come from the
+        ;; resolved cascade RECORD so they stay in lockstep with the
+        ;; actual row (head / pinned), never an id-only re-resolution
+        ;; that could borrow a foreign frame's same-id row. Only a
+        ;; RETRO/paused pin whose cascade was evicted falls back to the
+        ;; stored slot-id (nil cascade) — the head branches return the
+        ;; head's own id (or nil for a cold-start empty buffer).
+        eff-id  (or (:dispatch-id eff-cascade)
+                    (when retro-pin? slot-id))
+        cascade eff-cascade
         ;; rf2-70tkv — `:epoch-id` auto-follows head in LIVE+unpaused
         ;; mode when `epoch-history` is supplied (the reactive
         ;; `:rf.xray/focus` sub path). Mirrors the `eff-id` auto-
@@ -553,28 +628,51 @@
          focusable  (if slot-frame
                       (filterv #(= slot-frame (:frame %)) focusable*)
                       focusable*)
-         ;; rf2-s0s5x Phase A: resolve current-id through the same
+         ;; rf2-s0s5x Phase A: resolve current focus through the same
          ;; composer the spine sub uses, so in LIVE mode `j` steps
          ;; back from the CURRENT head rather than from a stale
          ;; stored id. rf2-r9lyy — pass show-ungrouped? so the
          ;; composer's pinnability check honours the opt-in.
-         current-id (:dispatch-id (compose-focus (get db :focus) cascades show-ungrouped?))
+         current    (compose-focus (get db :focus) cascades show-ungrouped?)
+         current-id (:dispatch-id current)
+         ;; rf2-xj3kbn — the composed focus carries the resolved row's
+         ;; `:frame`; thread it into the current-position lookup so the
+         ;; walk starts from the RIGHT row when the focused dispatch-id
+         ;; also occurs in another frame. Without the frame the id-only
+         ;; lookup finds the first same-id cascade (an earlier frame's),
+         ;; making prev/next a false boundary no-op or stepping from a
+         ;; foreign row. When `slot-frame` already scoped `focusable` to
+         ;; one frame the frame is redundant but harmless; the open
+         ;; (slot-frame nil, multi-frame) walk is where it matters.
+         current-frame (:frame current)
          ;; rf2-bz7flo — resolve the stepped row as a CASCADE record so its
          ;; `:frame` comes from the exact row stepped to. Re-resolving by
          ;; id alone (`cascade-by-id focusable new-id`) could pick a
          ;; foreign frame's same-id cascade when the step walk spans
          ;; frames (slot-frame unset, initial LIVE/head). frame + id stay
          ;; in lockstep with the row the user actually landed on.
-         stepped    (step-cascade focusable current-id delta)
+         stepped    (step-cascade focusable current-frame current-id delta)
          new-id     (:dispatch-id stepped)
+         new-frame  (:frame stepped)
          head-id    (head-dispatch-id focusable)]
      (if (or (nil? new-id)
              ;; rf2-fzbrw — boundary no-op. Stepping past either edge
-             ;; resolved to the same id we already hold; return db
+             ;; resolved to the same row we already hold; return db
              ;; unchanged so the ribbon's `:disabled` contract is
              ;; honoured at the reducer layer too. A keyboard j/k at
              ;; the edge has no observable effect.
-             (and (some? current-id) (= new-id current-id)))
+             ;;
+             ;; rf2-xj3kbn — the no-op test is frame-strict too: a
+             ;; genuine edge means the SAME `[frame dispatch-id]`
+             ;; coordinate, not just the same id. When a same-id
+             ;; cascade exists in another frame, stepping onto it is a
+             ;; REAL move even though the id matches — comparing id
+             ;; alone would swallow that step. Frameless focus (no
+             ;; `current-frame`) degrades to the id-only edge test.
+             (and (some? current-id)
+                  (= new-id current-id)
+                  (or (nil? current-frame)
+                      (= new-frame current-frame))))
        db
        (let [new-mode (if (= new-id head-id) :live :retro)
              frame-id (:frame stepped)

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -172,6 +172,43 @@
       ;; step-dispatch-id stays a thin projection of the same walk.
       (is (= :cx (spine/step-dispatch-id cascades :c0 +1))))))
 
+(deftest step-cascade-current-lookup-is-frame-strict-rf2-xj3kbn
+  (testing "rf2-xj3kbn — when the CURRENT dispatch-id itself is
+            duplicated across frames, the current-position lookup must
+            match `[frame dispatch-id]`, not the bare id. The id-only
+            lookup found the FIRST same-id cascade (an earlier frame's)
+            and stepped from the wrong index."
+    ;; :cx is the HEAD (idx 2, :frame/b) but also occurs at idx 0
+    ;; (:frame/a). prev from the head must land on :mid (idx 1), NOT be
+    ;; swallowed as a false boundary no-op off the idx-0 :frame/a row.
+    (let [cascades [(assoc (cascade :cx :frame/a) :event [:a-event])
+                    (assoc (cascade :mid :frame/b) :event [:mid-event])
+                    (assoc (cascade :cx :frame/b) :event [:b-event])]]
+      (testing "frame-strict 4-arity: current is :cx @ :frame/b (head)"
+        (let [stepped (spine/step-cascade cascades :frame/b :cx -1)]
+          (is (= :mid (:dispatch-id stepped))
+              "prev from the :frame/b :cx head lands on :mid, not a no-op
+               off the earlier :frame/a :cx")
+          (is (= :frame/b (:frame stepped)))
+          (is (= [:mid-event] (:event stepped)))))
+      (testing "frame-strict 4-arity: current is :cx @ :frame/a steps prev
+                to the head row at idx 0 (a true boundary)"
+        (let [stepped (spine/step-cascade cascades :frame/a :cx -1)]
+          (is (= :cx (:dispatch-id stepped)))
+          (is (= :frame/a (:frame stepped))
+              "prev from idx 0 clamps to idx 0 — its own :frame/a row")))
+      (testing "id-only 3-arity preserved (frameless callers): finds the
+                first :cx at idx 0"
+        (let [stepped (spine/step-cascade cascades :cx -1)]
+          (is (= :frame/a (:frame stepped))
+              "no current-frame → id-only fallback (first match at idx 0)")))
+      (testing "frame-strict falls back to id-only when no frame-matching
+                current row exists (stale stored frame must not hide a
+                valid current row)"
+        (let [stepped (spine/step-cascade cascades :frame/nope :cx -1)]
+          (is (= :frame/a (:frame stepped))
+              "no :cx in :frame/nope → id-only fallback to idx 0"))))))
+
 ;; ---- focusable-head-frame-id (rf2-boyc2) --------------------------------
 
 (deftest focusable-head-frame-id-returns-head-cascade-frame
@@ -1378,6 +1415,50 @@
       (is (= :c1 (get-in r [:focus :dispatch-id]))
           "prev from :c3 (cart head) skips :c2 (checkout) and lands on :c1
            (the only other cart cascade)"))))
+
+(deftest focus-step-reducer-prev-from-live-head-is-frame-strict-rf2-xj3kbn
+  (testing "rf2-xj3kbn — prev from LIVE head, no picker frame stored, when
+            the HEAD dispatch-id is ALSO present in an earlier frame. The
+            composer resolves the head as `[:cx :frame/b]`; the step
+            current-position lookup must key off `[frame dispatch-id]` so
+            prev lands on the immediate previous ROW (in the head's frame),
+            not be swallowed as a false boundary no-op off the earlier
+            `:frame/a` same-id cascade."
+    ;; LIVE list: [:cx@a, :mid@b, :cx@b(head)] — :cx duplicated across
+    ;; frames. slot-frame nil (no picker), :focus empty → composer derives
+    ;; the head :cx @ :frame/b.
+    (let [cascades [(cascade :cx :frame/a)
+                    (cascade :mid :frame/b)
+                    (cascade :cx :frame/b)]
+          db       {:focus {:mode :live}}
+          r        (spine/focus-step-reducer db cascades -1)]
+      (is (not= db r)
+          "prev is a REAL step, not a no-op — the pre-fix id-only lookup
+           found :cx @ :frame/a (idx 0) and clamped prev to a no-op")
+      (is (= :mid (get-in r [:focus :dispatch-id]))
+          "prev from the :frame/b :cx head lands on the immediately
+           previous row, :mid")
+      (is (= :frame/b (get-in r [:focus :frame]))
+          "the stepped row's frame is :frame/b — frame + id stay in
+           lockstep with the row actually stepped to")
+      (is (= :retro (get-in r [:focus :mode]))
+          "stepping off head pins RETRO"))))
+
+(deftest focus-step-reducer-frame-strict-step-resolves-epoch-rf2-xj3kbn
+  (testing "rf2-xj3kbn — the frame-strict prev resolves the stepped row's
+            settling :epoch-id (the downstream panels pivot on it). The
+            cross-frame same-id collision must not leak the wrong frame's
+            epoch into the focus."
+    (let [cascades [(cascade :cx :frame/a)
+                    (cascade :mid :frame/b)
+                    (cascade :cx :frame/b)]
+          ;; epoch ring keyed to :mid's settling epoch (the row prev lands on)
+          history  [{:epoch-id 42 :dispatch-id :mid}]
+          db       {:focus {:mode :live}}
+          r        (spine/focus-step-reducer db cascades history -1)]
+      (is (= :mid (get-in r [:focus :dispatch-id])))
+      (is (= 42 (get-in r [:focus :epoch-id]))
+          "the stepped :mid row's settling epoch resolves into focus"))))
 
 (deftest compose-focus-snaps-to-head-when-slot-id-is-ungrouped
   (testing "rf2-fzbrw — even in :retro, a stored slot pointing at


### PR DESCRIPTION
## Summary

The tools/xray spine step located the **current** row by **bare dispatch id**, so when the same event id cascades in two different frames, stepping (L2 `[◀ ▶]`, `j`/`k`) could start from the wrong frame's row — a frame-strict violation (rf2-xj3kbn).

## The mis-step (verified)

In a multi-frame list `[:cx@a, :mid@b, :cx@b(head)]`, LIVE focus auto-tracks the head (`:cx` in `:frame/b`) with no picker frame stored. Pressing `prev` should land on `:mid` in `:frame/b`. Pre-fix, the id-only current lookup found the FIRST `:cx` at index 0 (`:frame/a`), clamped `prev` to index 0, and resolved `:cx` again — a **false boundary no-op**. The L2 prev/next controls skip/fail for legitimate focused cascades.

Confirmed in a standalone repro: composed focus `{:dispatch-id :cx :frame :frame/b}` but id-only `step-cascade` stepped from the `:frame/a` row → `boundary no-op? true`.

## The frame-strict fix

Two coupled lookups are now frame-strict:

1. **`compose-focus` head-frame resolution** — the auto-tracked head is resolved as the actual head cascade RECORD (`head-cascade`, the last focusable row) rather than an id-only `cascade-by-id`. So the composed focus reports `[head-id, head-frame]` in lockstep even when `head-id` also occurs in an earlier frame (the id-only path returned the FIRST same-id row's frame). RETRO / LIVE-paused branches still resolve by the pinned id (+ stored frame).
2. **`step-cascade` 4-arity** `[cascades current-frame current-id delta]` — matches the current index by `[current-frame current-id]`, falling back to id-only for frameless focus or when no frame-matching current row exists. `focus-step-reducer` threads the composed focus's `:frame` in; its boundary no-op test is frame-strict too (a genuine edge is the same `[frame dispatch-id]` coordinate, so stepping onto a same-id cascade in another frame is a real move).

Single-frame stepping is unchanged (frameless / id-only fallback preserved; the existing `step-dispatch-id` 3-arity is untouched).

## Spec sync

`tools/xray/spec/018-Event-Spine.md` "Frame-strict cascade lookup" section extended with the rf2-xj3kbn current-position lookup (both the composer head-frame resolution and the `step-cascade` current index), plus the new test gates.

## Tests

`spine_cljs_test.cljs` adds:
- `step-cascade-current-lookup-is-frame-strict-rf2-xj3kbn` — 4-arity matches `[frame id]`; id-only 3-arity preserved; falls back to id-only when no frame-matching current row exists.
- `focus-step-reducer-prev-from-live-head-is-frame-strict-rf2-xj3kbn` — **load-bearing**: prev from a colliding-id LIVE head is a REAL step (not a no-op) and lands on `:mid` in `:frame/b`, frame + id in lockstep. This case fails on the pre-fix code.
- `focus-step-reducer-frame-strict-step-resolves-epoch-rf2-xj3kbn` — the stepped row's settling epoch resolves into focus.

## Gates

- `tools/xray` JVM: `clojure -M:test` → 1235 tests, 5698 assertions, 0 failures.
- `npm run test:cljs` (cross-artefact node-test, incl. the spine cljs tests) → 7968 tests, 36690 assertions, 0 failures.
- `npm run test:xray-feature-gate` → 15 scenarios, 0 failures, 13 matrix rows.
- clj-kondo on changed source + test → 0 errors, 0 warnings.

Rebased onto origin/main before push.