### PR TITLE
refactor(machines): clarity-naming callback alignment + fix spec/005 reg-machine re-export claim (rf2-a60b07, rf2-9g9j1a, rf2-zwy289)

### DIFF
--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -1600,12 +1600,12 @@ The runtime now tracks each declarative-`:spawn` spawn-id at the reserved runtim
 **What to look for** in the codebase:
 
 - Machine specs that declared `:spawn` WITHOUT an `:on-spawn` callback — these were silently leaking the spawned actor on state-exit (the runtime had no id to destroy). Pre-alpha these were broken by definition; the runtime-owned spawn-id tracking makes them correct without user-side rewrite.
-- Machine specs that hand-coded an `:exit` action equivalent to the auto-destroy desugar (e.g. `:exit (fn [data _] {:fx [[:rf.machine/destroy (:pending data)]]})`) — these continue to work unchanged (the keyword form of the destroy fx is preserved).
+- Machine specs that hand-coded an `:exit` action equivalent to the auto-destroy desugar (e.g. `:exit (fn [{:keys [data]}] {:fx [[:rf.machine/destroy (:pending data)]]})`) — these continue to work unchanged (the keyword form of the destroy fx is preserved).
 - User-supplied `:exit` action bodies that peek at the child's last snapshot before the auto-destroy fires — read it from the **runtime-db** partition at `[:rf.runtime/machines :snapshots (:pending data)]` (via `sub-machine` / the `:rf.db/runtime` cofx, not an app-db `(get-in db …)` read — snapshots no longer live in app-db). The composition rule ([§Composition with explicit `:entry` / `:exit`](../../spec/005-StateMachines.md#composition-with-explicit-entry--exit)) is unchanged: the user's `:exit` action runs BEFORE the auto-destroy, so the snapshot is still readable through the parent's recorded id.
 
 **What to do.** Type B because the rewrite depends on intent: a `:spawn` without `:on-spawn` was silently broken pre-fix (the actor leaked); it now works correctly under the runtime-owned spawn-id registry. The agent flags hit sites for human review rather than silently rewriting, since the v1 prose contract on `:on-spawn` was "required for from-action spawns" — code that depended on the leak being silent (e.g. tests asserting `[:rf.runtime/machines :snapshots]` has a stale entry after exit) needs explicit triage.
 
-**Public API** (in `re-frame.core` and the `reg-machine` / `:spawn` surface) is unchanged — `:on-spawn` callback signature is `(fn [data spawned-id] new-data)` exactly as before. The change is to the **runtime semantics** of where the spawn-id is stored: the user's `:data` is now user territory, and the runtime owns `[:rf.runtime/machines :spawned ...]`.
+**Public API** (in `re-frame.core` and the `reg-machine` / `:spawn` surface) is unchanged. The change is to the **runtime semantics** of where the spawn-id is stored: the user's `:data` is now user territory, and the runtime owns `[:rf.runtime/machines :spawned ...]`. As with every machine callback, `:on-spawn` receives the unified context map — `(fn [{:keys [data id]}] new-data)` (per [005 §Guards / §Actions](../../spec/005-StateMachines.md)).
 
 **Why:** the v1 prose contract conflated user data flow (where the user wants the id recorded for their own bookkeeping) with runtime mechanics (how the runtime locates the spawn for destroy). Splitting them — runtime-owned `[:rf.runtime/machines :spawned ...]` + advisory user `:on-spawn` — fixes the silent-leak bug, removes the runtime's reliance on a particular `:data` slot key, and makes `:spawn` declarations correct-by-default. Per [005 §Declarative `:spawn` §Desugaring rules](../../spec/005-StateMachines.md#desugaring-rules) and [Conventions §Reserved runtime-db keys](../../spec/Conventions.md#reserved-runtime-db-keys).
 
@@ -1628,13 +1628,13 @@ The actor-lifecycle fx-ids registered by `re-frame.machines` (Spec 005) are rena
 ;; before
 {:fx [[:spawn           {:machine-id :worker
                          :id-prefix  :worker
-                         :on-spawn   (fn [d id] (assoc d :pending id))}]
+                         :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}]
       [:destroy-machine actor-id]]}
 
 ;; after
 {:fx [[:rf.machine/spawn   {:machine-id :worker
                             :id-prefix  :worker
-                            :on-spawn   (fn [d id] (assoc d :pending id))}]
+                            :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}]
       [:rf.machine/destroy actor-id]]}
 ```
 
@@ -2998,17 +2998,17 @@ If a codebase has any pattern of "spawn an actor and thread its id through a sib
 
 ```clojure
 ;; before
-:action (fn [data _]
+:action (fn [_ctx]
           {:fx [[:rf.machine/spawn {:machine-id :notifier
-                                    :on-spawn   (fn [d id] (assoc d :notifier-id id))}]]})
-:action (fn [data _]
+                                    :on-spawn   (fn [{:keys [data id]}] (assoc data :notifier-id id))}]]})
+:action (fn [{:keys [data]}]
           {:fx [[:dispatch [(:notifier-id data) [:notify "..."]]]]})
 
 ;; after
