### PR TITLE
fix(schemas+routing): reg-app-schema frame resolution + reg-route rejection coverage (rf2-5429ec, rf2-2u6s4b)

### DIFF
--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -1294,7 +1294,7 @@
 ;; `:query-defaults` / `:query-retain` — author-named intent is the
 ;; trust boundary. Symmetrical to the rf2-3k3o7 value-side fix: hostile
 ;; URLs composed of N-unique keys would otherwise burn N permanent JVM
-;; keyword slots, and a bare `(reg-route :route/x {:path "/x"})` is the
+;; keyword slots, and a bare `(reg-route :route/x {} "/x")` is the
 ;; high-cardinality public-surface case where the DoS hits hardest.
 
 (deftest rf2-5ifai-no-vocabulary-route-keeps-all-keys-as-strings
@@ -2075,3 +2075,32 @@
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (= :rf.error/invalid-route-metadata (:rf.error/id (ex-data ex)))
           "non-map metadata surfaces the same canonical error id"))))
+
+(deftest reg-route-rejects-path-inside-metadata-map
+  (testing "rf2-wvh95f F1 / rf2-2u6s4b: under the canonical 3-slot grammar the
+            path pattern is the THIRD slot, so a `:path` LEFT INSIDE the
+            metadata map is a mislocated key and MUST be rejected loudly with
+            the structured `:rf.error/invalid-route-metadata` — NOT silently
+            accepted, downgraded to the generic unknown-bare-key path, or
+            allowed to throw a raw exception. Pins registry.cljc's
+            `(contains? metadata :path)` guard so a later refactor cannot
+            silently degrade it. The 3rd-slot value is intentionally distinct
+            from the metadata `:path` so the test proves the guard fires on the
+            METADATA key, not on the value slot."
+    (let [ex (try
+               (rf/reg-route :route/bad {:path "/bad"} "/ignored")
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "reg-route THROWS when :path is left inside the metadata map")
+      (let [data (ex-data ex)]
+        (is (= :rf.error/invalid-route-metadata (:rf.error/id data))
+            "the canonical structured error id (not the generic unknown-key path)")
+        (is (= 'rf/reg-route (:where data))
+            ":where names the public surface fn")
+        (is (= :route/bad (:route-id data))
+            ":route-id names the offending route")
+        (is (= [:path] (:keys data))
+            ":keys names exactly the mislocated key")
+        (is (= "/bad" (:value data))
+            ":value carries the misplaced path verbatim (the metadata :path, not the value slot)")))))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -140,6 +140,36 @@
        :extra    {:received opts-or-frame-id
                   :expected "keyword frame-id, frame value, or opts map"}})))
 
