### PR TITLE
refactor(impl): clarity-naming alignment ssr/ssr-ring/test-quiet/security (rf2-1lqm6t, rf2-2xwoqf, rf2-blgg58, rf2-glrmmd, rf2-l0afwf)

### DIFF
--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -43,9 +43,10 @@
        `:params` / `:query` schema declares any `:sensitive?` slot (decided
        through the SAME shared `:schemas/redact-validation-tags` seam).
 
-  Both stamp `:sensitive? true`, so the MCP egress gate
+  Both stamp `:sensitive? true`, so the MCP egress filter
   (`re-frame.mcp-base.sensitive/strip-sensitive`) ALSO drops the whole event
-  with the boot gate OFF — defence in depth (asserted below).
+  when `--allow-sensitive-reads` is disabled (`include? false`, the
+  restrictive default) — defence in depth (asserted below).
 
   ## Net property (verify-by-revert)
 
@@ -224,20 +225,21 @@
 (deftest machine-exception-sensitive-event-drops-at-mcp-egress
   (testing "rf2-md2wn0 — the production fail-closed contract: a sensitive
             machine's exception event is DROPPED by sens/strip-sensitive
-            when include-sensitive is OFF (the whole-event defence-in-depth
-            layer, not just per-slot redaction). This is the assertion the
-            old direct-projection test could never make — it only proved the
-            tag-level stamp, which MCP egress does not read."
+            when --allow-sensitive-reads is disabled (include? false, the
+            whole-event defence-in-depth layer, not just per-slot redaction).
+            This is the assertion the old direct-projection test could never
+            make — it only proved the tag-level stamp, which MCP egress does
+            not read."
     (declare-machine-marks!)
     (let [out          (emit-machine-action-exception-for sensitive-machine-id)
           [kept dropped] (sens/strip-sensitive [out] false)]
       (is (some? out) "the machine-action-exception trace was delivered")
       ;; The event production actually emits IS classified sensitive by the
-      ;; egress gate, so the boot-gate-off path drops it.
+      ;; egress filter, so the allow-sensitive-disabled path drops it.
       (is (true? (sens/sensitive-event? out))
           "MCP egress classifies the emitted event as sensitive (top-level flag)")
       (is (= 1 dropped) "the sensitive machine exception event dropped")
-      (is (empty? kept) "nothing egressed with the gate off"))))
+      (is (empty? kept) "nothing egressed with --allow-sensitive-reads disabled"))))
 
 (deftest machine-exception-data-verbatim-for-plain-machine
   (testing "rf2-zsm03 — a machine with NO :sensitive mark rides
@@ -351,8 +353,9 @@
   (testing "rf2-zsm03 / rf2-sxmeqs / rf2-md2wn0 — across arbitrary nestings of
             the sentinel inside :exception-data, a sensitive machine elides
             the WHOLE slot and hoists the TOP-LEVEL :sensitive?; the sentinel
-            never survives AND sens/strip-sensitive drops the event with the
-            gate off. Run over BOTH id-keys so the preferred :actor-id branch
+            never survives AND sens/strip-sensitive drops the event with
+            --allow-sensitive-reads disabled. Run over BOTH id-keys so the
+            preferred :actor-id branch
             (production) AND the :machine-id fallback both get property
             coverage — on the REAL emit path."
     (declare-machine-marks!)
@@ -451,20 +454,21 @@
 
 ;; ===========================================================================
 ;; REDACTION IS AT-SOURCE — the scrub happens at the trace egress chokepoint,
-;; so the sentinel is gone from the event REGARDLESS of the MCP boot gate.
-;; Unlike the MCP whole-event drop (which would also hide the useful "an
-;; action threw" / "a navigate rejected" signal from the agent), per-slot
-;; redaction lets the agent SEE the structural error while the secret stays
-;; off-box. So we pass the redacted events through the MCP egress with the
-;; gate ON (include? true — the MOST permissive, fully opted-in path) and
-;; confirm the sentinel STILL never reaches the boundary: the protection is
-;; the source scrub, not a gate decision.
+;; so the sentinel is gone from the event REGARDLESS of the --allow-sensitive-
+;; reads opt-in. Unlike the MCP whole-event drop (which would also hide the
+;; useful "an action threw" / "a navigate rejected" signal from the agent),
+;; per-slot redaction lets the agent SEE the structural error while the secret
+;; stays off-box. So we pass the redacted events through the MCP egress with
+;; --allow-sensitive-reads ENABLED (include? true — the MOST permissive, fully
+;; opted-in path) and confirm the sentinel STILL never reaches the boundary:
+;; the protection is the source scrub, not an opt-in decision.
 ;; ===========================================================================
 
 (deftest redaction-survives-even-the-opt-in-mcp-egress
-  (testing "rf2-zsm03 — the per-slot scrub is at-source: even with the MCP
-            boot gate fully ON (include? true), neither the machine
-            :exception-data nor the navigate :error egresses the sentinel"
+  (testing "rf2-zsm03 — the per-slot scrub is at-source: even with
+            --allow-sensitive-reads fully ENABLED (include? true), neither the
+            machine :exception-data nor the navigate :error egresses the
+            sentinel"
     (declare-machine-marks!)
     (let [machine-ev (emit-machine-action-exception-for sensitive-machine-id)
           nav-trace  (capture-navigate-failure sensitive-params-schema)

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -10,7 +10,10 @@
   crosses the trust boundary into the agent surface. Per Spec 009 Privacy:
   a trace event stamped top-level `:sensitive? true` MUST be DROPPED when
   the caller has not opted in (`include? = false`, the published default -
-  the `--allow-sensitive-reads` boot gate OFF). The pull-mode epoch tools
+  `--allow-sensitive-reads` disabled). NOTE the polarity: the restrictive
+  default is the *disabled* opt-in, which is the most protective posture
+  (sensitive events are dropped); enabling `--allow-sensitive-reads` is the
+  operator's deliberate raw-egress choice. The pull-mode epoch tools
   (`trace-window`, `watch-epochs`) and the snapshot tool feed their
   trace / epoch slices through `strip-sensitive` / `scrub-snapshot`; a
   miss here ships a declared-sensitive event off-box.
@@ -19,12 +22,13 @@
 
   ## Two complementary egress checks
 
-  1. **`strip-sensitive`** - the trace-event vector filter. With the gate
-     OFF, every `:sensitive?`-stamped event (including the fail-closed
-     malformed-truthy variants per rf2-ih7g4) MUST be removed.
-  2. **`scrub-snapshot`** - the per-frame snapshot walker. With the gate
-     OFF, no sensitive event may survive in any frame's `:traces` /
-     `:epochs` slice, at any frame-map shape.
+  1. **`strip-sensitive`** - the trace-event vector filter. With
+     `--allow-sensitive-reads` disabled (`include? false`), every
+     `:sensitive?`-stamped event (including the fail-closed malformed-truthy
+     variants per rf2-ih7g4) MUST be removed.
+  2. **`scrub-snapshot`** - the per-frame snapshot walker. With
+     `--allow-sensitive-reads` disabled, no sensitive event may survive in
+     any frame's `:traces` / `:epochs` slice, at any frame-map shape.
 
   ## Why property-style
 
@@ -32,7 +36,8 @@
   event vectors that interleave sensitive / non-sensitive / malformed-
   stamp events at arbitrary positions and counts, and snapshot maps with
   arbitrary frame counts + arbitrary sensitive/clean mixes - then asserts
-  the SENTINEL-bearing sensitive events never survive the gate-OFF egress.
+  the SENTINEL-bearing sensitive events never survive the
+  allow-sensitive-disabled egress.
   A hostile corpus pins the fail-closed malformed-stamp variants
   (string `\"true\"`, keyword, number, non-empty coll) that the rf2-ih7g4
   fail-CLOSED posture must drop.
@@ -41,7 +46,8 @@
 
   Reverting `sensitive-event?` to match only the literal `true`
   (the pre-rf2-ih7g4 fail-OPEN check) makes the malformed-stamp property
-  go RED - a `:sensitive? \"true\"` event survives the gate-OFF egress.
+  go RED - a `:sensitive? \"true\"` event survives the
+  allow-sensitive-disabled egress.
   Reverting the `scrub-snapshot` `:traces`/`:epochs` scrub makes the
   snapshot property go RED. Confirmed by temporary local revert + restore
   (see PR Quality gates)."
@@ -72,7 +78,8 @@
 ;;
 ;; The warning's having FIRED is still asserted structurally — the
 ;; `malformed-count` counter is the framework's observability hook, pinned by
-;; `gate-off-malformed-stamp-counts-as-dropped` — so the fail-closed log path
+;; `allow-sensitive-disabled-malformed-stamp-counts-as-dropped` — so the
+;; fail-closed log path
 ;; stays exercised + verified. A RED run keeps these diagnostics (the runner
 ;; replays the buffer), and clojure.test routes FAIL/ERROR/summary output
 ;; through `*test-out*` (the real `*out*`), so failure reporting is untouched.
@@ -86,8 +93,9 @@
   `gen/contains-string?` (rf2-n5bkm7).
 
   Why a deep scan and not just `:tags :value` + `sensitive-event?`
-  (rf2-h2yvs finding 1): the gate-OFF contract is \"the sentinel never
-  survives,\" not merely \"no survivor is still classified sensitive in its
+  (rf2-h2yvs finding 1): the allow-sensitive-disabled contract is \"the
+  sentinel never survives,\" not merely \"no survivor is still classified
+  sensitive in its
   primary slot.\" The generated sensitive event also plants the sentinel in
   `:tags :received`; a survivor with its `:sensitive?` stamp stripped (so it
   no longer classifies sensitive) and the sentinel only in `:received` would
@@ -147,13 +155,14 @@
   (gen/gen-vec (gen/gen-int 0 13) gen-event))
 
 ;; ---------------------------------------------------------------------------
-;; PROPERTY 1 - gate OFF: strip-sensitive removes every sensitive +
-;; malformed-stamp event; the sentinel never survives.
+;; PROPERTY 1 - allow-sensitive-reads DISABLED: strip-sensitive removes every
+;; sensitive + malformed-stamp event; the sentinel never survives.
 ;; ---------------------------------------------------------------------------
 
-(deftest gate-off-strips-every-sensitive-event
-  (testing "rf2-6wvh5 - with include? false (gate OFF), strip-sensitive drops
-            every :sensitive?-stamped (and malformed-truthy) event across 400
+(deftest allow-sensitive-disabled-strips-every-sensitive-event
+  (testing "rf2-6wvh5 - with include? false (--allow-sensitive-reads disabled,
+            the restrictive default), strip-sensitive drops every
+            :sensitive?-stamped (and malformed-truthy) event across 400
             generated mixed event vectors; the sentinel never survives"
     (let [result (gen/for-all
                    gen-event-vec 400 23
@@ -170,7 +179,7 @@
                        (and (not-any? contains-sentinel? kept)
                             (not-any? sens/sensitive-event? kept)))))]
       (is (nil? result)
-          (str "a sensitive event survived the gate-OFF egress: "
+          (str "a sensitive event survived the allow-sensitive-disabled egress: "
                (pr-str (when result (dissoc result :threw))))))))
 
 (deftest deep-scan-catches-secondary-slot-sentinel-survivor
@@ -187,7 +196,7 @@
                           :tags {:value "public-data"
                                  :received [sentinel]}}
           [kept dropped] (sens/strip-sensitive [survivor] false)]
-      ;; The gate keeps it (it is not classified sensitive) ...
+      ;; strip-sensitive keeps it (it is not classified sensitive) ...
       (is (= [survivor] kept))
       (is (zero? dropped))
       ;; ... so the OLD narrow checks would BOTH read clean (vacuous green):
@@ -200,7 +209,7 @@
           "the deep scan MUST catch the sentinel hiding in :tags :received")
       (is (contains-sentinel? survivor)))))
 
-(deftest gate-off-malformed-stamp-counts-as-dropped
+(deftest allow-sensitive-disabled-malformed-stamp-counts-as-dropped
   (testing "rf2-ih7g4 fail-closed - a malformed truthy stamp is dropped AND
             bumps the observability counter (not silently passed)"
     (doseq [stamp malformed-stamps]
@@ -219,14 +228,14 @@
                  " must bump the counter exactly once per event"))))))
 
 ;; ---------------------------------------------------------------------------
