### PR TITLE
docs(skills): dedup cross-platform installer block to canonical pointer (rf2-qxs55z.1)

### DIFF
--- a/skills/re-frame2-improver/README.md
+++ b/skills/re-frame2-improver/README.md
@@ -65,14 +65,7 @@ Pre-alpha. References catalogue currently has 6 leaves at launch; expected to gr
 
 **Link, never copy.** Claude Code loads skills from `~/.claude/skills/<name>/`. A `cp -r` copy snapshots the skill and then drifts as the repo is maintained — Claude Code keeps loading the stale copy, which silently falls behind the anti-pattern catalogue and the shared retro-protocol security boundary this skill loads. Always link the repo source.
 
-The cross-platform installer at the repo root links *every* re-frame2 skill (this one included) into `~/.claude/skills/`:
-
-```bash
-scripts/install-skills.sh                                              # macOS / Linux (symlinks)
-powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1    # Windows (junctions, no admin)
-```
-
-It is idempotent, refuses to clobber a non-link copy without `--force` (`-Force`), and supports `--check` (`-Check`). See [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md#skills--link-dont-copy) for the full setup.
+The cross-platform installer at the repo root links *every* re-frame2 skill (this one included) into `~/.claude/skills/`. See [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) for the canonical installer commands (macOS / Linux + Windows) and the idempotent / `--force` / `--check` behaviour, and [`CONTRIBUTING.md`](../../CONTRIBUTING.md#skills--link-dont-copy) for the full setup.
 
 To link just this one skill:
 

--- a/skills/re-frame2-pair-retro/README.md
+++ b/skills/re-frame2-pair-retro/README.md
@@ -67,14 +67,7 @@ Pre-alpha. Ports the v1 `re-frame-pair-improver` skill structure to target re-fr
 
 **Link, never copy.** Claude Code loads skills from `~/.claude/skills/<name>/`. A `cp -r` copy snapshots the skill and then drifts as the repo is maintained — Claude Code keeps loading the stale copy. For this skill that drift is a security concern, not just polish: the shared redaction / issue-filing protocol it loads is an active AI/off-box boundary, so a stale copy can miss later redaction, prompt-injection, or shell-safety hardening while still filing GitHub issues from sensitive pair-session recaps. Always link the repo source so the active skill is the maintained source by construction.
 
-The cross-platform installer at the repo root links *every* re-frame2 skill (this one included) into `~/.claude/skills/`:
-
-```bash
-scripts/install-skills.sh                                              # macOS / Linux (symlinks)
-powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1    # Windows (junctions, no admin)
-```
-
-It is idempotent, refuses to clobber a non-link copy without `--force` (`-Force`), and supports `--check` (`-Check`) to verify the links. See [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md#skills--link-dont-copy) for the full setup.
+The cross-platform installer at the repo root links *every* re-frame2 skill (this one included) into `~/.claude/skills/`. See [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) for the canonical installer commands (macOS / Linux + Windows) and the idempotent / `--force` / `--check` behaviour, and [`CONTRIBUTING.md`](../../CONTRIBUTING.md#skills--link-dont-copy) for the full setup.
 
 To link just this one skill:
 

--- a/skills/re-frame2-setup/README.md
+++ b/skills/re-frame2-setup/README.md
@@ -118,11 +118,11 @@ git clone https://github.com/day8/re-frame2.git
 cd re-frame2
 git checkout <release-tag-or-commit>     # pin to a version you've reviewed
 # Review skills/re-frame2-setup/SKILL.md and references/*.md before the next line
-scripts/install-skills.sh                                              # macOS / Linux (symlinks)
-powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1    # Windows (junctions, no admin)
 ```
 
-To upgrade: `git checkout` a newer reviewed tag in the same clone — the link follows it (so review the diff before bumping). The installer is idempotent, refuses to clobber a non-link copy without `--force` (`-Force`), and supports `--check` (`-Check`). See [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) and [`CONTRIBUTING.md` §skills — link, don't copy](../../CONTRIBUTING.md#skills--link-dont-copy) for the full rationale. For a team following along on one project, link from a shared reviewed checkout rather than committing a `cp -r` snapshot that will go stale.
+Then run the cross-platform installer. See [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) for the canonical installer commands (macOS / Linux + Windows) and the idempotent / `--force` / `--check` behaviour, and [`CONTRIBUTING.md` §skills — link, don't copy](../../CONTRIBUTING.md#skills--link-dont-copy) for the full rationale.
+
+To upgrade: `git checkout` a newer reviewed tag in the same clone — the link follows it (so review the diff before bumping). For a team following along on one project, link from a shared reviewed checkout rather than committing a `cp -r` snapshot that will go stale.
 
 ## Invoking it in Claude
 


### PR DESCRIPTION
## What

The `re-frame2-improver`, `re-frame2-pair-retro`, and `re-frame2-setup` skill READMEs each carried a near-verbatim copy of the repo-root cross-platform installer commands (`scripts/install-skills.sh` + the PowerShell line) plus the idempotent / `--force` / `--check` sentence — and then *already* pointed at the canonical block in `skills/README.md` §Installing. Classic "state once, point thereafter" redundancy.

This dedups: the three restated installer paragraphs are replaced with a single one-line pointer to `skills/README.md` §Installing (the canonical source). The per-skill "To link just this one skill" `ln -s` / junction commands are kept (they legitimately differ by skill name), as is each skill's distinctive surrounding prose.

## Why

Security-drift. Three near-verbatim copies of security-relevant install guidance ("link, never copy") drift dangerously — one copy gets a redaction / prompt-injection / shell-safety update, the others don't, while all three skills still file GitHub issues / load the shared retro-protocol boundary. Consolidating to the canonical block removes that staleness surface.

## Preserved per-skill framing (per ruling)

- **improver** — anti-pattern-catalogue + shared retro-protocol drift framing
- **pair-retro** — active AI/off-box security note (stale copy can miss redaction/prompt-injection hardening while still filing issues)
- **setup** — review-before-link clone/checkout sequence + pre-split caveat + upgrade framing

## Scope guard

Touches only the 3 named skill READMEs. Did NOT touch `skills/README.md` (the canonical source), `skills/re-frame2/README.md`, or `skills/re-frame2-pair/docs/LOCAL_DEV.md`.

## Gates (all green)

- `check_readme_links.py` (the new pointer link `#installing-link-never-copy` resolves) — pass
- `check_readme_inventories.py` — pass
- all `check_skill_*.py --ci` (incl. `check_skill_package_refs.py` + `check_skill_redirect_anchors.py`) — pass
- `re-frame2-setup/tests/setup_drift_test.clj` (bb) — 27 tests, 78 assertions, 0 failures
- BEAD-ID-LEAK grep on the 3 files — clean
- `mkdocs build --strict` — pass