### PR TITLE
refactor(core): inline marks/validate-marks! direct require (rf2-58bq1r)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -64,11 +64,14 @@
             ;; owned classification + `project-egress` are the public
             ;; boundary now). `re-frame.marks` stays a side-effect-only
             ;; require — it publishes the `:marks/*` late-bind hooks (the
-            ;; trace bus's `:marks/project-trace-event` emit chokepoint, the
-            ;; reg-* boundary `:marks/validate-marks!` fail-loud check, and
+            ;; trace bus's `:marks/project-trace-event` emit chokepoint and
             ;; `:marks/marks-for` — which DERIVES per-(kind,id) marks from the
             ;; registrar metadata at read time, no imperative side-table:
-            ;; rf2-ehexnw) that must be bound at boot. No `marks/*` symbols are
+            ;; rf2-ehexnw) that must be bound at boot. The reg-* boundary
+            ;; fail-loud check is no longer a hook: events / fx / cofx / subs
+            ;; call `re-frame.marks/validate-marks!` by DIRECT REQUIRE
+            ;; (rf2-58bq1r — always-on, same-artefact, cycle-free, already
+            ;; bundled, so the hop bought nothing). No `marks/*` symbols are
             ;; referenced from this façade any more.
             [re-frame.marks]
             ;; EP-0015 §3 (rf2-ueg1tn): required for its ns-load side-effect

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -30,10 +30,16 @@
   into the dispatched event vector's arg-map (the second element).
   The marks are DERIVED from the registrar meta at `re-frame.marks/marks-for`
   read time (rf2-ehexnw); reg-event only VALIDATES them fail-loud via