-;; PROPERTY 2 - gate ON + opt-in: include? true ships everything verbatim
-;; (the operator's deliberate raw-egress choice). Confirms the gate is the
-;; single control point - not an unconditional scrub.
+;; PROPERTY 2 - allow-sensitive-reads ENABLED (opt-in): include? true ships
+;; everything verbatim (the operator's deliberate raw-egress choice). Confirms
+;; the opt-in is the single control point - not an unconditional scrub.
 ;; ---------------------------------------------------------------------------
 
-(deftest gate-on-opt-in-passes-through-verbatim
+(deftest allow-sensitive-enabled-opt-in-passes-through-verbatim
   (testing "with include? true (operator opted in via --allow-sensitive-reads),
-            strip-sensitive is identity - the gate is the sole control point"
+            strip-sensitive is identity - the opt-in is the sole control point"
     (let [result (gen/for-all
                    gen-event-vec 200 29
                    (fn [events]
@@ -236,7 +245,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Snapshot generators + PROPERTY 3 - scrub-snapshot leaves no sensitive
-;; event in any frame's :traces / :epochs slice with the gate OFF.
+;; event in any frame's :traces / :epochs slice with --allow-sensitive-reads
+;; disabled.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private gen-frame
@@ -280,10 +290,11 @@
                   (some sens/sensitive-event? slices)))))
         scrubbed))
 
-(deftest gate-off-scrub-snapshot-leaves-no-sensitive-event
-  (testing "rf2-6wvh5 - with include? false, scrub-snapshot strips sensitive
-            events from EVERY frame's :traces/:epochs across 300 generated
-            multi-frame snapshots; :app-db is left untouched"
+(deftest allow-sensitive-disabled-scrub-snapshot-leaves-no-sensitive-event
+  (testing "rf2-6wvh5 - with include? false (--allow-sensitive-reads disabled),
+            scrub-snapshot strips sensitive events from EVERY frame's
+            :traces/:epochs across 300 generated multi-frame snapshots;
+            :app-db is left untouched"
     (let [result (gen/for-all
                    gen-snapshot 300 31
                    (fn [snap]

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -330,30 +330,37 @@
                       template (the error boundary cannot be bypassed
                       by a bug in the caller's error page).
 
-  Trusted shell-hook opts (per Spec 011 §Trusted shell hook contract,
-  rf2-o6ndb) — four optional strings the default shell injects RAW
-  into the rendered HTML envelope. The framework names them as
-  TRUSTED-STRING surfaces; the trust call itself is the caller's.
-  Structural-shape-checked at handler-construction time (non-string
-  non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid`); the
-  content is NOT escaped. Wiring any of these from untrusted input
-  (CMS field, tenant-admin form, query-string parameter) accepts an
-  arbitrary-script-injection XSS vector. Use the structured
-  alternatives (`reg-head` for head fragments, `reg-view*` +
+  Trusted shell-hook string opts (per Spec 011 §Trusted shell hook
+  contract, rf2-o6ndb) — four optional strings that cross the trust
+  boundary into the rendered HTML envelope. They split by injection
+  position: `:head` / `:body-end` are RAW content hooks (injected
+  verbatim), while `:script-src` / `:app-element-id` are escaped
+  attribute hooks (`escape-attr`'d into a quoted attribute value,
+  rf2-7x0qk). The framework names them as TRUSTED-STRING surfaces; the
+  trust call itself is the caller's. Structural-shape-checked at
+  handler-construction time (non-string non-nil values throw
+  `:rf.error/ssr-trusted-shell-opt-invalid`); the RAW content hooks are
+  NOT escaped. Wiring any of these from untrusted input (CMS field,
+  tenant-admin form, query-string parameter) accepts an arbitrary-
+  script-injection XSS vector via the raw content hooks. Use the
+  structured alternatives (`reg-head` for head fragments, `reg-view*` +
   `:rf.server/*` fx for body content) when the content originates
   upstream of the trust boundary.
 
-    :head           — (string) verbatim HTML inside `<head>...</head>`.
-                      Default: route-resolved head fragment.
-    :body-end       — (string) verbatim HTML before `</body>` — the
-                      escape hatch for analytics / third-party scripts.
-                      Default: nil (omitted).
-    :script-src     — (string) the client-side bootstrap script URL
-                      written into `<script src=\"...\">`. Default:
-                      \"/main.js\".
-    :app-element-id — (string) the id of the `<div>` wrapping the
-                      rendered body. Default: \"app\". The client-side
-                      hydrator reads this element by id.
+    :head           — (string, RAW content hook) verbatim HTML inside
+                      `<head>...</head>`. Default: route-resolved head
+                      fragment.
+    :body-end       — (string, RAW content hook) verbatim HTML before
+                      `</body>` — the escape hatch for analytics /
+                      third-party scripts. Default: nil (omitted).
+    :script-src     — (string, escaped attribute hook) the client-side
+                      bootstrap script URL written `escape-attr`'d into
+                      `<script src=\"...\">`. Default: \"/main.js\".
+    :app-element-id — (string, escaped attribute hook) the id of the
+                      `<div>` wrapping the rendered body, written
+                      `escape-attr`'d into `<div id=\"...\">`. Default:
+                      \"app\". The client-side hydrator reads this
+                      element by id.
 
   Returns:
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -397,11 +397,13 @@
        rf2-gtgf9 / rf2-pffil.
     3. trusted-shell-hook shape (`:head` / `:body-end` / `:script-src` /
        `:app-element-id` are strings or nil) via
-       `trust/validate-trusted-shell-opts!` — both shells inject these
-       RAW into the HTML envelope, so a structural mistake (map / vector
-       / symbol / number) surfaces here as
-       `:rf.error/ssr-trusted-shell-opt-invalid` at boot rather than as a
-       `ClassCastException` deep in the rendering path (rf2-o6ndb).
+       `trust/validate-trusted-shell-opts!` — both shells route these
+       into the HTML envelope (`:head` / `:body-end` as raw content
+       hooks, `:script-src` / `:app-element-id` as escaped attribute
+       hooks), so a structural mistake (map / vector / symbol / number)
+       surfaces here as `:rf.error/ssr-trusted-shell-opt-invalid` at
+       boot rather than as a `ClassCastException` deep in the rendering
+       path (rf2-o6ndb).
 
   Returns `opts` unchanged on success — composes into a `let` /
   threading position cleanly."

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
@@ -56,10 +56,15 @@
 (set! *warn-on-reflection* true)
 
 (def trusted-shell-string-opts
-  "The four trusted-string opts the shell injects RAW into the
-  rendered HTML. Construction-time validation gates structural shape
-  only; the trust semantic is documented at the handler docstring and
-  in Spec 011 §Trusted shell hook contract."
+  "The four trusted shell-hook string opts — the structural
+  string-validation set, NOT a raw-injection set. They split by
+  injection position: `:head` / `:body-end` are RAW content hooks
+  (injected verbatim), while `:script-src` / `:app-element-id` are
+  escaped attribute hooks (`escape-attr`'d into a quoted attribute
+  value, rf2-7x0qk). Construction-time validation gates structural
+  shape only; the trust + injection semantics are documented at the
+  ns docstring above, the handler docstring, and Spec 011 §Trusted
+  shell hook contract."
   [:head :body-end :script-src :app-element-id])
 
 (defn validate-trusted-shell-opts!
@@ -89,10 +94,12 @@
             'rf.ssr/trusted-shell
             (str "ssr-handler / stream-handler " (pr-str k)
                  " must be a string (or nil) — the four "
-                 "trusted shell-hook opts ("
+                 "trusted shell-hook string opts ("
                  (str/join ", " (map pr-str trusted-shell-string-opts))
-                 ") are injected RAW into the rendered HTML "
-                 "envelope (trusted-string contract per "
+                 ") cross the trust boundary into the rendered HTML "
+                 "envelope (:head / :body-end as raw content hooks, "
+                 ":script-src / :app-element-id as escaped attribute "
+                 "hooks; trusted-string contract per "
                  "Spec 011 §Trusted shell hook contract). "
                  "Got: " (pr-str (type v)) ".")
             {:recovery :supply-string-or-nil

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1335,12 +1335,16 @@
 ;; ===========================================================================
 ;; ssr-handler / stream-handler — trusted shell-hook contract (rf2-o6ndb)
 ;;
-;; The four shell-envelope opts that get injected RAW into the rendered
-;; HTML response — `:head`, `:body-end`, `:script-src`, `:app-element-id`
-;; — are TRUSTED STRINGS per Spec 011 §Trusted shell hook contract. The
-;; framework names the trust boundary (so apps reading any of them from
-;; untrusted input know they are opting into an arbitrary-script-
-;; injection XSS vector) AND structurally validates the shape at
+;; The four shell-envelope opts that cross the trust boundary into the
+;; rendered HTML response — `:head`, `:body-end`, `:script-src`,
+;; `:app-element-id` — are TRUSTED STRINGS per Spec 011 §Trusted shell
+;; hook contract. They split by injection position: `:head` / `:body-end`
+;; are RAW content hooks (injected verbatim), while `:script-src` /
+;; `:app-element-id` are escaped attribute hooks (escape-attr'd into a
+;; quoted attribute value, rf2-7x0qk — pinned below). The framework names
+;; the trust boundary (so apps reading any of them from untrusted input
+;; know they are opting into an arbitrary-script-injection XSS vector via
+;; the raw content hooks) AND structurally validates the shape at
 ;; handler-construction time so a structural mistake (passing a map, a
 ;; vector, a symbol, a number) surfaces as a clean structured error at
 ;; boot, not as a ClassCastException deep in the rendering path on the
@@ -1434,8 +1438,10 @@
 (deftest stream-handler-construction-rejects-non-string-trusted-shell-opts
   (testing "rf2-o6ndb: stream-handler shares the trusted-shell-hook
             structural contract — mirror of the ssr-handler test for the
-            chunked host adapter. The streaming prefix/suffix injects
-            the same four opts RAW into the rendered HTML envelope."
+            chunked host adapter. The streaming prefix/suffix routes the
+            same four opts into the rendered HTML envelope (:head /
+            :body-end as raw content hooks, :script-src / :app-element-id
+            as escaped attribute hooks)."
     (rf/reg-event :init/trusted-opt-stream
                      {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/trusted-opt-stream (fn [] [:div]))

--- a/implementation/test-quiet/deps.edn
+++ b/implementation/test-quiet/deps.edn
@@ -9,7 +9,11 @@
 ;;     0 failures, 0 errors.
 ;;
 ;; The cross-runtime quiet contract (rf2-nrk066) is pass-through stdout +
-;; central stderr buffering, SYMMETRIC across JVM / CLJS node / browser:
+;; red-replayed noise buffering. The buffering POLICY is symmetric across
+;; JVM / CLJS node / browser — buffer the noise channel, drop it on green,
+;; replay it on red — but the buffered SCOPE is runtime-specific: JVM
+;; buffers `*err*` / `System.err`; CLJS node buffers `console.warn` only;
+;; browser / Playwright diagnostics are owned by the browser harnesses:
 ;;
 ;;   - STDOUT is PASS-THROUGH, not summary-only. The reporter makes the
 ;;     reporter's OWN green output the canonical summary, but the runner
@@ -21,10 +25,13 @@
 ;;     to print", which under the repo's no-stray-println discipline is
 ;;     just the summary.
 ;;   - STDERR/WARNINGS are BUFFERED, replayed on red, dropped on green —
-;;     the JVM runner (`re-frame.test-quiet.runner`) and the CLJS node
-;;     runner (`re-frame.test-quiet.shadow-node`) both ring-buffer stderr
-;;     noise and replay it only when the run is RED, so warning-heavy
-;;     suites stay quiet on green WITHOUT ad-hoc local `*err*` sinks.
+;;     the JVM runner (`re-frame.test-quiet.runner`) buffers JVM stderr
+;;     (`*err*` / `System.err`) while the CLJS node runner
+;;     (`re-frame.test-quiet.shadow-node`) buffers `console.warn` warnings
+;;     ONLY (`console.error` / `process.stderr` pass straight through).
+;;     Both replay the buffer only when the run is RED, so warning-heavy
+;;     suites stay quiet on green WITHOUT ad-hoc local `*err*` sinks. The
+;;     narrower CLJS scope keeps real error channels visible even on green.
 ;;
 ;; Failures are unchanged — a failing namespace's banner + the failure
 ;; lines + the failure stack reach stdout exactly as before, and a red

--- a/spec/API.md
+++ b/spec/API.md
@@ -334,7 +334,7 @@ Standard route-related cofx (canonical detail in [012-Routing.md](012-Routing.md
 | `render-tree-hash` | Fn | `(render-tree-hash render-tree)` → 32-bit FNV-1a structural hash (lowercase hex). Identical output on JVM and CLJS for the same canonical-EDN representation. Per [011 §Hydration-mismatch detection](011-SSR.md). | v1 | advanced | 011 |
 | `project-error` | Fn | `(project-error frame-id trace-event)` → `:rf/public-error`. Applies the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. Per [011 §Server error projection](011-SSR.md). | v1 | advanced | 011 |
 | `render-head` | Fn | `(render-head head-id opts)` → `:rf/head-model` | v1 | advanced | 011 |
-| `active-head` | Fn | `(active-head)` / `(active-head frame-id)` → `:rf/head-model` | v1 | advanced | 011 |
+| `active-head` | Fn | `(active-head frame-id)` → `:rf/head-model`. Head rendering is a frame-scoped read, so the frame is **carried, not ambient**: the no-arg form was removed (EP-0002) and a `nil` `frame-id` raises `:rf.error/no-frame-context` rather than resolving against a synthesised default frame. | v1 | advanced | 011 |
 | `head-model->html` | Fn | `(head-model->html head-model)` / `(head-model->html head-model {:wrap? bool})` → inner-head HTML string | v1 | advanced | 011 |
 | `head-snapshot` | Fn | `(head-snapshot frame-id)` → `{head-id → :rf/head-model}`. Read the per-frame snapshot of last-produced head-models. Returns `{}` for a frame that has never seen a `render-head` call (or whose snapshot has been cleared via per-request frame teardown). Useful for tests, introspection, and tools. Re-exported as `rf/head-snapshot`. Per [011 §Head/meta contract](011-SSR.md). | v1 | advanced | 011 |
 | `streaming-render-shell` | Fn | `(streaming-render-shell root-hiccup)` → `{:shell-html "…" :continuations [{:id <id> :subtree <hiccup>} …]}`. Walks the tree once; at each `:rf/suspense-boundary` emits a `<template …suspense-fallback>` placeholder + records a continuation. Per [011 §Streaming SSR](011-SSR.md#streaming-ssr) — (a). | v1 | advanced | 011 |
@@ -357,14 +357,15 @@ Standard SSR-related fx (server-only; `:platforms #{:server}`):
 | `:rf.server/append-header` | `{:name :value}` (per `:rf.fx.server/append-header-args`) | 011 |
 | `:rf.server/set-cookie` | `:rf.server/cookie` map | 011 |
 | `:rf.server/delete-cookie` | `{:name ?:path ?:domain}` | 011 |
-| `:rf.server/redirect` | `{:location ?:status}` (default `:status 302`); truncates HTML | 011 |
+| `:rf.server/redirect` | `{:location ?:status}` (default `:status 302`); truncates HTML. **Caller-trusted** `:location` | 011 |
+| `:rf.server/safe-redirect` | `{:location ?:relative-only? ?:allow ?:status}` — the **caller-untrusted** variant; parses `:location`, rejects `javascript:` / `data:` / `vbscript:` schemes, and enforces `:relative-only?` / `:allow` allowlist before setting `:redirect`. Open-redirect mitigation for attacker-controlled `?next=` strings | 011 |
 
 Standard SSR-related subs:
 
 | Sub | Returns | Spec |
 |---|---|---|
 | `:rf/response` | The current request's response accumulator (status / headers / cookies / redirect) | 011 |
-| `:rf/head` | The head model for the active route (resolved via `(active-head)`) | 011 |
+| `:rf/head` | The head model for the active route (resolved via `(active-head frame-id)`) | 011 |
 | `:rf/public-error` | The sanitised public-error projection when an error page is being rendered; `nil` otherwise | 011 |
 
 Standard cofx (server-only):


### PR DESCRIPTION
Clarity/naming-review cluster across four disjoint impl artefacts. Each finding was verified against current source before editing; all changes are naming / docstring / comment / test-name only — no behaviour change.

## Per-bead

- **rf2-1lqm6t (ssr — SSR public API table):** `spec/API.md` `active-head` row dropped the removed no-arg `(active-head)` form and now documents the carried-frame contract (EP-0002; `nil` frame-id raises `:rf.error/no-frame-context`). Added the missing `:rf.server/safe-redirect` fx row (caller-untrusted open-redirect mitigation) and marked `:rf.server/redirect` caller-trusted; `:rf/head` sub note now resolves via `(active-head frame-id)`. Brings `spec/API.md` in line with `implementation/ssr` (seven server fx), `spec/011-SSR.md`, and `docs/api/09-ssr.md`. **Public API-table row** — api-manifest `gen --check` + `api-md-check` confirmed in sync (no var/tier change; the safe-redirect schema row + guide row already existed).

- **rf2-2xwoqf (ssr-ring — raw-content vs escaped-attribute vocabulary):** the four trusted shell-hook string opts split by injection position — `:head` / `:body-end` are RAW content hooks, `:script-src` / `:app-element-id` are escaped attribute hooks (`escape-attr`'d, rf2-7x0qk). Several docstrings/comments still called all four "RAW", hiding a security-load-bearing distinction. Reworded the ssr-handler docstring (ring.clj), the validate-construction-opts! docstring (lifecycle.clj), the `trusted-shell-string-opts` doc + validation-error message (trust.clj), and two stale test-comment blocks (ring_test.clj). Kept the `trusted-shell-string-opts` var name (it names the structural string-validation set, not raw injection — rename would be churn). Error id unchanged. `shell.clj` / `streaming.clj` were already correct.

- **rf2-blgg58 (test-quiet — policy-vs-scope):** `deps.edn` contract summary said "central stderr buffering, SYMMETRIC across JVM / CLJS node / browser" and that JVM + CLJS node "both ring-buffer stderr noise". Reworded to two-axis policy-vs-scope language matching the runtime docstrings: policy is symmetric; scope is runtime-specific (JVM `*err*`/`System.err`; CLJS node `console.warn` ONLY; browser owned by harnesses). Comment-only.

- **rf2-glrmmd:** **duplicate** of rf2-blgg58 (identical title + evidence). Done once under blgg58; glrmmd closed as dup.

- **rf2-l0afwf (security — egress gate polarity):** "gate OFF/ON" inverted the reader's security intuition (OFF = the *most* restrictive posture, sensitive events dropped). Renamed test names / section headers / docstrings / assertion text to name the actual control + posture: `gate-off-*` → `allow-sensitive-disabled-*` (`--allow-sensitive-reads` disabled / `include? false`); `gate-on-*` → `allow-sensitive-enabled-*` (enabled / `include? true`); "boot gate OFF/ON" → "`--allow-sensitive-reads` disabled/enabled". **No redaction behaviour change** — no logic, no boolean control args (`strip-sensitive false/true`), no assertion structure, no error/keyword ids touched; only strings, comments, and local deftest names (which have no external references). Verified by the elision probe staying green.

## Quality gates (all green)

- JVM `clojure -M:test`: ssr 358/1437, ssr-ring 157/724, security 86/637, test-quiet 23/83 — 0 failures.
- `npm run test:cljs`: 7968 tests / 36690 assertions, 0 failures (runs the `.cljc` security egress tests on CLJS node).
- `npm run test:elision`: PASS (42/42 sensitive symbols absent from production; confirms l0afwf naming did not change elision).
- api-manifest `gen --check`: in sync (488 vars). `api-md-check`: in sync (184 var-rows). `doc-guide-check`: in sync.
- `mkdocs build --strict`: built clean.
- clj-kondo: 0 errors (7 pre-existing warnings, none introduced).

Rebased onto origin/main; diff is exactly the 8 expected files across the four disjoint artefacts.