+(defn frame-target->opts
+  "Lift a `reg-app-schema` metadata `:frame` value — a frame TARGET — into the
+  `{:frame <target>}` opts shape `resolve-frame` consumes, so the singular
+  registration path resolves a target IDENTICALLY to the read surface.
+
+  rf2-5429ec — the bug this closes: the singular `reg-app-schema` previously
+  passed the bare `(:frame metadata)` value straight through `coerce-opts` as
+  if it were the WHOLE opts arg. For a frame-id keyword / frame value that
+  happens to work (coerce-opts lifts both to `{:frame target}`), but for a
+  NON-frame MAP target (e.g. `{:not :a-frame}`, or a raw frame-record-shaped
+  map) `coerce-opts` classifies it as an OPTS map and returns it verbatim —
+  with no `:frame` key — so `resolve-frame` saw no override and silently
+  borrowed the AMBIENT frame, registering the schema against the wrong frame
+  with no error. That contradicts spec/010-Schemas.md §Per-frame schemas and
+  spec/API.md §Schemas, which require an explicit `:frame` resolving to a
+  non-keyword target (a string, a vector, a non-frame map) to FAIL LOUD with
+  `:rf.error/bad-app-schemas-arg` (the no-silent-swallow principle).
+
+  The metadata `:frame` value is a frame TARGET (not an opts map), so we wrap
+  it back into `{:frame target}` and let `resolve-frame` apply the SAME
+  `frame/frame-target->id` + keyword-frame-id assertion the read surface uses.
+  A non-frame map target then resolves to itself (frame-target->id leaves a
+  non-frame map unchanged) and trips the keyword-frame-id guard → loud throw.
+  A `nil` target (no `:frame` in the metadata) yields `{}` — resolve from the
+  carried-invariant scope. Pure."
+  [frame-target]
+  (if (some? frame-target)
+    {:frame frame-target}
+    {}))
+
 (defn- best-effort-frame
   "Resolve the registration frame for an error payload WITHOUT throwing —
   the explicit `:frame` opt if present, else the carried-invariant scope
@@ -147,10 +177,16 @@
   `:rf.error/app-schema-runtime-path` payload (rf2-k0ew8n): the path-gate
   runs before the registration's own (throwing) frame resolution, so we
   must not let a missing scope (or a malformed opts shape) mask the
-  runtime-path rejection."
-  [opts-or-frame-id]
+  runtime-path rejection.
+
+  The argument is an OPTS map / opts-sugar (the bulk path's `opts-or-frame-id`,
+  or the singular path's `(frame-target->opts (:frame metadata))` lift) — i.e.
+  the same shape `resolve-frame` consumes — so this is the non-throwing twin of
+  the registration's own resolution and they never disagree on which frame the
+  error payload names (rf2-5429ec)."
+  [opts]
   (try
-    (resolve-frame (coerce-opts opts-or-frame-id))
+    (resolve-frame (coerce-opts opts))
     (catch #?(:clj Exception :cljs :default) _ nil)))
 
 (defn- extract-app-schema-from-metadata
@@ -731,10 +767,16 @@
   poisoning every subsequent commit's validation for the frame."
   [path metadata]
   (let [schema (extract-app-schema-from-metadata path metadata)
-        ;; The frame TARGET (if any) rides under `:frame` in the metadata
-        ;; map; `coerce-opts` normalises a keyword / frame-value target the
-        ;; SAME way the read surface does. The doc / source-coords ride along.
-        opts-or-frame-id (:frame metadata)]
+        ;; The frame TARGET (if any) rides under `:frame` in the metadata map.
+        ;; rf2-5429ec — it is a frame TARGET, NOT the whole opts arg, so lift it
+        ;; back into the `{:frame target}` opts shape `resolve-frame` consumes
+        ;; (via `frame-target->opts`). This makes the singular registration path
+        ;; resolve a target IDENTICALLY to the read surface: a keyword / frame
+        ;; value resolves to its frame id; a non-keyword target (a string, a
+        ;; vector, or a NON-frame MAP like `{:not :a-frame}`) FAILS LOUD with
+        ;; `:rf.error/bad-app-schemas-arg` rather than (the old bug) being read
+        ;; as a key-less opts map and silently borrowing the ambient frame.
+        frame-opts (frame-target->opts (:frame metadata))]
    ;; Per rf2-sk0ql — reject a malformed `path` shape BEFORE the store
    ;; mutation. A non-sequential scalar (bare keyword / string / number /
    ;; nil) would register fine but make `validate-app-schema!`'s
@@ -745,9 +787,8 @@
    ;; (`:rf.runtime/*` / legacy `:rf/runtime` first segment) with the
    ;; distinct `:rf.error/app-schema-runtime-path`. The frame is resolved
    ;; best-effort for the payload so a missing scope cannot mask it.
-   (assert-app-schema-path! path (best-effort-frame opts-or-frame-id))
-   (let [opts         (coerce-opts opts-or-frame-id)
-         frame-id     (resolve-frame opts)
+   (assert-app-schema-path! path (best-effort-frame frame-opts))
+   (let [frame-id     (resolve-frame frame-opts)
          ;; EP-0012 §Path shape (rf2-94o54l.2 + rf2-ujmc3u): a
          ;; `reg-app-schema` path is accepted as any sequential collection
          ;; but NORMALIZED to its canonical vector form before it becomes
@@ -770,14 +811,25 @@
          ;; (`frame-schema-entries`, `app-schema-meta-at`, the
          ;; `validate-app-schema!` destructure) and to avoid shadowing
          ;; `clojure.core/meta`.
-         ;; rf2-wvh95f F2 — `:doc` rides from the metadata map onto the stored
-         ;; schema-meta (the registration is now metadata-shaped); other
-         ;; standard reflection keys (`:tags`, …) ride along too. `:schema`
-         ;; here is the extracted schema; `:frame` is the resolved frame-id.
+         ;; rf2-wvh95f F2 — the registration is metadata-shaped, so the stored
+         ;; schema-meta IS the author's RegistrationMetadata map (`:doc`,
+         ;; `:tags`, `:platforms`, … and any open `:my/*` extension keys) with
+         ;; the runtime-stamped `:schema` / `:path` / `:frame` overlaid.
+         ;; rf2-5429ec (Evidence 2) — previously only `:doc` + `:tags` were
+         ;; copied through, silently DROPPING every other RegistrationMetadata
+         ;; key (`:platforms`, …) AND any additive / open metadata key, which
+         ;; contradicts Spec-Schemas §`AppSchemaMeta` (`[:merge
+         ;; RegistrationMetadata [:map :path :schema :frame]]`) and spec/API.md
+         ;; §`app-schema-meta-at` ("returns :path, :schema, :frame, source
+         ;; coords, and the rest of :rf/registration-metadata"). Start from the
+         ;; author map minus the two slots whose stored value is the RESOLVED
+         ;; form (`:schema` = the extracted schema; `:frame` = the resolved
+         ;; frame-id, not the original frame TARGET), then overlay the resolved
+         ;; `:schema` / `:path` / `:frame`. Open-map / future-additive keys ride
+         ;; through. Source-coords merge per the production-elision contract.
          schema-meta  (source-coords/merge-coords
-                        (cond-> {:schema schema :path path :frame frame-id}
-                          (some? (:doc metadata))  (assoc :doc  (:doc metadata))
-                          (some? (:tags metadata)) (assoc :tags (:tags metadata))))
+                        (assoc (dissoc metadata :schema :frame)
+                               :schema schema :path path :frame frame-id))
          ;; Capture the path's prior schema BEFORE the swap so the
          ;; hot-reload `:rf.schema/violation` check (rf2-ee38b.6) can
          ;; compare pre- vs post-reload shapes. nil on first registration.

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -328,17 +328,19 @@
           "an ordinary opts map is untouched"))))
 
 (deftest resolve-frame-rejects-non-keyword-frame-target-loud
-  (testing "rf2-7pllal — tightening: an explicit `:frame` that resolves to a
-            NON-keyword target (a string, a vector, a number) fails
-            loud with :rf.error/bad-app-schemas-arg rather than silently
-            becoming a registry key no keyword-id read can reach (no
-            silent swallow). Per rf2-wvh95f F2 the `:frame` target now rides
-            FLAT in the metadata map (`{:schema … :frame <target>}`); a
-            non-frame MAP `:frame` value is no longer a distinguishable
-            bad-target case (coerce-opts reads a map as an opts map, the
-            documented passthrough), so the bad-target set here is the
-            non-map scalars/vectors that still fail loud."
-    (doseq [bad-frame ["stringframe" [:a :b] 42]]
+  (testing "rf2-7pllal / rf2-5429ec — an explicit `:frame` that resolves to a
+            NON-keyword target (a string, a vector, a number, OR a non-frame
+            MAP) fails loud with :rf.error/bad-app-schemas-arg rather than
+            silently becoming a registry key no keyword-id read can reach (no
+            silent swallow). Per rf2-wvh95f F2 the `:frame` target rides FLAT in
+            the metadata map (`{:schema … :frame <target>}`); per rf2-5429ec the
+            singular registration path lifts that TARGET back into the
+            `{:frame target}` opts shape (`frame-target->opts`) so it resolves
+            IDENTICALLY to the read surface. A non-frame MAP target (`{:not
+            :a-frame}`) is therefore NOT a documented opts-map passthrough — it
+            is a bad frame target and MUST throw (Spec 010 §Per-frame schemas /
+            API §Schemas), closing the old silent-ambient-fallback bug."
+    (doseq [bad-frame ["stringframe" [:a :b] 42 {:not :a-frame}]]
       (let [before (schemas/snapshot-schemas-by-frame)
             thrown (try (rf/reg-app-schema [:user] {:schema [:map] :frame bad-frame})
                         (catch clojure.lang.ExceptionInfo e e))]
@@ -353,6 +355,71 @@
                 ":received carries the offending :frame value verbatim")))
         (is (= before (schemas/snapshot-schemas-by-frame))
             (str "store unchanged after rejecting :frame " (pr-str bad-frame)))))))
+
+(deftest explicit-frame-honoured-not-silently-replaced-by-ambient
+  (testing "rf2-5429ec — LOAD-BEARING: an explicit non-ambient :frame target in
+            reg-app-schema metadata is HONOURED (registers against the declared
+            frame), NEVER silently borrowed from the ambient/carried frame. The
+            singular path lifts the :frame TARGET into the {:frame target} opts
+            shape (frame-target->opts) and resolves it the SAME way the read
+            surface does — so a valid keyword target lands on its OWN frame and
+            the ambient frame is untouched. Before rf2-5429ec the bare target
+            was passed through coerce-opts as the whole opts arg; that worked for
+            a keyword but the same flawed plumbing silently dropped a non-frame
+            map target (covered by the bad-target test above). This pins the
+            POSITIVE half of the contract: the declared frame wins."
+    (binding [frame/*current-frame* :review/ambient]
+      (rf/reg-app-schema [:user] {:schema [:map [:id :int]] :frame :review/explicit})
+      (is (= [:map [:id :int]] (schemas/app-schema-at [:user] :review/explicit))
+          "schema landed on the explicitly-declared frame")
+      (is (nil? (schemas/app-schema-at [:user] :review/ambient))
+          "the AMBIENT frame was NOT silently used — no schema leaked onto it")
+      (is (= [:review/explicit] (keys (schemas/snapshot-schemas-by-frame)))
+          "exactly one frame entry, keyed by the declared target"))))
+
+(deftest meta-at-preserves-standard-and-open-registration-metadata
+  (testing "rf2-5429ec (Evidence 2) — app-schema-meta-at returns the FULL
+            registration-metadata surface: every standard RegistrationMetadata
+            key (:doc, :tags, :platforms, …) AND any open/additive :my/* key
+            rides onto the stored schema-meta alongside the runtime-stamped
+            :schema / :path / :frame. Per Spec-Schemas §AppSchemaMeta ([:merge
+            RegistrationMetadata [:map :path :schema :frame]]) and API §app-
+            schema-meta-at. Before the fix only :doc + :tags were copied, so
+            :platforms and open keys were silently dropped — pair-tools/agents
+            could not rely on the read surface as the full metadata anchor."
+    (rf/reg-app-schema [:user] {:schema    [:map]
+                                :doc       "User schema"
+                                :tags      #{:auth}
+                                :platforms #{:client}
+                                :my/tool   true})
+    (let [m (schemas/app-schema-meta-at [:user])]
+      (is (= [:map] (:schema m))         ":schema overlaid with the extracted form")
+      (is (= [:user] (:path m))          ":path runtime-stamped")
+      (is (some? (:frame m))             ":frame runtime-stamped")
+      (is (= "User schema" (:doc m))     ":doc preserved")
+      (is (= #{:auth} (:tags m))         ":tags preserved")
+      (is (= #{:client} (:platforms m))  ":platforms preserved (was dropped pre-fix)")
+      (is (= true (:my/tool m))          "open :my/* extension key preserved (was dropped pre-fix)"))))
+
+(deftest reg-app-schema-rejects-bare-schema-and-schemaless-metadata
+  (testing "rf2-5429ec coverage-gap — extract-app-schema-from-metadata fails
+            LOUD with :rf.error/bad-app-schema-metadata for the two authoring
+            slips the F2 (:schema-in-metadata) grammar must reject: a bare
+            old-style schema as the 2nd arg, and a metadata map with no :schema."
+    ;; (a) bare schema where the metadata map now goes (the common F2 slip)
+    (let [thrown (try (rf/reg-app-schema [:user] [:map [:id :int]])
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo thrown)
+          "a bare schema 2nd arg throws")
+      (is (= :rf.error/bad-app-schema-metadata (:rf.error/id (ex-data thrown)))
+          "names the bad-metadata category"))
+    ;; (b) metadata map present but no :schema key
+    (let [thrown (try (rf/reg-app-schema [:user] {:doc "no schema here"})
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo thrown)
+          "a :schema-less metadata map throws")
+      (is (= :rf.error/bad-app-schema-metadata (:rf.error/id (ex-data thrown)))
+          ":schema is REQUIRED — its absence is never an implicit pass"))))
 
 (deftest frame-value-without-explicit-id-uses-runnable-id
   (testing "rf2-7pllal — a no-id (direct) frame value routes to its


### PR DESCRIPTION
Correctness fixes from the PR #4767 review cluster (pr-4767-correctness).

## rf2-5429ec (P1, schemas) — reg-app-schema frame target + metadata preservation

**Evidence 1 — explicit map-shaped `:frame` silently fell back to the ambient frame.** `reg-app-schema` passed the bare `(:frame metadata)` value straight through `coerce-opts` as if it were the whole opts arg. A non-frame MAP target (e.g. `{:not :a-frame}`) was classified as an opts map with no `:frame` key, so `resolve-frame` saw no override and silently borrowed the AMBIENT frame — registering the schema against the wrong frame with no error. This contradicts spec/010-Schemas.md §Per-frame schemas and spec/API.md §Schemas (an explicit `:frame` resolving to a non-keyword target MUST fail loud with `:rf.error/bad-app-schemas-arg`).

Fix: new `frame-target->opts` lifts the metadata `:frame` TARGET into the `{:frame target}` opts shape `resolve-frame` consumes, so the singular registration path resolves a target IDENTICALLY to the read surface. A non-keyword target (string / vector / non-frame map) now trips the keyword-frame-id guard and throws.

**Evidence 2 — `app-schema-meta-at` dropped registration metadata.** The stored schema-meta copied only `:doc` + `:tags`, silently dropping every other RegistrationMetadata key (`:platforms`, …) and any open `:my/*` key — contradicting Spec-Schemas §AppSchemaMeta (`[:merge RegistrationMetadata [:map :path :schema :frame]]`) and the API contract. Fix: build schema-meta from the author metadata map (minus the resolved `:schema`/`:frame` slots) and overlay the runtime-stamped `:schema`/`:path`/`:frame`.

Tests pin: explicit non-ambient `:frame` honoured (not ambient); non-frame map `:frame` rejected loud; `app-schema-meta-at` preserves standard + open keys; bad / `:schema`-less metadata → `:rf.error/bad-app-schema-metadata`. The bug-specific assertions FAIL against pre-fix storage.cljc (verified by revert: 4 failures).

## rf2-2u6s4b (P2, routing) — reg-route `:path` rejection coverage + stale comment

- **Missing regression test:** registry.cljc rejects a `:path` left inside the metadata map with structured `:rf.error/invalid-route-metadata` (`:where 'rf/reg-route`, `:route-id`, `:keys [:path]`, `:value`), but nothing pinned it. Added a test asserting the full structured payload for `(reg-route :route/bad {:path "/bad"} "/ignored")`; the 3rd-slot value is intentionally distinct from the metadata `:path` so the test proves the guard fires on the METADATA key, not the value slot.
- **Stale comment:** rewrote a doc comment from the old 2-slot shape `(reg-route :route/x {:path "/x"})` to the canonical 3-slot `(reg-route :route/x {} "/x")`.

## Gates
- `npm run test:cljs` — 7968 tests / 36690 assertions, 0 failures
- `test-jvm-implementation.sh` (incl. schemas + routing) — 0 failures across all artefacts
- `npm run test:elision` — PASS (42/42 absent in production, control intact)
- error-catalogue channel conformance — 9 tests / 21 assertions, 0 failures
- `check_thrown_error_messages.py` — exit 0
- clj-kondo on changed files — errors: 0 (1 pre-existing `clojure.string` warning, unrelated)

No spec files touched (source + tests only), so mkdocs --strict not required.