### PR TITLE
[codex] Clarify EP image and initial-event semantics

### DIFF
--- a/docs/EP/EP-0026-image-api-simplification.md
+++ b/docs/EP/EP-0026-image-api-simplification.md
@@ -159,6 +159,11 @@ The image-selected namespaces are the union of all clause results. Exclusions
 are local to the include clause that contains them; they are not one global
 subtraction set.
 
+Selecting the same source namespace through more than one clause is idempotent:
+the descriptor is considered once. A same `[kind id]` collision between two
+different selected descriptors remains a collision inside the image and fails as
+described below.
+
 The glob grammar remains the EP-0023 grammar:
 
 - namespace strings are dot-separated;
@@ -183,11 +188,15 @@ Image composition is ordered data. A frame created with:
 builds a resolved generation using this precedence:
 
 ```text
-dispatch registrations
-  dominate frame registrations
+dispatch-local registration overlay
+  dominates frame registration overlay
   dominate image inline registrations, later image wins inside the tier
   dominate image namespace-selected registrations, later image wins inside the tier
 ```
+
+These are resolution layers, not mutations of the global registrar, the image
+value, or the frame's recorded image composition. Each layer contributes
+descriptor values to the resolved-generation calculation for its scope.
 
 Within one image:
 
@@ -203,6 +212,11 @@ order of the `:images` vector.
 
 Tooling must retain enough provenance to show which descriptors were shadowed,
 which layer won, and why. Layer dominance should be inspectable, not invisible.
+This is a deliberate amendment to EP-0023's exact replacement maps: the API
+gains a smaller data shape, and gives up the old coordinate-level winner
+declaration. The mitigation is that order is explicit in `:images`, collisions
+inside one selection clause still fail loud, and shadowed descriptors remain
+visible to diagnostics and tools.
 
 ### Inline registration grammar
 
@@ -312,16 +326,22 @@ image :registrations
   = inline local definitions in the image
 
 frame :registrations
-  = an implicit final image layer owned by the frame
+  = a frame-owned overlay in the frame's resolved generation
 
 dispatch :registrations
-  = an implicit final image layer owned by the dispatch envelope
+  = a cascade-local overlay owned by the dispatch envelope
 ```
 
 Frame-level `:registrations` use the same tuple grammar as image-level
 registrations. Dispatch-level `:registrations` use the same syntactic shape, but
 the exact allowed kind set is an open issue because overriding the triggering
 event handler itself may be too magical.
+
+Dispatch-level overlays are part of one event cascade's resolution context. They
+must not update the frame's recorded construction data, must not rewrite the
+image value, and must not affect unrelated cascades. If child dispatches inherit
+the overlay, that inheritance must be specified explicitly rather than falling
+out of queue implementation details.
 
 ### `:rf.cofx` is not a registration overlay
 
@@ -353,31 +373,20 @@ ordinary registration resolution, frame configuration, or host adapter setup. If
 a future host dependency cannot be modeled cleanly by registrations and frame
 configuration, it can return through a specific EP with concrete examples.
 
-### Naming note: `rf/program`
+### Program vocabulary boundary
 
-This EP deliberately uses `rf/image` because that is the current EP-0023 and
-code vocabulary. The emerging naming preference is to rename the value to
-`rf/program`, because it is the vocabulary of behavior that a frame can run:
-events, subscriptions, effects, coeffects, views, routes, flows, resources, and
-so on.
-
-If accepted separately, the likely spellings become:
-
-```clojure
-rf/program
-rf/program*
-:programs
-```
-
-Guide language can then say:
+This EP deliberately keeps `rf/image`. EP-0023 uses `program` for the event
+stream executed by a frame, and warns against using `program` for registration
+sets. The distinction remains useful here:
 
 ```text
-The program is the vocabulary of the application.
-The frame is one running instance of that vocabulary over state.
+image        = selected registration vocabulary loaded by a frame
+frame        = live execution context over state and runtime partitions
+event stream = the program executed by that frame
 ```
 
-This proposal does not bundle that rename. It keeps the API cleanup reviewable
-against the current `rf/image` surface.
+Any future rename from `rf/image` would need to explicitly revise that EP-0023
+vocabulary. This proposal does not do so.
 
 ## Rationale
 

--- a/docs/EP/EP-0027-frame-initial-events.md
+++ b/docs/EP/EP-0027-frame-initial-events.md
@@ -159,6 +159,12 @@ Frame construction proceeds in this order:
 Initial events are dispatched to the frame being constructed. The caller does
 not pass `{:frame ...}` for each step.
 
+Each setup step is an ordinary synchronous event dispatch into that frame. It
+uses the frame's resolved image generation, runs the normal event pipeline, opens
+the normal cascade/epoch boundary for that event, and records the event in the
+frame's event stream. Child dispatches emitted by a setup event follow the same
+queue/drain semantics as child dispatches emitted by any other event.
+
 If a synchronous setup step fails, construction fails loud. If the frame was
 registered before the failure, the implementation must tear it down or unregister
 it so failed construction does not leave a live half-created frame.
@@ -196,7 +202,9 @@ and is always the frame under construction. This prevents setup scripts from
 accidentally mutating a sibling frame.
 
 Per-event opts are ordinary dispatch opts, subject to the accepted dispatch
-grammar. That includes causal facts:
+grammar. They are still per-cascade data: they do not mutate the frame's
+recorded construction script, resolved image generation, or durable state except
+through effects returned by the event pipeline. That includes causal facts:
 
 ```clojure
 (rf/make-frame
@@ -283,7 +291,7 @@ harder to teach. One event is already expressible as a one-element
 
 This preserves the re-frame ethos: state changes go through events when you want
 the event pipeline, but data stays data. A setup script is not a callback; it is
-a small event program that constructs a scenario.
+the first explicit segment of the frame's event stream.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Summary

- Clarify EP-0026 namespace selection, explicit overlay layering, and dispatch-local overlay lifetime.
- Replace the `rf/program` naming note with an EP-0023-compatible program vocabulary boundary.
- Clarify EP-0027 initial events as ordinary cascade/epoch entries and per-event opts as per-cascade data.

## Validation

- `python scripts\check_ep_status_sync.py`
- `git diff --check`