-:action (fn [data _]
+:action (fn [_ctx]
           {:fx [[:rf.machine/spawn {:machine-id :notifier
                                     :system-id  :notifier}]]})
-:action (fn [data _]
+:action (fn [_ctx]
           {:fx [[:rf.machine/dispatch-to-system [:notifier [:notify "..."]]]]})
 ```
 
@@ -3106,7 +3106,7 @@ Codebases that hand-rolled spawn-and-join in machine specs — N siblings + coun
 ```clojure
 ;; before — hand-rolled spawn-and-join (boilerplate)
 {:hydrating
- {:entry  (fn [data _]
+ {:entry  (fn [{:keys [data]}]
             ;; Pre-populate cached buckets to avoid spawning them
             (-> data
                 (assoc :buckets-pending #{:cfg :flag :user :dash})

--- a/migration/from-re-frame-v1/async-flow-fx-to-reg-machine.md
+++ b/migration/from-re-frame-v1/async-flow-fx-to-reg-machine.md
@@ -101,7 +101,7 @@ This is the canonical async-flow shape from the lib's own README, adapted for a 
   {:initial :starting
    :states
    {:starting
-    {:entry  (fn [_data _ev] {:fx [[:dispatch [:db/connect]]]})
+    {:entry  (fn [_ctx] {:fx [[:dispatch [:db/connect]]]})
      :on     {:db/connect-success :loading-user-and-prefs
               :db/connect-failure :failed}}
 
@@ -116,10 +116,10 @@ This is the canonical async-flow shape from the lib's own README, adapted for a 
           :user-or-prefs-failed   :failed}}
 
     :ready  {:final? true
-             :entry  (fn [_data _ev] {:fx [[:dispatch [:app/ready]]]})}
+             :entry  (fn [_ctx] {:fx [[:dispatch [:app/ready]]]})}
 
     :failed {:final? true
-             :entry  (fn [_data _ev] {:fx [[:dispatch [:app/boot-failed]]]})}}})
+             :entry  (fn [_ctx] {:fx [[:dispatch [:app/boot-failed]]]})}}})
 
 ;; Kick the machine off from the app's entry point:
 (rf/dispatch [:app/boot [:start]])
@@ -136,7 +136,7 @@ What changed:
 
 ### `:first-dispatch`
 
-- **Default path.** Move the dispatched event into the initial state's `:entry` action: `{:entry (fn [_data _ev] {:fx [[:dispatch <event-vec>]]})}`. The machine bootstraps on its first received event; the parent dispatches that event (often the kickoff itself, e.g. `(rf/dispatch [:app/boot [:start]])`).
+- **Default path.** Move the dispatched event into the initial state's `:entry` action: `{:entry (fn [_ctx] {:fx [[:dispatch <event-vec>]]})}`. The machine bootstraps on its first received event; the parent dispatches that event (often the kickoff itself, e.g. `(rf/dispatch [:app/boot [:start]])`).
 - **If the flow's `:first-dispatch` is conditional on cofx or app-db at boot time** (uncommon but possible — e.g. "if user is authenticated, dispatch X; otherwise Y"): hoist the condition into the parent event that calls `rf/dispatch` to spawn / start the machine. The machine's `:entry` should be deterministic given the spec.
 - **If `:first-dispatch` is omitted** in the v1 flow (the flow starts when an external event arrives that matches one of its rules): the machine's initial state's `:entry` is a no-op (`{:entry nil}` or omitted); the first transition fires when the awaited event arrives.
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -1042,7 +1042,7 @@ Applied to machines: the transition table is a data DSL because it describes nam
 
 ## Inspectability bias
 
-> **Inspectability bias.** Machine tables should prefer **named guards and actions declared in the machine's `:guards` / `:actions` maps** over inline fns. The id (`:under-quota?`) carries semantic meaning that visualisers, AIs, and humans all read; an inline `(fn [data ev] ...)` is opaque to inspection. Inline fns are escape hatches for trivial logic (one-liners with no branching), not the default form.
+> **Inspectability bias.** Machine tables should prefer **named guards and actions declared in the machine's `:guards` / `:actions` maps** over inline fns. The id (`:under-quota?`) carries semantic meaning that visualisers, AIs, and humans all read; an inline `(fn [{:keys [data event]}] ...)` is opaque to inspection. Inline fns are escape hatches for trivial logic (one-liners with no branching), not the default form.
 
 The id is the meaning at the call site; the inline fn is opaque to readers. The machine-scoped resolution mechanics — how keyword references in transition slots resolve against the machine's `:guards` / `:actions` maps, and how cross-machine reuse via Clojure vars works — are specified once in [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler).
 
@@ -1568,7 +1568,7 @@ The snapshot's `:state` becomes the **third arm** described in [§Snapshot shape
 
 Nested parallel regions (a region whose own state-tree declares `:type :parallel`) are not supported in v1. The validator rejects them at registration with `:rf.error/machine-parallel-nested-not-supported`. Two-level nesting can be modelled as a flatter cross-product or, more idiomatically, as multiple top-level parallel-region machines.
 
-The `:data` slot is **shared** across every region — there is no `:data` slot on a region body, and there is no per-region `:data` slot inside the snapshot. Region states see and write the same `:data` map; the action-effect contract is unchanged (`(fn [data event] {:data {...}})`).
+The `:data` slot is **shared** across every region — there is no `:data` slot on a region body, and there is no per-region `:data` slot inside the snapshot. Region states see and write the same `:data` map; the action-effect contract is unchanged (`(fn [{:keys [data event]}] {:data {...}})`).
 
 ### Initial state
 
@@ -2485,7 +2485,7 @@ Per the runtime stamps three framework-reserved keys into every spawned actor's 
 Per [§Path conventions in machine bodies](#path-conventions-in-machine-bodies), the `:rf/*` namespace inside `:data` is reserved for runtime-managed keys; user code does not write under it. The actor reads these as ordinary `:data` lookups inside its actions:
 
 ```clojure
-:dispatch-done (fn [data _]
+:dispatch-done (fn [{:keys [data]}]
                  (when-let [parent-id (:rf/parent-id data)]
                    {:fx [[:dispatch [parent-id [:done (:result data)]]]]}))
 ```

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -880,7 +880,7 @@ Before the event-`:schema` arity this shape could not be expressed through `reg-
 
 The bare `(reg-event id meta (make-machine-handler spec))` composition does not stamp the meta — so a `:data-schema` declared on a hand-stamped machine is **inert** (validates nothing). `make-machine-handler` therefore **fails loud** when handed a `:data-schema`-bearing spec outside the home: it raises `:rf.error/machine-schema-requires-reg-machine`, directing the author to `reg-machine` / `reg-machine*` (and, when the machine also validates its event vector, the event-`:schema` arity). A schema-LESS spec is unaffected — it has nothing inert, so the bare `reg-event` + `make-machine-handler` composition stays legal for it (the lazy spawned-actor materialisation seam relies on it).
 
-Both forms live in `re-frame.machines` (the `day8/re-frame2-machines` artefact, per [Conventions.md](Conventions.md)) and are re-exported under `re-frame.core` for both JVM and CLJS callers. See [API.md §Machines](API.md#machines) for the canonical API table.
+Both forms live in `re-frame.machines` (the `day8/re-frame2-machines` artefact, per [Conventions.md](Conventions.md)). The `reg-machine` / `defmachine` **macros** are re-exported on the `re-frame.core` façade (they capture call-site source-coords); the plain-fn `reg-machine*` is **not** re-exported — reach it through `re-frame.machines/reg-machine*` (per [API.md §Front-porch boundary](API.md), the non-registration / plain-fn machine surface stays in its owning namespace). See [API.md §Machines](API.md#machines) for the canonical API table.
 
 Both forms return `machine-id` per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
 
@@ -905,7 +905,7 @@ The `reg-machine` convenience surface splits along Clojure's `let` / `let*`, `fn
 | `(rf/reg-machine* machine-id machine-spec opts)` | plain fn | None | Programmatic registration of the machine + event-vector-schema shape (the plain-fn counterpart of the opts macro arity). |
 | `(rf/defmachine name [doc] spec)` | **macro** (`def`-shape) | Yes — walks the inline literal `spec` at the **definition site** and co-locates per-element source + the reference-site `:source-coords` on each `:states`-tree map node onto the def'd value (per [§Value-registered machines](#value-registered-machines--defmachine)). Does not register — pair with `(reg-machine id name)`. | The `def`-then-register shape: `(defmachine m {…})` then `(reg-machine :id m)` so a value-registered machine carries per-element source. |
 
-The `reg-machine` / `defmachine` macros live at the `re-frame.core` boundary; the plain-fn surface lives in `re-frame.machines/reg-machine*` and is exposed publicly under `re-frame.core/reg-machine*` for both JVM and CLJS programmatic callers. The inline `reg-machine` macro emits `(reg-machine* …)` after stamping; the runtime never reaches both surfaces independently.
+The `reg-machine` / `defmachine` macros are re-exported on the `re-frame.core` façade; the plain-fn surface lives in `re-frame.machines/reg-machine*` and is reached through that namespace directly (it is **not** a `re-frame.core` façade export — front-porch shrink, rf2-wad2fl) for both JVM and CLJS programmatic callers. The inline `reg-machine` macro emits `(reg-machine* …)` after stamping; the runtime never reaches both surfaces independently.
 
 ### Source-coord stamping
 

--- a/spec/CP-5-MachineGuide.md
+++ b/spec/CP-5-MachineGuide.md
@@ -39,13 +39,14 @@ Acceptable inline cases (single non-branching expression):
 
 ```clojure
 ;; Trivial guard — single non-branching expression.
-:guard (fn [data _] (some? (:circle-id data)))
+:guard (fn [{:keys [data]}] (some? (:circle-id data)))
 
 ;; Trivial action — pure data update, single non-branching expression.
-:action (fn [_ [_ new-r]] {:data {:preview-radius new-r}})
+;; Event values are destructured from the :event vector inside the body.
+:action (fn [{[_ new-r] :event}] {:data {:preview-radius new-r}})
 
 ;; Trivial action — single :fx entry, no branching.
-:action (fn [data _]
+:action (fn [{:keys [data]}]
           {:fx [[:dispatch [:drawer/apply-radius
                             (:circle-id data)
                             (:preview-radius data)]]]})
@@ -55,23 +56,23 @@ Cases that should be named in `:guards` / `:actions` instead (branching, composi
 
 ```clojure
 ;; Branching → name it.
-:action (fn [data ev]
+:action (fn [{:keys [data event]}]
           (if (over-quota? data)
             {:data {:error :quota}}
             {:data {:attempts (inc (:attempts data))}
-             :fx   [[:dispatch [:audit/recorded ev]]]}))
+             :fx   [[:dispatch [:audit/recorded event]]]}))
 
 ;; Composed → name the composition.
-:action (fn [data ev]
-          (let [a (record-attempt data ev) b (clear-error data ev)]
+:action (fn [{:keys [data event]}]
+          (let [a (record-attempt data event) b (clear-error data event)]
             {:data (merge (:data a) (:data b))
              :fx   (into (:fx a []) (:fx b []))}))
 
 ;; Multi-fx + branching → name it.
-:guard (fn [data ev]
-         (and (under-quota? data ev)
-              (not (locked-out? data ev))
-              (some? (:credentials (second ev)))))
+:guard (fn [{:keys [data event]}]
+         (and (under-quota? data event)
+              (not (locked-out? data event))
+              (some? (:credentials (second event)))))
 ```
 
 For the third case (compound predicate), prefer naming the compound — `:eligible-to-submit?` in the machine's `:guards` map is what visualisers and AIs read on the transition arrow.

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -387,13 +387,14 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
      :guards
      {:under-retry-limit
       ;; Has this login had fewer than 3 prior attempts?
-      (fn [data _event]
+      (fn [{:keys [data]}]
         (< (:attempts data) 3))}
 
      :actions
      {:begin-submit
       ;; Clear the prior error and emit the HTTP request for credential check.
-      (fn [_data [_ creds]]
+      ;; Destructure the credentials out of the :event vector.
+      (fn [{[_ creds] :event}]
         {:data {:error nil}
          :fx   [[:http {:method     :post
                         :url        "/api/login"
@@ -403,23 +404,23 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
       :record-failure
       ;; Bump the attempts counter and surface a credentials error.
-      (fn [data _event]
+      (fn [{:keys [data]}]
         {:data {:attempts (inc (:attempts data))
                 :error    :credentials}})
 
       :lock-out
       ;; Lock the account after exceeding the retry limit.
-      (fn [_snap _event]
+      (fn [_ctx]
         {:data {:error :locked}})
 
       :clear-error
       ;; Reset the error before re-submitting.
-      (fn [_snap _event]
+      (fn [_ctx]
         {:data {:error nil}})
 
       :clear-and-record-success
       ;; On successful auth, clear any residual error state.
-      (fn [_snap _event]
+      (fn [_ctx]
         {:data {:error nil}})}
 
      :states
@@ -507,7 +508,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 ;; ... inside the machine spec:
 :actions
 {:spawn-fetch
- (fn [_ [_ url]]
+ (fn [{[_ url] :event}]
    {:fx [[:rf.machine/spawn {:machine-id :request/protocol
                              :id-prefix  :request/protocol
                              :data       {:url url}

--- a/spec/Pattern-AsyncEffect.md
+++ b/spec/Pattern-AsyncEffect.md
@@ -96,7 +96,7 @@ The most flexible option, and the right default for **per-call overrides**. The 
 
 ;; Receiver — :start-job action reads opts; falls back to a default when omitted.
 :start-job
-(fn [_ [_ input opts]]
+(fn [{[_ input opts] :event}]
   {:data {:total      (count input)
           :input      input
           :chunk-size (:chunk-size opts 100)
@@ -115,14 +115,14 @@ When a machine is **spawned by a parent** (per [005 §Declarative `:spawn`](005-
 ```clojure
 ;; Parent boot machine spawns the WebSocket connection child.
 :spawn {:machine-id :ws/socket
-         :data       (fn [{:keys [data]} _]
-                       {:url        (-> data :config :ws-url)
-                        :auth-token (-> data :session :token)
+         :data       (fn [{:keys [snapshot]}]
+                       {:url        (-> snapshot :data :config :ws-url)
+                        :auth-token (-> snapshot :data :session :token)
                         :retries    0
                         :backoff-ms 1000})}
 ```
 
-The fn signature is `(fn [parent-snapshot event] child-data)`. It runs at spawn time, in the parent's drain, with the parent's current snapshot — so values flow from parent to child without a dispatch hop and without the child needing to know about the parent's structure beyond what its `:data` fn extracts.
+The fn receives the unified context map — `(fn [{:keys [snapshot event]}] child-data)` — where `:snapshot` is the parent's current snapshot (read its working memory via `(-> snapshot :data ...)`). It runs at spawn time, in the parent's drain — so values flow from parent to child without a dispatch hop and without the child needing to know about the parent's structure beyond what its `:data` fn extracts.
 
 This is the right answer when the parameter is **derived from parent state at spawn time**. It is more direct than mechanism 1 because the parent does not need to construct an event payload and the child does not need to declare a `:start` action — `:data` arrives pre-populated.
 
@@ -136,7 +136,7 @@ For **boot-time-fixed values** that originate from the host environment — a bu
 :hydrate
 {:on {:succeeded
       {:target :ready
-       :action (fn [data _]
+       :action (fn [{:keys [data]}]
                  {:fx [[:dispatch [:ws/socket
                                    [:connect {:url        (-> data :config :ws-url)
                                               :auth-token (-> data :session :token)}]]]]})}}}

--- a/spec/Pattern-Boot.md
+++ b/spec/Pattern-Boot.md
@@ -84,43 +84,43 @@ Each phase uses `:spawn` to spawn the async work; transitions on success or fail
 
      :guards
      {:has-session-token?
-      (fn [_ _] (some? (.getItem js/localStorage "auth/token")))
+      (fn [_ctx] (some? (.getItem js/localStorage "auth/token")))
 
       :under-retry-limit?
-      (fn [data _] (< (:phase-attempt data) 3))}
+      (fn [{:keys [data]}] (< (:phase-attempt data) 3))}
 
      :actions
      {:set-phase
       ;; Update visible-progress slice in :data so the boot UI can render.
-      (fn [data [_ phase]]
+      (fn [{:keys [data] [_ phase] :event}]
         {:data (assoc data :phase phase :phase-attempt 0)})
 
       :record-config
-      (fn [data [_ config]]
+      (fn [{:keys [data] [_ config] :event}]
         {:data (assoc data :config config)})
 
       :record-user
-      (fn [data [_ user]]
+      (fn [{:keys [data] [_ user] :event}]
         {:data (assoc data :user user)})
 
       :bump-attempt
-      (fn [data _]
+      (fn [{:keys [data]}]
         {:data (update data :phase-attempt inc)})
 
       :record-error
-      (fn [data [_ err]]
+      (fn [{:keys [data] [_ err] :event}]
         {:data (assoc data :error err)})
 
       :resolve-initial-route
       ;; Reads :route from URL and seeds the :route slice (per Spec 012).
-      (fn [_ _]
+      (fn [_ctx]
         {:fx [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
 
       :enter-routing
       ;; Compound entry action for :routing — :set-phase + :resolve-initial-route
       ;; in one fn. (Per [005 §State nodes] :entry takes one fn or one
       ;; registered id, never a vector.)
-      (fn [data _]
+      (fn [{:keys [data]}]
         {:data (assoc data :phase :routing :phase-attempt 0)
          :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})}
 
@@ -134,7 +134,7 @@ Each phase uses `:spawn` to spawn the async work; transitions on success or fail
       {:entry  :set-phase
        :spawn {:machine-id :http/get
                 :data       {:url "/config"}
-                :on-spawn   (fn [d id] (assoc d :pending id))}
+                :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
        :on     {:succeeded {:target :authenticating
                             :action :record-config}
                 :failed    {:target :fatal-error
@@ -147,9 +147,11 @@ Each phase uses `:spawn` to spawn the async work; transitions on success or fail
        :spawn {:machine-id :auth/restore-session
                 ;; Spawn-spec :data fn — read the auth URL out of the boot
                 ;; machine's :data :config (per Pattern-AsyncEffect mechanism 2).
-                :data       (fn [{:keys [data]} _]
-                              {:auth-url (-> data :config :auth-url)})
-                :on-spawn   (fn [d id] (assoc d :pending id))}
+                ;; The :data fn receives the parent's context map; read its
+                ;; :data from the :snapshot slot (per 005 §Declarative :spawn).
+                :data       (fn [{:keys [snapshot]}]
+                              {:auth-url (-> snapshot :data :config :auth-url)})
+                :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
        :on     {:succeeded {:target :loading-profile}
                 :failed    [{:target :retrying-auth
                              :guard  :under-retry-limit?
@@ -166,9 +168,9 @@ Each phase uses `:spawn` to spawn the async work; transitions on success or fail
                 ;; Read the profile URL from the loaded config rather than
                 ;; hardcoding it — the boot machine threads host config in
                 ;; via the spawn-spec :data fn.
-                :data       (fn [{:keys [data]} _]
-                              {:url (-> data :config :profile-url)})
-                :on-spawn   (fn [d id] (assoc d :pending id))}
+                :data       (fn [{:keys [snapshot]}]
+                              {:url (-> snapshot :data :config :profile-url)})
+                :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
        :on     {:succeeded {:target :hydrating
                             :action :record-user}
                 :failed    {:target :profile-failed
@@ -310,21 +312,21 @@ The pattern, distilled to a worked sketch:
      :data    {:token nil :user nil :error nil}
 
      :guards
-     {:got-401? (fn [_ [_ {:keys [failure]}]]
+     {:got-401? (fn [{[_ {:keys [failure]}] :event}]
                   (and (= :rf.http/http-4xx (:kind failure))
                        (= 401 (:status failure))))
-      :token-stale? (fn [{:keys [data]} _]
+      :token-stale? (fn [{:keys [data]}]
                       (some? (:token data)))}                  ;; refresh viable
 
      :actions
-     {:record-token (fn [d [_ {:keys [token]}]] {:data (assoc d :token token)})
-      :record-user  (fn [d [_ {:keys [value]}]] {:data (assoc d :user value)})
-      :record-error (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+     {:record-token (fn [{:keys [data] [_ {:keys [token]}] :event}] {:data (assoc data :token token)})
+      :record-user  (fn [{:keys [data] [_ {:keys [value]}] :event}] {:data (assoc data :user value)})
+      :record-error (fn [{:keys [data] [_ {:keys [failure]}] :event}] {:data (assoc data :error failure)})}
 
      :states
      {:loading-me
       {:spawn {:src ::fetch-me
-                :data (fn [{:keys [data]} _] {:token (:token data)})}
+                :data (fn [{:keys [snapshot]}] {:token (-> snapshot :data :token)})}
        :on    {:succeeded {:target :authenticated :action :record-user}
                :failed    [{:guard  :got-401?
                             :target :refreshing

--- a/spec/Pattern-LongRunningWork.md
+++ b/spec/Pattern-LongRunningWork.md
@@ -50,13 +50,13 @@ A state machine that processes one batch per state transition, yields to the bro
                :input       nil
                :result      []}
      :guards
-     {:done?      (fn [data _] (>= (:processed data) (:total data)))
-      :more-work? (fn [data _] (<  (:processed data) (:total data)))}
+     {:done?      (fn [{:keys [data]}] (>= (:processed data) (:total data)))
+      :more-work? (fn [{:keys [data]}] (<  (:processed data) (:total data)))}
 
      :actions
      {:start-job
       ;; opts is an optional map; :chunk-size falls back to the default declared in :data above.
-      (fn [_ [_ input opts]]
+      (fn [{[_ input opts] :event}]
         {:data {:total      (count input)
                 :input      input
                 :chunk-size (:chunk-size opts 100)
@@ -64,7 +64,7 @@ A state machine that processes one batch per state transition, yields to the bro
                 :result     []}})
 
       :process-chunk
-      (fn [data _]
+      (fn [{:keys [data]}]
         (let [{:keys [input chunk-size processed result]} data
               chunk    (subvec input processed (min (+ processed chunk-size) (count input)))
               outputs  (mapv expensive-fn chunk)]

--- a/spec/Pattern-SSR-Loaders.md
+++ b/spec/Pattern-SSR-Loaders.md
@@ -49,18 +49,18 @@ A product-detail page needs three independent fetches before render: the product
      {:children
       [{:id         :product
         :machine-id :http/get-one
-        :data       (fn [snap _]
-                      {:url (str "/api/products/" (-> snap :data :product-id))
+        :data       (fn [{:keys [snapshot]}]
+                      {:url (str "/api/products/" (-> snapshot :data :product-id))
                        :decode ProductSchema})}
        {:id         :related
         :machine-id :http/get-one
-        :data       (fn [snap _]
-                      {:url (str "/api/products/" (-> snap :data :product-id) "/related")
+        :data       (fn [{:keys [snapshot]}]
+                      {:url (str "/api/products/" (-> snapshot :data :product-id) "/related")
                        :decode RelatedListSchema})}
        {:id         :reviews
         :machine-id :http/get-one
-        :data       (fn [snap _]
-                      {:url    (str "/api/products/" (-> snap :data :product-id) "/reviews")
+        :data       (fn [{:keys [snapshot]}]
+                      {:url    (str "/api/products/" (-> snapshot :data :product-id) "/reviews")
                        :params {:limit 10}
                        :decode ReviewListSchema})}]
       :join             :all
@@ -81,7 +81,7 @@ A product-detail page needs three independent fetches before render: the product
                                  [:assoc-in [:pdp :reviews] reviews]]}))}
 
     :error {:final? true
-            :entry  (fn [_ [_ _ reason]]
+            :entry  (fn [{[_ _ reason] :event}]
                       {:fx [[:rf.server/set-status 502]
                             [:assoc-in [:pdp :error] reason]]})}}})
 ```
@@ -97,16 +97,16 @@ A thin wrapper around `:rf.http/managed` — one state spawns the request; succe
    :states
    {:requesting
     {:spawn {:machine-id :rf.http/managed
-              :data       (fn [snap _] (assoc (:data snap) :method :get))}
+              :data       (fn [{:keys [snapshot]}] (assoc (:data snapshot) :method :get))}
      :on     {:succeeded  :done
               :failed     :failed-state}}
 
     :done   {:final? true
-             :entry (fn [data [_ _ result]]
+             :entry (fn [{:keys [data] [_ _ result] :event}]
                       {:fx [[:dispatch [(:rf/parent-id (-> data :env))
                                         [:loaded (:rf/invoke-id data) result]]]]})}
     :failed-state {:final? true
-                   :entry (fn [data [_ _ reason]]
+                   :entry (fn [{:keys [data] [_ _ reason] :event}]
                             {:fx [[:dispatch [(:rf/parent-id (-> data :env))
                                               [:failed (:rf/invoke-id data) reason]]]]})}}})
 ```

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -57,7 +57,7 @@ Per [005 §Transition resolution — deepest-wins with parent fallthrough](005-S
 The connection machine composes the locked substrate:
 
 - **Hierarchical states** ([005 §Hierarchical compound states](005-StateMachines.md#hierarchical-compound-states)) — `:active` is the parent of three connection-leaves; the parent owns the socket actor.
-- **`:after`** ([005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions)) — exponential backoff timer in `:reconnecting`, expressed as a **fn-form delay** `(fn [snap] ms)` that reads the current `:retries` and `:base-ms` from `:data`. The `:after`-epoch invariant ([005 §Epoch-based stale detection](005-StateMachines.md#epoch-based-stale-detection)) guarantees stale timers from prior `:reconnecting` visits are silently dropped on transitions away.
+- **`:after`** ([005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions)) — exponential backoff timer in `:reconnecting`, expressed as a **fn-form delay** `(fn [{:keys [snapshot]}] ms)` that reads the current `:retries` and `:base-ms` from the snapshot's `:data`. The `:after`-epoch invariant ([005 §Epoch-based stale detection](005-StateMachines.md#epoch-based-stale-detection)) guarantees stale timers from prior `:reconnecting` visits are silently dropped on transitions away.
 - **`:always`** ([005 §Eventless `:always` transitions](005-StateMachines.md#eventless-always-transitions)) — max-retries guard fires immediately on entry to `:reconnecting` if `:retries` exceeds the limit, transitioning straight to `:failed`. Also used to flush queued messages on entry to `:connected`.
 - **Machine-scoped `:guards` / `:actions`** ([005 §Registration — the machine IS the event handler](005-StateMachines.md#registration--the-machine-is-the-event-handler)) — for `:max-retries-exceeded?`, `:has-queued-messages?`, `:bump-retry-count`, `:flush-queue`, `:current-socket?`, etc.
 - **`:spawn`** ([005 §Declarative `:spawn`](005-StateMachines.md#declarative-spawn)) — `:active` invokes a `:websocket/socket` actor that owns the actual `WebSocket` object; the actor's lifetime is bound to the `:active` parent. Any transition that exits `:active` (to `:reconnecting`, to `:failed`, or to `:disconnected`) destroys the actor; re-entering `:active` after `:after` backoff spawns a fresh socket.
@@ -85,11 +85,11 @@ The connection machine composes the locked substrate:
 
      :guards
      {:max-retries-exceeded?
-      (fn [data _]
+      (fn [{:keys [data]}]
         (>= (:retries data) (:max-retries data)))
 
       :has-queued-messages?
-      (fn [data _]
+      (fn [{:keys [data]}]
         (seq (:queue data)))
 
       :current-socket?
@@ -97,36 +97,36 @@ The connection machine composes the locked substrate:
       ;; this machine currently owns. Connection-epoch staleness check
       ;; (Pattern-StaleDetection): replies from a prior socket-id are
       ;; suppressed without disturbing the live snapshot.
-      (fn [data [_ {:keys [source-socket-id]}]]
+      (fn [{:keys [data] [_ {:keys [source-socket-id]}] :event}]
         (= source-socket-id (:socket-id data)))}
 
      :actions
      {:record-connection-opts
       ;; Caller passes URL + token on :ws/connect; opts land in :data and
       ;; every subsequent reconnect re-reads them via :spawn's :data fn.
-      (fn [data [_ {:keys [url auth-token]}]]
+      (fn [{:keys [data] [_ {:keys [url auth-token]}] :event}]
         {:data (assoc data :url url :auth-token auth-token)})
 
       :refresh-token
       ;; The auth machine calls this after an out-of-band refresh; the
       ;; next :active entry's :spawn :data fn picks up the fresh token.
-      (fn [data [_ token]]
+      (fn [{:keys [data] [_ token] :event}]
         {:data (assoc data :auth-token token)})
 
-      :bump-retry (fn [data _] {:data (update data :retries inc)})
+      :bump-retry (fn [{:keys [data]}] {:data (update data :retries inc)})
 
       :ws/socket-ready
       ;; The child socket actor carries its own id back on entry
       ;; (carry-the-id-back-to-the-parent idiom); the parent records it so
       ;; :current-socket? and every (:socket-id data) dispatch have a value.
-      (fn [data [_ socket-id]] {:data (assoc data :socket-id socket-id)})
+      (fn [{:keys [data] [_ socket-id] :event}] {:data (assoc data :socket-id socket-id)})
 
       :clear-socket-id
-      (fn [data _] {:data (assoc data :socket-id nil)})
+      (fn [{:keys [data]}] {:data (assoc data :socket-id nil)})
 
       :send-auth
       ;; Route an :auth message into the live socket actor.
-      (fn [data _]
+      (fn [{:keys [data]}]
         {:fx [[:dispatch [(:socket-id data) [:send {:type  :auth
                                                     :token (:auth-token data)}]]]]})
 
@@ -134,7 +134,7 @@ The connection machine composes the locked substrate:
       ;; Compound entry action for :connected — :reset-retry + :resubscribe
       ;; in one fn. (Per [005 §State nodes] :entry takes one fn or one
       ;; registered id, never a vector.)
-      (fn [data _]
+      (fn [{:keys [data]}]
         {:data (assoc data :retries 0)
          :fx   (mapv (fn [topic]
                        [:dispatch [(:socket-id data)
@@ -143,21 +143,21 @@ The connection machine composes the locked substrate:
 
       :flush-queue
       ;; Send everything buffered while disconnected; clear the queue.
-      (fn [data _]
+      (fn [{:keys [data]}]
         {:data (assoc data :queue [])
          :fx   (mapv (fn [msg] [:dispatch [(:socket-id data) [:send msg]]])
                      (:queue data))})
 
       :enqueue-message
       ;; Buffer a send while the connection is not yet :connected.
-      (fn [data [_ msg]]
+      (fn [{:keys [data] [_ msg] :event}]
         {:data (update data :queue conj msg)})
 
       :register-request
       ;; Caller: [:ws/request {:request-id ..., :body ..., :reply ...}].
       ;; Record the in-flight entry, forward to the socket, schedule a timeout.
-      (fn [data [_ {:keys [request-id body reply timeout-ms]
-                    :or   {timeout-ms 30000}}]]
+      (fn [{:keys [data] [_ {:keys [request-id body reply timeout-ms]
+                             :or   {timeout-ms 30000}}] :event}]
         {:data (assoc-in data [:in-flight request-id]
                          {:reply-event reply :timeout-ms timeout-ms})
          :fx   [[:dispatch [(:socket-id data)
@@ -170,20 +170,20 @@ The connection machine composes the locked substrate:
                             :source-socket-id (:socket-id data)}]]}]]})
 
       :clear-request
-      (fn [data [_ {:keys [request-id]}]]
+      (fn [{:keys [data] [_ {:keys [request-id]}] :event}]
         {:data (update data :in-flight dissoc request-id)})
 
       :record-and-reset
       ;; Compound action — record fresh opts AND reset the retry counter.
       ;; Used on manual :ws/connect from :reconnecting / :failed (the
       ;; running app has refreshed the token; reconnect immediately).
-      (fn [data [_ {:keys [url auth-token]}]]
+      (fn [{:keys [data] [_ {:keys [url auth-token]}] :event}]
         {:data (-> data
                    (assoc :url url :auth-token auth-token)
                    (assoc :retries 0))})
 
       :record-error
-      (fn [data [_ err]] {:data (assoc data :error err)})}
+      (fn [{:keys [data] [_ err] :event}] {:data (assoc data :error err)})}
 
      :states
      {:disconnected
@@ -262,7 +262,7 @@ The connection machine composes the locked substrate:
                   ;; in-flight from a prior socket whose destroy hadn't
                   ;; flushed by the time the dispatch landed.
                   :ws/received {:guard  :current-socket?
-                                :action (fn [data [_ {:keys [body] :as ev}]]
+                                :action (fn [{:keys [data] [_ {:keys [body] :as ev}] :event}]
                                           (if-let [rid (:request-id body)]
                                             ;; Correlated reply — look up
                                             ;; the in-flight entry and
@@ -279,7 +279,7 @@ The connection machine composes the locked substrate:
 
                   ;; Override the parent's :ws/send: while :connected the
                   ;; message goes straight to the wire instead of queueing.
-                  :ws/send    {:action (fn [data [_ msg]]
+                  :ws/send    {:action (fn [{:keys [data] [_ msg] :event}]
                                          {:fx [[:dispatch [(:socket-id data)
                                                            [:send msg]]]]})}
 
@@ -299,8 +299,8 @@ The connection machine composes the locked substrate:
        ;; carries through the synthetic timer event so a transition out
        ;; of :reconnecting (e.g., a manual :ws/connect) makes the in-flight
        ;; backoff timer stale. Add a jitter term in production.
-       :after  {(fn [snap]
-                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
+       :after  {(fn [{:keys [snapshot]}]
+                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
                     (min (* base-ms (Math/pow 2 retries))
                          max-backoff-ms)))
                 {:target [:active]}}
@@ -343,7 +343,7 @@ To subscribe / unsubscribe at runtime, the running app dispatches sub/unsub even
 ```clojure
 ;; Subscribe to a topic — pure :data update + send.
 :ws/subscribe
-{:action (fn [data [_ topic]]
+{:action (fn [{:keys [data] [_ topic] :event}]
            {:data (update data :subscriptions conj topic)
             :fx   [[:dispatch [(:socket-id data) [:send {:type :subscribe :topic topic}]]]]})}
 ```


### PR DESCRIPTION
## Summary

Machines clarity-naming cluster (3 beads). Docs-only; no source or public-API name changed.

### rf2-a60b07 / rf2-9g9j1a (duplicates — one logical change)
**Verdict: renamed.** rf2-9g9j1a is a verbatim duplicate of rf2-a60b07 (same title, evidence, recommendation) — actioned once, the other closed as a dup.

Aligns every inline **machine callback example** onto the unified context-map shape. The runtime invokes every guard / action / entry / exit / on-spawn / `:after`-delay / spawn-spec `:data` callback with a SINGLE context-map argument (`transition.cljc` `callback-ctx` / `materialise-data`), per Spec 005 §Guards / §Actions. Authoring docs still taught the old slot-specific positional shapes (`(fn [data ev] ...)`, `(fn [_ [_ x]] ...)`, `(fn [d id] ...)`, `(fn [snap _] ...)`) which would generate arity-broken machine code.

Rewrites:
- `spec/CP-5-MachineGuide.md` — inline guard/action examples → `(fn [{:keys [data event]}] ...)`, event values destructured from `:event`.
- `spec/Construction-Prompts.md` — `:guards` / `:actions` map entries + the `:spawn-fetch` action.
- `spec/005-StateMachines.md` — stale illustrative phrases (`:inspectability bias`, the parallel-region action-effect contract, the `:dispatch-done` example).
- `spec/Pattern-AsyncEffect.md`, `Pattern-Boot.md`, `Pattern-LongRunningWork.md`, `Pattern-SSR-Loaders.md`, `Pattern-WebSocket.md` — guards, actions, entries, `:after` fn-delays, and spawn-spec `:data` fns (the latter read the parent via `:snapshot`, per the spawn-spec contract `transition.cljc:1964`).
- `migration/from-re-frame-v1/README.md` (M-34 / M-35) + `async-flow-fx-to-reg-machine.md`. The M-34 prose claim that `:on-spawn` is `(fn [data spawned-id] new-data)` "exactly as before" is corrected to the context-map signature.

Ordinary `reg-event` / `reg-sub` two-arity handlers are deliberately **left untouched** (verified each `(fn [_ [_ ...]] ...)` / `(fn [snap _] ...)` match is a sub/event handler, not a machine callback). The Spec 005:729 + Principles.md:40 rationale text describing the *eliminated* positional shapes is correct as-is and left untouched.

### rf2-zwy289
**Verdict: doc fix.** `spec/005-StateMachines.md:883` + `:908` claimed both `reg-machine` forms are re-exported under `re-frame.core`. That contradicts the implementation + manifest: `core.cljc:273-276` (reg-machine* is NO LONGER a façade export — rf2-wad2fl front-porch shrink) and `api-manifest.edn` (`re-frame.machines/reg-machine*` `facade?=false` vs `re-frame.core/reg-machine` + `defmachine` `facade?=true`). Corrected the prose: the `reg-machine` / `defmachine` MACROS stay on the façade (call-site source-coord capture); the plain-fn `reg-machine*` lives in `re-frame.machines` and is reached directly.

## Follow-up filed
- **rf2-k53mhd** — `spec/Pattern-SSR-Loaders.md` uses a top-level machine `:data` slot as a **fn** form (lines 41, 166). `build-initial-snapshot` (`parallel.cljc:255`) seeds `:data` as a VALUE (`(or (:data machine) {})`), never invoking a fn — only the spawn-spec `:data` admits a fn. Likely a correctness bug in the example, out of scope for a signature-naming pass; left untouched and filed.

## Gates
- `mkdocs build --strict` — PASS (rebased onto origin/main).
- machines JVM `clojure -M:test` — 779 tests / 2539 assertions, 0 failures, 0 errors (includes scxml conformance).
- `npm run test:cljs` — 7965 tests / 36677 assertions, 0 failures, 0 errors.
- api-manifest `gen --check` — N/A (no public machines name changed).
- clj-kondo — N/A (zero `.clj/.cljc/.cljs` files changed; docs-only).

Rebased onto origin/main; no conflicts on hot-zone `spec/005-StateMachines.md` (r6fuz2 already merged).