-  `re-frame.marks/validate-marks!` (an ALWAYS-ON validator — `re-frame.marks`
-  is core-owned and boot side-effect-required, so it is never absent; the
-  late-bind hop is the production-DCE/elision seam, not optional-artefact
-  decoupling — rf2-eq7m0x), no imperative stash."
+  `re-frame.marks/validate-marks!` — an ALWAYS-ON registration-time validator
+  reached by DIRECT REQUIRE (rf2-58bq1r). `re-frame.marks` is core-owned, lives
+  in the SAME artefact as events/fx/subs, and is already pinned into every
+  production bundle (it is side-effect-required by `re-frame.core`); the
+  validator fail-louds in prod as well as dev. The former `:marks/validate-marks!`
+  late-bind hop bought nothing for THIS key — it was not a DCE seam (marks is in
+  the bundle regardless), not optional-artefact decoupling (marks is never
+  absent), and the require is cycle-free (marks' transitive closure touches none
+  of events/fx/cofx/subs). The dev-gated marks PROJECTION hooks stay late-bound
+  (eq7m0x). No imperative stash."
   (:require [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
@@ -41,6 +47,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.cofx :as cofx]
             [re-frame.error :as error]
+            [re-frame.marks :as marks]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -911,18 +918,16 @@
     ;; Per Spec 015 §1. Event handlers: VALIDATE any declared `:sensitive` /
     ;; `:large` marks fail-loud BEFORE the registrar write (rf2-ehexnw); the
     ;; marks themselves are DERIVED from the registrar meta at `marks-for` read
-    ;; time, no imperative stash. Late-bound NOT to decouple from an absent
-    ;; artefact — `re-frame.marks` is core-owned and boot side-effect-required
-    ;; (core.cljc), so this hook is bound in every canonical build; the hop is
-    ;; the production-DCE/elision seam the rest of the marks surface uses, and
-    ;; `validate-marks!` itself is an ALWAYS-ON validator that fail-louds in prod
-    ;; too (rf2-eq7m0x). Runs for MACHINE registrations too: a machine's author
+    ;; time, no imperative stash. DIRECT REQUIRE (rf2-58bq1r): `marks` is
+    ;; core-owned, same-artefact, already pinned into the prod bundle, and
+    ;; always-on, so the former `:marks/validate-marks!` late-bind hop bought
+    ;; nothing here (no DCE seam, no optional-artefact decoupling) and the require
+    ;; is cycle-free. Runs for MACHINE registrations too: a machine's author
     ;; marks ride its `:event` reg meta (via `reg-machine` opts); `marks-for
     ;; :event <id>` returns those registrar-derived author marks (EP-0025
     ;; rf2-398kql removed the machine `:data-schema`→marks union — frame-declared
     ;; paths are now the sole app-db classification mechanism).
-    (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
-      (validate! :event meta))
+    (marks/validate-marks! :event meta)
     (let [requires-parsed (cofx/parse-requires id (:rf.cofx/requires meta))]
       (registrar/register! :event id
         (cond-> (assoc (-> meta source-coords/merge-coords merge-form-source)

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -23,6 +23,7 @@
             [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.marks :as marks]
             [re-frame.performance :as performance
              #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
@@ -44,10 +45,16 @@
   kind-specific registrar slots merged on top — `nil` for `reg-fx`, the
   `:recordable?` / `:provided?` grade flags for `reg-cofx`. `re-frame.cofx`
   reaches this through its existing `fx/` alias (the same single-definition
-  pattern as `runs-on-platform?` / `platform-for-frame-record`, rf2-4ymm0)."
+  pattern as `runs-on-platform?` / `platform-for-frame-record`, rf2-4ymm0).
+
+  Marks validation is a DIRECT call into `re-frame.marks/validate-marks!`
+  (rf2-58bq1r): an ALWAYS-ON registration-time validator in the same core
+  artefact, already pinned into every production bundle, reached without the
+  former `:marks/validate-marks!` late-bind hop (which was neither a DCE seam
+  nor optional-artefact decoupling for this always-on, same-artefact key; the
+  require is cycle-free)."
   [kind id meta handler-fn extra-slots]
-  (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
-    (validate! kind meta))
+  (marks/validate-marks! kind meta)
   (registrar/register! kind id (merge (assoc (source-coords/merge-coords meta)
                                              :handler-fn handler-fn)
                                       extra-slots)))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -152,15 +152,17 @@
    ;; EXCEPTION — the `:marks/*` rows are NOT an absent-optional-artefact
    ;; case (rf2-eq7m0x). `re-frame.marks` ships IN core and is side-
    ;; effect-required at boot (core.cljc), so the hooks are bound in
-   ;; every canonical build — `marks` is NEVER absent. The late-bind hop
-   ;; from events/fx/subs/cofx into `marks` is the production-DCE/elision
-   ;; SEAM, not decoupling: the dev-only marks projection surface rides
-   ;; `interop/debug-enabled?` and constant-folds out of `:advanced` +
-   ;; `goog.DEBUG=false` bundles (marks.cljc §Hot-path cost), so a direct
-   ;; `:require` would pin that dev-only surface into the prod bundle and
-   ;; regress elision. The always-on survivors (`:marks/validate-marks!`
-   ;; reg-time validator, `:marks/redact-event-by-registration` prod
-   ;; redactor) are reached through the SAME indirection. See the per-key
+   ;; every canonical build — `marks` is NEVER absent. For the DEV-GATED
+   ;; projection hooks the late-bind hop is the production-DCE/elision
+   ;; SEAM, not decoupling: their emit-time surface rides
+   ;; `interop/debug-enabled?` and is gated at the trace/emit! call sites,
+   ;; so the hop keeps the lookup off the always-on registration path. The
+   ;; always-on `:marks/redact-event-by-registration` prod redactor is
+   ;; reached through the SAME indirection. NOTE (rf2-58bq1r): the
+   ;; `:marks/validate-marks!` row is GONE — being always-on AND
+   ;; same-artefact AND already bundled, the seam rationale never applied to
+   ;; it, so reg-event / reg-fx / reg-cofx / reg-sub call
+   ;; `re-frame.marks/validate-marks!` by DIRECT REQUIRE. See the per-key
    ;; notes below.
    ;; ===========================================================================
 
@@ -180,16 +182,25 @@
    ;; ---- re-frame.marks (rf2-vw7f5 Spec 015 data classification) -------------
    ;; NOT an optional-artefact decoupling (rf2-eq7m0x): `re-frame.marks` ships IN
    ;; core and is boot side-effect-required (core.cljc), so these hooks are bound
-   ;; in every canonical build. The indirection is the production-DCE/elision
-   ;; SEAM. Two grades live on these rows:
-   ;;   - DCE / DEV-ONLY seam (constant-folds out of `:advanced` +
-   ;;     `goog.DEBUG=false` per marks.cljc §Hot-path cost): :marks/marks-for,
-   ;;     :marks/project-trace-event, :marks/resolve-sub-output-marks,
-   ;;     :marks/mark-sub-output!, :marks/clear-marks!,
-   ;;     :marks/clear-sub-output-marks!.
-   ;;   - ALWAYS-ON production survivors reached through the SAME indirection
-   ;;     (NOT DCE'd): :marks/validate-marks! (reg-time validator, above) and
-   ;;     :marks/redact-event-by-registration (production egress redactor).
+   ;; in every canonical build. For the DEV-GATED projection hooks the indirection
+   ;; is the production-DCE/elision SEAM — their emit-time surface rides
+   ;; `interop/debug-enabled?` and is gated at the trace/emit! call sites, so the
+   ;; late-bind hop keeps the lookup off the always-on registration path:
+   ;;   :marks/marks-for, :marks/project-trace-event,
+   ;;   :marks/resolve-sub-output-marks, :marks/mark-sub-output!,
+   ;;   :marks/clear-marks!, :marks/clear-sub-output-marks!.
+   ;; ALWAYS-ON production survivor still reached through the indirection:
+   ;;   :marks/redact-event-by-registration (the production egress redactor).
+   ;; NOTE (rf2-58bq1r): the `:marks/validate-marks!` hook row is GONE. It was the
+   ;; ONE always-on, NON-dev-gated marks key, so the DCE-seam rationale never
+   ;; applied to it: `re-frame.marks` lives in the SAME artefact as its only
+   ;; callers (events / fx / cofx / subs) and is already pinned into every
+   ;; production bundle, the validator fail-louds in prod, and the require is
+   ;; cycle-free (marks' transitive closure touches none of events/fx/cofx/subs).
+   ;; A before/after `:advanced` + goog.DEBUG=false bundle diff confirmed marks
+   ;; present and the dev-only sentinels still elided either way — the hop bought
+   ;; no decoupling and no elision win, so reg-event / reg-fx / reg-cofx / reg-sub
+   ;; now call `re-frame.marks/validate-marks!` by DIRECT REQUIRE.
    ;; NOTE (rf2-gjp7t6): the `:marks/add-marks` / `:marks/set-marks` hook rows
    ;; are GONE. EP-0015 §3 (rf2-mngp4o) removed the public imperative façade
    ;; exports; the hooks themselves had ZERO consumers and were kept only for
@@ -197,20 +208,6 @@
    ;; `set-marks` fns survive as test / conformance-only helpers reached by
    ;; DIRECT REQUIRE (the marks tests + the conformance corpus harness), never
    ;; through a late-bind hook.
-   ;; DCE-SEAM (rf2-eq7m0x): `re-frame.marks` is core-owned + boot side-effect-
-   ;; required (core.cljc), so this hook is bound in every canonical build. The
-   ;; late-bind hop into marks is the production-DCE/elision seam — the dev-only
-   ;; marks PROJECTION surface (`:marks/project-trace-event`, the sub-output
-   ;; propagation table) rides `interop/debug-enabled?` and constant-folds out of
-   ;; `:advanced` + `goog.DEBUG=false` bundles (marks.cljc §Hot-path cost); a
-   ;; direct `:require` would pin that dev-only surface into the prod bundle and
-   ;; regress elision. `validate-marks!` ITSELF is the ALWAYS-ON reg-time
-   ;; validator (NOT DCE'd — it fail-louds on every reg-* in prod too), reached
-   ;; through that same DCE-seam indirection.
-   {:key         :marks/validate-marks!
-    :producer-ns 're-frame.marks
-    :design-bead "rf2-ehexnw"
-    :description "ALWAYS-ON reg-time validator (NOT a DCE'd dev surface — fail-louds in production too). VALIDATE a registration's :sensitive / :large / :rf.egress/output-sensitivity declarations fail-loud at the reg-* boundary (raising :rf.error/bad-marks on a malformed declaration, before the registrar write so a bad registration never lands). NOTHING is stashed — per-(kind, id) marks are DERIVED from the registrar meta at :marks/marks-for read time (rf2-ehexnw), not duplicated into an imperative side-table. Replaces the deleted :marks/register-marks! (stash) and :marks/union-marks! (additive-merge) hooks. Called from reg-event / reg-fx / reg-cofx / reg-sub via this late-bind hook NOT to decouple core from an absent artefact (marks is core-owned + boot-bound, never absent) but because the hook routes through the production-DCE/elision seam the rest of the marks surface uses (rf2-eq7m0x)."}
    {:key         :marks/marks-for
     :producer-ns 're-frame.marks
     :design-bead "rf2-w46fpt"

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1830,7 +1830,19 @@
 
 (late-bind/set-fn! :marks/project-trace-event project-trace-event)
 (late-bind/set-fn! :marks/redact-event-by-registration redact-event-by-registration)
-(late-bind/set-fn! :marks/validate-marks!     validate-marks!)
+;; NOTE: the `:marks/validate-marks!` hook is GONE (rf2-58bq1r). It was the ONE
+;; ALWAYS-ON non-dev-gated marks late-bind key — unlike the dev-gated projection
+;; hooks below it was NOT a production-DCE seam: `re-frame.marks` is core-owned,
+;; lives in the SAME artefact as its only callers (events / fx / cofx / subs),
+;; and is already pinned into every production bundle (side-effect-required by
+;; `re-frame.core`), so the late-bind hop bought no decoupling and no elision win
+;; for this key (a before/after `:advanced` + goog.DEBUG=false bundle diff showed
+;; marks present and the dev-only sentinels still elided either way). The require
+;; from events/fx/subs → marks is cycle-free (marks' transitive closure touches
+;; none of events/fx/cofx/subs), so reg-event / reg-fx / reg-cofx / reg-sub now
+;; call `re-frame.marks/validate-marks!` by DIRECT REQUIRE. The dev-gated
+;; PROJECTION hooks below stay late-bound (the eq7m0x DCE-seam ruling — their
+;; emit-time surface is gated at the trace/emit! call sites).
 (late-bind/set-fn! :marks/marks-for           marks-for)
 ;; NOTE: the `:marks/declare-machine-schema-marks!` / `:marks/clear-machine-schema-marks!`
 ;; hooks are GONE (EP-0025, rf2-398kql). They published the writers of the

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -36,6 +36,7 @@
             [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.live-frame :as live-frame]
+            [re-frame.marks :as marks]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -246,9 +247,11 @@
     ;; The marks themselves are DERIVED from the registrar meta at `marks-for`
     ;; read time (no imperative stash). The propagation table
     ;; (`re-frame.marks/mark-sub-output!`) is updated on each sub-cache compute
-    ;; pass — see `compute-and-cache!`.
-    (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
-      (validate! :sub meta))
+    ;; pass — see `compute-and-cache!`. DIRECT REQUIRE (rf2-58bq1r): the
+    ;; always-on, same-artefact `validate-marks!` is called directly, not through
+    ;; the former `:marks/validate-marks!` late-bind hop (a vestigial indirection
+    ;; for this key — no DCE seam, no decoupling, cycle-free).
+    (marks/validate-marks! :sub meta)
     (registrar/register! :sub id
       (cond-> (assoc (source-coords/merge-coords meta)
                      :handler-fn    handler-fn
@@ -273,10 +276,11 @@
 
   rf2-ehexnw — VALIDATE marks fail-loud BEFORE the registrar write; marks are
   DERIVED from the registrar meta at read time, no imperative stash. Emits the
-  Spec 009 §`:rf.sub/create` materialisation trace. Returns `id`."
+  Spec 009 §`:rf.sub/create` materialisation trace. Returns `id`. DIRECT REQUIRE
+  (rf2-58bq1r): always-on, same-artefact validator called directly, not via the
+  former `:marks/validate-marks!` late-bind hop."
   [id meta handler-fn input-kind]
-  (when-let [validate! (late-bind/get-fn :marks/validate-marks!)]
-    (validate! :sub meta))
+  (marks/validate-marks! :sub meta)
   (registrar/register! :sub id
     (assoc (source-coords/merge-coords meta)
            :handler-fn    handler-fn


### PR DESCRIPTION
## What

`:marks/validate-marks!` was the ONE always-on, non-dev-gated marks late-bind key. This inlines it to a **direct require** and removes the late-bind hop (the publication, the directory row, and the four `late-bind/get-fn` call sites in `reg-event` / `reg-fx` / `reg-cofx` / `reg-sub`). The dev-gated marks **projection** hooks stay late-bound per the eq7m0x ruling.

## Why (the rf2-58bq1r probe verdict: inline is SAFE)

The eq7m0x "production-DCE/elision seam" rationale that keeps the projection hooks late-bound does **not** apply to `validate-marks!`:

1. **Cycle-free.** `re-frame.marks`' full transitive closure (`elision`, `error`, `frame`, `interop`, `late-bind`, `path`, `privacy`, `registrar`, `substrate.adapter` → `trace`, `source-coords`, `identity`, `interceptor`, `source-store`, `trace.tooling`, `trace.projection`, `editor-uri`) requires **none** of `events` / `fx` / `cofx` / `subs`. Confirmed by a clean `:advanced` compile (a CLJS require cycle hard-errors).
2. **No elision regression / no DCE harm.** `re-frame.marks` is core-owned, lives in the **same artefact** as its callers, and is **already pinned into every production bundle** (side-effect-required by `re-frame.core`; marks-only strings `rf.error/bad-marks` + `rf.egress/output-sensitivity` are present in the prod bundle before AND after). The validator is always-on (fail-louds in prod). The late-bind hop was never keeping marks out of the bundle.
3. **Strict win.** Before/after `:advanced` + `goog.DEBUG=false` bundle diff: dev-only sentinels still **42/42 absent**; bundle **281 bytes smaller** after inlining (the lookup shells + the dead `:marks/validate-marks!` key string are gone).

## Gates (all green)

- `test:elision`: production 42/42 absent (697980 → 697699 chars), control 42/42 present
- `test:cljs`: 7910 tests / 36439 assertions, 0 failures
- JVM core: 1694 tests / 7305 assertions, 0 failures
- `test:bundle-isolation`: PASS (21 artefacts, 40 sentinels absent) + uix/helix reagent-free PASS
- late-bind drift: 6 tests / 623 assertions, 0 failures
- clj-kondo: 0 errors, 0 new warnings (events/fx/subs clean; pre-existing core/marks warnings unchanged)

Closes rf2-58bq1r.
