### PR TITLE
refactor(core): remove unused mint-policies/mutation-statuses closed-set defs + fix docstring (rf2-h9902s)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -837,22 +837,15 @@
 
 (def default-mint-policy
   "The mint policy when no binding point selects one — the router's `:live`
-  default (EP-0017 §6). `:live` generates declared-absent generator-backed
+  default (EP-0017 §6). The valid mint policies are `:live`, `:strict`, and
+  `:explicit-live`. `:live` generates declared-absent generator-backed
   recordable values; the binding points (`resolve-mint-policy`) select
   `:strict` (the `:test` preset default; hard-wired for replay) or
-  `:explicit-live` (the declared-nondeterminism escape)."
+  `:explicit-live` (the declared-nondeterminism escape). An unrecognised value
+  is treated CONSERVATIVELY as non-generating (see `mint-policy-generates?`) —
+  an unknown policy must never silently mint a nondeterministic value into the
+  durable ledger."
   :live)
-
-(def mint-policies
-  "The closed set of EP-0017 §6 mint-policy values. `:live` (router default)
-  and `:explicit-live` (declared-nondeterminism escape) generate a
-  declared-absent generator-backed recordable fact; `:strict` (the `:test`
-  preset default; hard-wired for replay) does not. An unrecognised value is
-  treated CONSERVATIVELY as non-generating (see `mint-policy-generates?`) — an
-  unknown policy must never silently mint a nondeterministic value into the
-  durable ledger — but the registration/dispatch boundary uses this set to
-  reject typos loudly where it can."
-  #{:live :strict :explicit-live})
 
 (defn resolve-mint-policy
   "Resolve the effective cofx mint policy for a dispatch, MOST-SPECIFIC-WINS

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -103,16 +103,6 @@
 ;; stores FACTS, not derived booleans (`:pending?` / `:settled?` are public
 ;; derived sub values, computed in the subs layer, never stored).
 
-(def mutation-statuses
-  "The closed set of mutation-instance lifecycle states. A mutation is a
-  one-shot causal write (NOT a stale-while-revalidate cache), so the
-  lifecycle is simpler than a resource entry's: `:idle` (created, not yet
-  dispatched — rare; an execute settles directly to `:pending`),
-  `:pending` (in flight), `:success` (settled with a result),
-  `:error` (settled with a failure envelope). Per EP-0003 §Mutations
-  (mutation pending / error / result state)."
-  #{:idle :pending :success :error})
-
 (def terminal-statuses
   "The terminal mutation-instance statuses (the write has settled). A
   terminal instance is cleared by an explicit causal `:rf.mutation/clear`


### PR DESCRIPTION
## Summary

Bead **rf2-h9902s** (Mike-ruled 2026-06-20, authoritative). Behaviour-PRESERVING removal of two closed-set `def`s that documented a value-set as data but had **zero readers** across `implementation/`, plus a fix for a lying docstring.

## Changes

- **`re-frame.cofx/mint-policies`** (`implementation/core/src/re_frame/cofx.cljc`) — DELETED. Its docstring falsely claimed "the registration/dispatch boundary uses this set to reject typos loudly where it can", but nothing read it: `resolve-mint-policy` passes the policy through unvalidated and `mint-policy-generates?` does explicit `(= policy :live)` / `(= policy :explicit-live)` comparisons. Folded a neutral "valid mint policies are `:live`, `:strict`, `:explicit-live`" line and the EP-0017 §6 fail-safe explanation (unrecognised value -> conservative non-generating) into the `default-mint-policy` docstring. No promissory "rejects typos" / "enforced" claim retained.

- **`re-frame.resources.mutation-runtime/mutation-statuses`** (`implementation/resources/src/re_frame/resources/mutation_runtime.cljc`) — DELETED (pure documentation-as-data, no consumer). The adjacent `terminal-statuses` / `terminal?` (which IS read) are untouched.

No value-validation added — the programmer owns spelling; the fail-safe default is the net (an unknown mint policy can never mint a bad value into the durable ledger). No API or error-surface change.

## Verification

- `git grep -w` shows **zero** remaining code references to either symbol (the lone `mint-policies` hit in the MCP spec is a markdown anchor `#mint-policies` to a spec heading, not the deleted symbol).
- `terminal-statuses` / `terminal?` confirmed still wired.

## Gates (all green)

- `npm run test:cljs` — 7969 tests / 36700 assertions, 0 failures, 0 errors
- `scripts/test-jvm-implementation.sh` — all artefacts pass (core, resources, event-conformance/error-catalogue, etc.)
- clj-kondo — no new warnings introduced (baseline-identical warning set; no now-unused requires)
- mkdocs --strict not required: the edited docstrings are not doc-extracted (no mkdocstrings/literalinclude pulls them into the site)