### PR TITLE
fix(xray+ssr-loaders): align standalone panel count + correct top-level machine :data fn pattern (rf2-awweb3, rf2-k53mhd)

### DIFF
--- a/docs/xray/api/config-keys.md
+++ b/docs/xray/api/config-keys.md
@@ -118,7 +118,7 @@ Three more published constants name the inline-host CSS contract. These are cons
 | `default-layout-host-css-var` | `"--rf-xray-inline-width"` | The CSS custom property the recommended host snippet reads for its `flex-basis`. Xray never reads this property; the host's stylesheet is the single source of truth for inline width. |
 | `default-layout-host-width` | `"560px"` | Xray's recommended default value for `--rf-xray-inline-width`. |
 | `default-accent-css-var` | `"--rf-xray-accent"` | The CSS custom property the recommended host snippet publishes on `:root` for Xray's brand-accent colour. Host stylesheets read `var(--rf-xray-accent)` to colour their own dev chrome (resize handles, dock separators, story chips). |
-| `default-accent` | `"#7C5CFF"` | Xray's default brand-accent hex (matches `theme/tokens.cljc :accent-violet`). |
+| `default-accent` | `"#539bf5"` | Xray's default brand-accent hex (matches `theme/tokens.cljc :accent`, GitHub blue). |
 | `default-layout-host-snippet` | HTML+CSS block | A copy-pasteable host snippet carrying the recommended markup, `flex-basis` rule, `:root` accent publish, and `min-width: 320px` floor. Reported back to the user in the missing-host diagnostic so the actionable `console.error` already carries the fix. |
 
 ## Keybinding cluster

