### PR TITLE
[codex] Tighten EP normative clarity

### DIFF
--- a/docs/EP/EP-0026-image-api-simplification.md
+++ b/docs/EP/EP-0026-image-api-simplification.md
@@ -106,7 +106,9 @@ Non-goals:
 
 This section uses normative language so acceptance can graduate into specs with
 minimal rewriting. At `proposal` status it records the proposed contract, not a
-shipped guarantee.
+shipped guarantee. The open issues at the end are graduation blockers: this EP
+must not move to `final` until each dispatch-overlay question has an operator
+ruling or is explicitly deferred to a follow-on EP.
 
 ### Image keys
 
@@ -127,6 +129,10 @@ The following keys are retired from the ordinary public `rf/image` surface:
 :replace-standard
 :rf.image/requires
 ```
+
+If accepted, public image construction must reject these retired keys with
+actionable diagnostics rather than silently ignoring them or treating them as
+synonyms.
 
 `:replace-standard` may return only through a later, explicit standards-track
 decision that names real replaceable framework standards and their conformance
@@ -158,6 +164,11 @@ matches(clause :include) minus matches(clause :exclude)
 The image-selected namespaces are the union of all clause results. Exclusions
 are local to the include clause that contains them; they are not one global
 subtraction set.
+
+`:select-ns` defaults to an empty vector. An image with no `:select-ns` clauses
+selects no namespace-authored registrations and may still define inline
+`:registrations`. Each clause must contain at least one `:include` pattern;
+`:exclude` defaults to an empty vector.
 
 Selecting the same source namespace through more than one clause is idempotent:
 the descriptor is considered once. A same `[kind id]` collision between two
@@ -210,10 +221,11 @@ Across images, later images intentionally shadow earlier images for the same
 `[kind id]`. Shadowing is not ambient namespace load order; it is the explicit
 order of the `:images` vector.
 
-Tooling must retain enough provenance to show which descriptors were shadowed,
-which layer won, and why. Layer dominance should be inspectable, not invisible.
-This is a deliberate amendment to EP-0023's exact replacement maps: the API
-gains a smaller data shape, and gives up the old coordinate-level winner
+Assemblers must retain enough provenance to show which descriptors were
+shadowed, which layer won, and why. Layer dominance must be inspectable by Xray,
+Pair, error reporters, and other tooling rather than disappearing during
+resolution. This is a deliberate amendment to EP-0023's exact replacement maps:
+the API gains a smaller data shape, and gives up the old coordinate-level winner
 declaration. The mitigation is that order is explicit in `:images`, collisions
 inside one selection clause still fail loud, and shadowed descriptors remain
 visible to diagnostics and tools.
@@ -272,8 +284,8 @@ The omitted metadata maps normalize to `{}`.
 
 ### `rf/image` is an authoring macro
 
-The public `rf/image` form should be a macro for literal image specs. It should
-do for inline image entries what `reg-event`, `reg-sub`, `reg-view`, and other
+The public `rf/image` form is a macro for literal image specs. It must do for
+inline image entries what `reg-event`, `reg-sub`, `reg-view`, and other
 `reg-*` macros do for namespace-authored registrations:
 
 - capture source namespace, file, line, and column where available;
@@ -335,7 +347,10 @@ dispatch :registrations
 Frame-level `:registrations` use the same tuple grammar as image-level
 registrations. Dispatch-level `:registrations` use the same syntactic shape, but
 the exact allowed kind set is an open issue because overriding the triggering
-event handler itself may be too magical.
+event handler itself may be too magical. Until that ruling lands, image-level
+and frame-level overlays are the determinate part of this EP; dispatch-level
+overlays are accepted only if the final ruling records their allowed kind set
+and inheritance behavior.
 
 Dispatch-level overlays are part of one event cascade's resolution context. They
 must not update the frame's recorded construction data, must not rewrite the
@@ -412,8 +427,10 @@ part of the image/frame model.
 
 ## Backwards Compatibility
 
-re-frame2 is pre-alpha. No compatibility shims are required for off-pattern
-spellings.
+re-frame2 is pre-alpha. No compatibility shims are required, but this is still a
+breaking source migration for any code or documentation already using the
+EP-0023 image spellings. The retired keys must fail loudly during assembly so
+stale examples do not keep working by accident.
 
 Migration is source-level:
 
@@ -443,6 +460,9 @@ Expected implementation slices:
    inheritance rule, and source-stamping story.
 9. Update Xray, Pair, examples, tools, migration skill, and guide chapters that
    teach image assembly or stubbing.
+10. Add conformance tests for retired-key rejection, scoped namespace
+    selection, duplicate detection, cross-image shadow provenance, source
+    stamping, and frame/dispatch overlay precedence after the dispatch ruling.
 
 Guide-impact assessment:
 
@@ -453,6 +473,10 @@ Guide-impact assessment:
 - image composition docs should show layer dominance and shadow inspection.
 
 ## Open Issues
+
+These issues require recorded dispositions before this standards-track EP can
+graduate. If any answer is deferred, the final EP should narrow its normative
+surface and name the follow-on EP or bead that owns the deferred question.
 
 1. **Should dispatch-level `:registrations` allow every registration kind?**
    The recommended default is conservative: allow the kinds genuinely consulted

--- a/docs/EP/EP-0027-frame-initial-events.md
+++ b/docs/EP/EP-0027-frame-initial-events.md
@@ -108,6 +108,9 @@ Non-goals:
 ## Specification
 
 This section is proposed normative text. It binds only if the EP is accepted.
+The open issues at the end are graduation blockers unless the operator records
+that a question is intentionally deferred from the first `:initial-events`
+contract.
 
 ### Frame construction keys
 
@@ -123,6 +126,10 @@ Frame construction supports:
 `:initial-db` directly seeds the frame's app-db. `:initial-events` is an
 ordered vector of setup steps dispatched synchronously to the newly created
 frame.
+
+Omitting `:initial-events` and supplying an empty vector both mean "no setup
+events." A bare event vector is not a valid top-level `:initial-events` value;
+one boot event is represented as a one-step script.
 
 One boot event is a one-step script:
 
@@ -165,6 +172,12 @@ the normal cascade/epoch boundary for that event, and records the event in the
 frame's event stream. Child dispatches emitted by a setup event follow the same
 queue/drain semantics as child dispatches emitted by any other event.
 
+Setup steps run in vector order. The next step starts only after the previous
+step's synchronous event cascade has completed. If a step fails, no later setup
+steps run. Effects already committed by earlier successful synchronous steps
+are not rolled back; the cleanup guarantee applies to the partially constructed
+frame registration/lifecycle, not to arbitrary external effects.
+
 If a synchronous setup step fails, construction fails loud. If the frame was
 registered before the failure, the implementation must tear it down or unregister
 it so failed construction does not leave a live half-created frame.
@@ -201,6 +214,10 @@ User-supplied `:frame` inside step opts fails loud. The frame target is implicit
 and is always the frame under construction. This prevents setup scripts from
 accidentally mutating a sibling frame.
 
+The event value must be a non-empty event vector. The `:opts` value must be a
+map. Unknown step-map keys are not part of the public grammar and must fail
+loudly unless a later EP extends the setup step shape.
+
 Per-event opts are ordinary dispatch opts, subject to the accepted dispatch
 grammar. They are still per-cascade data: they do not mutate the frame's
 recorded construction script, resolved image generation, or durable state except
@@ -224,7 +241,7 @@ When `make-frame` is re-evaluated for an existing live frame id under the
 EP-0024 idempotent replacement policy, the new `:initial-events` value is
 recorded as the frame's construction script, but it is not automatically replayed
 into existing app-db. Replaying setup into a live frame can duplicate work and
-should happen only through an explicit reset or explicit event dispatch.
+must happen only through an explicit reset or explicit event dispatch.
 
 Hot reload may update the resolved image generation and the recorded setup
 script. It must not silently replay the setup script into durable state.
@@ -295,7 +312,10 @@ the first explicit segment of the frame's event stream.
 
 ## Backwards Compatibility
 
-re-frame2 is pre-alpha. No compatibility shim is required.
+re-frame2 is pre-alpha. No compatibility shim is required, but this is a
+breaking source migration for any existing examples or callers using
+`:on-create`. Implementations must reject `:on-create` in public frame specs
+rather than allowing two event-based initialization spellings to coexist.
 
 Migration is direct:
 
@@ -344,6 +364,8 @@ Expected implementation slices:
 9. Add conformance tests for construction order, per-event `:rf.cofx`, failure
    cleanup, reset replay, hot reload non-replay, provider creation, and Story
    setup alignment.
+10. Update diagnostics so invalid top-level shapes, bad step maps, user-supplied
+    `:frame` opts, and setup failures identify the setup step index and event.
 
 Guide-impact assessment:
 
@@ -356,12 +378,17 @@ Guide-impact assessment:
 
 ## Open Issues
 
+These issues require recorded dispositions before this standards-track EP can
+graduate. If any answer is deferred, the final EP should narrow the first
+`:initial-events` contract and name the follow-on EP or bead that owns the
+deferred question.
+
 1. **Should the event-script runner be public?** The recommended first step is
    internal or tool-tier. Make it public only if examples, Story, and tests need
    a reusable name outside frame construction.
 
 2. **What should the exact failure value be when a setup step fails?** The
-   contract should fail loud and identify the step index and event. The final
+   contract must fail loud and identify the step index and event. The final
    error id belongs in the implementation bead.
 
 3. **Should setup steps support labels?** A future map shape could allow


### PR DESCRIPTION
## Summary

- tighten EP-0026 normative language around retired image keys, `:select-ns` defaults, shadow provenance, `rf/image` macro behavior, dispatch-overlay graduation blockers, and implementation tests
- tighten EP-0027 normative language around `:initial-events` no-op/invalid shapes, step ordering and failure semantics, reset replay, `:on-create` rejection, diagnostics, and graduation blockers
- preserve the upstream EP clarifications already merged on `main`

## Validation

- `python scripts\check_ep_status_sync.py`
- `git diff --check --cached`
