### PR TITLE
chore: erase residual realm/app/event-program vocab in testbeds + repo-support (rf2-3uvwry, rf2-48kqke, rf2-2c8zq6, rf2-2f1x2x, rf2-3fdcy8)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,19 @@ on:
       - 'mkdocs.yml'
       - 'mkdocs_hooks.py'
       - 'TESTING.md'
+      # rf2-2c8zq6 — root-support surfaces the retired-composition gate now
+      # scans (README/CHANGELOG/SKILL-REDIRECT/AGENTS/CLAUDE + the JVM gate
+      # scripts). Listed so a drift there triggers the gate. (TESTING.md above
+      # is already on the surface.)
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'SKILL-REDIRECT.md'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'scripts/test-jvm-implementation.sh'
+      - 'scripts/test-jvm-tools.sh'
+      - 'scripts/test-fast-pr.sh'
+      - 'scripts/test-rigorous-local.sh'
       - 'requirements.txt'
       - 'scripts/check_doc_slugs.py'
       - 'scripts/_test_fixtures/check_doc_slugs/**'
@@ -93,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
-              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|requirements.txt|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|scripts/check_runtime_subsystem_grading.py|scripts/check_inject_cofx_residue.py|scripts/_test_fixtures/check_inject_cofx_residue/*|scripts/check_retired_composition_vocab.py|scripts/_test_fixtures/check_retired_composition_vocab/*|.github/workflows/docs.yml)
+              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|README.md|CHANGELOG.md|SKILL-REDIRECT.md|AGENTS.md|CLAUDE.md|scripts/test-jvm-implementation.sh|scripts/test-jvm-tools.sh|scripts/test-fast-pr.sh|scripts/test-rigorous-local.sh|requirements.txt|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|scripts/check_runtime_subsystem_grading.py|scripts/check_inject_cofx_residue.py|scripts/_test_fixtures/check_inject_cofx_residue/*|scripts/check_retired_composition_vocab.py|scripts/_test_fixtures/check_retired_composition_vocab/*|.github/workflows/docs.yml)
                 docs_surface=true ;;
             esac
           done <<< "$files"
@@ -289,7 +302,12 @@ jobs:
       # it repo-wide (facade exports, spec/API rows, doc/skill teaching
       # surface). This guard keeps the scrub done: it scans docs/api, docs/guide,
       # docs/EP, spec/, and skills/ markdown for the retired symbols as LIVE
-      # copy-pasteable public API (inside fenced code blocks) with a narrow
+      # copy-pasteable public API (inside fenced code blocks), and (rf2-2c8zq6)
+      # the root-support surfaces the dir scan misses — README.md, TESTING.md,
+      # CHANGELOG.md, SKILL-REDIRECT.md, AGENTS.md, CLAUDE.md, and the JVM gate
+      # scripts (scripts/test-*.sh) — for the retired ARCHITECTURE prose phrases
+      # "event[- ]program" / "realm[- ]routing" (removed-context mentions stay
+      # green). All with a narrow
       # self-documenting file allowlist for the historical / internal surface
       # (the EP docs, the migration skill, the implementor/Pair/Xray tooling
       # skills that read the retained-internal substrate, and the spec

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For about ten years now, the React world has been organised around a particular 
 
 re-frame rejects that. Instead, events update centralised state. Subscriptions derive values from that state. Views sit at the end of the flow — they're render functions over reactive inputs, and they fire when their inputs change, and that is the entire job they have. There is no useState in a re-frame view. There is no useEffect. There is no "lifting state up" because state was never down there in the first place. Views are not causal, they are derivative.
 
-**A re-frame2 app is, quite literally, a small virtual machine.** Registered handlers are the instruction set. Events — coming from user actions, FSM transitions, websocket frames, timers, whatever — are the instructions (collectively the program). The runtime executes every event through the same six-step pipeline, every time, no exceptions, no escape hatches. We call one iteration an epoch.
+**A re-frame2 frame is, quite literally, a small virtual machine.** An image loads behavior — registered handlers — into a frame, and those handlers are the instruction set. Events — coming from user actions, FSM transitions, websocket frames, timers, whatever — are the instructions, and a frame processes them as an event stream. The runtime runs every event through the same six-step pipeline, every time, no exceptions, no escape hatches. We call one iteration of the pipeline an epoch.
 
 > *Your language of choice should be Turing complete; your architecture shouldn't be.*
 >

--- a/TESTING.md
+++ b/TESTING.md
@@ -202,8 +202,8 @@ pass (017 §`:cannot-run` aggregation rule).
 
 **Failed-run artifacts.** A failed plan run can emit a
 `:rf.test/run-artifact` — the serializable, data-shaped record of one run
-(seed, event program, fx decisions, epoch tape, trace, result) — enough
-to replay it deterministically and re-derive the same evidence
+(seed, scripted event stream, fx decisions, epoch tape, trace, result) —
+enough to replay it deterministically and re-derive the same evidence
 (017 §Artifacts — Run artifact, §Run artifact and replay). A gate MAY
 capture and upload that artifact for a failed run so the failure is
 replayable off-CI; the artifact also feeds the determinism gate and the

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -64,8 +64,8 @@ const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
 // already computed to a stable path so the browser-gate workflow can
 // upload it as a downloadable post-mortem (spec/017
 // §Failed-run artifacts in CI). The substrate guarantees the low-level
-// `:rf.test/run-artifact` (seed / event-program / epoch tape) EXISTS and
-// is canonicalizable, but the play-scripts CI hook surfaces only the
+// `:rf.test/run-artifact` (seed / scripted event stream / epoch tape)
+// EXISTS and is canonicalizable, but the play-scripts CI hook surfaces only the
 // projected run-state (status + per-step results) — that projection is
 // the failure record this gate genuinely holds, and serialising the
 // full replayable artifact is a substrate change, not CI mechanics.
@@ -416,11 +416,11 @@ function summariseResults(results) {
  * This is the projected run-state evidence the runner already computed:
  * per-row expected/actual status plus the per-step diagnostics
  * (idx / type / message / expected / actual). It is NOT the full
- * low-level `:rf.test/run-artifact` (seed / event-program / epoch tape) —
- * the play-scripts CI hook surfaces only the projected state, and
- * serialising the replayable artifact is a substrate change, not CI
- * mechanics. The play's `:script` (the event program) lives in the
- * variant body, so a maintainer can pair this report with the named
+ * low-level `:rf.test/run-artifact` (seed / scripted event stream /
+ * epoch tape) — the play-scripts CI hook surfaces only the projected
+ * state, and serialising the replayable artifact is a substrate change,
+ * not CI mechanics. The play's `:script` (the scripted event stream)
+ * lives in the variant body, so a maintainer can pair this report with the named
  * variant/play to reproduce off-CI.
  *
  * Best-effort: a write failure here must never mask the real gate verdict,

--- a/scripts/_test_fixtures/check_retired_composition_vocab/negative/inline_span_field_name.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/negative/inline_span_field_name.md
@@ -1,0 +1,8 @@
+# Inline-span field name (negative fixture)
+
+The `:event-program` field of the `:rf.test/run-artifact` schema is a Story
+replay artifact field name. Named in an inline `code span`, it is a name being
+named, not live model prose, so it must stay GREEN.
+
+The run artifact carries a `event-program` vector under that key; the public
+app model is still image -> frame -> event stream.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/negative/phrase_in_fence_not_prose.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/negative/phrase_in_fence_not_prose.md
@@ -1,0 +1,10 @@
+# Retired phrase inside a fence (negative fixture)
+
+The prose-architecture family scans PROSE lines only. A retired phrase that
+appears inside a fenced code block (e.g. a sample log line or a data key) is
+not prose and is not a retired SYMBOL either, so it must stay GREEN.
+
+```text
+run-artifact parts: seed / event-program / epoch-tape
+routing-mode: realm-routing
+```

--- a/scripts/_test_fixtures/check_retired_composition_vocab/negative/removed_context_prose_phrases.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/negative/removed_context_prose_phrases.md
@@ -1,0 +1,13 @@
+# Removed-context architecture prose (negative fixture)
+
+A root-support surface that DISCUSSES the retired phrases as removed — the
+removed-context marker on each line shows the phrase is a name being named, not
+live model teaching. Must stay GREEN.
+
+The EP-0013 multi-realm substrate collapsed under EP-0023/EP-0024, so this tier
+carries no realm-routing section.
+
+The old "event program" framing was retired in favour of the event stream.
+
+The `:event-program` field was renamed; the run-artifact now records the
+scripted event stream.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_event_program_prose.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_event_program_prose.md
@@ -1,0 +1,8 @@
+# Event stream vs the retired phrase (positive fixture)
+
+A root-support surface that teaches an app's events as a program in PROSE — the
+retired model vocabulary (rf2-2c8zq6). The canonical model is image, frame, and
+the events that flow through it, so the one live line below MUST fire.
+
+Events are the instructions, and collectively they are the event program the
+runtime executes one epoch at a time.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_realm_routing_prose.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_realm_routing_prose.md
@@ -1,0 +1,8 @@
+# Frame routing vs the retired phrase (positive fixture)
+
+A root-support surface (a gate-explanation comment surface) that claims the old
+multi-realm contract is preserved — the retired vocabulary (rf2-2c8zq6).
+Routing is frame-scoped now, so the one live line below MUST fire.
+
+The event-conformance tier locks reg-event semantics and preserved
+realm-routing across the public contract.

--- a/scripts/check_retired_composition_vocab.py
+++ b/scripts/check_retired_composition_vocab.py
@@ -90,6 +90,21 @@ and vendor/build dirs are excluded; the tracked `spec/` source is the
 authoritative copy. `docs/EP` rides under `docs/` but is allowlisted as a whole
 (the EP docs ARE the retirement record).
 
+ROOT-SUPPORT COVERAGE (rf2-2c8zq6)
+
+The dir-tree scan above reaches docs/spec/skills markdown only. The root
+support surfaces a reader sees FIRST — README.md, TESTING.md, CHANGELOG.md,
+SKILL-REDIRECT.md, AGENTS.md, CLAUDE.md — plus the JVM gate scripts whose
+comments explain what each tier protects (scripts/test-*.sh) are scanned too
+(`_ROOT_SUPPORT_PROSE_FILES`). On those files the SYMBOL families still fire on
+any fenced Clojure, and a third PROSE-architecture family
+(`retired-architecture-prose`) fires on two distinctive multi-word phrases —
+`event[- ]program` and `realm[- ]routing` — wherever they teach the previous
+model rather than discuss its removal. A removed-context marker on the same
+line (`retired`, `removed`, `no longer`, `no realm-routing`, …) suppresses the
+hit, mirroring the symbol rules' prose/comment tolerance. The phrase set is
+kept TINY on purpose: bare `program` / `app` / `realm` words are far too noisy.
+
 Exit code:
     0  no live retired composition vocabulary on the teaching surface
     1  at least one live retired symbol (results printed file:line)
@@ -116,6 +131,43 @@ from typing import Iterable, NamedTuple
 DEFAULT_SCAN_DIRS = ("docs/api", "docs/guide", "docs/EP", "spec", "skills")
 
 _DOC_SUFFIXES = (".md",)
+
+# rf2-2c8zq6 — root-support surfaces the dir-tree scan above DOES NOT reach.
+# These are the first support files a reader/maintainer sees (the root README,
+# the testing matrix, the changelog, the skill redirect, the AI-agent
+# instruction files) plus the JVM gate scripts whose comments explain what each
+# tier protects. The dir scan covers docs/spec/skills markdown only, so without
+# this list a retired ARCHITECTURE phrase ("the event program", "preserved
+# realm-routing") can drift back onto root support without a CI failure.
+#
+# The prose-architecture family (`_PROSE_PATTERN`) runs over these files; the
+# symbol families ALSO run over the markdown ones (they carry fenced Clojure).
+# Listed as repo-relative forward-slash paths. KEEP HIGH-SIGNAL: each file is a
+# root-level support surface that teaches the public model or documents a gate.
+_ROOT_SUPPORT_MARKDOWN = (
+    "README.md",
+    "TESTING.md",
+    "CHANGELOG.md",
+    "SKILL-REDIRECT.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+)
+
+# Root support SCRIPTS whose comments explain the gates. Non-markdown, so only
+# the prose-architecture family runs (line-by-line; a shell comment is the
+# "prose" surface). The JVM gate scripts are where 2f1x2x found the stale
+# "preserved realm-routing" claim.
+_ROOT_SUPPORT_SCRIPTS = (
+    "scripts/test-jvm-implementation.sh",
+    "scripts/test-jvm-tools.sh",
+    "scripts/test-fast-pr.sh",
+    "scripts/test-rigorous-local.sh",
+)
+
+# Everything the prose-architecture family scans (markdown + scripts).
+_ROOT_SUPPORT_PROSE_FILES = frozenset(
+    _ROOT_SUPPORT_MARKDOWN + _ROOT_SUPPORT_SCRIPTS
+)
 
 # Directory names whose contents are never an authoritative teaching surface.
 # `docs/spec/` is the generated CI mirror of `spec/` (rm -rf + cp -r), so it
@@ -320,14 +372,75 @@ _RETIRED_FACADE_CALL_RE = re.compile(
     r"\(\s*rf/(?:app|module|realm)(?![\w.+!?<>=-])"
 )
 
+# (c) Retired ARCHITECTURE-TEACHING prose phrases (rf2-2c8zq6). The root-support
+#     surfaces (README, TESTING, the JVM gate comments) drifted not by planting
+#     a retired SYMBOL in a code fence but by teaching the previous model in
+#     PROSE: an app's event stream described as "the event program", a JVM gate
+#     comment claiming "realm-routing" is a preserved contract. The canonical
+#     public model is image -> frame -> event stream, so these two distinctive
+#     multi-word phrases read as live architecture vocabulary wherever they are
+#     NOT discussing the retirement itself.
+#
+#     Scope is DELIBERATELY two phrases only — `event[- ]program` and
+#     `realm[- ]routing`. They are multi-word and architecture-specific, so the
+#     false-positive surface is tiny (unlike a bare `program`, `app`, or `realm`
+#     word). A removed-context marker on the same line (`retired`, `removed`,
+#     `no longer`, `collapsed`, `superseded`, `deprecated`, `no <phrase>`, …)
+#     SUPPRESSES the hit: a sentence that says "this tier carries no
+#     realm-routing section" or "the event-program field was renamed" is
+#     discussing the removal, not teaching the model — exactly the same
+#     removed-context exemption the symbol rules grant prose + masked comments.
+_RETIRED_PROSE_RE = re.compile(
+    r"\b(?:event[- ]program|realm[- ]routing)\b",
+    re.IGNORECASE,
+)
+
+# Phrases that mark a line as DISCUSSING the retirement (removed-context), so a
+# retired prose phrase on that line is a name being named, not live teaching.
+# Mirrors the symbol rules' removed-context tolerance (prose + masked comments
+# never fire there either).
+_REMOVED_CONTEXT_RE = re.compile(
+    r"\b(?:retired|removed|remove|no longer|"
+    r"collapsed?|superseded?|supersedes|deprecated?|"
+    r"renamed|was\s+the|formerly|legacy|"
+    r"no\s+(?:realm[- ]routing|event[- ]program)|"
+    r"not?\s+(?:a\s+)?(?:realm[- ]routing|event[- ]program))\b",
+    re.IGNORECASE,
+)
+
+
+def _prose_hits(line: str, context: str = "") -> bool:
+    """True iff `line` teaches a retired architecture phrase as LIVE model prose.
+
+    A retired phrase (`event[- ]program` / `realm[- ]routing`) fires unless a
+    removed-context marker (`retired`, `removed`, `no longer`, `no
+    realm-routing`, …) appears in `context` — the line itself PLUS its immediate
+    neighbours. Prose wraps across lines, so a sentence like "…carries no\\n
+    realm-routing section." carries its removed-context marker on the PREVIOUS
+    line; the small window keeps the gate from firing on wrapped removed-context
+    prose while staying narrow enough not to swallow an unrelated nearby
+    sentence.
+    """
+    if not _RETIRED_PROSE_RE.search(line):
+        return False
+    haystack = context if context else line
+    return not _REMOVED_CONTEXT_RE.search(haystack)
+
+
 # Each family is a (kind, predicate) pair where the predicate maps a single
 # (masked) line to True iff it carries that family's drift. The strong family
 # uses `_strong_hits` (capture + internal-namespace filter); the facade-noun
-# family is a plain regex search.
+# family is a plain regex search. The prose family (`_prose_hits`) runs over
+# PROSE lines (outside fenced code) on the root-support surfaces, not the
+# fenced-code lines the symbol families consume.
 _RETIRED_PATTERNS = (
     ("retired-construction-symbol", _strong_hits),
     ("retired-facade-noun-call", lambda line: bool(_RETIRED_FACADE_CALL_RE.search(line))),
 )
+
+# The prose family is scanned separately (over non-fenced lines), so it is its
+# own (kind, predicate) entry rather than part of `_RETIRED_PATTERNS`.
+_PROSE_PATTERN = ("retired-architecture-prose", _prose_hits)
 
 
 class Finding(NamedTuple):
@@ -405,6 +518,53 @@ def _code_fence_lines(text: str) -> list[tuple[int, str]]:
     return out
 
 
+# Inline `code span` masking (single/double backtick runs). Length-preserving.
+# A retired phrase inside an inline span is a NAME being named (`event-program`
+# the schema field), not live model prose — masked out before the prose rule
+# runs, mirroring the symbol rules' inline-span tolerance.
+_INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1")
+
+
+def _mask_inline_code(line: str) -> str:
+    """Blank inline `code spans`, length-preserving, so a span name cannot fire."""
+    return _INLINE_CODE_SPAN_RE.sub(lambda m: " " * len(m.group(0)), line)
+
+
+def _prose_lines(text: str) -> list[tuple[int, str]]:
+    """Return (1-based-line-no, masked-content) for PROSE lines (outside fences).
+
+    The complement of `_code_fence_lines`: lines INSIDE a fenced code block are
+    omitted (the symbol families own those), and on the prose lines inline code
+    spans are masked (a `code-span` mention is a name, not live model prose).
+    Used only by the prose-architecture family on the root-support surfaces.
+    """
+    out: list[tuple[int, str]] = []
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+    for line_no, raw in enumerate(text.splitlines(), start=1):
+        m = _FENCE_RE.match(raw)
+        if m:
+            marks = m.group(2)
+            char = marks[0]
+            length = len(marks)
+            if not in_fence:
+                in_fence = True
+                fence_char = char
+                fence_len = length
+                continue
+            if char == fence_char and length >= fence_len:
+                in_fence = False
+                fence_char = ""
+                fence_len = 0
+                continue
+            # A content line inside a fence: not prose.
+            continue
+        if not in_fence:
+            out.append((line_no, _mask_inline_code(raw)))
+    return out
+
+
 # --------------------------------------------------------------------------
 # File iteration
 # --------------------------------------------------------------------------
@@ -442,8 +602,9 @@ def _scan_text(path: Path, text: str, rel_posix: str) -> list[Finding]:
 
     Allowlisted files (the historical / internal / migration surface) are
     skipped entirely — a worked example of the retired surface is correct
-    there. For every other file, scan only the masked fenced-code lines for a
-    retired symbol.
+    there. For every other file the SYMBOL families scan the masked fenced-code
+    lines; on the root-support surfaces the PROSE-architecture family also
+    scans the prose lines (`_prose_lines`) for a retired architecture phrase.
     """
     if _is_allowlisted(rel_posix):
         return []
@@ -454,6 +615,40 @@ def _scan_text(path: Path, text: str, rel_posix: str) -> list[Finding]:
             if predicate(masked):
                 snippet = raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
                 findings.append(Finding(path, line_no, f"live-retired:{kind}", snippet))
+    if rel_posix in _ROOT_SUPPORT_PROSE_FILES:
+        findings.extend(_scan_root_support_prose(path, text, rel_posix))
+    return findings
+
+
+def _scan_root_support_prose(path: Path, text: str, rel_posix: str) -> list[Finding]:
+    """Scan a root-support file's prose for retired architecture phrases.
+
+    Markdown root-support files are scanned over their PROSE lines (outside
+    fenced code, inline spans masked). Non-markdown scripts have no markdown
+    fences, so every line is the prose surface — a shell comment is exactly
+    where the gate-explanation prose lives.
+    """
+    kind, _predicate = _PROSE_PATTERN
+    raw = text.splitlines()
+    is_markdown = path.suffix in _DOC_SUFFIXES
+    if is_markdown:
+        lines = _prose_lines(text)
+    else:
+        # Scripts: scan every line, inline `spans` masked the same way so a
+        # `event-program` field name in a comment is a name, not live prose.
+        lines = [(i, _mask_inline_code(s)) for i, s in enumerate(raw, start=1)]
+    # Index masked content by line-no so the removed-context window can read the
+    # immediate neighbours (prose wraps across lines).
+    masked_by_no = {ln: m for ln, m in lines}
+    findings: list[Finding] = []
+    for line_no, masked in lines:
+        context = " ".join(
+            masked_by_no.get(n, "")
+            for n in (line_no - 1, line_no, line_no + 1)
+        )
+        if _prose_hits(masked, context):
+            snippet = raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
+            findings.append(Finding(path, line_no, f"live-retired:{kind}", snippet))
     return findings
 
 
@@ -469,6 +664,25 @@ def scan(scan_root: Path, repo_root: Path | None = None) -> list[Finding]:
             rel_posix = path.as_posix()
         text = path.read_text(encoding="utf-8", errors="replace")
         findings.extend(_scan_text(path, text, rel_posix))
+    return findings
+
+
+def scan_root_support(repo_root: Path) -> list[Finding]:
+    """Scan the root-support surfaces (`_ROOT_SUPPORT_PROSE_FILES`) for drift.
+
+    These individual files live at the repo root / under scripts/ and are not
+    reached by the dir-tree scan. Each is scanned via `_scan_text` (the symbol
+    families fire on any fenced Clojure; the prose-architecture family fires on
+    the prose surface). Missing files are skipped (a repo may not carry every
+    one).
+    """
+    findings: list[Finding] = []
+    for rel in sorted(_ROOT_SUPPORT_PROSE_FILES):
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        findings.extend(_scan_text(path, text, rel))
     return findings
 
 
@@ -498,6 +712,19 @@ _FIX_HINTS = {
         "instead. (`app-db` is a sanctioned EXISTING term — EP-0023:204 — and "
         "ordinary English `application` is fine; only the `rf/`-facade noun "
         "CALL is the drift.)"
+    ),
+    "retired-architecture-prose": (
+        "The phrases \"event program\" / \"event-program\" and \"realm "
+        "routing\" / \"realm-routing\" teach the RETIRED model in prose. The "
+        "canonical public model is image -> frame -> event stream: an image "
+        "loads behavior into a frame, and a frame processes its events as an "
+        "EVENT STREAM (not a 'program'); routing is FRAME-scoped (the EP-0013 "
+        "multi-realm substrate collapsed under EP-0023/EP-0024, so there is no "
+        "'realm routing'). Rewrite to 'event stream' (or, for a Story replay "
+        "artifact, the localized field name in an inline `code span`). If the "
+        "sentence is DISCUSSING the removal, say so on the same line "
+        "('retired', 'removed', 'no longer', 'no realm-routing', …) and the "
+        "gate will treat it as removed-context."
     ),
 }
 
@@ -594,6 +821,22 @@ def main(argv: list[str]) -> int:
             sys.stderr.write(f"scanning {n} markdown file(s) under {d}...\n")
         all_findings.extend(scan(scan_root, repo_root=repo_root))
 
+    # rf2-2c8zq6 — the root-support surfaces (README/TESTING/CHANGELOG/the JVM
+    # gate scripts, …) are individual files outside any scan dir. Cover them on
+    # the DEFAULT invocation (an explicit --scan-dir is a targeted run and skips
+    # them so the override stays predictable).
+    if not args.scan_dir:
+        if args.verbose:
+            present = [
+                r for r in sorted(_ROOT_SUPPORT_PROSE_FILES)
+                if (repo_root / r).is_file()
+            ]
+            sys.stderr.write(
+                f"scanning {len(present)} root-support file(s) for retired "
+                "architecture prose...\n"
+            )
+        all_findings.extend(scan_root_support(repo_root))
+
     if all_findings:
         _report(all_findings, repo_root)
         return 1
@@ -626,6 +869,12 @@ def _run_self_tests(verbose: bool = False) -> int:
     rewritten image/frame teaching, and the internal `re-frame.realm/` /
     `re-frame.frame/` namespace reads. A dedicated allowlist case scans a
     positive fixture AS IF it were an EP doc and asserts it does NOT fire.
+
+    A second block (rf2-2c8zq6) exercises the root-support PROSE-architecture
+    family: it scans the prose fixtures AS IF they were a root-support file
+    (rel_posix=README.md) so the prose family activates, asserting the live
+    "event program" / "realm-routing" teaching FIRES and every removed-context
+    / inline-span / in-fence counterpart stays GREEN.
     """
     cases: list[tuple[str, int]] = [
         # (fixture relative to fixture-root, expected finding count)
@@ -699,11 +948,47 @@ def _run_self_tests(verbose: bool = False) -> int:
         )
         failures += 1
 
+    # rf2-2c8zq6 — the root-support PROSE-architecture family. Scanned AS IF the
+    # fixture were a root-support file (rel_posix=README.md) so the prose family
+    # activates (it is gated to `_ROOT_SUPPORT_PROSE_FILES`).
+    prose_cases: list[tuple[str, int]] = [
+        # --- positives: live retired architecture prose must FIRE ---
+        ("positive/live_event_program_prose.md",       1),
+        ("positive/live_realm_routing_prose.md",        1),
+        # --- negatives: removed-context / inline-span / in-fence stay GREEN ---
+        ("negative/removed_context_prose_phrases.md",   0),
+        ("negative/inline_span_field_name.md",          0),
+        ("negative/phrase_in_fence_not_prose.md",       0),
+    ]
+    for fixture, expected in prose_cases:
+        path = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not path.is_file():
+            sys.stderr.write(
+                f"self-test FAIL: prose fixture {fixture!r} missing at {path}\n"
+            )
+            failures += 1
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        # rel_posix=README.md makes `_scan_text` run the prose family.
+        got = len(_scan_text(path, text, rel_posix="README.md"))
+        if got == expected:
+            if verbose:
+                sys.stderr.write(
+                    f"self-test PASS: {fixture} (prose findings={got})\n"
+                )
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} expected prose findings={expected}, "
+                f"got {got}\n"
+            )
+            failures += 1
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
+    total = len(cases) + 1 + len(prose_cases)
     if verbose:
-        sys.stderr.write(f"all {len(cases) + 1} self-tests passed.\n")
+        sys.stderr.write(f"all {total} self-tests passed.\n")
     return 0
 
 

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -67,8 +67,10 @@ artefacts=(
   # one-form event PUBLIC contract: `reg-event` as the single form with
   # reg-event-fx semantics, the three retired names as throwing stubs
   # raising their exact hard errors (production-survivable), the single
-  # `:rf/event-handler` wrapper (no `:event/kind`), and preserved
-  # realm-routing.
+  # `:rf/event-handler` wrapper (no `:event/kind`), and frame-scoped event
+  # routing (an image-loaded frame routes to its image, an image-less frame
+  # to the global registrar). The EP-0013 multi-realm substrate was retired
+  # under EP-0023/EP-0024 (rf2-afdlyr / rf2-tu2vr7) — no realm-routing here.
   implementation/event-conformance
 )
 

--- a/testbeds/tenant_switcher/README.md
+++ b/testbeds/tenant_switcher/README.md
@@ -1,15 +1,15 @@
 # `testbeds/tenant-switcher`
 
-A single Reagent app on a single frame (`:rf/default`) that switches the
+A single Reagent frame (`:rf/default`) that switches the
 **active principal** — an admin impersonating tenant `acme`, then `globex`,
 then back — while the scoped-cache keeps each tenant's loaded dashboard
 structurally isolated and *simultaneously live*.
 
 This is the multi-**scope** consumer the rest of the testbed tree lacks. Every
 other multi-tenant-shaped surface (e.g. `multi_frame/`) is multi-**frame**:
-one app per frame, each frame isolated. This one is multi-**scope**: one app,
-one frame, two tenant scopes coexisting in one cache, with the active scope
-deciding which entry a read can address.
+one frame per tenant, each frame isolated. This one is multi-**scope**: one
+frame, two tenant scopes coexisting in one resource cache, with the active
+scope deciding which entry a read can address.
 
 It is the live demonstrator of the guide's claim
 ([`docs/guide/concepts/server-state.md` §"The scoped key: a leak boundary that
@@ -22,8 +22,8 @@ Part-2 leak-boundary **scenario 5** (rf2-5e22yc, spun from rf2-wwhedk).
 
 - **Named scope resolver** (EP-0016 D3): `reg-resource-scope :tenant/scope`
   derives `[:rf.scope/tenant {:tenant-id …}]` from `[:viewer :active-tenant]`.
-  Pure, with declared `:inputs` so a tool can explain which app fact decides a
-  resource's identity.
+  Pure, with declared `:inputs` so a tool can explain which app-db fact decides
+  a resource's identity.
 - **Scoped resource**: `:tenant/dashboard` declares
   `:scope {:from-db :tenant/scope}`, so its cache key carries the active
   tenant structurally.

--- a/testbeds/tenant_switcher/core.cljs
+++ b/testbeds/tenant_switcher/core.cljs
@@ -3,9 +3,9 @@
 
   EP-0013/resources Part-2 leak-boundary scenario 5 (rf2-5e22yc, spun from
   rf2-wwhedk): the multi-SCOPE consumer the rest of the testbed tree lacks.
-  Every other multi-tenant-shaped surface in the repo is multi-FRAME (one app
-  per frame, each isolated). THIS one is multi-SCOPE: a SINGLE app, on a
-  SINGLE frame, switching the active principal — an admin impersonating
+  Every other multi-tenant-shaped surface in the repo is multi-FRAME (one
+  frame per tenant, each isolated). THIS one is multi-SCOPE: a SINGLE frame
+  switching the active principal — an admin impersonating
   tenant `acme`, then `globex`, then back — while the scoped-cache keeps each
   tenant's loaded dashboard structurally isolated and SIMULTANEOUSLY live.
 
@@ -88,7 +88,7 @@
 ;; The viewer's ACTIVE tenant lives at [:viewer :active-tenant]; the resolver
 ;; derives the concrete `[:rf.scope/tenant {:tenant-id …}]` from it. Pure —
 ;; it derives a scope and does nothing else. Declaring `:inputs` lets a tool
-;; explain which app fact decides a resource identity (and lets the runtime
+;; explain which app-db fact decides a resource identity (and lets the runtime
 ;; re-resolve only when that input changes). Nil when no tenant is active —
 ;; fail-closed by contract (never a silent shared/global read).
 
@@ -250,10 +250,11 @@
     (fn []
       [:div {:data-testid "tenant-switcher" :style {:font-family "sans-serif" :padding "1em"}}
        [:h1 "tenant-switcher testbed"]
-       [:p "One app, one frame. Switch the active tenant (impersonation), load
-            each tenant's dashboard, and watch the scoped-cache keep both
-            tenants' entries simultaneously live yet structurally isolated —
-            the active-scope view only ever reads the active tenant's data."]
+       [:p "One frame, two tenant scopes. Switch the active tenant
+            (impersonation), load each tenant's dashboard, and watch the
+            scoped-cache keep both tenants' entries simultaneously live yet
+            structurally isolated in one resource cache — the active-scope view
+            only ever reads the active tenant's data."]
 
        [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap :align-items :center}}
         [:span "Impersonate:"]
@@ -294,7 +295,7 @@
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence.
-  ;; `:rf/default` is this testbed's app frame, registered explicitly; the
+  ;; `:rf/default` is this testbed's frame, registered explicitly; the
   ;; boot dispatch runs under it and the render is wrapped in a
   ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
   (rf/reg-frame :rf/default {})

--- a/testbeds/tenant_switcher/spec.cjs
+++ b/testbeds/tenant_switcher/spec.cjs
@@ -3,8 +3,8 @@
  * Part-2 leak-boundary scenario 5).
  *
  * The LIVE demonstration of the scoped-cache leak boundary as a multi-SCOPE
- * consumer: one app, one frame, two tenant scopes simultaneously live in one
- * cache, with the active scope deciding which entry a read can address. The
+ * consumer: one frame, two tenant scopes simultaneously live in one
+ * resource cache, with the active scope deciding which entry a read can address. The
  * executable leak-boundary GUARANTEES (cross-user logout leak, wrong-scope
  * fail-closed read, scoped-invalidation isolation, lease-lifecycle
  * non-interference) are pinned by the CLJS unit suites


### PR DESCRIPTION
Cluster of 5 [realm-app-program-sweep] beads across examples-testbeds + repo-support. The realm collapse is done; canonical public model is **image -> frame -> event stream**. This PR erases residual realm/app/event-program teaching from those surfaces and extends the CI guard so it cannot drift back.

## Per-bead

- **rf2-3uvwry** (examples-testbeds): `examples/scripts/serve-and-run-story-play-scripts.cjs` comments called the replayed events an "event-program" / "the event program". Renamed the run-artifact prose to "scripted event stream". The normative `:event-program` field of the `:rf.test/run-artifact` schema in `tools/story/` is a Story-localized term, left unchanged (separate owner).
- **rf2-48kqke** (examples-testbeds): the `testbeds/tenant_switcher` README, namespace docstring, user-facing copy, and smoke comment taught the scenario as app/frame composition ("one app per frame", "one app, one frame", "app fact decides resource identity"). Rewritten as a single frame holding two tenant scopes in one resource cache, with the active tenant fact in app-db deciding which entry a read addresses. The testbed already models proper re-frame2 (app-db + events + subs, one isolated frame) and stays test-free; only teaching prose changed. Testbed recompiles clean.
- **rf2-3fdcy8** (repo-support): root `README.md` taught "a re-frame2 app is ... a small virtual machine" whose events are "the instructions (collectively the program)", and `TESTING.md` described a run-artifact as carrying an "event program". Rewritten around image -> frame -> event stream; TESTING uses "scripted event stream".
- **rf2-2f1x2x** (repo-support): `scripts/test-jvm-implementation.sh` comment claimed the event-conformance tier preserves "realm-routing". That substrate was retired; the tier explicitly carries no realm-routing section but DOES lock frame-scoped event routing. Comment corrected to actual scope; shell behavior unchanged.
- **rf2-2c8zq6** (repo-support): extended `scripts/check_retired_composition_vocab.py` to cover root-support surfaces (README/TESTING/CHANGELOG/SKILL-REDIRECT/AGENTS/CLAUDE + `scripts/test-*.sh`) and added a narrow PROSE-architecture family that fires on the two distinctive phrases `event[- ]program` / `realm[- ]routing` wherever they teach the previous model (removed-context mentions stay green; inline spans + fenced code masked). Positive + negative fixtures added and wired into `--self-test`. New root-support paths wired into `docs.yml` (`push.paths` + the `detect` classifier) so a drift on those files triggers the gate.

## Guard-coverage extension
- New scan set `_ROOT_SUPPORT_PROSE_FILES` (root markdown + JVM gate scripts), scanned in addition to the dir tree on the default invocation.
- New `retired-architecture-prose` family: two phrases only, kept tiny on purpose (bare program/app/realm words are too noisy). Removed-context suppression checks the line + immediate neighbours.
- 5 new fixtures (2 positive, 3 negative) covering live teaching, removed-context prose, an inline-span field name, and an in-fence phrase.

## Gates
- Retired-composition guard `--self-test`: PASS (now 19 cases incl. 5 prose cases)
- Retired-composition guard full scan: PASS (exit 0)
- `testbeds/tenant-switcher` shadow-cljs compile: PASS (0 warnings)
- clj-kondo on `testbeds/tenant_switcher/core.cljs`: 0 errors / 0 warnings
- `node --check` on touched `.cjs`: PASS
- `docs.yml` YAML + Python `py_compile` + `bash -n`: PASS
- Residue grep clean on the 5 touched surfaces

## Hot-zone note
`.github/workflows/docs.yml` is hot-zone, touched here only for the rf2-2c8zq6 CI wiring (new `push.paths` entries + the `detect` classifier line + a comment) — no step/logic change to existing gates. Sequence ahead of any other in-flight docs.yml PR.

## Out of scope / follow-up
- `implementation/README.md:195` carries the same stale "preserved realm-routing" claim. It is under `implementation/` (the sibling impl realm-worker's disjoint surface) and is not covered by the new root-support guard set, so it is left for that worker.

Do NOT merge.