--- a/spec/Pattern-SSR-Loaders.md
+++ b/spec/Pattern-SSR-Loaders.md
@@ -38,11 +38,10 @@ A product-detail page needs three independent fetches before render: the product
   {:doc      "Parallel loader for /products/:id. Fans out three HTTP fetches;
               joins on all-complete; writes results into app-db."
    :initial  :loading
-   :data     (fn [_ [_ {:keys [product-id]}]]
-               {:product-id product-id
-                :product    nil
-                :related    nil
-                :reviews    nil})
+   :data     {:product-id nil          ;; seeded at spawn time via the spawn-spec
+              :product    nil           ;; `:data` map (see §Wiring into the SSR
+              :related    nil           ;; request) — top-level `:data` is a literal
+              :reviews    nil}          ;; initial-data map, never a fn (Spec 005 §The snapshot)
    :states
    {:loading
     {:spawn-all
@@ -158,15 +157,17 @@ Read the cofx **once**, at `:rf/server-init` — bind the values into the loader
                            :locale     locale}}]]})))
 ```
 
-The loader's `:children` `:data` fns then close over the parent's `:data`:
+The loader's `:children` `:data` fns then read the parent's `:data` from
+the spawn-spec context map (`(fn [{:keys [snapshot event]}] data)` per
+[005 §Declarative `:spawn`](005-StateMachines.md#declarative-spawn)):
 
 ```clojure
 {:id         :product
  :machine-id :http/get-one
- :data       (fn [snap _]
-               {:url    (str "/api/products/" (-> snap :data :product-id))
-                :headers {"authorization" (str "Bearer " (-> snap :data :auth-token))
-                          "accept-language" (-> snap :data :locale)}
+ :data       (fn [{:keys [snapshot]}]
+               {:url    (str "/api/products/" (-> snapshot :data :product-id))
+                :headers {"authorization" (str "Bearer " (-> snapshot :data :auth-token))
+                          "accept-language" (-> snapshot :data :locale)}
                 :decode ProductSchema})}
 ```
 

--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -63,7 +63,8 @@ The tab-bar render order + the registry `:id` each tab lands on
 
 All nine ids are focusable via `focus!`. The standalone-mountable `Panel`
 re-views (per [`spec/API.md`](./spec/API.md) §Additional public surfaces)
-are the first six; **Graph** and **Modules** are L4-only registry tabs
+are the first seven — Epoch, app-db, Views, Trace, Machine, Routes, and
+Resources; **Graph** and **Modules** are L4-only registry tabs
 (shell-internal, focusable but not independently mountable).
 
 ### Static mode — the 5 browse surfaces (registry catalogue, event-independent)
@@ -125,7 +126,7 @@ right-side host to the app layout (DOM order: `<main>` first, host
 ```
 
 ```css
-:root { --rf-xray-accent: #7C5CFF; }
+:root { --rf-xray-accent: #539bf5; }
 .app-shell { display: flex; min-height: 100vh; }
 [data-rf-xray-host] {
   flex: 0 0 var(--rf-xray-inline-width, 560px);

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -50,7 +50,7 @@ is the supported host-resize knob — see §Resizing the inline host
 below):
 
 ```css
-:root { --rf-xray-accent: #7C5CFF; } /* brand-accent var (rf2-9ovfb) — see below */
+:root { --rf-xray-accent: #539bf5; } /* brand-accent var (rf2-9ovfb) — see below */
 body { margin: 0; }
 .app-shell { display: flex; min-height: 100vh; }
 [data-rf-xray-host] {
@@ -215,8 +215,8 @@ MUST NOT block host app startup.
 
 Per `rf2-9ovfb`, the recommended host snippet publishes a second CSS
 custom property — `--rf-xray-accent` — set on `:root` to Xray's
-brand violet (`#7C5CFF`, matching `theme/tokens.cljc`'s
-`:accent-violet` and `spec/007-UX-IA.md` §Colour system). Host
+brand accent (`#539bf5` — GitHub blue, matching `theme/tokens.cljc`'s
+`:accent` and `spec/007-UX-IA.md` §Colour system). Host
 applications can read this variable from anywhere in their own
 stylesheet to colour dev chrome that should harmonise with Xray:
 

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -55,7 +55,7 @@ does not read or set the property — the host's stylesheet is the
 single source of truth for inline width.
 
 The recommended snippet also publishes `--rf-xray-accent` (default
-`#7C5CFF` — the brand violet) on `:root` so host stylesheets can
+`#539bf5` — the GitHub-blue brand accent) on `:root` so host stylesheets can
 read it to colour their own dev chrome (resize handles, dock
 separators, story chips) without forking the hex (rf2-9ovfb). See
 `spec/011-Launch-Modes.md` §Brand-accent CSS variable.
@@ -109,9 +109,9 @@ day8.re-frame2-xray.config/default-accent-css-var
 ;;   from CLJS — the host's stylesheet is the single source of truth.
 
 day8.re-frame2-xray.config/default-accent
-;; "#7C5CFF"
+;; "#539bf5"
 ;; — the default value Xray publishes for --rf-xray-accent. Matches
-;;   theme/tokens.cljc's :accent-violet and spec/007-UX-IA.md
+;;   theme/tokens.cljc's :accent (GitHub blue) and spec/007-UX-IA.md
 ;;   §Colour system.
 
 day8.re-frame2-xray.config/default-layout-host-snippet


### PR DESCRIPTION
Two disjoint fixes, one commit each. Verified against current source before editing.

## rf2-awweb3 — tools/xray standalone panel count (P2 clarity-naming)
README said the standalone-mountable Dynamic `Panel` re-views "are the first six". The API spec (`tools/xray/spec/API.md`), the panel reg-view list, and the `mount-*!` facades in `panels.cljs` all expose **seven**: Epoch, app-db, Views, Trace, Machine, Routes, Resources (Graph + Modules are L4-only, no mount facade). Corrected the README count/names to match the API + implementation.

Secondary doc-consistency pass (from the bead): the published `--rf-xray-accent` default and the `default-accent` constant are `#539bf5` (GitHub blue, theme `:accent`) per `config.cljc` and the theme tests (`tokens_cljs_test`, `global_styles_cljs_test`) — not `#7C5CFF` / `:accent-violet` (the retired tone, `spec/021`). Aligned the API.md narrative + the `default-accent` constant doc, the config-keys.md row, and the recommended host snippet in README + `011-Launch-Modes`. (Testbed chrome + historical design-narrative `#7C5CFF` refs left alone — out of scope, not published-default claims.)

Spec kept in sync in the same PR (standing rule).

## rf2-k53mhd — Pattern-SSR-Loaders top-level machine :data fn (P3 correctness)
**Verdict: doc was wrong, fixed the doc** (not an engine bug). The engine contract is unambiguous: `parallel/build-initial-snapshot` seeds the initial snapshot's `:data` verbatim as a value (`(or (:data machine) {})`) and never invokes a fn there; Spec 005 (§The snapshot, §Registration) defines top-level `:data` as an initial-data **map**. The only `:data` fn-form is the spawn-spec slot (`transition/materialise-data`, context-map shape `(fn [{:keys [snapshot event]}] data)`). XState v5 parity does not require a top-level fn — re-frame2 routes input-derived init through the spawn-spec `:data`.

- Line 41: replaced the unsupported top-level `:data (fn [_ [_ {:keys [product-id]}]] ...)` with the literal initial-data map. The per-call `product-id` already arrives via the spawn-spec `:data` map at `:rf/server-init` — the doc's own wiring.
- Line 166: fixed the loader-children spawn-spec `:data` from the wrong positional `(fn [snap _] ...)` to the supported context-map `(fn [{:keys [snapshot]}] ...)`, matching the sibling children in the same doc.

## Gates
- `mkdocs build --strict`: exit 0
- xray JVM tests (`clojure -M:test`): 1235 tests / 5698 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 7968 tests / 36690 assertions, 0 failures, 0 errors
- clj-kondo: 0 errors (pre-existing warnings only; no source changed — docs-only diff)

xray-feature-gate is a browser feature-matrix gate exercising live behaviour, not doc strings; this diff has zero source/test deltas, so it is unaffected.

Do not merge.